### PR TITLE
SAV-70: Fix sync push deadlock

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -108,6 +108,9 @@
             - name: onto da A
               tag: ^(da-)
               command: ./scripts/deploy_lan.sh da tamanu-facility-server-da-a
+            - name: onto da B
+              tag: ^(da-)
+              command: ./scripts/deploy_lan.sh da tamanu-facility-server-da-b
             - name: onto uat
               tag: ^uat-
               command: ./scripts/deploy_lan.sh uat tamanu-lan-server-uat

--- a/packages/lan/__tests__/sync/pushOutgoingChanges.test.js
+++ b/packages/lan/__tests__/sync/pushOutgoingChanges.test.js
@@ -26,7 +26,10 @@ describe('pushOutgoingChanges', () => {
               // Have to load test function within test scope so that we can mock config per test case
               // https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
               const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
-              const centralServer = { push: jest.fn().mockImplementation(async () => {}) };
+              const centralServer = {
+                push: jest.fn().mockImplementation(async () => {}),
+                completePush: jest.fn().mockImplementation(async () => true),
+              };
               await pushOutgoingChanges(centralServer, 'sessionId', changes);
               expect(centralServer.push).toHaveBeenCalled();
             },
@@ -52,7 +55,10 @@ describe('pushOutgoingChanges', () => {
               // Have to load test function within test scope so that we can mock config per test case
               // https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
               const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
-              const centralServer = { push: jest.fn().mockImplementation(async () => {}) };
+              const centralServer = {
+                push: jest.fn().mockImplementation(async () => {}),
+                completePush: jest.fn().mockImplementation(async () => true),
+              };
               await pushOutgoingChanges(centralServer, 'sessionId', changes);
               expect(centralServer.push.mock.calls.length).toBeGreaterThanOrEqual(2);
             },
@@ -77,7 +83,10 @@ describe('pushOutgoingChanges', () => {
               // Have to load test function within test scope so that we can mock config per test case
               // https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
               const { pushOutgoingChanges } = require('../../app/sync/pushOutgoingChanges');
-              const centralServer = { push: jest.fn().mockImplementation(async () => {}) };
+              const centralServer = {
+                push: jest.fn().mockImplementation(async () => {}),
+                completePush: jest.fn().mockImplementation(async () => true),
+              };
               await pushOutgoingChanges(centralServer, 'sessionId', changes);
               expect(
                 centralServer.push.mock.calls.flatMap(([_sessionId, page]) => page).length,

--- a/packages/lan/app/sync/pushOutgoingChanges.js
+++ b/packages/lan/app/sync/pushOutgoingChanges.js
@@ -8,13 +8,11 @@ export const pushOutgoingChanges = async (centralServer, sessionId, changes) => 
     const page = changes.slice(startOfPage, endOfPage);
 
     const startTime = Date.now();
-    await centralServer.push(sessionId, page, {
-      pushedSoFar: endOfPage,
-      totalToPush: changes.length,
-    });
+    await centralServer.push(sessionId, page);
     const endTime = Date.now();
 
     startOfPage = endOfPage;
     limit = calculatePageLimit(limit, endTime - startTime);
   }
+  await centralServer.completePush(sessionId);
 };

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -156,7 +156,7 @@ export class CentralServerConnection {
     return this.post(`sync/${sessionId}/push`, {}, { changes });
   }
 
-  async completeSyncSession(sessionId: string): Promise<void> {
+  async completePush(sessionId: string): Promise<void> {
     // first off, mark the push as complete on central
     await this.post(`sync/${sessionId}/push/complete`, {}, {});
 

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -156,9 +156,9 @@ export class CentralServerConnection {
     return this.post(`sync/${sessionId}/push`, {}, { changes });
   }
 
-  async completePush(sessionId: string): Promise<void> {
+  async completePush(sessionId: string, tablesToInclude: string[]): Promise<void> {
     // first off, mark the push as complete on central
-    await this.post(`sync/${sessionId}/push/complete`, {}, {});
+    await this.post(`sync/${sessionId}/push/complete`, {}, { tablesToInclude });
 
     // now poll the complete check endpoint until we get a valid response - it takes a while for
     // the pushed changes to finish persisting to the central database

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -171,7 +171,7 @@ export class CentralServerConnection {
       }
       await sleepAsync(waitTime);
     }
-    throw new Error(`Could not fetch a valid pull count after ${maxAttempts} attempts`);
+    throw new Error(`Could not fetch if push has been completed after ${maxAttempts} attempts`);
   }
 
   setToken(token: string): void {

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -194,6 +194,7 @@ export class MobileSyncManager {
     if (outgoingChanges.length > 0) {
       await pushOutgoingChanges(
         this.centralServer,
+        modelsToPush,
         sessionId,
         outgoingChanges,
         (total, pushedRecords) =>

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -194,7 +194,6 @@ export class MobileSyncManager {
     if (outgoingChanges.length > 0) {
       await pushOutgoingChanges(
         this.centralServer,
-        modelsToPush,
         sessionId,
         outgoingChanges,
         (total, pushedRecords) =>

--- a/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
@@ -33,5 +33,5 @@ export const pushOutgoingChanges = async (
 
     progressCallback(changes.length, pushedRecordsCount);
   }
-  await centralServer.completeSyncSession(sessionId);
+  await centralServer.completePush(sessionId);
 };

--- a/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
@@ -1,10 +1,7 @@
 import { SyncRecord } from '../types';
-import { SYNC_DIRECTIONS } from '../../../models/types';
-import { MODELS_MAP } from '../../../models/modelsMap';
 
 import { CentralServerConnection } from '../CentralServerConnection';
 import { calculatePageLimit } from './calculatePageLimit';
-import { getModelsForDirection } from './getModelsForDirection';
 
 /**
  * Push outgoing changes in batches
@@ -15,7 +12,6 @@ import { getModelsForDirection } from './getModelsForDirection';
  */
 export const pushOutgoingChanges = async (
   centralServer: CentralServerConnection,
-  outgoingModels: typeof MODELS_MAP,
   sessionId: string,
   changes: SyncRecord[],
   progressCallback: (total: number, progressCount: number) => void,
@@ -28,13 +24,7 @@ export const pushOutgoingChanges = async (
     const endOfPage = Math.min(startOfPage + limit, changes.length);
     const page = changes.slice(startOfPage, endOfPage);
     const startTime = Date.now();
-    await centralServer.push(
-      sessionId,
-      page,
-      endOfPage,
-      changes.length,
-      Object.values(outgoingModels).map(m => m.getTableNameForSync()),
-    );
+    await centralServer.push(sessionId, page);
     const endTime = Date.now();
 
     startOfPage = endOfPage;
@@ -43,4 +33,5 @@ export const pushOutgoingChanges = async (
 
     progressCallback(changes.length, pushedRecordsCount);
   }
+  await centralServer.completeSyncSession(sessionId);
 };

--- a/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
@@ -1,4 +1,5 @@
 import { SyncRecord } from '../types';
+import { MODELS_MAP } from '../../../models/modelsMap';
 
 import { CentralServerConnection } from '../CentralServerConnection';
 import { calculatePageLimit } from './calculatePageLimit';
@@ -12,6 +13,7 @@ import { calculatePageLimit } from './calculatePageLimit';
  */
 export const pushOutgoingChanges = async (
   centralServer: CentralServerConnection,
+  outgoingModels: typeof MODELS_MAP,
   sessionId: string,
   changes: SyncRecord[],
   progressCallback: (total: number, progressCount: number) => void,
@@ -33,5 +35,8 @@ export const pushOutgoingChanges = async (
 
     progressCallback(changes.length, pushedRecordsCount);
   }
-  await centralServer.completePush(sessionId);
+  await centralServer.completePush(
+    sessionId,
+    Object.values(outgoingModels).map(m => m.getTableNameForSync()),
+  );
 };

--- a/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
@@ -30,7 +30,7 @@ export const snapshotOutgoingChanges = async (
   outgoingModels: typeof MODELS_MAP,
   since: number,
 ): Promise<SyncRecord[]> => {
-  const outgoingChanges = [];
+  let outgoingChanges = [];
 
   // snapshot inside a transaction (Serializable is the default isolation level),
   // so that other changes made while this snapshot
@@ -46,7 +46,8 @@ export const snapshotOutgoingChanges = async (
       const sanitizedSyncRecords = model.sanitizeRecordDataForPush
         ? model.sanitizeRecordDataForPush(syncRecordsForModel)
         : syncRecordsForModel;
-      outgoingChanges.push(...sanitizedSyncRecords);
+
+      outgoingChanges = outgoingChanges.concat(sanitizedSyncRecords);
     }
 
     return outgoingChanges;

--- a/packages/shared-src/src/migrations/1675214968409-addPushTimestampsToSyncSession.js
+++ b/packages/shared-src/src/migrations/1675214968409-addPushTimestampsToSyncSession.js
@@ -1,0 +1,12 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('sync_sessions', 'persist_completed_at', {
+    type: DataTypes.DATE,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('sync_sessions', 'persist_completed_at');
+}

--- a/packages/shared-src/src/models/SyncSession.js
+++ b/packages/shared-src/src/models/SyncSession.js
@@ -10,6 +10,7 @@ export class SyncSession extends Model {
         startTime: { type: DataTypes.DATE },
         lastConnectionTime: { type: DataTypes.DATE },
         snapshotCompletedAt: { type: DataTypes.DATE },
+        persistCompletedAt: { type: DataTypes.DATE },
         completedAt: { type: DataTypes.DATE },
         error: { type: DataTypes.TEXT },
         debugInfo: { type: DataTypes.JSON },

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -290,8 +290,41 @@ class CentralSyncManager {
     );
   }
 
-  async addIncomingChanges(sessionId, changes, { pushedSoFar, totalToPush }, tablesToInclude) {
-    const { models, sequelize } = this.store;
+  async persistIncomingChanges(sessionId) {
+    const { sequelize, models } = this.store;
+    await models.SyncSession.addDebugInfo(sessionId, { beganPersistAt: new Date() });
+
+    const modelsToInclude = getModelsForDirection(models, SYNC_DIRECTIONS.PUSH_TO_CENTRAL);
+
+    // commit the changes to the db
+    await sequelize.transaction(async () => {
+      // we tick-tock the global clock to make sure there is a unique tick for these changes, and
+      // to acquire a lock on the sync time row in the local system facts table, so that no sync
+      // pull snapshot can start while this save is still in progress
+      // the pull snapshot starts by updating the current time, so this locks that out while the
+      // save transaction happens, to avoid the snapshot missing records that get during this save
+      // but aren't visible in the db to be snapshot until the transaction commits, so would
+      // otherwise be completely skipped over by that sync client
+      const { tock } = await this.tickTockGlobalClock();
+      await saveIncomingChanges(sequelize, modelsToInclude, sessionId, true);
+      // store the sync tick on save with the incoming changes, so they can be compared for
+      // edits with the outgoing changes
+      await updateSnapshotRecords(
+        sequelize,
+        sessionId,
+        { savedAtSyncTick: tock },
+        { direction: SYNC_SESSION_DIRECTION.INCOMING },
+      );
+    });
+    // mark persisted so that client polling "completePush" can stop
+    await models.SyncSession.update(
+      { persistCompletedAt: new Date() },
+      { where: { id: sessionId } },
+    );
+  }
+
+  async addIncomingChanges(sessionId, changes) {
+    const { sequelize } = this.store;
     await this.connectToSession(sessionId);
     const incomingSnapshotRecords = changes.map(c => ({
       ...c,
@@ -305,35 +338,22 @@ class CentralSyncManager {
       `CentralSyncManager.addIncomingChanges: Adding ${incomingSnapshotRecords.length} changes for ${sessionId}`,
     );
     await insertSnapshotRecords(sequelize, sessionId, incomingSnapshotRecords);
+  }
 
-    if (pushedSoFar === totalToPush) {
-      const modelsToInclude = tablesToInclude
-        ? filterModelsFromName(models, tablesToInclude)
-        : getModelsForDirection(models, SYNC_DIRECTIONS.PUSH_TO_CENTRAL);
+  async completePush(sessionId) {
+    await this.connectToSession(sessionId);
 
-      // commit the changes to the db
-      await sequelize.transaction(async () => {
-        // we tick-tock the global clock to make sure there is a unique tick for these changes, and
-        // to acquire a lock on the sync time row in the local system facts table, so that no sync
-        // pull snapshot can start while this save is still in progress
-        // the pull snapshot starts by updating the current time, so this locks that out while the
-        // save transaction happens, to avoid the snapshot missing records that get during this save
-        // but aren't visible in the db to be snapshot until the transaction commits, so would
-        // otherwise be completely skipped over by that sync client
-        const { tock } = await this.tickTockGlobalClock();
-        await saveIncomingChanges(sequelize, modelsToInclude, sessionId, true);
-        // store the sync tick on save with the incoming changes, so they can be compared for
-        // edits with the outgoing changes
-        await updateSnapshotRecords(
-          sequelize,
-          sessionId,
-          { savedAtSyncTick: tock },
-          { direction: SYNC_SESSION_DIRECTION.INCOMING },
-        );
-      });
-      await models.SyncSession.addDebugInfo(sessionId, {
-        pushCompletedAt: await models.LocalSystemFact.get(CURRENT_SYNC_TIME_KEY),
-      });
+    // don't await persisting, the client should asynchronously poll as it may take longer than
+    // the http request timeout
+    this.persistIncomingChanges(sessionId);
+  }
+
+  async checkPushComplete(sessionId) {
+    const session = await this.connectToSession(sessionId);
+    // respond with whether the push is properly complete, i.e. has been persisted to the db tables
+    if (!session.persistCompletedAt) {
+      return false;
     }
+    return true;
   }
 }

--- a/packages/sync-server/app/sync/buildSyncRoutes.js
+++ b/packages/sync-server/app/sync/buildSyncRoutes.js
@@ -88,9 +88,10 @@ export const buildSyncRoutes = ctx => {
   syncRoutes.post(
     '/:sessionId/push/complete',
     asyncHandler(async (req, res) => {
-      const { params } = req;
+      const { params, body } = req;
       const { sessionId } = params;
-      await syncManager.completePush(sessionId);
+      const { tablesToInclude } = body;
+      await syncManager.completePush(sessionId, tablesToInclude);
       res.json({});
     }),
   );


### PR DESCRIPTION
### Changes

Rather than the central server trying to be too clever a smooth with handling the last batch of sync records, this changes the client to be in charge of telling it the push is complete, and then polling until it has finished persisting to the db. The poll is the important bit, as it allows it to asynchronously persist, meaning that if it takes longer than the HTTP timeout, the brown stuff doesn't hit the fan.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] ~UI Screenshots added to the Linear issue~
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
