### PR TITLE
Cherry pick to staging: don't use NaN as test input data (#3315)

### DIFF
--- a/packages/lan/__tests__/sync/calculatePageLimit.test.js
+++ b/packages/lan/__tests__/sync/calculatePageLimit.test.js
@@ -21,7 +21,7 @@ describe('calculatePageLimit', () => {
       fc.property(fc.float(), fc.float(), (a, b) => {
         expect(calculatePageLimit(a, b)).toEqual(expect.any(Number));
       }),
-      fc.property(fc.double(), fc.double(), (a, b) => {
+      fc.property(fc.double({ noNaN: true }), fc.double({ noNaN: true }), (a, b) => {
         expect(calculatePageLimit(a, b)).toEqual(expect.any(Number));
       }),
     );

--- a/packages/lan/__tests__/sync/pushOutgoingChanges.test.js
+++ b/packages/lan/__tests__/sync/pushOutgoingChanges.test.js
@@ -9,7 +9,7 @@ const limitConfig = fc.record({
   minLimit: fc.integer({ min: 1, max: 999 }),
   maxLimit: fc.integer({ min: 1000, max: 100000 }),
   optimalTimePerPageMs: fc.integer({ min: 50, max: 10000 }),
-  maxLimitChangePerPage: fc.double({ min: 0.1, max: 0.9 }),
+  maxLimitChangePerPage: fc.double({ min: 0.1, max: 0.9, noNaN: true }),
 });
 
 describe('pushOutgoingChanges', () => {


### PR DESCRIPTION
To fix flakey tests