### PR TITLE
EPI-347: Fix dev builds

### DIFF
--- a/scripts/build_server_zip.sh
+++ b/scripts/build_server_zip.sh
@@ -13,7 +13,7 @@ TARGET_PATH="${2-.}"
 # copy folder before modifying so we don't break the linux release
 cp -r "./packages/$WORKSPACE/$LINUX_RELEASE_FOLDER" "./packages/$WORKSPACE/$WINDOWS_RELEASE_FOLDER"
 
-# get rid of node_modules from the linux release
+# get rid of node_modules from the copied linux release
 pushd "./packages/$WORKSPACE/$WINDOWS_RELEASE_FOLDER"
 mv ./node_modules/shared .
 rm -rf node_modules

--- a/scripts/build_server_zip.sh
+++ b/scripts/build_server_zip.sh
@@ -2,16 +2,19 @@
 set -euxo pipefail
 
 WORKSPACE="${1?must specify a workspace}"
-RELEASE_FOLDER="release-nodejs"
+LINUX_RELEASE_FOLDER="release-nodejs"
+WINDOWS_RELEASE_FOLDER="release-windows"
 TARGET_PATH="${2-.}"
 
+# this script depends on the following steps having been run:
+# ./scripts/build_shared.sh
+# ./scripts/build_package_release.sh "$WORKSPACE"
 
-# build release
-./scripts/build_shared.sh
-./scripts/build_package_release.sh "$WORKSPACE"
+# copy folder before modifying so we don't break the linux release
+cp -r "./packages/$WORKSPACE/$LINUX_RELEASE_FOLDER" "./packages/$WORKSPACE/$WINDOWS_RELEASE_FOLDER"
 
-# get rid of extraneous junk from the linux release
-pushd "./packages/$WORKSPACE/$RELEASE_FOLDER"
+# get rid of node_modules from the linux release
+pushd "./packages/$WORKSPACE/$WINDOWS_RELEASE_FOLDER"
 mv ./node_modules/shared .
 rm -rf node_modules
 popd
@@ -23,7 +26,7 @@ VERSION="${MAYBE_VERSION?could not calculate version}"
 DIR_NAME="release-v$VERSION"
 SUFFIX="$CI_BRANCH-v$VERSION-${CI_COMMIT_ID:0:10}"
 ZIP_NAME="tamanu-$WORKSPACE-$SUFFIX.zip"
-mv "$RELEASE_FOLDER" "$DIR_NAME"
+mv "$WINDOWS_RELEASE_FOLDER" "$DIR_NAME"
 zip -r "$ZIP_NAME" "$DIR_NAME"
 rm -rf "$DIR_NAME"
 popd


### PR DESCRIPTION
### Changes

Dev builds are failing, likely because the `build_server_zip.sh` script overwrites the linux build and messes with shared.

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
