### PR TITLE
WAITM-606: Fix vitals calculated questions

### DIFF
--- a/packages/desktop/app/components/NestedVitalsModal.js
+++ b/packages/desktop/app/components/NestedVitalsModal.js
@@ -16,12 +16,7 @@ export const NestedVitalsModal = React.memo(({ field, patient }) => {
     <>
       <OutlinedButton onClick={openModal}>Record vitals</OutlinedButton>
       <Modal open={isOpen} onClose={closeModal} title="Record vitals">
-        <VitalsForm
-          editedObject={field.value || {}}
-          patient={patient}
-          onSubmit={onSubmit}
-          onClose={closeModal}
-        />
+        <VitalsForm patient={patient} onSubmit={onSubmit} onClose={closeModal} />
       </Modal>
     </>
   );

--- a/packages/desktop/app/components/Surveys/SurveyScreen.js
+++ b/packages/desktop/app/components/Surveys/SurveyScreen.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { runCalculations } from 'shared/utils/calculations';
 import styled from 'styled-components';
 import { checkVisibility } from '../../utils';
 import { FormGrid } from '../FormGrid';
@@ -10,15 +11,29 @@ const StyledButtonRow = styled(ButtonRow)`
   margin-top: 24px;
 `;
 
+const useCalculatedFormValues = (components, values, setFieldValue) => {
+  useEffect(() => {
+    // recalculate dynamic fields
+    const calculatedValues = runCalculations(components, values);
+    // write values that have changed back into answers
+    Object.entries(calculatedValues)
+      .filter(([k, v]) => values[k] !== v)
+      .map(([k, v]) => setFieldValue(k, v));
+  }, [components, values, setFieldValue]);
+};
+
 export const SurveyScreen = ({
   components,
   values = {},
+  setFieldValue,
   onStepForward,
   onStepBack,
   submitButton,
   patient,
   cols = 1,
 }) => {
+  useCalculatedFormValues(components, values, setFieldValue);
+
   const questionElements = components
     .filter(c => checkVisibility(c, values, components))
     .map(c => <SurveyQuestion component={c} patient={patient} key={c.id} />);

--- a/packages/desktop/app/components/Surveys/SurveyScreenPaginator.js
+++ b/packages/desktop/app/components/Surveys/SurveyScreenPaginator.js
@@ -12,17 +12,6 @@ const COMPLETE_MESSAGE = `
   or use the Back button to review answers.
 `;
 
-const useCalculatedFormValues = (components, values, setFieldValue) => {
-  useEffect(() => {
-    // recalculate dynamic fields
-    const calculatedValues = runCalculations(components, values);
-    // write values that have changed back into answers
-    Object.entries(calculatedValues)
-      .filter(([k, v]) => values[k] !== v)
-      .map(([k, v]) => setFieldValue(k, v));
-  }, [components, values, setFieldValue]);
-};
-
 const Text = styled.div`
   margin-bottom: 10px;
 `;
@@ -59,8 +48,6 @@ export const SurveyScreenPaginator = ({
   const { components } = survey;
   const { onStepBack, onStepForward, screenIndex } = usePaginatedForm(components);
 
-  useCalculatedFormValues(components, values, setFieldValue);
-
   const maxIndex = components
     .map(x => x.screenIndex)
     .reduce((max, current) => Math.max(max, current), 0);
@@ -71,6 +58,7 @@ export const SurveyScreenPaginator = ({
     return (
       <SurveyScreen
         values={values}
+        setFieldValue={setFieldValue}
         patient={patient}
         components={screenComponents}
         onStepForward={onStepForward}

--- a/packages/desktop/app/forms/VitalsForm.js
+++ b/packages/desktop/app/forms/VitalsForm.js
@@ -7,7 +7,7 @@ import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { ModalLoader, ConfirmCancelRow, Form } from '../components';
 import { SurveyScreen } from '../components/Surveys';
 import { useVitalsSurvey } from '../api/queries';
-import { getValidationSchema } from '../utils';
+import { getFormInitialValues, getValidationSchema } from '../utils';
 
 const ErrorMessage = () => {
   return (
@@ -20,7 +20,7 @@ const ErrorMessage = () => {
   );
 };
 
-export const VitalsForm = React.memo(({ patient, onSubmit, onClose, editedObject }) => {
+export const VitalsForm = React.memo(({ patient, onSubmit, onClose }) => {
   const { data: vitalsSurvey, isLoading, isError } = useVitalsSurvey();
   const validationSchema = useMemo(() => getValidationSchema(vitalsSurvey), [vitalsSurvey]);
 
@@ -42,7 +42,7 @@ export const VitalsForm = React.memo(({ patient, onSubmit, onClose, editedObject
       validationSchema={validationSchema}
       initialValues={{
         [VITALS_DATA_ELEMENT_IDS.dateRecorded]: getCurrentDateTimeString(),
-        ...editedObject,
+        ...getFormInitialValues(vitalsSurvey.components, patient),
       }}
       validate={({ [VITALS_DATA_ELEMENT_IDS.dateRecorded]: date, ...values }) => {
         const errors = {};
@@ -54,12 +54,14 @@ export const VitalsForm = React.memo(({ patient, onSubmit, onClose, editedObject
 
         return errors;
       }}
-      render={({ submitForm }) => {
+      render={({ submitForm, values, setFieldValue }) => {
         return (
           <SurveyScreen
             components={vitalsSurvey.components}
             patient={patient}
             cols={2}
+            values={values}
+            setFieldValue={setFieldValue}
             submitButton={
               <ConfirmCancelRow confirmText="Record" onConfirm={submitForm} onCancel={onClose} />
             }
@@ -74,9 +76,4 @@ VitalsForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   patient: PropTypes.object.isRequired,
-  editedObject: PropTypes.shape({}),
-};
-
-VitalsForm.defaultProps = {
-  editedObject: null,
 };

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/surveyCalculations.spec.ts
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/surveyCalculations.spec.ts
@@ -30,6 +30,19 @@ describe('Survey calculations', () => {
       expect(calculations.TEST_2).toEqual(99);
     });
 
+    it('should round the value to the configured number of decimal places', () => {
+      const survey = makeDummySurvey([
+        {
+          code: 'TEST',
+          type: 'CalculatedQuestion',
+          calculation: '13 / 3',
+          config: { rounding: 1 },
+        },
+      ]);
+      const calculations = runCalculations(survey, {});
+      expect(calculations.TEST).toEqual(4.3);
+    });
+
     it('should use substitutions', () => {
       const survey = makeDummySurvey([
         { code: 'TEST', type: FieldTypes.CALCULATED, calculation: 'TEST_1 + TEST_2' },
@@ -70,27 +83,21 @@ describe('Survey calculations', () => {
 
   describe('Results', () => {
     it('should return correct values for absent result field', () => {
-      const survey = makeDummySurvey([
-        { code: 'TEST', type: 'Number' },
-      ]);
+      const survey = makeDummySurvey([{ code: 'TEST', type: 'Number' }]);
       const { result, resultText } = getResultValue(survey, { TEST: 123 });
       expect(result).toEqual(0);
       expect(resultText).toEqual('');
     });
 
     it('should use a result field', () => {
-      const survey = makeDummySurvey([
-        { code: 'TEST', type: 'Result' },
-      ]);
+      const survey = makeDummySurvey([{ code: 'TEST', type: 'Result' }]);
       const { result, resultText } = getResultValue(survey, { TEST: 123 });
       expect(result).toEqual(123);
       expect(resultText).toEqual('123%');
     });
 
     it('should be OK with a result field that has no value', () => {
-      const survey = makeDummySurvey([
-        { code: 'TEST', type: 'Result' },
-      ]);
+      const survey = makeDummySurvey([{ code: 'TEST', type: 'Result' }]);
       const { result, resultText } = getResultValue(survey, {});
       expect(result).toEqual(0);
       expect(resultText).toEqual('');

--- a/packages/mobile/App/ui/helpers/calculations.ts
+++ b/packages/mobile/App/ui/helpers/calculations.ts
@@ -4,19 +4,20 @@ import { ISurveyScreenComponent } from '~/types/ISurvey';
 // set up math context
 const math = create(allMath);
 
-export function runCalculations(
-  components: ISurveyScreenComponent[],
-  values: any,
-): any {
+export function runCalculations(components: ISurveyScreenComponent[], values: any): any {
   const inputValues = { ...values };
   const calculatedValues = {};
 
   for (const c of components) {
     if (c.calculation) {
       try {
-        const value = math.evaluate(c.calculation, inputValues);
+        let value = math.evaluate(c.calculation, inputValues);
         if (!Number.isFinite(value)) {
           throw new Error('Value is not a valid number');
+        }
+        const config = c.getConfigObject();
+        if (config.rounding) {
+          value = parseFloat(parseFloat(value).toFixed(config.rounding));
         }
         inputValues[c.dataElement.code] = value;
         calculatedValues[c.dataElement.code] = value;

--- a/packages/shared-src/__tests__/utils/calculations.test.js
+++ b/packages/shared-src/__tests__/utils/calculations.test.js
@@ -52,6 +52,19 @@ describe('Survey calculations', () => {
       expect(calculations.TEST_2).toEqual(99);
     });
 
+    it('should round the value to the configured number of decimal places', () => {
+      const survey = makeDummySurvey([
+        {
+          code: 'TEST',
+          type: 'CalculatedQuestion',
+          calculation: '13 / 3',
+          config: '{ "rounding": 1 }',
+        },
+      ]);
+      const calculations = runCalculations(survey, {});
+      expect(calculations.TEST).toEqual(4.3);
+    });
+
     it('should use substitutions', () => {
       const survey = makeDummySurvey([
         { code: 'TEST_1' },

--- a/packages/shared-src/src/utils/calculations.js
+++ b/packages/shared-src/src/utils/calculations.js
@@ -31,8 +31,7 @@ export function runCalculations(components, values) {
         }
         const config = getConfigObject(c.id, c.config);
         if (config.rounding) {
-          value = parseFloat(value);
-          value = value.toFixed(config.rounding);
+          value = parseFloat(parseFloat(value).toFixed(config.rounding));
         }
         inputValues[c.dataElement.code] = value;
         calculatedValues[c.dataElement.id] = value;

--- a/packages/shared-src/src/utils/calculations.js
+++ b/packages/shared-src/src/utils/calculations.js
@@ -3,6 +3,17 @@ import { create, all as allMath } from 'mathjs';
 // set up math context
 const math = create(allMath);
 
+function getConfigObject(componentId, config) {
+  if (!config) return {};
+  try {
+    return JSON.parse(config);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid config in survey screen component ${componentId}`);
+    return {};
+  }
+}
+
 export function runCalculations(components, values) {
   const inputValues = {};
   // calculation expression use "code"
@@ -14,9 +25,14 @@ export function runCalculations(components, values) {
   for (const c of components) {
     if (c.calculation) {
       try {
-        const value = math.evaluate(c.calculation, inputValues);
+        let value = math.evaluate(c.calculation, inputValues);
         if (Number.isNaN(value)) {
           throw new Error('Value is NaN');
+        }
+        const config = getConfigObject(c.id, c.config);
+        if (config.rounding) {
+          value = parseFloat(value);
+          value = value.toFixed(config.rounding);
         }
         inputValues[c.dataElement.code] = value;
         calculatedValues[c.dataElement.id] = value;


### PR DESCRIPTION
### Changes

- On Desktop show calculation on form entry
- On Desktop and Mobile add rounding

desktop and mobile are 2 seperate linear tickets (WAITM-606 & WAITM-607) but since they are so similar I've bundled them into 1 PR.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
