### PR TITLE
WAITM-611: Mobile location group autocomplete

### DIFF
--- a/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
+++ b/packages/desktop/app/components/Field/SurveyQuestionAutocomplete.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { connectApi } from '../../api/connectApi';
 import { Suggester } from '../../utils/suggester';
 import { AutocompleteField } from './AutocompleteField';
@@ -14,7 +13,7 @@ const getSuggesterEndpointForConfig = config => {
   if (config?.source === 'Department') return 'department';
   if (config?.source === 'User') return 'practitioner';
   if (config?.source === 'LocationGroup') {
-    return config.type === 'all' ? 'locationGroup' : 'facilityLocationGroup';
+    return config.scope === 'allFacilities' ? 'locationGroup' : 'facilityLocationGroup';
   }
 
   // autocomplete component won't crash when given an invalid endpoint, it just logs an error.

--- a/packages/mobile/App/types/ISurvey.ts
+++ b/packages/mobile/App/types/ISurvey.ts
@@ -29,6 +29,8 @@ export type SurveyScreenValidationCriteria = {
 export type SurveyScreenConfig = {
   rounding?: number;
   column?: string;
+  source?: string;
+  scope?: string;
 };
 
 export interface ISurveyScreenComponent {

--- a/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
@@ -2,14 +2,24 @@ import React from 'react';
 import { Routes } from '~/ui/helpers/routes';
 import { Suggester } from '~/ui/helpers/suggester';
 import { AutocompleteSourceToColumnMap } from '~/ui/helpers/constants';
+import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
 import { StyledText } from '~/ui/styled/common';
 import { theme } from '~/ui/styled/theme';
-
 import { AutocompleteModalField } from './AutocompleteModalField';
 
-export const SurveyQuestionAutocomplete = ({ ...props }): JSX.Element => {
+const useFilterByResource = ({ source, scope }) => {
+  const { facilityId } = useFacility();
+
+  if (source === 'LocationGroup') {
+    return scope === 'allFacilities' ? {} : { facility: facilityId };
+  }
+  return {};
+};
+
+export const SurveyQuestionAutocomplete = (props): JSX.Element => {
   const { models } = useBackend();
+  const filter = useFilterByResource(props.config);
   const { source, where } = props.config;
 
   const columnName = AutocompleteSourceToColumnMap[source];
@@ -24,8 +34,14 @@ export const SurveyQuestionAutocomplete = ({ ...props }): JSX.Element => {
 
   const suggester = new Suggester(
     models[source],
-    { where, column: columnName },
-    (val) => ({ label: val[columnName], value: val.id }),
+    {
+      where: { ...where, ...filter },
+      column: columnName,
+    },
+    val => ({
+      label: val[columnName],
+      value: val.id,
+    }),
   );
 
   return (

--- a/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
@@ -12,9 +12,10 @@ import { SurveyScreenConfig } from '~/types';
 const useFilterByResource = ({ source, scope }: SurveyScreenConfig): object => {
   const { facilityId } = useFacility();
 
-  if (source === 'LocationGroup') {
-    return scope === 'allFacilities' ? {} : { facility: facilityId };
+  if (source === 'LocationGroup' && scope !== 'allFacilities') {
+    return { facility: facilityId };
   }
+
   return {};
 };
 

--- a/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
@@ -7,8 +7,9 @@ import { useBackend } from '~/ui/hooks';
 import { StyledText } from '~/ui/styled/common';
 import { theme } from '~/ui/styled/theme';
 import { AutocompleteModalField } from './AutocompleteModalField';
+import { SurveyScreenConfig } from '~/types';
 
-const useFilterByResource = ({ source, scope }) => {
+const useFilterByResource = ({ source, scope }: SurveyScreenConfig): object => {
   const { facilityId } = useFacility();
 
   if (source === 'LocationGroup') {


### PR DESCRIPTION
### Changes

- Mobile location group autocomplete

Screenshots
All Location Groups
![Screen Shot 2023-01-26 at 1 36 25 PM](https://user-images.githubusercontent.com/12807916/214727418-7a3d271b-18d3-4160-9f35-20e5e13d2853.png)

Facility Location Groups
![Screen Shot 2023-01-26 at 1 33 50 PM](https://user-images.githubusercontent.com/12807916/214727444-1bb3fe4a-8c3f-446a-8757-beb7e4263b55.png)


### Checklist

- [x] Code is finished
- n/a Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
