### PR TITLE
EPI-354: Update mapping for new Imaging Request statuses

### DIFF
--- a/packages/shared-src/src/models/fhir/ServiceRequest.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest.js
@@ -143,11 +143,7 @@ export class FhirServiceRequest extends FhirResource {
           value: upstream.id,
         }),
       ],
-      status: {
-        [IMAGING_REQUEST_STATUS_TYPES.PENDING]: FHIR_REQUEST_STATUS.DRAFT,
-        [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: FHIR_REQUEST_STATUS.ACTIVE,
-        [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: FHIR_REQUEST_STATUS.COMPLETED,
-      }[upstream.status],
+      status: status(upstream),
       intent: FHIR_REQUEST_INTENT.ORDER._,
       category: [
         new FhirCodeableConcept({
@@ -265,4 +261,17 @@ function locationCode(upstream) {
       text: facility.name,
     }),
   ];
+}
+
+function status(upstream) {
+  return (
+    {
+      [IMAGING_REQUEST_STATUS_TYPES.CANCELLED]: FHIR_REQUEST_STATUS.REVOKED,
+      [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: FHIR_REQUEST_STATUS.COMPLETED,
+      [IMAGING_REQUEST_STATUS_TYPES.DELETED]: FHIR_REQUEST_STATUS.REVOKED,
+      [IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR]: FHIR_REQUEST_STATUS.ENTERED_IN_ERROR,
+      [IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS]: FHIR_REQUEST_STATUS.ACTIVE,
+      [IMAGING_REQUEST_STATUS_TYPES.PENDING]: FHIR_REQUEST_STATUS.DRAFT,
+    }[upstream.status] ?? FHIR_REQUEST_STATUS.UNKNOWN
+  );
 }


### PR DESCRIPTION
### Changes

Adds FHIR support for the statuses added in WAITM-608 (#3453) and WAITM-609 (#3452).

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any db schema or other changes that could impact downstream data analysis
