### PR TITLE
Staging fix SAV-58: Show permission required modal when record vitals without permission

### DIFF
--- a/packages/desktop/app/components/ForbiddenErrorModal.js
+++ b/packages/desktop/app/components/ForbiddenErrorModal.js
@@ -1,14 +1,24 @@
 import React, { useCallback } from 'react';
+import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import Typography from '@material-ui/core/Typography';
 
 import { getErrorMessage, removeForbiddenError } from '../store/specialModals';
 import { Modal } from './Modal';
 import { ModalActionRow } from './ModalActionRow';
 
-const COPY_TEXT = `You don't have permission to perform this action, please contact your system administrator if you believe you should have permission.`;
+export const FORBIDDEN_ERROR_MESSAGE = `You don't have permission to perform this action, please contact your system administrator if you believe you should have permission.`;
 
+const StyledTypography = styled.p`
+  margin: 60px 20px;
+`;
+
+export const ForbiddenError = ({ onConfirm, confirmText }) => (
+  <>
+    <StyledTypography gutterBottom>{FORBIDDEN_ERROR_MESSAGE}</StyledTypography>
+    <ModalActionRow onConfirm={onConfirm} confirmText={confirmText} />
+  </>
+);
 export const ForbiddenErrorModal = () => {
   const history = useHistory();
   const errorMessage = useSelector(getErrorMessage);
@@ -27,8 +37,7 @@ export const ForbiddenErrorModal = () => {
 
   return (
     <Modal title="Forbidden" open onClose={handleClose}>
-      <Typography gutterBottom>{COPY_TEXT}</Typography>
-      <ModalActionRow onConfirm={handleConfirm} confirmText="Navigate back" />
+      <ForbiddenError onConfirm={handleConfirm} confirmText="Navigate back" />
     </Modal>
   );
 };

--- a/packages/desktop/app/forms/VitalsForm.js
+++ b/packages/desktop/app/forms/VitalsForm.js
@@ -31,7 +31,7 @@ export const VitalsForm = React.memo(({ patient, onSubmit, onClose, editedObject
   }
 
   if (isError) {
-    if (error.name === 'ForbiddenError') {
+    if (error?.name === 'ForbiddenError') {
       return (
         <Modal title="Permission required" open onClose={onClose}>
           <ForbiddenError onConfirm={onClose} confirmText="Close" />

--- a/packages/desktop/app/forms/VitalsForm.js
+++ b/packages/desktop/app/forms/VitalsForm.js
@@ -8,6 +8,8 @@ import { ModalLoader, ConfirmCancelRow, Form } from '../components';
 import { SurveyScreen } from '../components/Surveys';
 import { useVitalsSurvey } from '../api/queries';
 import { getValidationSchema } from '../utils';
+import { ForbiddenError } from '../components/ForbiddenErrorModal';
+import { Modal } from '../components/Modal';
 
 const ErrorMessage = () => {
   return (
@@ -21,7 +23,7 @@ const ErrorMessage = () => {
 };
 
 export const VitalsForm = React.memo(({ patient, onSubmit, onClose, editedObject }) => {
-  const { data: vitalsSurvey, isLoading, isError } = useVitalsSurvey();
+  const { data: vitalsSurvey, isLoading, isError, error } = useVitalsSurvey();
   const validationSchema = useMemo(() => getValidationSchema(vitalsSurvey), [vitalsSurvey]);
 
   if (isLoading) {
@@ -29,6 +31,13 @@ export const VitalsForm = React.memo(({ patient, onSubmit, onClose, editedObject
   }
 
   if (isError) {
+    if (error.name === 'ForbiddenError') {
+      return (
+        <Modal title="Permission required" open onClose={onClose}>
+          <ForbiddenError onConfirm={onClose} confirmText="Close" />
+        </Modal>
+      );
+    }
     return <ErrorMessage />;
   }
 


### PR DESCRIPTION
### Ticket: SAV-58

### Changes
- Show permission required modal when record vitals without permission

### Screenshots:
<img width="704" alt="Screen Shot 2023-01-18 at 7 37 22 am" src="https://user-images.githubusercontent.com/63621318/213051229-86e7dc58-1d43-46f3-9f63-a65a7edc1f68.png">


### Checklist
- [x] Code is finished
- [x] UI Screenshots added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
