### PR TITLE
TAN-1969: Department not displaying when viewing document at the encounter level

### DIFF
--- a/packages/shared-src/src/models/DocumentMetadata.js
+++ b/packages/shared-src/src/models/DocumentMetadata.js
@@ -59,6 +59,10 @@ export class DocumentMetadata extends Model {
     });
   }
 
+  static getListReferenceAssociations() {
+    return ['department'];
+  }
+
   static buildSyncFilter(patientIds) {
     if (patientIds.length === 0) {
       return null;


### PR DESCRIPTION
### Changes
Added the relationship with department on document metadata model

Fixed:
The department is not displayed when viewing the document at the encounter level
Before:
<img width="846" alt="image" src="https://user-images.githubusercontent.com/17033058/217104125-2cdb73b5-f9f3-457d-b4b9-9f0207b1d798.png">

After:
<img width="999" alt="image" src="https://user-images.githubusercontent.com/17033058/217104208-f1654223-fa80-4d06-ab36-59e966791174.png">


_Add a brief description of the changes in this PR to help give the reviewer context._

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
