### PR TITLE
SAV-76: Only run imaging results data migration on central

### DIFF
--- a/packages/shared-src/src/migrations/1669589923823-createImagingResultsTable.js
+++ b/packages/shared-src/src/migrations/1669589923823-createImagingResultsTable.js
@@ -1,4 +1,7 @@
 import { DataTypes, Sequelize } from 'sequelize';
+// TODO: shouldn't import config in migrations (it makes db schema state underivable without knowing config across the whole history of the deployment)
+// See SAV-77
+import config from 'config';
 
 export async function up(query) {
   await query.createTable('imaging_results', {
@@ -62,11 +65,15 @@ export async function up(query) {
   });
 
   await query.renameColumn('imaging_requests', 'results', 'legacy_results');
-  await query.sequelize.query(`
-    INSERT INTO imaging_results (id, created_at, updated_at, imaging_request_id, description)
-    SELECT uuid_generate_v4(), ir.updated_at, ir.updated_at, ir.id, ir.legacy_results FROM imaging_requests ir
-    WHERE ir.legacy_results IS NOT NULL AND ir.legacy_results != '';
+  if (!config.serverFacilityId) {
+    // only insert imaging_results on the central server
+    // facility servers can sync new results down
+    await query.sequelize.query(`
+      INSERT INTO imaging_results (id, created_at, updated_at, imaging_request_id, description)
+      SELECT uuid_generate_v4(), ir.updated_at, ir.updated_at, ir.id, ir.legacy_results FROM imaging_requests ir
+      WHERE ir.legacy_results IS NOT NULL AND ir.legacy_results != '';
   `);
+  }
 }
 
 export async function down(query) {


### PR DESCRIPTION
### Changes

Prevents the data migration (but not the schema migration) for the new `imaging_results` table from running on facility servers, to allow them to sync down the migrated data from the central server.

For a justification of why we want to do this, including why it involves importing config and why we're changing an existing migration, see the card.

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
