### PR TITLE
WAITM-588 If area/location suggester has only one option, auto fill it

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -95,7 +95,7 @@ class BaseAutocomplete extends Component {
   }
 
   updateValue = async () => {
-    const { value, suggester } = this.props;
+    const { value, suggester, autofill } = this.props;
 
     if (!suggester || value === undefined) {
       return;
@@ -126,7 +126,7 @@ class BaseAutocomplete extends Component {
   };
 
   fetchOptions = async ({ value, reason }) => {
-    const { suggester, options } = this.props;
+    const { suggester, options, autofill, name } = this.props;
 
     if (reason === 'suggestion-selected') {
       this.clearOptions();
@@ -136,6 +136,18 @@ class BaseAutocomplete extends Component {
     const suggestions = suggester
       ? await suggester.fetchSuggestions(value)
       : options.filter(x => x.label.toLowerCase().includes(value.toLowerCase()));
+
+    if (autofill && value === '' && suggestions.length === 1) {
+      const autoSelectOption = suggestions[0];
+      this.setState({
+        selectedOption: {
+          value: autoSelectOption.label,
+          tag: autoSelectOption.tag,
+        },
+      });
+      this.handleSuggestionChange({ value: autoSelectOption.value, name });
+      return;
+    }
 
     this.setState({ suggestions });
   };
@@ -294,6 +306,7 @@ BaseAutocomplete.propTypes = {
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     }),
   ),
+  autofill: PropTypes.bool,
 };
 
 BaseAutocomplete.defaultProps = {
@@ -307,6 +320,7 @@ BaseAutocomplete.defaultProps = {
   value: '',
   options: [],
   suggester: null,
+  autofill: false,
 };
 
 export const AutocompleteInput = styled(BaseAutocomplete)`

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -88,6 +88,7 @@ export const LocationInput = React.memo(
           suggester={locationGroupSuggester}
           value={groupId}
           disabled={disabled}
+          autofill
         />
         <AutocompleteInput
           label={label}
@@ -100,6 +101,7 @@ export const LocationInput = React.memo(
           value={locationId}
           onChange={handleChange}
           className={className}
+          autofill
         />
       </>
     );


### PR DESCRIPTION
### Changes

- Add new `autofill` prop to autocomplete component
- Make add `autofill` to LocationField

### Checklist

- [X] Code is finished
- [X] UI Screenshots added to the Linear issue
- [X] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
