### PR TITLE
EPI-329: Cannot export from non general patient listing

### DIFF
--- a/packages/desktop/app/components/SurveyResponseDetailsModal.js
+++ b/packages/desktop/app/components/SurveyResponseDetailsModal.js
@@ -115,7 +115,7 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
 
   return (
     <Modal title="Survey response" open={!!surveyResponseId} onClose={onClose}>
-      <Table data={answerRows} columns={COLUMNS} />
+      <Table data={answerRows} columns={COLUMNS} allowExport={false} />
     </Modal>
   );
 };

--- a/packages/desktop/app/components/Table/DownloadDataButton.js
+++ b/packages/desktop/app/components/Table/DownloadDataButton.js
@@ -24,13 +24,14 @@ function getHeaderValue(column) {
 
 export function DownloadDataButton({ exportName, columns, data }) {
   const { showSaveDialog, openPath } = useElectron();
+  const exportableColumns = columns.filter(c => c.isExportable !== false);
   const onDownloadData = async () => {
-    const header = columns.map(getHeaderValue);
+    const header = exportableColumns.map(getHeaderValue);
     const rows = await Promise.all(
       data.map(async d => {
         const dx = {};
         await Promise.all(
-          columns.map(async c => {
+          exportableColumns.map(async c => {
             const headerValue = getHeaderValue(c);
             if (c.asyncExportAccessor) {
               const value = await c.asyncExportAccessor(d);

--- a/packages/desktop/app/components/TriageTable.js
+++ b/packages/desktop/app/components/TriageTable.js
@@ -30,6 +30,7 @@ const useColumns = () => {
         }
       },
       accessor: TriageWaitTimeCell,
+      isExportable: false,
     },
     { key: 'chiefComplaint', title: 'Chief complaint' },
     { key: 'displayId' },

--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -30,42 +30,40 @@ const TriageCell = ({ arrivalTime, children }) => (
   </Tooltip>
 );
 
-export const TriageWaitTimeCell = React.memo(
-  ({ encounterType, triageTime, closedTime, arrivalTime }) => {
-    const [, updateState] = useState({});
+export const TriageWaitTimeCell = ({ encounterType, triageTime, closedTime, arrivalTime }) => {
+  const [, updateState] = useState({});
 
-    // arrivalTime is an optional field and the ui prompts the user to enter it only if arrivalTime
-    // is different to triageTime so we should assume the arrivalTime is the triageTime if arrivalTime
-    // is undefined
-    const assumedArrivalTime = arrivalTime || triageTime;
+  // arrivalTime is an optional field and the ui prompts the user to enter it only if arrivalTime
+  // is different to triageTime so we should assume the arrivalTime is the triageTime if arrivalTime
+  // is undefined
+  const assumedArrivalTime = arrivalTime || triageTime;
 
-    // recalculate every 30 seconds
-    useEffect(() => {
-      if (!closedTime) {
-        const interval = setInterval(() => updateState({}), MINUTE * 0.5);
-        return () => clearInterval(interval);
-      }
-      return () => {};
-    }, [closedTime]);
-
-    switch (encounterType) {
-      case ENCOUNTER_TYPES.TRIAGE:
-        return (
-          <TriageCell arrivalTime={assumedArrivalTime}>
-            <div>{getDuration(assumedArrivalTime)}</div>
-            <div>{`Triage at ${format(new Date(triageTime), 'h:mma')}`}</div>
-          </TriageCell>
-        );
-      case ENCOUNTER_TYPES.OBSERVATION:
-      case ENCOUNTER_TYPES.EMERGENCY:
-        return (
-          <TriageCell arrivalTime={arrivalTime}>{`Seen at ${format(
-            new Date(closedTime),
-            'h:mma',
-          )}`}</TriageCell>
-        );
-      default:
-        return <PlainCell>Admitted</PlainCell>;
+  // recalculate every 30 seconds
+  useEffect(() => {
+    if (!closedTime) {
+      const interval = setInterval(() => updateState({}), MINUTE * 0.5);
+      return () => clearInterval(interval);
     }
-  },
-);
+    return () => {};
+  }, [closedTime]);
+
+  switch (encounterType) {
+    case ENCOUNTER_TYPES.TRIAGE:
+      return (
+        <TriageCell arrivalTime={assumedArrivalTime}>
+          <div>{getDuration(assumedArrivalTime)}</div>
+          <div>{`Triage at ${format(new Date(triageTime), 'h:mma')}`}</div>
+        </TriageCell>
+      );
+    case ENCOUNTER_TYPES.OBSERVATION:
+    case ENCOUNTER_TYPES.EMERGENCY:
+      return (
+        <TriageCell arrivalTime={arrivalTime}>{`Seen at ${format(
+          new Date(closedTime),
+          'h:mma',
+        )}`}</TriageCell>
+      );
+    default:
+      return <PlainCell>Admitted</PlainCell>;
+  }
+};

--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -30,40 +30,42 @@ const TriageCell = ({ arrivalTime, children }) => (
   </Tooltip>
 );
 
-export const TriageWaitTimeCell = ({ encounterType, triageTime, closedTime, arrivalTime }) => {
-  const [, updateState] = useState({});
+export const TriageWaitTimeCell = React.memo(
+  ({ encounterType, triageTime, closedTime, arrivalTime }) => {
+    const [, updateState] = useState({});
 
-  // arrivalTime is an optional field and the ui prompts the user to enter it only if arrivalTime
-  // is different to triageTime so we should assume the arrivalTime is the triageTime if arrivalTime
-  // is undefined
-  const assumedArrivalTime = arrivalTime || triageTime;
+    // arrivalTime is an optional field and the ui prompts the user to enter it only if arrivalTime
+    // is different to triageTime so we should assume the arrivalTime is the triageTime if arrivalTime
+    // is undefined
+    const assumedArrivalTime = arrivalTime || triageTime;
 
-  // recalculate every 30 seconds
-  useEffect(() => {
-    if (!closedTime) {
-      const interval = setInterval(() => updateState({}), MINUTE * 0.5);
-      return () => clearInterval(interval);
+    // recalculate every 30 seconds
+    useEffect(() => {
+      if (!closedTime) {
+        const interval = setInterval(() => updateState({}), MINUTE * 0.5);
+        return () => clearInterval(interval);
+      }
+      return () => {};
+    }, [closedTime]);
+
+    switch (encounterType) {
+      case ENCOUNTER_TYPES.TRIAGE:
+        return (
+          <TriageCell arrivalTime={assumedArrivalTime}>
+            <div>{getDuration(assumedArrivalTime)}</div>
+            <div>{`Triage at ${format(new Date(triageTime), 'h:mma')}`}</div>
+          </TriageCell>
+        );
+      case ENCOUNTER_TYPES.OBSERVATION:
+      case ENCOUNTER_TYPES.EMERGENCY:
+        return (
+          <TriageCell arrivalTime={arrivalTime}>{`Seen at ${format(
+            new Date(closedTime),
+            'h:mma',
+          )}`}</TriageCell>
+        );
+      default:
+        return <PlainCell>Admitted</PlainCell>;
     }
-    return () => {};
-  }, [closedTime]);
-
-  switch (encounterType) {
-    case ENCOUNTER_TYPES.TRIAGE:
-      return (
-        <TriageCell arrivalTime={assumedArrivalTime}>
-          <div>{getDuration(assumedArrivalTime)}</div>
-          <div>{`Triage at ${format(new Date(triageTime), 'h:mma')}`}</div>
-        </TriageCell>
-      );
-    case ENCOUNTER_TYPES.OBSERVATION:
-    case ENCOUNTER_TYPES.EMERGENCY:
-      return (
-        <TriageCell arrivalTime={arrivalTime}>{`Seen at ${format(
-          new Date(closedTime),
-          'h:mma',
-        )}`}</TriageCell>
-      );
-    default:
-      return <PlainCell>Admitted</PlainCell>;
-  }
-};
+  },
+);

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -44,7 +44,7 @@ const LISTING_COLUMNS = [
   status,
 ];
 
-const LocationCell = React.memo(({ locationName, plannedLocationName, style }) => (
+const LocationCell = ({ locationName, plannedLocationName, style }) => (
   <div style={{ minWidth: 180, ...style }}>
     {locationName}
     {plannedLocationName && (
@@ -53,7 +53,7 @@ const LocationCell = React.memo(({ locationName, plannedLocationName, style }) =
       </Typography>
     )}
   </div>
-));
+);
 
 const LocationGroupCell = ({ locationGroupName, plannedLocationGroupName }) => (
   <LocationCell


### PR DESCRIPTION
### Changes

Currently we are unable to use memoized components (React.memo()) on table accessors****. The problem here is that it returns a specific type of React component that is not callable as a function which produces an error. Data cells in table are usually pretty small so we can probably avoid using React.memo for the time being without too much trouble.

**** After having a closer look I noticed that:
- It's not entirely React.memo() usage, but only referencing it directly (i.e. `accessor: MemoizedComponent`).
- React.memo() can be used if the accessor is a function that returns said component (i.e. `accessor: props => <MemoizedComponent {...props} />`).
- Accessors cannot use components with hooks if the components are referenced directly, they need to be returned from a function instead.

This only covers the export button not doing anything, I couldn't replicate the styles getting messed up.