### PR TITLE
WAITM-225: Fix the names of snomed/atc columns

### DIFF
--- a/packages/shared-src/src/migrations/077_changeCertifiableVaccinesCodeColumns.ts
+++ b/packages/shared-src/src/migrations/077_changeCertifiableVaccinesCodeColumns.ts
@@ -1,0 +1,11 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface) {
+  await query.renameColumn('certifiable_vaccines', 'atc_code', 'vaccine_code');
+  await query.renameColumn('certifiable_vaccines', 'target_snomed_code', 'target_code');
+}
+
+export async function down(query: QueryInterface) {
+  await query.renameColumn('certifiable_vaccines', 'vaccine_code', 'atc_code');
+  await query.renameColumn('certifiable_vaccines', 'target_code', 'target_snomed_code');
+}

--- a/packages/shared-src/src/models/CertifiableVaccine.js
+++ b/packages/shared-src/src/models/CertifiableVaccine.js
@@ -8,23 +8,27 @@ export class CertifiableVaccine extends Model {
     super.init(
       {
         id: primaryKey,
+        // ICD11 code for the vaccine type
         icd11DrugCode: {
           type: Sequelize.STRING,
           allowNull: false,
         },
+        // ICD11 code for the targeted disease
         icd11DiseaseCode: {
           type: Sequelize.STRING,
           allowNull: false,
         },
-        atcCode: {
+        // SNOMED CT or ATC code for the vaccine type
+        vaccineCode: {
           type: Sequelize.STRING,
           allowNull: false,
         },
-        // SNOMED CT code for targeted disease or agent
-        targetSnomedCode: {
+        // SNOMED CT or ATC code for targeted disease
+        targetCode: {
           type: Sequelize.STRING,
           allowNull: true,
         },
+        // EU authorisation code for the vaccine product
         euProductCode: {
           type: Sequelize.STRING,
           allowNull: true,
@@ -76,10 +80,6 @@ export class CertifiableVaccine extends Model {
   }
 
   usableForEuDcc() {
-    return (
-      this.euProductCode !== null &&
-      this.targetedDiseaseSnomedCode !== null &&
-      this.manufacturerId !== null
-    );
+    return this.euProductCode !== null && this.targetCode !== null && this.manufacturerId !== null;
   }
 }

--- a/packages/sync-server/__tests__/integrations/EuDcc/Translation.test.js
+++ b/packages/sync-server/__tests__/integrations/EuDcc/Translation.test.js
@@ -30,8 +30,8 @@ describe('EU DCC: Vaccination', () => {
       manufacturerId: data.vaxManu.id,
       icd11DrugCode: 'XM68M6',
       icd11DiseaseCode: 'RA01.0',
-      atcCode: 'J07BX03',
-      targetSnomedCode: '840539006',
+      vaccineCode: 'J07BX03',
+      targetCode: '840539006',
       euProductCode: 'EU/1/20/1528',
       maximumDosage: 3,
     });

--- a/packages/sync-server/app/integrations/EuDcc/Translation.js
+++ b/packages/sync-server/app/integrations/EuDcc/Translation.js
@@ -113,8 +113,8 @@ export async function createEuDccVaccinationData(administeredVaccineId, { models
     dob,
     [EUDCC_CERTIFICATE_TYPES.VACCINATION]: [
       {
-        tg: certVax.targetSnomedCode,
-        vp: certVax.atcCode,
+        tg: certVax.targetCode,
+        vp: certVax.vaccineCode,
         mp: certVax.euProductCode,
         ma: certVax.manufacturer.code,
         dn: SCHEDULE_TO_SEQUENCE[schedule],


### PR DESCRIPTION
Original names were based on a misunderstanding of what those codes were. In actuality they are the codes for the disease (target) and the vaccine, in _either_ ATC or SNOMED CT systems, with SNOMED CT preferred (more precise).