### PR TITLE
WAITM-618 Override column header when exporting vitals table

### DIFF
--- a/packages/desktop/app/components/DateDisplay.js
+++ b/packages/desktop/app/components/DateDisplay.js
@@ -27,6 +27,16 @@ export const formatTime = date =>
     '__:__',
   ); // 12:30 am
 
+export const formatTimeWithSeconds = date =>
+  intlFormatDate(
+    date,
+    {
+      timeStyle: 'medium',
+      hour12: true,
+    },
+    '__:__:__',
+  ); // 12:30:00 am
+
 const formatShortExplicit = date =>
   intlFormatDate(date, {
     dateStyle: 'medium',

--- a/packages/desktop/app/components/Table/DownloadDataButton.js
+++ b/packages/desktop/app/components/Table/DownloadDataButton.js
@@ -36,8 +36,7 @@ export function DownloadDataButton({ exportName, columns, data }) {
         await Promise.all(
           columnsWithOverrides.map(async c => {
             const headerValue = getHeaderValue(c);
-            const { exportOverrides = {} } = c;
-            if (exportOverrides.asyncExportAccessor) {
+            if (c.asyncExportAccessor) {
               const value = await c.asyncExportAccessor(d);
               dx[headerValue] = value;
               return;

--- a/packages/desktop/app/components/Table/DownloadDataButton.js
+++ b/packages/desktop/app/components/Table/DownloadDataButton.js
@@ -24,15 +24,20 @@ function getHeaderValue(column) {
 
 export function DownloadDataButton({ exportName, columns, data }) {
   const { showSaveDialog, openPath } = useElectron();
+  const columnsWithOverrides = columns.map(c => {
+    const { exportOverrides = {}, ...rest } = c;
+    return { ...rest, ...exportOverrides };
+  });
   const onDownloadData = async () => {
-    const header = columns.map(getHeaderValue);
+    const header = columnsWithOverrides.map(getHeaderValue);
     const rows = await Promise.all(
       data.map(async d => {
         const dx = {};
         await Promise.all(
-          columns.map(async c => {
+          columnsWithOverrides.map(async c => {
             const headerValue = getHeaderValue(c);
-            if (c.asyncExportAccessor) {
+            const { exportOverrides = {} } = c;
+            if (exportOverrides.asyncExportAccessor) {
               const value = await c.asyncExportAccessor(d);
               dx[headerValue] = value;
               return;

--- a/packages/desktop/app/components/VitalsTable.js
+++ b/packages/desktop/app/components/VitalsTable.js
@@ -5,6 +5,7 @@ import { useEncounter } from '../contexts/Encounter';
 import { Colors } from '../constants';
 import { VitalsTableCell, VitalsTableHeadCell, VitalsTableMeasureCell } from './VitalsTableCell';
 import { useVitals } from '../api/queries/useVitals';
+import { formatShortest, formatTimeWithSeconds } from './DateDisplay';
 
 const StyledTable = styled(Table)`
   table {
@@ -63,6 +64,9 @@ export const VitalsTable = React.memo(() => {
               validationCriteria={validationCriteria}
             />
           );
+        },
+        exportOverrides: {
+          title: `${formatShortest(date)} ${formatTimeWithSeconds(date)}`,
         },
       })),
   ];


### PR DESCRIPTION
### Changes

- Allow overriding field values when exporting tables
- Override vitals column headers with more consistent formatting

### Checklist

- [X] Code is finished
- [X] UI Screenshots added to the Linear issue
- [X] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
