### PR TITLE
EPI-305: Mark patient for sync on creating encounters etc.

### DIFF
--- a/packages/desktop/app/store/patient.js
+++ b/packages/desktop/app/store/patient.js
@@ -30,7 +30,7 @@ export const syncPatient = () => async (dispatch, getState, { api }) => {
     type: PATIENT_SYNCING,
     data: true,
   });
-  await api.put(`patient/${patient.id}`, { markedForSync: true });
+  await api.post(`patientFacility`, { patientId: patient.id });
   dispatch(reloadPatient(patient.id));
 
   // typically it takes a while for sync to complete

--- a/packages/lan/__mocks__/config.js
+++ b/packages/lan/__mocks__/config.js
@@ -1,6 +1,0 @@
-const actual = jest.requireActual('config');
-const foo = {
-  ...actual,
-  serverFacilityId: 'ref/facility/ba',
-};
-export default foo;

--- a/packages/lan/__tests__/apiv1/Patient.test.js
+++ b/packages/lan/__tests__/apiv1/Patient.test.js
@@ -23,7 +23,7 @@ describe('Patient', () => {
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
     // set up facility for patient to be marked for sync at
-    await models.Facility.create(fake(models.Facility, { id: config.serverFacilityId }));
+    await models.Facility.findOne({ where: { id: config.serverFacilityId } });
     patient = await models.Patient.create(await createDummyPatient(models));
   });
   afterAll(() => ctx.close());

--- a/packages/lan/__tests__/apiv1/Patient.test.js
+++ b/packages/lan/__tests__/apiv1/Patient.test.js
@@ -22,8 +22,6 @@ describe('Patient', () => {
     baseApp = ctx.baseApp;
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
-    // set up facility for patient to be marked for sync at
-    await models.Facility.findOne({ where: { id: config.serverFacilityId } });
     patient = await models.Patient.create(await createDummyPatient(models));
   });
   afterAll(() => ctx.close());

--- a/packages/lan/__tests__/apiv1/Triage.test.js
+++ b/packages/lan/__tests__/apiv1/Triage.test.js
@@ -25,8 +25,8 @@ describe('Triage', () => {
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
 
-    facility = await models.Facility.create({
-      ...fake(models.Facility, { id: config.serverFacilityId }),
+    facility = await models.Facility.findOne({
+      where: { id: config.serverFacilityId },
     });
 
     [emergencyDepartment] = await models.Department.upsert({

--- a/packages/lan/__tests__/sync/onSaveMarkPatientForSync.test.js
+++ b/packages/lan/__tests__/sync/onSaveMarkPatientForSync.test.js
@@ -1,0 +1,192 @@
+import { beforeAll, describe, it } from '@jest/globals';
+
+import { fake, fakeReferenceData } from 'shared/test-helpers/fake';
+
+import { createTestContext } from '../utilities';
+
+const fakeRecordFnByMarkForSyncModel = {
+  DocumentMetadata: async (models, patientId) => {
+    const { DocumentMetadata } = models;
+    return fake(DocumentMetadata, { patientId });
+  },
+  Encounter: async (models, patientId) => {
+    const { Facility, Location, Department, User, Encounter } = models;
+    const facility = await Facility.create(fake(Facility));
+    const location = await Location.create(fake(Location, { facilityId: facility.id }));
+    const department = await Department.create(fake(Department, { facilityId: facility.id }));
+    const user = await User.create(fake(User));
+    return fake(Encounter, {
+      patientId,
+      locationId: location.id,
+      departmentId: department.id,
+      examinerId: user.id,
+    });
+  },
+  PatientAdditionalData: async (models, patientId) => {
+    const { PatientAdditionalData } = models;
+    return fake(PatientAdditionalData, { patientId });
+  },
+  PatientAllergy: async (models, patientId) => {
+    const { PatientAllergy, User, ReferenceData } = models;
+    const user = await User.create(fake(User));
+    const allergy = await ReferenceData.create(fakeReferenceData());
+    return fake(PatientAllergy, { patientId, practitionerId: user.id, allergyId: allergy.id });
+  },
+  PatientBirthData: async (models, patientId) => {
+    const { PatientBirthData } = models;
+    return fake(PatientBirthData, { patientId });
+  },
+  PatientCarePlan: async (models, patientId) => {
+    const { PatientCarePlan, ReferenceData, User } = models;
+    const user = await User.create(fake(User));
+    const carePlan = await ReferenceData.create(fakeReferenceData());
+    return fake(PatientCarePlan, { patientId, examinerId: user.id, carePlanId: carePlan.id });
+  },
+  PatientCondition: async (models, patientId) => {
+    const { PatientCondition, ReferenceData, User } = models;
+    const user = await User.create(fake(User));
+    const condition = await ReferenceData.create(fakeReferenceData());
+    return fake(PatientCondition, { patientId, examinerId: user.id, conditionId: condition.id });
+  },
+  PatientDeathData: async (models, patientId) => {
+    const { PatientDeathData, User } = models;
+    const user = await User.create(fake(User));
+    return fake(PatientDeathData, {
+      patientId,
+      clinicianId: user.id,
+      recentSurgery: 'yes',
+      wasPregnant: 'yes',
+      pregnancyContributed: 'yes',
+      stillborn: 'yes',
+    });
+  },
+  PatientFamilyHistory: async (models, patientId) => {
+    const { PatientFamilyHistory, ReferenceData, User } = models;
+    const user = await User.create(fake(User));
+    const diagnosis = await ReferenceData.create(fakeReferenceData());
+    return fake(PatientFamilyHistory, {
+      patientId,
+      practitionerId: user.id,
+      diagnosisId: diagnosis.id,
+    });
+  },
+  // PatientFieldValue: async (models, patientId) => {
+  //   const { PatientFieldValue, PatientFieldDefinition } = models;
+  //   const definition = await PatientFieldDefinition.create(
+  //     fake(PatientFieldDefinition, {
+  //       fieldType: 'string',
+  //       visibilityStatus: 'current',
+  //     }),
+  //   );
+  //   return PatientFieldValue.create(
+  //     fake(PatientFieldValue, { patientId, definitionId: definition.id }),
+  //   );
+  // },
+  // PatientIssue: async (models, patientId) => {
+  //   const { PatientIssue } = models;
+  //   return PatientIssue.create(fake(PatientIssue, { patientId, type: 'issue' }));
+  // },
+  // PatientSecondaryId: async (models, patientId) => {
+  //   const { PatientSecondaryId } = models;
+  //   return PatientSecondaryId.create(fake(PatientSecondaryId, { patientId }));
+  // },
+};
+
+describe('databaseState', () => {
+  let ctx, models, Patient, PatientFacility;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    Patient = models.Patient;
+    PatientFacility = models.PatientFacility;
+  });
+
+  afterAll(() => ctx.close());
+
+  const expectPatientFacility = async (patientId, toExist) => {
+    const patientFacility = await PatientFacility.findOne({
+      where: {
+        patientId,
+        facilityId: 'balwyn',
+      },
+    });
+    if (toExist) {
+      expect(patientFacility).toBeTruthy();
+    } else {
+      expect(patientFacility).toBeFalsy();
+    }
+  };
+
+  it('creating a patient marks them for sync', async () => {
+    const patient = await Patient.create(fake(Patient));
+    await expectPatientFacility(patient.id, true);
+  });
+
+  it('creating a patient via bulk create does not mark them for sync', async () => {
+    // this tests that when they get bulk created during the sync pull process they are not
+    // immediately marked for sync
+    const patient = fake(Patient);
+    await Patient.bulkCreate([fake(Patient)]);
+    await expectPatientFacility(patient.id, false);
+  });
+
+  it('updating a patient via modify-then-save marks them for sync', async () => {
+    // create a patient without using hooks so we don't mark them for sync on create
+    const patient = await Patient.create(fake(Patient), {
+      hooks: false,
+    });
+    await expectPatientFacility(patient.id, false);
+    patient.firstName = 'Change';
+    await patient.save();
+    await expectPatientFacility(patient.id, true);
+  });
+
+  it('updating a patient via update() marks them for sync', async () => {
+    // create a patient without using hooks so we don't mark them for sync on create
+    const patient = await Patient.create(fake(Patient), {
+      hooks: false,
+    });
+    await expectPatientFacility(patient.id, false);
+    await patient.update({ firstName: 'Change' });
+    await expectPatientFacility(patient.id, true);
+  });
+
+  it('updating a patient via bulk update does not mark them for sync', async () => {
+    // create a patient without using hooks so we don't mark them for sync on create
+    const patient = await Patient.create(fake(Patient), {
+      hooks: false,
+    });
+    await expectPatientFacility(patient.id, false);
+    await Patient.update({ firstName: 'Change' }, { where: { id: patient.id } });
+    await expectPatientFacility(patient.id, false);
+  });
+
+  it('creating a record in a relevant table marks the patient for sync', async () => {
+    for (const [modelName, fakeRecord] of Object.entries(fakeRecordFnByMarkForSyncModel)) {
+      // create a patient without using hooks so we don't mark them for sync on create
+      const patient = await Patient.create(fake(Patient), {
+        hooks: false,
+      });
+      await expectPatientFacility(patient.id, false);
+      const record = await fakeRecord(models, patient.id);
+      await models[modelName].create(record);
+      await expectPatientFacility(patient.id, true);
+    }
+  });
+
+  it('bulk creating records in a relevant table does not mark the patient for sync', async () => {
+    // this tests that when they get bulk created during the sync pull process the patient is not
+    // immediately marked for sync
+    for (const [modelName, fakeRecord] of Object.entries(fakeRecordFnByMarkForSyncModel)) {
+      // create a patient without using hooks so we don't mark them for sync on create
+      const patient = await Patient.create(fake(Patient), {
+        hooks: false,
+      });
+      await expectPatientFacility(patient.id, false);
+      const record = await fakeRecord(models, patient.id);
+      await models[modelName].bulkCreate([record]);
+      await expectPatientFacility(patient.id, false);
+    }
+  });
+});

--- a/packages/lan/app/routes/apiv1/index.js
+++ b/packages/lan/app/routes/apiv1/index.js
@@ -23,6 +23,7 @@ import { medication } from './medication';
 import { notePages } from './note';
 import { ongoingCondition } from './ongoingCondition';
 import { patient, patientCarePlan, patientIssue, patientFieldDefinition } from './patient';
+import { patientFacility } from './patientFacility';
 import { procedure } from './procedure';
 import { program } from './program';
 import { referenceData } from './referenceData';
@@ -101,3 +102,4 @@ referenceDataRoutes.use('/user', user);
 // sync endpoints
 syncRoutes.use('/sync', sync);
 syncRoutes.use('/syncHealth', syncHealth);
+syncRoutes.use('/patientFacility', patientFacility);

--- a/packages/lan/app/routes/apiv1/index.js
+++ b/packages/lan/app/routes/apiv1/index.js
@@ -41,6 +41,9 @@ import { user } from './user';
 import { vitals } from './vitals';
 
 export const apiv1 = express.Router();
+const patientDataRoutes = express.Router();
+const referenceDataRoutes = express.Router();
+const syncRoutes = express.Router();
 
 // auth endpoints (added pre auth check)
 apiv1.post('/login', loginHandler);
@@ -50,47 +53,51 @@ apiv1.use('/changePassword', changePassword);
 apiv1.use(authMiddleware);
 apiv1.use(constructPermission);
 
-// patient data endpoints
-apiv1.use('/allergy', allergy);
-apiv1.use('/appointments', appointments);
-apiv1.use('/diagnosis', diagnosis);
-apiv1.use('/encounter', encounter);
-apiv1.use('/familyHistory', familyHistory);
-apiv1.use('/imagingRequest', imagingRequest);
-apiv1.use('/invoices', invoices);
-apiv1.use('/labRequest', labRequest);
-apiv1.use('/labTest', labTest);
-apiv1.use('/medication', medication);
-apiv1.use('/notePages', notePages);
-apiv1.use('/ongoingCondition', ongoingCondition);
-apiv1.use('/patient', patient);
-apiv1.use('/patientCarePlan', patientCarePlan);
-apiv1.use('/patientIssue', patientIssue);
-apiv1.use('/procedure', procedure);
-apiv1.use('/referral', referral);
-apiv1.use('/surveyResponse', surveyResponse);
-apiv1.use('/triage', triage);
-apiv1.use('/vitals', vitals);
+apiv1.use(patientDataRoutes); // see below for specifics
+apiv1.use(referenceDataRoutes); // see below for specifics
+apiv1.use(syncRoutes); // see below for specifics
 
-// system/reference data endpoints
-apiv1.use('/asset', asset);
-apiv1.use('/attachment', attachment);
-apiv1.use('/certificateNotification', certificateNotification);
-apiv1.use('/department', department);
-apiv1.use('/invoiceLineTypes', invoiceLineTypes);
-apiv1.use('/labRequestLog', labRequestLog);
-apiv1.use('/location', location);
-apiv1.use('/locationGroup', locationGroup);
-apiv1.use('/patientFieldDefinition', patientFieldDefinition);
-apiv1.use('/program', program);
-apiv1.use('/referenceData', referenceData);
-apiv1.use('/reportRequest', reportRequest);
-apiv1.use('/reports', reports);
-apiv1.use('/scheduledVaccine', scheduledVaccine);
-apiv1.use('/suggestions', suggestions);
-apiv1.use('/survey', survey);
-apiv1.use('/user', user);
+// patient data endpoints
+patientDataRoutes.use('/allergy', allergy);
+patientDataRoutes.use('/appointments', appointments);
+patientDataRoutes.use('/diagnosis', diagnosis);
+patientDataRoutes.use('/encounter', encounter);
+patientDataRoutes.use('/familyHistory', familyHistory);
+patientDataRoutes.use('/imagingRequest', imagingRequest);
+patientDataRoutes.use('/invoices', invoices);
+patientDataRoutes.use('/labRequest', labRequest);
+patientDataRoutes.use('/labTest', labTest);
+patientDataRoutes.use('/medication', medication);
+patientDataRoutes.use('/notePages', notePages);
+patientDataRoutes.use('/ongoingCondition', ongoingCondition);
+patientDataRoutes.use('/patient', patient);
+patientDataRoutes.use('/patientCarePlan', patientCarePlan);
+patientDataRoutes.use('/patientIssue', patientIssue);
+patientDataRoutes.use('/procedure', procedure);
+patientDataRoutes.use('/referral', referral);
+patientDataRoutes.use('/surveyResponse', surveyResponse);
+patientDataRoutes.use('/triage', triage);
+patientDataRoutes.use('/vitals', vitals);
+
+// reference data endpoints
+referenceDataRoutes.use('/asset', asset);
+referenceDataRoutes.use('/attachment', attachment);
+referenceDataRoutes.use('/certificateNotification', certificateNotification);
+referenceDataRoutes.use('/department', department);
+referenceDataRoutes.use('/invoiceLineTypes', invoiceLineTypes);
+referenceDataRoutes.use('/labRequestLog', labRequestLog);
+referenceDataRoutes.use('/location', location);
+referenceDataRoutes.use('/locationGroup', locationGroup);
+referenceDataRoutes.use('/patientFieldDefinition', patientFieldDefinition);
+referenceDataRoutes.use('/program', program);
+referenceDataRoutes.use('/referenceData', referenceData);
+referenceDataRoutes.use('/reportRequest', reportRequest);
+referenceDataRoutes.use('/reports', reports);
+referenceDataRoutes.use('/scheduledVaccine', scheduledVaccine);
+referenceDataRoutes.use('/suggestions', suggestions);
+referenceDataRoutes.use('/survey', survey);
+referenceDataRoutes.use('/user', user);
 
 // sync endpoints
-apiv1.use('/sync', sync);
-apiv1.use('/syncHealth', syncHealth);
+syncRoutes.use('/sync', sync);
+syncRoutes.use('/syncHealth', syncHealth);

--- a/packages/lan/app/routes/apiv1/index.js
+++ b/packages/lan/app/routes/apiv1/index.js
@@ -3,46 +3,46 @@ import express from 'express';
 import { constructPermission } from 'shared/permissions/middleware';
 import { loginHandler, authMiddleware } from '../../middleware/auth';
 
-import { user } from './user';
-import { patient, patientCarePlan, patientIssue, patientFieldDefinition } from './patient';
-import { encounter } from './encounter';
-import { vitals } from './vitals';
-import { procedure } from './procedure';
-import { suggestions } from './suggestions';
-import { triage } from './triage';
-import { referenceData } from './referenceData';
-import { diagnosis } from './diagnosis';
-import { medication } from './medication';
 import { allergy } from './allergy';
-import { ongoingCondition } from './ongoingCondition';
+import { appointments } from './appointments';
+import { asset } from './asset';
+import { attachment } from './attachment';
+import { certificateNotification } from './certificateNotification';
+import { changePassword } from './changePassword';
+import { department } from './department';
+import { diagnosis } from './diagnosis';
+import { encounter } from './encounter';
 import { familyHistory } from './familyHistory';
+import { imagingRequest } from './imaging';
+import { invoices, invoiceLineTypes } from './invoice';
 import { labRequest, labTest } from './labs';
 import { labRequestLog } from './labRequestLog';
-import { program } from './program';
-import { survey } from './survey';
-import { surveyResponse } from './surveyResponse';
-import { referral } from './referral';
-import { imagingRequest } from './imaging';
-import { reports } from './reports';
-import { reportRequest } from './reportRequest';
-import { appointments } from './appointments';
-import { invoices, invoiceLineTypes } from './invoice';
-import { notePages } from './note';
-import { resetPassword } from './resetPassword';
-import { changePassword } from './changePassword';
-import { certificateNotification } from './certificateNotification';
-
-import { asset } from './asset';
-import { department } from './department';
 import { location } from './location';
 import { locationGroup } from './locationGroup';
-import { attachment } from './attachment';
+import { medication } from './medication';
+import { notePages } from './note';
+import { ongoingCondition } from './ongoingCondition';
+import { patient, patientCarePlan, patientIssue, patientFieldDefinition } from './patient';
+import { procedure } from './procedure';
+import { program } from './program';
+import { referenceData } from './referenceData';
+import { referral } from './referral';
+import { reportRequest } from './reportRequest';
+import { reports } from './reports';
+import { resetPassword } from './resetPassword';
 import { scheduledVaccine } from './scheduledVaccine';
+import { suggestions } from './suggestions';
+import { survey } from './survey';
+import { surveyResponse } from './surveyResponse';
 import { sync } from './sync';
 import { syncHealth } from './syncHealth';
+import { triage } from './triage';
+import { user } from './user';
+import { vitals } from './vitals';
 
 export const apiv1 = express.Router();
 
+// auth endpoints (added pre auth check)
 apiv1.post('/login', loginHandler);
 apiv1.use('/resetPassword', resetPassword);
 apiv1.use('/changePassword', changePassword);
@@ -50,50 +50,47 @@ apiv1.use('/changePassword', changePassword);
 apiv1.use(authMiddleware);
 apiv1.use(constructPermission);
 
-apiv1.use('/suggestions', suggestions);
-apiv1.use('/user', user);
-apiv1.use('/patient', patient);
-apiv1.use('/encounter', encounter);
-apiv1.use('/vitals', vitals);
-apiv1.use('/procedure', procedure);
-apiv1.use('/triage', triage);
-apiv1.use('/referenceData', referenceData);
-apiv1.use('/diagnosis', diagnosis);
-apiv1.use('/patientIssue', patientIssue);
-apiv1.use('/familyHistory', familyHistory);
+// patient data endpoints
 apiv1.use('/allergy', allergy);
-apiv1.use('/ongoingCondition', ongoingCondition);
-apiv1.use('/medication', medication);
+apiv1.use('/appointments', appointments);
+apiv1.use('/diagnosis', diagnosis);
+apiv1.use('/encounter', encounter);
+apiv1.use('/familyHistory', familyHistory);
+apiv1.use('/imagingRequest', imagingRequest);
+apiv1.use('/invoices', invoices);
 apiv1.use('/labRequest', labRequest);
 apiv1.use('/labTest', labTest);
-apiv1.use('/labRequestLog', labRequestLog);
-apiv1.use('/referral', referral);
-apiv1.use('/imagingRequest', imagingRequest);
-apiv1.use('/scheduledVaccine', scheduledVaccine);
-apiv1.use('/program', program);
-apiv1.use('/survey', survey);
-apiv1.use('/surveyResponse', surveyResponse);
-apiv1.use('/certificateNotification', certificateNotification);
-
-apiv1.use('/reports', reports);
-apiv1.use('/reportRequest', reportRequest);
-apiv1.use('/patientCarePlan', patientCarePlan);
-apiv1.use('/patientFieldDefinition', patientFieldDefinition);
-apiv1.use('/appointments', appointments);
-
-apiv1.use('/invoices', invoices);
-apiv1.use('/invoiceLineTypes', invoiceLineTypes);
-
+apiv1.use('/medication', medication);
 apiv1.use('/notePages', notePages);
+apiv1.use('/ongoingCondition', ongoingCondition);
+apiv1.use('/patient', patient);
+apiv1.use('/patientCarePlan', patientCarePlan);
+apiv1.use('/patientIssue', patientIssue);
+apiv1.use('/procedure', procedure);
+apiv1.use('/referral', referral);
+apiv1.use('/surveyResponse', surveyResponse);
+apiv1.use('/triage', triage);
+apiv1.use('/vitals', vitals);
 
+// system/reference data endpoints
 apiv1.use('/asset', asset);
-
+apiv1.use('/attachment', attachment);
+apiv1.use('/certificateNotification', certificateNotification);
 apiv1.use('/department', department);
+apiv1.use('/invoiceLineTypes', invoiceLineTypes);
+apiv1.use('/labRequestLog', labRequestLog);
 apiv1.use('/location', location);
 apiv1.use('/locationGroup', locationGroup);
+apiv1.use('/patientFieldDefinition', patientFieldDefinition);
+apiv1.use('/program', program);
+apiv1.use('/referenceData', referenceData);
+apiv1.use('/reportRequest', reportRequest);
+apiv1.use('/reports', reports);
+apiv1.use('/scheduledVaccine', scheduledVaccine);
+apiv1.use('/suggestions', suggestions);
+apiv1.use('/survey', survey);
+apiv1.use('/user', user);
 
-apiv1.use('/attachment', attachment);
-
+// sync endpoints
 apiv1.use('/sync', sync);
-
 apiv1.use('/syncHealth', syncHealth);

--- a/packages/lan/app/routes/apiv1/patient/patient.js
+++ b/packages/lan/app/routes/apiv1/patient/patient.js
@@ -19,8 +19,6 @@ import { getOrderClause } from '../../../database/utils';
 import { requestBodyToRecord, dbRecordToResponse, pickPatientBirthData } from './utils';
 import { PATIENT_SORT_KEYS } from './constants';
 
-const { serverFacilityId } = config;
-
 const patientRoute = express.Router();
 
 patientRoute.get(

--- a/packages/lan/app/routes/apiv1/patient/patient.js
+++ b/packages/lan/app/routes/apiv1/patient/patient.js
@@ -2,7 +2,6 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import config from 'config';
 import { QueryTypes, Op } from 'sequelize';
-import { isEqual } from 'lodash';
 
 import { NotFoundError } from 'shared/errors';
 import { PATIENT_REGISTRY_TYPES, VISIBILITY_STATUSES } from 'shared/constants';
@@ -46,15 +45,8 @@ patientRoute.put(
   asyncHandler(async (req, res) => {
     const {
       db,
-      models: {
-        Patient,
-        PatientAdditionalData,
-        PatientBirthData,
-        PatientFacility,
-        PatientSecondaryId,
-      },
+      models: { Patient, PatientAdditionalData, PatientBirthData, PatientSecondaryId },
       params,
-      syncManager,
     } = req;
     req.checkPermission('read', 'Patient');
     const patient = await Patient.findByPk(params.id);
@@ -63,63 +55,49 @@ patientRoute.put(
       throw new NotFoundError();
     }
 
-    const alreadyMarkedForSync = await PatientFacility.findOne({
-      where: { patientId: patient.id, facilityId: serverFacilityId },
+    req.checkPermission('write', patient);
+
+    await db.transaction(async () => {
+      // First check if displayId changed to create a secondaryId record
+      if (req.body.displayId && req.body.displayId !== patient.displayId) {
+        const oldDisplayIdType = isGeneratedDisplayId(patient.displayId)
+          ? 'secondaryIdType-tamanu-display-id'
+          : 'secondaryIdType-nhn';
+        await PatientSecondaryId.create({
+          value: patient.displayId,
+          visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
+          typeId: oldDisplayIdType,
+          patientId: patient.id,
+        });
+      }
+
+      await patient.update(requestBodyToRecord(req.body));
+
+      const patientAdditionalData = await PatientAdditionalData.findOne({
+        where: { patientId: patient.id },
+      });
+
+      if (!patientAdditionalData) {
+        await PatientAdditionalData.create({
+          ...requestBodyToRecord(req.body),
+          patientId: patient.id,
+        });
+      } else {
+        await patientAdditionalData.update(requestBodyToRecord(req.body));
+      }
+
+      const patientBirth = await PatientBirthData.findOne({
+        where: { patientId: patient.id },
+      });
+      const recordData = requestBodyToRecord(req.body);
+      const patientBirthRecordData = pickPatientBirthData(PatientBirthData, recordData);
+
+      if (patientBirth) {
+        await patientBirth.update(patientBirthRecordData);
+      }
+
+      await patient.writeFieldValues(req.body.patientFields);
     });
-    const markingForSync = !alreadyMarkedForSync && isEqual(req.body, { markedForSync: true });
-    if (markingForSync) {
-      // no need to check write permission or update patient record itself,
-      // just create a link between the patient and this facility
-      await PatientFacility.create({
-        patientId: patient.id,
-        facilityId: serverFacilityId,
-      });
-      syncManager.triggerSync();
-    } else {
-      req.checkPermission('write', patient);
-
-      await db.transaction(async () => {
-        // First check if displayId changed to create a secondaryId record
-        if (req.body.displayId && req.body.displayId !== patient.displayId) {
-          const oldDisplayIdType = isGeneratedDisplayId(patient.displayId)
-            ? 'secondaryIdType-tamanu-display-id'
-            : 'secondaryIdType-nhn';
-          await PatientSecondaryId.create({
-            value: patient.displayId,
-            visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
-            typeId: oldDisplayIdType,
-            patientId: patient.id,
-          });
-        }
-
-        await patient.update(requestBodyToRecord(req.body));
-
-        const patientAdditionalData = await PatientAdditionalData.findOne({
-          where: { patientId: patient.id },
-        });
-
-        if (!patientAdditionalData) {
-          await PatientAdditionalData.create({
-            ...requestBodyToRecord(req.body),
-            patientId: patient.id,
-          });
-        } else {
-          await patientAdditionalData.update(requestBodyToRecord(req.body));
-        }
-
-        const patientBirth = await PatientBirthData.findOne({
-          where: { patientId: patient.id },
-        });
-        const recordData = requestBodyToRecord(req.body);
-        const patientBirthRecordData = pickPatientBirthData(PatientBirthData, recordData);
-
-        if (patientBirth) {
-          await patientBirth.update(patientBirthRecordData);
-        }
-
-        await patient.writeFieldValues(req.body.patientFields);
-      });
-    }
 
     res.send(dbRecordToResponse(patient));
   }),
@@ -130,7 +108,7 @@ patientRoute.post(
   asyncHandler(async (req, res) => {
     const {
       db,
-      models: { Patient, PatientAdditionalData, PatientBirthData, PatientFacility },
+      models: { Patient, PatientAdditionalData, PatientBirthData },
     } = req;
     req.checkPermission('create', 'Patient');
     const requestData = requestBodyToRecord(req.body);
@@ -149,11 +127,6 @@ patientRoute.post(
         patientId: createdPatient.id,
       });
       await createdPatient.writeFieldValues(req.body.patientFields);
-
-      await PatientFacility.create({
-        patientId: createdPatient.id,
-        facilityId: serverFacilityId,
-      });
 
       if (patientRegistryType === PATIENT_REGISTRY_TYPES.BIRTH_REGISTRY) {
         await PatientBirthData.create({

--- a/packages/lan/app/routes/apiv1/patientFacility.js
+++ b/packages/lan/app/routes/apiv1/patientFacility.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import config from 'config';
+import { NotFoundError } from 'shared/errors';
+
+export const patientFacility = express.Router();
+
+patientFacility.post('/$', async (req, res) => {
+  const { models, body, syncManager } = req;
+  const { patientId } = body;
+
+  // slightly unusual to check read permissions in a post endpoint, but if you can read patients,
+  // you can mark them for sync
+  req.checkPermission('read', 'Patient');
+
+  const patient = await models.Patient.findByPk(patientId);
+  if (!patient) {
+    throw new NotFoundError();
+  }
+
+  const facilityId = config.serverFacilityId;
+
+  // this endpoint functions as a "find or update", avoiding any issues where another device marks
+  // the patient for sync, and that copy syncs in after the user is already in the patient page
+  const record = await models.PatientFacility.findOrCreate({ facilityId, patientId });
+
+  // trigger a sync to immediately start pulling data for this patient
+  syncManager.triggerSync();
+
+  res.send(record);
+});

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -96,7 +96,6 @@
     "tiny-async-pool": "^1.2.0",
     "umzug": "^2.3.0",
     "uuid": "^8.1.0",
-    "wayfarer": "^7.0.1",
     "winston": "^3.2.1",
     "winston-transport": "^4.5.0",
     "xlsx": "^0.16.9",

--- a/packages/mobile/App/models/Attachment.ts
+++ b/packages/mobile/App/models/Attachment.ts
@@ -1,8 +1,7 @@
 import { Entity, Column, AfterLoad } from 'typeorm/browser';
 import { SYNC_DIRECTIONS } from './types';
 import { BaseModel } from './BaseModel';
-import { SurveyResponseAnswer } from './SurveyResponseAnswer';
-import { readFileInDocuments, deleteFileInDocuments } from '../ui/helpers/file';
+import { readFileInDocuments } from '../ui/helpers/file';
 
 @Entity('attachment')
 export class Attachment extends BaseModel {
@@ -22,32 +21,6 @@ export class Attachment extends BaseModel {
 
   static uploadLimit = 1;
 
-  static async filterExportRecords(ids: string[]) {
-    // Only export attachments that are attached to a survey response answers
-    // Attachments that are orphaned will be cleaned up later.
-    const attachmentAnswers = await SurveyResponseAnswer.getRepository()
-      .createQueryBuilder('survey_response_answer')
-      .where('survey_response_answer.body IN (:...ids)', { ids })
-      .getMany();
-
-    return attachmentAnswers.map(a => a.body);
-  }
-
-  static async postExportCleanUp(): Promise<void> {
-    // Clean up all attachments and their associated files after export.
-    // We might have a lot of scenarios that attachments may hang around
-    // like exiting while doing survey,... So I feel that it is safest
-    // to do clean everything after exporting.
-    const attachments = await this.getRepository()
-      .createQueryBuilder('attachment')
-      .select('filePath')
-      .getRawMany();
-    for (const { filePath } of attachments) {
-      await deleteFileInDocuments(filePath);
-    }
-    await this.getRepository().clear();
-  }
-
   @AfterLoad()
   async populateDataFromPath(): Promise<void> {
     // Sqlite cannot handle select query with very large blob.
@@ -61,8 +34,8 @@ export class Attachment extends BaseModel {
     }
   }
 
-  static excludedSyncColumns: string[] = [
-    ...BaseModel.excludedSyncColumns,
-    'filePath'
-  ];
+  // TODO only sync attachments that are actually associated with a survey response, not orphans
+  // TODO clean up attachments after they've been synced to the central server
+
+  static excludedSyncColumns: string[] = [...BaseModel.excludedSyncColumns, 'filePath'];
 }

--- a/packages/mobile/App/models/Attachment.ts
+++ b/packages/mobile/App/models/Attachment.ts
@@ -34,8 +34,10 @@ export class Attachment extends BaseModel {
     }
   }
 
-  // TODO only sync attachments that are actually associated with a survey response, not orphans
-  // TODO clean up attachments after they've been synced to the central server
+  // TODOs
+  // - only sync attachments that are actually associated with a survey response, not orphans
+  // - clean up attachments after they've been synced to the central server
+  // for original code, see https://github.com/beyondessential/tamanu/commit/c8f5891159733b8da5571ca301dead1fbd52ac1e
 
   static excludedSyncColumns: string[] = [...BaseModel.excludedSyncColumns, 'filePath'];
 }

--- a/packages/mobile/App/models/BaseModel.ts
+++ b/packages/mobile/App/models/BaseModel.ts
@@ -197,12 +197,6 @@ export abstract class BaseModel extends BaseEntity {
     return instance.save();
   }
 
-  static async filterExportRecords(ids: string[]) {
-    return ids;
-  }
-
-  static async postExportCleanUp() {}
-
   static syncDirection = null;
 
   static uploadLimit = 100;

--- a/packages/mobile/App/models/BaseModel.ts
+++ b/packages/mobile/App/models/BaseModel.ts
@@ -123,33 +123,6 @@ export abstract class BaseModel extends BaseEntity {
     this.updatedAtSyncTick = syncTick;
   }
 
-  async findParent<T extends typeof BaseModel>(
-    parentModel: T,
-    parentProperty: string,
-  ): Promise<AbstractInstanceType<T>> {
-    let entity: AbstractInstanceType<T>;
-    const parentValue = this[parentProperty];
-
-    if (typeof parentValue === 'string') {
-      entity = (await parentModel.findOne({
-        where: { id: parentValue },
-      })) as AbstractInstanceType<T>;
-    } else if (typeof parentValue === 'object') {
-      entity = (await parentModel.findOne({
-        where: { id: parentValue.id },
-      })) as AbstractInstanceType<T>;
-    } else {
-      const thisModel = this.constructor as typeof BaseModel;
-      entity = await thisModel
-        .getRepository()
-        .createQueryBuilder()
-        .relation(thisModel, parentProperty)
-        .of(this)
-        .loadOne();
-    }
-    return entity;
-  }
-
   /*
     Convenient helper for creating a new record.
 
@@ -214,16 +187,5 @@ export abstract class BaseModel extends BaseEntity {
     // specific plural handling, and a couple of other unique cases, are handled on the relevant
     // model (see Diagnosis and Medication)
     return `${this.getRepository().metadata.tableName}s`;
-  }
-
-  getPlainData(): ModelPojo {
-    const thisModel = this.constructor as typeof BaseModel;
-    const repo = thisModel.getRepository();
-    const { metadata } = repo;
-    const allColumns = [
-      ...metadata.columns,
-      ...metadata.relationIds, // typeorm thinks these aren't columns
-    ].map(({ propertyName }) => propertyName);
-    return pick(this, allColumns) as ModelPojo;
   }
 }

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -143,7 +143,6 @@ export class Encounter extends BaseModel implements IEncounter {
   vitals: Vitals[];
 
   @BeforeInsert()
-  @BeforeUpdate()
   async markPatientForSync(): Promise<void> {
     await Patient.markForSync(this.patientId);
   }

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -1,4 +1,13 @@
-import { Entity, Column, ManyToOne, OneToMany, Index, RelationId } from 'typeorm/browser';
+import {
+  BeforeInsert,
+  BeforeUpdate,
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  RelationId,
+} from 'typeorm/browser';
 import { startOfDay, addHours, subDays } from 'date-fns';
 import { getUniqueId } from 'react-native-device-info';
 import { BaseModel, IdRelation } from './BaseModel';
@@ -132,6 +141,12 @@ export class Encounter extends BaseModel implements IEncounter {
     ({ encounter }) => encounter,
   )
   vitals: Vitals[];
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  async markPatientForSync(): Promise<void> {
+    await Patient.markForSync(this.patientId);
+  }
 
   static async getOrCreateCurrentEncounter(
     patientId: string,

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -144,7 +144,7 @@ export class Encounter extends BaseModel implements IEncounter {
 
   @BeforeInsert()
   async markPatientForSync(): Promise<void> {
-    await Patient.markForSync(this.patientId);
+    await Patient.markForSync(this.patient);
   }
 
   static async getOrCreateCurrentEncounter(

--- a/packages/mobile/App/models/PatientAdditionalData.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.ts
@@ -202,7 +202,7 @@ export class PatientAdditionalData extends BaseModel implements IPatientAddition
 
   @BeforeInsert()
   async markPatientForSync(): Promise<void> {
-    await Patient.markForSync(this.patientId);
+    await Patient.markForSync(this.patient);
   }
 
   static getTableNameForSync(): string {

--- a/packages/mobile/App/models/PatientAdditionalData.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.ts
@@ -200,6 +200,12 @@ export class PatientAdditionalData extends BaseModel implements IPatientAddition
     }
   }
 
+  @BeforeInsert()
+  @BeforeUpdate()
+  async markPatientForSync(): Promise<void> {
+    await Patient.markForSync(this.patientId);
+  }
+
   static getTableNameForSync(): string {
     return 'patient_additional_data';
   }

--- a/packages/mobile/App/models/PatientAdditionalData.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.ts
@@ -201,7 +201,6 @@ export class PatientAdditionalData extends BaseModel implements IPatientAddition
   }
 
   @BeforeInsert()
-  @BeforeUpdate()
   async markPatientForSync(): Promise<void> {
     await Patient.markForSync(this.patientId);
   }

--- a/packages/mobile/App/models/PatientIssue.ts
+++ b/packages/mobile/App/models/PatientIssue.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, ManyToOne, RelationId } from 'typeorm/browser';
+import { Entity, Column, ManyToOne, RelationId, BeforeInsert, BeforeUpdate } from 'typeorm/browser';
 import { BaseModel } from './BaseModel';
 import { Patient } from './Patient';
 import { IPatientIssue, PatientIssueType } from '~/types';
@@ -26,4 +26,10 @@ export class PatientIssue extends BaseModel implements IPatientIssue {
   patient: Patient;
   @RelationId(({ patient }) => patient)
   patientId: string;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  async markPatientForSync(): Promise<void> {
+    await Patient.markForSync(this.patientId);
+  }
 }

--- a/packages/mobile/App/models/PatientIssue.ts
+++ b/packages/mobile/App/models/PatientIssue.ts
@@ -28,7 +28,6 @@ export class PatientIssue extends BaseModel implements IPatientIssue {
   patientId: string;
 
   @BeforeInsert()
-  @BeforeUpdate()
   async markPatientForSync(): Promise<void> {
     await Patient.markForSync(this.patientId);
   }

--- a/packages/mobile/App/models/PatientIssue.ts
+++ b/packages/mobile/App/models/PatientIssue.ts
@@ -29,6 +29,6 @@ export class PatientIssue extends BaseModel implements IPatientIssue {
 
   @BeforeInsert()
   async markPatientForSync(): Promise<void> {
-    await Patient.markForSync(this.patientId);
+    await Patient.markForSync(this.patient);
   }
 }

--- a/packages/mobile/App/models/PatientSecondaryId.ts
+++ b/packages/mobile/App/models/PatientSecondaryId.ts
@@ -29,7 +29,6 @@ export class PatientSecondaryId extends BaseModel implements IPatientSecondaryId
   patientId: string;
 
   @BeforeInsert()
-  @BeforeUpdate()
   async markPatientForSync(): Promise<void> {
     await Patient.markForSync(this.patientId);
   }

--- a/packages/mobile/App/models/PatientSecondaryId.ts
+++ b/packages/mobile/App/models/PatientSecondaryId.ts
@@ -30,6 +30,6 @@ export class PatientSecondaryId extends BaseModel implements IPatientSecondaryId
 
   @BeforeInsert()
   async markPatientForSync(): Promise<void> {
-    await Patient.markForSync(this.patientId);
+    await Patient.markForSync(this.patient);
   }
 }

--- a/packages/mobile/App/models/PatientSecondaryId.ts
+++ b/packages/mobile/App/models/PatientSecondaryId.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, ManyToOne, RelationId } from 'typeorm/browser';
+import { Entity, Column, ManyToOne, RelationId, BeforeInsert, BeforeUpdate } from 'typeorm/browser';
 import { BaseModel, IdRelation } from './BaseModel';
 import { Patient } from './Patient';
 import { ReferenceData, ReferenceDataRelation } from './ReferenceData';
@@ -27,4 +27,10 @@ export class PatientSecondaryId extends BaseModel implements IPatientSecondaryId
   patient: Patient;
   @RelationId(({ patient }) => patient)
   patientId: string;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  async markPatientForSync(): Promise<void> {
+    await Patient.markForSync(this.patientId);
+  }
 }

--- a/packages/mobile/App/services/sync/utils/executeCrud.ts
+++ b/packages/mobile/App/services/sync/utils/executeCrud.ts
@@ -23,7 +23,9 @@ export const executeInserts = async (
 
   for (const batchOfRows of chunkRows(deduplicated)) {
     try {
-      await model.insert(batchOfRows);
+      // insert with listeners turned off, so that it doesn't cause a patient to be marked for
+      // sync when e.g. an encounter associated with a sync-everywhere vaccine is synced in
+      await model.insert(batchOfRows, { listeners: false });
     } catch (e) {
       // try records individually, some may succeed and we want to capture the
       // specific one with the error

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
@@ -9,7 +9,7 @@ import { executeInserts, executeUpdates, executeDeletes } from './executeCrud';
 import { MODELS_MAP } from '../../../models/modelsMap';
 import { BaseModel } from '../../../models/BaseModel';
 import { readFileInDocuments } from '../../../ui/helpers/file';
-import { getDirPath, getFilePath } from './getFilePath';
+import { getDirPath } from './getFilePath';
 
 /**
  * Save changes for a single model in batch because SQLite only support limited number of parameters
@@ -77,7 +77,9 @@ export const saveIncomingChanges = async (
       const batchString = Buffer.from(base64, 'base64').toString();
 
       const batch = JSON.parse(batchString);
-      const sanitizedBatch = model.sanitizePulledRecordData ? model.sanitizePulledRecordData(batch) : batch;
+      const sanitizedBatch = model.sanitizePulledRecordData
+        ? model.sanitizePulledRecordData(batch)
+        : batch;
 
       await saveChangesForModel(model, sanitizedBatch);
 

--- a/packages/shared-src/src/models/DocumentMetadata.js
+++ b/packages/shared-src/src/models/DocumentMetadata.js
@@ -2,6 +2,8 @@ import { Sequelize } from 'sequelize';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
 import { buildEncounterLinkedSyncFilterJoins } from './buildEncounterLinkedSyncFilter';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
+
 export class DocumentMetadata extends Model {
   static init({ primaryKey, ...options }) {
     super.init(
@@ -36,6 +38,8 @@ export class DocumentMetadata extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -11,6 +11,7 @@ import { InvalidOperationError } from 'shared/errors';
 import { dateTimeType } from './dateTimeTypes';
 
 import { Model } from './Model';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class Encounter extends Model {
   static init({ primaryKey, hackToSkipEncounterValidation, ...options }) {
@@ -62,6 +63,7 @@ export class Encounter extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static getFullReferenceAssociations() {

--- a/packages/shared-src/src/models/Model.js
+++ b/packages/shared-src/src/models/Model.js
@@ -109,15 +109,6 @@ export class Model extends sequelize.Model {
     });
   }
 
-  // list of callbacks to call after model is initialised
-  static afterInitCallbacks = [];
-
-  // adds a function to be called once model is initialised
-  // (useful for hooks and anything else that needs an initialised model)
-  static afterInit(fn) {
-    this.afterInitCallbacks.push(fn);
-  }
-
   static sanitizeForCentralServer(values) {
     // implement on the specific model if needed
     return values;

--- a/packages/shared-src/src/models/Patient.js
+++ b/packages/shared-src/src/models/Patient.js
@@ -39,7 +39,7 @@ export class Patient extends Model {
         ],
       },
     );
-    onSaveMarkPatientForSync(this, 'id');
+    onSaveMarkPatientForSync(this, 'id', 'afterSave');
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/Patient.js
+++ b/packages/shared-src/src/models/Patient.js
@@ -2,6 +2,7 @@ import { Sequelize, Op } from 'sequelize';
 import { SYNC_DIRECTIONS, LAB_REQUEST_STATUSES } from 'shared/constants';
 import { Model } from './Model';
 import { dateType, dateTimeType } from './dateTimeTypes';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class Patient extends Model {
   static init({ primaryKey, ...options }) {
@@ -38,6 +39,7 @@ export class Patient extends Model {
         ],
       },
     );
+    onSaveMarkPatientForSync(this, 'id');
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientAdditionalData.js
+++ b/packages/shared-src/src/models/PatientAdditionalData.js
@@ -2,6 +2,7 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientAdditionalData extends Model {
   static init({ primaryKey, ...options }) {
@@ -47,6 +48,7 @@ export class PatientAdditionalData extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientAllergy.js
+++ b/packages/shared-src/src/models/PatientAllergy.js
@@ -4,6 +4,7 @@ import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
 import { dateTimeType } from './dateTimeTypes';
 import { getCurrentDateTimeString } from '../utils/dateTime';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientAllergy extends Model {
   static init({ primaryKey, ...options }) {
@@ -21,6 +22,7 @@ export class PatientAllergy extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientBirthData.js
+++ b/packages/shared-src/src/models/PatientBirthData.js
@@ -5,6 +5,7 @@ import { dateTimeType } from './dateTimeTypes';
 
 import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientBirthData extends Model {
   static init({ primaryKey, ...options }) {
@@ -40,6 +41,7 @@ export class PatientBirthData extends Model {
         },
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientCarePlan.js
+++ b/packages/shared-src/src/models/PatientCarePlan.js
@@ -3,6 +3,7 @@ import { Model } from './Model';
 import { dateTimeType } from './dateTimeTypes';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
 import { getCurrentDateTimeString } from '../utils/dateTime';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientCarePlan extends Model {
   static init({ primaryKey, ...options }) {
@@ -19,6 +20,7 @@ export class PatientCarePlan extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientCondition.js
+++ b/packages/shared-src/src/models/PatientCondition.js
@@ -4,6 +4,7 @@ import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
 import { dateTimeType } from './dateTimeTypes';
 import { getCurrentDateTimeString } from '../utils/dateTime';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientCondition extends Model {
   static init({ primaryKey, ...options }) {
@@ -22,6 +23,7 @@ export class PatientCondition extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientDeathData.js
+++ b/packages/shared-src/src/models/PatientDeathData.js
@@ -4,6 +4,7 @@ import { InvalidOperationError } from 'shared/errors';
 import { dateType } from './dateTimeTypes';
 import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientDeathData extends Model {
   static init({ primaryKey, ...options }) {
@@ -63,6 +64,7 @@ export class PatientDeathData extends Model {
         },
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientFamilyHistory.js
+++ b/packages/shared-src/src/models/PatientFamilyHistory.js
@@ -4,6 +4,7 @@ import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
 import { dateTimeType } from './dateTimeTypes';
 import { getCurrentDateTimeString } from '../utils/dateTime';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientFamilyHistory extends Model {
   static init({ primaryKey, ...options }) {
@@ -22,6 +23,7 @@ export class PatientFamilyHistory extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientFieldValue.js
+++ b/packages/shared-src/src/models/PatientFieldValue.js
@@ -2,6 +2,7 @@ import { Sequelize } from 'sequelize';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientFieldValue extends Model {
   static init({ primaryKey, ...options }) {
@@ -35,6 +36,7 @@ export class PatientFieldValue extends Model {
         ],
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientIssue.js
+++ b/packages/shared-src/src/models/PatientIssue.js
@@ -5,6 +5,7 @@ import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
 import { dateTimeType } from './dateTimeTypes';
 import { getCurrentDateTimeString } from '../utils/dateTime';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientIssue extends Model {
   static init({ primaryKey, ...options }) {
@@ -27,6 +28,7 @@ export class PatientIssue extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/PatientSecondaryId.js
+++ b/packages/shared-src/src/models/PatientSecondaryId.js
@@ -2,6 +2,7 @@ import { Sequelize } from 'sequelize';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
 import { buildPatientLinkedSyncFilter } from './buildPatientLinkedSyncFilter';
+import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
 export class PatientSecondaryId extends Model {
   static init({ primaryKey, ...options }) {
@@ -22,6 +23,7 @@ export class PatientSecondaryId extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
       },
     );
+    onSaveMarkPatientForSync(this);
   }
 
   static initRelations(models) {

--- a/packages/shared-src/src/models/onSaveMarkPatientForSync.js
+++ b/packages/shared-src/src/models/onSaveMarkPatientForSync.js
@@ -1,10 +1,13 @@
 import config from 'config';
 
-const HOOK_TRIGGER = 'beforeSave';
 const HOOK_NAME = 'markPatientForSync';
 
 // any interaction with a non-syncing patient should mark it for ongoing sync
-export const onSaveMarkPatientForSync = (model, patientIdField = 'patientId') => {
+export const onSaveMarkPatientForSync = (
+  model,
+  patientIdField = 'patientId',
+  hookTrigger = 'afterCreate',
+) => {
   const facilityId = config.serverFacilityId;
   if (!facilityId) {
     // no need to add the hook on the central server
@@ -14,8 +17,8 @@ export const onSaveMarkPatientForSync = (model, patientIdField = 'patientId') =>
   // we remove and add the hook because Sequelize doesn't have a good way
   // to detect which hooks have already been added to a model in its
   // public API
-  model.removeHook(HOOK_TRIGGER, HOOK_NAME);
-  model.addHook(HOOK_TRIGGER, HOOK_NAME, async record => {
+  model.removeHook(hookTrigger, HOOK_NAME);
+  model.addHook(hookTrigger, HOOK_NAME, async record => {
     // for some models (e.g. DocumentMetadata) patient is an optional field; check it is defined
     const patientId = record[patientIdField];
     if (!patientId) {

--- a/packages/shared-src/src/models/onSaveMarkPatientForSync.js
+++ b/packages/shared-src/src/models/onSaveMarkPatientForSync.js
@@ -4,7 +4,7 @@ const HOOK_TRIGGER = 'beforeSave';
 const HOOK_NAME = 'markPatientForSync';
 
 // any interaction with a non-syncing patient should mark it for ongoing sync
-export const onSaveMarkPatientForSync = model => {
+export const onSaveMarkPatientForSync = (model, patientIdField = 'patientId') => {
   const facilityId = config.serverFacilityId;
   if (!facilityId) {
     // no need to add the hook on the central server
@@ -15,8 +15,9 @@ export const onSaveMarkPatientForSync = model => {
   // to detect which hooks have already been added to a model in its
   // public API
   model.removeHook(HOOK_TRIGGER, HOOK_NAME);
-  model.addHook(HOOK_TRIGGER, HOOK_NAME, async ({ patientId }) => {
+  model.addHook(HOOK_TRIGGER, HOOK_NAME, async record => {
     // for some models (e.g. DocumentMetadata) patient is an optional field; check it is defined
+    const patientId = record[patientIdField];
     if (!patientId) {
       return;
     }

--- a/packages/shared-src/src/models/onSaveMarkPatientForSync.js
+++ b/packages/shared-src/src/models/onSaveMarkPatientForSync.js
@@ -1,12 +1,22 @@
 import config from 'config';
 
+// by default, we use "afterCreate" as the hook trigger
+// only single-creates of related tables should mark patients for sync, as anything more aggressive
+// would lead to accidentally marking patients for sync when they shouldn't be
+// as an example, when a facility has "syncAllLabRequests" turned on, the lab requests encounters
+// will sync in, but
+// - shouldn't mark the patient for sync when saved during the sync pull process (which uses bulk-create)
+// - shouldn't mark the patient for sync when updated as part of processing the lab request (which
+//   is why we don't trigger on updates)
+const DEFAULT_HOOK_TRIGGER = 'afterCreate';
 const HOOK_NAME = 'markPatientForSync';
+const DEFAULT_PATIENT_ID_FIELD = 'patientId';
 
 // any interaction with a non-syncing patient should mark it for ongoing sync
 export const onSaveMarkPatientForSync = (
   model,
-  patientIdField = 'patientId',
-  hookTrigger = 'afterCreate',
+  patientIdField = DEFAULT_PATIENT_ID_FIELD,
+  hookTrigger = DEFAULT_HOOK_TRIGGER,
 ) => {
   const facilityId = config.serverFacilityId;
   if (!facilityId) {

--- a/packages/shared-src/src/models/onSaveMarkPatientForSync.js
+++ b/packages/shared-src/src/models/onSaveMarkPatientForSync.js
@@ -1,0 +1,34 @@
+import config from 'config';
+
+const HOOK_TRIGGER = 'beforeSave';
+const HOOK_NAME = 'markPatientForSync';
+
+// any interaction with a non-syncing patient should mark it for ongoing sync
+export const onSaveMarkPatientForSync = model => {
+  const facilityId = config.serverFacilityId;
+  if (!facilityId) {
+    // no need to add the hook on the central server
+    return;
+  }
+
+  // we remove and add the hook because Sequelize doesn't have a good way
+  // to detect which hooks have already been added to a model in its
+  // public API
+  model.removeHook(HOOK_TRIGGER, HOOK_NAME);
+  model.addHook(HOOK_TRIGGER, HOOK_NAME, async ({ patientId }) => {
+    // for some models (e.g. DocumentMetadata) patient is an optional field; check it is defined
+    if (!patientId) {
+      return;
+    }
+
+    // upsert patient_facilities record to mark the patient for sync in this facility
+    await model.sequelize.query(
+      `
+      INSERT INTO patient_facilities (patient_id, facility_id)
+      VALUES (:patientId, :facilityId )
+      ON CONFLICT (patient_id, facility_id) DO NOTHING;
+    `,
+      { replacements: { patientId, facilityId } },
+    );
+  });
+};

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -124,7 +124,6 @@
     "transliteration": "^2.2.0",
     "umzug": "^2.3.0",
     "uuid": "^8.1.0",
-    "wayfarer": "^7.0.1",
     "winston": "^3.2.1",
     "winston-transport": "^4.5.0",
     "xlsx": "^0.16.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18821,11 +18821,6 @@ nano@^6.4.4:
     lodash.isempty "^4.4.0"
     request "^2.85.0"
 
-nanoassert@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
-  integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
-
 nanoclone@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
@@ -25967,13 +25962,6 @@ watchpack@^2.3.1:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
-
-wayfarer@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/wayfarer/-/wayfarer-7.0.1.tgz#17a64d351d49f9d3d6c508155867df7658184ce3"
-  integrity sha512-yf+kAlOYnJRjLxflLy+1+xEclb6222EAVvAjSY+Yz2qAIDrXeN5wLl/G302Mwv3E0KMg1HT/WDGsvSymX0U7Rw==
-  dependencies:
-    nanoassert "^1.1.0"
 
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"


### PR DESCRIPTION
### Changes

This was a missed feature from the first pass at v2 sync, d'oh

Also cleaned up the `/patient` endpoint so that it doesn't deal with marking for sync, as it was always a bit of a weird responsibility but definitely makes sense to have its own endpoint now it is backed by a db table.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
