### PR TITLE
WAITM-592 Allow finalising patient move immediately from plan move modal

### DIFF
--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -153,7 +153,7 @@ const Text = styled(BodyText)`
   margin-top: -5px;
 `;
 
-export const LocationAvailabilityWarningMessage = ({ locationId }) => {
+export const LocationAvailabilityWarningMessage = ({ locationId, ...props }) => {
   const { data, isSuccess } = useLocationSuggestion(locationId);
 
   if (!isSuccess) {
@@ -164,7 +164,7 @@ export const LocationAvailabilityWarningMessage = ({ locationId }) => {
 
   if (status === LOCATION_AVAILABILITY_STATUS.RESERVED) {
     return (
-      <Text>
+      <Text {...props}>
         <span style={{ color: Colors.alert }}>*</span> This location is reserved by another patient.
         Please ensure the bed is available before confirming.
       </Text>
@@ -173,7 +173,7 @@ export const LocationAvailabilityWarningMessage = ({ locationId }) => {
 
   if (status === LOCATION_AVAILABILITY_STATUS.OCCUPIED) {
     return (
-      <Text>
+      <Text {...props}>
         <span style={{ color: Colors.alert }}>*</span> This location is occupied by another patient.
         Please ensure the bed is available before confirming.
       </Text>

--- a/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
+++ b/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
@@ -15,7 +15,7 @@ import {
 import { ModalActionRow } from '../../../components/ModalActionRow';
 import { useLocalisation } from '../../../contexts/Localisation';
 
-const PatientMoveActions = [
+const patientMoveActionOptions = [
   { label: 'Finalise', value: 'finalise' },
   { label: 'Plan', value: 'plan' },
 ];
@@ -65,7 +65,7 @@ export const BeginPatientMoveModal = React.memo(({ onClose, open, encounter }) =
                   name="action"
                   label="Would you like to finalise or plan the patient move?"
                   component={RadioField}
-                  options={PatientMoveActions}
+                  options={patientMoveActionOptions}
                   style={{ gridColumn: '1/-1' }}
                 />
               </Container>

--- a/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
+++ b/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
@@ -10,17 +10,17 @@ import {
   Modal,
   LocalisedLocationField,
   LocationAvailabilityWarningMessage,
+  RadioField,
 } from '../../../components';
 import { ModalActionRow } from '../../../components/ModalActionRow';
 import { useLocalisation } from '../../../contexts/Localisation';
 
 const Container = styled.div`
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr 1fr;
   grid-row-gap: 20px;
-  padding-bottom: 75px;
-  max-width: 360px;
-  margin: 30px auto 40px;
+  margin: 30px auto 20px;
+  grid-column-gap: 30px;
 `;
 
 const Text = styled(BodyText)`
@@ -33,15 +33,7 @@ export const BeginPatientMoveModal = React.memo(({ onClose, open, encounter }) =
   const { getLocalisation } = useLocalisation();
   const plannedMoveTimeoutHours = getLocalisation('templates.plannedMoveTimeoutHours');
   return (
-    <Modal title="Plan patient move" open={open} onClose={onClose}>
-      <Text>
-        Select a location to plan the patient move and reserve a bed. The new location will not be
-        reflected in the patient encounter until you finalise the move.
-        <br />
-        <br />
-        If the move is not finalised within {plannedMoveTimeoutHours} hours, the location will be
-        deemed ‘Available’ again.
-      </Text>
+    <Modal title="Move patient" open={open} onClose={onClose}>
       <Form
         initialValues={{ plannedLocationId: encounter.plannedLocationId }}
         onSubmit={submit}
@@ -54,6 +46,21 @@ export const BeginPatientMoveModal = React.memo(({ onClose, open, encounter }) =
               <Container>
                 <Field name="plannedLocationId" component={LocalisedLocationField} required />
                 <LocationAvailabilityWarningMessage locationId={values?.plannedLocationId} />
+                <Field
+                  name="action"
+                  label="Would you like to finalise or plan the patient move?"
+                  component={RadioField}
+                  options={[
+                    { label: 'Finalise', value: 0 },
+                    { label: 'Plan', value: 1 },
+                  ]}
+                  style={{ gridColumn: '1/-1' }}
+                />
+                <Text fullWidth>
+                  By selecting ‘Plan’ the new location will not be reflected in the patient
+                  encounter until you finalise the move. If the move is not finalised within{' '}
+                  {plannedMoveTimeoutHours} hours, the location will be deemed ‘Available’ again.
+                </Text>
               </Container>
               <ModalActionRow confirmText="Confirm" onConfirm={submitForm} onCancel={onClose} />
             </>

--- a/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
+++ b/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
@@ -60,7 +60,10 @@ export const BeginPatientMoveModal = React.memo(({ onClose, open, encounter }) =
             <>
               <Container>
                 <Field name="plannedLocationId" component={LocalisedLocationField} required />
-                <LocationAvailabilityWarningMessage locationId={values?.plannedLocationId} />
+                <LocationAvailabilityWarningMessage
+                  locationId={values?.plannedLocationId}
+                  style={{ gridColumn: '2', marginTop: '-35px', fontSize: '12px' }}
+                />
                 <Field
                   name="action"
                   label="Would you like to finalise or plan the patient move?"

--- a/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
+++ b/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
@@ -23,8 +23,8 @@ const PatientMoveActions = [
 const Container = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-row-gap: 20px;
-  margin: 30px auto 20px;
+  grid-row-gap: 35px;
+  margin: 20px auto 20px;
   grid-column-gap: 30px;
 `;
 

--- a/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
+++ b/packages/desktop/app/views/patients/components/BeginPatientMoveModal.js
@@ -30,6 +30,7 @@ const Container = styled.div`
 
 const Text = styled(BodyText)`
   color: ${props => props.theme.palette.text.secondary};
+  padding-bottom: 20px;
 `;
 
 export const BeginPatientMoveModal = React.memo(({ onClose, open, encounter }) => {


### PR DESCRIPTION
### Changes

- Re-title modal to "Move patient"
- Add radio buttons for Finalise/Plan
- Update `onSubmit` to swap `locationId` and `plannedLocationId` depending on actions 

### Checklist

- [X] Code is finished
- [X] UI Screenshots added to the Linear issue
- [X] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
