### PR TITLE
SAV-80: Improve patient search performance

### DIFF
--- a/packages/lan/__tests__/apiv1/Patient.search.test.js
+++ b/packages/lan/__tests__/apiv1/Patient.search.test.js
@@ -381,9 +381,10 @@ describe('Patient search', () => {
       });
     });
 
-    it('should get a list of patients by location', async () => {
+    it('should get a list of patients by location (not on all-patients listing)', async () => {
       const response = await app.get('/v1/patient').query({
         locationId: locations[0].id,
+        facilityId: locations[0].facilityId,
       });
       expect(response).toHaveSucceeded();
 
@@ -393,9 +394,10 @@ describe('Patient search', () => {
       });
     });
 
-    it('should get a list of patients by location group', async () => {
+    it('should get a list of patients by location group (not on all-patients listing)', async () => {
       const response = await app.get('/v1/patient').query({
         locationGroupId: locationGroups[0].id,
+        facilityId: locationGroups[0].facilityId,
       });
       expect(response).toHaveSucceeded();
 
@@ -405,9 +407,10 @@ describe('Patient search', () => {
       });
     });
 
-    it('should get a list of patients by department', async () => {
+    it('should get a list of patients by department (not on all-patients listing)', async () => {
       const response = await app.get('/v1/patient').query({
         departmentId: departments[0].id,
+        facilityId: departments[0].facilityId,
       });
       expect(response).toHaveSucceeded();
 
@@ -542,9 +545,10 @@ describe('Patient search', () => {
       expectSorted(response.body.data, x => x.encounterType, true);
     });
 
-    it('should sort by location', async () => {
+    it('should sort by location (not on all-patients listing)', async () => {
       const response = await app.get('/v1/patient').query({
         orderBy: 'locationName',
+        facilityId: locations[0].facilityId,
       });
 
       expect(response).toHaveSucceeded();
@@ -552,9 +556,10 @@ describe('Patient search', () => {
       expectSorted(response.body.data, x => x.locationName);
     });
 
-    it('should sort by department', async () => {
+    it('should sort by department (not on all-patients listing)', async () => {
       const response = await app.get('/v1/patient').query({
         orderBy: 'departmentName',
+        facilityId: departments[0].facilityId,
       });
 
       expect(response).toHaveSucceeded();

--- a/packages/lan/app/routes/apiv1/patient/patient.js
+++ b/packages/lan/app/routes/apiv1/patient/patient.js
@@ -258,10 +258,39 @@ patientRoute.get(
         filterParams[k] = parseFloat(filterParams[k]);
       });
 
+    // Check if this is the main patient listing and change FROM and SELECT
+    // clauses to improve query speed by removing unused joins
+    const isAllPatientsListing = !filterParams.facilityId;
     const filters = createPatientFilters(filterParams);
     const whereClauses = filters.map(f => f.sql).join(' AND ');
 
-    const from = `
+    const from = isAllPatientsListing
+      ? `
+      FROM patients
+        LEFT JOIN (
+            SELECT patient_id, max(start_date) AS most_recent_open_encounter
+            FROM encounters
+            WHERE end_date IS NULL
+            GROUP BY patient_id
+          ) recent_encounter_by_patient
+          ON patients.id = recent_encounter_by_patient.patient_id
+        LEFT JOIN encounters
+          ON (patients.id = encounters.patient_id AND recent_encounter_by_patient.most_recent_open_encounter = encounters.start_date)
+        LEFT JOIN reference_data AS village
+          ON (village.type = 'village' AND village.id = patients.village_id)
+        LEFT JOIN (
+          SELECT
+            patient_id,
+            ARRAY_AGG(value) AS secondary_ids
+          FROM patient_secondary_ids
+          GROUP BY patient_id
+        ) psi
+          ON (patients.id = psi.patient_id)
+        LEFT JOIN patient_facilities
+          ON (patient_facilities.patient_id = patients.id AND patient_facilities.facility_id = :facilityId)
+      ${whereClauses && `WHERE ${whereClauses}`}
+      `
+      : `
       FROM patients
         LEFT JOIN (
             SELECT patient_id, max(start_date) AS most_recent_open_encounter
@@ -321,24 +350,38 @@ patientRoute.get(
       return;
     }
 
+    const select = isAllPatientsListing
+      ? `
+      SELECT
+        patients.*,
+        encounters.id AS encounter_id,
+        encounters.encounter_type,
+        village.id AS village_id,
+        village.name AS village_name,
+        patient_facilities.patient_id IS NOT NULL as marked_for_sync
+      `
+      : `
+      SELECT
+        patients.*,
+        encounters.id AS encounter_id,
+        encounters.encounter_type,
+        department.id AS department_id,
+        department.name AS department_name,
+        location.id AS location_id,
+        location.name AS location_name,
+        location_group.name AS location_group_name,
+        planned_location_group.name AS planned_location_group_name,
+        planned_location.id AS planned_location_id,
+        planned_location.name AS planned_location_name,
+        encounters.planned_location_start_time,
+        village.id AS village_id,
+        village.name AS village_name,
+        patient_facilities.patient_id IS NOT NULL as marked_for_sync
+    `;
+
     const result = await req.db.query(
       `
-        SELECT
-          patients.*,
-          encounters.id AS encounter_id,
-          encounters.encounter_type,
-          department.id AS department_id,
-          department.name AS department_name,
-          location.id AS location_id,
-          location.name AS location_name,
-          location_group.name AS location_group_name,
-          planned_location_group.name AS planned_location_group_name,
-          planned_location.id AS planned_location_id,
-          planned_location.name AS planned_location_name,
-          encounters.planned_location_start_time,
-          village.id AS village_id,
-          village.name AS village_name,
-          patient_facilities.patient_id IS NOT NULL as marked_for_sync
+        ${select}
         ${from}
 
         ORDER BY ${sortKey} ${sortDirection}, ${secondarySearchTerm} NULLS LAST


### PR DESCRIPTION
### Changes

Really not pleased with the results as the endpoint got even messier - still, creating a different endpoint would end in so much WET(ness) that it didn't made much sense either. For what I could investigate, these are the least amount of joins that we need for proper functioning of the "all patients" table.

I tried checking the performance of the query but couldn't get a clean baseline to begin with, it seems that it does improve it by a little, but I would've imagine it improving a lot more. Other patient listings do seem to work faster all the time, probably because of the filter in encounters so maybe that's the actual biggest bottleneck.