### PR TITLE
EPI-319: Fix ServiceRequest.subject.display mapping

### DIFF
--- a/packages/shared-src/src/models/fhir/ServiceRequest.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest.js
@@ -183,7 +183,7 @@ export class FhirServiceRequest extends FhirResource {
       subject: new FhirReference({
         type: 'upstream://patient',
         reference: upstream.encounter.patient.id,
-        display: upstream.encounter.patient.displayId,
+        display: `${upstream.encounter.patient.firstName} ${upstream.encounter.patient.lastName}`,
       }),
       occurrenceDateTime: dateTimeStringIntoCountryTimezone(upstream.requestedDate),
       requester: new FhirReference({

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -169,7 +169,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
         subject: {
           reference: `Patient/${resources.pat.id}`,
           type: 'Patient',
-          display: resources.patient.displayId,
+          display: `${resources.patient.firstName} ${resources.patient.lastName}`,
         },
         occurrenceDateTime: format(
           dateTimeStringIntoCountryTimezone('2022-03-04 15:30:00'),
@@ -321,7 +321,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
               subject: {
                 reference: `Patient/${resources.pat.id}`,
                 type: 'Patient',
-                display: resources.patient.displayId,
+                display: `${resources.patient.firstName} ${resources.patient.lastName}`,
               },
               occurrenceDateTime: format(
                 dateTimeStringIntoCountryTimezone('2023-11-12 13:14:15'),


### PR DESCRIPTION
### Changes

Was pulling the displayId instead of name.

### Checklist

- [x] Code is finished
- [x] Tests are written

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)