### PR TITLE
Staging fix: EPI-188: Add a min-height to printout notes when empty

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/SimplePrintout.js
@@ -27,6 +27,7 @@ const NotesBox = styled(Box)`
   margin-bottom: 16px;
   border: 1px solid black;
   height: ${props => (props.$height ? props.$height : '75px')};
+  min-height: ${props => (props.$minHeight ? props.$minHeight : '150px')};
   text-overflow: ellipsis;
   overflow: hidden;
 `;
@@ -35,6 +36,7 @@ export const NotesSection = ({
   notes = [],
   title = 'Notes:',
   height,
+  emptyMinHeight,
   boldTitle,
   separator = ' ',
 }) => {
@@ -42,7 +44,7 @@ export const NotesSection = ({
   return (
     <>
       <Text $boldTitle={boldTitle}>{title}</Text>
-      <NotesBox $height={height}>
+      <NotesBox $height={height} $minHeight={noteContentList.length ? '0px' : emptyMinHeight}>
         {separator ? noteContentList.join(separator) : noteContentList}
       </NotesBox>
     </>


### PR DESCRIPTION
### Changes

Cherry-picks #3412 onto staging.

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
  - [x] any db schema or other changes that could impact downstream data analysis
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
