### PR TITLE
WAITM-528 Fixup NaN calculation questions

### DIFF
--- a/packages/shared-src/__tests__/utils/calculations.test.js
+++ b/packages/shared-src/__tests__/utils/calculations.test.js
@@ -27,21 +27,25 @@ function makeDummySurvey(components) {
 describe('Survey calculations', () => {
   describe('CalculatedField', () => {
     it('should run a trivial calculation', () => {
-      const survey = makeDummySurvey([{ code: 'TEST', type: 'Calculated', calculation: '1' }]);
+      const survey = makeDummySurvey([
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: '1' },
+      ]);
       const calculations = runCalculations(survey, {});
       expect(calculations.TEST).toEqual(1);
     });
 
     it('should run a simple calculation', () => {
-      const survey = makeDummySurvey([{ code: 'TEST', type: 'Calculated', calculation: '1 + 1' }]);
+      const survey = makeDummySurvey([
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: '1 + 1' },
+      ]);
       const calculations = runCalculations(survey, {});
       expect(calculations.TEST).toEqual(2);
     });
 
     it('should run several calculations', () => {
       const survey = makeDummySurvey([
-        { code: 'TEST', type: 'Calculated', calculation: '3 * 5' },
-        { code: 'TEST_2', type: 'Calculated', calculation: '100 - 1' },
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: '3 * 5' },
+        { code: 'TEST_2', type: 'CalculatedQuestion', calculation: '100 - 1' },
       ]);
       const calculations = runCalculations(survey, {});
       expect(calculations.TEST).toEqual(15);
@@ -52,7 +56,7 @@ describe('Survey calculations', () => {
       const survey = makeDummySurvey([
         { code: 'TEST_1' },
         { code: 'TEST_2' },
-        { code: 'TEST', type: 'Calculated', calculation: 'TEST_1 + TEST_2' },
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: 'TEST_1 + TEST_2' },
       ]);
       const calculations = runCalculations(survey, {
         TEST_1: 24,
@@ -65,8 +69,8 @@ describe('Survey calculations', () => {
       const survey = makeDummySurvey([
         { code: 'TEST_1' },
         { code: 'TEST_2' },
-        { code: 'TEST_BEFORE', type: 'Calculated', calculation: 'TEST_1 + TEST_2' },
-        { code: 'TEST_AFTER', type: 'Calculated', calculation: 'TEST_BEFORE + 2000' },
+        { code: 'TEST_BEFORE', type: 'CalculatedQuestion', calculation: 'TEST_1 + TEST_2' },
+        { code: 'TEST_AFTER', type: 'CalculatedQuestion', calculation: 'TEST_BEFORE + 2000' },
       ]);
       const calculations = runCalculations(survey, {
         TEST_1: 24,
@@ -78,9 +82,9 @@ describe('Survey calculations', () => {
     it('should register errored calculations as undefined', () => {
       const survey = makeDummySurvey([
         { code: 'TEST_1' },
-        { code: 'TEST_WORKS', type: 'Calculated', calculation: 'TEST_1 * 3' },
-        { code: 'TEST_BROKEN', type: 'Calculated', calculation: 'TEST_NONEXISTENT' },
-        { code: 'TEST_BROKEN_2', type: 'Calculated', calculation: '1 + + / * 4' },
+        { code: 'TEST_WORKS', type: 'CalculatedQuestion', calculation: 'TEST_1 * 3' },
+        { code: 'TEST_BROKEN', type: 'CalculatedQuestion', calculation: 'TEST_NONEXISTENT' },
+        { code: 'TEST_BROKEN_2', type: 'CalculatedQuestion', calculation: '1 + + / * 4' },
       ]);
       const calculations = runCalculations(survey, {
         TEST_1: 5,

--- a/packages/shared-src/src/models/SurveyResponse.js
+++ b/packages/shared-src/src/models/SurveyResponse.js
@@ -222,6 +222,10 @@ export class SurveyResponse extends Model {
         throw new Error(`no data element for question: ${dataElementId}`);
       }
       const body = getStringValue(dataElement.type, value);
+      // Don't create null answers
+      if (body === null) {
+        continue;
+      }
       await models.SurveyResponseAnswer.create({
         dataElementId: dataElement.id,
         body,

--- a/packages/shared-src/src/utils/fields.js
+++ b/packages/shared-src/src/utils/fields.js
@@ -1,9 +1,10 @@
 import { inRange } from 'lodash';
 import { log } from '../services/logging';
+import { PROGRAM_DATA_ELEMENT_TYPES } from '../constants/surveys';
 
 export function getStringValue(type, value) {
   switch (type) {
-    case 'Calculated':
+    case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED:
       return value.toFixed(1);
     default:
       return `${value}`;
@@ -12,12 +13,12 @@ export function getStringValue(type, value) {
 
 function compareData(dataType, expected, given) {
   switch (dataType) {
-    case 'Binary':
+    case PROGRAM_DATA_ELEMENT_TYPES.BINARY:
       if (expected === 'yes' && given === true) return true;
       if (expected === 'no' && given === false) return true;
       break;
-    case 'Number':
-    case 'Calculated': {
+    case PROGRAM_DATA_ELEMENT_TYPES.NUMBER:
+    case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED: {
       // we check within a threshold because strict equality is actually pretty rare
       const parsed = parseFloat(expected);
       const diff = Math.abs(parsed - given);
@@ -26,7 +27,7 @@ function compareData(dataType, expected, given) {
       if (diff < threshold) return true;
       break;
     }
-    case 'MultiSelect':
+    case PROGRAM_DATA_ELEMENT_TYPES.MULTI_SELECT:
       return given.split(', ').includes(expected);
     default:
       if (expected === given) return true;

--- a/packages/shared-src/src/utils/fields.js
+++ b/packages/shared-src/src/utils/fields.js
@@ -3,6 +3,9 @@ import { log } from '../services/logging';
 import { PROGRAM_DATA_ELEMENT_TYPES } from '../constants/surveys';
 
 export function getStringValue(type, value) {
+  if (value === null) {
+    return null;
+  }
   switch (type) {
     case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED:
       return value.toFixed(1);


### PR DESCRIPTION
### Changes

- When a calculated question returns `NaN` it gets converted to `null` and then converted to a string `"null"`
  - Instead, skip null answers when creating survey response answers
- Also update usages of data element type names to use values from constants

### Checklist

- [X] Code is finished
- [X] Tests are written
- [X] UI Screenshots added to the Linear issue
- [X] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
