### PR TITLE
EPI-157 + EPI-188: Fix modal sort, correct copy, and fix PDF

### DIFF
--- a/packages/desktop/app/components/LabRequestsTable.js
+++ b/packages/desktop/app/components/LabRequestsTable.js
@@ -26,7 +26,7 @@ const encounterColumns = [
   { key: 'labRequestType', title: 'Type', accessor: getRequestType, sortable: false },
   { key: 'status', title: 'Status', accessor: getStatus, sortable: false },
   { key: 'displayName', title: 'Requested by', accessor: getRequestedBy, sortable: false },
-  { key: 'requestedDate', title: 'Date', accessor: getDate, sortable: false },
+  { key: 'requestedDate', title: 'Request date', accessor: getDate, sortable: false },
   { key: 'priority', title: 'Priority', accessor: getPriority },
   { key: 'laboratory', title: 'Laboratory', accessor: getLaboratory },
 ];

--- a/packages/desktop/app/components/PatientPrinting/ListTable.js
+++ b/packages/desktop/app/components/PatientPrinting/ListTable.js
@@ -2,49 +2,48 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import { Typography, Box } from '@material-ui/core';
-
-const Table = styled(Box)`
-  border-top: 1px solid black;
-  border-left: 1px solid black;
+const Table = styled.table`
+  border: 1px solid black;
   margin-top: 10px;
   margin-bottom: 16px;
+  border-spacing: 0px;
+  border-collapse: collapse;
+  width: 100%;
 `;
 
-const Row = styled(Box)`
-  display: grid;
-  grid-template-columns: ${props => props.$gridTemplateColumns};
+const Row = styled.tr`
   border-bottom: 1px solid black;
 `;
 
-const Cell = styled(Box)`
+const Header = styled.th`
   border-right: 1px solid black;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-`;
-
-const Text = styled(Typography)`
-  font-size: 14px;
-`;
-const StrongText = styled(Text)`
   font-weight: 600;
 `;
 
-export const ListTable = ({ columns, data, gridTemplateColumns }) => {
+const Cell = styled.td`
+  border-right: 1px solid black;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 14px;
+`;
+
+export const ListTable = ({ columns, data }) => {
   return (
     <Table>
-      <Row $gridTemplateColumns={gridTemplateColumns}>
-        {columns.map(({ title, style = { paddingLeft: '1rem' } }) => (
-          <Cell>
-            <StrongText style={style}>{title}</StrongText>
-          </Cell>
+      <Row>
+        {columns.map(({ key, title, style }) => (
+          <Header key={key} style={{ paddingLeft: '0.5rem', ...style }}>
+            {title}
+          </Header>
         ))}
       </Row>
       {data.map(row => (
-        <Row $gridTemplateColumns={gridTemplateColumns}>
-          {columns.map(({ key, accessor, style = { paddingLeft: '1rem' } }) => (
-            <Cell>
-              <Text style={style}>{accessor ? accessor(row) : row[key]}</Text>
+        <Row key={row.id}>
+          {columns.map(({ key, accessor, style }) => (
+            <Cell key={key} style={{ paddingLeft: '0.5rem', ...style }}>
+              {accessor ? accessor(row) : row[key]}
             </Cell>
           ))}
         </Row>
@@ -56,5 +55,4 @@ export const ListTable = ({ columns, data, gridTemplateColumns }) => {
 ListTable.propTypes = {
   columns: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,
-  gridTemplateColumns: PropTypes.string.isRequired,
 };

--- a/packages/desktop/app/components/PatientPrinting/MultipleLabRequestsPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/MultipleLabRequestsPrintout.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { Typography } from '@material-ui/core';
 import Divider from '@material-ui/core/Divider';
 
 import { getCurrentDateString } from 'shared/utils/dateTime';
@@ -44,37 +43,43 @@ const columns = [
   {
     key: 'displayId',
     title: 'Test ID',
+    style: { width: '13.33%' },
   },
   {
     key: 'date',
     title: 'Request date',
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
+    style: { width: '13.33%' },
   },
   {
     key: 'requestedBy',
     title: 'Requesting clinician',
     accessor: ({ requestedBy }) => requestedBy?.displayName,
+    style: { width: '13.33%' },
   },
   {
     key: 'sampleTime',
     title: 'Sample time',
     accessor: ({ sampleTime }) => <DateDisplay date={sampleTime} showTime />,
-    style: { textAlign: 'center' },
+    style: { textAlign: 'center', width: '13.33%' },
   },
   {
     key: 'priority',
     title: 'Priority',
     accessor: ({ priority }) => priority?.name || '',
+    style: { width: '13.33%' },
   },
   {
     key: 'category',
     title: 'Test category',
     accessor: ({ category }) => category?.name || '',
+    style: { width: '13.33%' },
   },
   {
     key: 'testType',
     title: 'Test type',
     accessor: ({ tests }) => tests?.map(test => test.labTestType?.name).join(', ') || '',
+    style: { width: '20%' },
   },
 ];
 
@@ -123,11 +128,7 @@ export const MultipleLabRequestsPrintout = React.memo(
           </StyledDiv>
         </RowContainer>
 
-        <ListTable
-          data={labRequests}
-          columns={columns}
-          gridTemplateColumns="2fr 2fr 2fr 2fr 2fr 2fr 3fr"
-        />
+        <ListTable data={labRequests} columns={columns} />
         <StyledNotesSectionWrapper>
           <NotesSection title="Notes" notes={notes} height="auto" separator={null} boldTitle />
         </StyledNotesSectionWrapper>

--- a/packages/desktop/app/components/PatientPrinting/MultiplePrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/MultiplePrescriptionPrintout.js
@@ -56,25 +56,28 @@ const columns = [
     key: 'medication',
     title: 'Medication',
     accessor: ({ medication }) => (medication || {}).name,
+    style: { width: '31.25%' },
   },
   {
     key: 'prescription',
     title: 'Instructions',
+    style: { width: '31.25%' },
   },
   {
     key: 'route',
     title: 'Route',
     accessor: ({ route }) => DRUG_ROUTE_VALUE_TO_LABEL[route] || '',
+    style: { width: '12.5%' },
   },
   {
     key: 'quantity',
     title: 'Quantity',
-    style: { textAlign: 'center' },
+    style: { textAlign: 'center', width: '12.5%' },
   },
   {
     key: 'repeats',
     title: 'Repeats',
-    style: { textAlign: 'center' },
+    style: { textAlign: 'center', width: '12.5%' },
   },
 ];
 
@@ -114,11 +117,7 @@ export const MultiplePrescriptionPrintout = React.memo(
           </StyledDiv>
         </RowContainer>
 
-        <ListTable
-          data={prescriptions}
-          columns={columns}
-          gridTemplateColumns="5fr 5fr 2fr 2fr 2fr"
-        />
+        <ListTable data={prescriptions} columns={columns} />
         <StyledNotesSectionWrapper>
           <NotesSection title="Notes" boldTitle />
         </StyledNotesSectionWrapper>

--- a/packages/desktop/app/components/PatientPrinting/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/PrintMultipleLabRequestsSelectionForm.js
@@ -72,6 +72,8 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
     api.get(`encounter/${encodeURIComponent(encounter.id)}/labRequests`, {
       includeNotePages: 'true',
       status: 'reception_pending',
+      order: 'asc',
+      orderBy: 'requestedDate',
     }),
   );
 

--- a/packages/desktop/app/components/PatientPrinting/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/PrintMultipleLabRequestsSelectionForm.js
@@ -38,7 +38,7 @@ const COLUMNS = [
   },
   {
     key: COLUMN_KEYS.DATE,
-    title: 'Date',
+    title: 'Request date',
     sortable: false,
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
   },

--- a/packages/desktop/app/forms/LabRequestForm.js
+++ b/packages/desktop/app/forms/LabRequestForm.js
@@ -109,7 +109,7 @@ export const LabRequestForm = ({
         <Field name="displayId" label="Lab request number" disabled component={TextField} />
         <Field
           name="requestedDate"
-          label="Order date"
+          label="Request date"
           required
           component={DateTimeField}
           saveDateAsString


### PR DESCRIPTION
### Changes

This PR updates the copy (which had three different words to refer to the `requestedDate` column), adds a sort order, and rewrites the PDF to use normal tables instead of grid layout.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
