### PR TITLE
SAV-51: staging-fix: don't override incorrect cred error message

### DIFF
--- a/packages/desktop/app/api/TamanuApi.js
+++ b/packages/desktop/app/api/TamanuApi.js
@@ -232,7 +232,7 @@ export class TamanuApi {
     }
 
     // handle auth expiring
-    if (response.status === 401 && this.onAuthFailure) {
+    if (response.status === 401 && endpoint !== 'login' && this.onAuthFailure) {
       clearLocalStorage();
       const message = 'Your session has expired. Please log in again.';
       this.onAuthFailure(message);


### PR DESCRIPTION
### Changes
Saw this same logic used in mobile to deal with 401 error messages
on login endpoint it refers to incorrect credentials
and when a user is logged in an expired token will also send 401

### Checklist
Staging fix
- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
