### PR TITLE
WAITM-589 Move location availability warning on check-in modal

### DIFF
--- a/packages/desktop/app/forms/EncounterForm.js
+++ b/packages/desktop/app/forms/EncounterForm.js
@@ -63,6 +63,14 @@ export const EncounterForm = React.memo(
             suggester={practitionerSuggester}
           />
           <Field name="locationId" component={LocalisedLocationField} required />
+          <LocationAvailabilityWarningMessage
+            locationId={values?.locationId}
+            style={{
+              gridColumn: '2',
+              marginTop: '-1.2rem',
+              fontSize: '12px',
+            }}
+          />
           <LocalisedField
             name="referralSourceId"
             suggester={referralSourceSuggester}
@@ -81,9 +89,6 @@ export const EncounterForm = React.memo(
             rows={2}
             style={{ gridColumn: 'span 2' }}
           />
-          <div style={{ gridColumn: '1/-1' }}>
-            <LocationAvailabilityWarningMessage locationId={values?.locationId} />
-          </div>
           <div style={{ gridColumn: 2, textAlign: 'right' }}>
             <Button variant="contained" onClick={submitForm} color="primary">
               {buttonText}


### PR DESCRIPTION
### Changes

- Move the location availability warning under the location field to be more in line with other usages

### Checklist

- [X] Code is finished
- [X] UI Screenshots added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
