### PR TITLE
WAITM-533: staging-fix: Port fiji aspen medici report to use location hierarchy

### DIFF
--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { upperFirst } from 'lodash';
-import { utcToZonedTime, zonedTimeToUtc, formatInTimeZone } from 'date-fns-tz';
+import { utcToZonedTime } from 'date-fns-tz';
 import {
   REFERENCE_TYPES,
   NOTE_RECORD_TYPES,
@@ -37,8 +37,15 @@ const fakeAllData = async models => {
   const { id: departmentId } = await models.Department.create(
     fake(models.Department, { facilityId, name: 'Emergency dept.' }),
   );
+  const locationGroup = await models.LocationGroup.create(
+    fake(models.LocationGroup, { facilityId, name: 'Emergency area' }),
+  );
   const { id: location1Id } = await models.Location.create(
-    fake(models.Location, { facilityId, name: 'Emergency room 1' }),
+    fake(models.Location, {
+      facilityId,
+      locationGroupId: locationGroup.id,
+      name: 'Emergency room 1',
+    }),
   );
   const { id: location2Id } = await models.Location.create(
     fake(models.Location, { facilityId, name: 'Emergency room 2' }),
@@ -130,7 +137,7 @@ const fakeAllData = async models => {
       startDate: createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 54, 225),
       endDate: createLocalDateTimeStringFromUTC(2022, 6 - 1, 12, 0, 2, 54, 225), // Make sure this works
       encounterType: ENCOUNTER_TYPES.ADMISSION,
-      reasonForEncounter: 'Severe Migrane',
+      reasonForEncounter: 'Severe Migraine',
       patientBillingTypeId,
       locationId: location1Id,
       departmentId,
@@ -375,7 +382,7 @@ describe('fijiAspenMediciReport', () => {
         encounterStartDate: '2022-06-09T00:02:54.000Z',
         encounterEndDate: '2022-06-12T00:02:54.000Z',
         encounterType: 'AR-DRG',
-        reasonForEncounter: 'Severe Migrane',
+        reasonForEncounter: 'Severe Migraine',
 
         // New fields
         weight: 2100,
@@ -398,7 +405,7 @@ describe('fijiAspenMediciReport', () => {
         // Location/Department
         locations: [
           {
-            location: 'Emergency room 1',
+            location: 'Emergency area, Emergency room 1',
             assignedTime: '2022-06-09T00:02:54+00:00',
           },
           {

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -216,23 +216,24 @@ location_info as (
     e.id encounter_id,
     case when count("from") = 0
       then json_build_array(json_build_object(
-        'location', l.name,
+        'location', coalesce(lg.name || ', ', '') || l.name,
         'assignedTime', e.start_date::timestamp at time zone :timezone_string
       ))
       else 
         array_to_json(json_build_object(
-          'location', first_from, --first "from" from note
+          'location', coalesce(lgfrom.name || ', ', '') || first_from, --first "from" from note
           'assignedTime', e.start_date::timestamp at time zone :timezone_string
         ) ||
         array_agg(
           json_build_object(
-            'location', "to",
+            'location', coalesce(lgto.name || ', ', '') || "to",
             'assignedTime', nh.date::timestamp at time zone :timezone_string
           ) ORDER BY nh.date
         ))
     end location_history
   from encounters e
   left join locations l on e.location_id = l.id
+  left join location_groups lg on lg.id = l.location_group_id
   left join note_history nh
   on nh.encounter_id = e.id and nh.place = 'location'
   left join (
@@ -243,9 +244,12 @@ location_info as (
     from note_history nh2
     order by date
     limit 1
-  ) first_from
-  on e.id = first_from.enc_id
-  group by e.id, l.name, e.start_date, first_from
+  ) first_from on e.id = first_from.enc_id
+  left join locations lto on nh."to" = lto.name
+  left join location_groups lgto on lgto.id = lto.location_group_id
+  left join locations lfrom on first_from = lfrom.name
+  left join location_groups lgfrom on lgfrom.id = lfrom.location_group_id
+  group by e.id, lg.name, lgfrom.name, l.name, e.start_date, first_from
 ),
 triage_info as (
   select


### PR DESCRIPTION
### Changes
Update to fiji aspen medici report to return `location_group` in location object like
```
{
              "assignedTime": "2022-06-09T00:02:54+00:00",
              "location": "Emergency area, Emergency room 1"
}
```

### Checklist

- [x] Code
- [x] Tests
- [n/a] UI Screenshots
- [n/a] Update the runbook
- [n/a] Include any config changes in the release PR changelog
- [ ] Update the [release PR](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle) changelog with a ticket reference (e.g. TAN-001 or WAITM-001 will be automatically linked)
- [ ] Add testing notes to the Linear issue
