### PR TITLE
No issue: Update mobile README

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -43,12 +43,6 @@ If you are about to use IOS simulators you will also need to go into the `ios` f
 cd ios && pod install
 ```
 
-### Configure environment
-
-```
-cp .sampleenv .env
-```
-
 ### Making Project runnable
 
 #### Xcode


### PR DESCRIPTION
### Changes

While George was setting up, noticed that the onboarding docs were outdated (the .sampleenv file no longer exists plus it's not neeeded).

After updating the slab post, here's the README update to match that.

Removed file in this commit: https://github.com/beyondessential/tamanu/pull/1872/commits/f19b6d902770a07a3baf29f89d282db3b1d53792