### PR TITLE
WAITM-591: Add option to filter areas by facility on surveys

### DIFF
--- a/packages/desktop/app/api/suggesters.js
+++ b/packages/desktop/app/api/suggesters.js
@@ -22,7 +22,5 @@ export const usePatientSuggester = () => {
 
 export const useLocationGroupSuggester = () => {
   const api = useApi();
-  return new Suggester(api, 'locationGroup', {
-    baseQueryParameters: { filterByFacility: true },
-  });
+  return new Suggester(api, 'facilityLocationGroup');
 };

--- a/packages/desktop/app/api/suggesters.js
+++ b/packages/desktop/app/api/suggesters.js
@@ -19,8 +19,3 @@ export const usePatientSuggester = () => {
     }),
   });
 };
-
-export const useLocationGroupSuggester = () => {
-  const api = useApi();
-  return new Suggester(api, 'facilityLocationGroup');
-};

--- a/packages/desktop/app/components/Appointments/AppointmentForm.js
+++ b/packages/desktop/app/components/Appointments/AppointmentForm.js
@@ -1,13 +1,11 @@
 import React, { useCallback } from 'react';
 import * as yup from 'yup';
-
 import { APPOINTMENT_STATUSES } from 'shared/constants';
 import { FormGrid } from '../FormGrid';
 import { Field, Form, AutocompleteField, SelectField, DateTimeField } from '../Field';
 import { ConfirmCancelRow } from '../ButtonRow';
 import { FormSeparatorLine } from '../FormSeparatorLine';
-
-import { useApi, useLocationGroupSuggester, usePatientSuggester, useSuggester } from '../../api';
+import { useApi, usePatientSuggester, useSuggester } from '../../api';
 import { appointmentTypeOptions } from '../../constants';
 
 export const AppointmentForm = props => {
@@ -16,7 +14,7 @@ export const AppointmentForm = props => {
   const isUpdating = !!appointment;
   const clinicianSuggester = useSuggester('practitioner');
   const patientSuggester = usePatientSuggester();
-  const locationGroupSuggester = useLocationGroupSuggester();
+  const locationGroupSuggester = useSuggester('facilityLocationGroup');
 
   let initialValues = {};
   if (isUpdating) {

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { LOCATION_AVAILABILITY_TAG_CONFIG, LOCATION_AVAILABILITY_STATUS } from 'shared/constants';
 import { AutocompleteInput } from './AutocompleteField';
-import { useApi, useLocationGroupSuggester } from '../../api';
+import { useApi, useSuggester } from '../../api';
 import { Suggester } from '../../utils/suggester';
 import { useLocalisation } from '../../contexts/Localisation';
 import { Colors } from '../../constants';
@@ -53,7 +53,7 @@ export const LocationInput = React.memo(
     const [groupId, setGroupId] = useState('');
     const [locationId, setLocationId] = useState(value);
     const suggester = locationSuggester(api, groupId);
-    const locationGroupSuggester = useLocationGroupSuggester();
+    const locationGroupSuggester = useSuggester('facilityLocationGroup');
     const { data } = useLocationSuggestion(locationId);
 
     // when the location is selected, set the group value automatically if it's not set yet

--- a/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
+++ b/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
@@ -13,7 +13,8 @@ const getSuggesterEndpointForConfig = config => {
   if (config?.source === 'Location') return 'location';
   if (config?.source === 'Department') return 'department';
   if (config?.source === 'User') return 'practitioner';
-  if (config?.source === 'LocationGroup') return 'locationGroup';
+  if (config?.source === 'LocationGroup') return 'facilityLocationGroup';
+  if (config?.source === 'AllLocationGroups') return 'locationGroup';
 
   // autocomplete component won't crash when given an invalid endpoint, it just logs an error.
   return null;

--- a/packages/desktop/app/components/SearchBar/AppointmentsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AppointmentsSearchBar.js
@@ -3,11 +3,11 @@ import { startOfDay } from 'date-fns';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { DateTimeField, AutocompleteField, LocalisedField, SelectField } from '../Field';
 import { appointmentTypeOptions, appointmentStatusOptions } from '../../constants';
-import { useLocationGroupSuggester, useSuggester } from '../../api';
+import { useSuggester } from '../../api';
 
 export const AppointmentsSearchBar = ({ onSearch }) => {
   const practitionerSuggester = useSuggester('practitioner');
-  const locationGroupSuggester = useLocationGroupSuggester();
+  const locationGroupSuggester = useSuggester('facilityLocationGroup');
 
   return (
     <CustomisableSearchBar

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -26,7 +26,7 @@ import {
   DateTimeField,
   TextField,
 } from '../../components/Field';
-import { useApi, useSuggester, useLocationGroupSuggester } from '../../api';
+import { useApi, useSuggester } from '../../api';
 import { ImagingRequestPrintout } from '../../components/PatientPrinting/ImagingRequestPrintout';
 import { useLocalisation } from '../../contexts/Localisation';
 import { ENCOUNTER_TAB_NAMES } from './encounterTabNames';
@@ -84,7 +84,7 @@ const PrintButton = ({ imagingRequest, patient }) => {
 };
 
 const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imagingTypes }) => {
-  const locationGroupSuggester = useLocationGroupSuggester();
+  const locationGroupSuggester = useSuggester('facilityLocationGroup');
 
   return (
     <FormGrid columns={3}>

--- a/packages/desktop/app/views/scheduling/AppointmentsCalendar.js
+++ b/packages/desktop/app/views/scheduling/AppointmentsCalendar.js
@@ -14,7 +14,7 @@ import { Button } from '../../components/Button';
 import { AutocompleteInput, MultiselectInput } from '../../components/Field';
 import { Suggester } from '../../utils/suggester';
 import { Colors, appointmentTypeOptions } from '../../constants';
-import { useApi, useLocationGroupSuggester } from '../../api';
+import { useApi, useSuggester } from '../../api';
 
 const LeftContainer = styled.div`
   min-height: 100vh;
@@ -74,7 +74,7 @@ const TodayButton = styled(Button)`
 
 export const AppointmentsCalendar = () => {
   const api = useApi();
-  const locationGroupSuggester = useLocationGroupSuggester();
+  const locationGroupSuggester = useSuggester('facilityLocationGroup');
 
   const [date, setDate] = useState(new Date());
   const [filterValue, setFilterValue] = useState('');

--- a/packages/lan/app/routes/apiv1/suggestions.js
+++ b/packages/lan/app/routes/apiv1/suggestions.js
@@ -198,6 +198,11 @@ createAllRecordsSuggesterRoute('locationGroup', 'LocationGroup', VISIBILITY_CRIT
 
 createNameSuggester('locationGroup', 'LocationGroup', filterByFacilityWhereBuilder);
 
+// Location groups filtered by facility. Used in the survey form autocomplete
+createNameSuggester('facilityLocationGroup', 'LocationGroup', (search, query) =>
+  filterByFacilityWhereBuilder(search, { ...query, filterByFacility: true }),
+);
+
 createSuggester(
   'survey',
   'Survey',


### PR DESCRIPTION
### Changes

Add option to filter areas by facility on surveys.

### Checklist

- [x] Code is finished
- na Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
