### PR TITLE
No ticket: Use static strings for admin import errors

### DIFF
--- a/packages/sync-server/app/admin/errors.js
+++ b/packages/sync-server/app/admin/errors.js
@@ -20,25 +20,53 @@ export class DataImportError extends Error {
     this.rowNumber = rowNumber;
   }
 
+  static get kind() {
+    return 'DataImportError';
+  }
+
   toJSON() {
     return {
       sheet: this.sheetName,
       row: this.rowNumber,
-      kind: this.constructor.name,
+      kind: this.constructor.kind,
       message: this.previous.toString(),
     };
   }
 }
 
-export class DataLoaderError extends DataImportError {}
-export class ForeignkeyResolutionError extends DataImportError {}
-export class UpsertionError extends DataImportError {}
-export class ValidationError extends DataImportError {}
-export class WorkSheetError extends DataImportError {}
+export class DataLoaderError extends DataImportError {
+  static get kind() {
+    return 'DataLoaderError';
+  }
+}
+export class ForeignkeyResolutionError extends DataImportError {
+  static get kind() {
+    return 'ForeignkeyResolutionError';
+  }
+}
+export class UpsertionError extends DataImportError {
+  static get kind() {
+    return 'UpsertionError';
+  }
+}
+export class ValidationError extends DataImportError {
+  static get kind() {
+    return 'ValidationError';
+  }
+}
+export class WorkSheetError extends DataImportError {
+  static get kind() {
+    return 'WorkSheetError';
+  }
+}
 
 export class ImporterMetadataError extends DataImportError {
   constructor(error) {
     super('metadata', -2, error);
+  }
+
+  static get kind() {
+    return 'ImporterMetadataError';
   }
 }
 


### PR DESCRIPTION
### Changes

- Class names get mangled in release build, use static strings instead

### Checklist

- [X] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
