### PR TITLE
EPI-357: Don't fail sync pulls if another sync is persisting

### DIFF
--- a/packages/lan/app/sync/CentralServerConnection.js
+++ b/packages/lan/app/sync/CentralServerConnection.js
@@ -220,10 +220,10 @@ export class CentralServerConnection {
     // first, set the pull filter on the central server, which will kick of a snapshot of changes
     // to pull
     const body = { since, facilityId: config.serverFacilityId };
-    await this.fetch(`sync/${sessionId}/pullFilter`, { method: 'POST', body });
+    await this.fetch(`sync/${sessionId}/pull/initiate`, { method: 'POST', body });
 
     // then, poll the pull ready endpoint until we get a valid response - it takes a while for
-    // setPullFilter to finish populating the snapshot of changes
+    // pull/initiate to finish populating the snapshot of changes
     await this.pollUntilTrue(`sync/${sessionId}/pull/ready`);
 
     // finally, fetch the metadata for the changes we're about to pull

--- a/packages/lan/app/sync/CentralServerConnection.js
+++ b/packages/lan/app/sync/CentralServerConnection.js
@@ -212,14 +212,14 @@ export class CentralServerConnection {
     const { sessionId } = await this.fetch('sync', { method: 'POST' });
 
     // then, poll the sync/:sessionId/ready endpoint until we get a valid response
-    // this is because POST /sync (especially the tickTockGlobalClock action) might get blocked 
+    // this is because POST /sync (especially the tickTockGlobalClock action) might get blocked
     // and take a while if the central server is concurrently persist records from another client
     await this.pollUntilTrue(`sync/${sessionId}/ready`);
 
     // finally, fetch the new tick from starting the session
-    const { startSince } = await this.fetch(`sync/${sessionId}/metadata`);
+    const { startedAtTick } = await this.fetch(`sync/${sessionId}/metadata`);
 
-    return { sessionId, startSince };
+    return { sessionId, startedAtTick };
   }
 
   async endSyncSession(sessionId) {
@@ -232,7 +232,7 @@ export class CentralServerConnection {
     const body = { since, facilityId: config.serverFacilityId };
     await this.fetch(`sync/${sessionId}/pull/initiate`, { method: 'POST', body });
 
-    // then, poll the pull ready endpoint until we get a valid response - it takes a while for
+    // then, poll the pull/ready endpoint until we get a valid response - it takes a while for
     // pull/initiate to finish populating the snapshot of changes
     await this.pollUntilTrue(`sync/${sessionId}/pull/ready`);
 

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -112,7 +112,7 @@ class FacilitySyncManager {
     // pull incoming changes also returns the sync tick that the central server considers this
     // session to have synced up to
     await createSnapshotTable(this.sequelize, sessionId);
-    const { totalToPull, pullUntil } = await pullIncomingChanges(
+    const { totalPulled, pullUntil } = await pullIncomingChanges(
       this.centralServer,
       this.sequelize,
       sessionId,
@@ -120,8 +120,8 @@ class FacilitySyncManager {
     );
 
     await this.sequelize.transaction(async () => {
-      if (totalToPull > 0) {
-        log.debug(`FacilitySyncManager.runSync: Saving a total of ${totalToPull} changes`);
+      if (totalPulled > 0) {
+        log.debug(`FacilitySyncManager.runSync: Saving a total of ${totalPulled} changes`);
         await saveIncomingChanges(
           this.sequelize,
           getModelsForDirection(this.models, SYNC_DIRECTIONS.PULL_FROM_CENTRAL),

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -68,7 +68,7 @@ class FacilitySyncManager {
     log.info(`FacilitySyncManager.runSync: began sync run`);
 
     // the first step of sync is to start a session and retrieve the session id
-    const { sessionId, tick: newSyncClockTime } = await this.centralServer.startSyncSession();
+    const { sessionId, startSince: newSyncClockTime } = await this.centralServer.startSyncSession();
 
     // ~~~ Push phase ~~~ //
 

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -68,7 +68,10 @@ class FacilitySyncManager {
     log.info(`FacilitySyncManager.runSync: began sync run`);
 
     // the first step of sync is to start a session and retrieve the session id
-    const { sessionId, startSince: newSyncClockTime } = await this.centralServer.startSyncSession();
+    const {
+      sessionId,
+      startedAtTick: newSyncClockTime,
+    } = await this.centralServer.startSyncSession();
 
     // ~~~ Push phase ~~~ //
 

--- a/packages/lan/app/sync/pullIncomingChanges.js
+++ b/packages/lan/app/sync/pullIncomingChanges.js
@@ -59,5 +59,5 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
     limit = calculatePageLimit(limit, pullTime);
   }
 
-  return { totalToPull, pullUntil };
+  return { totalPulled: totalToPull, pullUntil };
 };

--- a/packages/lan/app/sync/pullIncomingChanges.js
+++ b/packages/lan/app/sync/pullIncomingChanges.js
@@ -9,10 +9,9 @@ import { calculatePageLimit } from './calculatePageLimit';
 const { persistedCacheBatchSize } = config.sync;
 
 export const pullIncomingChanges = async (centralServer, sequelize, sessionId, since) => {
-  // setting the pull filter also returns the sync tick (or point on the sync timeline) that the
+  // initiating pull also returns the sync tick (or point on the sync timeline) that the
   // central server considers this session will be up to after pulling all changes
-  const { tick } = await centralServer.setPullFilter(sessionId, since);
-  const totalToPull = await centralServer.fetchPullCount(sessionId);
+  const { totalToPull, pullUntil } = await centralServer.initiatePull(sessionId, since);
 
   let fromId;
   let limit = calculatePageLimit();
@@ -60,5 +59,5 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
     limit = calculatePageLimit(limit, pullTime);
   }
 
-  return { count: totalToPull, tick };
+  return { totalToPull, pullUntil };
 };

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -127,9 +127,9 @@ export class CentralServerConnection {
     await this.pollUntilTrue(`sync/${sessionId}/ready`);
 
     // finally, fetch the new tick from starting the session
-    const { startSince } = await this.get(`sync/${sessionId}/metadata`, {});
+    const { startedAtTick } = await this.get(`sync/${sessionId}/metadata`, {});
 
-    return { sessionId, startSince };
+    return { sessionId, startedAtTick };
   }
 
   async endSyncSession(sessionId: string) {
@@ -152,7 +152,7 @@ export class CentralServerConnection {
     };
     await this.post(`sync/${sessionId}/pull/initiate`, {}, body, {});
 
-    // poll the pull count endpoint until we get a valid response - it takes a while for
+    // poll the pull/ready endpoint until we get a valid response - it takes a while for
     // pull/initiate to finish populating the snapshot of changes
     await this.pollUntilTrue(`sync/${sessionId}/pull/ready`);
 

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -140,10 +140,10 @@ export class CentralServerConnection {
       tablesForFullResync,
       isMobile: true,
     };
-    await this.post(`sync/${sessionId}/pullFilter`, {}, body, {});
+    await this.post(`sync/${sessionId}/pull/initiate`, {}, body, {});
 
     // poll the pull count endpoint until we get a valid response - it takes a while for
-    // setPullFilter to finish populating the snapshot of changes
+    // pull/initiate to finish populating the snapshot of changes
     await this.pollUntilTrue(`sync/${sessionId}/pull/count`);
 
     // finally, fetch the count of changes to pull and sync tick the pull runs up until

--- a/packages/mobile/App/services/sync/MobileSyncManager.test.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.test.ts
@@ -76,7 +76,9 @@ describe('MobileSyncManager', () => {
       jest.spyOn(mobileSyncManager, 'syncIncomingChanges').mockImplementationOnce(jest.fn());
       const startSyncSessionSpy = jest
         .spyOn(centralServerConnection, 'startSyncSession')
-        .mockImplementationOnce(jest.fn(async () => mockSessionId));
+        .mockImplementationOnce(
+          jest.fn(async () => ({ sessionId: mockSessionId, startedAtTick: mockSyncTick })),
+        );
       jest.spyOn(centralServerConnection, 'endSyncSession').mockImplementationOnce(jest.fn());
 
       await mobileSyncManager.runSync();
@@ -96,7 +98,9 @@ describe('MobileSyncManager', () => {
         .mockImplementationOnce(jest.fn());
       jest
         .spyOn(centralServerConnection, 'startSyncSession')
-        .mockImplementationOnce(jest.fn(async () => mockSessionId));
+        .mockImplementationOnce(
+          jest.fn(async () => ({ sessionId: mockSessionId, startedAtTick: mockSyncTick })),
+        );
       jest.spyOn(centralServerConnection, 'endSyncSession').mockImplementationOnce(jest.fn());
 
       await mobileSyncManager.runSync();
@@ -113,7 +117,9 @@ describe('MobileSyncManager', () => {
       jest
         .spyOn(centralServerConnection, 'startSyncSession')
         .mockReturnValueOnce(
-          new Promise(resolve => resolve({ sessionId: mockSessionId, tick: mockSyncTick })),
+          new Promise(resolve =>
+            resolve({ sessionId: mockSessionId, startedAtTick: mockSyncTick }),
+          ),
         );
       jest.spyOn(centralServerConnection, 'endSyncSession').mockImplementationOnce(jest.fn());
 
@@ -131,7 +137,9 @@ describe('MobileSyncManager', () => {
       jest
         .spyOn(centralServerConnection, 'startSyncSession')
         .mockReturnValueOnce(
-          new Promise(resolve => resolve({ sessionId: mockSessionId, tick: mockSyncTick })),
+          new Promise(resolve =>
+            resolve({ sessionId: mockSessionId, startedAtTick: mockSyncTick }),
+          ),
         );
       jest.spyOn(centralServerConnection, 'endSyncSession').mockImplementationOnce(jest.fn());
 

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -155,7 +155,7 @@ export class MobileSyncManager {
     await clearPersistedSyncSessionRecords();
 
     // the first step of sync is to start a session and retrieve the session id
-    const { sessionId, tick: newSyncClockTime } = await this.centralServer.startSyncSession();
+    const { sessionId, startSince: newSyncClockTime } = await this.centralServer.startSyncSession();
 
     console.log('MobileSyncManager.runSync(): Sync started');
 
@@ -190,6 +190,10 @@ export class MobileSyncManager {
 
     const modelsToPush = getModelsForDirection(this.models, SYNC_DIRECTIONS.PUSH_TO_CENTRAL);
     const outgoingChanges = await snapshotOutgoingChanges(modelsToPush, pushSince);
+
+    console.log(
+      `MobileSyncManager.syncOutgoingChanges(): Finished snapshot ${outgoingChanges.length} outgoing changes`,
+    );
 
     if (outgoingChanges.length > 0) {
       await pushOutgoingChanges(

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -155,7 +155,10 @@ export class MobileSyncManager {
     await clearPersistedSyncSessionRecords();
 
     // the first step of sync is to start a session and retrieve the session id
-    const { sessionId, startSince: newSyncClockTime } = await this.centralServer.startSyncSession();
+    const {
+      sessionId,
+      startedAtTick: newSyncClockTime,
+    } = await this.centralServer.startSyncSession();
 
     console.log('MobileSyncManager.runSync(): Sync started');
 

--- a/packages/mobile/App/services/sync/utils/pullIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pullIncomingChanges.ts
@@ -40,7 +40,7 @@ export const pullIncomingChanges = async (
   tableNames: string[],
   tablesForFullResync: string[],
   progressCallback: (total: number, progressCount: number) => void,
-): Promise<{ totalToPull: number; pullUntil: number }> => {
+): Promise<{ totalPulled: number; pullUntil: number }> => {
   const { totalToPull, pullUntil } = await centralServer.initiatePull(
     sessionId,
     since,
@@ -49,7 +49,7 @@ export const pullIncomingChanges = async (
   );
 
   if (!totalToPull) {
-    return { totalToPull: 0, pullUntil };
+    return { totalPulled: 0, pullUntil };
   }
 
   await Promise.all(
@@ -90,5 +90,5 @@ export const pullIncomingChanges = async (
     progressCallback(totalToPull, totalPulled);
   }
 
-  return { totalToPull, pullUntil };
+  return { totalPulled: totalToPull, pullUntil };
 };

--- a/packages/mobile/App/services/sync/utils/pullIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pullIncomingChanges.ts
@@ -40,17 +40,16 @@ export const pullIncomingChanges = async (
   tableNames: string[],
   tablesForFullResync: string[],
   progressCallback: (total: number, progressCount: number) => void,
-): Promise<{ count: number; tick: number }> => {
-  const { tick } = await centralServer.setPullFilter(
+): Promise<{ totalToPull: number; pullUntil: number }> => {
+  const { totalToPull, pullUntil } = await centralServer.initiatePull(
     sessionId,
     since,
     tableNames,
     tablesForFullResync,
   );
-  const totalToPull = await centralServer.fetchPullCount(sessionId);
 
   if (!totalToPull) {
-    return { count: 0, tick };
+    return { totalToPull: 0, pullUntil };
   }
 
   await Promise.all(
@@ -91,5 +90,5 @@ export const pullIncomingChanges = async (
     progressCallback(totalToPull, totalPulled);
   }
 
-  return { count: totalToPull, tick };
+  return { totalToPull, pullUntil };
 };

--- a/packages/shared-src/src/migrations/1675735054280-addPullSinceAndPullUntil.js
+++ b/packages/shared-src/src/migrations/1675735054280-addPullSinceAndPullUntil.js
@@ -1,0 +1,17 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('sync_sessions', 'pull_since', {
+    type: DataTypes.BIGINT,
+    allowNull: true,
+  });
+  await query.addColumn('sync_sessions', 'pull_until', {
+    type: DataTypes.BIGINT,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('sync_sessions', 'pull_since');
+  await query.removeColumn('sync_sessions', 'pull_until');
+}

--- a/packages/shared-src/src/migrations/1675813034942-addStartSinceColumn.js
+++ b/packages/shared-src/src/migrations/1675813034942-addStartSinceColumn.js
@@ -1,0 +1,12 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('sync_sessions', 'start_since', {
+    type: DataTypes.BIGINT,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('sync_sessions', 'start_since');
+}

--- a/packages/shared-src/src/migrations/1675813034942-addStartedAtTickColumn.js
+++ b/packages/shared-src/src/migrations/1675813034942-addStartedAtTickColumn.js
@@ -1,12 +1,12 @@
 import { DataTypes } from 'sequelize';
 
 export async function up(query) {
-  await query.addColumn('sync_sessions', 'start_since', {
+  await query.addColumn('sync_sessions', 'started_at_tick', {
     type: DataTypes.BIGINT,
     allowNull: true,
   });
 }
 
 export async function down(query) {
-  await query.removeColumn('sync_sessions', 'start_since');
+  await query.removeColumn('sync_sessions', 'started_at_tick');
 }

--- a/packages/shared-src/src/models/SyncSession.js
+++ b/packages/shared-src/src/models/SyncSession.js
@@ -12,6 +12,7 @@ export class SyncSession extends Model {
         snapshotCompletedAt: { type: DataTypes.DATE },
         persistCompletedAt: { type: DataTypes.DATE },
         completedAt: { type: DataTypes.DATE },
+        startSince: { type: DataTypes.BIGINT },
         pullSince: { type: DataTypes.BIGINT },
         pullUntil: { type: DataTypes.BIGINT },
         error: { type: DataTypes.TEXT },

--- a/packages/shared-src/src/models/SyncSession.js
+++ b/packages/shared-src/src/models/SyncSession.js
@@ -12,7 +12,7 @@ export class SyncSession extends Model {
         snapshotCompletedAt: { type: DataTypes.DATE },
         persistCompletedAt: { type: DataTypes.DATE },
         completedAt: { type: DataTypes.DATE },
-        startSince: { type: DataTypes.BIGINT },
+        startedAtTick: { type: DataTypes.BIGINT },
         pullSince: { type: DataTypes.BIGINT },
         pullUntil: { type: DataTypes.BIGINT },
         error: { type: DataTypes.TEXT },

--- a/packages/shared-src/src/models/SyncSession.js
+++ b/packages/shared-src/src/models/SyncSession.js
@@ -12,6 +12,8 @@ export class SyncSession extends Model {
         snapshotCompletedAt: { type: DataTypes.DATE },
         persistCompletedAt: { type: DataTypes.DATE },
         completedAt: { type: DataTypes.DATE },
+        pullSince: { type: DataTypes.BIGINT },
+        pullUntil: { type: DataTypes.BIGINT },
         error: { type: DataTypes.TEXT },
         debugInfo: { type: DataTypes.JSON },
       },

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -135,7 +135,7 @@ class CentralSyncManager {
   }
 
   // set pull filter begins creating a snapshot of changes to pull at this point in time
-  async setPullFilter(sessionId, params) {
+  async initiatePull(sessionId, params) {
     // first check if the snapshot is already being processed, to throw a sane error if (for some
     // reason) the client managed to kick off the pull twice (ran into this in v1.24.0 and v1.24.1)
     const isAlreadyProcessing = await this.checkSnapshotIsProcessing(sessionId);
@@ -182,7 +182,7 @@ class CentralSyncManager {
         where: { facilityId, updatedAtSyncTick: { [Op.gt]: since } },
       });
       log.debug(
-        `CentralSyncManager.setPullFilter: ${newPatientFacilities.length} patients newly marked for sync for ${facilityId}`,
+        `CentralSyncManager.initiatePull: ${newPatientFacilities.length} patients newly marked for sync for ${facilityId}`,
       );
       const patientIdsForFullSync = newPatientFacilities.map(n => n.patientId);
 
@@ -258,7 +258,7 @@ class CentralSyncManager {
       // time throughout the snapshot process
       await session.update({ snapshotCompletedAt: new Date() });
     } catch (error) {
-      log.error('CentralSyncManager.setPullFilter encountered an error', error);
+      log.error('CentralSyncManager.initiatePull encountered an error', error);
       await session.update({ error: error.message });
     } finally {
       await unmarkSnapshotAsProcessing();

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -292,6 +292,7 @@ class CentralSyncManager {
       sessionId,
       SYNC_SESSION_DIRECTION.OUTGOING,
     );
+    await this.store.models.SyncSession.addDebugInfo(sessionId, { totalToPull });
     const { pullUntil } = session;
     return { totalToPull, pullUntil };
   }
@@ -309,7 +310,12 @@ class CentralSyncManager {
 
   async persistIncomingChanges(sessionId, tablesToInclude) {
     const { sequelize, models } = this.store;
-    await models.SyncSession.addDebugInfo(sessionId, { beganPersistAt: new Date() });
+    const totalPushed = await countSyncSnapshotRecords(
+      sequelize,
+      sessionId,
+      SYNC_SESSION_DIRECTION.INCOMING,
+    );
+    await models.SyncSession.addDebugInfo(sessionId, { beganPersistAt: new Date(), totalPushed });
 
     const modelsToInclude = tablesToInclude
       ? filterModelsFromName(models, tablesToInclude)

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -75,7 +75,7 @@ class CentralSyncManager {
     });
 
     // no await as prepare session (especially the tickTockGlobalClock action) might get blocked
-    // and take a while if the central server is concurrently persist records from another client.
+    // and take a while if the central server is concurrently persisting records from another client.
     // Client should poll for the result later.
     this.prepareSession(syncSession);
 
@@ -90,7 +90,7 @@ class CentralSyncManager {
     const { tick } = await this.tickTockGlobalClock();
 
     await this.store.sequelize.models.SyncSession.update(
-      { startSince: tick },
+      { startedAtTick: tick },
       { where: { id: syncSession.id } },
     );
   }
@@ -280,7 +280,7 @@ class CentralSyncManager {
 
   async checkSessionReady(sessionId) {
     const session = await this.connectToSession(sessionId);
-    if (session.startSince === null) {
+    if (session.startedAtTick === null) {
       return false;
     }
 
@@ -309,8 +309,8 @@ class CentralSyncManager {
 
   async fetchSyncMetadata(sessionId) {
     // Minimum metadata info for now but can grow in the future
-    const { startSince } = await this.connectToSession(sessionId);
-    return { startSince };
+    const { startedAtTick } = await this.connectToSession(sessionId);
+    return { startedAtTick };
   }
 
   async fetchPullMetadata(sessionId) {

--- a/packages/sync-server/app/sync/buildSyncRoutes.js
+++ b/packages/sync-server/app/sync/buildSyncRoutes.js
@@ -18,16 +18,6 @@ export const buildSyncRoutes = ctx => {
     }),
   );
 
-  // fetch sync metadata
-  syncRoutes.get(
-    '/:sessionId/metadata',
-    asyncHandler(async (req, res) => {
-      const { params } = req;
-      const { startSince } = await syncManager.fetchSyncMetadata(params.sessionId);
-      res.json({ startSince });
-    }),
-  );
-
   // fetch if the session is ready to start syncing
   syncRoutes.get(
     '/:sessionId/ready',
@@ -36,6 +26,16 @@ export const buildSyncRoutes = ctx => {
       const { sessionId } = params;
       const ready = await syncManager.checkSessionReady(sessionId);
       res.json(ready);
+    }),
+  );
+
+  // fetch sync metadata
+  syncRoutes.get(
+    '/:sessionId/metadata',
+    asyncHandler(async (req, res) => {
+      const { params } = req;
+      const { startedAtTick } = await syncManager.fetchSyncMetadata(params.sessionId);
+      res.json({ startedAtTick });
     }),
   );
 

--- a/packages/sync-server/app/sync/buildSyncRoutes.js
+++ b/packages/sync-server/app/sync/buildSyncRoutes.js
@@ -18,6 +18,27 @@ export const buildSyncRoutes = ctx => {
     }),
   );
 
+  // fetch sync metadata
+  syncRoutes.get(
+    '/:sessionId/metadata',
+    asyncHandler(async (req, res) => {
+      const { params } = req;
+      const { startSince } = await syncManager.fetchSyncMetadata(params.sessionId);
+      res.json({ startSince });
+    }),
+  );
+
+  // fetch if the session is ready to start syncing
+  syncRoutes.get(
+    '/:sessionId/ready',
+    asyncHandler(async (req, res) => {
+      const { params } = req;
+      const { sessionId } = params;
+      const ready = await syncManager.checkSessionReady(sessionId);
+      res.json(ready);
+    }),
+  );
+
   // set the since and facilityId for a pull session
   syncRoutes.post(
     '/:sessionId/pull/initiate',

--- a/packages/sync-server/app/sync/buildSyncRoutes.js
+++ b/packages/sync-server/app/sync/buildSyncRoutes.js
@@ -20,7 +20,7 @@ export const buildSyncRoutes = ctx => {
 
   // set the since and facilityId for a pull session
   syncRoutes.post(
-    '/:sessionId/pullFilter',
+    '/:sessionId/pull/initiate',
     asyncHandler(async (req, res) => {
       const { params, body } = req;
       const {
@@ -34,7 +34,7 @@ export const buildSyncRoutes = ctx => {
       if (isNaN(since)) {
         throw new Error('Must provide "since" when creating a pull filter, even if it is 0');
       }
-      await syncManager.setPullFilter(params.sessionId, {
+      await syncManager.initiatePull(params.sessionId, {
         since,
         facilityId,
         tablesToInclude,


### PR DESCRIPTION
### Changes

The mechanism we use to let things run asynchronously on the central server, and poll until finished on the client, did not consider that the simple `tickTockSyncClock` might take longer than the http request timeout. This can happen because tick-tocking gets blocked while a sync push is persisting. This is intentional (so that we don't take a snapshot while the database is partially synced) but caused issues in Nauru when this set of conditions was hit.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
