### PR TITLE
Remove @injectConfig decorator and decorators from babel

### DIFF
--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -1,3 +1,4 @@
+import _config from 'config';
 import { log } from 'shared/services/logging';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { CURRENT_SYNC_TIME_KEY } from 'shared/sync/constants';
@@ -8,15 +9,14 @@ import {
   getModelsForDirection,
   saveIncomingChanges,
 } from 'shared/sync';
-import { injectConfig } from 'shared/utils/withConfig';
 
 import { pushOutgoingChanges } from './pushOutgoingChanges';
 import { pullIncomingChanges } from './pullIncomingChanges';
 import { snapshotOutgoingChanges } from './snapshotOutgoingChanges';
 
-export
-@injectConfig
-class FacilitySyncManager {
+export class FacilitySyncManager {
+  config = _config;
+
   models = null;
 
   sequelize = null;
@@ -29,6 +29,14 @@ class FacilitySyncManager {
     this.models = models;
     this.sequelize = sequelize;
     this.centralServer = centralServer;
+  }
+
+  static overrideConfig(override) {
+    this.config = override;
+  }
+
+  static restoreConfig() {
+    this.config = _config.default;
   }
 
   async triggerSync() {

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -15,7 +15,15 @@ import { pullIncomingChanges } from './pullIncomingChanges';
 import { snapshotOutgoingChanges } from './snapshotOutgoingChanges';
 
 export class FacilitySyncManager {
-  config = _config;
+  static config = _config;
+
+  static overrideConfig(override) {
+    this.config = override;
+  }
+
+  static restoreConfig() {
+    this.config = _config;
+  }
 
   models = null;
 
@@ -29,14 +37,6 @@ export class FacilitySyncManager {
     this.models = models;
     this.sequelize = sequelize;
     this.centralServer = centralServer;
-  }
-
-  static overrideConfig(override) {
-    this.config = override;
-  }
-
-  static restoreConfig() {
-    this.config = _config.default;
   }
 
   async triggerSync() {

--- a/packages/lan/babel.config.js
+++ b/packages/lan/babel.config.js
@@ -14,9 +14,7 @@ module.exports = api => {
       ],
     ],
     plugins: [
-      ['@babel/plugin-proposal-decorators', { version: '2022-03' }],
       '@babel/plugin-proposal-class-properties',
-      '@babel/plugin-proposal-class-static-block', // for decorators
       '@babel/plugin-proposal-export-default-from',
       '@babel/plugin-proposal-logical-assignment-operators',
     ],

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -24,8 +24,6 @@
   "devDependencies": {
     "@babel/core": "^7.19.6",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-class-static-block": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.0",
     "@babel/plugin-proposal-export-default-from": "^7.18.10",
     "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
     "@babel/preset-env": "^7.19.4",

--- a/packages/shared-src/src/utils/withConfig.js
+++ b/packages/shared-src/src/utils/withConfig.js
@@ -9,22 +9,3 @@ export function withConfig(fn) {
   inner.overrideConfig = fn;
   return inner;
 }
-
-/** Injects a .config static property into the class, use as a decorator */
-export function injectConfig(value, { kind }) {
-  if (kind !== 'class') {
-    throw new Error('injectConfig can only be used on classes');
-  }
-
-  return class extends value {
-    static config = config;
-
-    static overrideConfig(override) {
-      this.config = override;
-    }
-
-    static restoreConfig() {
-      this.config = config;
-    }
-  };
-}

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -31,7 +31,15 @@ const errorMessageFromSession = session =>
 // changes in the database when a sync fails on the facility server end
 
 export class CentralSyncManager {
-  config = _config;
+  static config = _config;
+
+  static overrideConfig(override) {
+    this.config = override;
+  }
+
+  static restoreConfig() {
+    this.config = _config;
+  }
 
   currentSyncTick;
 
@@ -46,14 +54,6 @@ export class CentralSyncManager {
       this.constructor.config.sync.lapsedSessionCheckFrequencySeconds * 1000,
     );
     ctx.onClose(this.close);
-  }
-
-  static overrideConfig(override) {
-    this.config = override;
-  }
-
-  static restoreConfig() {
-    this.config = _config.default;
   }
 
   close = () => clearInterval(this.purgeInterval);

--- a/packages/sync-server/babel.config.js
+++ b/packages/sync-server/babel.config.js
@@ -16,9 +16,7 @@ module.exports = api => {
       '@babel/preset-react',
     ],
     plugins: [
-      ['@babel/plugin-proposal-decorators', { version: '2022-03' }],
       '@babel/plugin-proposal-class-properties',
-      '@babel/plugin-proposal-class-static-block', // for decorators
       '@babel/plugin-proposal-export-default-from',
       '@babel/plugin-proposal-logical-assignment-operators',
     ],

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -34,8 +34,6 @@
   "devDependencies": {
     "@babel/core": "^7.19.6",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-class-static-block": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.0",
     "@babel/plugin-proposal-export-default-from": "^7.18.10",
     "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
     "@babel/preset-env": "^7.19.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,7 +1975,7 @@
     "@babel/helper-replace-supers" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.19.0":
+"@babel/helper-create-class-features-plugin@^7.18.6":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz#bfd6904620df4e46470bae4850d66be1054c404b"
   integrity sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==
@@ -2375,7 +2375,7 @@
     "@babel/traverse" "^7.18.2"
     "@babel/types" "^7.18.2"
 
-"@babel/helper-replace-supers@^7.18.6", "@babel/helper-replace-supers@^7.18.9", "@babel/helper-replace-supers@^7.19.1":
+"@babel/helper-replace-supers@^7.18.6", "@babel/helper-replace-supers@^7.18.9":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz#e1592a9b4b368aa6bdb8784a711e0bcbf0612b78"
   integrity sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==
@@ -2735,17 +2735,6 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
-"@babel/plugin-proposal-decorators@^7.20.0":
-  version "7.20.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.20.0.tgz#3acef1f1206d7a6a1436aa6ccf9ed7b1bd06aff7"
-  integrity sha512-vnuRRS20ygSxclEYikHzVrP9nZDFXaSzvJxGLQNAiBX041TmhS4hOUHWNIpq/q4muENuEP9XPJFXTNFejhemkg==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.19.0"
-    "@babel/helper-plugin-utils" "^7.19.0"
-    "@babel/helper-replace-supers" "^7.19.1"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/plugin-syntax-decorators" "^7.19.0"
-
 "@babel/plugin-proposal-dynamic-import@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz#c19c897eaa46b27634a00fee9fb7d829158704b2"
@@ -3065,13 +3054,6 @@
   integrity sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
-
-"@babel/plugin-syntax-decorators@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.19.0.tgz#5f13d1d8fce96951bea01a10424463c9a5b3a599"
-  integrity sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.19.0"
 
 "@babel/plugin-syntax-dynamic-import@^7.2.0", "@babel/plugin-syntax-dynamic-import@^7.8.0", "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"


### PR DESCRIPTION
### Changes

Decorators cause us grief or spurious errors in some places (swc, vs code, possible storybook...) and don't provide enough value to keep.

### Checklist

- [x] Code is finished