### PR TITLE
WAITM-525: Get latest encounter for vitals

### DIFF
--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -150,6 +150,7 @@ export class Encounter extends BaseModel implements IEncounter {
       .andWhere("startDate >= datetime(:date, 'unixepoch')", {
         date: formatDateForQuery(date),
       })
+      .orderBy('startDate', 'DESC')
       .getOne();
 
     if (found) return found;

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -142,7 +142,7 @@ export class Encounter extends BaseModel implements IEncounter {
     const found = await repo
       .createQueryBuilder('encounter')
       .where('patientId = :patientId', { patientId })
-      .where('endDate IS NOT NULL')
+      .where('endDate IS NULL')
       .orderBy('startDate', 'DESC')
       .getOne();
 


### PR DESCRIPTION
### Changes

When submitting a survey or vitals on mobile, we try to add the survey response record to an existing encounter if possible and if not we create one.

However the current logic for getting an encounter is a bit strange as follows:
- Select all the encounters after 3am today for the patient
- Regardless of whether there is an endDate or not
- Get one at random of them

This change updates the logic to be:
- Select all the open encounters for the patient (ie. ones where there is no end date)
- Get the latest one of them (ie. Order by startDate)


### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
