### PR TITLE
WAITM-601: Mobile idle logout UI

### DIFF
--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -30,6 +30,7 @@ interface AuthContextData {
   ability: PureAbility;
   signIn: (params: SyncConnectionParameters) => Promise<void>;
   signOut: () => void;
+  signOutClient: (signedOutFromInactivity: boolean) => void;
   isUserAuthenticated: () => boolean;
   setUserFirstSignIn: () => void;
   checkFirstSession: () => boolean;
@@ -105,6 +106,12 @@ const Provider = ({
   const signOut = (): void => {
     backend.stopSyncService(); // we deliberately don't await this
     signOutUser();
+    signOutClient(false);
+  };
+
+  // Sign out UI while preserving sync service
+  const signOutClient = (signedOutFromInactivity: boolean): void => {
+    setSignedInStatus(false);
     const currentRoute = navRef.current?.getCurrentRoute().name;
     const signUpRoutes = [
       Routes.SignUpStack.Index,
@@ -114,7 +121,12 @@ const Provider = ({
     if (!signUpRoutes.includes(currentRoute)) {
       navRef.current?.reset({
         index: 0,
-        routes: [{ name: Routes.SignUpStack.Index }],
+        routes: [{
+          name: Routes.SignUpStack.Index,
+          params: {
+            signedOutFromInactivity,
+          },
+        }],
       });
     }
   };
@@ -162,6 +174,7 @@ const Provider = ({
         setUserFirstSignIn,
         signIn,
         signOut,
+        signOutClient,
         isUserAuthenticated,
         checkFirstSession,
         user,

--- a/packages/mobile/App/ui/helpers/selectors.ts
+++ b/packages/mobile/App/ui/helpers/selectors.ts
@@ -10,3 +10,8 @@ export const authUserSelector = createSelector(
   (state: ReduxStoreProps) => state.auth.user,
   user => user,
 );
+
+export const authSignedInSelector = createSelector(
+  (state: ReduxStoreProps) => state.auth.signedIn,
+  signedIn => signedIn,
+);

--- a/packages/mobile/App/ui/interfaces/Screens/SignUpStack/Intro.tsx
+++ b/packages/mobile/App/ui/interfaces/Screens/SignUpStack/Intro.tsx
@@ -1,5 +1,6 @@
-import { NavigationProp } from '@react-navigation/native';
+import { NavigationProp, RouteProp } from '@react-navigation/native';
 
 export interface IntroScreenProps {
   navigation: NavigationProp<any>;
+  route: RouteProp<any, any>;
 }

--- a/packages/mobile/App/ui/interfaces/Screens/SignUpStack/index.ts
+++ b/packages/mobile/App/ui/interfaces/Screens/SignUpStack/index.ts
@@ -1,2 +1,9 @@
+import { RouteProp } from '@react-navigation/native';
+
+export * from './Index';
 export * from './Intro';
 export * from './RegisterAccountStep1Props';
+
+export type IndexStackProps = {
+  route: RouteProp<any, any>;
+};

--- a/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
@@ -17,20 +17,29 @@ import { IntroScreenProps } from '../../../interfaces/Screens/SignUpStack/Intro'
 
 export const IntroScreen: FunctionComponent<any> = ({
   navigation,
+  route,
 }: IntroScreenProps) => {
-  // const onNavigateToNewAccount = useCallback(() => {
-  //   navigation.navigate(Routes.SignUpStack.RegisterAccountStep1);
-  // }, []);
-
   const onNavigateToSignIn = useCallback(() => {
     navigation.navigate(Routes.SignUpStack.SignIn);
   }, []);
+
+  const { signedOutFromInactivity } = route.params;
 
   return (
     <FullView background={theme.colors.WHITE}>
       <StyledSafeAreaView>
         <CenterView marginTop={screenPercentageToDP(13.36, Orientation.Height)}>
           <LogoV1Icon />
+        </CenterView>
+        <CenterView>
+          {signedOutFromInactivity && (
+            <StyledText
+              color={theme.colors.ALERT}
+              marginTop={screenPercentageToDP(15.32, Orientation.Height)}
+            >
+              Signed out from inactivity
+            </StyledText>
+          )}
         </CenterView>
         <CenterView marginTop={screenPercentageToDP(26.36, Orientation.Height)}>
           <StyledText

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -33,7 +33,10 @@ export const Core: FunctionComponent<any> = () => {
       initialRouteName={initialRouteName}
     >
       <Stack.Screen name={Routes.Autocomplete.Modal} component={AutocompleteModalScreen} />
-      <Stack.Screen name={Routes.SignUpStack.Index} component={SignUpStack} />
+      <Stack.Screen
+        name={Routes.SignUpStack.Index}
+        component={SignUpStack}
+        initialParams={{ signedOutFromInactivity: false }} />
       <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
       <Stack.Screen
         options={noSwipeGestureOnNavigator}

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -27,7 +27,7 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
     [],
   );
 
-  const handleResetIdle = (): false => {
+  const handleResetIdle = (): boolean => {
     if (signedIn) {
       debouncedResetIdle();
     }

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -12,7 +12,7 @@ interface DetectIdleLayerProps {
 }
 
 const ONE_MINUTE = 1000 * 60;
-const UI_EXPIRY_TIME = ONE_MINUTE * 30; // 30 minutes
+const UI_EXPIRY_TIME = ONE_MINUTE * 30;
 
 export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElement => {
   const [idle, setIdle] = useState(0);

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -8,7 +8,6 @@ import { useAuth } from '../../contexts/AuthContext';
 
 interface DetectIdleLayerProps {
   children: ReactNode;
-
 }
 
 const ONE_MINUTE = 1000 * 60;

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -27,10 +27,12 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
     [],
   );
 
-  const handleResetIdle = (): boolean => {
+  const handleResetIdle = (): false => {
     if (signedIn) {
       debouncedResetIdle();
     }
+    // Returns false to indicate that this component
+    // shouldn't block native components from becoming the JS responder
     return false;
   };
 
@@ -55,10 +57,11 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
     let timer;
     if (signedIn) {
       timer = setInterval(() => {
-        if (idle > UI_EXPIRY_TIME) {
+        const newIdle = idle + ONE_MINUTE;
+        setIdle(newIdle);
+        if (newIdle >= UI_EXPIRY_TIME) {
           handleIdleLogout();
         }
-        setIdle(idle + ONE_MINUTE);
       }, ONE_MINUTE);
     }
     return () => {

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -11,7 +11,8 @@ interface DetectIdleLayerProps {
 
 }
 
-const UI_EXPIRY_TIME = 1000 * 60 * 30; // 30 minutes
+const ONE_MINUTE = 1000 * 60;
+const UI_EXPIRY_TIME = ONE_MINUTE * 30; // 30 minutes
 
 export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElement => {
   const [idle, setIdle] = useState(0);
@@ -44,10 +45,6 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
     if (signedIn) {
       hideEvent = Keyboard.addListener('keyboardDidHide', handleResetIdle);
       showEvent = Keyboard.addListener('keyboardDidShow', handleResetIdle);
-    } else {
-      // Removing listeners on logout
-      hideEvent?.remove();
-      showEvent?.remove();
     }
     return () => {
       hideEvent?.remove();
@@ -62,13 +59,8 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
         if (idle > UI_EXPIRY_TIME) {
           handleIdleLogout();
         }
-        setIdle(idle + 1000);
-        console.log('idle timer (ms):', idle);
-      }, 1000);
-    } else {
-      // Removing listeners and resetting idle timer on logout
-      setIdle(0);
-      clearInterval(timer);
+        setIdle(idle + ONE_MINUTE);
+      }, ONE_MINUTE);
     }
     return () => {
       clearInterval(timer);

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -1,0 +1,91 @@
+import { debounce } from 'lodash';
+import React, { ReactElement, ReactNode, useCallback, useRef, useEffect, useState } from 'react';
+import { Keyboard, PanResponder } from 'react-native';
+import { useSelector } from 'react-redux';
+import { authSignedInSelector } from '~/ui/helpers/selectors';
+import { StyledView } from '~/ui/styled/common';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface DetectIdleLayerProps {
+  children: ReactNode;
+
+}
+
+const UI_EXPIRY_TIME = 1000 * 60 * 30; // 30 minutes
+
+export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElement => {
+  const [idle, setIdle] = useState(0);
+  const signedIn = useSelector(authSignedInSelector);
+  const { signOutClient } = useAuth();
+
+  const resetIdle = (): void => {
+    setIdle(0);
+  };
+
+  const debouncedResetIdle = useCallback(
+    debounce(resetIdle, 300),
+    [],
+  );
+
+  const handleResetIdle = (): boolean => {
+    if (signedIn) {
+      debouncedResetIdle();
+    }
+    return false;
+  };
+
+  const handleIdleLogout = (): void => {
+    signOutClient(true);
+  };
+
+  useEffect(() => {
+    let hideEvent;
+    let showEvent;
+    if (signedIn) {
+      hideEvent = Keyboard.addListener('keyboardDidHide', handleResetIdle);
+      showEvent = Keyboard.addListener('keyboardDidShow', handleResetIdle);
+    } else {
+      // Removing listeners on logout
+      hideEvent?.remove();
+      showEvent?.remove();
+    }
+    return () => {
+      hideEvent?.remove();
+      showEvent?.remove();
+    };
+  }, [signedIn]);
+
+  useEffect(() => {
+    let timer;
+    if (signedIn) {
+      timer = setInterval(() => {
+        if (idle > UI_EXPIRY_TIME) {
+          handleIdleLogout();
+        }
+        setIdle(idle + 1000);
+        console.log('idle timer (ms):', idle);
+      }, 1000);
+    } else {
+      // Removing listeners and resetting idle timer on logout
+      setIdle(0);
+      clearInterval(timer);
+    }
+    return () => {
+      clearInterval(timer);
+    };
+  }, [idle, signedIn]);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponderCapture: handleResetIdle,
+      onStartShouldSetPanResponderCapture: handleResetIdle,
+      onPanResponderTerminationRequest: handleResetIdle,
+    }),
+  );
+
+  return (
+    <StyledView height="100%" {...panResponder.current.panHandlers}>
+      {children}
+    </StyledView>
+  );
+};

--- a/packages/mobile/App/ui/navigation/stacks/Root.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Root.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import { Root } from 'popup-ui';
 import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
 import { PersistGate } from 'redux-persist/integration/react';
@@ -9,25 +9,31 @@ import { AuthProvider } from '../../contexts/AuthContext';
 import { FacilityProvider } from '../../contexts/FacilityContext';
 import { LocalisationProvider } from '../../contexts/LocalisationContext';
 import { Core } from './Core';
+import { StyledView } from '~/ui/styled/common';
+import { DetectIdleLayer } from './DetectIdleLayer';
 
 export const RootStack = (): ReactElement => {
   const navigationRef = React.useRef<NavigationContainerRef>(null);
   return (
     <SafeAreaProvider>
       <Root>
-        <Provider store={store}>
-          <PersistGate loading={null} persistor={persistor}>
-            <NavigationContainer ref={navigationRef}>
-              <LocalisationProvider>
-                <AuthProvider navRef={navigationRef}>
-                  <FacilityProvider>
-                    <Core />
-                  </FacilityProvider>
-                </AuthProvider>
-              </LocalisationProvider>
-            </NavigationContainer>
-          </PersistGate>
-        </Provider>
+        <StyledView>
+          <Provider store={store}>
+            <PersistGate loading={null} persistor={persistor}>
+              <NavigationContainer ref={navigationRef}>
+                <LocalisationProvider>
+                  <AuthProvider navRef={navigationRef}>
+                    <FacilityProvider>
+                      <DetectIdleLayer>
+                        <Core />
+                      </DetectIdleLayer>
+                    </FacilityProvider>
+                  </AuthProvider>
+                </LocalisationProvider>
+              </NavigationContainer>
+            </PersistGate>
+          </Provider>
+        </StyledView>
       </Root>
     </SafeAreaProvider>
   );

--- a/packages/mobile/App/ui/navigation/stacks/Root.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Root.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 import { Root } from 'popup-ui';
 import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
 import { PersistGate } from 'redux-persist/integration/react';
@@ -9,7 +9,6 @@ import { AuthProvider } from '../../contexts/AuthContext';
 import { FacilityProvider } from '../../contexts/FacilityContext';
 import { LocalisationProvider } from '../../contexts/LocalisationContext';
 import { Core } from './Core';
-import { StyledView } from '~/ui/styled/common';
 import { DetectIdleLayer } from './DetectIdleLayer';
 
 export const RootStack = (): ReactElement => {
@@ -17,23 +16,21 @@ export const RootStack = (): ReactElement => {
   return (
     <SafeAreaProvider>
       <Root>
-        <StyledView>
-          <Provider store={store}>
-            <PersistGate loading={null} persistor={persistor}>
-              <NavigationContainer ref={navigationRef}>
-                <LocalisationProvider>
-                  <AuthProvider navRef={navigationRef}>
-                    <FacilityProvider>
-                      <DetectIdleLayer>
-                        <Core />
-                      </DetectIdleLayer>
-                    </FacilityProvider>
-                  </AuthProvider>
-                </LocalisationProvider>
-              </NavigationContainer>
-            </PersistGate>
-          </Provider>
-        </StyledView>
+        <Provider store={store}>
+          <PersistGate loading={null} persistor={persistor}>
+            <NavigationContainer ref={navigationRef}>
+              <LocalisationProvider>
+                <AuthProvider navRef={navigationRef}>
+                  <FacilityProvider>
+                    <DetectIdleLayer>
+                      <Core />
+                    </DetectIdleLayer>
+                  </FacilityProvider>
+                </AuthProvider>
+              </LocalisationProvider>
+            </NavigationContainer>
+          </PersistGate>
+        </Provider>
       </Root>
     </SafeAreaProvider>
   );

--- a/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
@@ -8,6 +8,7 @@ import { RegisterAccountStep1Container } from '../screens/signup/RegisterAccount
 import { RegisterAccountStep2Container } from '../screens/signup/RegisterAccountScreenStep2';
 import { RegisterAccountStep3Container } from '../screens/signup/RegisterAccountScreenStep3';
 import { SignIn } from '../screens/signup/SignIn';
+import { IndexStackProps } from '~/ui/interfaces/Screens/SignUpStack';
 
 import { ResetPassword } from '../screens/signup/ResetPassword';
 import { ChangePassword } from '../screens/signup/ChangePassword';
@@ -19,40 +20,45 @@ const Stack = createStackNavigator();
 
 const TransitionStyle = TransitionPresets.SlideFromRightIOS;
 
-export const SignUpStack = (): ReactElement => (
-  <RegisterAccountProvider>
-    <Stack.Navigator headerMode="none">
-      <Stack.Screen
-        name={Routes.SignUpStack.Intro}
-        component={IntroScreen}
-        options={TransitionStyle}
-      />
-      <Stack.Screen
-        name={Routes.SignUpStack.RegisterAccountStep1}
-        component={RegisterAccountStep1Container}
-      />
-      <Stack.Screen
-        name={Routes.SignUpStack.RegisterAccountStep2}
-        component={RegisterAccountStep2Container}
-      />
-      <Stack.Screen
-        name={Routes.SignUpStack.RegisterAccountStep3}
-        component={RegisterAccountStep3Container}
-      />
-      <Stack.Screen 
-        name={Routes.SignUpStack.SignIn} 
-        component={SignIn} options={TransitionStyle} 
-      />
-      <Stack.Screen
-        name={Routes.SignUpStack.ResetPassword}
-        component={ResetPassword}
-        options={TransitionStyle}
-      />
-      <Stack.Screen
-        name={Routes.SignUpStack.ChangePassword}
-        component={ChangePassword}
-        options={TransitionStyle}
-      />
-    </Stack.Navigator>
-  </RegisterAccountProvider>
-);
+export const SignUpStack = ({ route }: IndexStackProps): ReactElement => {
+  const { signedOutFromInactivity } = route.params;
+  return (
+    <RegisterAccountProvider>
+      <Stack.Navigator headerMode="none">
+        <Stack.Screen
+          name={Routes.SignUpStack.Intro}
+          component={IntroScreen}
+          initialParams={{ signedOutFromInactivity }}
+          options={TransitionStyle}
+        />
+        <Stack.Screen
+          name={Routes.SignUpStack.RegisterAccountStep1}
+          component={RegisterAccountStep1Container}
+        />
+        <Stack.Screen
+          name={Routes.SignUpStack.RegisterAccountStep2}
+          component={RegisterAccountStep2Container}
+        />
+        <Stack.Screen
+          name={Routes.SignUpStack.RegisterAccountStep3}
+          component={RegisterAccountStep3Container}
+        />
+        <Stack.Screen
+          name={Routes.SignUpStack.SignIn}
+          component={SignIn}
+          options={TransitionStyle}
+        />
+        <Stack.Screen
+          name={Routes.SignUpStack.ResetPassword}
+          component={ResetPassword}
+          options={TransitionStyle}
+        />
+        <Stack.Screen
+          name={Routes.SignUpStack.ChangePassword}
+          component={ChangePassword}
+          options={TransitionStyle}
+        />
+      </Stack.Navigator>
+    </RegisterAccountProvider>
+  );
+};

--- a/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
@@ -16,7 +16,9 @@ import { ChangePassword } from '../screens/signup/ChangePassword';
 // Contexts
 import { RegisterAccountProvider } from '../../contexts/RegisterAccountContext';
 
-const Stack = createStackNavigator();
+const Stack = createStackNavigator({initialRouteParams: {
+  signedOutFromInactivity: false,
+}});
 
 const TransitionStyle = TransitionPresets.SlideFromRightIOS;
 

--- a/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/SignUp.tsx
@@ -16,9 +16,7 @@ import { ChangePassword } from '../screens/signup/ChangePassword';
 // Contexts
 import { RegisterAccountProvider } from '../../contexts/RegisterAccountContext';
 
-const Stack = createStackNavigator({initialRouteParams: {
-  signedOutFromInactivity: false,
-}});
+const Stack = createStackNavigator();
 
 const TransitionStyle = TransitionPresets.SlideFromRightIOS;
 


### PR DESCRIPTION
### Changes

- Track idle time and logout after 30 mins (currently this is hardcoded as outlined in ticket for this iteration)
- This logout is not a hard logout and will preserve central server connection in case of sync
- Display a "Logged out due to inactivity" alert text on sign-up Index route I added this in because it felt too weird to show nothing. We will get a designed up version of this and implement as part of epic im thinking.

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
