### PR TITLE
WAITM-566: Fix desktop validation

### DIFF
--- a/packages/desktop/app/components/Field/Form.js
+++ b/packages/desktop/app/components/Field/Form.js
@@ -130,7 +130,14 @@ export class Form extends React.PureComponent {
   };
 
   render() {
-    const { onSubmit, showInlineErrorsOnly, showErrorDialog = true, ...props } = this.props;
+    const {
+      onSubmit,
+      showInlineErrorsOnly,
+      showErrorDialog = true,
+      validateOnChange,
+      validateOnBlur,
+      ...props
+    } = this.props;
     const { validationErrors, isErrorDialogVisible } = this.state;
 
     // read children from additional props rather than destructuring so
@@ -143,8 +150,8 @@ export class Form extends React.PureComponent {
       <>
         <Formik
           onSubmit={onSubmit}
-          validateOnChange={false}
-          validateOnBlur={false}
+          validateOnChange={validateOnChange}
+          validateOnBlur={validateOnBlur}
           initialStatus={{
             page: 1,
           }}
@@ -172,6 +179,8 @@ Form.propTypes = {
   render: PropTypes.func.isRequired,
   showInlineErrorsOnly: PropTypes.bool,
   initialValues: PropTypes.shape({}),
+  validateOnChange: PropTypes.bool,
+  validateOnBlur: PropTypes.bool,
 };
 
 Form.defaultProps = {
@@ -179,4 +188,6 @@ Form.defaultProps = {
   onError: null,
   onSuccess: null,
   initialValues: {},
+  validateOnChange: false,
+  validateOnBlur: false,
 };

--- a/packages/desktop/app/components/Surveys/SurveyQuestion.js
+++ b/packages/desktop/app/components/Surveys/SurveyQuestion.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { getComponentForQuestionType, getConfigObject, mapOptionsToValues } from '../../utils';
 import { Field } from '../Field';
@@ -7,7 +7,7 @@ const Text = styled.div`
   margin-bottom: 10px;
 `;
 
-export const SurveyQuestion = ({ component, patient, errors }) => {
+export const SurveyQuestion = ({ component, patient, inputRef }) => {
   const {
     dataElement,
     detail,
@@ -16,7 +16,6 @@ export const SurveyQuestion = ({ component, patient, errors }) => {
     text: componentText,
     validationCriteria,
   } = component;
-  const [questionRef, setQuestionRef] = useState(null);
   const { defaultText, type, defaultOptions, id } = dataElement;
   const configObject = getConfigObject(id, componentConfig);
   const text = componentText || defaultText;
@@ -26,26 +25,11 @@ export const SurveyQuestion = ({ component, patient, errors }) => {
   const validationCriteriaObject = getConfigObject(id, validationCriteria);
   const required = validationCriteriaObject?.mandatory || null;
 
-  useEffect(() => {
-    if (!errors || Object.keys(errors).length === 0) {
-      return;
-    }
-
-    const firstErrorKey = Object.keys(errors)[0];
-    if (firstErrorKey === id && questionRef !== null) {
-      questionRef.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }, [id, errors, questionRef]);
-
   if (!FieldComponent) return <Text>{text}</Text>;
 
   return (
     <Field
-      inputRef={node => {
-        if (node !== null) {
-          setQuestionRef(node);
-        }
-      }}
+      inputRef={inputRef}
       label={text}
       component={FieldComponent}
       patient={patient}

--- a/packages/desktop/app/views/programs/SurveyView.js
+++ b/packages/desktop/app/views/programs/SurveyView.js
@@ -74,6 +74,8 @@ export const SurveyView = ({ survey, onSubmit, onCancel, patient, currentUser })
       onSubmit={onSubmitSurvey}
       render={renderSurvey}
       validationSchema={validationSchema}
+      validateOnChange
+      validateOnBlur
     />
   );
 


### PR DESCRIPTION
### Changes
- Set validation on blur and on change for the survey forms
- Move scrolling to the screen level and make it imperative based on clicking next button

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
