### PR TITLE
Revert "EPI-287: Disable generic error toasts (#3421)"

### DIFF
--- a/packages/desktop/app/api/TamanuApi.js
+++ b/packages/desktop/app/api/TamanuApi.js
@@ -251,8 +251,7 @@ export class TamanuApi {
     }
     const message = error?.message || response.status;
     if (showUnknownErrorToast && isErrorUnknown(error, response)) {
-      // disabled for v1.24.0 release but should be re-enabled on dev
-      // notifyError(['Network request failed', `Path: ${path}`, `Message: ${message}`]);
+      notifyError(['Network request failed', `Path: ${path}`, `Message: ${message}`]);
     }
     throw new Error(`Facility server error response: ${message}`);
   }


### PR DESCRIPTION
This reverts commit 41756284576623231e9cc97818edd45add5a40a3.

### Changes

Reinstates generic error toasts on dev for v1.25, now that we've got time to fix and test all the commonly-occurring errors.

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
