### PR TITLE
TAN-2034: fix Last name cut off

### DIFF
--- a/packages/shared-src/src/utils/patientCertificates/PatientDetailsSection.js
+++ b/packages/shared-src/src/utils/patientCertificates/PatientDetailsSection.js
@@ -38,14 +38,18 @@ export const PatientDetailsSection = ({
 
             return (
               <Col key={key}>
-                <P>{`${label}: ${value}`}</P>
+                <P mb={5}>
+                  <P bold>{label}:</P> {value}
+                </P>
               </Col>
             );
           })}
         </Row>
         {uvci && (
           <Row>
-            <P>UVCI: {uvci}</P>
+            <P>
+              <P bold>UVCI:</P> {uvci}
+            </P>
           </Row>
         )}
       </Col>

--- a/packages/shared-src/src/utils/patientCertificates/PatientDetailsSection.js
+++ b/packages/shared-src/src/utils/patientCertificates/PatientDetailsSection.js
@@ -30,7 +30,7 @@ export const PatientDetailsSection = ({
   ];
   return (
     <Row>
-      <Col style={{ width: '80%' }}>
+      <Col style={{ width: '68%' }}>
         <Row>
           {detailsToDisplay.map(({ key, label: defaultLabel, accessor }) => {
             const value = (accessor ? accessor(patient, getLocalisation) : patient[key]) || '';
@@ -49,7 +49,7 @@ export const PatientDetailsSection = ({
           </Row>
         )}
       </Col>
-      <Col style={{ width: '20%' }}>{vdsSrc && <VDSImage src={vdsSrc} />}</Col>
+      <Col style={{ width: '32%' }}>{vdsSrc && <VDSImage src={vdsSrc} />}</Col>
     </Row>
   );
 };

--- a/packages/shared-src/src/utils/patientCertificates/Typography.js
+++ b/packages/shared-src/src/utils/patientCertificates/Typography.js
@@ -34,6 +34,13 @@ const styles = StyleSheet.create({
 export const H1 = props => <Text style={styles.h1} {...props} />;
 export const H2 = props => <Text style={styles.h2} {...props} />;
 export const H3 = props => <Text style={styles.h3} {...props} />;
-export const P = ({ mt = 0, mb, ...props }) => (
-  <Text {...props} style={[styles.p, { marginTop: mt, marginBottom: mb }]} />
+export const P = ({ mt = 0, mb, bold = false, ...props }) => (
+  <Text
+    {...props}
+    style={[
+      styles.p,
+      { marginTop: mt, marginBottom: mb },
+      ...(bold ? [{ fontFamily: 'Helvetica-Bold' }] : []),
+    ]}
+  />
 );


### PR DESCRIPTION
### Changes
Fixed Vaccination Certificate - Last name cut off

_Add a brief description of the changes in this PR to help give the reviewer context._
Fixed this issue.
https://linear.app/bes/issue/TAN-2034/vaccination-certificate-last-name-cut-off

Before Fix:
<img width="790" alt="image" src="https://user-images.githubusercontent.com/17033058/217025904-88806f1a-ccea-4a17-98c5-8242b63c6440.png">

After fix:
Long Name:
<img width="750" alt="image" src="https://user-images.githubusercontent.com/17033058/217027150-8244b3cf-4f2a-422f-b2ea-e1d938bd195a.png">

Smaller name
<img width="751" alt="image" src="https://user-images.githubusercontent.com/17033058/217026731-b50d0d26-9ee2-4fc2-ab6d-eb0e68914e3b.png">

For any reason, I'm not receiving the pdf with the QRCode in my email. I have fixed that but as you guys can see, there is no QR Code attached to it.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
