### PR TITLE
TAN-2033 Hide discharge disposition when set to hidden

### DIFF
--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -17,6 +17,7 @@ import { useElectron } from '../../contexts/Electron';
 import { Colors } from '../../constants';
 import { useCertificate } from '../../utils/useCertificate';
 import { getFullLocationName } from '../../utils/location';
+import { useLocalisation } from '../../contexts/Localisation';
 
 const Container = styled.div`
   background: ${Colors.white};
@@ -120,6 +121,9 @@ const MedicationsList = ({ medications }) => {
 const SummaryPage = React.memo(({ encounter, discharge }) => {
   const { title, subTitle, logo } = useCertificate();
 
+  const { getLocalisation } = useLocalisation();
+  const dischargeDispositionVisible = !getLocalisation('fields.dischargeDisposition.hidden');
+
   const patient = useSelector(state => state.patient);
 
   const {
@@ -169,7 +173,7 @@ const SummaryPage = React.memo(({ encounter, discharge }) => {
           <Label>Department: </Label>
           {getFullLocationName(location)}
         </div>
-        {discharge && (
+        {discharge && dischargeDispositionVisible && (
           <div>
             <Label>Discharge disposition: </Label>
             {discharge.disposition?.name}

--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -122,10 +122,10 @@ const SummaryPage = React.memo(({ encounter, discharge }) => {
   const { title, subTitle, logo } = useCertificate();
 
   const { getLocalisation } = useLocalisation();
-  const dischargeDispositionVisible = !getLocalisation('fields.dischargeDisposition.hidden');
+  const dischargeDispositionVisible =
+    getLocalisation('fields.dischargeDisposition.hidden') === false;
 
   const patient = useSelector(state => state.patient);
-
   const {
     diagnoses,
     procedures,


### PR DESCRIPTION
### Changes

Hide discharge disposition from summary when field is set to hidden.
https://linear.app/bes/issue/TAN-2033/hide-discharge-disposition-from-discharge-summary-when-this-field-is
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-2033: Hide discharge disposition when set to hidden`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
