### PR TITLE
WAITM-18 Automatically send email for published tests

### DIFF
--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -1,5 +1,21 @@
 import { ICAO_DOCUMENT_TYPES, LAB_REQUEST_STATUSES } from '../constants';
 
+async function fetchMostRecentEmailAddress(patientId, models) {
+  const surveyQuestion = 'pde-FijCOVRDT008'; // TODO: fetch this from somewhere
+  /*
+    `SELECT body
+       FROM survey_response_answers
+       LEFT JOIN survey_responses
+        ON (survey_responses.id = survey_response_answers.response_id)
+       LEFT JOIN encounters
+        ON (survey_responses.encounter_id = encounters.id)
+       WHERE
+          data_element_id = :questionId
+        AND
+          encounters.patient_id = :patientId`,
+   */
+}
+
 export async function createLabRequestNotifications(labRequests, models) {
   const notifications = await Promise.all(
     labRequests
@@ -13,7 +29,7 @@ export async function createLabRequestNotifications(labRequests, models) {
           type: ICAO_DOCUMENT_TYPES.PROOF_OF_TESTING,
           requiresSigning: false,
           patientId: encounter.patientId,
-          // TODO: fowardAddress: {pull from surveys}
+          forwardAddress: await fetchMostRecentEmailAddress(encounter.patientId, models),
         };
       }),
   );

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -2,38 +2,34 @@ import { ICAO_DOCUMENT_TYPES, LAB_REQUEST_STATUSES } from '../constants';
 
 async function fetchMostRecentEmailAddress(patientId, models) {
   const surveyQuestion = 'pde-FijCOVRDT008'; // TODO: fetch this from somewhere
-  /*
-    `SELECT body
-       FROM survey_response_answers
-       LEFT JOIN survey_responses
-        ON (survey_responses.id = survey_response_answers.response_id)
-       LEFT JOIN encounters
-        ON (survey_responses.encounter_id = encounters.id)
-       WHERE
-          data_element_id = :questionId
-        AND
-          encounters.patient_id = :patientId`,
-   */
+  const answer = await models.SurveyResponseAnswer.findOne({
+    include: {
+      model: models.SurveyResponse,
+      as: 'surveyResponse',
+      include: { model: models.Encounter, where: { patientId }, as: 'encounter' },
+    },
+    where: { data_element_id: surveyQuestion },
+    order: [['created_at', 'DESC']],
+  });
+
+  return answer;
 }
 
-export async function createLabRequestNotifications(labRequests, models) {
-  const notifications = await Promise.all(
-    labRequests
-      .filter(labRequest => labRequest.get('labTestCategoryId') === 'labTestCategory-COVID') // TODO: fetch this from somewhere
-      .filter(labRequest => labRequest.get('status') === LAB_REQUEST_STATUSES.PUBLISHED)
-      .map(async labRequest => {
-        const encounter = await models.Encounter.findOne({
-          where: { id: labRequest.get('encounterId') },
-        });
-        return {
-          type: ICAO_DOCUMENT_TYPES.PROOF_OF_TESTING,
-          requiresSigning: false,
-          patientId: encounter.patientId,
-          forwardAddress: await fetchMostRecentEmailAddress(encounter.patientId, models),
-        };
-      }),
-  );
+export async function createLabRequestNotifications(labRequest, models) {
+  if (
+    labRequest.labTestCategoryId === 'labTestCategory-COVID' && // TODO: fetch this from somewhere
+    labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED
+  ) {
+    const encounter = await models.Encounter.findOne({ where: { id: labRequest.encounterId } });
 
-  // Bulk create action sets off a hook to send these out
-  await models.CertificateNotification.bulkCreate(notifications);
+    // Bulk create action sets off a hook to send these out
+    await models.CertificateNotification.bulkCreate([
+      {
+        type: ICAO_DOCUMENT_TYPES.PROOF_OF_TESTING,
+        requiresSigning: false,
+        patientId: encounter.patientId,
+        forwardAddress: await fetchMostRecentEmailAddress(encounter.patientId, models),
+      },
+    ]);
+  }
 }

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -19,7 +19,7 @@ async function fetchMostRecentEmailAddress(patientId, models) {
       data_element_id: questionId,
       [Op.not]: [{ body: '' }],
     },
-    order: [['end_time', 'DESC']],
+    order: [[{ model: models.SurveyResponse, as: 'surveyResponse' }, 'end_time', 'DESC']],
   });
   return answer?.body;
 }

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -19,7 +19,7 @@ async function fetchMostRecentEmailAddress(patientId, models) {
       data_element_id: questionId,
       [Op.not]: [{ body: '' }],
     },
-    order: [['created_at', 'DESC']],
+    order: [['end_time', 'DESC']],
   });
   return answer?.body;
 }

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -1,23 +1,32 @@
+import { Op } from 'sequelize';
+import config from 'config';
 import { ICAO_DOCUMENT_TYPES, LAB_REQUEST_STATUSES } from '../constants';
 
 async function fetchMostRecentEmailAddress(patientId, models) {
-  const surveyQuestion = 'pde-FijCOVRDT008'; // TODO: fetch this from somewhere
+  const questionId = config?.questionCodeIds?.email;
+  if (!questionId) {
+    return null;
+  }
+
+  // Find the most recent non-empty answer to the question
   const answer = await models.SurveyResponseAnswer.findOne({
     include: {
       model: models.SurveyResponse,
       as: 'surveyResponse',
       include: { model: models.Encounter, where: { patientId }, as: 'encounter' },
     },
-    where: { data_element_id: surveyQuestion },
+    where: {
+      data_element_id: questionId,
+      [Op.ne]: [{ body: '' }],
+    },
     order: [['created_at', 'DESC']],
   });
-
-  return answer;
+  return answer?.body;
 }
 
 export async function createLabRequestNotifications(labRequest, models) {
   if (
-    labRequest.labTestCategoryId === 'labTestCategory-COVID' && // TODO: fetch this from somewhere
+    labRequest.labTestCategoryId === config?.notifications?.certificates?.labTestCategoryId &&
     labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED
   ) {
     const encounter = await models.Encounter.findOne({ where: { id: labRequest.encounterId } });
@@ -28,6 +37,7 @@ export async function createLabRequestNotifications(labRequest, models) {
         type: ICAO_DOCUMENT_TYPES.PROOF_OF_TESTING,
         requiresSigning: false,
         patientId: encounter.patientId,
+        // If forward address is null, the communication service will attempt to use the patient.email field
         forwardAddress: await fetchMostRecentEmailAddress(encounter.patientId, models),
       },
     ]);

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -29,7 +29,7 @@ export async function createLabRequestNotifications(labRequest, models) {
     labRequest.labTestCategoryId === config?.notifications?.certificates?.labTestCategoryId &&
     labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED
   ) {
-    const encounter = await models.Encounter.findOne({ where: { id: labRequest.encounterId } });
+    const encounter = await models.Encounter.findByPk(labRequest.encounterId);
 
     // Bulk create action sets off a hook to send these out
     await models.CertificateNotification.bulkCreate([

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -24,7 +24,7 @@ async function fetchMostRecentEmailAddress(patientId, models) {
   return answer?.body;
 }
 
-export async function createLabRequestNotifications(labRequest, models) {
+export async function createSingleLabRequestNotification(labRequest, models) {
   if (
     labRequest.labTestCategoryId === config?.notifications?.certificates?.labTestCategoryId &&
     labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED
@@ -41,5 +41,11 @@ export async function createLabRequestNotifications(labRequest, models) {
         forwardAddress: await fetchMostRecentEmailAddress(encounter.patientId, models),
       },
     ]);
+  }
+}
+
+export async function createMultiLabRequestNotifications(labRequests, models) {
+  for (const request of labRequests) {
+    await createSingleLabRequestNotification(request, models);
   }
 }

--- a/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabRequestNotifications.js
@@ -17,7 +17,7 @@ async function fetchMostRecentEmailAddress(patientId, models) {
     },
     where: {
       data_element_id: questionId,
-      [Op.ne]: [{ body: '' }],
+      [Op.not]: [{ body: '' }],
     },
     order: [['created_at', 'DESC']],
   });

--- a/packages/shared-src/src/tasks/CreateLabResultNotifications.js
+++ b/packages/shared-src/src/tasks/CreateLabResultNotifications.js
@@ -1,0 +1,23 @@
+import { ICAO_DOCUMENT_TYPES, LAB_REQUEST_STATUSES } from '../constants';
+
+export async function createLabRequestNotifications(labRequests, models) {
+  const notifications = await Promise.all(
+    labRequests
+      .filter(labRequest => labRequest.get('labTestCategoryId') === 'labTestCategory-COVID') // TODO: fetch this from somewhere
+      .filter(labRequest => labRequest.get('status') === LAB_REQUEST_STATUSES.PUBLISHED)
+      .map(async labRequest => {
+        const encounter = await models.Encounter.findOne({
+          where: { id: labRequest.get('encounterId') },
+        });
+        return {
+          type: ICAO_DOCUMENT_TYPES.PROOF_OF_TESTING,
+          requiresSigning: false,
+          patientId: encounter.patientId,
+          // TODO: fowardAddress: {pull from surveys}
+        };
+      }),
+  );
+
+  // Bulk create action sets off a hook to send these out
+  await models.CertificateNotification.bulkCreate(notifications);
+}

--- a/packages/sync-server/subCommands/serve.js
+++ b/packages/sync-server/subCommands/serve.js
@@ -82,7 +82,7 @@ export async function serve(options) {
       // Create certificate notifications for published results
       if (config.notifications.certificates.labTestCategoryId) {
         context.store.models.LabRequest.addHook(
-          'afterBulkUpdate',
+          'afterBulkUpdate', // This model uses a simpleCRUD handler for put which triggers a bulk update action
           'create published test results notification hook',
           labRequest => {
             createLabRequestNotifications(labRequest.attributes, context.store.models);
@@ -91,7 +91,7 @@ export async function serve(options) {
       }
       // Send out queued certificate notifications
       context.store.models.CertificateNotification.addHook(
-        'afterBulkCreate',
+        'afterBulkCreate', // This model uses a simpleCRUD handler for push which triggers a bulk update action
         'create certificate notification hook',
         certificateNotifications => {
           sendCertificateNotifications(certificateNotifications, context.store.models);

--- a/packages/sync-server/subCommands/serve.js
+++ b/packages/sync-server/subCommands/serve.js
@@ -80,11 +80,11 @@ export async function serve(options) {
     }
     if (config.notifications.certificates) {
       // Create certificate notifications for published results
-      context.store.models.LabRequests.addHook(
+      context.store.models.LabRequest.addHook(
         'afterBulkUpdate',
         'create published test results notification hook',
-        labRequests => {
-          createLabRequestNotifications(labRequests, context.store.models);
+        labRequest => {
+          createLabRequestNotifications(labRequest.attributes, context.store.models);
         },
       );
       // Send out queued certificate notifications

--- a/packages/sync-server/subCommands/serve.js
+++ b/packages/sync-server/subCommands/serve.js
@@ -3,6 +3,7 @@ import config from 'config';
 import { log } from 'shared/services/logging';
 import { createReferralNotification } from 'shared/tasks/CreateReferralNotification';
 import { sendCertificateNotifications } from 'shared/tasks/SendCertificateNotifications';
+import { createLabRequestNotifications } from 'shared/tasks/CreateLabRequestNotifications';
 
 import { createApp } from '../app/createApp';
 import { startScheduledTasks } from '../app/tasks';
@@ -78,6 +79,15 @@ export async function serve(options) {
       );
     }
     if (config.notifications.certificates) {
+      // Create certificate notifications for published results
+      context.store.models.LabRequests.addHook(
+        'afterBulkUpdate',
+        'create published test results notification hook',
+        labRequests => {
+          createLabRequestNotifications(labRequests, context.store.models);
+        },
+      );
+      // Send out queued certificate notifications
       context.store.models.CertificateNotification.addHook(
         'afterBulkCreate',
         'create certificate notification hook',

--- a/packages/sync-server/subCommands/serve.js
+++ b/packages/sync-server/subCommands/serve.js
@@ -82,7 +82,7 @@ export async function serve(options) {
       // Create certificate notifications for published results
       if (config.notifications.certificates.labTestCategoryId) {
         context.store.models.LabRequest.addHook(
-          'afterBulkUpdate', // This model uses a simpleCRUD handler for put which triggers a bulk update action
+          'afterBulkUpdate', // Sync triggers bulk actions, even if it's only updating one entry
           'create published test results notification hook',
           labRequest => {
             createLabRequestNotifications(labRequest.attributes, context.store.models);
@@ -91,7 +91,7 @@ export async function serve(options) {
       }
       // Send out queued certificate notifications
       context.store.models.CertificateNotification.addHook(
-        'afterBulkCreate', // This model uses a simpleCRUD handler for push which triggers a bulk update action
+        'afterBulkCreate', // Sync triggers bulk actions, even if it's only for one entry
         'create certificate notification hook',
         certificateNotifications => {
           sendCertificateNotifications(certificateNotifications, context.store.models);

--- a/packages/sync-server/subCommands/serve.js
+++ b/packages/sync-server/subCommands/serve.js
@@ -80,13 +80,15 @@ export async function serve(options) {
     }
     if (config.notifications.certificates) {
       // Create certificate notifications for published results
-      context.store.models.LabRequest.addHook(
-        'afterBulkUpdate',
-        'create published test results notification hook',
-        labRequest => {
-          createLabRequestNotifications(labRequest.attributes, context.store.models);
-        },
-      );
+      if (config.notifications.certificates.labTestCategoryId) {
+        context.store.models.LabRequest.addHook(
+          'afterBulkUpdate',
+          'create published test results notification hook',
+          labRequest => {
+            createLabRequestNotifications(labRequest.attributes, context.store.models);
+          },
+        );
+      }
       // Send out queued certificate notifications
       context.store.models.CertificateNotification.addHook(
         'afterBulkCreate',


### PR DESCRIPTION
This is built off of the certificate notifications from [this PR](https://github.com/beyondessential/tamanu/pull/1739)

When a lab request of a particular category (i.e `labTestCategory-COVID`) is updated to the `published` status, create a certificate notification

My `sync-server/config/local.json` now includes:
```
    "notifications": {
        "certificates": {
            "labTestCategoryId": "labTestCategory-COVID"
        }
    },
    "questionCodeIds": {
        "email": "pde-FijCOVRDT008"
    },

```