### PR TITLE
EPI-343: Use encounter endDate for Medici report

### DIFF
--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -332,15 +332,15 @@ describe('fijiAspenMediciReport', () => {
     it.each([
       // [ expectedResults, period.start, period.end ]
       [1, '2022-06-09', '2022-10-09'],
-      [0, '2022-06-10', '2022-10-09'],
-      [0, '2022-06-09T00:02:53-02:00', '2022-10-09'],
-      [1, '2022-06-09T00:02:53Z', '2022-10-09'],
-      [0, '2022-06-09T00:02:55Z', '2022-10-09'],
-      [1, '2022-06-09T00:02:55+01:00', '2022-10-09'],
-      [0, '2022-06-09T00:02:53-01:00', '2022-10-09'],
-      // Dates/times inputted without timezone will be server timezone
-      [0, createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 55).replace(' ', 'T'), '2023'],
-      [1, createLocalDateTimeStringFromUTC(2022, 6 - 1, 9, 0, 2, 53).replace(' ', 'T'), '2023'],
+      [0, '2022-06-15', '2022-10-09'],
+      [0, '2022-06-12T00:02:53-02:00', '2022-10-09'],
+      [1, '2022-06-12T00:02:53Z', '2022-10-09'],
+      [0, '2022-06-12T00:02:55Z', '2022-10-09'],
+      [1, '2022-06-12T00:02:55+01:00', '2022-10-09'],
+      [0, '2022-06-12T00:02:53-01:00', '2022-10-09'],
+      // Dates/times input without timezone will be server timezone
+      [0, createLocalDateTimeStringFromUTC(2022, 6 - 1, 12, 0, 2, 55).replace(' ', 'T'), '2023'],
+      [1, createLocalDateTimeStringFromUTC(2022, 6 - 1, 12, 0, 2, 53).replace(' ', 'T'), '2023'],
     ])(
       'Date filtering: Should return %p result(s) between %p and %s',
       async (expectedResults, start, end) => {

--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -407,6 +407,7 @@ describe('fijiAspenMediciReport', () => {
         // Note that seconds is the highest level of precision - so the milliseconds are truncated
         encounterStartDate: '2022-06-09T00:02:54.000Z',
         encounterEndDate: '2022-06-12T00:02:54.000Z',
+        dischargeDate: '2022-06-12T00:02:54.000Z',
         encounterType: 'AR-DRG',
         reasonForEncounter: 'Severe Migrane',
 

--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -125,6 +125,20 @@ const fakeAllData = async models => {
       dateOfBirth: '1952-10-12',
     }),
   );
+  // open encounter
+  await models.Encounter.create(
+    fake(models.Encounter, {
+      patientId: patient.id,
+      startDate: createLocalDateTimeStringFromUTC(2022, 6 - 1, 15, 0, 2, 54, 225),
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      reasonForEncounter: 'Severe Migrane',
+      patientBillingTypeId,
+      locationId: location1Id,
+      departmentId,
+      examinerId,
+    }),
+  );
+  // closed encounter
   const { id: encounterId } = await models.Encounter.create(
     fake(models.Encounter, {
       patientId: patient.id,

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -362,25 +362,14 @@ left join department_info di2 on di2.encounter_id = e.id
 left join discharge_disposition_info ddi on ddi.encounter_id = e.id
 
 WHERE true
-  AND coalesce(billing.id, '-') LIKE coalesce($billing_type, '%%')
-  AND CASE
-    WHEN $from_date IS NOT NULL
-      THEN (e.start_date::timestamp at time zone :timezone_string) >= $from_date::timestamptz
-    ELSE
-      true
+  AND coalesce(billing.id, '-') LIKE coalesce($billing_type, '%%')  
+  AND (e.start_date::timestamp at time zone :timezone_string) >= $from_date::timestamptz
+  AND (e.start_date::timestamp at time zone :timezone_string) <= $to_date::timestamptz
+  AND CASE WHEN ($input_encounter_ids) IS NOT NULL
+    THEN e.id in ($input_encounter_ids)
+  ELSE
+    true
   END
-  AND CASE
-    WHEN $to_date IS NOT NULL
-      THEN (e.start_date::timestamp at time zone :timezone_string) <= $to_date::timestamptz
-    ELSE
-      true
-  END
-  AND CASE
-    WHEN ($input_encounter_ids) IS NOT NULL
-      THEN e.id in ($input_encounter_ids)
-    ELSE
-      true
-    END
 
 ORDER BY e.start_date DESC
 LIMIT $limit OFFSET $offset;

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -363,9 +363,9 @@ left join department_info di2 on di2.encounter_id = e.id
 left join discharge_disposition_info ddi on ddi.encounter_id = e.id
 
 WHERE true
-  AND coalesce(billing.id, '-') LIKE coalesce($billing_type, '%%')  
-  AND (e.start_date::timestamp at time zone $timezone_string) >= $from_date::timestamptz
-  AND (e.start_date::timestamp at time zone $timezone_string) <= $to_date::timestamptz
+  AND coalesce(billing.id, '-') LIKE coalesce($billing_type, '%%')
+  AND (e.end_date::timestamp at time zone $timezone_string) >= $from_date::timestamptz
+  AND (e.end_date::timestamp at time zone $timezone_string) <= $to_date::timestamptz
   AND CASE WHEN coalesce(array_length($input_encounter_ids::varchar[], 1), 0) != 0
     THEN e.id = ANY(SELECT unnest($input_encounter_ids::varchar[]))
   ELSE

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -364,6 +364,7 @@ left join discharge_disposition_info ddi on ddi.encounter_id = e.id
 
 WHERE true
   AND coalesce(billing.id, '-') LIKE coalesce($billing_type, '%%')
+  AND e.end_date IS NOT NULL
   AND (e.end_date::timestamp at time zone $timezone_string) >= $from_date::timestamptz
   AND (e.end_date::timestamp at time zone $timezone_string) <= $to_date::timestamptz
   AND CASE WHEN coalesce(array_length($input_encounter_ids::varchar[], 1), 0) != 0

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -306,6 +306,7 @@ billing.name "patientBillingType",
 e.id "encounterId",
 e.start_date::timestamp at time zone $timezone_string "encounterStartDate",
 e.end_date::timestamp at time zone $timezone_string "encounterEndDate",
+e.end_date::timestamp at time zone $timezone_string "dischargeDate",
 case e.encounter_type
   when 'admission' then 'AR-DRG'
   when 'imaging' then 'AR-DRG'


### PR DESCRIPTION
### Changes

- Do some formatting of the query to make it easier to read
- Use binds instead of replacements so postgres can better plan/optimise the query
- Add `dischargeDate` to the report
- Filter from encounter end date
- Exclude encounters which don't have an end date

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
