### PR TITLE
WAITM-607: Fix mobile vitals rounding

### DIFF
--- a/packages/mobile/App/models/SurveyScreenComponent.ts
+++ b/packages/mobile/App/models/SurveyScreenComponent.ts
@@ -3,7 +3,7 @@ import { BaseModel } from './BaseModel';
 
 import { Survey } from './Survey';
 import { ProgramDataElement } from './ProgramDataElement';
-import { ISurveyScreenComponent, ValidationCriteria } from '~/types';
+import { ISurveyScreenComponent, SurveyScreenValidationCriteria } from '~/types';
 import { SYNC_DIRECTIONS } from './types';
 
 @Entity('survey_screen_component')
@@ -80,7 +80,7 @@ export class SurveyScreenComponent extends BaseModel implements ISurveyScreenCom
     }
   }
 
-  getValidationCriteriaObject(): ValidationCriteria {
+  getValidationCriteriaObject(): SurveyScreenValidationCriteria {
     if (!this.validationCriteria) return {};
 
     try {

--- a/packages/mobile/App/types/ISurvey.ts
+++ b/packages/mobile/App/types/ISurvey.ts
@@ -19,27 +19,25 @@ export enum SurveyTypes {
   Vitals = 'vitals',
 }
 
-export type ValidationCriteria = {
+export type SurveyScreenValidationCriteria = {
   min?: number;
   max?: number;
   mandatory?: boolean;
   normalRange?: { min: number; max: number };
 };
 
-export type SurveyScreenComponentConfig = {
+export type SurveyScreenConfig = {
   rounding?: number;
+  column?: string;
 };
 
 export interface ISurveyScreenComponent {
   id: ID;
-
   required: boolean;
-
   survey?: ISurvey;
   surveyId?: string;
   dataElement?: IProgramDataElement;
   dataElementId?: string;
-  config: SurveyScreenComponentConfig;
   screenIndex?: number;
   componentIndex?: number;
   text?: string;
@@ -50,9 +48,8 @@ export interface ISurveyScreenComponent {
   options?: string;
   calculation?: string;
   source?: string;
-
-  getConfigObject();
-  getValidationCriteriaObject: () => ValidationCriteria;
+  getConfigObject: () => SurveyScreenConfig;
+  getValidationCriteriaObject: () => SurveyScreenValidationCriteria;
   getOptions();
 }
 

--- a/packages/mobile/App/types/ISurvey.ts
+++ b/packages/mobile/App/types/ISurvey.ts
@@ -24,7 +24,11 @@ export type ValidationCriteria = {
   max?: number;
   mandatory?: boolean;
   normalRange?: { min: number; max: number };
-}
+};
+
+export type SurveyScreenComponentConfig = {
+  rounding?: number;
+};
 
 export interface ISurveyScreenComponent {
   id: ID;
@@ -35,7 +39,7 @@ export interface ISurveyScreenComponent {
   surveyId?: string;
   dataElement?: IProgramDataElement;
   dataElementId?: string;
-
+  config: SurveyScreenComponentConfig;
   screenIndex?: number;
   componentIndex?: number;
   text?: string;

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/helpers.ts
@@ -4,7 +4,7 @@ import { AutocompleteSourceToColumnMap } from '~/ui/helpers/constants';
 import { getAgeFromDate } from '~/ui/helpers/date';
 import { FieldTypes } from '~/ui/helpers/fields';
 import { joinNames } from '~/ui/helpers/user';
-import { IPatient, ISurveyScreenComponent, IUser, ValidationCriteria } from '~/types';
+import { IPatient, ISurveyScreenComponent, IUser, SurveyScreenValidationCriteria } from '~/types';
 
 function getInitialValue(dataElement): string {
   switch (dataElement.type) {
@@ -71,7 +71,7 @@ export function getFormInitialValues(
 
 function getFieldValidator(
   dataElement,
-  validationCriteria: ValidationCriteria,
+  validationCriteria: SurveyScreenValidationCriteria,
 ): null | Yup.BooleanSchema | Yup.DateSchema | Yup.StringSchema | Yup.NumberSchema {
   switch (dataElement.type) {
     case FieldTypes.INSTRUCTION:

--- a/packages/mobile/App/ui/components/VitalsTable/VitalsTableCell.tsx
+++ b/packages/mobile/App/ui/components/VitalsTable/VitalsTableCell.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { StyledView, StyledText } from '/styled/common';
 import { theme } from '/styled/theme';
 import { screenPercentageToDP, Orientation } from '/helpers/screen';
-import { ISurveyResponseAnswer, SurveyScreenComponentConfig } from '~/types';
+import { ISurveyResponseAnswer, SurveyScreenConfig } from '~/types';
 
 interface VitalsTableCellProps {
   data?: ISurveyResponseAnswer;
-  config?: SurveyScreenComponentConfig;
+  config?: SurveyScreenConfig;
   needsAttention: boolean;
   isOdd: boolean;
 }

--- a/packages/mobile/App/ui/components/VitalsTable/VitalsTableCell.tsx
+++ b/packages/mobile/App/ui/components/VitalsTable/VitalsTableCell.tsx
@@ -2,40 +2,48 @@ import React from 'react';
 import { StyledView, StyledText } from '/styled/common';
 import { theme } from '/styled/theme';
 import { screenPercentageToDP, Orientation } from '/helpers/screen';
-import { ISurveyResponseAnswer } from '~/types';
+import { ISurveyResponseAnswer, SurveyScreenComponentConfig } from '~/types';
 
 interface VitalsTableCellProps {
   data?: ISurveyResponseAnswer;
+  config?: SurveyScreenComponentConfig;
   needsAttention: boolean;
   isOdd: boolean;
 }
 
 export const VitalsTableCell = ({
   data,
+  config,
   needsAttention,
   isOdd,
-}: VitalsTableCellProps) : JSX.Element => {
-  const cellValue = data?.body || '';
+}: VitalsTableCellProps): JSX.Element => {
+  let cellValue = '';
+  if (data?.body) {
+    cellValue = data?.body;
+    if (config?.rounding) {
+      cellValue = parseFloat(cellValue).toFixed(config.rounding);
+    }
+  }
   return (
     <StyledView
       height={screenPercentageToDP(6.46, Orientation.Height)}
       justifyContent="center"
       alignItems="center"
       flexDirection="row"
-      background={isOdd ? theme.colors.BACKGROUND_GREY : theme.colors.WHITE }
+      background={isOdd ? theme.colors.BACKGROUND_GREY : theme.colors.WHITE}
     >
       <StyledText
         fontSize={screenPercentageToDP(1.57, Orientation.Height)}
         fontWeight={500}
         color={theme.colors.TEXT_SUPER_DARK}
-
       >
         {cellValue}
       </StyledText>
       {needsAttention && (
         <StyledText
           marginLeft={screenPercentageToDP(0.4, Orientation.Width)}
-          color={theme.colors.ALERT}>
+          color={theme.colors.ALERT}
+        >
           *
         </StyledText>
       )}

--- a/packages/mobile/App/ui/components/VitalsTable/index.tsx
+++ b/packages/mobile/App/ui/components/VitalsTable/index.tsx
@@ -11,7 +11,7 @@ import { StyledText, StyledView } from '~/ui/styled/common';
 import { theme } from '~/ui/styled/theme';
 import { VitalsTableRowHeader } from './VitalsTableRowHeader';
 import { VitalsTableCell } from './VitalsTableCell';
-import { ValidationCriteria } from '~/types';
+import { SurveyScreenValidationCriteria } from '~/types';
 import { Orientation, screenPercentageToDP } from '~/ui/helpers/screen';
 
 interface VitalsTableProps {
@@ -21,7 +21,7 @@ interface VitalsTableProps {
 
 const checkNeedsAttention = (
   value: string,
-  validationCriteria: ValidationCriteria = {},
+  validationCriteria: SurveyScreenValidationCriteria = {},
 ): boolean => {
   const { normalRange } = validationCriteria;
   const fValue = parseFloat(value);
@@ -29,89 +29,91 @@ const checkNeedsAttention = (
   return fValue > normalRange.max || fValue < normalRange.min;
 };
 
-export const VitalsTable = memo(({ data, columns }: VitalsTableProps): JSX.Element => {
-  const [vitalsSurvey, error] = useBackendEffect(({ models }) => models.Survey.getVitalsSurvey());
-  const [showNeedsAttentionInfo, setShowNeedsAttentionInfo] = useState(false);
+export const VitalsTable = memo(
+  ({ data, columns }: VitalsTableProps): JSX.Element => {
+    const [vitalsSurvey, error] = useBackendEffect(({ models }) => models.Survey.getVitalsSurvey());
+    const [showNeedsAttentionInfo, setShowNeedsAttentionInfo] = useState(false);
 
-  if (!vitalsSurvey) {
-    return <LoadingScreen />;
-  }
+    if (!vitalsSurvey) {
+      return <LoadingScreen />;
+    }
 
-  if (error) {
-    return <ErrorScreen error={error} />;
-  }
+    if (error) {
+      return <ErrorScreen error={error} />;
+    }
 
-  // Date is the column so remove it from rows
-  const components = vitalsSurvey.components.filter(
-    c => c.dataElementId !== VitalsDataElements.dateRecorded,
-  );
+    // Date is the column so remove it from rows
+    const components = vitalsSurvey.components.filter(
+      c => c.dataElementId !== VitalsDataElements.dateRecorded,
+    );
 
-  return (
-    <StyledView height="100%" background={theme.colors.BACKGROUND_GREY}>
-      <StyledView
-        borderBottomWidth={1}
-        borderColor={theme.colors.BOX_OUTLINE}
-        background={theme.colors.WHITE}
-      >
-        {/* Lines extending to end page underneath vitals entry so
+    return (
+      <StyledView height="100%" background={theme.colors.BACKGROUND_GREY}>
+        <StyledView
+          borderBottomWidth={1}
+          borderColor={theme.colors.BOX_OUTLINE}
+          background={theme.colors.WHITE}
+        >
+          {/* Lines extending to end page underneath vitals entry so
         table doesn't cut off if only one or two vital rows */}
-        {Array.from({ length: components.length + 1 }).fill(0).map((_, i) => (
-          <StyledView
-            marginTop={3}
-            position="absolute"
-            borderBottomWidth={i ? 0 : 1}
-            borderColor={theme.colors.BOX_OUTLINE}
-            left={screenPercentageToDP(31.63, Orientation.Width)}
-            top={screenPercentageToDP(6.46, Orientation.Height) * i}
-            height={screenPercentageToDP(6.46, Orientation.Height)}
-            zIndex={0}
-            width="100%"
-            background={i % 2 === 0 ? theme.colors.WHITE : theme.colors.BACKGROUND_GREY} />
-        ))}
-        <Table
-          Title={VitalsTableTitle}
-          tableHeader={vitalsTableHeader}
-          rows={components.map(component => {
-            const rowValidationCriteria = component.getValidationCriteriaObject();
-            const { dataElement } = component;
-            const { name, id } = dataElement;
-            return {
-              rowKey: 'dataElementId',
-              rowTitle: id,
-              rowHeader: (i) => (
-                <VitalsTableRowHeader
-                  title={name}
-                  isOdd={i % 2 === 0}
-                />
-              ),
-              cell: (cellData, i): JSX.Element => {
-                const value = cellData?.body || '';
-                const needsAttention = checkNeedsAttention(value, rowValidationCriteria);
-                if (needsAttention && !showNeedsAttentionInfo) setShowNeedsAttentionInfo(true);
-                return (
-                  <VitalsTableCell
-                    data={cellData}
-                    key={cellData?.id || id}
-                    needsAttention={needsAttention}
-                    isOdd={i % 2 === 0}
-                  />
-                );
-              },
-            };
-          })}
-          columns={columns}
-          cells={data}
-        />
-      </StyledView>
-      {showNeedsAttentionInfo && (
-        <StyledView background={theme.colors.BACKGROUND_GREY} padding={10}>
-          <StyledText
-            fontSize={screenPercentageToDP(1.57, Orientation.Height)}
-            fontWeight={500}
-            color={theme.colors.ALERT}>*Vital needs attention
-          </StyledText>
+          {Array.from({ length: components.length + 1 })
+            .fill(0)
+            .map((_, i) => (
+              <StyledView
+                marginTop={3}
+                position="absolute"
+                borderBottomWidth={i ? 0 : 1}
+                borderColor={theme.colors.BOX_OUTLINE}
+                left={screenPercentageToDP(31.63, Orientation.Width)}
+                top={screenPercentageToDP(6.46, Orientation.Height) * i}
+                height={screenPercentageToDP(6.46, Orientation.Height)}
+                zIndex={0}
+                width="100%"
+                background={i % 2 === 0 ? theme.colors.WHITE : theme.colors.BACKGROUND_GREY}
+              />
+            ))}
+          <Table
+            Title={VitalsTableTitle}
+            tableHeader={vitalsTableHeader}
+            rows={components.map(component => {
+              const rowValidationCriteria = component.getValidationCriteriaObject();
+              const { dataElement } = component;
+              const { name, id } = dataElement;
+              return {
+                rowKey: 'dataElementId',
+                rowTitle: id,
+                rowHeader: i => <VitalsTableRowHeader title={name} isOdd={i % 2 === 0} />,
+                cell: (cellData, i): JSX.Element => {
+                  const value = cellData?.body || '';
+                  const needsAttention = checkNeedsAttention(value, rowValidationCriteria);
+                  if (needsAttention && !showNeedsAttentionInfo) setShowNeedsAttentionInfo(true);
+                  return (
+                    <VitalsTableCell
+                      data={cellData}
+                      key={cellData?.id || id}
+                      needsAttention={needsAttention}
+                      isOdd={i % 2 === 0}
+                    />
+                  );
+                },
+              };
+            })}
+            columns={columns}
+            cells={data}
+          />
         </StyledView>
-      )}
-    </StyledView>
-  );
-});
+        {showNeedsAttentionInfo && (
+          <StyledView background={theme.colors.BACKGROUND_GREY} padding={10}>
+            <StyledText
+              fontSize={screenPercentageToDP(1.57, Orientation.Height)}
+              fontWeight={500}
+              color={theme.colors.ALERT}
+            >
+              *Vital needs attention
+            </StyledText>
+          </StyledView>
+        )}
+      </StyledView>
+    );
+  },
+);


### PR DESCRIPTION
### Changes

Make sure that vitals table values are rounded when displaying. They are rounded when entered into the vitals form but historical values might be un-rounded and so rounding needs to happen at the display side too.

### Checklist

- [x] Code is finished
- n/a Tests are written
- n/a UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
