### PR TITLE
sav-19 Remove mandatory doctor/nurse field

### DIFF
--- a/packages/desktop/app/forms/FamilyHistoryForm.js
+++ b/packages/desktop/app/forms/FamilyHistoryForm.js
@@ -6,7 +6,7 @@ import { Form, Field, DateField, AutocompleteField, TextField } from '../compone
 import { FormGrid } from '../components/FormGrid';
 import { ConfirmCancelRow } from '../components/ButtonRow';
 
-import { foreignKey } from '../utils/validation';
+import { foreignKey, optionalForeignKey } from '../utils/validation';
 
 export const FamilyHistoryForm = ({
   onCancel,
@@ -54,6 +54,7 @@ export const FamilyHistoryForm = ({
     }}
     validationSchema={yup.object().shape({
       diagnosisId: foreignKey('Diagnosis is required'),
+      practitionerId: optionalForeignKey(),
       recordedDate: yup.date().required(),
     })}
   />

--- a/packages/desktop/app/forms/FamilyHistoryForm.js
+++ b/packages/desktop/app/forms/FamilyHistoryForm.js
@@ -37,7 +37,6 @@ export const FamilyHistoryForm = ({
         <Field
           name="practitionerId"
           label="Doctor/nurse"
-          required
           component={AutocompleteField}
           suggester={practitionerSuggester}
         />
@@ -55,7 +54,6 @@ export const FamilyHistoryForm = ({
     }}
     validationSchema={yup.object().shape({
       diagnosisId: foreignKey('Diagnosis is required'),
-      practitionerId: foreignKey('Doctor/nurse is required'),
       recordedDate: yup.date().required(),
     })}
   />


### PR DESCRIPTION
### Changes

The doctor/nurse field on the family history form on the patient side bar is no longer a mandatory field

### Checklist

- [x] Code is finished
- [N/A] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [N/A] any config/settings changes and manual deployment steps
- [N/A] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [N/A] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
