### PR TITLE
SAV-91: Discharge at 11pm, not 11am

### DIFF
--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -99,7 +99,7 @@
     // schedule: 5 fields == first is minutes, 6 fields == first is SECONDS
     "outpatientDischarger": {
       // every day at 11 PM
-      "schedule": "0 11 * * *",
+      "schedule": "0 23 * * *",
       "batchSize": 1000,
       "batchSleepAsyncDurationInMilliseconds": 50
     },


### PR DESCRIPTION
### Changes

The config for the autodischarger was not written in the 24 hour time format that cron expects, meaning the discharger runs at the wrong time by default.

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
