### PR TITLE
Add location groups to hard coded permissions

### DIFF
--- a/packages/shared-src/src/roles.js
+++ b/packages/shared-src/src/roles.js
@@ -153,6 +153,11 @@ export const practitioner = [
   { verb: 'create', noun: 'Location' },
   { verb: 'write', noun: 'Location' },
 
+  { verb: 'list', noun: 'LocationGroup' },
+  { verb: 'read', noun: 'LocationGroup' },
+  { verb: 'create', noun: 'LocationGroup' },
+  { verb: 'write', noun: 'LocationGroup' },
+
   { verb: 'list', noun: 'Attachment' },
   { verb: 'read', noun: 'Attachment' },
 


### PR DESCRIPTION
### Changes

- We tend to use the `Location` permission for `LocationGroup` checks, but `LocationGroup` permission checks still occur on the auto generated endpoints (i.e. CRUDHelper + suggester)
  - When running with hardcoded permissions this functionality is broken
  - Re-add `LocationGroup` permissions to the roles file