### PR TITLE
No-issue: fix hot re loading

### DIFF
--- a/packages/desktop/app/index.js
+++ b/packages/desktop/app/index.js
@@ -56,3 +56,11 @@ function start() {
 }
 
 start();
+
+// Add this work around for webpack hot module reloading. We should be able to remove it if we update
+// our webpack version to a version higher than 5.40 @see https://github.com/webpack-contrib/webpack-hot-middleware/issues/390
+if (process.env.NODE_ENV === 'development') {
+  if (module.hot) {
+    module.hot.accept();
+  }
+}

--- a/packages/desktop/webpack.config.renderer.dev.js
+++ b/packages/desktop/webpack.config.renderer.dev.js
@@ -3,9 +3,8 @@
 import path from 'path';
 import fs from 'fs';
 import webpack from 'webpack';
-import chalk from 'chalk';
 import merge from 'webpack-merge';
-import { spawn, execSync } from 'child_process';
+import { spawn } from 'child_process';
 import baseConfig from './webpack.config.base';
 import CheckNodeEnv from './internals/scripts/CheckNodeEnv';
 
@@ -223,6 +222,8 @@ export default merge.smart(baseConfig, {
     publicPath,
     compress: true,
     noInfo: true,
+    liveReload: false,
+    hot: true,
     stats: 'errors-only',
     inline: true,
     lazy: false,


### PR DESCRIPTION
### Changes

Fix hot reloading. The secret to debugging this was to set liveReload to false and then hotOnly true (see [webpack docs](https://v4.webpack.js.org/configuration/dev-server/#devserverhotonly)). Then there was an error in the console complaining about hot module not accepted and I was able to look it up from there.

In the issue that I added to the comment it mentioned that the issue with hot modules being accepted is fixed in webpack but I tried the latest version and it still wouldn't work without the workaround. I then decided to revert the version of webpack since I didn't want to bring in any regression risk for this change.

Also note that although the hot reload now works, it still isn't perfect in places where there is global state that the view depends on. However it should still improve developer experience a lot in the desktop app.

**Screenshots**

https://user-images.githubusercontent.com/12807916/217149187-c021cbd7-0538-4232-a843-51aa8935a5a0.mov



### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
