### PR TITLE
WAITM-591: Fix Location Group Autocompletes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,15 @@ jobs:
 
     - run: yarn test
       working-directory: packages/mobile
+
+  # Dummy job to have a stable name for PR requirements
+  tests-pass:
+    name: Tests pass
+    needs:
+      - test
+      - lint
+      - migrations
+      - test-mobile
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Tests pass"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "This repo contains all the packages for Tamanu",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csca",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "CSCA tooling for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
+++ b/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
@@ -13,8 +13,9 @@ const getSuggesterEndpointForConfig = config => {
   if (config?.source === 'Location') return 'location';
   if (config?.source === 'Department') return 'department';
   if (config?.source === 'User') return 'practitioner';
-  if (config?.source === 'LocationGroup') return 'facilityLocationGroup';
-  if (config?.source === 'AllLocationGroups') return 'locationGroup';
+  if (config?.source === 'LocationGroup') {
+    return config.type === 'all' ? 'locationGroup' : 'facilityLocationGroup';
+  }
 
   // autocomplete component won't crash when given an invalid endpoint, it just logs an error.
   return null;

--- a/packages/desktop/app/components/LabRequestsTable.js
+++ b/packages/desktop/app/components/LabRequestsTable.js
@@ -26,7 +26,7 @@ const encounterColumns = [
   { key: 'labRequestType', title: 'Type', accessor: getRequestType, sortable: false },
   { key: 'status', title: 'Status', accessor: getStatus, sortable: false },
   { key: 'displayName', title: 'Requested by', accessor: getRequestedBy, sortable: false },
-  { key: 'requestedDate', title: 'Date', accessor: getDate, sortable: false },
+  { key: 'requestedDate', title: 'Request date', accessor: getDate, sortable: false },
   { key: 'priority', title: 'Priority', accessor: getPriority },
   { key: 'laboratory', title: 'Laboratory', accessor: getLaboratory },
 ];

--- a/packages/desktop/app/components/PatientPrinting/ListTable.js
+++ b/packages/desktop/app/components/PatientPrinting/ListTable.js
@@ -2,49 +2,48 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import { Typography, Box } from '@material-ui/core';
-
-const Table = styled(Box)`
-  border-top: 1px solid black;
-  border-left: 1px solid black;
+const Table = styled.table`
+  border: 1px solid black;
   margin-top: 10px;
   margin-bottom: 16px;
+  border-spacing: 0px;
+  border-collapse: collapse;
+  width: 100%;
 `;
 
-const Row = styled(Box)`
-  display: grid;
-  grid-template-columns: ${props => props.$gridTemplateColumns};
+const Row = styled.tr`
   border-bottom: 1px solid black;
 `;
 
-const Cell = styled(Box)`
+const Header = styled.th`
   border-right: 1px solid black;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-`;
-
-const Text = styled(Typography)`
-  font-size: 14px;
-`;
-const StrongText = styled(Text)`
   font-weight: 600;
 `;
 
-export const ListTable = ({ columns, data, gridTemplateColumns }) => {
+const Cell = styled.td`
+  border-right: 1px solid black;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 14px;
+`;
+
+export const ListTable = ({ columns, data }) => {
   return (
     <Table>
-      <Row $gridTemplateColumns={gridTemplateColumns}>
-        {columns.map(({ title, style = { paddingLeft: '1rem' } }) => (
-          <Cell>
-            <StrongText style={style}>{title}</StrongText>
-          </Cell>
+      <Row>
+        {columns.map(({ key, title, style }) => (
+          <Header key={key} style={{ paddingLeft: '0.5rem', ...style }}>
+            {title}
+          </Header>
         ))}
       </Row>
       {data.map(row => (
-        <Row $gridTemplateColumns={gridTemplateColumns}>
-          {columns.map(({ key, accessor, style = { paddingLeft: '1rem' } }) => (
-            <Cell>
-              <Text style={style}>{accessor ? accessor(row) : row[key]}</Text>
+        <Row key={row.id}>
+          {columns.map(({ key, accessor, style }) => (
+            <Cell key={key} style={{ paddingLeft: '0.5rem', ...style }}>
+              {accessor ? accessor(row) : row[key]}
             </Cell>
           ))}
         </Row>
@@ -56,5 +55,4 @@ export const ListTable = ({ columns, data, gridTemplateColumns }) => {
 ListTable.propTypes = {
   columns: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,
-  gridTemplateColumns: PropTypes.string.isRequired,
 };

--- a/packages/desktop/app/components/PatientPrinting/MultipleLabRequestsPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/MultipleLabRequestsPrintout.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { Typography } from '@material-ui/core';
 import Divider from '@material-ui/core/Divider';
 
 import { getCurrentDateString } from 'shared/utils/dateTime';
@@ -44,37 +43,43 @@ const columns = [
   {
     key: 'displayId',
     title: 'Test ID',
+    style: { width: '13.33%' },
   },
   {
     key: 'date',
     title: 'Request date',
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
+    style: { width: '13.33%' },
   },
   {
     key: 'requestedBy',
     title: 'Requesting clinician',
     accessor: ({ requestedBy }) => requestedBy?.displayName,
+    style: { width: '13.33%' },
   },
   {
     key: 'sampleTime',
     title: 'Sample time',
     accessor: ({ sampleTime }) => <DateDisplay date={sampleTime} showTime />,
-    style: { textAlign: 'center' },
+    style: { textAlign: 'center', width: '13.33%' },
   },
   {
     key: 'priority',
     title: 'Priority',
     accessor: ({ priority }) => priority?.name || '',
+    style: { width: '13.33%' },
   },
   {
     key: 'category',
     title: 'Test category',
     accessor: ({ category }) => category?.name || '',
+    style: { width: '13.33%' },
   },
   {
     key: 'testType',
     title: 'Test type',
     accessor: ({ tests }) => tests?.map(test => test.labTestType?.name).join(', ') || '',
+    style: { width: '20%' },
   },
 ];
 
@@ -123,11 +128,7 @@ export const MultipleLabRequestsPrintout = React.memo(
           </StyledDiv>
         </RowContainer>
 
-        <ListTable
-          data={labRequests}
-          columns={columns}
-          gridTemplateColumns="2fr 2fr 2fr 2fr 2fr 2fr 3fr"
-        />
+        <ListTable data={labRequests} columns={columns} />
         <StyledNotesSectionWrapper>
           <NotesSection title="Notes" notes={notes} height="auto" separator={null} boldTitle />
         </StyledNotesSectionWrapper>

--- a/packages/desktop/app/components/PatientPrinting/MultiplePrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/MultiplePrescriptionPrintout.js
@@ -56,25 +56,28 @@ const columns = [
     key: 'medication',
     title: 'Medication',
     accessor: ({ medication }) => (medication || {}).name,
+    style: { width: '31.25%' },
   },
   {
     key: 'prescription',
     title: 'Instructions',
+    style: { width: '31.25%' },
   },
   {
     key: 'route',
     title: 'Route',
     accessor: ({ route }) => DRUG_ROUTE_VALUE_TO_LABEL[route] || '',
+    style: { width: '12.5%' },
   },
   {
     key: 'quantity',
     title: 'Quantity',
-    style: { textAlign: 'center' },
+    style: { textAlign: 'center', width: '12.5%' },
   },
   {
     key: 'repeats',
     title: 'Repeats',
-    style: { textAlign: 'center' },
+    style: { textAlign: 'center', width: '12.5%' },
   },
 ];
 
@@ -114,11 +117,7 @@ export const MultiplePrescriptionPrintout = React.memo(
           </StyledDiv>
         </RowContainer>
 
-        <ListTable
-          data={prescriptions}
-          columns={columns}
-          gridTemplateColumns="5fr 5fr 2fr 2fr 2fr"
-        />
+        <ListTable data={prescriptions} columns={columns} />
         <StyledNotesSectionWrapper>
           <NotesSection title="Notes" boldTitle />
         </StyledNotesSectionWrapper>

--- a/packages/desktop/app/components/PatientPrinting/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/PrintMultipleLabRequestsSelectionForm.js
@@ -38,7 +38,7 @@ const COLUMNS = [
   },
   {
     key: COLUMN_KEYS.DATE,
-    title: 'Date',
+    title: 'Request date',
     sortable: false,
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
   },
@@ -72,6 +72,8 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
     api.get(`encounter/${encodeURIComponent(encounter.id)}/labRequests`, {
       includeNotePages: 'true',
       status: 'reception_pending',
+      order: 'asc',
+      orderBy: 'requestedDate',
     }),
   );
 

--- a/packages/desktop/app/forms/EncounterForm.js
+++ b/packages/desktop/app/forms/EncounterForm.js
@@ -63,6 +63,14 @@ export const EncounterForm = React.memo(
             suggester={practitionerSuggester}
           />
           <Field name="locationId" component={LocalisedLocationField} required />
+          <LocationAvailabilityWarningMessage
+            locationId={values?.locationId}
+            style={{
+              gridColumn: '2',
+              marginTop: '-1.2rem',
+              fontSize: '12px',
+            }}
+          />
           <LocalisedField
             name="referralSourceId"
             suggester={referralSourceSuggester}
@@ -81,9 +89,6 @@ export const EncounterForm = React.memo(
             rows={2}
             style={{ gridColumn: 'span 2' }}
           />
-          <div style={{ gridColumn: '1/-1' }}>
-            <LocationAvailabilityWarningMessage locationId={values?.locationId} />
-          </div>
           <div style={{ gridColumn: 2, textAlign: 'right' }}>
             <Button variant="contained" onClick={submitForm} color="primary">
               {buttonText}

--- a/packages/desktop/app/forms/LabRequestForm.js
+++ b/packages/desktop/app/forms/LabRequestForm.js
@@ -109,7 +109,7 @@ export const LabRequestForm = ({
         <Field name="displayId" label="Lab request number" disabled component={TextField} />
         <Field
           name="requestedDate"
-          label="Order date"
+          label="Request date"
           required
           component={DateTimeField}
           saveDateAsString

--- a/packages/desktop/app/package.json
+++ b/packages/desktop/app/package.json
@@ -3,7 +3,7 @@
   "main": "./dist/main.prod.js",
   "name": "Tamanu",
   "productName": "Tamanu",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Tamanu",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/lan/app/middleware/versionCompatibility.js
+++ b/packages/lan/app/middleware/versionCompatibility.js
@@ -4,8 +4,8 @@ import { buildVersionCompatibilityCheck } from 'shared/utils';
 // server, set MIN_CLIENT_VERSION to reflect that, and desktop users will be logged out until they
 // have updated.
 
-export const MIN_CLIENT_VERSION = '1.24.0';
-export const MAX_CLIENT_VERSION = '1.24.0'; // note that higher patch versions will be allowed to connect
+export const MIN_CLIENT_VERSION = '1.25.0';
+export const MAX_CLIENT_VERSION = '1.25.0'; // note that higher patch versions will be allowed to connect
 
 export const versionCompatibility = (req, res, next) =>
   buildVersionCompatibilityCheck(MIN_CLIENT_VERSION, MAX_CLIENT_VERSION)(req, res, next);

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lan",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Lan server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-server",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Meta server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "1.24.53",
+  "version": "1.25.54",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/qr-tester/package.json
+++ b/packages/qr-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-tester",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "BES QR Code Tester App / Website",
   "author": "",
   "license": "UNLICENSED",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "index.js",
   "license": "SEE LICENSE IN license",
   "scripts": {

--- a/packages/shared-src/package.json
+++ b/packages/shared-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-src",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Common code across Tamanu packages",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/shared-src/shared.package.json
+++ b/packages/shared-src/shared.package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Common code across Tamanu packages (generated)",
   "main": "index.js",
   "types": "types/",

--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -319,7 +319,6 @@ describe('fijiAspenMediciReport', () => {
   let models;
   let fakedata;
 
-  // Reset everything between each test. Might be innefficient but there's only 2 tests
   beforeAll(async () => {
     ctx = await createTestContext();
     models = ctx.store.models;
@@ -329,26 +328,58 @@ describe('fijiAspenMediciReport', () => {
 
   afterAll(() => ctx.close());
 
-  it.each([
-    // [ expectedResults, period.start, period.end ]
-    [1, '2022-06-09', '2022-10-09'],
-    [0, '2022-06-10', '2022-10-09'],
-    [0, '2022-06-09T00:02:53-02:00', '2022-10-09'],
-    [1, '2022-06-09T00:02:53Z', '2022-10-09'],
-    [0, '2022-06-09T00:02:55Z', '2022-10-09'],
-    [1, '2022-06-09T00:02:55+01:00', '2022-10-09'],
-    [0, '2022-06-09T00:02:53-01:00', '2022-10-09'],
-    // Dates/times inputted without timezone will be server timezone
-    [0, createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 55).replace(' ', 'T'), '2023'],
-    [1, createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 53).replace(' ', 'T'), '2023'],
-  ])('should return %p result between %p and %s', async (expectedResults, start, end) => {
-    const query = `period.start=${encodeURIComponent(start)}&period.end=${encodeURIComponent(end)}`;
-    const response = await app
-      .get(`/v1/integration/fijiAspenMediciReport?${query}`)
-      .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
+  describe('should filter encounters correctly', () => {
+    it.each([
+      // [ expectedResults, period.start, period.end ]
+      [1, '2022-06-09', '2022-10-09'],
+      [0, '2022-06-10', '2022-10-09'],
+      [0, '2022-06-09T00:02:53-02:00', '2022-10-09'],
+      [1, '2022-06-09T00:02:53Z', '2022-10-09'],
+      [0, '2022-06-09T00:02:55Z', '2022-10-09'],
+      [1, '2022-06-09T00:02:55+01:00', '2022-10-09'],
+      [0, '2022-06-09T00:02:53-01:00', '2022-10-09'],
+      // Dates/times inputted without timezone will be server timezone
+      [0, createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 55).replace(' ', 'T'), '2023'],
+      [1, createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 53).replace(' ', 'T'), '2023'],
+    ])(
+      'Date filtering: Should return %p result(s) between %p and %s',
+      async (expectedResults, start, end) => {
+        const query = `period.start=${encodeURIComponent(start)}&period.end=${encodeURIComponent(
+          end,
+        )}`;
+        const response = await app
+          .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+          .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
-    expect(response).toHaveSucceeded();
-    expect(response.body.data.length).toEqual(expectedResults);
+        expect(response).toHaveSucceeded();
+        expect(response.body.data.length).toEqual(expectedResults);
+      },
+    );
+
+    it('should filter by encounter id - 0 results', async () => {
+      const query = `period.start=2022-05-09&period.end=2022-10-09&encounters=${encodeURIComponent([
+        'nonexistant-id',
+      ])}`;
+      const response = await app
+        .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+        .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
+
+      expect(response).toHaveSucceeded();
+      expect(response.body.data.length).toEqual(0);
+    });
+
+    it('should filter by encounter id - 1 result', async () => {
+      const query = `period.start=2022-05-09&period.end=2022-10-09&encounters=${encodeURIComponent([
+        fakedata.encounterId,
+        'nonexistant-id',
+      ])}`;
+      const response = await app
+        .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+        .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
+
+      expect(response).toHaveSucceeded();
+      expect(response.body.data.length).toEqual(1);
+    });
   });
 
   it(`Should produce a simple report`, async () => {

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -346,6 +346,7 @@ left join discharge_disposition_info ddi on ddi.encounter_id = e.id
 where coalesce(billing.id, '-') like coalesce(:billing_type, '%%')
 AND CASE WHEN :from_date IS NOT NULL THEN (e.start_date::timestamp at time zone :timezone_string) >= :from_date::timestamptz ELSE true END
 AND CASE WHEN :to_date IS NOT NULL THEN (e.start_date::timestamp at time zone :timezone_string) <= :to_date::timestamptz ELSE true END
+AND CASE WHEN (:input_encounter_ids) IS NOT NULL THEN e.id in (:input_encounter_ids) ELSE true END
 order by e.start_date desc
 limit :limit offset :offset;
 `;
@@ -364,8 +365,13 @@ routes.get(
   '/',
   asyncHandler(async (req, res) => {
     const { sequelize } = req.store;
-    const { 'period.start': fromDate, 'period.end': toDate, limit, offset = 0 } = req.query;
-
+    const {
+      'period.start': fromDate,
+      'period.end': toDate,
+      limit,
+      encounters,
+      offset = 0,
+    } = req.query;
     if (!COUNTRY_TIMEZONE) {
       throw new Error('A countryTimeZone must be configured in local.json for this report to run');
     }
@@ -375,6 +381,7 @@ routes.get(
       replacements: {
         from_date: parseDateParam(fromDate, COUNTRY_TIMEZONE),
         to_date: parseDateParam(toDate, COUNTRY_TIMEZONE),
+        input_encounter_ids: encounters ? encounters.split(',') : null,
         billing_type: null,
         timezone_string: COUNTRY_TIMEZONE,
         limit: limit ?? null, // Limit of null means no limit

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -7,16 +7,16 @@ import { InvalidClientHeadersError } from 'shared/errors';
 // not supported.
 export const SUPPORTED_CLIENT_VERSIONS = {
   'Tamanu LAN Server': {
-    min: '1.24.0',
-    max: '1.24.0', // note that higher patch versions will be allowed to connect
+    min: '1.25.0',
+    max: '1.25.0', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Desktop': {
-    min: '1.24.0',
-    max: '1.24.0', // note that higher patch versions will be allowed to connect
+    min: '1.25.0',
+    max: '1.25.0', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Mobile': {
-    min: '1.24.46',
-    max: '1.24.53', // note that higher patch versions will be allowed to connect
+    min: '1.25.54',
+    max: '1.25.54', // note that higher patch versions will be allowed to connect
   },
   'fiji-vps': {
     min: null,

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-server",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Sync server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",


### PR DESCRIPTION
### Changes

Location Group Autocompletes were throwing an error when trying to display an answer in a survey. This is because the Survey code that displays answers uses the source from config to look up the model to get the record for the answer. Since the AllLocationGroups source key doesn't map to a model, it didn't work. There were a couple of options to fix this. One would have been to add a mapping in the survey code from AllLocationGroups to LocationGroup but that would be introducing a new pattern so I've gone instead with updating the config as below. This feature hasn't been released yet so there is no config in the wild using AllLocationGroups as the source.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
