### PR TITLE
Add magic psql script for windows

### DIFF
--- a/scripts/psql-on-deployed-windows.ps1
+++ b/scripts/psql-on-deployed-windows.ps1
@@ -1,0 +1,21 @@
+# get to latest tamanu
+cd \Tamanu
+$latest = Get-ChildItem -Attributes Directory | Sort-Object -Property BaseName -Descending | Select -First 1
+cd $latest
+
+$config = type .\config\local.json | ConvertFrom-JSON
+
+# get to latest postgres
+cd '\Program Files\PostgreSQL'
+$latest = Get-ChildItem -Attributes Directory | Sort-Object -Property BaseName -Descending | Select -First 1
+cd $latest
+
+chcp 1252
+$env:PGHOST = "localhost"
+$env:PGDATABASE = $config.db.name
+$env:PGUSER = $config.db.username
+$env:PGPASSWORD = $config.db.password
+$env:PSQL_HISTORY= '\Tamanu\psql.history'
+.\bin\psql.exe
+
+pause


### PR DESCRIPTION
### Changes

This is a powershell script that:
1. finds the latest tamanu install
2. reads its local.json config
3. finds the latest postgres install (in case we ever have two)
4. sets the right windows codepage so utf-8 works (or at least so psql stops complaining about it)
5. launches psql with the config from tamanu

No need to ever type in a database name, username, or copy paste a password again! This just automates this bit for you.

#### Quick use

Copy to the server, right click and use "Run with powershell"

#### More permanent

1. Copy to `C:\Tamanu\psql.ps1`
2. Either make a new shortcut or edit the existing PSQL one on the desktop:
3. Set starting/working directory to `C:\Tamanu`
4. Set run/executable to `powershell.exe -noexit -File C:\Tamanu\psql.ps1`

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
