### PR TITLE
Github Actions: Fix tests-pass job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
 
   # Dummy job to have a stable name for PR requirements
   tests-pass:
+    if: always() # always run even if dependencies fail
     name: Tests pass
     needs:
       - test
@@ -226,4 +227,6 @@ jobs:
       - test-mobile
     runs-on: ubuntu-latest
     steps:
-    - run: echo "Tests pass"
+    # fail if ANY dependency has failed or been skipped or cancelled
+    - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')"
+      run: exit 1


### PR DESCRIPTION
### Changes

On advice from Github support, the dummy job needs to be set to always run, so it can then evaluate if it should fail the build. Otherwise a skipped or cancelled dependency, such as happens when the build is cancelled in favour of a new commit on the PR, would cause the tests-pass job to pass the build unwantedly.

Incidentally this construction also lets us be more flexible with the fail condition if we wish to: for example, we could have the storybook job run even though it's broken and specifically allow it through here.

### Checklist

- [x] Code is finished