### PR TITLE
EPI-270: Add ethnicity extension to patient data

### DIFF
--- a/packages/shared-src/src/migrations/1674517247633-addExtensionToFhirPatients.js
+++ b/packages/shared-src/src/migrations/1674517247633-addExtensionToFhirPatients.js
@@ -1,0 +1,13 @@
+const TABLE = { schema: 'fhir', tableName: 'patients' };
+
+export async function up(query) {
+  await query.addColumn(TABLE, 'extension', {
+    type: 'fhir.extension[]',
+    allowNull: false,
+    defaultValue: '{}',
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn(TABLE, 'extension');
+}

--- a/packages/shared-src/src/models/fhir/Patient.js
+++ b/packages/shared-src/src/models/fhir/Patient.js
@@ -14,15 +14,13 @@ import {
 } from '../../constants';
 import {
   FhirAddress,
-  FhirCodeableConcept,
-  FhirCoding,
   FhirContactPoint,
-  FhirExtension,
   FhirHumanName,
   FhirIdentifier,
   FhirPatientLink,
   FhirReference,
 } from '../../services/fhirTypes';
+import { nzEthnicity } from './extensions';
 
 export class FhirPatient extends FhirResource {
   static init(options, models) {
@@ -172,39 +170,6 @@ export class FhirPatient extends FhirResource {
 
 function compactBy(array, access = identity) {
   return array.filter(access);
-}
-
-function nzEthnicity(patient) {
-  function getEthnicity(ethnicityId) {
-    switch (ethnicityId) {
-      case 'ethnicity-Fiji':
-        return { code: '36111', display: 'Fijian/iTaukei' };
-      case 'ethnicity-FID':
-        return { code: '43112', display: 'Fijian Indian' };
-      case null:
-        return { code: '99999', display: 'Not Stated' };
-      default:
-        return { code: '61199', display: 'Other Ethnicity nec' };
-    }
-  }
-
-  if (!config.localisation.data.features.fhirNewZealandEthnicity) return [];
-  const { code, display } = getEthnicity(patient?.additionalData?.ethnicityId);
-
-  return [
-    new FhirExtension({
-      url: 'http://hl7.org.nz/fhir/StructureDefinition/nz-ethnicity',
-      valueCodeableConcept: new FhirCodeableConcept({
-        coding: [
-          new FhirCoding({
-            system: config.hl7.dataDictionaries.ethnicityId,
-            code,
-            display,
-          }),
-        ],
-      }),
-    }),
-  ];
 }
 
 function extension(patient) {

--- a/packages/shared-src/src/models/fhir/extensions.js
+++ b/packages/shared-src/src/models/fhir/extensions.js
@@ -1,0 +1,35 @@
+import config from 'config';
+import { FhirCodeableConcept, FhirCoding, FhirExtension } from 'shared/services/fhirTypes';
+
+function getEthnicity(ethnicityId) {
+  switch (ethnicityId) {
+    case 'ethnicity-Fiji':
+      return { code: '36111', display: 'Fijian/iTaukei' };
+    case 'ethnicity-FID':
+      return { code: '43112', display: 'Fijian Indian' };
+    case null:
+      return { code: '99999', display: 'Not Stated' };
+    default:
+      return { code: '61199', display: 'Other Ethnicity nec' };
+  }
+}
+
+export function nzEthnicity(patient, overrideConfig = config) {
+  if (!overrideConfig.localisation.data.features.fhirNewZealandEthnicity) return [];
+  const { code, display } = getEthnicity(patient?.additionalData?.ethnicityId);
+
+  return [
+    new FhirExtension({
+      url: 'http://hl7.org.nz/fhir/StructureDefinition/nz-ethnicity',
+      valueCodeableConcept: new FhirCodeableConcept({
+        coding: [
+          new FhirCoding({
+            system: config.hl7.dataDictionaries.ethnicityId,
+            code,
+            display,
+          }),
+        ],
+      }),
+    }),
+  ];
+}

--- a/packages/shared-src/src/models/fhir/extensions.js
+++ b/packages/shared-src/src/models/fhir/extensions.js
@@ -14,6 +14,7 @@ function getEthnicity(ethnicityId) {
   }
 }
 
+// overrideConfig parameter is just for testing and isn't intended to be used in live code
 export function nzEthnicity(patient, overrideConfig = config) {
   if (!overrideConfig.localisation.data.features.fhirNewZealandEthnicity) return [];
   const { code, display } = getEthnicity(patient?.additionalData?.ethnicityId);

--- a/packages/shared-src/src/models/fhir/extensions.js
+++ b/packages/shared-src/src/models/fhir/extensions.js
@@ -1,5 +1,5 @@
-import config from 'config';
 import { FhirCodeableConcept, FhirCoding, FhirExtension } from 'shared/services/fhirTypes';
+import { withConfig } from 'shared/utils/withConfig';
 
 function getEthnicity(ethnicityId) {
   switch (ethnicityId) {
@@ -14,9 +14,8 @@ function getEthnicity(ethnicityId) {
   }
 }
 
-// overrideConfig parameter is just for testing and isn't intended to be used in live code
-export function nzEthnicity(patient, overrideConfig = config) {
-  if (!overrideConfig.localisation.data.features.fhirNewZealandEthnicity) return [];
+export const nzEthnicity = withConfig((patient, config) => {
+  if (!config.localisation.data.features.fhirNewZealandEthnicity) return [];
   const { code, display } = getEthnicity(patient?.additionalData?.ethnicityId);
 
   return [
@@ -33,4 +32,4 @@ export function nzEthnicity(patient, overrideConfig = config) {
       }),
     }),
   ];
-}
+});

--- a/packages/sync-server/__tests__/hl7fhir/materialised/Patient.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/Patient.test.js
@@ -161,6 +161,7 @@ describe(`Materialised FHIR - Patient`, () => {
               ],
               birthDate: format(new Date(patient.dateOfBirth), 'yyyy-MM-dd'),
               deceasedDateTime: format(new Date(patient.dateOfDeath), 'yyyy-MM-dd'),
+              extension: [],
               gender: patient.sex,
               identifier: [
                 {

--- a/packages/sync-server/__tests__/hl7fhir/materialised/extensions.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/extensions.test.js
@@ -1,0 +1,39 @@
+import config from 'config';
+import { nzEthnicity } from 'shared/models/fhir/extensions';
+import { valueAsFhir } from 'shared/utils/pgComposite/sequelizeType';
+
+describe('New Zealand ethnicity extension', () => {
+  const patient = {
+    additionalData: {
+      ethnicityId: null,
+    },
+  };
+
+  it('returns empty array when feature flag is off', () => {
+    const extension = nzEthnicity(patient);
+    expect(extension).toMatchObject([]);
+    expect(extension.length).toBe(0);
+  });
+
+  it('returns a fhir extension when feature flag is on', () => {
+    const mockConfig = {
+      hl7: config.hl7,
+      localisation: { data: { features: { fhirNewZealandEthnicity: true, ano: true } } },
+    };
+    const extension = nzEthnicity(patient, mockConfig);
+    expect(valueAsFhir(extension)).toMatchObject([
+      {
+        url: 'http://hl7.org.nz/fhir/StructureDefinition/nz-ethnicity',
+        valueCodeableConcept: {
+          coding: [
+            {
+              display: 'Not Stated',
+              code: '99999',
+              system: 'http://data-dictionary.tamanu-fiji.org/extensions/ethnic-group-code.html',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/sync-server/__tests__/hl7fhir/materialised/extensions.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/extensions.test.js
@@ -18,7 +18,7 @@ describe('New Zealand ethnicity extension', () => {
   it('returns a fhir extension when feature flag is on', () => {
     const mockConfig = {
       hl7: config.hl7,
-      localisation: { data: { features: { fhirNewZealandEthnicity: true, ano: true } } },
+      localisation: { data: { features: { fhirNewZealandEthnicity: true } } },
     };
     const extension = nzEthnicity.overrideConfig(patient, mockConfig);
     expect(valueAsFhir(extension)).toMatchObject([

--- a/packages/sync-server/__tests__/hl7fhir/materialised/extensions.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/extensions.test.js
@@ -20,7 +20,7 @@ describe('New Zealand ethnicity extension', () => {
       hl7: config.hl7,
       localisation: { data: { features: { fhirNewZealandEthnicity: true, ano: true } } },
     };
-    const extension = nzEthnicity(patient, mockConfig);
+    const extension = nzEthnicity.overrideConfig(patient, mockConfig);
     expect(valueAsFhir(extension)).toMatchObject([
       {
         url: 'http://hl7.org.nz/fhir/StructureDefinition/nz-ethnicity',

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -346,6 +346,7 @@ const rootLocalisationSchema = yup
         enableCovidClearanceCertificate: yup.boolean().required(),
         editDisplayId: yup.boolean().required(),
         patientPlannedMove: yup.boolean().required(),
+        fhirNewZealandEthnicity: yup.boolean().required(),
       })
       .required()
       .noUnknown(),

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -594,7 +594,8 @@
         "mergePopulatedPADRecords": true,
         "enableCovidClearanceCertificate": false,
         "editDisplayId": false,
-        "patientPlannedMove": false
+        "patientPlannedMove": false,
+        "fhirNewZealandEthnicity": false
       },
       "templates": {
         "letterhead": {
@@ -720,7 +721,8 @@
       "patientDisplayId": "http://tamanu.io/data-dictionary/application-reference-number.html",
       "labRequestDisplayId": "http://tamanu.io/data-dictionary/labrequest-reference-number.html",
       "areaExternalCode": "http://data-dictionary.tamanu-fiji.org/rispacs-billing-code.html",
-      "serviceRequestId": "http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html"
+      "serviceRequestId": "http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html",
+      "ethnicityId": "http://data-dictionary.tamanu-fiji.org/extensions/ethnic-group-code.html"
     }
   },
   "s3": {},


### PR DESCRIPTION
### Changes

In the end this wasn't so big of an update. I spent quite some time trying to get a unit test that covers this but "ran out of time" trying to mock config. It seems that everything that's imported from `shared` won't read any changes made to the config after the tests have started. Importing from `shared-src` would work but since this is inside a model, it has to be connected to the database and even then, the model will error with the custom types.

After talking with @mcccclean, he suggested we could either use an external function and just test the function based or we could pass the config as an argument. Since the latter involves touching a class method that's inherited, I think we probably want the first approach.