### PR TITLE
WAITM-566: Fix mandatory field validation

### DIFF
--- a/packages/desktop/app/components/Field/Form.js
+++ b/packages/desktop/app/components/Field/Form.js
@@ -69,6 +69,8 @@ export class Form extends React.PureComponent {
       const formErrors = await validateForm(values);
       if (Object.entries(formErrors).length) {
         this.setErrors(formErrors);
+        // Set submitting false before throwing the error so that the form is reset
+        // for future form submissions
         setSubmitting(false);
         throw new ValidationError('Form was not filled out correctly');
       }
@@ -81,7 +83,6 @@ export class Form extends React.PureComponent {
         ...rest,
         setErrors: this.setErrors,
       });
-      setSubmitting(false);
       if (onSuccess) {
         onSuccess(result);
       }

--- a/packages/desktop/app/components/Field/Form.js
+++ b/packages/desktop/app/components/Field/Form.js
@@ -58,14 +58,20 @@ export class Form extends React.PureComponent {
     }
 
     setSubmitting(true);
+    const values = getValues();
 
     // validation phase
-    const values = getValues();
-    const formErrors = await validateForm(values);
-    if (Object.entries(formErrors).length) {
-      this.setErrors(formErrors);
-      setSubmitting(false);
-      throw new ValidationError('Form was not filled out correctly');
+    const { validateOnChange, validateOnBlur } = this.props;
+
+    // Only validate here if we are not validating on blur or change elsewhere. Formik doesn't
+    // handle double validating. @see https://github.com/jaredpalmer/formik/issues/1209
+    if (!validateOnChange && !validateOnBlur) {
+      const formErrors = await validateForm(values);
+      if (Object.entries(formErrors).length) {
+        this.setErrors(formErrors);
+        setSubmitting(false);
+        throw new ValidationError('Form was not filled out correctly');
+      }
     }
 
     // submission phase
@@ -75,6 +81,7 @@ export class Form extends React.PureComponent {
         ...rest,
         setErrors: this.setErrors,
       });
+      setSubmitting(false);
       if (onSuccess) {
         onSuccess(result);
       }

--- a/packages/desktop/app/forms/VitalsForm.js
+++ b/packages/desktop/app/forms/VitalsForm.js
@@ -60,9 +60,7 @@ export const VitalsForm = React.memo(({ patient, onSubmit, onClose }) => {
       }}
       validate={({ [VITALS_DATA_ELEMENT_IDS.dateRecorded]: date, ...values }) => {
         const errors = {};
-
-        // All readings are either numbers or strings
-        if (!Object.values(values).some(x => ['number', 'string'].includes(typeof x))) {
+        if (Object.values(values).every(x => x === '' || x === null || x === undefined)) {
           errors.form = 'At least one recording must be entered.';
         }
 


### PR DESCRIPTION
### Changes
Fix mandatory field validation. Only validate here if we are not validating on blur or change elsewhere. Formik doesn't handle validating on change and on submit very well. @see https://github.com/jaredpalmer/formik/issues/1209

Also I noticed a regression on vitals while I was testing where the validation for at least one field being filled out had become outdated so I fixed that as well.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
