### PR TITLE
WAITM-615: Hide Cancelled Lab Requests On Mobile

### DIFF
--- a/packages/mobile/App/models/LabRequest.ts
+++ b/packages/mobile/App/models/LabRequest.ts
@@ -10,6 +10,8 @@ import { User } from './User';
 import { ISO9075_SQLITE_DEFAULT } from './columnDefaults';
 import { DateTimeStringColumn } from './DateColumns';
 
+const HIDDEN_STATUSES = ['deleted', 'entered-in-error', 'cancelled'];
+
 @Entity('labRequest')
 export class LabRequest extends BaseModel implements ILabRequest {
   static syncDirection = SYNC_DIRECTIONS.BIDIRECTIONAL;
@@ -86,6 +88,7 @@ export class LabRequest extends BaseModel implements ILabRequest {
       .createQueryBuilder('labRequest')
       .leftJoinAndSelect('labRequest.encounter', 'encounter')
       .where('encounter.patient = :patientId', { patientId })
+      .andWhere('labRequest.status NOT IN (:...status)', { status: HIDDEN_STATUSES })
       .leftJoinAndSelect('labRequest.labTestCategory', 'labTestCategory')
       .getMany();
   }


### PR DESCRIPTION
### Changes

- Hide Lab Requests with a status Deleted, Cancelled and Enterred-In-Error on mobile

### Checklist

- [x] Code is finished
- na Tests are written
- na UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
