### PR TITLE
WAITM-523 Don't use routed modals in encounter actions

### DIFF
--- a/packages/desktop/app/components/ChangeEncounterTypeModal.js
+++ b/packages/desktop/app/components/ChangeEncounterTypeModal.js
@@ -5,7 +5,7 @@ import { useEncounter } from '../contexts/Encounter';
 import { Modal } from './Modal';
 import { ChangeEncounterTypeForm } from '../forms/ChangeEncounterTypeForm';
 
-export const ChangeEncounterTypeModal = React.memo(({ open, encounter, onClose }) => {
+export const ChangeEncounterTypeModal = React.memo(({ open, encounter, onClose, newType }) => {
   const { writeAndViewEncounter } = useEncounter();
   const { navigateToEncounter } = usePatientNavigation();
   const changeEncounterType = useCallback(
@@ -26,6 +26,7 @@ export const ChangeEncounterTypeModal = React.memo(({ open, encounter, onClose }
         onSubmit={changeEncounterType}
         onCancel={onClose}
         encounter={encounter}
+        initialNewType={newType}
       />
     </Modal>
   );

--- a/packages/desktop/app/components/Modal.js
+++ b/packages/desktop/app/components/Modal.js
@@ -1,8 +1,5 @@
 import React, { memo } from 'react';
 
-import { connect } from 'react-redux';
-import { push } from 'connected-react-router';
-
 import styled from 'styled-components';
 import MuiDialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -10,7 +7,6 @@ import DialogActions from '@material-ui/core/DialogActions';
 import PrintIcon from '@material-ui/icons/Print';
 import CloseIcon from '@material-ui/icons/Close';
 import { Box, CircularProgress, IconButton, Typography } from '@material-ui/core';
-import { getCurrentRoute } from '../store/router';
 import { Colors } from '../constants';
 import { useElectron } from '../contexts/Electron';
 import { Button } from './Button';

--- a/packages/desktop/app/components/Modal.js
+++ b/packages/desktop/app/components/Modal.js
@@ -177,13 +177,3 @@ export const ModalLoader = ({ loadingText }) => (
     {loadingText && <Typography>{loadingText}</Typography>}
   </Loader>
 );
-
-export const connectRoutedModal = (baseRoute, suffix) =>
-  connect(
-    state => ({
-      open: getCurrentRoute(state).startsWith(`${baseRoute}/${suffix}`),
-    }),
-    dispatch => ({
-      onClose: () => dispatch(push(baseRoute)),
-    }),
-  );

--- a/packages/desktop/app/forms/ChangeEncounterTypeForm.js
+++ b/packages/desktop/app/forms/ChangeEncounterTypeForm.js
@@ -5,15 +5,13 @@ import { Form } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { ConfirmCancelRow } from '../components/ButtonRow';
 
-import { useUrlSearchParams } from '../utils/useUrlSearchParams';
 import { ENCOUNTER_OPTIONS_BY_VALUE } from '../constants';
 
-export const ChangeEncounterTypeForm = ({ onSubmit, onCancel, encounter }) => {
-  const query = useUrlSearchParams();
+export const ChangeEncounterTypeForm = ({ onSubmit, onCancel, encounter, initialNewType }) => {
   return (
     <Form
       initialValues={{
-        encounterType: query.get('type'),
+        encounterType: initialNewType,
         // Used in creation of associated notes
         submittedTime: getCurrentDateTimeString(),
       }}

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -1,5 +1,4 @@
-import React, { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
 import { ENCOUNTER_TYPES } from 'shared/constants';
 import { useLocalisation } from '../../../contexts/Localisation';
 import { DischargeModal } from '../../../components/DischargeModal';
@@ -10,22 +9,40 @@ import { BeginPatientMoveModal } from './BeginPatientMoveModal';
 import { FinalisePatientMoveModal } from './FinalisePatientMoveModal';
 import { CancelPatientMoveModal } from './CancelPatientMoveModal';
 import { usePatientNavigation } from '../../../utils/usePatientNavigation';
-import { Button, connectRoutedModal } from '../../../components';
+import { Button } from '../../../components';
 import { DropdownButton } from '../../../components/DropdownButton';
 import { MoveModal } from './MoveModal';
 
-const EncounterActionDropdown = ({ encounter }) => {
-  const { navigateToEncounter, navigateToSummary } = usePatientNavigation();
+const ENCOUNTER_MODALS = {
+  NONE: 'none',
+
+  CHANGE_CLINICIAN: 'changeClinician',
+  CHANGE_DEPARTMENT: 'changeDepartment',
+  CHANGE_LOCATION: 'changeLocation',
+  CHANGE_TYPE: 'changeType',
+
+  DISCHARGE: 'discharge',
+
+  BEGIN_MOVE: 'beginMove',
+  FINALISE_MOVE: 'finaliseMove',
+  CANCEL_MOVE: 'cancelMove',
+};
+
+const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType }) => {
+  const { navigateToSummary } = usePatientNavigation();
   const { getLocalisation } = useLocalisation();
 
-  const onChangeEncounterType = type => navigateToEncounter(encounter.id, `changeType`, { type });
-  const onDischargeOpen = () => navigateToEncounter(encounter.id, 'discharge');
-  const onChangeDepartment = () => navigateToEncounter(encounter.id, 'changeDepartment');
-  const onChangeClinician = () => navigateToEncounter(encounter.id, 'changeClinician');
-  const onPlanLocationChange = () => navigateToEncounter(encounter.id, 'beginMove');
-  const onFinaliseLocationChange = () => navigateToEncounter(encounter.id, 'finaliseMove');
-  const onCancelLocationChange = () => navigateToEncounter(encounter.id, 'cancelMove');
-  const onChangeLocation = () => navigateToEncounter(encounter.id, 'move');
+  const onChangeEncounterType = type => {
+    setNewEncounterType(type);
+    setOpenModal(ENCOUNTER_MODALS.CHANGE_TYPE);
+  };
+  const onDischargeOpen = () => setOpenModal(ENCOUNTER_MODALS.DISCHARGE);
+  const onChangeDepartment = () => setOpenModal(ENCOUNTER_MODALS.CHANGE_DEPARTMENT);
+  const onChangeClinician = () => setOpenModal(ENCOUNTER_MODALS.CHANGE_CLINICIAN);
+  const onPlanLocationChange = () => setOpenModal(ENCOUNTER_MODALS.BEGIN_MOVE);
+  const onFinaliseLocationChange = () => setOpenModal(ENCOUNTER_MODALS.FINALISE_MOVE);
+  const onCancelLocationChange = () => setOpenModal(ENCOUNTER_MODALS.CANCEL_MOVE);
+  const onChangeLocation = () => setOpenModal(ENCOUNTER_MODALS.CHANGE_LOCATION);
   const onViewSummary = () => navigateToSummary();
 
   if (encounter.endDate) {
@@ -106,56 +123,57 @@ const EncounterActionDropdown = ({ encounter }) => {
   return <DropdownButton actions={actions} />;
 };
 
-const getConnectRoutedModal = ({ category, patientId, encounterId }, suffix) =>
-  connectRoutedModal(`/patients/${category}/${patientId}/encounter/${encounterId}`, suffix);
-
 export const EncounterActions = React.memo(({ encounter }) => {
-  const params = useParams();
-
-  const RoutedDischargeModal = useMemo(() => getConnectRoutedModal(params, 'discharge'), [params])(
-    DischargeModal,
-  );
-
-  const RoutedChangeEncounterTypeModal = useMemo(
-    () => getConnectRoutedModal(params, 'changeType'),
-    [params],
-  )(ChangeEncounterTypeModal);
-
-  const RoutedChangeDepartmentModal = useMemo(
-    () => getConnectRoutedModal(params, 'changeDepartment'),
-    [params],
-  )(ChangeDepartmentModal);
-
-  const RoutedChangeClinicianModal = useMemo(
-    () => getConnectRoutedModal(params, 'changeClinician'),
-    [params],
-  )(ChangeClinicianModal);
-
-  const RoutedCancelMoveModal = useMemo(() => getConnectRoutedModal(params, 'cancelMove'), [
-    params,
-  ])(CancelPatientMoveModal);
-
-  const RoutedBeginMoveModal = useMemo(() => getConnectRoutedModal(params, 'beginMove'), [params])(
-    BeginPatientMoveModal,
-  );
-
-  const RoutedFinaliseMoveModal = useMemo(() => getConnectRoutedModal(params, 'finaliseMove'), [
-    params,
-  ])(FinalisePatientMoveModal);
-
-  const RoutedMoveModal = useMemo(() => getConnectRoutedModal(params, 'move'), [params])(MoveModal);
+  const [openModal, setOpenModal] = useState(ENCOUNTER_MODALS.NONE);
+  const [newEncounterType, setNewEncounterType] = useState();
+  const onClose = () => setOpenModal(ENCOUNTER_MODALS.NONE);
 
   return (
     <>
-      <EncounterActionDropdown encounter={encounter} />
-      <RoutedDischargeModal encounter={encounter} />
-      <RoutedChangeEncounterTypeModal encounter={encounter} />
-      <RoutedChangeDepartmentModal />
-      <RoutedChangeClinicianModal />
-      <RoutedMoveModal encounter={encounter} />
-      <RoutedBeginMoveModal encounter={encounter} />
-      <RoutedFinaliseMoveModal encounter={encounter} />
-      <RoutedCancelMoveModal encounter={encounter} />
+      <EncounterActionDropdown
+        encounter={encounter}
+        setOpenModal={setOpenModal}
+        setNewEncounterType={setNewEncounterType}
+      />
+      <DischargeModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.DISCHARGE}
+        onClose={onClose}
+      />
+      <ChangeEncounterTypeModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.CHANGE_TYPE}
+        onClose={onClose}
+        newType={newEncounterType}
+      />
+      <ChangeDepartmentModal
+        open={openModal === ENCOUNTER_MODALS.CHANGE_DEPARTMENT}
+        onClose={onClose}
+      />
+      <ChangeClinicianModal
+        open={openModal === ENCOUNTER_MODALS.CHANGE_CLINICIAN}
+        onClose={onClose}
+      />
+      <MoveModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.CHANGE_LOCATION}
+        onClose={onClose}
+      />
+      <BeginPatientMoveModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.BEGIN_MOVE}
+        onClose={onClose}
+      />
+      <FinalisePatientMoveModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.FINALISE_MOVE}
+        onClose={onClose}
+      />
+      <CancelPatientMoveModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.CANCEL_MOVE}
+        onClose={onClose}
+      />
     </>
   );
 });


### PR DESCRIPTION
### Changes

- Remove routed modal functionality from EncounterActions
- Allow passing in initial value for ChangeEncounterType modal/form

### Checklist

- [X] Code is finished
- [X] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
