### PR TITLE
WAITM-448: staging-fix: correctly handle min max zero for survey validation

### DIFF
--- a/packages/desktop/app/utils/survey.js
+++ b/packages/desktop/app/utils/survey.js
@@ -269,10 +269,10 @@ export const getValidationSchema = surveyData => {
       switch (type) {
         case PROGRAM_DATA_ELEMENT_TYPES.NUMBER: {
           valueSchema = yup.number().nullable();
-          if (min) {
+          if (typeof min === 'number' && !isNaN(min)) {
             valueSchema = valueSchema.min(min, `${text} must be at least ${min}${unit}`);
           }
-          if (max) {
+          if (typeof max === 'number' && !isNaN(max)) {
             valueSchema = valueSchema.max(max, `${text} can not exceed ${max}${unit}`);
           }
           break;


### PR DESCRIPTION
### Changes
Previously min max values of 0 where not being handled due to classic mistake on my behalf

### Checklist
Staging tweak on desktop
- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
