### PR TITLE
Fix double fetch on program patient listing

### DIFF
--- a/packages/desktop/app/containers/Programs/Patients.js
+++ b/packages/desktop/app/containers/Programs/Patients.js
@@ -71,9 +71,9 @@ class Patients extends Component {
         this.props.collection.setSorting(sort.id, sort.desc ? 1 : -1);
       }
       if (keyword) this.props.collection.setKeyword(keyword);
-      this.props.collection.setPageSize(pageSize);
+
       const patientFilters = JSON.parse(patientFiltersString);
-      await this.props.collection.getPage(page, null, null, { data: patientFilters });
+      await this.props.collection.getPage(page, null, null, { data: patientFilters, pageSize });
       this.setState({ loading: false });
     } catch (err) {
       this.setState({ loading: false });


### PR DESCRIPTION
There was an issue where it would first flash all patients, and then show just females after that. If a search resulted in only men, it would also show those men