### PR TITLE
Fix migration

### DIFF
--- a/packages/shared-src/src/migrations/016_addNoteInImagingRequest.js
+++ b/packages/shared-src/src/migrations/016_addNoteInImagingRequest.js
@@ -2,12 +2,12 @@ const Sequelize = require('sequelize');
 
 module.exports = {
   up: async query => {
-    await query.addColumn('imaging_request', 'note', {
+    await query.addColumn('imaging_requests', 'note', {
       type: Sequelize.STRING,
       allowNull: true,
     });
   },
   down: async query => {
-    await query.removeColumn('imaging_request', 'note');
+    await query.removeColumn('imaging_requests', 'note');
   },
 };


### PR DESCRIPTION
Old habits die hard - we use singular table names in Tupaia...

I wondered how this worked the first time! 🤔 My guess is that because I was using `SQLite` locally, the migration didn't actually run and the database was updated based on the model changes