### PR TITLE
draft no-issue: custom date type lint for models and migrations

### DIFF
--- a/packages/shared-src/.eslintrc
+++ b/packages/shared-src/.eslintrc
@@ -5,5 +5,35 @@
     "jasmine": true,
     "jest": true,
     "es6": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/migrations/**/*.js"],
+      "rules": {
+        "no-restricted-properties": [1, {
+          "object": "Sequelize",
+          "property": "DATE",
+          "message": "use DataTypes.DATESTRING or DataTypes.DATETIMESTRING types for all new columns"
+      }, {
+        "object": "DataTypes",
+        "property": "DATE",
+        "message": "use DataTypes.DATESTRING or DataTypes.DATETIMESTRING types for all new columns"
+      }]
+      }
+    },
+    {
+      "files": ["**/models/**/*.js"],
+      "rules": {
+        "no-restricted-properties": [1, {
+          "object": "Sequelize",
+          "property": "DATE",
+          "message": "use custom dateTimeTypes.js types for all new columns"
+      }, {
+        "object": "DataTypes",
+        "property": "DATE",
+        "message": "use custom dateTimeTypes.js types for all new columns"
+      }]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
### Changes

Currently set these to warning only
But it could also be error that is overridden

![Screen Shot 2022-10-13 at 5 32 26 PM](https://user-images.githubusercontent.com/38335330/195502538-f58f9d49-2c8b-40b0-88d0-a90c0ec0be22.png)

These could be silenced in some cases.

Maybe should incorporate with `@beyondessential/eslint-config-js`
