### PR TITLE
TAN-1648: Properly display patient view page

### DIFF
--- a/packages/desktop/app/App.js
+++ b/packages/desktop/app/App.js
@@ -8,6 +8,7 @@ import { checkIsLoggedIn } from './store/auth';
 import { getCurrentRoute } from './store/router';
 import { LoginView } from './views';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { DecisionSupportModal } from './components/DecisionSupportModal';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
 
@@ -33,13 +34,15 @@ export function App({ sidebar, children }) {
   return (
     <AppContainer>
       {sidebar}
-      <ErrorBoundary errorKey={currentRoute}>
-        <AppContentsContainer>
-          {children}
-          <DecisionSupportModal />
-          <ForbiddenErrorModal />
-        </AppContentsContainer>
-      </ErrorBoundary>
+      <PromiseErrorBoundary>
+        <ErrorBoundary errorKey={currentRoute}>
+          <AppContentsContainer>
+            {children}
+            <DecisionSupportModal />
+            <ForbiddenErrorModal />
+          </AppContentsContainer>
+        </ErrorBoundary>
+      </PromiseErrorBoundary>
     </AppContainer>
   );
 }

--- a/packages/desktop/app/api/TamanuApi.js
+++ b/packages/desktop/app/api/TamanuApi.js
@@ -3,8 +3,8 @@ import qs from 'qs';
 
 import { buildAbilityForUser } from 'shared/permissions/buildAbility';
 import { VERSION_COMPATIBILITY_ERRORS, SERVER_TYPES } from 'shared/constants';
+import { ForbiddenError } from 'shared/errors';
 import { LOCAL_STORAGE_KEYS } from '../constants';
-import { setForbiddenError } from '../store';
 
 const { HOST, TOKEN, LOCALISATION, SERVER, PERMISSIONS } = LOCAL_STORAGE_KEYS;
 
@@ -90,16 +90,11 @@ export class TamanuApi {
     this.authHeader = null;
     this.onVersionIncompatible = null;
     this.user = null;
-    this.reduxStore = null;
 
     const host = window.localStorage.getItem(HOST);
     if (host) {
       this.setHost(host);
     }
-  }
-
-  setReduxStore(store) {
-    this.reduxStore = store;
   }
 
   setHost(host) {
@@ -209,8 +204,8 @@ export class TamanuApi {
     const { error } = await getResponseJsonSafely(response);
 
     // handle forbidden error and trigger catch all modal
-    if (response.status === 403 && error && this.reduxStore) {
-      this.reduxStore.dispatch(setForbiddenError(error));
+    if (response.status === 403 && error) {
+      throw new ForbiddenError(error?.message);
     }
 
     // handle auth expiring

--- a/packages/desktop/app/components/PromiseErrorBoundary.js
+++ b/packages/desktop/app/components/PromiseErrorBoundary.js
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { ForbiddenError } from 'shared/errors';
+import { setForbiddenError } from '../store';
+
+// This will catch all unhandled promise rejections.
+// The intent is to open the Forbidden Error catch-all modal
+// when the caller didn't handle the error.
+export const PromiseErrorBoundary = ({ children }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const handleUnhandledRejection = event => {
+      event.preventDefault();
+      if (event.reason instanceof ForbiddenError) {
+        dispatch(setForbiddenError());
+      } else {
+        console.error(event.reason);
+      }
+    };
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+    };
+  }, [dispatch]);
+
+  return <>{children}</>;
+};

--- a/packages/desktop/app/store/initStore.js
+++ b/packages/desktop/app/store/initStore.js
@@ -31,7 +31,5 @@ export function initStore(api) {
   const persistedReducers = persistCombineReducers(persistConfig, createReducers(history));
   const store = createStore(persistedReducers, {}, enhancers);
 
-  api.setReduxStore(store);
-
   return { store, history };
 }

--- a/packages/desktop/app/store/patient.js
+++ b/packages/desktop/app/store/patient.js
@@ -12,10 +12,19 @@ export const clearPatient = () => ({
 export const reloadPatient = id => async (dispatch, getState, { api }) => {
   dispatch({ type: PATIENT_LOAD_START, id });
 
+  // Fetch this separate from the other patient information
+  // (handling it differently to avoid breaking patient view page)
+  let currentEncounter;
+  try {
+    currentEncounter = await api.get(`patient/${id}/currentEncounter`);
+  } catch (e) {
+    // Ignore error
+    currentEncounter = null;
+  }
+
   try {
     const [
       patient,
-      currentEncounter,
       familyHistory,
       allergies,
       issues,
@@ -24,7 +33,6 @@ export const reloadPatient = id => async (dispatch, getState, { api }) => {
       additionalData,
     ] = await Promise.all([
       api.get(`patient/${id}`),
-      api.get(`patient/${id}/currentEncounter`),
       api.get(`patient/${id}/familyHistory`),
       api.get(`patient/${id}/allergies`),
       api.get(`patient/${id}/issues`),

--- a/packages/desktop/app/views/patients/components/PatientEncounterSummary.js
+++ b/packages/desktop/app/views/patients/components/PatientEncounterSummary.js
@@ -165,6 +165,18 @@ export const PatientEncounterSummary = ({
   openTriage,
   encounter,
 }) => {
+  // This means that we set null when retrieving the encounter
+  // because the request had an error
+  if (encounter === null) {
+    return (
+      <NoVisitContainer>
+        <NoVisitTitle variant="h2">
+          You do not have the necessary permissions to read encounters
+        </NoVisitTitle>
+      </NoVisitContainer>
+    );
+  }
+
   if (patient.dateOfDeath) {
     return <PatientDeathSummary patient={patient} />;
   }

--- a/packages/lan/app/routes/apiv1/crudHelpers.js
+++ b/packages/lan/app/routes/apiv1/crudHelpers.js
@@ -79,6 +79,7 @@ export const simpleGetList = (modelName, foreignKey = '', options = {}) =>
     const { models, params, query } = req;
     const { order = 'ASC', orderBy } = query;
     const { additionalFilters = {}, include = [] } = options;
+    req.checkPermission('list', modelName);
 
     const model = models[modelName];
     const associations = model.getListReferenceAssociations(models) || [];

--- a/packages/shared-src/src/roles.js
+++ b/packages/shared-src/src/roles.js
@@ -200,6 +200,8 @@ export const practitioner = [
   { verb: 'read', noun: 'PatientSecondaryId' },
   { verb: 'write', noun: 'PatientSecondaryId' },
   { verb: 'create', noun: 'PatientSecondaryId' },
+
+  { verb: 'list', noun: 'Note' },
 ];
 
 // "Manage all" is a special case in CASL for the admin to grant everything


### PR DESCRIPTION
This PR hopes to overcome two problems:
- Previously, being able to successfully `read` a patient also required to be able to `read` encounters, which seemed unideal.
- The catch-all forbidden error modal is unnecessary sometimes: when the component making the request actually handles the error.

I decided to handle the patient load in a similar fashion, but making it so that if the current encounter has an error, it doesn't stop from retrieving everything else. In any case, having the error and setting it doesn't really seem to be doing anything I could look on the app: it may not be ideal, but it could be dealt when we fully remove redux or perhaps it could be followed up by refactoring that specific query into all components that need a patient's current encounter.

Because that was the only piece of functionality using the redux store inside the TamanuApi singleton I decided to remove it altogether.