### PR TITLE
WAITM-591: Fix Location Group Autocompletes 

### DIFF
--- a/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
+++ b/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
@@ -13,8 +13,9 @@ const getSuggesterEndpointForConfig = config => {
   if (config?.source === 'Location') return 'location';
   if (config?.source === 'Department') return 'department';
   if (config?.source === 'User') return 'practitioner';
-  if (config?.source === 'LocationGroup') return 'facilityLocationGroup';
-  if (config?.source === 'AllLocationGroups') return 'locationGroup';
+  if (config?.source === 'LocationGroup') {
+    return config.scope === 'allFacilities' ? 'locationGroup' : 'facilityLocationGroup';
+  }
 
   // autocomplete component won't crash when given an invalid endpoint, it just logs an error.
   return null;


### PR DESCRIPTION
**Changes**
Location Group Autocompletes were throwing an error when trying to display an answer in a survey. This is because the Survey code that displays answers uses the source from config to look up the model to get the record for the answer. Since the AllLocationGroups source key doesn't map to a model, it didn't work. There were a couple of options to fix this. One would have been to add a mapping in the survey code from AllLocationGroups to LocationGroup but that would be introducing a new pattern so I've gone instead with updating the config as below. This feature hasn't been released yet so there is no config in the wild using AllLocationGroups as the source.

**Checklist**
 Code is finished
 Tests are written
 UI Screenshots added to the Linear issue
 Testing notes added to the Linear issue
Upon merging:

 Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
 with a ticket reference (e.g. TAN-123: a one line description, keep the lists sorted)
 any config/settings changes and manual deployment steps
 Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
 Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed](https://github.com/beyondessential/tamanu/pull/3384#issue-1529675969)