### PR TITLE
SAV-45: Add 'Area' field to 'New procedure' modal

### DIFF
--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -10,15 +10,15 @@ import { useLocalisation } from '../../contexts/Localisation';
 import { Colors } from '../../constants';
 import { BodyText } from '../Typography';
 
-const locationSuggester = (api, groupValue) => {
+const locationSuggester = (api, groupValue, enableLocationStatus) => {
   return new Suggester(api, 'location', {
     formatter: ({ name, id, locationGroup, availability }) => {
       return {
         value: id,
         label: name,
         locationGroup,
-        availability,
-        tag: LOCATION_AVAILABILITY_TAG_CONFIG[availability],
+        availability: enableLocationStatus ? availability : null,
+        tag: enableLocationStatus ? LOCATION_AVAILABILITY_TAG_CONFIG[availability] : null,
       };
     },
     baseQueryParameters: { filterByFacility: true, locationGroupId: groupValue },
@@ -48,11 +48,12 @@ export const LocationInput = React.memo(
     className,
     value,
     onChange,
+    enableLocationStatus = true,
   }) => {
     const api = useApi();
     const [groupId, setGroupId] = useState('');
     const [locationId, setLocationId] = useState(value);
-    const suggester = locationSuggester(api, groupId);
+    const suggester = locationSuggester(api, groupId, enableLocationStatus);
     const locationGroupSuggester = useSuggester('facilityLocationGroup');
     const { data } = useLocationSuggestion(locationId);
 

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -13,6 +13,7 @@ import {
   AutocompleteField,
   TextField,
   FormGroup,
+  LocationField,
 } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { ConfirmCancelRow } from '../components/ButtonRow';
@@ -31,7 +32,6 @@ export const ProcedureForm = React.memo(
     editedObject,
     anaestheticSuggester,
     procedureSuggester,
-    locationSuggester,
     practitionerSuggester,
   }) => (
     <Form
@@ -41,7 +41,7 @@ export const ProcedureForm = React.memo(
         const getButtonText = isCompleted => {
           if (isCompleted) return 'Finalise';
           if (editedObject?.id) return 'Update';
-          return 'Create';
+          return 'Submit';
         };
 
         const isCompleted = !!values.completed;
@@ -61,11 +61,18 @@ export const ProcedureForm = React.memo(
                 </div>
                 <FormGrid style={{ gridColumn: 'span 2' }}>
                   <Field
-                    name="locationId"
+                    locationGroupLabel="Procedure area"
                     label="Procedure location"
+                    name="locationId"
+                    required
+                    component={LocationField}
+                  />
+                  <Field
+                    name="physicianId"
+                    label="Physician"
                     required
                     component={AutocompleteField}
-                    suggester={locationSuggester}
+                    suggester={practitionerSuggester}
                   />
                   <Field
                     name="date"
@@ -84,19 +91,7 @@ export const ProcedureForm = React.memo(
                   />
                   <Field name="endTime" label="Time ended" component={TimeField} saveDateAsString />
                 </FormGrid>
-                <Field
-                  name="physicianId"
-                  label="Physician"
-                  required
-                  component={AutocompleteField}
-                  suggester={practitionerSuggester}
-                />
-                <Field
-                  name="assistantId"
-                  label="Assistant"
-                  component={AutocompleteField}
-                  suggester={practitionerSuggester}
-                />
+
                 <Field
                   name="anaesthetistId"
                   label="Anaesthetist"
@@ -110,6 +105,12 @@ export const ProcedureForm = React.memo(
                   suggester={anaestheticSuggester}
                   rows={4}
                   style={{ gridColumn: 'span 2' }}
+                />
+                <Field
+                  name="assistantId"
+                  label="Assistant"
+                  component={AutocompleteField}
+                  suggester={practitionerSuggester}
                 />
                 <Field
                   name="note"

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -69,7 +69,7 @@ export const ProcedureForm = React.memo(
                   />
                   <Field
                     name="physicianId"
-                    label="Physician"
+                    label="Clinician"
                     required
                     component={AutocompleteField}
                     suggester={practitionerSuggester}
@@ -153,7 +153,7 @@ export const ProcedureForm = React.memo(
         date: yup.date().required(),
         startTime: yup.date(),
         endTime: yup.date(),
-        physicianId: foreignKey('Physician must be selected'),
+        physicianId: foreignKey('Clinician must be selected'),
         assistantId: optionalForeignKey(),
         anaesthetistId: optionalForeignKey(),
         anaestheticId: optionalForeignKey(),

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -64,6 +64,7 @@ export const ProcedureForm = React.memo(
                     locationGroupLabel="Procedure area"
                     label="Procedure location"
                     name="locationId"
+                    enableLocationStatus={false}
                     required
                     component={LocationField}
                   />

--- a/packages/lan/__tests__/apiv1/Triage.test.js
+++ b/packages/lan/__tests__/apiv1/Triage.test.js
@@ -226,10 +226,11 @@ describe('Triage', () => {
   });
 
   describe('Listing & filtering', () => {
-
     let createTestTriage;
 
     beforeAll(async () => {
+      await models.Triage.truncate({ cascade: true });
+
       // create a few test triages
       const { id: locationId } = await models.Location.create({
         ...fake(models.Location),


### PR DESCRIPTION
### Ticket: SAV-45

### Changes
- Add 'Area' field to 'New procedure' modal
- Reordered some procedure fields
- Renamed Physician to Clinician

### Screenshots
<img width="955" alt="Screen Shot 2023-01-04 at 6 14 03 am" src="https://user-images.githubusercontent.com/63621318/210456841-7eb3aa7e-dbf1-4b34-9211-4e403cd441e4.png">


### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
