### PR TITLE
WAITM-80 Allow specifying defaultDateRange in database defined reports

### DIFF
--- a/packages/lan/__tests__/apiv1/Reports.test.js
+++ b/packages/lan/__tests__/apiv1/Reports.test.js
@@ -35,7 +35,8 @@ describe('Reports', () => {
           parameters: [{ parameterField: 'EmailField', name: 'email' }],
           defaultDateRange: 'allTime',
         }),
-        query: 'SELECT id, email from users WHERE email LIKE :email;',
+        query:
+          'SELECT id, email from users WHERE CASE WHEN :email IS NOT NULL THEN email = :email ELSE TRUE END;',
       });
     });
     it('should run a simple database defined report', async () => {

--- a/packages/lan/__tests__/apiv1/Reports.test.js
+++ b/packages/lan/__tests__/apiv1/Reports.test.js
@@ -35,6 +35,7 @@ describe('Reports', () => {
           parameters: [{ parameterField: 'EmailField', name: 'email' }],
         }),
         query: 'SELECT id, email from users WHERE email LIKE :email;',
+        defaultDateRange: 'allTime',
       });
     });
     it('should run a simple database defined report', async () => {

--- a/packages/lan/__tests__/apiv1/Reports.test.js
+++ b/packages/lan/__tests__/apiv1/Reports.test.js
@@ -33,9 +33,9 @@ describe('Reports', () => {
         userId: user.id,
         queryOptions: JSON.stringify({
           parameters: [{ parameterField: 'EmailField', name: 'email' }],
+          defaultDateRange: 'allTime',
         }),
         query: 'SELECT id, email from users WHERE email LIKE :email;',
-        defaultDateRange: 'allTime',
       });
     });
     it('should run a simple database defined report', async () => {

--- a/packages/lan/app/routes/apiv1/reports.js
+++ b/packages/lan/app/routes/apiv1/reports.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import * as reportUtils from 'shared/reports';
-import { REPORT_STATUSES } from 'shared/constants';
+import { REPORT_STATUSES, REPORT_DATE_RANGE_LABELS } from 'shared/constants';
 import { createNamedLogger } from 'shared/services/logging/createNamedLogger';
 import { assertReportEnabled } from '../../utils/assertReportEnabled';
 
@@ -46,7 +46,9 @@ reports.get(
         id: version.id,
         name: r.name,
         dataSourceOptions: version.queryOptions.dataSources,
-        dateRangeLabel: version.queryOptions.dateRangeLabel,
+        dateRangeLabel:
+          version.queryOptions.dateRangeLabel ||
+          REPORT_DATE_RANGE_LABELS[version.queryOptions.defaultDateRange],
         parameters: version.getParameters(),
         version: version.versionNumber,
       };

--- a/packages/shared-src/src/constants/reports.js
+++ b/packages/shared-src/src/constants/reports.js
@@ -22,3 +22,15 @@ export const REPORT_EXPORT_FORMATS = {
 export const REPORT_STATUSES = { DRAFT: 'draft', PUBLISHED: 'published' };
 
 export const REPORT_STATUSES_VALUES = Object.values(REPORT_STATUSES);
+
+export const REPORT_DEFAULT_DATE_RANGES = {
+  ALL_TIME: 'allTime',
+  THIRTY_DAYS: '30days',
+};
+export const REPORT_DATE_RANGE_LABELS = {
+  [REPORT_DEFAULT_DATE_RANGES.ALL_TIME]: 'Date range (or leave blank for all data)',
+  [REPORT_DEFAULT_DATE_RANGES.THIRTY_DAYS]:
+    'Date range (or leave blank for the past 30 days of data)',
+};
+
+export const REPORT_DEFAULT_DATE_RANGES_VALUES = Object.values(REPORT_DEFAULT_DATE_RANGES);

--- a/packages/shared-src/src/models/ReportDefinitionVersion.js
+++ b/packages/shared-src/src/models/ReportDefinitionVersion.js
@@ -23,7 +23,8 @@ const optionsValidator = yup.object({
   dateRangeLabel: yup.string(),
   defaultDateRange: yup
     .string()
-    .oneOf(REPORT_DEFAULT_DATE_RANGES_VALUES),
+    .oneOf(REPORT_DEFAULT_DATE_RANGES_VALUES)
+    .required(),
 });
 
 const generateReportFromQueryData = queryData => {

--- a/packages/shared-src/src/models/ReportDefinitionVersion.js
+++ b/packages/shared-src/src/models/ReportDefinitionVersion.js
@@ -23,8 +23,7 @@ const optionsValidator = yup.object({
   dateRangeLabel: yup.string(),
   defaultDateRange: yup
     .string()
-    .oneOf(REPORT_DEFAULT_DATE_RANGES_VALUES)
-    .required(),
+    .oneOf(REPORT_DEFAULT_DATE_RANGES_VALUES),
 });
 
 const generateReportFromQueryData = queryData => {

--- a/packages/shared-src/src/reports/reportDefinitions.js
+++ b/packages/shared-src/src/reports/reportDefinitions.js
@@ -5,23 +5,21 @@ import {
   IMAGING_REQUEST_STATUS_OPTIONS,
   MANNER_OF_DEATH_OPTIONS,
   LAB_REQUEST_STATUS_OPTIONS,
+  REPORT_DATE_RANGE_LABELS,
 } from 'shared/constants';
-
-const LAST_30_DAYS_DATE_LABEL = 'Date range (or leave blank for the past 30 days of data)';
-const ALL_TIME_DATE_LABEL = 'Date range (or leave blank for all data)';
 
 export const REPORT_DEFINITIONS = [
   {
     name: 'Incomplete referrals',
     id: 'incomplete-referrals',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'PractitionerField' }],
   },
   {
     name: 'Recent Diagnoses',
     id: 'recent-diagnoses',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -43,7 +41,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Admissions - Line list',
     id: 'admissions',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -73,7 +71,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Vaccine - Line list',
     id: 'vaccine-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -85,7 +83,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Tuvalu Vaccine - Line list with consent',
     id: 'tuvalu-vaccine-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     filterDateRangeAsStrings: true,
     parameters: [
@@ -97,7 +95,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'COVID vaccine campaign - Line list',
     id: 'covid-vaccine-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [{ parameterField: 'VillageField' }],
@@ -106,94 +104,94 @@ export const REPORT_DEFINITIONS = [
     name: 'COVID vaccine campaign - First dose summary',
     id: 'covid-vaccine-summary-dose1',
     filterDateRangeAsStrings: true,
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'COVID vaccine campaign - Second dose summary',
     id: 'covid-vaccine-summary-dose2',
     filterDateRangeAsStrings: true,
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Adverse Event Following Immunization',
     id: 'aefi',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'Samoa Adverse Event Following Immunisation',
     id: 'samoa-aefi',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'Number of patients registered by date',
     id: 'number-patients-registered-by-date',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     filterDateRangeAsStrings: true,
   },
   {
     name: 'Registered patients - Line list',
     id: 'registered-patients',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     filterDateRangeAsStrings: true,
   },
   {
     name: 'COVID-19 Tests - Line list',
     id: 'fiji-covid-swab-lab-test-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
   },
   {
     name: 'Fiji Traveller COVID-19 Tests - Line list',
     id: 'fiji-traveller-covid-lab-test-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'LabTestLaboratoryField' }],
   },
   {
     name: 'Palau COVID-19 Test - Line list',
     id: 'palau-covid-swab-lab-test-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'Nauru COVID-19 Test - Line list',
     id: 'nauru-covid-swab-lab-test-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Palau COVID-19 Case Report - Line list',
     id: 'palau-covid-case-report-line-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'Kiribati COVID-19 Test - Line list',
     id: 'kiribati-covid-swab-lab-test-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Samoa COVID-19 Test - Line list',
     id: 'samoa-covid-swab-lab-test-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
   },
   {
     name: 'COVID-19 Tests - Summary',
     id: 'covid-swab-lab-tests-summary',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
@@ -201,25 +199,25 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'India assistive technology device - Line list',
     id: 'india-assistive-technology-device-line-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'Iraq assistive technology device - Line list',
     id: 'iraq-assistive-technology-device-line-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'PNG assistive technology device - Line list',
     id: 'png-assistive-technology-device-line-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'Fiji recent attendance - Line list',
     id: 'fiji-recent-attendance-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -230,7 +228,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji NCD primary screening  - Line list',
     id: 'fiji-ncd-primary-screening-line-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [
       {
@@ -257,7 +255,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji NCD primary screening pending referrals - Line list',
     id: 'fiji-ncd-primary-screening-pending-referrals-line-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [
       {
@@ -284,7 +282,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji NCD primary screening - Summary',
     id: 'fiji-ncd-primary-screening-summary',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [
       {
@@ -357,7 +355,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji Aspen encounter summary - Line list',
     id: 'fiji-aspen-encounter-summary-line-list',
-    dateRangeLabel: ALL_TIME_DATE_LABEL, // TODO: Changed in new PR
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME, // TODO: Changed in new PR
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -386,7 +384,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Generic Survey Export - Line List',
     id: 'generic-survey-export-line-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [
       { parameterField: 'VillageField' },
@@ -433,7 +431,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Imaging requests - Line list',
     id: 'imaging-requests-line-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -455,7 +453,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Deceased patients - Line list',
     id: 'deceased-patients-line-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -488,7 +486,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Lab requests - Line list',
     id: 'lab-requests-line-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [
       {
@@ -509,14 +507,14 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji Aspen hospital admissions - Summary',
     id: 'fiji-aspen-hospital-admissions-summary',
-    dateRangeLabel: ALL_TIME_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
     dataSourceOptions: [REPORT_DATA_SOURCES.THIS_FACILITY],
     parameters: [],
   },
   {
     name: 'Registered births - Line list',
     id: 'registered-births-line-list',
-    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
+    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
     filterDateRangeAsStrings: true,

--- a/packages/shared-src/src/reports/reportDefinitions.js
+++ b/packages/shared-src/src/reports/reportDefinitions.js
@@ -6,20 +6,24 @@ import {
   MANNER_OF_DEATH_OPTIONS,
   LAB_REQUEST_STATUS_OPTIONS,
   REPORT_DATE_RANGE_LABELS,
+  REPORT_DEFAULT_DATE_RANGES,
 } from 'shared/constants';
+
+const LAST_30_DAYS_DATE_LABEL = REPORT_DATE_RANGE_LABELS[REPORT_DEFAULT_DATE_RANGES.THIRTY_DAYS];
+const ALL_TIME_DATE_LABEL = REPORT_DATE_RANGE_LABELS[REPORT_DEFAULT_DATE_RANGES.ALL_TIME];
 
 export const REPORT_DEFINITIONS = [
   {
     name: 'Incomplete referrals',
     id: 'incomplete-referrals',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'PractitionerField' }],
   },
   {
     name: 'Recent Diagnoses',
     id: 'recent-diagnoses',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -41,7 +45,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Admissions - Line list',
     id: 'admissions',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -71,7 +75,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Vaccine - Line list',
     id: 'vaccine-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -83,7 +87,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Tuvalu Vaccine - Line list with consent',
     id: 'tuvalu-vaccine-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     filterDateRangeAsStrings: true,
     parameters: [
@@ -95,7 +99,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'COVID vaccine campaign - Line list',
     id: 'covid-vaccine-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [{ parameterField: 'VillageField' }],
@@ -104,94 +108,94 @@ export const REPORT_DEFINITIONS = [
     name: 'COVID vaccine campaign - First dose summary',
     id: 'covid-vaccine-summary-dose1',
     filterDateRangeAsStrings: true,
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'COVID vaccine campaign - Second dose summary',
     id: 'covid-vaccine-summary-dose2',
     filterDateRangeAsStrings: true,
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Adverse Event Following Immunization',
     id: 'aefi',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'Samoa Adverse Event Following Immunisation',
     id: 'samoa-aefi',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'Number of patients registered by date',
     id: 'number-patients-registered-by-date',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     filterDateRangeAsStrings: true,
   },
   {
     name: 'Registered patients - Line list',
     id: 'registered-patients',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     filterDateRangeAsStrings: true,
   },
   {
     name: 'COVID-19 Tests - Line list',
     id: 'fiji-covid-swab-lab-test-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
   },
   {
     name: 'Fiji Traveller COVID-19 Tests - Line list',
     id: 'fiji-traveller-covid-lab-test-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'LabTestLaboratoryField' }],
   },
   {
     name: 'Palau COVID-19 Test - Line list',
     id: 'palau-covid-swab-lab-test-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'Nauru COVID-19 Test - Line list',
     id: 'nauru-covid-swab-lab-test-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Palau COVID-19 Case Report - Line list',
     id: 'palau-covid-case-report-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'Kiribati COVID-19 Test - Line list',
     id: 'kiribati-covid-swab-lab-test-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Samoa COVID-19 Test - Line list',
     id: 'samoa-covid-swab-lab-test-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
   },
   {
     name: 'COVID-19 Tests - Summary',
     id: 'covid-swab-lab-tests-summary',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
@@ -199,25 +203,25 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'India assistive technology device - Line list',
     id: 'india-assistive-technology-device-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'Iraq assistive technology device - Line list',
     id: 'iraq-assistive-technology-device-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'PNG assistive technology device - Line list',
     id: 'png-assistive-technology-device-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
   },
   {
     name: 'Fiji recent attendance - Line list',
     id: 'fiji-recent-attendance-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -228,7 +232,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji NCD primary screening  - Line list',
     id: 'fiji-ncd-primary-screening-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [
       {
@@ -255,7 +259,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji NCD primary screening pending referrals - Line list',
     id: 'fiji-ncd-primary-screening-pending-referrals-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [
       {
@@ -282,7 +286,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji NCD primary screening - Summary',
     id: 'fiji-ncd-primary-screening-summary',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [
       {
@@ -355,7 +359,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji Aspen encounter summary - Line list',
     id: 'fiji-aspen-encounter-summary-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME, // TODO: Changed in new PR
+    dateRangeLabel: ALL_TIME_DATE_LABEL, // TODO: Changed in new PR
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -384,7 +388,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Generic Survey Export - Line List',
     id: 'generic-survey-export-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [
       { parameterField: 'VillageField' },
@@ -431,7 +435,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Imaging requests - Line list',
     id: 'imaging-requests-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -453,7 +457,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Deceased patients - Line list',
     id: 'deceased-patients-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     filterDateRangeAsStrings: true,
     parameters: [
@@ -486,7 +490,7 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Lab requests - Line list',
     id: 'lab-requests-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [
       {
@@ -507,14 +511,14 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Fiji Aspen hospital admissions - Summary',
     id: 'fiji-aspen-hospital-admissions-summary',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.ALL_TIME,
+    dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.THIS_FACILITY],
     parameters: [],
   },
   {
     name: 'Registered births - Line list',
     id: 'registered-births-line-list',
-    dateRangeLabel: REPORT_DATE_RANGE_LABELS.THIRTY_DAYS,
+    dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
     filterDateRangeAsStrings: true,

--- a/packages/shared-src/src/utils/getQueryReplacementsFromParams.js
+++ b/packages/shared-src/src/utils/getQueryReplacementsFromParams.js
@@ -1,8 +1,27 @@
+import { subDays, startOfDay } from 'date-fns';
+import { REPORT_DEFAULT_DATE_RANGES } from 'shared/constants';
+
 const CATCH_ALL_FROM_DATE = '01-01-1970';
 
-export const getQueryReplacementsFromParams = (paramDefinitions, params = {}) => {
+export const getQueryReplacementsFromParams = (
+  paramDefinitions,
+  params = {},
+  dateRange = REPORT_DEFAULT_DATE_RANGES.ALL_TIME,
+) => {
+  let fromDate = null;
+  switch (dateRange) {
+    case REPORT_DEFAULT_DATE_RANGES.ALL_TIME:
+      fromDate = new Date(CATCH_ALL_FROM_DATE);
+      break;
+    case REPORT_DEFAULT_DATE_RANGES.THIRTY_DAYS:
+      // If we have a toDate, but no fromDate, run 30 days prior to the toDate
+      fromDate = startOfDay(subDays(params.toDate ? new Date(params.toDate) : new Date(), 30));
+      break;
+    default:
+      throw new Error('Unknown date range for report generation');
+  }
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: '%' }), {
-    fromDate: new Date(CATCH_ALL_FROM_DATE),
+    fromDate,
     toDate: new Date(),
   });
   return { ...paramDefaults, ...params };

--- a/packages/shared-src/src/utils/getQueryReplacementsFromParams.js
+++ b/packages/shared-src/src/utils/getQueryReplacementsFromParams.js
@@ -20,7 +20,7 @@ export const getQueryReplacementsFromParams = (
     default:
       throw new Error('Unknown date range for report generation');
   }
-  const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: '%' }), {
+  const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {
     fromDate,
     toDate: new Date(),
   });

--- a/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
+++ b/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
@@ -112,6 +112,7 @@ describe('importReport actions', () => {
         },
         userId: 'test-user-id',
         versionNumber: 3,
+        defaultDateRange: 'allTime',
       });
     });
     it('calls the correct functions and updates version when versionNumber supplied', async () => {
@@ -127,6 +128,7 @@ describe('importReport actions', () => {
         },
         userId: 'test-user-id',
         versionNumber: 1,
+        defaultDateRange: 'allTime',
       });
     });
     it('throws error when versionNumber is invalid', async () => {

--- a/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
+++ b/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
@@ -109,10 +109,10 @@ describe('importReport actions', () => {
         query: 'test-query',
         queryOptions: {
           parameters: [{ parameterField: 'TestField', name: 'test' }],
+          defaultDateRange: 'allTime',
         },
         userId: 'test-user-id',
         versionNumber: 3,
-        defaultDateRange: 'allTime',
       });
     });
     it('calls the correct functions and updates version when versionNumber supplied', async () => {
@@ -125,10 +125,10 @@ describe('importReport actions', () => {
         query: 'test-query',
         queryOptions: {
           parameters: [{ parameterField: 'TestField', name: 'test' }],
+          defaultDateRange: 'allTime',
         },
         userId: 'test-user-id',
         versionNumber: 1,
-        defaultDateRange: 'allTime',
       });
     });
     it('throws error when versionNumber is invalid', async () => {

--- a/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
+++ b/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
@@ -17,7 +17,8 @@ const getUnparsedVersionData = num =>
   `{ ${num ? `"versionNumber": ${num},` : ''} "query": "test-query", "queryOptions": {
     "parameters": [ 
         { "parameterField": "TestField", "name": "test" }
-    ]
+    ],
+    "defaultDateRange": "allTime"
   } }`;
 
 jest.mock('shared/services/logging', () => ({


### PR DESCRIPTION
### Changes

- Allow a `defaultDateRange` value of `allTime/30days`
- Calculate `fromDate` using appropriate logic
- Load a default date range label based on value

### Checklist

- [ ] Code
- [ ] Tests
- [ ] UI Screenshots
- [ ] Update the runbook
- [ ] Include any config changes in the release PR changelog
- [ ] Update the [release PR](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle) changelog with a ticket reference (e.g. TAN-001 or WAITM-001 will be automatically linked)
- [ ] Add testing notes to the Linear issue
