### PR TITLE
Staging fix SAV-56: Survey responses not viewable mobile

### DIFF
--- a/packages/mobile/App/models/Survey.ts
+++ b/packages/mobile/App/models/Survey.ts
@@ -72,21 +72,4 @@ export class Survey extends BaseModel implements ISurvey {
       id: vitalsSurvey.id,
     };
   }
-
-  static async getResponses(
-    surveyId: string,
-    patientId?: string
-  ): Promise<ISurveyResponse[]> {
-    const patientFilter = patientId
-      ? { encounter: { patient: { id: patientId } } }
-      : {};
-    const responses = await Database.models.SurveyResponse.find({
-      where: {
-        survey: surveyId,
-        ...patientFilter,
-      },
-      relations: ['encounter', 'survey', 'encounter.patient'],
-    });
-    return responses;
-  }
 }

--- a/packages/mobile/App/ui/navigation/screens/programs/tabs/ProgramViewHistoryScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/tabs/ProgramViewHistoryScreen/index.tsx
@@ -30,9 +30,9 @@ export const ProgramViewHistoryScreen = ({
         return null;
       }
 
-      return models.Survey.getResponses(
+      return models.SurveyResponse.getForPatient(
+        selectedPatient.id,
         surveyId,
-        selectedPatient ? selectedPatient.id : null
       );
     },
     [navigation.isFocused, latestResponseId],


### PR DESCRIPTION
### Ticket: SAV-56

### Changes
- Fixed Survey responses not viewable mobile

### Checklist
- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
