### PR TITLE
QR tester tool: add "new" dev CA key

### DIFF
--- a/packages/qr-tester/www/js/csca/dev.js
+++ b/packages/qr-tester/www/js/csca/dev.js
@@ -1,10 +1,20 @@
-const PUBLIC_KEY = `
+const PUBLIC_KEY_OLD = `
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbFWYwdXqXLduhP4PuV0zQjGgvnbL
 +r3Wiy8PXnUjKWSDXCwEcl84/UFXj/IyB5mkwVXLtRK+moY89dG3+6fGaQ==
 -----END PUBLIC KEY-----
 `.trim();
 
+const PUBLIC_KEY_NEW = `
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkgWybGNvC+QC4ueSz6fYRCO8nTQO
+vaz71Avpj0tmzz1dIE3mCZkbA3UGdm7jpQOv65kkAiE7rA+dJ/YBFjfNIw==
+-----END PUBLIC KEY-----
+`.trim();
+
 export default async function publicKeys() {
-  return [KEYUTIL.getKey(PUBLIC_KEY)];
+  return [
+    KEYUTIL.getKey(PUBLIC_KEY_OLD),
+    KEYUTIL.getKey(PUBLIC_KEY_NEW),
+  ];
 }


### PR DESCRIPTION
### Changes

A new dev CSCA was created way back when the JS-based CSCA infra was made. This adds its root key to the QR tester tool.

### Checklist

- [x] Code is finished