### PR TITLE
EPI-110: Update button positioning

### DIFF
--- a/packages/desktop/app/components/PatientInfoPane/InfoPaneList.js
+++ b/packages/desktop/app/components/PatientInfoPane/InfoPaneList.js
@@ -18,7 +18,6 @@ const TitleContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  flex-grow: 1;
   border-bottom: 1px solid #ebebeb;
   padding-bottom: 0.5rem;
 `;

--- a/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
+++ b/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
@@ -2,7 +2,6 @@ import React, { memo, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { Box } from '@material-ui/core';
 import { OutlinedButton } from '../Button';
 import { InfoPaneList } from './InfoPaneList';
 import { CoreInfoDisplay } from './PatientCoreInfo';

--- a/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
+++ b/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
@@ -111,6 +111,8 @@ const CauseOfDeathButton = memo(({ openModal }) => {
 const PrintSection = memo(({ patient }) => <PatientPrintDetailsModal patient={patient} />);
 
 const Container = styled.div`
+  display: flex;
+  flex-direction: column;
   position: relative;
   background: ${Colors.white};
   box-shadow: 1px 0 3px rgba(0, 0, 0, 0.1);
@@ -119,6 +121,9 @@ const Container = styled.div`
 `;
 
 const ListsSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
   padding: 5px 25px 25px 25px;
 `;
 
@@ -167,7 +172,6 @@ export const PatientInfoPane = () => {
           {showCauseOfDeathButton && <CauseOfDeathButton openModal={openModal} />}
           <PrintSection patient={patient} readonly={readonly} />
         </Buttons>
-        <Box mt={12} />
         {showRecordDeathActions && (
           <RecordDeathSection patient={patient} openDeathModal={openModal} />
         )}

--- a/packages/desktop/app/components/RecordDeathSection.js
+++ b/packages/desktop/app/components/RecordDeathSection.js
@@ -17,6 +17,8 @@ const TypographyLink = styled(Typography)`
   text-decoration: underline;
   text-align: right;
   cursor: pointer;
+  padding-top: 10px;
+  margin-top: auto;
 `;
 
 export const RecordDeathSection = memo(({ patient, openDeathModal }) => {


### PR DESCRIPTION
### Changes

Previously I just added a separator element to generate a gap between the ID forms button and the record death button. After reviewed it was noticed that the button should actually stay close to the bottom of the screen, similar to the log out button.