### PR TITLE
WAITM-399 Prevent lab tests re-ordering on data submit

### DIFF
--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -84,6 +84,7 @@ const ResultsPane = React.memo(({ labRequest, patient }) => {
         columns={sexAppropriateColumns}
         endpoint={`labRequest/${labRequest.id}/tests`}
         onRowClick={openModal}
+        initialSort={{ order: 'asc', orderBy: 'id' }}
       />
     </>
   );


### PR DESCRIPTION
### Changes

- Apply default ordering to lab test table in lab request view

### Checklist

- [X] Code is finished
- [X] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
