### PR TITLE
EPI-351: Update Medici report API

### DIFF
--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -396,6 +396,15 @@ describe('fijiAspenMediciReport', () => {
     });
   });
 
+  it('should produce reports without any params', async () => {
+    const response = await app
+      .get('/v1/integration/fijiAspenMediciReport')
+      .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
+
+    expect(response).toHaveSucceeded();
+    expect(response.body.data.length).toEqual(2);
+  });
+
   it(`Should produce a simple report`, async () => {
     const { patient, encounterId } = fakedata;
     // act

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -413,7 +413,7 @@ routes.get(
         to_date: parseDateParam(toDate, COUNTRY_TIMEZONE),
         input_encounter_ids: encounters?.split(',') ?? [],
         billing_type: null,
-        limit,
+        limit: parseInt(limit, 10),
         offset, // Should still be able to offset even with no limit
         timezone_string: COUNTRY_TIMEZONE,
       },

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -394,7 +394,7 @@ routes.get(
     const {
       'period.start': fromDate,
       'period.end': toDate,
-      limit,
+      limit = 100,
       encounters,
       offset = 0,
     } = req.query;
@@ -409,7 +409,7 @@ routes.get(
         to_date: parseDateParam(toDate, COUNTRY_TIMEZONE),
         input_encounter_ids: encounters?.split(',') ?? [],
         billing_type: null,
-        limit: limit ?? null, // Limit of null means no limit
+        limit,
         offset, // Should still be able to offset even with no limit
         timezone_string: COUNTRY_TIMEZONE,
       },

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -373,7 +373,7 @@ WHERE true
     true
   END
 
-ORDER BY e.start_date DESC
+ORDER BY e.end_date DESC
 LIMIT $limit OFFSET $offset;
 `;
 


### PR DESCRIPTION
### Changes

The specs have changed and now we want to:
- Get rid of `period.start` and `period.end` params being mandatory, they should be optional.
- Set a default pagination limit to 100.
- Order by an encounter dispatch datetime (end date/discharge date).