### PR TITLE
TAN-1911: Write script to rectify Fiji Aspen db record times

### DIFF
--- a/manual_fiji_dst_rectification.sql
+++ b/manual_fiji_dst_rectification.sql
@@ -1,4 +1,11 @@
 -- encounters
+SELECT COUNT(*)
+FROM encounters
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE encounters
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -10,6 +17,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- discharges
+SELECT COUNT(*)
+FROM discharges
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE discharges
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval
@@ -19,6 +33,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- note_pages
+SELECT COUNT(*)
+FROM note_pages
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE note_pages
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -29,6 +50,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- note_items
+SELECT COUNT(*)
+FROM note_items
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE note_items
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -39,6 +67,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- medications
+SELECT COUNT(*)
+FROM encounter_medications
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE encounter_medications
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -50,6 +85,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- lab requests
+SELECT COUNT(*)
+FROM lab_requests
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE lab_requests
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -61,6 +103,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- lab tests
+SELECT COUNT(*)
+FROM lab_tests
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE lab_tests
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -72,6 +121,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- vitals
+SELECT COUNT(*)
+FROM vitals
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE vitals
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -82,6 +138,13 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- imaging requests
+SELECT COUNT(*)
+FROM imaging_requests
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
 UPDATE imaging_requests
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,

--- a/manual_fiji_dst_rectification.sql
+++ b/manual_fiji_dst_rectification.sql
@@ -1,11 +1,67 @@
--- encounters
-SELECT COUNT(*)
+SELECT COUNT(*) AS encounters_count
 FROM encounters
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
       created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
+SELECT COUNT(*) AS discharges_count
+FROM discharges
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS note_pages_count
+FROM note_pages
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS note_items_count
+FROM note_items
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS encounter_medications_count
+FROM encounter_medications
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS lab_requests_count
+FROM lab_requests
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS lab_tests_count
+FROM lab_tests
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS vitals_count
+FROM vitals
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+SELECT COUNT(*) AS imaging_requests_count
+FROM imaging_requests
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- encounters
 UPDATE encounters
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -17,13 +73,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- discharges
-SELECT COUNT(*)
-FROM discharges
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE discharges
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval
@@ -33,13 +82,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- note_pages
-SELECT COUNT(*)
-FROM note_pages
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE note_pages
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -50,13 +92,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- note_items
-SELECT COUNT(*)
-FROM note_items
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE note_items
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -67,13 +102,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- medications
-SELECT COUNT(*)
-FROM encounter_medications
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE encounter_medications
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -85,13 +113,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- lab requests
-SELECT COUNT(*)
-FROM lab_requests
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE lab_requests
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -103,13 +124,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- lab tests
-SELECT COUNT(*)
-FROM lab_tests
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE lab_tests
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -121,13 +135,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- vitals
-SELECT COUNT(*)
-FROM vitals
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE vitals
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,
@@ -138,13 +145,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
 -- imaging requests
-SELECT COUNT(*)
-FROM imaging_requests
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 UPDATE imaging_requests
 SET updated_at = updated_at - '1 hour'::interval,
     created_at = created_at - '1 hour'::interval,

--- a/manual_fiji_dst_rectification.sql
+++ b/manual_fiji_dst_rectification.sql
@@ -105,7 +105,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 -- lab tests
 UPDATE lab_tests
 SET updated_at = current_timestamp(3),
-    date = date::timestamp - '1 hour'::interval,
     completed_date = completed_date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND

--- a/manual_fiji_dst_rectification.sql
+++ b/manual_fiji_dst_rectification.sql
@@ -1,0 +1,92 @@
+-- encounters
+UPDATE encounters
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    start_date = start_date::timestamp - '1 hour'::interval,
+    end_date = end_date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- discharges
+UPDATE discharges
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- note_pages
+UPDATE note_pages
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    date = date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- note_items
+UPDATE note_items
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    date = date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- medications
+UPDATE encounter_medications
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    date = date::timestamp - '1 hour'::interval,
+    end_date = end_date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- lab requests
+UPDATE lab_requests
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    sample_time = sample_time::timestamp - '1 hour'::interval,
+    requested_date = requested_date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- lab tests
+UPDATE lab_tests
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    date = date::timestamp - '1 hour'::interval,
+    completed_date = completed_date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- vitals
+UPDATE vitals
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    date_recorded = date_recorded::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
+
+-- imaging requests
+UPDATE imaging_requests
+SET updated_at = updated_at - '1 hour'::interval,
+    created_at = created_at - '1 hour'::interval,
+    requested_date = requested_date::timestamp - '1 hour'::interval
+WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
+      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
+      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;

--- a/manual_fiji_dst_rectification.sql
+++ b/manual_fiji_dst_rectification.sql
@@ -5,13 +5,6 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
-SELECT COUNT(*) AS discharges_count
-FROM discharges
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 SELECT COUNT(*) AS note_pages_count
 FROM note_pages
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
@@ -63,8 +56,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- encounters
 UPDATE encounters
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     start_date = start_date::timestamp - '1 hour'::interval,
     end_date = end_date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
@@ -72,19 +64,9 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
 
--- discharges
-UPDATE discharges
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval
-WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
-      created_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
-      created_at < '2022-11-14T07:30:00+12:00'::timestamptz;
-
 -- note_pages
 UPDATE note_pages
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     date = date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
@@ -93,8 +75,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- note_items
 UPDATE note_items
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     date = date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
@@ -103,8 +84,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- medications
 UPDATE encounter_medications
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     date = date::timestamp - '1 hour'::interval,
     end_date = end_date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
@@ -114,8 +94,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- lab requests
 UPDATE lab_requests
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     sample_time = sample_time::timestamp - '1 hour'::interval,
     requested_date = requested_date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
@@ -125,8 +104,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- lab tests
 UPDATE lab_tests
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     date = date::timestamp - '1 hour'::interval,
     completed_date = completed_date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
@@ -136,8 +114,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- vitals
 UPDATE vitals
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     date_recorded = date_recorded::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND
@@ -146,8 +123,7 @@ WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
 
 -- imaging requests
 UPDATE imaging_requests
-SET updated_at = updated_at - '1 hour'::interval,
-    created_at = created_at - '1 hour'::interval,
+SET updated_at = current_timestamp(3),
     requested_date = requested_date::timestamp - '1 hour'::interval
 WHERE updated_at >= '2022-11-13T01:00:00+12:00'::timestamptz AND
       updated_at < '2022-11-14T07:30:00+12:00'::timestamptz AND


### PR DESCRIPTION
### Changes

**Don't merge!** This is a script to be run manually in Fiji Aspen to set all the timestamps for everything backwards. We need to do this for complicated client-relationship reasons that Megs understands better than I do. It's in a PR because this way it's easier to review.

Because it's changing updatedAt and createdAt, our plan is to:
1. Take the central server down
2. Apply this to the facility and central DBs so everything ends up in the same state
3. Turn it back on

Review covers both "is this doing what the card asks?", "has Kennedy missed anything really important that makes this a bad idea?", and "is the operational plan sound?"

### Checklist

