### PR TITLE
WAITM-225: Use vaccine IDs for VDS translation query

### DIFF
--- a/packages/sync-server/__tests__/integrations/VdsNc/Translation.test.js
+++ b/packages/sync-server/__tests__/integrations/VdsNc/Translation.test.js
@@ -1,10 +1,7 @@
 import { expect } from 'chai';
 import { fake } from 'shared/test-helpers/fake';
 import { createTestContext } from 'sync-server/__tests__/utilities';
-import {
-  createVdsNcTestData,
-  createVdsNcVaccinationData,
-} from '../../../app/integrations/VdsNc';
+import { createVdsNcTestData, createVdsNcVaccinationData } from '../../../app/integrations/VdsNc';
 
 describe('VDS: Proof of Vaccination', () => {
   let ctx;
@@ -13,7 +10,32 @@ describe('VDS: Proof of Vaccination', () => {
     ctx = await createTestContext();
   });
 
-  afterAll(() => ctx.close());
+  beforeEach(async () => {
+    const { ReferenceData } = ctx.store.models;
+
+    ctx.azVaxDrug = await ReferenceData.create({
+      ...fake(ReferenceData),
+      id: 'drug-COVID-19-Astra-Zeneca',
+      type: 'vaccine',
+      name: 'ChAdOx1-S',
+    });
+
+    ctx.pfVaxDrug = await ReferenceData.create({
+      ...fake(ReferenceData),
+      id: 'drug-COVID-19-Pfizer',
+      type: 'vaccine',
+      name: 'Comirnaty',
+    });
+  });
+
+  afterEach(async () => {
+    await ctx.pfVaxDrug.destroy();
+    await ctx.azVaxDrug.destroy();
+  });
+
+  afterAll(async () => {
+    await ctx.close();
+  });
 
   it('fetches data for a non-vaccinated patient', async () => {
     // Arrange
@@ -58,10 +80,10 @@ describe('VDS: Proof of Vaccination', () => {
       Encounter,
       Facility,
       Location,
-      ReferenceData,
       ScheduledVaccine,
       AdministeredVaccine,
     } = ctx.store.models;
+    const { azVaxDrug } = ctx;
 
     const patient = await Patient.create({
       ...fake(Patient),
@@ -76,13 +98,6 @@ describe('VDS: Proof of Vaccination', () => {
       passport: 'A2345678',
     });
     await patient.reload();
-
-    const azVaxDrug = await ReferenceData.create({
-      ...fake(ReferenceData),
-      id: 'drug-COVID-19-Astra-Zeneca',
-      type: 'vaccine',
-      name: 'ChAdOx1-S',
-    });
 
     const scheduledAz = await ScheduledVaccine.create({
       ...fake(ScheduledVaccine),
@@ -157,10 +172,10 @@ describe('VDS: Proof of Vaccination', () => {
       Encounter,
       Facility,
       Location,
-      ReferenceData,
       ScheduledVaccine,
       AdministeredVaccine,
     } = ctx.store.models;
+    const { azVaxDrug, pfVaxDrug } = ctx;
 
     const patient = await Patient.create({
       ...fake(Patient),
@@ -175,20 +190,6 @@ describe('VDS: Proof of Vaccination', () => {
       passport: 'A0101001',
     });
     await patient.reload();
-
-    const azVaxDrug = await ReferenceData.create({
-      ...fake(ReferenceData),
-      id: 'drug-COVID-19-Astra-Zeneca',
-      type: 'vaccine',
-      name: 'ChAdOx1-S',
-    });
-
-    const pfVaxDrug = await ReferenceData.create({
-      ...fake(ReferenceData),
-      id: 'drug-COVID-19-Pfizer',
-      type: 'vaccine',
-      name: 'Comirnaty',
-    });
 
     const scheduledPf1 = await ScheduledVaccine.create({
       ...fake(ScheduledVaccine),

--- a/packages/sync-server/__tests__/integrations/VdsNc/Translation.test.js
+++ b/packages/sync-server/__tests__/integrations/VdsNc/Translation.test.js
@@ -79,6 +79,7 @@ describe('VDS: Proof of Vaccination', () => {
 
     const azVaxDrug = await ReferenceData.create({
       ...fake(ReferenceData),
+      id: 'drug-COVID-19-Astra-Zeneca',
       type: 'vaccine',
       name: 'ChAdOx1-S',
     });
@@ -177,12 +178,14 @@ describe('VDS: Proof of Vaccination', () => {
 
     const azVaxDrug = await ReferenceData.create({
       ...fake(ReferenceData),
+      id: 'drug-COVID-19-Astra-Zeneca',
       type: 'vaccine',
       name: 'ChAdOx1-S',
     });
 
     const pfVaxDrug = await ReferenceData.create({
       ...fake(ReferenceData),
+      id: 'drug-COVID-19-Pfizer',
       type: 'vaccine',
       name: 'Comirnaty',
     });

--- a/packages/sync-server/app/integrations/VdsNc/Translation.js
+++ b/packages/sync-server/app/integrations/VdsNc/Translation.js
@@ -39,7 +39,8 @@ export const createVdsNcVaccinationData = async (patientId, { models }) => {
     ScheduledVaccine,
   } = models;
 
-  const countryCode = (await getLocalisation()).country['alpha-3'];
+  const { country, covidVaccines } = await getLocalisation();
+  const countryCode = country['alpha-3'];
 
   const { firstName, lastName, dateOfBirth, sex } = await Patient.findOne({
     where: { id: patientId },
@@ -48,7 +49,7 @@ export const createVdsNcVaccinationData = async (patientId, { models }) => {
   const vaccinations = await AdministeredVaccine.findAll({
     where: {
       '$encounter.patient_id$': patientId,
-      '$scheduledVaccine.label$': ['COVID-19 AZ', 'COVID-19 Pfizer'],
+      '$scheduledVaccine.vaccine_id$': covidVaccines,
       status: 'GIVEN',
     },
     include: [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+timeout="20m"
+
 echo "Running tests"
 for workspace in shared-src lan sync-server meta-server; do
-  echo "=== Running tests in $workspace"
-  yarn workspace $workspace \
+  echo "=== Running tests in $workspace (timeout $timeout)"
+  timeout --kill-after="30s" --signal="TERM" "$timeout" \
+    yarn workspace $workspace \
     run test-coverage \
     --coverageReporters=json-summary
   echo "==============================="


### PR DESCRIPTION
The VDS translation was still using labels for filtering, but we've changed everything else to use IDs.