### PR TITLE
Add some fields to HTTP logs

### DIFF
--- a/packages/shared-src/src/services/logging/color.js
+++ b/packages/shared-src/src/services/logging/color.js
@@ -6,8 +6,8 @@ const {
   color,
 } = config?.log || {};
 
-const colorise = color 
-  ? (hex) => chalk.hex(hex) 
+const colorise = color
+  ? (hex) => chalk.hex(hex)
   : (ignoredHex) => (text => text);
 */
 // TEMP: Disable chalk & its import as it seems to not run correctly on AWS
@@ -19,4 +19,5 @@ export const COLORS = {
   blue: colorise('729fcf'),
   red: colorise('ef2929'),
   yellow: colorise('e9b96e'),
+  magenta: colorise('ff00ff'),
 };

--- a/packages/shared-src/src/services/logging/console.js
+++ b/packages/shared-src/src/services/logging/console.js
@@ -22,7 +22,7 @@ const additionalDataFormatter = (obj = {}) => {
 const logFormat = winston.format.printf(({ level, message, childLabel, timestamp, ...rest }) => {
   const restString = additionalDataFormatter(rest);
   if (restString === '') {
-    return `${COLORS.grey(timestamp)} ${level}:${childLabel ? `${childLabel} - ` : ''}${message}`;
+    return `${COLORS.grey(timestamp)} ${level}: ${childLabel ? `${childLabel} - ` : ''}${message}`;
   }
 
   return `${COLORS.grey(timestamp)} ${level}: ${message} ${COLORS.grey(restString)}`;

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -24,7 +24,7 @@ function field(str, { prefix = '', suffix = '', color = String } = {}) {
 }
 
 function getSendTime(res) {
-  if (!res._startAt) return;
+  if (!res._startAt) return null;
 
   // time elapsed from response headers sent
   const elapsed = process.hrtime(res._startAt);

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -47,7 +47,7 @@ const httpFormatter = (tokens, req, res) => {
     field(req._bytesRead?.toFixed(0), { prefix: 'bytesRecv=' }),
     field(res._bytesWritten?.toFixed(0), { prefix: 'bytesSent=' }),
     field(res.getHeader('content-type')?.match(/\/([\w+]+);?/)?.[1], { prefix: 'contentType=' }),
-    field(tokens['response-time'](req, res), { prefix: 'processingTime=' suffix: 'ms' }),
+    field(tokens['response-time'](req, res), { prefix: 'processingTime=', suffix: 'ms' }),
     field(getSendTime(res), { prefix: 'sendTime=', suffix: 'ms' }),
     field(userId?.[userId?.length - 1], { color: COLORS.magenta, prefix: 'user=' }),
   ]

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -44,11 +44,11 @@ const httpFormatter = (tokens, req, res) => {
     field(tokens.url(req, res)),
     '-', // separator for named fields
     field(status, { color: getStatusColor(status), prefix: 'status=' }),
-    field(req._bytesRead?.toFixed(0), { prefix: 'bytes-recv=' }),
-    field(res._bytesWritten?.toFixed(0), { prefix: 'bytes-sent=' }),
-    field(res.getHeader('content-type')?.match(/\/([\w+]+);?/)?.[1], { prefix: 'content=' }),
-    field(tokens['response-time'](req, res), { prefix: 'time-proc=', suffix: 'ms' }),
-    field(getSendTime(res), { prefix: 'time-send=', suffix: 'ms' }),
+    field(req._bytesRead?.toFixed(0), { prefix: 'bytesRecv=' }),
+    field(res._bytesWritten?.toFixed(0), { prefix: 'bytesSent=' }),
+    field(res.getHeader('content-type')?.match(/\/([\w+]+);?/)?.[1], { prefix: 'contentType=' }),
+    field(tokens['response-time'](req, res), { prefix: 'processingTime=' suffix: 'ms' }),
+    field(getSendTime(res), { prefix: 'sendTime=', suffix: 'ms' }),
     field(userId?.[userId?.length - 1], { color: COLORS.magenta, prefix: 'user=' }),
   ]
     .filter(Boolean)

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -23,6 +23,15 @@ function field(str, { prefix = '', suffix = '', color = String } = {}) {
   return `${prefix}${color(`${str}${suffix}`)}`;
 }
 
+function getSendTime(req, res) {
+  if (!req._startAt) return;
+
+  // time elapsed from response headers sent
+  const elapsed = process.hrtime(res._startAt);
+  const ms = elapsed[0] * 1e3 + elapsed[1] * 1e-6;
+  return ms.toFixed(3);
+}
+
 const httpFormatter = (tokens, req, res) => {
   const status = tokens.status(req, res);
   const userId = req.user?.id?.split('-');
@@ -36,6 +45,7 @@ const httpFormatter = (tokens, req, res) => {
     '-', // separator for named fields
     field(status, { color: getStatusColor(status), prefix: 'status=' }),
     field(tokens['response-time'](req, res), { prefix: 'time-proc=', suffix: 'ms' }),
+    field(getSendTime(req, res), { prefix: 'time-send=', suffix: 'ms' }),
     field(userId?.[userId?.length - 1], { color: COLORS.magenta, prefix: 'user=' }),
   ]
     .filter(Boolean)

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -46,6 +46,7 @@ const httpFormatter = (tokens, req, res) => {
     field(status, { color: getStatusColor(status), prefix: 'status=' }),
     field(req._bytesRead?.toFixed(0), { prefix: 'bytes-recv=' }),
     field(res._bytesWritten?.toFixed(0), { prefix: 'bytes-sent=' }),
+    field(res.getHeader('content-type')?.match(/\/([\w+]+);?/)?.[1], { prefix: 'content=' }),
     field(tokens['response-time'](req, res), { prefix: 'time-proc=', suffix: 'ms' }),
     field(getSendTime(res), { prefix: 'time-send=', suffix: 'ms' }),
     field(userId?.[userId?.length - 1], { color: COLORS.magenta, prefix: 'user=' }),

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -36,6 +36,7 @@ const httpFormatter = (tokens, req, res) => {
     '-', // separator for named fields
     field(status, { color: getStatusColor(status), prefix: 'status=' }),
     field(tokens['response-time'](req, res), { prefix: 'time-proc=', suffix: 'ms' }),
+    field(userId?.[userId?.length - 1], { color: COLORS.magenta, prefix: 'user=' }),
   ]
     .filter(Boolean)
     .join(' ');

--- a/packages/shared-src/src/services/logging/http.js
+++ b/packages/shared-src/src/services/logging/http.js
@@ -23,8 +23,8 @@ function field(str, { prefix = '', suffix = '', color = String } = {}) {
   return `${prefix}${color(`${str}${suffix}`)}`;
 }
 
-function getSendTime(req, res) {
-  if (!req._startAt) return;
+function getSendTime(res) {
+  if (!res._startAt) return;
 
   // time elapsed from response headers sent
   const elapsed = process.hrtime(res._startAt);
@@ -47,7 +47,7 @@ const httpFormatter = (tokens, req, res) => {
     field(req._bytesRead?.toFixed(0), { prefix: 'bytes-recv=' }),
     field(res._bytesWritten?.toFixed(0), { prefix: 'bytes-sent=' }),
     field(tokens['response-time'](req, res), { prefix: 'time-proc=', suffix: 'ms' }),
-    field(getSendTime(req, res), { prefix: 'time-send=', suffix: 'ms' }),
+    field(getSendTime(res), { prefix: 'time-send=', suffix: 'ms' }),
     field(userId?.[userId?.length - 1], { color: COLORS.magenta, prefix: 'user=' }),
   ]
     .filter(Boolean)


### PR DESCRIPTION
### Changes

This started as just something to add (the last bit of) the user ID to the http log, but I added a bunch of other fields and fixed others:

- User ID (only the part after the last `-`, which makes it shorter and, with UUIDs, still relatively collision-proof). Makes it easier to:
  - (on Facility) estimate how many users are using Tamanu right now
  - (on Facility) filter by one particular user to see "a session"
  - (on Central) see which facility is talking to the server (assuming each facility has its own login)
  - _note_: this is probably the most contentious of these new fields
- Processing time (was: "response time"). This is an existing field but "renamed" (though it didn't really have a name before). Essentially that field measures the time it takes for the server to process the request, from when we start receiving it, to when we start sending the response.
- Sending time. This is the time between starting sending the response and finishing sending the response.
- Content Type. This is the second bit of the content-type response header. So generally it will be `json`, but could be `pdf`, `png`, `plain`, maybe even `html`, on occasion.
- Bytes received. This is actual bytes read from the socket for this request, without depending on or trusting request headers. Note this includes headers.
- Bytes sent. The same but for bytes written. This replaces reading the `content-length` header, which generally didn't work.

A new logging line would look like this:

```
2022-12-13T03:02:05.267Z http: ::1 GET /v1/patient?page=0&rowsPerPage=10&order=asc&matchSecondaryIds=true - status=304 bytes-recv=2125 bytes-sent=3887 content=json time-proc=10.251ms time-send=0.307ms user=147e86e3c14b
```

Here broken down across lines for clarity, showing an unauthenticated request (login) and then with the user ID (user/me):

```
2022-12-13T03:02:05.188Z
	http: ::1 POST /v1/login
    status=200
    bytes-recv=720
    bytes-sent=2997
    content=json
    time-proc=268.100ms
    time-send=2.201ms

2022-12-13T03:02:05.193Z
    http: ::1 GET /v1/user/me
    status=200
    bytes-recv=1394
    bytes-sent=3592
    content=json
    time-proc=2.489ms
    time-send=0.385ms
    user=147e86e3c14b
```

### Checklist

- [x] Code is finished
