### PR TITLE
WAITM-591: add location group autocomplete field to mobile 

### DIFF
--- a/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
+++ b/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
@@ -13,8 +13,9 @@ const getSuggesterEndpointForConfig = config => {
   if (config?.source === 'Location') return 'location';
   if (config?.source === 'Department') return 'department';
   if (config?.source === 'User') return 'practitioner';
-  if (config?.source === 'LocationGroup') return 'facilityLocationGroup';
-  if (config?.source === 'AllLocationGroups') return 'locationGroup';
+  if (config?.source === 'LocationGroup') {
+    return config.type === 'all' ? 'locationGroup' : 'facilityLocationGroup';
+  }
 
   // autocomplete component won't crash when given an invalid endpoint, it just logs an error.
   return null;

--- a/packages/mobile/App/migrations/1673396917000-addLocationGroupTable.ts
+++ b/packages/mobile/App/migrations/1673396917000-addLocationGroupTable.ts
@@ -58,12 +58,6 @@ const LocationGroupTable = new Table({
   ],
 });
 
-const locationTableForeignKey = new TableForeignKey({
-  columnNames: ['locationGroupId'],
-  referencedColumnNames: ['id'],
-  referencedTableName: 'locationGroup',
-});
-
 const ifNotExist = true;
 
 export class addLocationGroupTable1673396917000 implements MigrationInterface {
@@ -72,16 +66,33 @@ export class addLocationGroupTable1673396917000 implements MigrationInterface {
     await queryRunner.createTable(LocationGroupTable, ifNotExist);
 
     // Add relation from location to locationGroup
-    // await queryRunner.createForeignKey('location', locationTableForeignKey);
+    await queryRunner.addColumn(
+      'location',
+      new TableColumn({
+        name: 'locationGroupId',
+        isNullable: true,
+        type: 'varchar',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'location',
+      new TableForeignKey({
+        columnNames: ['locationGroupId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'locationGroup',
+      }),
+    );
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {
     // Drop relation from location to locationGroup
-    // const locationTable = await queryRunner.getTable('location');
-    // const foreignKey = locationTable.foreignKeys.find(
-    //   fk => fk.columnNames.indexOf('locationGroupId') !== -1,
-    // );
-    // await queryRunner.dropForeignKey('location', foreignKey);
+    const locationTable = await queryRunner.getTable('location');
+    const foreignKey = locationTable.foreignKeys.find(
+      fk => fk.columnNames.indexOf('locationGroupId') !== -1,
+    );
+    await queryRunner.dropForeignKey('location', foreignKey);
+    await queryRunner.dropColumn('location', 'locationGroupId');
 
     // Drop locationGroup Table
     await queryRunner.dropTable('locationGroup');

--- a/packages/mobile/App/migrations/1673396917000-addLocationGroupTable.ts
+++ b/packages/mobile/App/migrations/1673396917000-addLocationGroupTable.ts
@@ -1,0 +1,89 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey } from 'typeorm';
+
+const BaseColumns = [
+  new TableColumn({
+    name: 'id',
+    type: 'varchar',
+    isPrimary: true,
+  }),
+  new TableColumn({
+    name: 'createdAt',
+    type: 'datetime',
+    default: "datetime('now')",
+  }),
+  new TableColumn({
+    name: 'updatedAt',
+    type: 'datetime',
+    default: "datetime('now')",
+  }),
+  new TableColumn({
+    name: 'updatedAtSyncTick',
+    type: 'bigint',
+    isNullable: false,
+    default: -999,
+  }),
+];
+
+const LocationGroupTable = new Table({
+  name: 'locationGroup',
+  columns: [
+    ...BaseColumns,
+    new TableColumn({
+      name: 'code',
+      type: 'varchar',
+      default: "''",
+    }),
+    new TableColumn({
+      name: 'name',
+      type: 'varchar',
+      default: "''",
+    }),
+    new TableColumn({
+      name: 'visibilityStatus',
+      type: 'varchar',
+      default: "'current'",
+    }),
+    new TableColumn({
+      name: 'facilityId',
+      type: 'varchar',
+      isNullable: true,
+    }),
+  ],
+  foreignKeys: [
+    new TableForeignKey({
+      columnNames: ['facilityId'],
+      referencedTableName: 'facility',
+      referencedColumnNames: ['id'],
+    }),
+  ],
+});
+
+const locationTableForeignKey = new TableForeignKey({
+  columnNames: ['locationGroupId'],
+  referencedColumnNames: ['id'],
+  referencedTableName: 'locationGroup',
+});
+
+const ifNotExist = true;
+
+export class addLocationGroupTable1673396917000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    // Add locationGroup Table
+    await queryRunner.createTable(LocationGroupTable, ifNotExist);
+
+    // Add relation from location to locationGroup
+    // await queryRunner.createForeignKey('location', locationTableForeignKey);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop relation from location to locationGroup
+    // const locationTable = await queryRunner.getTable('location');
+    // const foreignKey = locationTable.foreignKeys.find(
+    //   fk => fk.columnNames.indexOf('locationGroupId') !== -1,
+    // );
+    // await queryRunner.dropForeignKey('location', foreignKey);
+
+    // Drop locationGroup Table
+    await queryRunner.dropTable('locationGroup');
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -11,6 +11,7 @@ import { updateLabRequestDateColumns1666171050000 } from './1666171050000-update
 import { addFieldUpdateTicksToPAD1668987530000 } from './1668987530000-addFieldUpdateTicksToPAD';
 import { addDefaultLastSuccessfulSyncPull1669160460000 } from './1669160460000-addDefaultLastSuccessfulSyncPull';
 import { resyncPatientAdditionalData1669855692000 } from './1669855692000-resyncPatientAdditionalData';
+import { addLocationGroupTable1673396917000 } from './1673396917000-addLocationGroupTable';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -25,4 +26,5 @@ export const migrationList = [
   addFieldUpdateTicksToPAD1668987530000,
   addDefaultLastSuccessfulSyncPull1669160460000,
   resyncPatientAdditionalData1669855692000,
+  addLocationGroupTable1673396917000,
 ];

--- a/packages/mobile/App/models/Location.ts
+++ b/packages/mobile/App/models/Location.ts
@@ -4,6 +4,7 @@ import { ILocation } from '../types';
 import { BaseModel } from './BaseModel';
 import { Encounter } from './Encounter';
 import { Facility } from './Facility';
+import { LocationGroup } from './LocationGroup';
 import { AdministeredVaccine } from './AdministeredVaccine';
 import { VisibilityStatus } from '../visibilityStatuses';
 import { SYNC_DIRECTIONS } from './types';
@@ -38,4 +39,10 @@ export class Location extends BaseModel implements ILocation {
     administeredVaccine => administeredVaccine.location,
   )
   administeredVaccines: AdministeredVaccine[];
+
+  // @ManyToOne(() => LocationGroup)
+  // locationGroup: LocationGroup;
+  //
+  // @RelationId(({ locationGroup }) => locationGroup)
+  // locationGroupId: string;
 }

--- a/packages/mobile/App/models/Location.ts
+++ b/packages/mobile/App/models/Location.ts
@@ -40,9 +40,9 @@ export class Location extends BaseModel implements ILocation {
   )
   administeredVaccines: AdministeredVaccine[];
 
-  // @ManyToOne(() => LocationGroup)
-  // locationGroup: LocationGroup;
-  //
-  // @RelationId(({ locationGroup }) => locationGroup)
-  // locationGroupId: string;
+  @ManyToOne(() => LocationGroup)
+  locationGroup: LocationGroup;
+
+  @RelationId(({ locationGroup }) => locationGroup)
+  locationGroupId: string;
 }

--- a/packages/mobile/App/models/LocationGroup.ts
+++ b/packages/mobile/App/models/LocationGroup.ts
@@ -1,0 +1,38 @@
+import { Column, OneToMany, RelationId } from 'typeorm';
+import { Entity, ManyToOne } from 'typeorm/browser';
+import { IFacility, ILocationGroup } from '../types';
+import { BaseModel } from './BaseModel';
+import { Facility } from './Facility';
+import { Location } from './Location';
+import { VisibilityStatus } from '../visibilityStatuses';
+import { SYNC_DIRECTIONS } from './types';
+
+@Entity('locationGroup')
+export class LocationGroup extends BaseModel implements ILocationGroup {
+  static syncDirection = SYNC_DIRECTIONS.PULL_FROM_CENTRAL;
+
+  @Column({ default: '' })
+  code: string;
+
+  @Column({ default: '' })
+  name: string;
+
+  @Column({ default: VisibilityStatus.Current })
+  visibilityStatus: string;
+
+  @ManyToOne(() => Facility)
+  facility: IFacility;
+
+  @RelationId(({ facility }) => facility)
+  facilityId: string;
+
+  // @OneToMany(
+  //   () => Location,
+  //   ({ locationGroup }) => locationGroup,
+  // )
+  // locations: Location[];
+
+  static getTableNameForSync(): string {
+    return 'location_groups';
+  }
+}

--- a/packages/mobile/App/models/LocationGroup.ts
+++ b/packages/mobile/App/models/LocationGroup.ts
@@ -26,11 +26,11 @@ export class LocationGroup extends BaseModel implements ILocationGroup {
   @RelationId(({ facility }) => facility)
   facilityId: string;
 
-  // @OneToMany(
-  //   () => Location,
-  //   ({ locationGroup }) => locationGroup,
-  // )
-  // locations: Location[];
+  @OneToMany(
+    () => Location,
+    ({ locationGroup }) => locationGroup,
+  )
+  locations: Location[];
 
   static getTableNameForSync(): string {
     return 'location_groups';

--- a/packages/mobile/App/models/modelsMap.ts
+++ b/packages/mobile/App/models/modelsMap.ts
@@ -21,6 +21,7 @@ import { Attachment } from './Attachment';
 import { Facility } from './Facility';
 import { Department } from './Department';
 import { Location } from './Location';
+import { LocationGroup } from './LocationGroup';
 import { BaseModel } from './BaseModel';
 import { LabRequest } from './LabRequest';
 import { LabTest } from './LabTest';
@@ -52,6 +53,7 @@ export const MODELS_MAP = {
   Facility,
   Department,
   Location,
+  LocationGroup,
   LabRequest,
   LabTest,
   LabTestType,

--- a/packages/mobile/App/types/ILocationGroup.ts
+++ b/packages/mobile/App/types/ILocationGroup.ts
@@ -1,0 +1,10 @@
+import { ID } from './ID';
+import { IFacility } from './IFacility';
+
+export interface ILocationGroup {
+  id: ID;
+  code: string;
+  name: string;
+  facility?: IFacility;
+  visibilityStatus: string;
+}

--- a/packages/mobile/App/types/index.ts
+++ b/packages/mobile/App/types/index.ts
@@ -22,5 +22,6 @@ export * from './IReferral';
 export * from './IPatientAditionalData';
 export * from './IFacility';
 export * from './ILocation';
+export * from './ILocationGroup';
 export * from './IDepartment';
 export * from './DateString';


### PR DESCRIPTION
### Changes

Location Group autocompletes were added to desktop and this PR makes mobile compatible with them. Location Groups were not used in mobile before this so I had to add a new migration and model for them.

- Add LocationGroup model
- Add migration for locationGroups and relation from location to them
- Add Location Group

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
