### PR TITLE
Sync: Skip calling the db when deleting nothing

### DIFF
--- a/packages/shared-src/src/sync/saveIncomingChanges.js
+++ b/packages/shared-src/src/sync/saveIncomingChanges.js
@@ -41,8 +41,10 @@ const saveUpdates = async (model, incomingRecords, idToExistingRecord, isCentral
   );
 };
 
-const saveDeletes = async (model, recordIds) =>
-  model.destroy({ where: { id: { [Op.in]: recordIds } } });
+const saveDeletes = async (model, recordIds) => {
+  if (recordIds.length === 0) return;
+  await model.destroy({ where: { id: { [Op.in]: recordIds } } });
+}
 
 const saveChangesForModel = async (model, changes, isCentralServer) => {
   const sanitizeData = d =>

--- a/packages/shared-src/src/sync/saveIncomingChanges.js
+++ b/packages/shared-src/src/sync/saveIncomingChanges.js
@@ -44,7 +44,7 @@ const saveUpdates = async (model, incomingRecords, idToExistingRecord, isCentral
 const saveDeletes = async (model, recordIds) => {
   if (recordIds.length === 0) return;
   await model.destroy({ where: { id: { [Op.in]: recordIds } } });
-}
+};
 
 const saveChangesForModel = async (model, changes, isCentralServer) => {
   const sanitizeData = d =>


### PR DESCRIPTION
### Changes

If there's nothing to delete, we can skip a call to the database; it's very minor but saves a network roundtrip!

### Checklist

- [x] Code is finished