### PR TITLE
EPI-342: Fix Windows CI build upload

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -22,7 +22,6 @@
               command: ./scripts/build_package_release.sh lan
             - name: package windows release
               tag: ^(master$|dev$|staging-|ci-)
-              service: app-without-db
               command: ./scripts/build_server_zip.sh lan ./deploy
         - name: for desktop installer
           exclude: ^deploy-meta$
@@ -35,7 +34,6 @@
               command: ./scripts/build_package_release.sh sync-server
             - name: package windows release
               tag: ^(master$|dev$|staging-|ci-)
-              service: app-without-db
               command: ./scripts/build_server_zip.sh sync-server ./deploy
         - name: for meta release
           tag: ^(dev$|deploy-meta$|master$|ci-)

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -16,13 +16,27 @@
       steps:
         - name: for lan
           exclude: ^deploy-meta$
-          command: ./scripts/build_package_release.sh lan
+          type: serial
+          steps:
+            - name: build linux release
+              command: ./scripts/build_package_release.sh lan
+            - name: package windows release
+              tag: ^(master$|dev$|staging-|ci-)
+              service: app-without-db
+              command: ./scripts/build_server_zip.sh lan ./deploy
         - name: for desktop installer
           exclude: ^deploy-meta$
           command: ./scripts/build_desktop.sh build-only
         - name: for sync release
           exclude: ^deploy-meta$
-          command: ./scripts/build_package_release.sh sync-server
+          type: serial
+          steps:
+            - name: build linux release
+              command: ./scripts/build_package_release.sh sync-server
+            - name: package windows release
+              tag: ^(master$|dev$|staging-|ci-)
+              service: app-without-db
+              command: ./scripts/build_server_zip.sh sync-server ./deploy
         - name: for meta release
           tag: ^(dev$|deploy-meta$|master$|ci-)
           command: ./scripts/build_package_release.sh meta-server
@@ -127,15 +141,6 @@
             - name: onto prod
               tag: ^(master|deploy-meta)$
               command: ./scripts/deploy_meta.sh prod tamanu-meta-server-prod-16
-        - name: package server zips
-          tag: ^(master$|dev$|staging-|ci-)
-          service: app-without-db
-          type: serial
-          steps:
-            - name: build central server zip
-              command: ./scripts/build_server_zip.sh sync-server ./deploy
-            - name: build facility server zip
-              command: ./scripts/build_server_zip.sh lan ./deploy
         - name: upload all artefacts to s3
           exclude: ^(release-desktop-|deploy-meta$)
           service: awsdeployment


### PR DESCRIPTION
### Changes

Codeship steps run the windows build in parallel with the s3 upload, and this breaks stuff.

Doesn't need to be a hotfix because it's just changing CI/CD config.

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
