### PR TITLE
EPI-287: Disable on staging for v1.24.0 release

### DIFF
--- a/packages/desktop/app/api/TamanuApi.js
+++ b/packages/desktop/app/api/TamanuApi.js
@@ -251,7 +251,8 @@ export class TamanuApi {
     }
     const message = error?.message || response.status;
     if (showUnknownErrorToast && isErrorUnknown(error, response)) {
-      notifyError(['Network request failed', `Path: ${path}`, `Message: ${message}`]);
+      // disabled for v1.24.0 release but should be re-enabled on dev
+      // notifyError(['Network request failed', `Path: ${path}`, `Message: ${message}`]);
     }
     throw new Error(`Facility server error response: ${message}`);
   }


### PR DESCRIPTION
### Changes

Because we can't be 100% sure we've caught all the new error toasts showing up at _expected_ times, we're going to disable this for for v1.24.0 release and re-enable it later.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
  - [x] any db schema or other changes that could impact downstream data analysis
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
