### PR TITLE
WAITM-294 Allow configured reports to run in local time zone on sync

### DIFF
--- a/packages/shared-src/src/services/database.js
+++ b/packages/shared-src/src/services/database.js
@@ -57,6 +57,7 @@ async function connectToDatabase(dbOptions) {
     host = null,
     port = null,
     verbose = false,
+    timeZone = null,
   } = dbOptions;
   let { name, sqlitePath = null } = dbOptions;
 
@@ -89,9 +90,13 @@ async function connectToDatabase(dbOptions) {
           `${util.inspect(query)}; -- ${util.inspect(obj.bind || [], { breakLength: Infinity })}`,
         )
     : null;
-  const options = sqlitePath
+  let options = sqlitePath
     ? { dialect: 'sqlite', dialectModule: sqlite3, storage: sqlitePath }
     : { dialect: 'postgres' };
+  if (timeZone) {
+    // Set up sequelize to read out values in specified timezone
+    options = { ...options, dialectOptions: { useUTC: false }, timezone: timeZone };
+  }
   const sequelize = new Sequelize(name, username, password, {
     ...options,
     host,

--- a/packages/sync-server/app/database/index.js
+++ b/packages/sync-server/app/database/index.js
@@ -5,7 +5,7 @@ import { addHooks } from './hooks';
 
 let existingConnection = null;
 
-export async function initDatabase({ testMode = false }) {
+export async function initDatabase({ testMode = false, timeZone = null }) {
   // connect to database
   if (existingConnection) {
     return existingConnection;
@@ -16,6 +16,7 @@ export async function initDatabase({ testMode = false }) {
     testMode,
     makeEveryModelParanoid: true,
     saltRounds: config.auth.saltRounds,
+    timeZone,
   }).init();
 
   // drop and recreate db

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -270,6 +270,7 @@ const rootLocalisationSchema = yup
       .required()
       .noUnknown(),
     disabledReports: yup.array(yup.string().required()).defined(),
+    localTimeReports: yup.array(yup.string().required()).defined(),
   })
   .required()
   .noUnknown();

--- a/packages/sync-server/app/subCommands/report.js
+++ b/packages/sync-server/app/subCommands/report.js
@@ -8,6 +8,7 @@ import { EmailService } from '../services/EmailService';
 import { ReportRunner } from '../report/ReportRunner';
 import { initDatabase } from '../database';
 import { setupEnv } from '../env';
+import { getLocalisation } from '../localisation';
 
 const REPORT_HEAP_INTERVAL_MS = 1000;
 
@@ -20,7 +21,13 @@ async function report(options) {
     }, REPORT_HEAP_INTERVAL_MS);
   }
 
-  const store = await initDatabase({ testMode: false });
+  const localisation = await getLocalisation();
+  const { localTimeReports = [], timeZone = null } = localisation;
+
+  const store = await initDatabase({
+    testMode: false,
+    timeZone: localTimeReports.includes(options.name) ? timeZone : null,
+  });
   setupEnv();
   try {
     const { name, parameters, recipients } = options;

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -487,7 +487,10 @@
       "sync": {
         "syncAllEncountersForTheseScheduledVaccines": []
       },
-      "disabledReports": []
+      "disabledReports": [],
+      // List of reports to be generated with local time (from timeZone field)
+      // All others are generated in UTC
+      "localTimeReports": []
     }
   },
   "reportProcess": {


### PR DESCRIPTION
- Add a field to config to define local time reports
- When spawning a new report sub process, set sequelize to read in the local time zone