### PR TITLE
EPI-136: Use separate completed_at datetime field instead of created_at

### DIFF
--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -157,7 +157,7 @@ const ImagingResultsSection = ({ values, practitionerSuggester }) => {
             }
             disabled
           />
-          <DateTimeInput label="Completed" value={result.createdAt} disabled />
+          <DateTimeInput label="Completed" value={result.completedAt} disabled />
           {result.externalUrl && (
             <Button color="secondary" onClick={openExternalUrl(result.externalUrl)}>
               View image (external link)

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -236,8 +236,8 @@ imagingRequest.put(
 
     if (newResultDescription?.length > 0) {
       const newResult = await ImagingResult.create({
-        createdAt: parseISO(newResultDate),
         description: newResultDescription,
+        completedAt: newResultDate,
         completedById: newResultCompletedBy,
         imagingRequestId: imagingRequestObject.id,
       });

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { startOfDay, endOfDay, parseISO } from 'date-fns';
+import { startOfDay, endOfDay } from 'date-fns';
 import { Op } from 'sequelize';
 import { NOTE_TYPES, AREA_TYPE_TO_IMAGING_TYPE, IMAGING_AREA_TYPES } from 'shared/constants';
 import { NotFoundError } from 'shared/errors';

--- a/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
+++ b/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
@@ -1,0 +1,22 @@
+import { DataTypes } from 'sequelize';
+
+const ISO9075_DATE_TIME_FMT = 'YYYY-MM-DD HH24:MI:SS';
+
+export async function up(query) {
+  await query.addColumn('imaging_results', 'completed_at', {
+    type: DataTypes.DATETIMESTRING,
+    notNull: false,
+  });
+  await query.sequelize.query(`
+    UPDATE imaging_results
+    SET completed_at = TO_CHAR(created_at, '${ISO9075_DATE_TIME_FMT}')
+  `);
+  await query.changeColumn('imaging_results', 'completed_at', {
+    type: DataTypes.DATETIMESTRING,
+    notNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('imaging_results', 'completed_at');
+}

--- a/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
+++ b/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
@@ -5,7 +5,7 @@ const ISO9075_DATE_TIME_FMT = 'YYYY-MM-DD HH24:MI:SS';
 export async function up(query) {
   await query.addColumn('imaging_results', 'completed_at', {
     type: DataTypes.DATETIMESTRING,
-    notNull: false,
+    allowNull: true,
   });
   await query.sequelize.query(`
     UPDATE imaging_results
@@ -13,7 +13,7 @@ export async function up(query) {
   `);
   await query.changeColumn('imaging_results', 'completed_at', {
     type: DataTypes.DATETIMESTRING,
-    notNull: true,
+    allowNull: false,
   });
 }
 

--- a/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
+++ b/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Sequelize } from 'sequelize';
 
 const ISO9075_DATE_TIME_FMT = 'YYYY-MM-DD HH24:MI:SS';
 

--- a/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
+++ b/packages/shared-src/src/migrations/1673584098057-imagingResultsUseSeparateDateField.js
@@ -14,6 +14,11 @@ export async function up(query) {
   await query.changeColumn('imaging_results', 'completed_at', {
     type: DataTypes.DATETIMESTRING,
     allowNull: false,
+    defaultValue: Sequelize.fn(
+      'to_char',
+      Sequelize.fn('current_timestamp', 3),
+      ISO9075_DATE_TIME_FMT,
+    ),
   });
 }
 

--- a/packages/shared-src/src/models/ImagingResult.js
+++ b/packages/shared-src/src/models/ImagingResult.js
@@ -6,6 +6,7 @@ import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
 import { buildEncounterLinkedSyncFilter } from './buildEncounterLinkedSyncFilter';
 import { dateTimeType } from './dateTimeTypes';
+import { getCurrentDateTimeString } from '../utils/dateTime';
 
 export class ImagingResult extends Model {
   static init(options) {
@@ -22,7 +23,10 @@ export class ImagingResult extends Model {
           allowNull: false,
           defaultValue: 'current',
         },
-        completedAt: dateTimeType('completedAt', { allowNull: false }),
+        completedAt: dateTimeType('completedAt', {
+          allowNull: false,
+          defaultValue: getCurrentDateTimeString,
+        }),
         description: {
           type: DataTypes.TEXT,
           allowNull: false,

--- a/packages/shared-src/src/models/ImagingResult.js
+++ b/packages/shared-src/src/models/ImagingResult.js
@@ -5,6 +5,7 @@ import { SYNC_DIRECTIONS } from 'shared/constants';
 
 import { Model } from './Model';
 import { buildEncounterLinkedSyncFilter } from './buildEncounterLinkedSyncFilter';
+import { dateTimeType } from './dateTimeTypes';
 
 export class ImagingResult extends Model {
   static init(options) {
@@ -21,6 +22,7 @@ export class ImagingResult extends Model {
           allowNull: false,
           defaultValue: 'current',
         },
+        completedAt: dateTimeType('completedAt', { allowNull: false }),
         description: {
           type: DataTypes.TEXT,
           allowNull: false,

--- a/packages/shared-src/src/models/fhir/Observation.js
+++ b/packages/shared-src/src/models/fhir/Observation.js
@@ -7,6 +7,7 @@ import { arrayOf } from './utils';
 import { FhirAnnotation, FhirIdentifier, FhirReference } from '../../services/fhirTypes';
 import { FHIR_INTERACTIONS, FHIR_ISSUE_TYPE, IMAGING_REQUEST_STATUS_TYPES } from '../../constants';
 import { Deleted, Invalid } from '../../utils/fhir';
+import { getCurrentDateTimeString, toDateTimeString } from '../../utils/dateTime';
 
 export class FhirObservation extends FhirResource {
   static init(options, models) {
@@ -14,6 +15,7 @@ export class FhirObservation extends FhirResource {
       {
         identifier: arrayOf('identifier', DataTypes.FHIR_IDENTIFIER),
         basedOn: arrayOf('basedOn', DataTypes.FHIR_REFERENCE),
+        started: DataTypes.DATE,
         status: {
           type: DataTypes.TEXT,
           allowNull: false,
@@ -33,6 +35,7 @@ export class FhirObservation extends FhirResource {
     return yup.object({
       identifier: yup.array().of(FhirIdentifier.asYup()),
       basedOn: yup.array().of(FhirReference.asYup()),
+      started: yup.date().optional(),
       status: yup.string().required(),
       note: yup.array().of(FhirAnnotation.asYup()),
     });
@@ -97,6 +100,7 @@ export class FhirObservation extends FhirResource {
         imagingRequestId: imagingRequest.id,
         description: results,
         externalCode: imagingAccessCode,
+        completedAt: this.started ? toDateTimeString(this.started) : getCurrentDateTimeString(),
       });
     }
 


### PR DESCRIPTION
### Changes

Created_at doesn't survive sync intact. Also lets us use a DATETIMESTRING type instead of a TIMESTAMPTZ.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] Testing notes added to the Linear issue