### PR TITLE
TAN-1156: Add filter param support

### DIFF
--- a/packages/sync-server/__tests__/hl7fhir/patient.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/patient.test.js
@@ -6,7 +6,7 @@ import { patientToHL7Patient, getPatientWhereClause } from '../../app/hl7fhir/pa
 
 import { validate } from './hl7utilities';
 
-describe('HL7 Patient', () => {
+describe('HL7 Patient functions', () => {
   let models;
   let ctx;
 
@@ -17,98 +17,102 @@ describe('HL7 Patient', () => {
 
   afterAll(() => ctx.close());
 
-  it('Should produce a valid HL7 patient', async () => {
-    const patientData = await createDummyPatient(models);
-    const patient = await models.Patient.create(patientData);
-    const additional = await models.PatientAdditionalData.create({
-      patientId: patient.id,
-      ...(await createDummyPatientAdditionalData()),
+  describe('patientToHL7Patient', () => {
+    it('Should produce a valid HL7 patient', async () => {
+      const patientData = await createDummyPatient(models);
+      const patient = await models.Patient.create(patientData);
+      const additional = await models.PatientAdditionalData.create({
+        patientId: patient.id,
+        ...(await createDummyPatientAdditionalData()),
+      });
+
+      const hl7 = patientToHL7Patient(patient, additional || {});
+      const { result, errors } = validate(hl7);
+      expect(errors).toHaveLength(0);
+      expect(result).toEqual(true);
     });
 
-    const hl7 = patientToHL7Patient(patient, additional || {});
-    const { result, errors } = validate(hl7);
-    expect(errors).toHaveLength(0);
-    expect(result).toEqual(true);
+    it('Should produce a valid HL7 patient from minimal data', async () => {
+      const hl7 = patientToHL7Patient({}, {});
+      const { result, errors } = validate(hl7);
+      expect(errors).toHaveLength(0);
+      expect(result).toEqual(true);
+    });
   });
 
-  it('Should produce a valid HL7 patient from minimal data', async () => {
-    const hl7 = patientToHL7Patient({}, {});
-    const { result, errors } = validate(hl7);
-    expect(errors).toHaveLength(0);
-    expect(result).toEqual(true);
-  });
+  describe('getPatientWhereClause', () => {
+    it('Should output a valid sequelize where clause', async () => {
+      const patientData = await createDummyPatient(models, {
+        firstName: 'John',
+        lastName: 'Doe',
+        sex: 'male',
+      });
+      const patient = await models.Patient.create(patientData);
+      await models.PatientAdditionalData.create({
+        patientId: patient.id,
+        ...(await createDummyPatientAdditionalData()),
+        primaryContactNumber: '0123456',
+      });
+      const query = { given: 'john', family: 'doe', telecom: '0123456', gender: 'male' };
+      const whereClause = getPatientWhereClause(null, query);
+      const patients = await models.Patient.findAll({
+        where: whereClause,
+        include: [{ association: 'additionalData' }],
+      });
+      expect(patients.length).toBe(1);
+    });
 
-  it('Should output a valid sequelize where clause', async () => {
-    const patientData = await createDummyPatient(models, {
-      firstName: 'John',
-      lastName: 'Doe',
-      sex: 'male',
+    it('Should handle modifiers in the query', async () => {
+      // Patient created in previous test
+      const query = {
+        'given:contains': 'oh',
+        'family:starts-with': 'do',
+        telecom: '0123456',
+        gender: 'male',
+      };
+      const whereClause = getPatientWhereClause(null, query);
+      const patients = await models.Patient.findAll({
+        where: whereClause,
+        include: [{ association: 'additionalData' }],
+      });
+      expect(patients.length).toBe(1);
     });
-    const patient = await models.Patient.create(patientData);
-    await models.PatientAdditionalData.create({
-      patientId: patient.id,
-      ...(await createDummyPatientAdditionalData()),
-      primaryContactNumber: '0123456',
-    });
-    const query = { given: 'john', family: 'doe', telecom: '0123456', gender: 'male' };
-    const whereClause = getPatientWhereClause(null, query);
-    const patients = await models.Patient.findAll({
-      where: whereClause,
-      include: [{ association: 'additionalData' }],
-    });
-    expect(patients.length).toBe(1);
-  });
 
-  it('Should handle modifiers in the query', async () => {
-    // Patient created in previous test
-    const query = {
-      'given:contains': 'oh',
-      'family:starts-with': 'do',
-      telecom: '0123456',
-      gender: 'male',
-    };
-    const whereClause = getPatientWhereClause(null, query);
-    const patients = await models.Patient.findAll({
-      where: whereClause,
-      include: [{ association: 'additionalData' }],
+    it('Should handle _filter param in the query', async () => {
+      // Patient created in previous test
+      const query = {
+        _filter: 'given co oh and family sw do and telecom eq 0123456 and gender eq male',
+      };
+      const whereClause = getPatientWhereClause(null, query);
+      const patients = await models.Patient.findAll({
+        where: whereClause,
+        include: [{ association: 'additionalData' }],
+      });
+      expect(patients.length).toBe(1);
     });
-    expect(patients.length).toBe(1);
-  });
 
-  it('Should handle _filter param in the query', async () => {
-    // Patient created in previous test
-    const query = {
-      _filter: 'given co oh and family sw do and telecom eq 0123456 and gender eq male',
-    };
-    const whereClause = getPatientWhereClause(null, query);
-    const patients = await models.Patient.findAll({
-      where: whereClause,
-      include: [{ association: 'additionalData' }],
+    it('Should handle a combination of params and _filter param in the query', async () => {
+      // Patient created in previous test
+      const query = {
+        'given:contains': 'oh',
+        'family:starts-with': 'do',
+        _filter: 'telecom eq 0123456 and gender eq male',
+      };
+      const whereClause = getPatientWhereClause(null, query);
+      const patients = await models.Patient.findAll({
+        where: whereClause,
+        include: [{ association: 'additionalData' }],
+      });
+      expect(patients.length).toBe(1);
     });
-    expect(patients.length).toBe(1);
-  });
 
-  it('Should handle a combination of params and _filter param in the query', async () => {
-    // Patient created in previous test
-    const query = {
-      'given:contains': 'oh',
-      'family:starts-with': 'do',
-      _filter: 'telecom eq 0123456 and gender eq male',
-    };
-    const whereClause = getPatientWhereClause(null, query);
-    const patients = await models.Patient.findAll({
-      where: whereClause,
-      include: [{ association: 'additionalData' }],
+    it('Should ignore query params that are not patient fields', () => {
+      const query = { foo: 'bar', given: 'john' };
+      const displayId = 'test-display-id-123456';
+      const whereClause = getPatientWhereClause(displayId, query);
+      const filters = whereClause[Op.and];
+      const keys = filters.map(obj => Object.keys(obj)[0]);
+      expect(keys).toMatchObject(['displayId', 'firstName']);
     });
-    expect(patients.length).toBe(1);
-  });
-
-  it('Should ignore query params that are not patient fields', () => {
-    const query = { foo: 'bar', given: 'john' };
-    const displayId = 'test-display-id-123456';
-    const whereClause = getPatientWhereClause(displayId, query);
-    const filters = whereClause[Op.and];
-    const keys = filters.map(obj => Object.keys(obj)[0]);
-    expect(keys).toMatchObject(['displayId', 'firstName']);
   });
 });

--- a/packages/sync-server/__tests__/hl7fhir/patient.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/patient.test.js
@@ -75,7 +75,35 @@ describe('HL7 Patient', () => {
     expect(patients.length).toBe(1);
   });
 
-  it('Should ignore unknown query params', () => {
+  it('Should handle _filter param in the query', async () => {
+    // Patient created in previous test
+    const query = {
+      _filter: 'given co oh and family sw do and telecom eq 0123456 and gender eq male',
+    };
+    const whereClause = getPatientWhereClause(null, query);
+    const patients = await models.Patient.findAll({
+      where: whereClause,
+      include: [{ association: 'additionalData' }],
+    });
+    expect(patients.length).toBe(1);
+  });
+
+  it('Should handle a combination of params and _filter param in the query', async () => {
+    // Patient created in previous test
+    const query = {
+      'given:contains': 'oh',
+      'family:starts-with': 'do',
+      _filter: 'telecom eq 0123456 and gender eq male',
+    };
+    const whereClause = getPatientWhereClause(null, query);
+    const patients = await models.Patient.findAll({
+      where: whereClause,
+      include: [{ association: 'additionalData' }],
+    });
+    expect(patients.length).toBe(1);
+  });
+
+  it('Should ignore query params that are not patient fields', () => {
     const query = { foo: 'bar', given: 'john' };
     const displayId = 'test-display-id-123456';
     const whereClause = getPatientWhereClause(displayId, query);

--- a/packages/sync-server/__tests__/hl7fhir/utils.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/utils.test.js
@@ -115,6 +115,14 @@ describe('HL7FHIR module utils', () => {
           ],
           logic: [Op.or],
         },
+        {
+          str: 'given co and and family co and',
+          expressions: [
+            ['given', 'co', 'and'],
+            ['family', 'co', 'and'],
+          ],
+          logic: [Op.and],
+        },
       ];
 
       testCases.forEach(test => {

--- a/packages/sync-server/__tests__/hl7fhir/utils.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/utils.test.js
@@ -1,0 +1,197 @@
+import { Op } from 'sequelize';
+import { ValidationError } from 'yup';
+import { createTestContext } from '../utilities';
+
+import {
+  getExpressionsAndLogic,
+  nestFilters,
+  getFilterFromParam,
+  hl7ParameterTypes,
+} from '../../app/hl7fhir/utils';
+
+describe('HL7FHIR module utils', () => {
+  let models;
+  let ctx;
+
+  const testPrefixes = ['co', 'eq'];
+  const testFields = {
+    given: {
+      parameterType: hl7ParameterTypes.string,
+      fieldName: 'firstName',
+      columnName: 'first_name',
+      supportedPrefixes: testPrefixes,
+    },
+    family: {
+      parameterType: hl7ParameterTypes.string,
+      fieldName: 'lastName',
+      columnName: 'last_name',
+      supportedPrefixes: testPrefixes,
+    },
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  describe('getExpressionsAndLogic', () => {
+    it('Should return an object containing two arrays', () => {
+      const testCases = ['', 'given co jo', 'given co jo and family eq doe'];
+      testCases.forEach((testStr, i) => {
+        const testObj = getExpressionsAndLogic(testStr);
+
+        // Only check for exact match on first test case, assume
+        // that destructuring will suffice with the others.
+        if (i === 0) {
+          expect(testObj).toMatchObject({
+            expressions: [''],
+            logic: [],
+          });
+        }
+
+        const { expressions, logic } = testObj;
+        expect(Array.isArray(expressions)).toBe(true);
+        expect(Array.isArray(logic)).toBe(true);
+      });
+    });
+
+    it('Should return strings inside expressions array', () => {
+      const testStr = 'given eq john and telecom eq 123456';
+      const { expressions } = getExpressionsAndLogic(testStr);
+      expressions.forEach(expression => {
+        expect(typeof expression).toBe('string');
+      });
+    });
+
+    it('Should return sequelize operators inside logic array', () => {
+      const testStr = 'given eq john and family eq doe or telecom eq 123456';
+      const { logic } = getExpressionsAndLogic(testStr);
+      expect(logic).toMatchObject([Op.and, Op.or]);
+    });
+
+    it('Should correctly parse expressions', () => {
+      const testCases = [
+        {
+          str: 'given eq "peter" and birthdate eq 2014-10-10',
+          expressions: ['given eq "peter"', 'birthdate eq 2014-10-10'],
+          logic: [Op.and],
+        },
+        {
+          str: 'code eq http://loinc.org|1234-5',
+          expressions: ['code eq http://loinc.org|1234-5'],
+          logic: [],
+        },
+        {
+          str: 'given co u and family co lar or telecom eq 123456',
+          expressions: ['given co u', 'family co lar', 'telecom eq 123456'],
+          logic: [Op.and, Op.or],
+        },
+        {
+          str: 'name co "abc def" and telecom eq 123456',
+          expressions: ['name co "abc def"', 'telecom eq 123456'],
+          logic: [Op.and],
+        },
+        {
+          str: 'name co "and or" or telecom eq 123456',
+          expressions: ['name co "and or"', 'telecom eq 123456'],
+          logic: [Op.or],
+        },
+      ];
+
+      testCases.forEach(test => {
+        const expectedObj = { expressions: test.expressions, logic: test.logic };
+        const testObj = getExpressionsAndLogic(test.str);
+        expect(testObj).toEqual(expectedObj);
+
+        // Expressions should always have one more item than logic
+        expect(testObj.expressions.length).toBe(testObj.logic.length + 1);
+      });
+    });
+  });
+
+  describe('nestFilters', () => {
+    it('Should nest filters accordingly', () => {
+      const filters = [
+        { firstName: { [Op.substring]: 'jo' } },
+        { lasttName: { [Op.substring]: 'do' } },
+        { sex: { [Op.eq]: 'other' } },
+        { dateOfBirth: { [Op.eq]: '1990-10-20' } },
+        { primaryContactNumber: { [Op.eq]: '123456' } },
+      ];
+      const logic = [Op.and, Op.or, Op.or, Op.and];
+      const testObj = nestFilters(filters, logic);
+      // Use toEqual to check all deeply nested object chain
+      expect(testObj).toEqual({
+        [Op.and]: [
+          filters[0],
+          { [Op.or]: [filters[1], filters[2], { [Op.and]: [filters[3], filters[4]] }] },
+        ],
+      });
+      expect(testObj[Op.and][1][Op.or][2][Op.and][1]).toBe(filters[4]);
+    });
+
+    it('Should throw an error if called with wrong params', () => {
+      // Logic is empty
+      expect(() => nestFilters([], [])).toThrow();
+
+      // Disproportionate ammount of filters vs logic
+      expect(() => nestFilters(['a'], ['a', 'b', 'c'])).toThrow();
+    });
+  });
+
+  describe('getFilterFromParam', () => {
+    it('Should get null if _filter is undefined', () => {
+      const value = getFilterFromParam(undefined);
+      expect(value).toBe(null);
+    });
+
+    it('Should return a valid sequelize where clause with one expression', async () => {
+      const testStr = 'given eq zxy';
+      const filter = getFilterFromParam(testStr, testFields);
+      expect(filter).toEqual({
+        firstName: { [Op.eq]: 'zxy' },
+      });
+      expect(filter.firstName[Op.eq]).toBe('zxy');
+
+      // Look up something, if the where clause was invalid,
+      // it would throw an error instead.
+      const results = await models.Patient.findAll({ where: filter });
+      expect(results).toBeTruthy();
+    });
+
+    it('Should return a valid sequelize where clause with more than one expression', async () => {
+      const testStr = 'given eq zxy and family eq abc';
+      const filter = getFilterFromParam(testStr, testFields);
+      expect(filter).toEqual({
+        [Op.and]: [{ firstName: { [Op.eq]: 'zxy' } }, { lastName: { [Op.eq]: 'abc' } }],
+      });
+
+      // Look up something, if the where clause was invalid,
+      // it would throw an error instead.
+      const results = await models.Patient.findAll({ where: filter });
+      expect(results).toBeTruthy();
+    });
+
+    it('Should accept expressions with a quoted "value"', () => {
+      const parameter = 'given';
+      const prefix = 'co';
+      // This is the referenced value. It should support being quoted.
+      const value = '"pet"';
+      const testStr = `${parameter} ${prefix} ${value}`;
+      const filter = getFilterFromParam(testStr, testFields);
+      expect(filter).toEqual({
+        firstName: { [Op.substring]: 'pet' },
+      });
+      expect(filter.firstName[Op.substring]).toBe('pet');
+    });
+
+    it('Should throw a ValidationError if _filter contains unsupported or unknown expressions', () => {
+      const testCases = ['', 'somethingbad', 'unsupported eq peter', 'given unsupported peter'];
+      testCases.forEach(testStr => {
+        expect(() => getFilterFromParam(testStr)).toThrow(ValidationError);
+      });
+    });
+  });
+});

--- a/packages/sync-server/__tests__/hl7fhir/utils.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/utils.test.js
@@ -47,7 +47,7 @@ describe('HL7FHIR module utils', () => {
         // that destructuring will suffice with the others.
         if (i === 0) {
           expect(testObj).toMatchObject({
-            expressions: [''],
+            expressions: [],
             logic: [],
           });
         }
@@ -58,11 +58,14 @@ describe('HL7FHIR module utils', () => {
       });
     });
 
-    it('Should return strings inside expressions array', () => {
+    it('Should return arrays of strings inside expressions array', () => {
       const testStr = 'given eq john and telecom eq 123456';
       const { expressions } = getExpressionsAndLogic(testStr);
       expressions.forEach(expression => {
-        expect(typeof expression).toBe('string');
+        expect(Array.isArray(expression)).toBe(true);
+        expression.forEach(lexeme => {
+          expect(typeof lexeme).toBe('string');
+        });
       });
     });
 
@@ -76,27 +79,40 @@ describe('HL7FHIR module utils', () => {
       const testCases = [
         {
           str: 'given eq "peter" and birthdate eq 2014-10-10',
-          expressions: ['given eq "peter"', 'birthdate eq 2014-10-10'],
+          expressions: [
+            ['given', 'eq', '"peter"'],
+            ['birthdate', 'eq', '2014-10-10'],
+          ],
           logic: [Op.and],
         },
         {
           str: 'code eq http://loinc.org|1234-5',
-          expressions: ['code eq http://loinc.org|1234-5'],
+          expressions: [['code', 'eq', 'http://loinc.org|1234-5']],
           logic: [],
         },
         {
           str: 'given co u and family co lar or telecom eq 123456',
-          expressions: ['given co u', 'family co lar', 'telecom eq 123456'],
+          expressions: [
+            ['given', 'co', 'u'],
+            ['family', 'co', 'lar'],
+            ['telecom', 'eq', '123456'],
+          ],
           logic: [Op.and, Op.or],
         },
         {
           str: 'name co "abc def" and telecom eq 123456',
-          expressions: ['name co "abc def"', 'telecom eq 123456'],
+          expressions: [
+            ['name', 'co', '"abc def"'],
+            ['telecom', 'eq', '123456'],
+          ],
           logic: [Op.and],
         },
         {
           str: 'name co "and or" or telecom eq 123456',
-          expressions: ['name co "and or"', 'telecom eq 123456'],
+          expressions: [
+            ['name', 'co', '"and or"'],
+            ['telecom', 'eq', '123456'],
+          ],
           logic: [Op.or],
         },
       ];

--- a/packages/sync-server/__tests__/hl7fhir/utils.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/utils.test.js
@@ -123,6 +123,14 @@ describe('HL7FHIR module utils', () => {
           ],
           logic: [Op.and],
         },
+        {
+          str: 'given co "and" and family co "and"',
+          expressions: [
+            ['given', 'co', '"and"'],
+            ['family', 'co', '"and"'],
+          ],
+          logic: [Op.and],
+        },
       ];
 
       testCases.forEach(test => {

--- a/packages/sync-server/app/hl7fhir/patient.js
+++ b/packages/sync-server/app/hl7fhir/patient.js
@@ -8,6 +8,7 @@ import {
   getDefaultOperator,
   modifiers,
   hl7PatientFields,
+  getFilterFromParam,
 } from './utils';
 
 function patientName(patient, additional) {
@@ -102,6 +103,12 @@ export function getPatientWhereClause(displayId, query = {}) {
   // Handle search by ID separately
   if (displayId) {
     filters.push({ displayId });
+  }
+
+  // Parse the _filter param and add it to the list of filters
+  const filterParamObj = getFilterFromParam(query._filter, hl7PatientFields);
+  if (filterParamObj !== null) {
+    filters.push(filterParamObj);
   }
 
   // Create a filter for each query param

--- a/packages/sync-server/app/hl7fhir/schema.js
+++ b/packages/sync-server/app/hl7fhir/schema.js
@@ -52,6 +52,9 @@ const baseParameters = {
   // Patients don't have a status parameter,
   // this is just for backwards compatibility.
   status: yup.string(),
+  // _filter requires parsing, validation will be performed later.
+  // We need it here to preserve it after initial validation
+  _filter: yup.string(),
 };
 
 // Returns an object with patient parameters as keys

--- a/packages/sync-server/app/hl7fhir/utils.js
+++ b/packages/sync-server/app/hl7fhir/utils.js
@@ -136,6 +136,7 @@ export const hl7PatientFields = {
     fieldName: 'firstName',
     columnName: 'first_name',
     supportedModifiers: stringTypeModifiers,
+    supportedPrefixes: stringTypePrefixes,
     validationSchema: yup.string(),
   },
   family: {
@@ -143,6 +144,7 @@ export const hl7PatientFields = {
     fieldName: 'lastName',
     columnName: 'last_name',
     supportedModifiers: stringTypeModifiers,
+    supportedPrefixes: stringTypePrefixes,
     validationSchema: yup.string(),
   },
   gender: {
@@ -150,6 +152,7 @@ export const hl7PatientFields = {
     fieldName: 'sex',
     columnName: 'sex',
     supportedModifiers: [],
+    supportedPrefixes: [],
     validationSchema: yup.string().oneOf(['male', 'female', 'other']),
   },
   birthdate: {
@@ -157,6 +160,7 @@ export const hl7PatientFields = {
     fieldName: 'dateOfBirth',
     columnName: 'date_of_birth',
     supportedModifiers: [],
+    supportedPrefixes: [],
     validationSchema: yup
       .string()
       // eslint-disable-next-line no-template-curly-in-string
@@ -173,6 +177,7 @@ export const hl7PatientFields = {
     fieldName: 'additionalData.cityTown',
     columnName: 'additionalData.city_town',
     supportedModifiers: stringTypeModifiers,
+    supportedPrefixes: stringTypePrefixes,
     validationSchema: yup.string(),
   },
   'address-city': {
@@ -180,6 +185,7 @@ export const hl7PatientFields = {
     fieldName: 'additionalData.cityTown',
     columnName: 'additionalData.city_town',
     supportedModifiers: stringTypeModifiers,
+    supportedPrefixes: stringTypePrefixes,
     validationSchema: yup.string(),
   },
   // TODO: telecom could also be email or other phones
@@ -188,6 +194,7 @@ export const hl7PatientFields = {
     fieldName: '$additionalData.primary_contact_number$',
     columnName: 'additionalData.primary_contact_number',
     supportedModifiers: [],
+    supportedPrefixes: [],
     validationSchema: yup.string(),
   },
 };

--- a/packages/sync-server/app/hl7fhir/utils.js
+++ b/packages/sync-server/app/hl7fhir/utils.js
@@ -284,7 +284,7 @@ export function getFilterFromParam(_filter, resourceFields = {}) {
 
     // Get parameter options or default to empty object (to be able to destructure it)
     const parameterOptions = resourceFields[parameter] || {};
-    const { fieldName, supportedPrefixes, parameterType } = parameterOptions;
+    const { fieldName, columnName, supportedPrefixes, parameterType } = parameterOptions;
 
     // Make sure expression is valid and keep track of invalid ones
     if (
@@ -304,7 +304,8 @@ export function getFilterFromParam(_filter, resourceFields = {}) {
     const unquotedValue = value.match(/^".+"$/) ? value.replace(/"/g, '') : value;
 
     // Create and add filter
-    filters.push({ [fieldName]: { [operator]: unquotedValue } });
+    const queryObject = getQueryObject(columnName, unquotedValue, operator, null, parameterType);
+    filters.push({ [fieldName]: queryObject });
   });
 
   // Query should fail if any expression is invalid

--- a/packages/sync-server/app/hl7fhir/utils.js
+++ b/packages/sync-server/app/hl7fhir/utils.js
@@ -67,17 +67,6 @@ export function getParamAndModifier(fullParam) {
   return fullParam.split(':', 2);
 }
 
-// Prefixes supported by Tamanu with the corresponding
-// sequelize operators.
-/*
-const prefixes = {
-  eq: Op.eq,
-  co: Op.substring,
-  sw: Op.startsWith,
-  ew: Op.endsWith,
-};
-*/
-
 // All of the HL7 search parameter types
 export const hl7ParameterTypes = {
   number: 'number',
@@ -89,6 +78,17 @@ export const hl7ParameterTypes = {
   quantity: 'quantity',
   uri: 'uri',
   special: 'special',
+};
+
+// Prefixes supported by Tamanu with the corresponding
+// sequelize operators. Classified by HL7 search parameter type.
+const prefixes = {
+  [hl7ParameterTypes.string]: {
+    eq: Op.eq,
+    co: Op.substring,
+    sw: Op.startsWith,
+    ew: Op.endsWith,
+  },
 };
 
 // Modifiers supported by Tamanu with the corresponding

--- a/packages/sync-server/app/hl7fhir/utils.js
+++ b/packages/sync-server/app/hl7fhir/utils.js
@@ -91,6 +91,8 @@ const prefixes = {
   },
 };
 
+const stringTypePrefixes = Object.keys(prefixes[hl7ParameterTypes.string]);
+
 // Modifiers supported by Tamanu with the corresponding
 // sequelize operator. Classified by HL7 search parameter type.
 export const modifiers = {
@@ -102,7 +104,7 @@ export const modifiers = {
   },
 };
 
-export const stringTypeModifiers = Object.keys(modifiers.string);
+const stringTypeModifiers = Object.keys(modifiers[hl7ParameterTypes.string]);
 
 export function getDefaultOperator(type) {
   if (type === hl7ParameterTypes.string) {

--- a/packages/sync-server/app/hl7fhir/utils.js
+++ b/packages/sync-server/app/hl7fhir/utils.js
@@ -83,15 +83,23 @@ export const hl7ParameterTypes = {
 // Prefixes supported by Tamanu with the corresponding
 // sequelize operators. Classified by HL7 search parameter type.
 const prefixes = {
+  [hl7ParameterTypes.date]: {
+    eq: Op.eq,
+  },
   [hl7ParameterTypes.string]: {
     eq: Op.eq,
     co: Op.substring,
     sw: Op.startsWith,
     ew: Op.endsWith,
   },
+  [hl7ParameterTypes.token]: {
+    eq: Op.eq,
+  },
 };
 
+const dateTypePrefixes = Object.keys(prefixes[hl7ParameterTypes.date]);
 const stringTypePrefixes = Object.keys(prefixes[hl7ParameterTypes.string]);
+const tokenTypePrefixes = Object.keys(prefixes[hl7ParameterTypes.token]);
 
 // Modifiers supported by Tamanu with the corresponding
 // sequelize operator. Classified by HL7 search parameter type.
@@ -152,7 +160,7 @@ export const hl7PatientFields = {
     fieldName: 'sex',
     columnName: 'sex',
     supportedModifiers: [],
-    supportedPrefixes: [],
+    supportedPrefixes: tokenTypePrefixes,
     validationSchema: yup.string().oneOf(['male', 'female', 'other']),
   },
   birthdate: {
@@ -160,7 +168,7 @@ export const hl7PatientFields = {
     fieldName: 'dateOfBirth',
     columnName: 'date_of_birth',
     supportedModifiers: [],
-    supportedPrefixes: [],
+    supportedPrefixes: dateTypePrefixes,
     validationSchema: yup
       .string()
       // eslint-disable-next-line no-template-curly-in-string
@@ -194,7 +202,7 @@ export const hl7PatientFields = {
     fieldName: '$additionalData.primary_contact_number$',
     columnName: 'additionalData.primary_contact_number',
     supportedModifiers: [],
-    supportedPrefixes: [],
+    supportedPrefixes: tokenTypePrefixes,
     validationSchema: yup.string(),
   },
 };

--- a/packages/sync-server/app/hl7fhir/utils.js
+++ b/packages/sync-server/app/hl7fhir/utils.js
@@ -217,7 +217,7 @@ export function getExpressionsAndLogic(_filter) {
 
   // Split _filter string into lexemes (separated by any amount of whitespace)
   // Note: whitespace is permitted inside quotes
-  const lexemes = _filter.match(/".+"|\S+/g) || [];
+  const lexemes = _filter.match(/".+?"|\S+/g) || [];
 
   // Each expression has a max of three lexemes
   // (parameter - operator - value) for now


### PR DESCRIPTION
The last piece of the puzzle for this card. Adding support to the `_filter` param. Decided that it was probably a good idea to add test the helper functions used, and also the helper's helper functions as well (trying to make sure that this won't break silently, it seemed that just testing the surface level could end up having problems).

EDIT: BTW, the lint report says `3 style errors (run yarn lint-fix to solve)` but I won't solve them here because they were picked up from dev (unrelated files), probably solved by now anyway.