### PR TITLE
WAITM-609: Imaging request cancellations

### DIFF
--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -47,7 +47,7 @@ export const CancelModal = React.memo(({ imagingRequest, buttonText }) => {
   const { getLocalisation } = useLocalisation();
   const [open, setOpen] = useState(false);
   const [reason, setReason] = useState(null);
-  const options = getLocalisation('imagingRequestCancellationReasons') || [];
+  const options = getLocalisation('imagingCancellationReasons') || [];
 
   const onConfirm = async () => {
     const reasonText = options.find(x => x.value === reason);

--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Modal } from './Modal';
+import { Button } from '../components/Button';
+import { ConfirmCancelRow } from './ButtonRow';
+
+export const CancelModal = ({ imagingRequest, buttonText }) => {
+  const [open, setOpen] = useState(false);
+  const onConfirm = () => {
+    console.log('confirm...', imagingRequest);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+  return (
+    <>
+      <Button variant="text" onClick={() => setOpen(true)}>
+        {buttonText}
+      </Button>
+      <Modal width="sm" title="Cancel imaging request" onClose={onClose} open={open}>
+        <div>Please select reason for cancelling imaging request and click Confirm</div>
+        <ConfirmCancelRow onCancel={onClose} onConfirm={onConfirm} cancelText="Close" />
+      </Modal>
+    </>
+  );
+};

--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -1,12 +1,38 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { push } from 'connected-react-router';
+import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
 import { Modal } from './Modal';
-import { Button } from '../components/Button';
+import { Button } from './Button';
 import { ConfirmCancelRow } from './ButtonRow';
+import { SelectInput } from './Field';
+import { useLocalisation } from '../contexts/Localisation';
+import { ENCOUNTER_TAB_NAMES } from '../views/patients/encounterTabNames';
+import { useApi } from '../api';
 
-export const CancelModal = ({ imagingRequest, buttonText }) => {
+export const CancelModal = React.memo(({ imagingRequest, buttonText }) => {
+  const api = useApi();
+  const dispatch = useDispatch();
+  const params = useParams();
+  const { getLocalisation } = useLocalisation();
   const [open, setOpen] = useState(false);
-  const onConfirm = () => {
+  const [reason, setReason] = useState(null);
+  const options = getLocalisation('imagingRequestCancellationReasons') || [];
+
+  const onConfirm = async () => {
+    console.log('reason...', reason);
     console.log('confirm...', imagingRequest);
+
+    await api.put(`imagingRequest/${imagingRequest.id}`, {
+      status: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+    });
+    // Todo: investigate refactoring url util?
+    dispatch(
+      push(
+        `/patients/${params.category}/${params.patientId}/encounter/${params.encounterId}?tab=${ENCOUNTER_TAB_NAMES.IMAGING}`,
+      ),
+    );
   };
   const onClose = () => {
     setOpen(false);
@@ -18,8 +44,15 @@ export const CancelModal = ({ imagingRequest, buttonText }) => {
       </Button>
       <Modal width="sm" title="Cancel imaging request" onClose={onClose} open={open}>
         <div>Please select reason for cancelling imaging request and click Confirm</div>
+        <SelectInput
+          label="Reason for cancellation"
+          name="reasonForCancellation"
+          options={options}
+          value={reason}
+          onChange={({ target: { value } }) => setReason(value)}
+        />
         <ConfirmCancelRow onCancel={onClose} onConfirm={onConfirm} cancelText="Close" />
       </Modal>
     </>
   );
-};
+});

--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
+import * as yup from 'yup';
 import styled from 'styled-components';
 import { Modal } from './Modal';
-import { Button } from './Button';
 import { ConfirmCancelRow } from './ButtonRow';
-import { SelectInput } from './Field';
+import { SelectField, Form, Field } from './Field';
 import { BodyText } from './Typography';
 
 const ModalBody = styled.div`
@@ -18,41 +18,37 @@ const Wrapper = styled.div`
   margin: 0 auto 50px;
   max-width: 350px;
 `;
+const isReasonForDelete = reason => reason === 'duplicate' || reason === 'entered-in-error';
 
 export const CancelModal = React.memo(
-  ({ title, bodyText, onConfirm, options, helperText, buttonText }) => {
-    const [open, setOpen] = useState(false);
-    const [reason, setReason] = useState(null);
-    const isReasonForDelete = reason === 'duplicate' || reason === 'entered-in-error';
-
-    const onClose = () => {
-      setOpen(false);
-    };
-
+  ({ title, bodyText, onConfirm, options, helperText, open, onClose }) => {
     return (
       <>
-        <Button variant="text" onClick={() => setOpen(true)}>
-          {buttonText}
-        </Button>
         <Modal width="sm" title={title} onClose={onClose} open={open}>
-          <ModalBody>
-            <BodyText>{bodyText}</BodyText>
-            <Wrapper>
-              <SelectInput
-                label="Reason for cancellation"
-                name="reasonForCancellation"
-                options={options}
-                value={reason}
-                onChange={({ target: { value } }) => setReason(value)}
-                helperText={isReasonForDelete ? helperText : null}
-              />
-            </Wrapper>
-            <ConfirmCancelRow
-              onCancel={onClose}
-              onConfirm={() => onConfirm(reason, isReasonForDelete)}
-              cancelText="Close"
-            />
-          </ModalBody>
+          <Form
+            onSubmit={({ reasonForCancellation }) =>
+              onConfirm(reasonForCancellation, isReasonForDelete(reasonForCancellation))
+            }
+            initialValues={{}}
+            validationSchema={yup.object().shape({
+              reasonForCancellation: yup.string().required(),
+            })}
+            render={({ values, submitForm }) => (
+              <ModalBody>
+                <BodyText>{bodyText}</BodyText>
+                <Wrapper>
+                  <Field
+                    component={SelectField}
+                    label="Reason for cancellation"
+                    name="reasonForCancellation"
+                    options={options}
+                    helperText={isReasonForDelete(values.reasonForCancellation) ? helperText : null}
+                  />
+                </Wrapper>
+                <ConfirmCancelRow onCancel={onClose} onConfirm={submitForm} cancelText="Close" />
+              </ModalBody>
+            )}
+          />
         </Modal>
       </>
     );

--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -21,36 +21,31 @@ const Wrapper = styled.div`
 const isReasonForDelete = reason => reason === 'duplicate' || reason === 'entered-in-error';
 
 export const CancelModal = React.memo(
-  ({ title, bodyText, onConfirm, options, helperText, open, onClose }) => {
-    return (
-      <>
-        <Modal width="sm" title={title} onClose={onClose} open={open}>
-          <Form
-            onSubmit={({ reasonForCancellation }) =>
-              onConfirm(reasonForCancellation, isReasonForDelete(reasonForCancellation))
-            }
-            initialValues={{}}
-            validationSchema={yup.object().shape({
-              reasonForCancellation: yup.string().required(),
-            })}
-            render={({ values, submitForm }) => (
-              <ModalBody>
-                <BodyText>{bodyText}</BodyText>
-                <Wrapper>
-                  <Field
-                    component={SelectField}
-                    label="Reason for cancellation"
-                    name="reasonForCancellation"
-                    options={options}
-                    helperText={isReasonForDelete(values.reasonForCancellation) ? helperText : null}
-                  />
-                </Wrapper>
-                <ConfirmCancelRow onCancel={onClose} onConfirm={submitForm} cancelText="Close" />
-              </ModalBody>
-            )}
-          />
-        </Modal>
-      </>
-    );
-  },
+  ({ title, bodyText, onConfirm, options, helperText, open, onClose }) => (
+    <Modal width="sm" title={title} onClose={onClose} open={open}>
+      <Form
+        onSubmit={({ reasonForCancellation }) =>
+          onConfirm(reasonForCancellation, isReasonForDelete(reasonForCancellation))
+        }
+        validationSchema={yup.object().shape({
+          reasonForCancellation: yup.string().required(),
+        })}
+        render={({ values, submitForm }) => (
+          <ModalBody>
+            <BodyText>{bodyText}</BodyText>
+            <Wrapper>
+              <Field
+                component={SelectField}
+                label="Reason for cancellation"
+                name="reasonForCancellation"
+                options={options}
+                helperText={isReasonForDelete(values.reasonForCancellation) ? helperText : null}
+              />
+            </Wrapper>
+            <ConfirmCancelRow onCancel={onClose} onConfirm={submitForm} cancelText="Close" />
+          </ModalBody>
+        )}
+      />
+    </Modal>
+  ),
 );

--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { push } from 'connected-react-router';
-import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
+import { IMAGING_REQUEST_STATUS_CONFIG } from 'shared/constants';
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
 import { PatientNameDisplay } from './PatientNameDisplay';
@@ -12,36 +12,8 @@ import { reloadImagingRequest } from '../store';
 import { useLocalisation } from '../contexts/Localisation';
 import { StatusTag } from './Tag';
 
-export const IMAGING_REQUEST_CONFIG = {
-  [IMAGING_REQUEST_STATUS_TYPES.PENDING]: {
-    label: 'Pending',
-    color: '#CB6100',
-    background: '#FAF0E6',
-  },
-  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: {
-    label: 'Completed',
-    color: '#19934E',
-    background: '#DEF0EE',
-  },
-  [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: {
-    label: 'In progress',
-    color: '#4101C9;',
-    background: '#ECE6FA',
-  },
-  [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: {
-    label: 'Cancelled',
-    color: '#444444;',
-    background: '#EDEDED',
-  },
-  unknown: {
-    label: 'Unknown',
-    color: '#444444;',
-    background: '#EDEDED',
-  },
-};
-
 const StatusDisplay = React.memo(({ status }) => {
-  const { background, color, label } = IMAGING_REQUEST_CONFIG[status];
+  const { background, color, label } = IMAGING_REQUEST_STATUS_CONFIG[status];
   return (
     <StatusTag $background={background} $color={color}>
       {label}

--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -25,7 +25,7 @@ const getDisplayName = ({ requestedBy }) => (requestedBy || {}).displayName || '
 const getPatientName = ({ encounter }) => <PatientNameDisplay patient={encounter.patient} />;
 const getStatus = ({ status }) => <StatusDisplay status={status} />;
 const getRequestType = imagingTypes => ({ imagingType }) =>
-  imagingTypes[imagingType]?.label || `Unknown ${imagingType?.name || null}` || 'Unknown';
+  imagingTypes[imagingType]?.label || 'Unknown';
 const getDate = ({ requestedDate }) => <DateDisplay date={requestedDate} showTime />;
 
 export const ImagingRequestsTable = React.memo(({ encounterId, searchParameters }) => {

--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -1,37 +1,56 @@
 import React, { useCallback } from 'react';
-import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { push } from 'connected-react-router';
-
-import { IMAGING_REQUEST_STATUS_LABELS } from 'shared/constants';
+import { IMAGING_REQUEST_STATUS_LABELS, IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
-
-import { IMAGING_REQUEST_COLORS } from '../constants';
 import { PatientNameDisplay } from './PatientNameDisplay';
 import { reloadPatient } from '../store/patient';
 import { useEncounter } from '../contexts/Encounter';
 import { reloadImagingRequest } from '../store';
 import { useLocalisation } from '../contexts/Localisation';
+import { StatusTag } from './Tag';
 
-const StatusLabel = styled.div`
-  background: ${p => p.color};
-  border-radius: 0.3rem;
-  padding: 0.3rem;
-`;
+export const IMAGING_REQUEST_CONFIG = {
+  [IMAGING_REQUEST_STATUS_TYPES.PENDING]: {
+    label: 'Pending',
+    color: '#CB6100',
+    background: '#FAF0E6',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: {
+    label: 'Completed',
+    color: '#19934E',
+    background: '#DEF0EE',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: {
+    label: 'In progress',
+    color: '#888888;',
+    background: '#ECE6FA',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: {
+    label: 'Cancelled',
+    color: '#444444;',
+    background: '#EDEDED',
+  },
+  unknown: {
+    label: 'Unknown',
+    color: '#444444;',
+    background: '#EDEDED',
+  },
+};
 
 const StatusDisplay = React.memo(({ status }) => (
-  <StatusLabel color={IMAGING_REQUEST_COLORS[status] || IMAGING_REQUEST_COLORS.unknown}>
-    {IMAGING_REQUEST_STATUS_LABELS[status] || 'Unknown'}
-  </StatusLabel>
+  <StatusTag $background={IMAGING_REQUEST_CONFIG[status]}>
+    {IMAGING_REQUEST_CONFIG[status] || 'Unknown'}
+  </StatusTag>
 ));
 
 const getDisplayName = ({ requestedBy }) => (requestedBy || {}).displayName || 'Unknown';
 const getPatientName = ({ encounter }) => <PatientNameDisplay patient={encounter.patient} />;
 const getStatus = ({ status }) => <StatusDisplay status={status} />;
 const getRequestType = imagingTypes => ({ imagingType }) =>
-  imagingTypes[imagingType]?.label || 'Unknown'(imagingType || {}).name || 'Unknown';
+  imagingTypes[imagingType]?.label || `Unknown ${imagingType?.name || null}` || 'Unknown';
 const getDate = ({ requestedDate }) => <DateDisplay date={requestedDate} showTime />;
 
 export const ImagingRequestsTable = React.memo(({ encounterId, searchParameters }) => {

--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { push } from 'connected-react-router';
-import { IMAGING_REQUEST_STATUS_LABELS, IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
+import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
 import { PatientNameDisplay } from './PatientNameDisplay';
@@ -25,7 +25,7 @@ export const IMAGING_REQUEST_CONFIG = {
   },
   [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: {
     label: 'In progress',
-    color: '#888888;',
+    color: '#4101C9;',
     background: '#ECE6FA',
   },
   [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: {
@@ -40,11 +40,14 @@ export const IMAGING_REQUEST_CONFIG = {
   },
 };
 
-const StatusDisplay = React.memo(({ status }) => (
-  <StatusTag $background={IMAGING_REQUEST_CONFIG[status]}>
-    {IMAGING_REQUEST_CONFIG[status] || 'Unknown'}
-  </StatusTag>
-));
+const StatusDisplay = React.memo(({ status }) => {
+  const { background, color, label } = IMAGING_REQUEST_CONFIG[status];
+  return (
+    <StatusTag $background={background} $color={color}>
+      {label}
+    </StatusTag>
+  );
+});
 
 const getDisplayName = ({ requestedBy }) => (requestedBy || {}).displayName || 'Unknown';
 const getPatientName = ({ encounter }) => <PatientNameDisplay patient={encounter.patient} />;

--- a/packages/desktop/app/components/Tag.js
+++ b/packages/desktop/app/components/Tag.js
@@ -15,3 +15,15 @@ export const Tag = styled.div`
   font-size: 14px;
   line-height: 18px;
 `;
+
+export const StatusTag = styled.div`
+  position: relative;
+  display: inline-block;
+  background: ${p => (p.$background ? p.$background : DEFAULTS.background)};
+  color: ${p => (p.$color ? p.$color : DEFAULTS.color)};
+  padding: 6px 13px;
+  border-radius: 20px;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+`;

--- a/packages/desktop/app/components/Tag.js
+++ b/packages/desktop/app/components/Tag.js
@@ -19,8 +19,8 @@ export const Tag = styled.div`
 export const StatusTag = styled.div`
   position: relative;
   display: inline-block;
-  background: ${p => (p.$background ? p.$background : DEFAULTS.background)};
-  color: ${p => (p.$color ? p.$color : DEFAULTS.color)};
+  background: ${p => p.$background || DEFAULTS.background};
+  color: ${p => p.$color || DEFAULTS.color};
   padding: 6px 13px;
   border-radius: 20px;
   font-weight: 400;

--- a/packages/desktop/app/components/TopBar.js
+++ b/packages/desktop/app/components/TopBar.js
@@ -84,6 +84,18 @@ export const SimpleTopBar = React.memo(({ title, children, className }) => (
   </AppBar>
 ));
 
+SimpleTopBar.propTypes = {
+  title: PropTypes.string,
+  subTitle: PropTypes.string,
+  className: PropTypes.string,
+};
+
+SimpleTopBar.defaultProps = {
+  title: null,
+  subTitle: null,
+  className: '',
+};
+
 const Container = styled.div`
   display: flex;
   align-items: center;

--- a/packages/desktop/app/components/TopBar.js
+++ b/packages/desktop/app/components/TopBar.js
@@ -86,13 +86,11 @@ export const SimpleTopBar = React.memo(({ title, children, className }) => (
 
 SimpleTopBar.propTypes = {
   title: PropTypes.string,
-  subTitle: PropTypes.string,
   className: PropTypes.string,
 };
 
 SimpleTopBar.defaultProps = {
   title: null,
-  subTitle: null,
   className: '',
 };
 

--- a/packages/desktop/app/components/TopBar.js
+++ b/packages/desktop/app/components/TopBar.js
@@ -75,6 +75,15 @@ TopBar.defaultProps = {
   className: '',
 };
 
+export const SimpleTopBar = React.memo(({ title, children, className }) => (
+  <AppBar className={className}>
+    <Bar>
+      <TopBarHeading variant="h1">{title}</TopBarHeading>
+      {children}
+    </Bar>
+  </AppBar>
+));
+
 const Container = styled.div`
   display: flex;
   align-items: center;

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -3,7 +3,6 @@ import { capitalize } from 'lodash';
 import { createValueIndex } from 'shared/utils/valueIndex';
 import {
   ENCOUNTER_TYPES,
-  IMAGING_REQUEST_STATUS_TYPES,
   NOTE_TYPES,
   APPOINTMENT_TYPES,
   APPOINTMENT_STATUSES,
@@ -70,13 +69,6 @@ export const LAB_REQUEST_COLORS = {
   [LAB_REQUEST_STATUSES.TO_BE_VERIFIED]: '#caf',
   [LAB_REQUEST_STATUSES.VERIFIED]: '#5af',
   [LAB_REQUEST_STATUSES.PUBLISHED]: '#afa',
-  unknown: '#333',
-};
-
-export const IMAGING_REQUEST_COLORS = {
-  [IMAGING_REQUEST_STATUS_TYPES.PENDING]: '#faa',
-  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: '#afa',
-  [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: '#aaf',
   unknown: '#333',
 };
 

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -269,6 +269,7 @@ const ImagingRequestInfoPane = React.memo(
 
 export const ImagingRequestView = () => {
   const api = useApi();
+  const [open, setOpen] = useState(false);
   const dispatch = useDispatch();
   const params = useParams();
   const imagingRequest = useSelector(state => state.imagingRequest);
@@ -316,15 +317,19 @@ export const ImagingRequestView = () => {
     <>
       <SimpleTopBar title="Imaging request">
         {!isCancelled && (
-          <CancelModal
-            title="Cancel imaging request"
-            helperText="This reason will permanently delete the imaging request record"
-            buttonText="Cancel request"
-            bodyText="Please select reason for cancelling imaging request and click 'Confirm'"
-            options={cancellationReasonOptions}
-            onConfirm={onConfirmCancel}
-          />
+          <Button variant="text" onClick={() => setOpen(true)}>
+            Cancel request
+          </Button>
         )}
+        <CancelModal
+          title="Cancel imaging request"
+          helperText="This reason will permanently delete the imaging request record"
+          bodyText="Please select reason for cancelling imaging request and click 'Confirm'"
+          options={cancellationReasonOptions}
+          open={open}
+          onClose={() => setOpen(false)}
+          onConfirm={onConfirmCancel}
+        />
         <PrintButton imagingRequest={imagingRequest} patient={patient} />
       </SimpleTopBar>
       <ContentPane>

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -292,7 +292,7 @@ export const ImagingRequestView = () => {
   };
 
   const onConfirmCancel = async (reason, isReasonForDelete) => {
-    const reasonText = cancellationReasonOptions.find(x => x.value === reason);
+    const reasonText = cancellationReasonOptions.find(x => x.value === reason).label;
     const note = `Request cancelled. Reason: ${reasonText}`;
     const status = isReasonForDelete
       ? IMAGING_REQUEST_STATUS_TYPES.DELETED

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -81,7 +81,8 @@ const PrintButton = ({ imagingRequest, patient }) => {
 
 const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imagingTypes }) => {
   const locationGroupSuggester = useSuggester('facilityLocationGroup');
-
+  // const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
+  const isCancelled = false;
   return (
     <FormGrid columns={3}>
       <TextInput value={imagingRequest.id} label="Request ID" disabled />
@@ -95,7 +96,13 @@ const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imag
         label="Priority"
         disabled
       />
-      <Field name="status" label="Status" component={SelectField} options={STATUS_OPTIONS} />
+      <Field
+        name="status"
+        label="Status"
+        component={SelectField}
+        options={isCancelled ? [{ value: 'cancelled', label: 'Cancelled' }] : STATUS_OPTIONS}
+        disabled={isCancelled}
+      />
       <DateTimeInput value={imagingRequest.requestedDate} label="Request date and time" disabled />
       {(values.status === IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS ||
         values.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED) && (
@@ -198,6 +205,8 @@ const ImagingRequestInfoPane = React.memo(
   ({ imagingRequest, onSubmit, practitionerSuggester, imagingTypes }) => {
     const { getLocalisation } = useLocalisation();
     const imagingPriorities = getLocalisation('imagingPriorities') || [];
+    // const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
+    const isCancelled = false;
 
     return (
       <Formik
@@ -244,7 +253,13 @@ const ImagingRequestInfoPane = React.memo(
                   }}
                 />
               )}
-              <ButtonRow>{dirty && <Button type="submit">Save</Button>}</ButtonRow>
+              <ButtonRow style={{ marginTop: 20 }}>
+                {!isCancelled && (
+                  <Button disabled={!dirty} type="submit">
+                    Save
+                  </Button>
+                )}
+              </ButtonRow>
             </Form>
           );
         }}
@@ -278,10 +293,14 @@ export const ImagingRequestView = () => {
 
   if (patient.loading) return <LoadingIndicator />;
 
+  const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
+
   return (
     <>
       <SimpleTopBar title="Imaging request">
-        <CancelModal buttonText="Cancel request" imagingRequest={imagingRequest} />
+        {!isCancelled && (
+          <CancelModal buttonText="Cancel request" imagingRequest={imagingRequest} />
+        )}
         <PrintButton imagingRequest={imagingRequest} patient={patient} />
       </SimpleTopBar>
       <ContentPane>

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -100,7 +100,11 @@ const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imag
         name="status"
         label="Status"
         component={SelectField}
-        options={isCancelled ? [{ value: 'cancelled', label: 'Cancelled' }] : STATUS_OPTIONS}
+        options={
+          isCancelled
+            ? [{ value: IMAGING_REQUEST_STATUS_TYPES.CANCELLED, label: 'Cancelled' }]
+            : STATUS_OPTIONS
+        }
         disabled={isCancelled}
       />
       <DateTimeInput value={imagingRequest.requestedDate} label="Request date and time" disabled />

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -315,12 +315,14 @@ export const ImagingRequestView = () => {
 
   if (patient.loading) return <LoadingIndicator />;
 
-  const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
+  const isCancellable =
+    imagingRequest.status !== IMAGING_REQUEST_STATUS_TYPES.CANCELLED &&
+    imagingRequest.status !== IMAGING_REQUEST_STATUS_TYPES.COMPLETED;
 
   return (
     <>
       <SimpleTopBar title="Imaging request">
-        {!isCancelled && (
+        {isCancellable && (
           <Button variant="text" onClick={() => setOpen(true)}>
             Cancel request
           </Button>

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -6,10 +6,9 @@ import { useParams } from 'react-router-dom';
 import { shell } from 'electron';
 import { pick } from 'lodash';
 import styled from 'styled-components';
-
 import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
-
+import { CancelModal } from '../../components/CancelModal';
 import { useCertificate } from '../../utils/useCertificate';
 import { Button } from '../../components/Button';
 import { ContentPane } from '../../components/ContentPane';
@@ -30,6 +29,7 @@ import { useApi, useSuggester } from '../../api';
 import { ImagingRequestPrintout } from '../../components/PatientPrinting/ImagingRequestPrintout';
 import { useLocalisation } from '../../contexts/Localisation';
 import { ENCOUNTER_TAB_NAMES } from './encounterTabNames';
+import { SimpleTopBar } from '../../components';
 
 const STATUS_OPTIONS = [
   { value: 'pending', label: 'Pending' },
@@ -72,11 +72,7 @@ const PrintButton = ({ imagingRequest, patient }) => {
           />
         )}
       </Modal>
-      <Button
-        variant="outlined"
-        onClick={openModal}
-        style={{ marginRight: '0.5rem', marginBottom: '30px' }}
-      >
+      <Button variant="outlined" onClick={openModal} style={{ marginLeft: '0.5rem' }}>
         Print request
       </Button>
     </>
@@ -281,16 +277,22 @@ export const ImagingRequestView = () => {
   };
 
   if (patient.loading) return <LoadingIndicator />;
+
   return (
-    <ContentPane>
-      <PrintButton imagingRequest={imagingRequest} patient={patient} />
-      <ImagingRequestInfoPane
-        imagingRequest={imagingRequest}
-        onSubmit={onSubmit}
-        practitionerSuggester={practitionerSuggester}
-        locationSuggester={locationSuggester}
-        imagingTypes={imagingTypes}
-      />
-    </ContentPane>
+    <>
+      <SimpleTopBar title="Imaging request">
+        <CancelModal buttonText="Cancel request" imagingRequest={imagingRequest} />
+        <PrintButton imagingRequest={imagingRequest} patient={patient} />
+      </SimpleTopBar>
+      <ContentPane>
+        <ImagingRequestInfoPane
+          imagingRequest={imagingRequest}
+          onSubmit={onSubmit}
+          practitionerSuggester={practitionerSuggester}
+          locationSuggester={locationSuggester}
+          imagingTypes={imagingTypes}
+        />
+      </ContentPane>
+    </>
   );
 };

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -8,6 +8,7 @@ import {
   INVOICE_STATUSES,
   NOTE_RECORD_TYPES,
   VITALS_DATA_ELEMENT_IDS,
+  IMAGING_REQUEST_STATUS_TYPES,
 } from 'shared/constants';
 import { uploadAttachment } from '../../utils/uploadAttachment';
 import { notePageListHandler } from '../../routeHandlers';
@@ -136,7 +137,16 @@ encounterRelations.get(
   '/:id/documentMetadata',
   paginatedGetList('DocumentMetadata', 'encounterId'),
 );
-encounterRelations.get('/:id/imagingRequests', simpleGetList('ImagingRequest', 'encounterId'));
+encounterRelations.get(
+  '/:id/imagingRequests',
+  simpleGetList('ImagingRequest', 'encounterId', {
+    additionalFilters: {
+      status: {
+        [Op.ne]: IMAGING_REQUEST_STATUS_TYPES.DELETED,
+      },
+    },
+  }),
+);
 
 encounterRelations.get('/:id/notePages', notePageListHandler(NOTE_RECORD_TYPES.ENCOUNTER));
 

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -174,6 +174,7 @@ imagingRequest.put(
       },
     } = req;
     req.checkPermission('read', 'ImagingRequest');
+
     const imagingRequestObject = await ImagingRequest.findByPk(id);
     if (!imagingRequestObject) throw new NotFoundError();
     req.checkPermission('write', 'ImagingRequest');

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -2,7 +2,12 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { startOfDay, endOfDay } from 'date-fns';
 import { Op } from 'sequelize';
-import { NOTE_TYPES, AREA_TYPE_TO_IMAGING_TYPE, IMAGING_AREA_TYPES } from 'shared/constants';
+import {
+  NOTE_TYPES,
+  AREA_TYPE_TO_IMAGING_TYPE,
+  IMAGING_AREA_TYPES,
+  IMAGING_REQUEST_STATUS_TYPES,
+} from 'shared/constants';
 import { NotFoundError } from 'shared/errors';
 import { toDateTimeString } from 'shared/utils/dateTime';
 import { getNoteWithType, mapQueryFilters, getCaseInsensitiveFilter } from '../../database/utils';
@@ -393,7 +398,9 @@ globalImagingRequests.get(
     const { count } = databaseResponse;
     const { rows } = databaseResponse;
 
-    const data = rows.map(x => x.get({ plain: true }));
+    const data = rows
+      .map(x => x.get({ plain: true }))
+      .filter(x => x.status !== IMAGING_REQUEST_STATUS_TYPES.DELETED);
     res.send({
       count,
       data,

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -386,7 +386,10 @@ globalImagingRequests.get(
 
     // Query database
     const databaseResponse = await models.ImagingRequest.findAndCountAll({
-      where: imagingRequestFilters,
+      where: {
+        ...imagingRequestFilters,
+        status: { [Op.ne]: IMAGING_REQUEST_STATUS_TYPES.DELETED },
+      },
       order: orderBy ? [[orderBy, order.toUpperCase()]] : undefined,
       include: [requestedBy, encounter, areas],
       limit: rowsPerPage,
@@ -398,9 +401,7 @@ globalImagingRequests.get(
     const { count } = databaseResponse;
     const { rows } = databaseResponse;
 
-    const data = rows
-      .map(x => x.get({ plain: true }))
-      .filter(x => x.status !== IMAGING_REQUEST_STATUS_TYPES.DELETED);
+    const data = rows.map(x => x.get({ plain: true }));
     res.send({
       count,
       data,

--- a/packages/shared-src/src/constants/statuses.js
+++ b/packages/shared-src/src/constants/statuses.js
@@ -6,19 +6,45 @@ export const IMAGING_REQUEST_STATUS_TYPES = {
   DELETED: 'deleted',
 };
 
-export const IMAGING_REQUEST_STATUS_LABELS = {
-  [IMAGING_REQUEST_STATUS_TYPES.PENDING]: 'Pending',
-  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: 'Completed',
-  [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: 'Cancelled',
-  [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: 'In progress',
+export const IMAGING_REQUEST_STATUS_CONFIG = {
+  [IMAGING_REQUEST_STATUS_TYPES.PENDING]: {
+    label: 'Pending',
+    color: '#CB6100',
+    background: '#FAF0E6',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: {
+    label: 'Completed',
+    color: '#19934E',
+    background: '#DEF0EE',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: {
+    label: 'In progress',
+    color: '#4101C9;',
+    background: '#ECE6FA',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: {
+    label: 'Cancelled',
+    color: '#444444;',
+    background: '#EDEDED',
+  },
+  [IMAGING_REQUEST_STATUS_TYPES.DELETED]: {
+    label: 'Deleted',
+    color: '#444444;',
+    background: '#EDEDED',
+  },
+  unknown: {
+    label: 'Unknown',
+    color: '#444444;',
+    background: '#EDEDED',
+  },
 };
 
-export const IMAGING_REQUEST_STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES).map(
-  s => ({
-    label: IMAGING_REQUEST_STATUS_LABELS[s],
+export const IMAGING_REQUEST_STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES)
+  .filter(x => x !== IMAGING_REQUEST_STATUS_TYPES.DELETED)
+  .map(s => ({
+    label: IMAGING_REQUEST_STATUS_CONFIG[s].label,
     value: s,
-  }),
-);
+  }));
 
 export const APPOINTMENT_TYPES = {
   STANDARD: 'Standard',

--- a/packages/shared-src/src/constants/statuses.js
+++ b/packages/shared-src/src/constants/statuses.js
@@ -2,11 +2,13 @@ export const IMAGING_REQUEST_STATUS_TYPES = {
   PENDING: 'pending',
   IN_PROGRESS: 'in_progress',
   COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
 };
 
 export const IMAGING_REQUEST_STATUS_LABELS = {
   [IMAGING_REQUEST_STATUS_TYPES.PENDING]: 'Pending',
   [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: 'Completed',
+  [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: 'Cancelled',
   [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: 'In progress',
 };
 

--- a/packages/shared-src/src/constants/statuses.js
+++ b/packages/shared-src/src/constants/statuses.js
@@ -3,6 +3,7 @@ export const IMAGING_REQUEST_STATUS_TYPES = {
   IN_PROGRESS: 'in_progress',
   COMPLETED: 'completed',
   CANCELLED: 'cancelled',
+  DELETED: 'deleted',
 };
 
 export const IMAGING_REQUEST_STATUS_LABELS = {

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -334,7 +334,7 @@ const rootLocalisationSchema = yup
           const values = conf.map(x => x.value);
           if (!values.includes('duplicate')) {
             return ctx.createError({
-              message: 'imagingCancellationReasons must include an option with value = clinic',
+              message: 'imagingCancellationReasons must include an option with value = duplicate',
             });
           }
           if (!values.includes('entered-in-error')) {

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -321,12 +321,31 @@ const rootLocalisationSchema = yup
         label: yup.string().required(),
       }),
     ),
-    imagingRequestCancellationReasons: yup.array(
-      yup.object({
-        value: yup.string().required(),
-        label: yup.string().required(),
+    imagingCancellationReasons: yup
+      .array(
+        yup.object({
+          value: yup.string().required(),
+          label: yup.string().required(),
+        }),
+      )
+      .test({
+        name: 'imagingCancellationReasons',
+        test(conf, ctx) {
+          const values = conf.map(x => x.value);
+          if (!values.includes('duplicate')) {
+            return ctx.createError({
+              message: 'imagingCancellationReasons must include an option with value = clinic',
+            });
+          }
+          if (!values.includes('entered-in-error')) {
+            return ctx.createError({
+              message:
+                'imagingCancellationReasons must include an option with value = entered-in-error',
+            });
+          }
+          return true;
+        },
       }),
-    ),
     triageCategories: yup
       .array(
         yup.object({

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -321,6 +321,12 @@ const rootLocalisationSchema = yup
         label: yup.string().required(),
       }),
     ),
+    imagingRequestCancellationReasons: yup.array(
+      yup.object({
+        value: yup.string().required(),
+        label: yup.string().required(),
+      }),
+    ),
     triageCategories: yup
       .array(
         yup.object({

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -646,7 +646,7 @@
           "label": "STAT"
         }
       ],
-      "imagingRequestCancellationReasons": [{
+      "imagingCancellationReasons": [{
         "value": "clinical",
         "label": "Clinical reason"
       },{

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -646,6 +646,25 @@
           "label": "STAT"
         }
       ],
+      "imagingRequestCancellationReasons": [{
+        "value": "clinical",
+        "label": "Clinical reason"
+      },{
+        "value": "duplicate",
+        "label": "Duplicate"
+      },{
+        "value": "entered-in-error",
+        "label": "Entered in error"
+      },{
+        "value": "patient-discharged",
+        "label": "Patient discharged"
+      },{
+        "value": "patient-refused",
+        "label": "Patient refused"
+      },{
+        "value": "other",
+        "label": "Other"
+      }],
       "printMeasures": {
         "stickerLabelPage": {
           "pageWidth": "210mm",


### PR DESCRIPTION
### Changes

- add cancellation button and modal for imaging requests
- filter out deleted imaging requests in the imaging requests fetch endpoints
- update styles of imaging request view and table to match designs
- refactor config for imaging requests so that it's all in one place

#### Screenshots:

**Imaging Request Cancellation Modal**
![Screen Shot 2023-01-27 at 3 16 09 PM](https://user-images.githubusercontent.com/12807916/214996064-d1f5eee0-4011-4621-9fdc-933ae6e71c89.png)

**Display Status in Table with Updated Status Tags**
![Screen Shot 2023-01-27 at 3 15 57 PM](https://user-images.githubusercontent.com/12807916/214996074-9172a3f2-e909-4a1c-a497-e9d8430e2e41.png)

**Read Only View of a Cancelled Request with Attached Note**
![Screen Shot 2023-01-27 at 3 15 39 PM](https://user-images.githubusercontent.com/12807916/214996080-1a258c98-2b50-4feb-b0e1-db14af0f036a.png)

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
