### PR TITLE
Improve FHIR dateTime parsing to be able to use timezones

### DIFF
--- a/packages/shared-src/src/utils/fhir/datetime.js
+++ b/packages/shared-src/src/utils/fhir/datetime.js
@@ -11,6 +11,7 @@ import {
   formatISO9075,
   formatRFC3339,
 } from 'date-fns';
+import { getTimezoneOffset, zonedTimeToUtc } from 'date-fns-tz';
 import { pick } from 'lodash';
 import { date as yupDate, number, object, string } from 'yup';
 
@@ -31,7 +32,26 @@ function extractTz(str) {
   return null;
 }
 
-function dateParts(date, str, form) {
+function normalizeTz(tz, date) {
+  const offset = getTimezoneOffset(tz, date) / 1000;
+  if (isNaN(offset)) return null;
+
+  const sign = offset < 0 ? '-' : '+';
+  const hours = Math.floor(Math.abs(offset) / 3600);
+  const minutes = Math.floor((Math.abs(offset) % 3600) / 60);
+  const seconds = Math.floor(Math.abs(offset) % 60);
+
+  let offsetSuffix = `${sign}${hours.toString().padStart(2, '0')}:${minutes
+    .toString()
+    .padStart(2, '0')}`;
+  if (seconds !== 0) {
+    offsetSuffix += `:${seconds.toString().padStart(2, '0')}`;
+  }
+
+  return offsetSuffix;
+}
+
+function dateParts(date, withTz, str, form) {
   let tz = null;
   if (form.endsWith('X') && str.endsWith('Z')) {
     tz = '+00:00';
@@ -41,7 +61,12 @@ function dateParts(date, str, form) {
   } else if (form.endsWith('X')) {
     const tzh = extractTz(str);
     if (tzh) tz = `${tzh}:00`;
+  } else if (withTz) {
+    // no timezone in the format, use provided timezone
+    date = zonedTimeToUtc(date, withTz);
+    tz = normalizeTz(tz, date);
   }
+  // else: no timezone in the format, using system timezone to parse and no tz in the output
 
   return {
     plain: date,
@@ -116,12 +141,14 @@ const FORMS = {
   yyyy: [FHIR_DATETIME_PRECISION.YEARS, ['year']],
 };
 
-export function parseDateTime(str, ref = new Date()) {
+export function parseDateTime(str, { ref = new Date(), withTz = null } = {}) {
   for (const [form, [precision, extract]] of Object.entries(FORMS)) {
     const date = parse(str, form, ref);
     if (isValid(date)) {
-      const parts = dateParts(date, str, form);
+      const parts = dateParts(date, withTz, str, form);
       return {
+        // note this is the input precision; when using withTz, the value
+        // will include a tz even if the precision isn't *_WITH_TIMEZONE.
         precision,
         ...pick(parts, COMMONS),
         value: pick(parts, extract),


### PR DESCRIPTION
### Changes

- This is for the medici report
- It's kinda FHIR related, and wants to accept its datetime formats
- So let's use the FHIR tooling I've made!
- But we want to be able to use `countryTimeZone` config when no offset is specified on the input.
- Hence, add an option to do that to the tooling.

### Checklist

- [x] Code
