### PR TITLE
Staging fix: Revert removal of Attachment.sanitizeForCentralServer

### DIFF
--- a/packages/shared-src/src/models/Attachment.js
+++ b/packages/shared-src/src/models/Attachment.js
@@ -17,4 +17,8 @@ export class Attachment extends Model {
       },
     );
   }
+
+  static sanitizeForCentralServer({ data, ...restOfValues }) {
+    return { ...restOfValues, data: Buffer.from(data, 'base64') };
+  }
 }

--- a/packages/sync-server/app/attachment.js
+++ b/packages/sync-server/app/attachment.js
@@ -39,11 +39,11 @@ attachmentRoutes.post(
     }
 
     const { Attachment } = req.store.models;
-    const { type, size, data } = req.body;
+    const { type, size, data } = Attachment.sanitizeForCentralServer(req.body);
     const attachment = await Attachment.create({
       type,
       size,
-      data: Buffer.from(data, 'base64'),
+      data,
     });
 
     // Send only the ID to be able to link it to metadata


### PR DESCRIPTION
### Changes

In #3261, we removed the sanitisation function used by sync, because Attachments don't sync on desktop. Strangely, they do actually sync as their upload mechanism on mobile. We should probably change this to be consistent on both, but for this staging branch let's just revert that change

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
