### PR TITLE
WAITM-600 Add activity monitor, auto refresh token, auto logout inactive

### DIFF
--- a/packages/desktop/app/App.js
+++ b/packages/desktop/app/App.js
@@ -11,7 +11,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { DecisionSupportModal } from './components/DecisionSupportModal';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
-import { IdleLogoutModal } from './components/IdleLogoutModal';
+import { UserActivityMonitor } from './components/UserActivityMonitor';
 
 const AppContainer = styled.div`
   display: flex;
@@ -42,7 +42,7 @@ export function App({ sidebar, children }) {
             {children}
             <DecisionSupportModal />
             <ForbiddenErrorModal />
-            <IdleLogoutModal />
+            <UserActivityMonitor />
           </AppContentsContainer>
         </ErrorBoundary>
       </PromiseErrorBoundary>

--- a/packages/desktop/app/App.js
+++ b/packages/desktop/app/App.js
@@ -11,6 +11,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { DecisionSupportModal } from './components/DecisionSupportModal';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
+import { IdleLogoutModal } from './components/IdleLogoutModal';
 
 const AppContainer = styled.div`
   display: flex;
@@ -27,6 +28,7 @@ const AppContentsContainer = styled.div`
 export function App({ sidebar, children }) {
   const isUserLoggedIn = useSelector(checkIsLoggedIn);
   const currentRoute = useSelector(getCurrentRoute);
+
   if (!isUserLoggedIn) {
     return <LoginView />;
   }
@@ -40,6 +42,7 @@ export function App({ sidebar, children }) {
             {children}
             <DecisionSupportModal />
             <ForbiddenErrorModal />
+            <IdleLogoutModal />
           </AppContentsContainer>
         </ErrorBoundary>
       </PromiseErrorBoundary>

--- a/packages/desktop/app/api/TamanuApi.js
+++ b/packages/desktop/app/api/TamanuApi.js
@@ -20,8 +20,6 @@ const getResponseJsonSafely = async response => {
   }
 };
 
-const REFRESH_DURATION = 2.5 * 60 * 1000; // refresh if token is more than 2.5 minutes old
-
 const getVersionIncompatibleMessage = (error, response) => {
   if (error.message === VERSION_COMPATIBILITY_ERRORS.LOW) {
     const minAppVersion = response.headers.get('X-Min-Client-Version');
@@ -212,12 +210,6 @@ export class TamanuApi {
       ...otherConfig,
     });
     if (response.ok) {
-      const timeSinceRefresh = Date.now() - this.lastRefreshed;
-      if (timeSinceRefresh > REFRESH_DURATION) {
-        this.lastRefreshed = Date.now();
-        this.refreshToken();
-      }
-
       if (returnResponse) {
         return response;
       }

--- a/packages/desktop/app/components/IdleLogoutModal.js
+++ b/packages/desktop/app/components/IdleLogoutModal.js
@@ -14,9 +14,9 @@ export const IdleLogoutModal = () => {
   const { onLogout, refreshToken } = useAuth();
   const { getLocalisation } = useLocalisation();
 
-  const { enabled, timeoutDuration, warningPromptDuration, refreshInterval } = getLocalisation(
-    'features.idleTimeout',
-  );
+  // Can't fetch localisation prior to login so add defaults
+  const { enabled = false, timeoutDuration = 0, warningPromptDuration = 0, refreshInterval = 0 } =
+    getLocalisation('features.idleTimeout') || {};
 
   const onIdle = () => {
     // TODO: WAITM-598 Replace this full logout with a login modal

--- a/packages/desktop/app/components/IdleLogoutModal.js
+++ b/packages/desktop/app/components/IdleLogoutModal.js
@@ -1,0 +1,48 @@
+/*
+ * NOTE: Currently this component simply holds the idle timer functionality
+ * TODO: Build actual modals: WAITM-598 WAITM-599
+ */
+
+import { useSelector } from 'react-redux';
+import { useIdleTimer } from 'react-idle-timer';
+import { useLocalisation } from '../contexts/Localisation';
+import { useAuth } from '../contexts/Auth';
+import { checkIsLoggedIn } from '../store/auth';
+
+export const IdleLogoutModal = () => {
+  const isUserLoggedIn = useSelector(checkIsLoggedIn);
+  const { onLogout, refreshToken } = useAuth();
+  const { getLocalisation } = useLocalisation();
+
+  const { enabled, timeoutDuration, warningPromptDuration, refreshInterval } = getLocalisation(
+    'features.idleTimeout',
+  );
+
+  const onIdle = () => {
+    // TODO: WAITM-598 Replace this full logout with a login modal
+    onLogout();
+  };
+
+  const onAction = () => {
+    if (isUserLoggedIn) {
+      refreshToken();
+    }
+  };
+
+  const onPrompt = () => {
+    // TODO: WAITM-599 Display idle warning modal
+  };
+
+  useIdleTimer({
+    onIdle,
+    onAction,
+    onPrompt,
+    events: ['keydown', 'mousedown', 'mousemove'],
+    startOnMount: enabled,
+    timeout: timeoutDuration * 1000,
+    promptTimeout: warningPromptDuration * 1000,
+    throttle: refreshInterval * 1000,
+  });
+
+  return null;
+};

--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -9,7 +9,7 @@ import { useLocalisation } from '../contexts/Localisation';
 import { useAuth } from '../contexts/Auth';
 import { checkIsLoggedIn } from '../store/auth';
 
-export const IdleLogoutModal = () => {
+export const UserActivityMonitor = () => {
   const isUserLoggedIn = useSelector(checkIsLoggedIn);
   const { onLogout, refreshToken } = useAuth();
   const { getLocalisation } = useLocalisation();

--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -1,5 +1,6 @@
 import { useSelector, useDispatch } from 'react-redux';
 import { logout } from '../store';
+import { useApi } from '../api';
 
 // This is just a redux selector for now.
 // This should become its own proper context once the auth stuff
@@ -7,6 +8,7 @@ import { logout } from '../store';
 
 export const useAuth = () => {
   const dispatch = useDispatch();
+  const api = useApi();
 
   return {
     ...useSelector(state => ({
@@ -16,5 +18,6 @@ export const useAuth = () => {
       centralHost: state.auth.server?.centralHost,
     })),
     onLogout: () => dispatch(logout()),
+    refreshToken: () => api.refreshToken(),
   };
 };

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -234,6 +234,7 @@
     "react-dom": "^16.8.5",
     "react-dropzone": "^4.2.10",
     "react-events": "^1.0.1",
+    "react-idle-timer": "^5.4.2",
     "react-mixin-manager": "^1.0.2",
     "react-redux": "^7.1.0",
     "react-responsive-modal": "^2.1.0",

--- a/packages/lan/app/middleware/auth.js
+++ b/packages/lan/app/middleware/auth.js
@@ -145,6 +145,9 @@ export async function loginHandler(req, res, next) {
 export async function refreshHandler(req, res) {
   const { user } = req;
 
+  // Run after auth middleware, requires valid token but no other permission
+  req.flagPermissionChecked();
+
   const token = getToken(user);
   res.send({ token });
 }

--- a/packages/lan/app/routes/apiv1/index.js
+++ b/packages/lan/app/routes/apiv1/index.js
@@ -1,7 +1,7 @@
 import express from 'express';
 
 import { constructPermission } from 'shared/permissions/middleware';
-import { loginHandler, authMiddleware } from '../../middleware/auth';
+import { loginHandler, refreshHandler, authMiddleware } from '../../middleware/auth';
 
 import { allergy } from './allergy';
 import { appointments } from './appointments';
@@ -54,6 +54,7 @@ apiv1.use('/changePassword', changePassword);
 apiv1.use(authMiddleware);
 apiv1.use(constructPermission);
 
+apiv1.post('/refresh', refreshHandler);
 apiv1.use(patientDataRoutes); // see below for specifics
 apiv1.use(referenceDataRoutes); // see below for specifics
 apiv1.use(syncRoutes); // see below for specifics

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -346,6 +346,15 @@ const rootLocalisationSchema = yup
         enableCovidClearanceCertificate: yup.boolean().required(),
         editDisplayId: yup.boolean().required(),
         patientPlannedMove: yup.boolean().required(),
+        idleTimeout: yup
+          .object()
+          .shape({
+            enabled: yup.boolean().required(),
+            timeoutDuration: yup.number().required(),
+            warningPromptDuration: yup.number().required(),
+            refreshInterval: yup.number().required(),
+          })
+          .required(),
       })
       .required()
       .noUnknown(),

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -594,7 +594,14 @@
         "mergePopulatedPADRecords": true,
         "enableCovidClearanceCertificate": false,
         "editDisplayId": false,
-        "patientPlannedMove": false
+        "patientPlannedMove": false,
+        "idleTimeout": {
+          "enabled": false,
+          // All values in seconds
+          "timeoutDuration": 600,
+          "warningPromptDuration": 30,
+          "refreshInterval": 150
+        }
       },
       "templates": {
         "letterhead": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21826,6 +21826,11 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-idle-timer@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-5.4.2.tgz#69e20044cf2ecc421aef99cd82298c526d8acf37"
+  integrity sha512-ofCS/qpFjm6ZguEyePvtf9YMDnLj7zZfeLXRWGRpsC6Ga47H4dm7EvoUW8MsozGEGy8zCvPK0Sk6YuAnwLEzRQ==
+
 react-input-autosize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"


### PR DESCRIPTION
### Changes

- Add `react-idle-timer` library to desktop app
- Update localisation to include `features.idleTimeout`
- Enable `/refresh` endpoint on lan
- Remove `TamanuApi` level auto-refresh (use the activity refresh instead)
- Detect user idle
  - Send `/refresh` request when user is active
  - Log user out if idle too long

### Checklist

- [X] Code is finished
- [ ] Testing notes added to the Linear issue