### PR TITLE
SAV-45: Prevent autofill Location field when there is pre-filled value

### DIFF
--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -104,7 +104,7 @@ export const LocationInput = React.memo(
           suggester={locationGroupSuggester}
           value={groupId}
           disabled={locationGroupSelectIsDisabled || disabled}
-          autofill
+          autofill={!value} // do not autofill if there is a pre-filled value
         />
         <AutocompleteInput
           label={label}
@@ -117,7 +117,7 @@ export const LocationInput = React.memo(
           value={locationId}
           onChange={handleChange}
           className={className}
-          autofill
+          autofill={!value} // do not autofill if there is a pre-filled value
         />
       </>
     );


### PR DESCRIPTION
### Ticket: SAV-45

### Changes
- Prevent autofill Location field when there is pre-filled value

### Checklist
- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
