### PR TITLE
Staging fix SAV-64: Disable auto release to nauru demo

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -55,9 +55,9 @@
             - name: onto staging
               tag: ^(staging-)
               command: ./scripts/deploy_sync.sh staging tamanu-central-server-staging-16
-            - name: onto nauru demo
-              tag: ^(master$)
-              command: ./scripts/deploy_sync.sh nauru-demo tamanu-central-server-nauru-demo
+            # - name: onto nauru demo
+            #   tag: ^(master$)
+            #   command: ./scripts/deploy_sync.sh nauru-demo tamanu-central-server-nauru-demo
             - name: onto klaus
               tag: ^(klaus-)
               command: ./scripts/deploy_sync.sh klaus tamanu-central-server-klaus
@@ -111,12 +111,12 @@
             - name: onto staging B
               tag: ^(staging-)
               command: ./scripts/deploy_lan.sh staging tamanu-facility-server-staging-16b
-            - name: onto nauru demo
-              tag: ^(master$)
-              command: ./scripts/deploy_lan.sh nauru-demo tamanu-facility-server-nauru-demo
-            - name: onto nauru demo 2
-              tag: ^(master$)
-              command: ./scripts/deploy_lan.sh nauru-demo tamanu-facility-server-nauru-demo-2
+            # - name: onto nauru demo
+            #   tag: ^(master$)
+            #   command: ./scripts/deploy_lan.sh nauru-demo tamanu-facility-server-nauru-demo
+            # - name: onto nauru demo 2
+            #   tag: ^(master$)
+            #   command: ./scripts/deploy_lan.sh nauru-demo tamanu-facility-server-nauru-demo-2
         - name: the meta server
           service: awsdeployment
           type: serial


### PR DESCRIPTION
### Ticket: SAV-64

### Changes
- Temporarily disable auto release to nauru demo because they are on training with previous version (requested from Megan)

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
