### PR TITLE
TAN-2051: Fix Order when displaying referrals

### DIFF
--- a/packages/mobile/App/models/Referral.ts
+++ b/packages/mobile/App/models/Referral.ts
@@ -4,6 +4,7 @@ import { GenericFormValues, ICreateSurveyResponse, IReferral } from '~/types';
 import { Encounter } from './Encounter';
 import { SurveyResponse } from './SurveyResponse';
 import { SYNC_DIRECTIONS } from './types';
+import { SurveyScreenComponent } from './SurveyScreenComponent';
 
 @Entity('referral')
 export class Referral extends BaseModel implements IReferral {
@@ -64,7 +65,15 @@ export class Referral extends BaseModel implements IReferral {
       .leftJoinAndSelect('surveyResponse.survey', 'survey')
       .leftJoinAndSelect('surveyResponse.answers', 'answers')
       .leftJoinAndSelect('answers.dataElement', 'dataElement')
+      .leftJoinAndSelect(SurveyScreenComponent, 'screenComponent',
+        'screenComponent.dataElementId = dataElement.id and screenComponent.surveyId = survey.id')
       .where('initiatingEncounter.patientId = :patientId', { patientId })
+      .orderBy(
+        {
+          'screenComponent.screenIndex': 'ASC',
+          'screenComponent.componentIndex': 'ASC',
+        },
+      )
       .getMany();
   }
 }


### PR DESCRIPTION
### Changes
- Fixed order for displaying referral answers.
Related issue: https://linear.app/bes/issue/TAN-2051/referral-responses-not-submitting-in-correct-order-on-mobile

Before the fix:
![image](https://user-images.githubusercontent.com/17033058/217681094-1eb5cf78-2c1a-4fa9-a17f-1cd37f64b0c9.png)

After the fix:
![image](https://user-images.githubusercontent.com/17033058/217681158-018ce588-4971-46fc-829c-0ad3ce587429.png)
 


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
