### PR TITLE
SAV-45: Disable editing location field when in different facility

### DIFF
--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -83,14 +83,13 @@ export const LocationInput = React.memo(
       onChange({ target: { value: event.target.value, name } });
     };
 
-    // Disable the location field if the location group is not selected yet
-    // const belongsToCurrentFacility = location?.facilityId
-    //   ? facility.id === location.facilityId
-    //   : true;
-    const fakeFacility = 'ref/facility/b'; // TODO remove
-    const belongsToCurrentFacility = fakeFacility ? facility.id === fakeFacility : true; // TODO remove
-    const locationSelectIsDisabled = !groupId || !belongsToCurrentFacility;
-    const locationGroupSelectIsDisabled = !belongsToCurrentFacility;
+    // Disable the location field + location group field if:
+    // 1. In edit mode (already has existing value)
+    // 2. Existing location has different facility than the current facility
+    const existingLocationHasSameFacility =
+      value && location?.facilityId ? facility.id === location.facilityId : true;
+    const locationSelectIsDisabled = !groupId || !existingLocationHasSameFacility;
+    const locationGroupSelectIsDisabled = !existingLocationHasSameFacility;
 
     return (
       <>

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -69,7 +69,8 @@ export const LocationInput = React.memo(
         onChange({ target: { value: '', name } });
       }
 
-      // Set existing location group if there's any for edit mode
+      // Initialise the location group state
+      // if the form is being opened in edit mode (i.e. there are existing values)
       if (value && !groupId && location?.locationGroup?.id) {
         setGroupId(location.locationGroup.id);
       }
@@ -84,9 +85,10 @@ export const LocationInput = React.memo(
       onChange({ target: { value: event.target.value, name } });
     };
 
-    // Disable the location field + location group field if:
-    // 1. In edit mode (already has existing value)
-    // 2. Existing location has different facility than the current facility
+    // Disable the location and location group fields if:
+    // 1. In edit mode (form already is initialised with pre-filled values); and
+    // 2. The existing location has a different facility than the current facility
+    // Disable just the location field if location group has not been chosen or pre-filled
     const existingLocationHasSameFacility =
       value && location?.facilityId ? facility.id === location.facilityId : true;
     const locationSelectIsDisabled = !groupId || !existingLocationHasSameFacility;

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -69,10 +69,11 @@ export const LocationInput = React.memo(
         onChange({ target: { value: '', name } });
       }
 
-      if (location?.id && location?.locationGroup?.id) {
+      // Set existing location group if there's any for edit mode
+      if (value && !groupId && location?.locationGroup?.id) {
         setGroupId(location.locationGroup.id);
       }
-    }, [onChange, name, groupId, location?.id, location?.locationGroup]);
+    }, [onChange, value, name, groupId, location?.id, location?.locationGroup]);
 
     const handleChangeCategory = event => {
       setGroupId(event.target.value);

--- a/packages/lan/__tests__/apiv1/Suggestions.test.js
+++ b/packages/lan/__tests__/apiv1/Suggestions.test.js
@@ -190,6 +190,29 @@ describe('Suggestions', () => {
       expect(filteredResult).toHaveSucceeded();
       expect(filteredResult?.body?.length).toEqual(2);
     });
+
+    it('should return facilityId with suggestion list', async () => {
+      await models.Location.truncate({ cascade: true });
+      const facility = await models.Facility.create({
+        id: 'test-facility',
+        code: 'test-facility',
+        name: 'Test Facility',
+      });
+      const locationGroup = await findOneOrCreate(models, models.LocationGroup, {
+        id: 'test-area',
+        name: 'Test Area',
+      });
+      await findOneOrCreate(models, models.Location, {
+        name: 'Bed 1',
+        locationGroupId: locationGroup.id,
+        visibilityStatus: 'current',
+        facilityId: facility.id,
+      });
+      const result = await userApp.get('/v1/suggestions/location');
+      expect(result).toHaveSucceeded();
+      expect(result?.body?.length).toEqual(1);
+      expect(result.body[0].facilityId).toEqual(facility.id);
+    });
   });
 
   describe('General functionality (via diagnoses)', () => {

--- a/packages/lan/app/routes/apiv1/suggestions.js
+++ b/packages/lan/app/routes/apiv1/suggestions.js
@@ -178,7 +178,7 @@ createSuggester(
   },
   async location => {
     const availability = await location.getAvailability();
-    const { name, code, id, maxOccupancy } = location;
+    const { name, code, id, maxOccupancy, facilityId } = location;
 
     const lg = await location.getLocationGroup();
     const locationGroup = lg && { name: lg.name, code: lg.code, id: lg.id };
@@ -188,6 +188,7 @@ createSuggester(
       maxOccupancy,
       id,
       availability,
+      facilityId,
       ...(locationGroup && { locationGroup }),
     };
   },


### PR DESCRIPTION
### Ticket: SAV-45

### Changes
- Disable location edit when in different facility (more context here: https://linear.app/bes/issue/SAV-45#comment-b2dd3617)

### Screenshots
<img width="936" alt="Screen Shot 2023-01-06 at 7 02 36 am" src="https://user-images.githubusercontent.com/63621318/210902997-d3f5f339-109b-419d-95a9-37ad47f49a24.png">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
