### PR TITLE
EPI-361: Use EXPLAIN instead of EXPLAIN ANALYZE for report import

### DIFF
--- a/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
+++ b/packages/sync-server/__tests__/subCommands/importReport/actions.test.js
@@ -89,12 +89,10 @@ describe('importReport actions', () => {
     });
     it('calls the correct functions and creates version', async () => {
       const readFileSpy = jest.spyOn(fs, 'readFile').mockResolvedValue(getUnparsedVersionData());
-      const explainAnalyzeQuerySpy = jest
-        .spyOn(importUtils, 'explainAnalyzeQuery')
-        .mockResolvedValue();
+      const verifyQuerySpy = jest.spyOn(importUtils, 'verifyQuery').mockResolvedValue();
       await createVersion('/path', mockDefinition, mockVersions, mockStore, true);
       expect(readFileSpy).toHaveBeenCalledWith('/path');
-      expect(explainAnalyzeQuerySpy).toHaveBeenCalledWith(
+      expect(verifyQuerySpy).toHaveBeenCalledWith(
         'test-query',
         [{ name: 'test', parameterField: 'TestField' }],
         mockStore,
@@ -118,7 +116,7 @@ describe('importReport actions', () => {
     });
     it('calls the correct functions and updates version when versionNumber supplied', async () => {
       jest.spyOn(fs, 'readFile').mockResolvedValue(getUnparsedVersionData(1));
-      jest.spyOn(importUtils, 'explainAnalyzeQuery').mockResolvedValue();
+      jest.spyOn(importUtils, 'verifyQuery').mockResolvedValue();
       await createVersion('/path', mockDefinition, [{ versionNumber: 1 }], mockStore);
       expect(log.warn).nthCalledWith(1, `Version 1 already exists, ${OVERWRITING_TEXT}`);
       expect(mockStore.models.ReportDefinitionVersion.upsert).toBeCalledWith({
@@ -134,7 +132,7 @@ describe('importReport actions', () => {
     });
     it('throws error when versionNumber is invalid', async () => {
       jest.spyOn(fs, 'readFile').mockResolvedValue(getUnparsedVersionData(3));
-      jest.spyOn(importUtils, 'explainAnalyzeQuery').mockResolvedValue();
+      jest.spyOn(importUtils, 'verifyQuery').mockResolvedValue();
       expect(
         createVersion('/path', mockDefinition, [{ versionNumber: 1 }], mockStore),
       ).rejects.toThrow(getVersionError({ versionNumber: 3 }));

--- a/packages/sync-server/app/subCommands/importReport/actions.js
+++ b/packages/sync-server/app/subCommands/importReport/actions.js
@@ -21,7 +21,7 @@ export async function createVersion(file, definition, versions, store, verbose) 
   const { ReportDefinitionVersion } = store.models;
 
   log.info('Analyzing query');
-  await reportUtils.explainAnalyzeQuery(
+  await reportUtils.verifyQuery(
     versionData.query,
     versionData.queryOptions?.parameters,
     store,

--- a/packages/sync-server/app/subCommands/importReport/utils.js
+++ b/packages/sync-server/app/subCommands/importReport/utils.js
@@ -19,9 +19,10 @@ export function getLatestVersion(versions, status) {
     .find(v => !status || v.status === status);
 }
 
-export async function explainAnalyzeQuery(query, paramDefinitions = [], store, verbose) {
+export async function verifyQuery(query, paramDefinitions = [], store, verbose) {
   try {
-    const results = await store.sequelize.query(`EXPLAIN ANALYZE ${query}`, {
+    // use EXPLAIN instead of PREPARE because we don't want to stuff around deallocating the statement
+    const results = await store.sequelize.query(`EXPLAIN ${query}`, {
       type: QueryTypes.SELECT,
       replacements: getQueryReplacementsFromParams(paramDefinitions),
     });
@@ -29,7 +30,7 @@ export async function explainAnalyzeQuery(query, paramDefinitions = [], store, v
       const formattedResults = results.reduce(
         (a1, x) =>
           `${a1}\n${Object.entries(x).reduce((a2, [k, v]) => `${a2}\x1b[1m${k}:\x1b[0m ${v}`, '')}`,
-        'Explain analyze output:',
+        'Explain output:',
       );
       log.info(formattedResults);
     }


### PR DESCRIPTION
### Changes

`EXPLAIN ANALYZE` actually runs the query, which can take a while for big reports.

We don't use `PREPARE` because that leaves the query lying around until it's deallocated, and because the `-v` output might be useful to someone at some point.

### Checklist

- [x] Code is finished
- [x] Tests are written

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
