### PR TITLE
WAITM-599 Logout warning modal

### DIFF
--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -1,9 +1,9 @@
 /*
  * NOTE: Currently this component simply holds the idle timer functionality
- * TODO: Build actual modals: WAITM-598 WAITM-599
+ * TODO: Build actual modals: WAITM-598
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useIdleTimer } from 'react-idle-timer';
 import Typography from '@material-ui/core/Typography';
@@ -15,11 +15,22 @@ import { checkIsLoggedIn } from '../store/auth';
 import { Modal } from './Modal';
 import { ModalActionRow } from './ModalActionRow';
 
-const IdleWarningModal = ({ open, duration, onConfirm, onClose }) => {
+const IdleWarningModal = ({ open, remainingDuration, onConfirm, onClose }) => {
+  const [, updateState] = useState({});
+  // Re-render modal on timer so countdown updates correctly
+  useEffect(() => {
+    const interval = setInterval(() => updateState({}), 500);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
   return (
     <Modal title="Login timeout" open={open}>
       <Typography>
-        {`Your login is about to expire due to inactivity. You will be logged out in ${duration} seconds.`}
+        {`Your login is about to expire due to inactivity. You will be logged out in ${Math.ceil(
+          remainingDuration() / 1000,
+        )} seconds.`}
       </Typography>
       <ModalActionRow
         confirmText="Stay logged in"
@@ -56,7 +67,7 @@ export const UserActivityMonitor = () => {
     setShowWarning(true);
   };
 
-  useIdleTimer({
+  const { getRemainingTime } = useIdleTimer({
     onIdle,
     onAction,
     onPrompt,
@@ -70,7 +81,7 @@ export const UserActivityMonitor = () => {
   return (
     <IdleWarningModal
       open={showWarning}
-      duration={warningPromptDuration}
+      remainingDuration={getRemainingTime}
       onConfirm={() => setShowWarning(false)}
       onClose={onLogout}
     />

--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useIdleTimer } from 'react-idle-timer';
 import Typography from '@material-ui/core/Typography';
+import styled from 'styled-components';
 
 import { useLocalisation } from '../contexts/Localisation';
 import { useAuth } from '../contexts/Auth';
@@ -14,6 +15,11 @@ import { checkIsLoggedIn } from '../store/auth';
 
 import { Modal } from './Modal';
 import { ModalActionRow } from './ModalActionRow';
+
+const WarningModalContainer = styled.div`
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+`;
 
 const IdleWarningModal = ({ open, remainingDuration, onConfirm, onClose }) => {
   const [, updateState] = useState({});
@@ -27,11 +33,14 @@ const IdleWarningModal = ({ open, remainingDuration, onConfirm, onClose }) => {
 
   return (
     <Modal title="Login timeout" open={open}>
-      <Typography>
-        {`Your login is about to expire due to inactivity. You will be logged out in ${Math.ceil(
-          remainingDuration() / 1000,
-        )} seconds.`}
-      </Typography>
+      <WarningModalContainer>
+        <Typography>Your login is about to expire due to inactivity.</Typography>
+        <Typography>
+          You will be logged out in{' '}
+          <span style={{ fontWeight: 'bold' }}>{Math.ceil(remainingDuration() / 1000)}</span>{' '}
+          seconds.
+        </Typography>
+      </WarningModalContainer>
       <ModalActionRow
         confirmText="Stay logged in"
         cancelText="Logout"

--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -73,6 +73,7 @@ export const UserActivityMonitor = () => {
     onPrompt,
     events: ['keydown', 'mousedown', 'mousemove'],
     startOnMount: enabled,
+    startManually: !enabled, // IdleTimer needs one of the start methods set to true
     timeout: timeoutDuration * 1000,
     promptTimeout: warningPromptDuration * 1000,
     throttle: refreshInterval * 1000,

--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -3,14 +3,37 @@
  * TODO: Build actual modals: WAITM-598 WAITM-599
  */
 
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useIdleTimer } from 'react-idle-timer';
+import Typography from '@material-ui/core/Typography';
+
 import { useLocalisation } from '../contexts/Localisation';
 import { useAuth } from '../contexts/Auth';
 import { checkIsLoggedIn } from '../store/auth';
 
+import { Modal } from './Modal';
+import { ModalActionRow } from './ModalActionRow';
+
+const IdleWarningModal = ({ open, duration, onConfirm, onClose }) => {
+  return (
+    <Modal title="Login timeout" open={open}>
+      <Typography>
+        {`Your login is about to expire due to inactivity. You will be logged out in ${duration} seconds.`}
+      </Typography>
+      <ModalActionRow
+        confirmText="Stay logged in"
+        cancelText="Logout"
+        onConfirm={onConfirm}
+        onCancel={onClose}
+      />
+    </Modal>
+  );
+};
+
 export const UserActivityMonitor = () => {
   const isUserLoggedIn = useSelector(checkIsLoggedIn);
+  const [showWarning, setShowWarning] = useState(false);
   const { onLogout, refreshToken } = useAuth();
   const { getLocalisation } = useLocalisation();
 
@@ -30,7 +53,7 @@ export const UserActivityMonitor = () => {
   };
 
   const onPrompt = () => {
-    // TODO: WAITM-599 Display idle warning modal
+    setShowWarning(true);
   };
 
   useIdleTimer({
@@ -44,5 +67,12 @@ export const UserActivityMonitor = () => {
     throttle: refreshInterval * 1000,
   });
 
-  return null;
+  return (
+    <IdleWarningModal
+      open={showWarning}
+      duration={warningPromptDuration}
+      onConfirm={() => setShowWarning(false)}
+      onClose={onLogout}
+    />
+  );
 };

--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -37,7 +37,9 @@ const IdleWarningModal = ({ open, remainingDuration, onConfirm, onClose }) => {
         <Typography>Your login is about to expire due to inactivity.</Typography>
         <Typography>
           You will be logged out in{' '}
-          <span style={{ fontWeight: 'bold' }}>{Math.ceil(remainingDuration() / 1000)}</span>{' '}
+          <span style={{ fontWeight: 'bold' }}>
+            {open ? Math.ceil(remainingDuration() / 1000) : '-'}
+          </span>{' '}
           seconds.
         </Typography>
       </WarningModalContainer>
@@ -76,7 +78,7 @@ export const UserActivityMonitor = () => {
     setShowWarning(true);
   };
 
-  const { getRemainingTime } = useIdleTimer({
+  const { reset, getRemainingTime } = useIdleTimer({
     onIdle,
     onAction,
     onPrompt,
@@ -92,7 +94,10 @@ export const UserActivityMonitor = () => {
     <IdleWarningModal
       open={showWarning}
       remainingDuration={getRemainingTime}
-      onConfirm={() => setShowWarning(false)}
+      onConfirm={() => {
+        setShowWarning(false);
+        reset();
+      }}
       onClose={onLogout}
     />
   );


### PR DESCRIPTION
### Changes

- Add a warning prompt modal to display before a user is logged out for being idle
- Fix error where activity monitor was always running, even when feature flag set to false

### Checklist

- [X] Code is finished
- [X] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
