### PR TITLE
CI: Add dummy job for tests-pass status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,15 @@ jobs:
 
     - run: yarn test
       working-directory: packages/mobile
+
+  # Dummy job to have a stable name for PR requirements
+  tests-pass:
+    name: Tests pass
+    needs:
+      - test
+      - lint
+      - migrations
+      - test-mobile
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Tests pass"


### PR DESCRIPTION
### Changes

Stuff learned from OSS! This is a dummy job with a set name that depends on all the tests we require to pass. This makes it simple to add just this job to github's branch protection requirements, and the actual set of requirements needed to achieve a pass is then essentially defined in code. This also future-proofs changes to the CI config by decoupling the exact test layout from the PR requirements in less accessible github config.

![image](https://user-images.githubusercontent.com/155787/211224939-c46a0e4a-90bd-4f3a-99d8-7fe1695c334e.png)

![image](https://user-images.githubusercontent.com/155787/211224991-ee016416-b0ac-49b2-b154-8db4992213b4.png)

<sup>(if we enable this, let's _not_ require branches to be up to date... fine for small projects but makes it really tough to merge things at scale)</sup>

![image](https://user-images.githubusercontent.com/155787/211224974-547c21f4-0c40-4a5c-815b-e17e8e566ea8.png)

### Checklist

- [x] Code is finished