### PR TITLE
Reconcile patient additional data

### DIFF
--- a/packages/lan/__tests__/apiv1/Patient.test.js
+++ b/packages/lan/__tests__/apiv1/Patient.test.js
@@ -69,7 +69,8 @@ describe('Patient', () => {
       expect(result).toHaveSucceeded();
 
       const id = result.body.id;
-      const additional = await models.PatientAdditionalData.findOne({ where: { patientId: id } });
+      const patientRecord = await models.Patient.findOne({ where: { id } });
+      const additional = await patientRecord.getAdditionalData();
       expect(additional).toBeTruthy();
       expect(additional).toHaveProperty('passport', 'TEST-PASSPORT');
     });

--- a/packages/lan/app/routes/apiv1/patient.js
+++ b/packages/lan/app/routes/apiv1/patient.js
@@ -58,9 +58,7 @@ patientRoute.put(
     req.checkPermission('write', patient);
     await patient.update(requestBodyToRecord(req.body));
 
-    const patientAdditionalData = await PatientAdditionalData.findOne({
-      where: { patientId: patient.id },
-    });
+    const patientAdditionalData = await patient.getAdditionalData();
 
     if (!patientAdditionalData) {
       await PatientAdditionalData.create({

--- a/packages/lan/app/tasks/SenaitePoller.js
+++ b/packages/lan/app/tasks/SenaitePoller.js
@@ -27,6 +27,10 @@ export class SenaitePoller extends ScheduledTask {
     this.runInitialTasks();
   }
 
+  getName() {
+    return 'SenaitePoller';
+  }
+
   async runInitialTasks() {
     await this.login();
   }

--- a/packages/lan/app/tasks/SyncTask.js
+++ b/packages/lan/app/tasks/SyncTask.js
@@ -12,6 +12,10 @@ export class SyncTask extends ScheduledTask {
     this.runImmediately();
   }
 
+  getName() {
+    return 'SyncTask';
+  }
+
   async run() {
     return this.context.syncManager.runSync();
   }

--- a/packages/shared-src/src/migrations/036_addPADConflictsField.js
+++ b/packages/shared-src/src/migrations/036_addPADConflictsField.js
@@ -5,7 +5,6 @@ module.exports = {
     // missing columns to add
     await query.addColumn('patient_additional_data', 'conflicts', {
       type: Sequelize.TEXT,
-      default: '',
     });
   },
   down: async query => {

--- a/packages/shared-src/src/migrations/036_addPADConflictsField.js
+++ b/packages/shared-src/src/migrations/036_addPADConflictsField.js
@@ -1,0 +1,14 @@
+const Sequelize = require('sequelize');
+
+module.exports = {
+  up: async query => {
+    // missing columns to add
+    await query.addColumn('patient_additional_data', 'conflicts', {
+      type: Sequelize.TEXT,
+      default: '',
+    });
+  },
+  down: async query => {
+    await query.removeColumn('patient_additional_data', 'conflicts');
+  },
+};

--- a/packages/shared-src/src/models/Model.js
+++ b/packages/shared-src/src/models/Model.js
@@ -93,6 +93,20 @@ export class Model extends sequelize.Model {
     });
   }
 
+  static async markRecordDeleted(id) {
+    // use update instead of destroy so we can change both fields
+    const [num] = await this.update(
+      {
+        deletedAt: Sequelize.literal('CURRENT_TIMESTAMP'),
+        updatedAt: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      {
+        where: { id },
+      },
+    );
+    return num;
+  }
+
   static getListReferenceAssociations() {
     // List of relations to include when fetching this model
     // as part of a list (eg to display in a table)

--- a/packages/shared-src/src/models/Patient.js
+++ b/packages/shared-src/src/models/Patient.js
@@ -54,6 +54,15 @@ export class Patient extends Model {
     });
   }
 
+  getAdditionalData() {
+    return this.sequelize.models.PatientAdditionalData.findOne({
+      where: {
+        patientId: this.id
+      },
+      order: [['createdAt', 'ASC NULLS FIRST']],
+    });
+  }
+
   static async getSyncIds() {
     const patients = await this.sequelize.models.Patient.findAll({
       where: { markedForSync: true },

--- a/packages/shared-src/src/models/PatientAdditionalData.js
+++ b/packages/shared-src/src/models/PatientAdditionalData.js
@@ -20,6 +20,9 @@ export class PatientAdditionalData extends Model {
         birthCertificate: Sequelize.STRING,
         drivingLicense: Sequelize.STRING,
         passport: Sequelize.STRING,
+
+        // json field to track conflicts during record merging
+        conflicts: Sequelize.TEXT,
       },
       {
         ...options,
@@ -58,18 +61,18 @@ export class PatientAdditionalData extends Model {
     return ['countryOfBirth'];
   }
 
-  appendOverwriteRecord(newOverwrites) {
+  appendConflictRecords(newConflicts) {
     // TODO: actually add this field to the record & include it with a migration 
     // (this function doesn't really do anything until then)
 
     // the auto-reconciler will save older values of fields here for manual
     // reconciliation later
-    let overwrites = [];
-    if (this.overwrites) {
-      overwrites = JSON.parse(this.overwrites);
+    let conflicts = [];
+    if (this.conflicts) {
+      conflicts = JSON.parse(this.conflicts);
     }
 
-    overwrites = [...overwrites, ...newOverwrites];
-    this.overwrites = JSON.stringify(overwrites);
+    conflicts = [...conflicts, ...newConflicts];
+    this.conflicts = JSON.stringify(conflicts);
   }
 }

--- a/packages/shared-src/src/models/PatientAdditionalData.js
+++ b/packages/shared-src/src/models/PatientAdditionalData.js
@@ -57,4 +57,19 @@ export class PatientAdditionalData extends Model {
   static getFullReferenceAssociations() {
     return ['countryOfBirth'];
   }
+
+  appendOverwriteRecord(newOverwrites) {
+    // TODO: actually add this field to the record & include it with a migration 
+    // (this function doesn't really do anything until then)
+
+    // the auto-reconciler will save older values of fields here for manual
+    // reconciliation later
+    let overwrites = [];
+    if (this.overwrites) {
+      overwrites = JSON.parse(this.overwrites);
+    }
+
+    overwrites = [...overwrites, ...newOverwrites];
+    this.overwrites = JSON.stringify(overwrites);
+  }
 }

--- a/packages/shared-src/src/models/PatientAdditionalData.js
+++ b/packages/shared-src/src/models/PatientAdditionalData.js
@@ -62,8 +62,6 @@ export class PatientAdditionalData extends Model {
   }
 
   appendConflictRecords(newConflicts) {
-    // (this function doesn't really do anything until then)
-
     // the auto-reconciler will save older values of fields here for manual
     // reconciliation later
     let conflicts = [];

--- a/packages/shared-src/src/models/PatientAdditionalData.js
+++ b/packages/shared-src/src/models/PatientAdditionalData.js
@@ -62,7 +62,6 @@ export class PatientAdditionalData extends Model {
   }
 
   appendConflictRecords(newConflicts) {
-    // TODO: actually add this field to the record & include it with a migration 
     // (this function doesn't really do anything until then)
 
     // the auto-reconciler will save older values of fields here for manual

--- a/packages/shared-src/src/tasks/ScheduledTask.js
+++ b/packages/shared-src/src/tasks/ScheduledTask.js
@@ -5,7 +5,7 @@ export class ScheduledTask {
     // We can't use reflection here (this.constructor.name) as
     // the class names are not preserved in minified builds.
     // Each scheduled task should override getName() with the appropriate name.
-    return '??';
+    throw new Error("getName() must be overriden when inheriting from ScheduledTask");
   }
 
   constructor(schedule, log) {

--- a/packages/shared-src/src/tasks/ScheduledTask.js
+++ b/packages/shared-src/src/tasks/ScheduledTask.js
@@ -2,8 +2,10 @@ import { scheduleJob } from 'node-schedule';
 
 export class ScheduledTask {
   getName() {
-    // get class name from reflection
-    return this.constructor.name;
+    // We can't use reflection here (this.constructor.name) as
+    // the class names are not preserved in minified builds.
+    // Each scheduled task should override getName() with the appropriate name.
+    return '??';
   }
 
   constructor(schedule, log) {

--- a/packages/sync-server/app/database/wrapper/sqlWrapper.js
+++ b/packages/sync-server/app/database/wrapper/sqlWrapper.js
@@ -41,17 +41,7 @@ export class SqlWrapper {
 
   async markRecordDeleted(channel, id) {
     return this.sequelize.channelRouter(channel, async model => {
-      // use update instead of destroy so we can change both fields
-      const [num] = await model.update(
-        {
-          deletedAt: Sequelize.literal('CURRENT_TIMESTAMP'),
-          updatedAt: Sequelize.literal('CURRENT_TIMESTAMP'),
-        },
-        {
-          where: { id },
-        },
-      );
-      return num;
+      return model.markRecordDeleted(id);
     });
   }
   //------------------------------------

--- a/packages/sync-server/app/tasks/AdditionalDataReconciler.js
+++ b/packages/sync-server/app/tasks/AdditionalDataReconciler.js
@@ -1,0 +1,98 @@
+import config from 'config';
+
+import { ScheduledTask } from 'shared/tasks';
+import { log } from 'shared/services/logging';
+
+const KEYS_TO_IGNORE = [
+  'id',
+  'updatedAt', 
+  'createdAt', 
+  'deletedAt', 
+  'pushedAt',
+  'pulledAt', 
+  'markedForPush',
+];
+
+export class AdditionalDataReconciler extends ScheduledTask {
+
+  constructor(context) {
+    // TODO every 5 seconds is much much too often
+    super('*/5 * * * * *', log);
+    this.context = context;
+    this.runImmediately();
+  }
+
+  getName() {
+    return 'AdditionalDataReconciler';
+  }
+
+  async reconcilePatient(patientId) {
+    const { models, sequelize } = this.context.store;
+    
+    const records = await models.PatientAdditionalData.findAll({
+      where: {
+        patientId
+      },
+      order: [['createdAt', 'ASC NULLS FIRST']],
+    });
+
+    // grab first record as primary
+    const primary = records[0];
+    const subsequent = records.slice(1);
+
+    // save values of later records to primary record
+    const overwrites = [];
+    let didExtend = false;
+    const extend = record => {
+      Object.entries(record.dataValues)
+        .map(([key, value]) => {
+          if (KEYS_TO_IGNORE.includes(key)) return;
+          if (value === null) return; // always ignore incoming nulls
+          const existingValue = primary[key];
+          if (value === existingValue) return; // no difference = no write
+
+          didExtend = true;
+
+          if (existingValue !== null) {
+            // writing over a non-null with a non-null, log it against the record
+            overwrites.push({ key, newValue: value, oldValue: existingValue });
+          }
+          primary[key] = value;
+        });
+    }
+    subsequent.map(r => extend(r));
+
+    await sequelize.transaction(async () => {
+      primary.appendOverwriteRecord(overwrites);
+      await primary.save();
+
+      // delete all duplicates
+      for (let sub of subsequent) {
+        await models.PatientAdditionalData.markRecordDeleted(sub.id);
+      }
+
+      log.info(`[AdditionalDataReconciler] Reconciled ${subsequent.length} duplicate PADs for ${primary.patientId}`);
+    });
+  }
+
+  async run() {
+    // query for duplicate PAD items
+    const { sequelize } = this.context.store;
+    const [duplicateResults] = await sequelize.query(`
+      SELECT 
+        patient_id, COUNT(*) 
+      FROM 
+        patient_additional_data 
+      WHERE
+        patient_additional_data.deleted_at IS NULL
+      GROUP BY patient_id 
+      HAVING COUNT(*) > 1;
+    `);
+
+    // reconcile each duplicated PAD item 
+    for (let r of duplicateResults) {
+      await this.reconcilePatient(r.patient_id);
+      return;
+    }
+  }
+}

--- a/packages/sync-server/app/tasks/AdditionalDataReconciler.js
+++ b/packages/sync-server/app/tasks/AdditionalDataReconciler.js
@@ -55,7 +55,12 @@ export class AdditionalDataReconciler extends ScheduledTask {
 
           if (existingValue !== null) {
             // writing over a non-null with a non-null, log it against the record
-            overwrites.push({ key, newValue: value, oldValue: existingValue });
+            overwrites.push({ 
+              key,
+              newValue: value, 
+              oldValue: existingValue,
+              date: new Date(),
+            });
           }
           primary[key] = value;
         });

--- a/packages/sync-server/app/tasks/AdditionalDataReconciler.js
+++ b/packages/sync-server/app/tasks/AdditionalDataReconciler.js
@@ -16,7 +16,7 @@ const KEYS_TO_IGNORE = [
 export class AdditionalDataReconciler extends ScheduledTask {
 
   constructor(context) {
-    super('0 */5 * * * *', log);
+    super(config.schedules.additionalDataReconciler, log);
     this.context = context;
     this.runImmediately();
   }

--- a/packages/sync-server/app/tasks/AdditionalDataReconciler.js
+++ b/packages/sync-server/app/tasks/AdditionalDataReconciler.js
@@ -35,9 +35,7 @@ export class AdditionalDataReconciler extends ScheduledTask {
       order: [['createdAt', 'ASC NULLS FIRST']],
     });
 
-    // grab first record as primary
-    const primary = records[0];
-    const subsequent = records.slice(1);
+    const [primary, ...subsequent] = records;
 
     // save values of later records to primary record
     const conflicts = [];

--- a/packages/sync-server/app/tasks/OutpatientDischarger.js
+++ b/packages/sync-server/app/tasks/OutpatientDischarger.js
@@ -17,6 +17,10 @@ export class OutpatientDischarger extends ScheduledTask {
     this.run();
   }
 
+  getName() {
+    return 'OutpatientDischarger';
+  }
+
   async run() {
     const oldEncounters = await this.models.Encounter.findAll({
       where: {

--- a/packages/sync-server/app/tasks/PatientEmailCommunicationProcessor.js
+++ b/packages/sync-server/app/tasks/PatientEmailCommunicationProcessor.js
@@ -11,6 +11,10 @@ export class PatientEmailCommunicationProcessor extends ScheduledTask {
     this.context = context;
   }
 
+  getName() {
+    return 'PatientEmailCommunicationProcessor';
+  }
+
   async run() {
     const { Patient, PatientCommunication } = this.context.store.models;
     let emailsToBeSent = await PatientCommunication.findAll({

--- a/packages/sync-server/app/tasks/ReportRequestProcessor.js
+++ b/packages/sync-server/app/tasks/ReportRequestProcessor.js
@@ -16,6 +16,10 @@ export class ReportRequestProcessor extends ScheduledTask {
     this.context = context;
   }
 
+  getName() {
+    return 'ReportRequestProcessor';
+  }
+
   async run() {
     const requests = await this.context.store.models.ReportRequest.findAll({
       where: {

--- a/packages/sync-server/app/tasks/index.js
+++ b/packages/sync-server/app/tasks/index.js
@@ -1,8 +1,14 @@
 import { OutpatientDischarger } from './OutpatientDischarger';
 import { PatientEmailCommunicationProcessor } from './PatientEmailCommunicationProcessor';
 import { ReportRequestProcessor } from './ReportRequestProcessor';
+import { AdditionalDataReconciler } from './AdditionalDataReconciler';
 
-const TASKS = [OutpatientDischarger, ReportRequestProcessor, PatientEmailCommunicationProcessor];
+const TASKS = [
+  OutpatientDischarger,
+  ReportRequestProcessor, 
+  PatientEmailCommunicationProcessor,
+  AdditionalDataReconciler,
+];
 
 export function startScheduledTasks(context) {
   const tasks = TASKS.map(Task => new Task(context));

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -32,7 +32,8 @@
     "allowedOrigin": ""
   },
   "schedules": {
-    "outpatientDischarger": "0 0 2 ? * * *"
+    "outpatientDischarger": "0 0 2 ? * * *",
+    "additionalDataReconciler": "0 */5 * * * *"
   },
   "localisation": {
     "labResultWidget": {


### PR DESCRIPTION
Hopefully the final piece of the https://github.com/beyondessential/tamanu-backlog/issues/776 puzzle.

Main changes:
- add a new scheduled task to reconcile duplicate patient additional data records
- add a new `conflicts` field to the PatientAdditionalData model to track conflicts encountered during auto-merge

RAYG changes:
- fixed an issue where scheduled task names were displaying incorrectly on prod
- refactored the delete record method to be Model.delete(id) rather than Database.delete(model, id)
- made fetches for PAD records go through the patient model rather than bespoke queries each time 