### PR TITLE
Hotfix: Add indexes to some fields that could benefit from them

### DIFF
--- a/packages/shared-src/src/migrations/1675378800220-addEncounterIndexes.js
+++ b/packages/shared-src/src/migrations/1675378800220-addEncounterIndexes.js
@@ -44,8 +44,8 @@ export async function down(query) {
   await query.removeIndex('note_pages', 'note_pages_date');
   await query.removeIndex('note_items', 'note_items_note_page_id');
 
-  await query.removeIndex('survey_response_answers', 'survey_response_answers_response_id');
   await query.removeIndex('survey_responses', 'survey_responses_survey_id');
+  await query.removeIndex('survey_response_answers', 'survey_response_answers_response_id');
 
   await query.removeIndex('lab_tests', 'lab_tests_lab_request_id');
 }

--- a/packages/shared-src/src/migrations/1675378800220-addEncounterIndexes.js
+++ b/packages/shared-src/src/migrations/1675378800220-addEncounterIndexes.js
@@ -18,12 +18,19 @@ export async function up(query) {
   await query.addIndex('note_pages', {
     fields: ['date'],
   });
+  await query.addIndex('note_items', {
+    fields: ['note_page_id'],
+  });
 
   await query.addIndex('survey_responses', {
     fields: ['survey_id'],
   });
   await query.addIndex('survey_response_answers', {
     fields: ['response_id'],
+  });
+
+  await query.addIndex('lab_tests', {
+    fields: ['lab_request_id'],
   });
 }
 
@@ -35,7 +42,10 @@ export async function down(query) {
 
   await query.removeIndex('note_pages', 'note_pages_record_id');
   await query.removeIndex('note_pages', 'note_pages_date');
+  await query.removeIndex('note_items', 'note_items_note_page_id');
 
   await query.removeIndex('survey_response_answers', 'survey_response_answers_response_id');
   await query.removeIndex('survey_responses', 'survey_responses_survey_id');
+
+  await query.removeIndex('lab_tests', 'lab_tests_lab_request_id');
 }

--- a/packages/shared-src/src/migrations/1675378800220-addEncounterIndexes.js
+++ b/packages/shared-src/src/migrations/1675378800220-addEncounterIndexes.js
@@ -1,0 +1,41 @@
+export async function up(query) {
+  await query.addIndex('encounters', {
+    fields: ['start_date'],
+  });
+  await query.addIndex('encounters', {
+    fields: ['end_date'],
+  });
+  await query.addIndex('encounters', {
+    fields: ['encounter_type'],
+  });
+  await query.addIndex('encounters', {
+    fields: ['location_id'],
+  });
+
+  await query.addIndex('note_pages', {
+    fields: ['record_id'],
+  });
+  await query.addIndex('note_pages', {
+    fields: ['date'],
+  });
+
+  await query.addIndex('survey_responses', {
+    fields: ['survey_id'],
+  });
+  await query.addIndex('survey_response_answers', {
+    fields: ['response_id'],
+  });
+}
+
+export async function down(query) {
+  await query.removeIndex('encounters', 'encounters_start_date');
+  await query.removeIndex('encounters', 'encounters_end_date');
+  await query.removeIndex('encounters', 'encounters_encounter_type');
+  await query.removeIndex('encounters', 'encounters_location_id');
+
+  await query.removeIndex('note_pages', 'note_pages_record_id');
+  await query.removeIndex('note_pages', 'note_pages_date');
+
+  await query.removeIndex('survey_response_answers', 'survey_response_answers_response_id');
+  await query.removeIndex('survey_responses', 'survey_responses_survey_id');
+}


### PR DESCRIPTION
### Changes

Just did a pass over the schema looking for commonly-filtered/sorted columns on tables that tend to have a lot of records, and added those. The main one is endDate on encounter, which is constantly filtered by null/non-null, but I also found a fair few regularly-traversed foreign key relations that hadn't had an index added automatically for some reason.

- Encounter
  - startDate
  - endDate
  - encounterType
  - locationId
- NotePage
  - date
  - recordId
- NoteItem
  - notePageId
- SurveyResponse
  - surveyId (much more important now that Vitals is a survey)
- SurveyResponseAnswers
  - responseId
- LabTest
  - labRequestId

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
