### PR TITLE
No Issue: Hide Vitals and Referrals From Programs List

### DIFF
--- a/packages/lan/app/routes/apiv1/program.js
+++ b/packages/lan/app/routes/apiv1/program.js
@@ -15,7 +15,7 @@ program.get(
     req.checkPermission('list', 'Program');
     const { models, ability } = req;
     const records = await models.Program.findAll({
-      include: [{ association: 'surveys' }],
+      include: [{ association: 'surveys', where: { surveyType: 'programs' } }],
     });
 
     // Don't include programs that don't have any permitted survey to submit


### PR DESCRIPTION
### Changes

When we import a Referrals or Vitals Survey, we create a Program record in the database to contain it. This is not really ideal since the Referrals and Vitals don't need a Program and it results in an empty Program displaying in the Select Program field (see screenshot below). This change simply filters out any programs for Vitals and Referrals surveys so that they don't display in the desktop app.

I considered also updating the Programs Importer to stop it creating Programs records for Vitals and Referrals but it is not as trivial as I thought and involves a bit of regression risk so I decided to simply go with the quick win.

Before
![Screen Shot 2023-01-13 at 1 52 17 PM](https://user-images.githubusercontent.com/12807916/212212585-76a5aa58-e266-4cc6-ab97-7973be5d8b0e.png)

After
![Screen Shot 2023-01-13 at 1 51 54 PM](https://user-images.githubusercontent.com/12807916/212212597-5a58aa6c-178f-40ba-8cd9-4995db9bf5c9.png)


### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
