### PR TITLE
EPI-287: Fix places in the code where we expect 404s

### DIFF
--- a/packages/desktop/app/api/queries/useVitals.js
+++ b/packages/desktop/app/api/queries/useVitals.js
@@ -1,13 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { VITALS_DATA_ELEMENT_IDS } from 'shared/constants/surveys';
-import { useApi } from '../index';
+import { useApi, isErrorUnknownAllow404s } from '../index';
 import { useVitalsSurvey } from './useVitalsSurvey';
 import { getConfigObject } from '../../utils';
 
 export const useVitals = encounterId => {
   const api = useApi();
   const vitalsQuery = useQuery(['encounterVitals', encounterId], () =>
-    api.get(`encounter/${encounterId}/vitals`, { rowsPerPage: 50 }),
+    api.get(
+      `encounter/${encounterId}/vitals`,
+      { rowsPerPage: 50 },
+      { isErrorUnknown: isErrorUnknownAllow404s },
+    ),
   );
 
   const surveyQuery = useVitalsSurvey();

--- a/packages/desktop/app/api/queries/useVitalsSurvey.js
+++ b/packages/desktop/app/api/queries/useVitalsSurvey.js
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { useApi } from '../useApi';
+import { useApi, isErrorUnknownAllow404s } from '../index';
 
 export const useVitalsSurvey = () => {
   const api = useApi();
-  return useQuery(['survey', { type: 'vitals' }], () => api.get(`survey/vitals`));
+  return useQuery(['survey', { type: 'vitals' }], () =>
+    api.get(`survey/vitals`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
+  );
 };

--- a/packages/desktop/app/components/ReferralTable.js
+++ b/packages/desktop/app/components/ReferralTable.js
@@ -117,7 +117,7 @@ const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
         );
         setName(user.displayName);
       } catch (e) {
-        if (e.message === '404') {
+        if (e.message === 'Facility server error response: 404') {
           setName(referralByAnswer.body);
         } else {
           setName('Unknown');

--- a/packages/desktop/app/components/ReferralTable.js
+++ b/packages/desktop/app/components/ReferralTable.js
@@ -8,7 +8,7 @@ import { DropdownButton } from './DropdownButton';
 
 import { EncounterModal } from './EncounterModal';
 import { useEncounter } from '../contexts/Encounter';
-import { useApi } from '../api';
+import { useApi, isErrorUnknownAllow404s } from '../api';
 import { SurveyResponseDetailsModal } from './SurveyResponseDetailsModal';
 import { DeleteButton } from './Button';
 import { ConfirmModal } from './ConfirmModal';
@@ -110,7 +110,11 @@ const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
       }
 
       try {
-        const user = await api.get(`user/${encodeURIComponent(referralByAnswer.body)}`);
+        const user = await api.get(
+          `user/${encodeURIComponent(referralByAnswer.body)}`,
+          {},
+          { isErrorUnknown: isErrorUnknownAllow404s },
+        );
         setName(user.displayName);
       } catch (e) {
         if (e.message === '404') {

--- a/packages/desktop/app/components/SyncHealthNotification.js
+++ b/packages/desktop/app/components/SyncHealthNotification.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import styled from 'styled-components';
 
 import { ApiContext } from '../api';
+import { useAuth } from '../contexts/Auth';
 import { Colors } from '../constants';
 
 const Container = styled.div`
@@ -21,11 +22,14 @@ const Container = styled.div`
 
 export const SyncHealthNotificationComponent = () => {
   const api = useContext(ApiContext);
+  const { currentUser } = useAuth();
   const [message, setMessage] = useState();
 
   useEffect(() => {
     let isMounted = true;
     (async () => {
+      // don't attempt to get syncHealth when not logged in
+      if (!currentUser) return;
       const res = await api.get('syncHealth');
       if (!isMounted) return;
       if (!res.healthy) {
@@ -35,7 +39,7 @@ export const SyncHealthNotificationComponent = () => {
     return () => {
       isMounted = false;
     };
-  }, [api]);
+  }, [api, currentUser]);
 
   // We only set a message if the server is unhealthy, so as long as message is undefined,
   // we don't need to render a warning.

--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -9,7 +9,7 @@ import { DIAGNOSIS_CERTAINTIES_TO_HIDE } from 'shared/constants';
 
 import { PrintPortal, PrintLetterhead } from '../../components/PatientPrinting';
 import { LocalisedText } from '../../components/LocalisedText';
-import { useApi } from '../../api';
+import { useApi, isErrorUnknownAllow404s } from '../../api';
 import { Button } from '../../components/Button';
 import { DateDisplay } from '../../components/DateDisplay';
 import { useEncounter } from '../../contexts/Encounter';
@@ -236,7 +236,11 @@ export const DischargeSummaryView = React.memo(() => {
   useEffect(() => {
     (async () => {
       if (encounter?.id) {
-        const data = await api.get(`encounter/${encounter?.id}/discharge`);
+        const data = await api.get(
+          `encounter/${encounter?.id}/discharge`,
+          {},
+          { isErrorUnknown: isErrorUnknownAllow404s },
+        );
         setDischarge(data);
       }
     })();

--- a/packages/desktop/app/views/patients/panes/InvoicingPane.js
+++ b/packages/desktop/app/views/patients/panes/InvoicingPane.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { useEncounter } from '../../../contexts/Encounter';
-import { useApi } from '../../../api';
+import { useApi, isErrorUnknownAllow404s } from '../../../api';
 import { isInvoiceEditable } from '../../../utils';
 import { InvoiceLineItemModal } from '../../../components/InvoiceLineItemModal';
 import { InvoicePriceChangeItemModal } from '../../../components/InvoicePriceChangeItemModal';
@@ -52,7 +52,11 @@ export const InvoicingPane = React.memo(({ encounter }) => {
 
   const getInvoice = useCallback(async () => {
     try {
-      const invoiceResponse = await api.get(`encounter/${encounter.id}/invoice`);
+      const invoiceResponse = await api.get(
+        `encounter/${encounter.id}/invoice`,
+        {},
+        { isErrorUnknown: isErrorUnknownAllow404s },
+      );
       setInvoice(invoiceResponse);
     } catch (e) {
       // do nothing


### PR DESCRIPTION
### Changes

EPI-287 shows a toast for unexpected errors that aren't handled in any other way. As per discussion on that PR, we're treating 404s as unexpected errors by default. This PR goes through and makes sure places where we actually _expect_ 404s don't show a toast.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
