### PR TITLE
Redux refactor: auth

### DIFF
--- a/packages/desktop/app/App.js
+++ b/packages/desktop/app/App.js
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import 'typeface-roboto';
 import { Colors } from './constants';
 
-import { checkIsLoggedIn } from './store/auth';
 import { getCurrentRoute } from './store/router';
 import { LoginView } from './views';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { DecisionSupportModal } from './components/DecisionSupportModal';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
+import { useAuth } from './contexts/Auth';
 
 const AppContainer = styled.div`
   display: flex;
@@ -25,9 +25,9 @@ const AppContentsContainer = styled.div`
 `;
 
 export function App({ sidebar, children }) {
-  const isUserLoggedIn = useSelector(checkIsLoggedIn);
+  const { isLoggedIn } = useAuth();
   const currentRoute = useSelector(getCurrentRoute);
-  if (!isUserLoggedIn) {
+  if (!isLoggedIn) {
     return <LoginView />;
   }
 

--- a/packages/desktop/app/Root.js
+++ b/packages/desktop/app/Root.js
@@ -18,18 +18,23 @@ import { ReferralProvider } from './contexts/Referral';
 import { ElectronProvider } from './contexts/ElectronProvider';
 import { ImagingRequestsProvider } from './contexts/ImagingRequests';
 import { PatientSearchProvider } from './contexts/PatientSearch';
+import { AuthProvider } from './contexts/Auth';
 
 const StateContextProviders = ({ children, store }) => (
   <EncounterProvider store={store}>
-    <ReferralProvider>
-      <ImagingRequestsProvider>
-        <LabRequestProvider store={store}>
-          <PatientSearchProvider>
-            <LocalisationProvider store={store}>{children}</LocalisationProvider>
-          </PatientSearchProvider>
-        </LabRequestProvider>
-      </ImagingRequestsProvider>
-    </ReferralProvider>
+    <AuthProvider>
+      <ReferralProvider>
+        <ImagingRequestsProvider>
+          <LabRequestProvider store={store}>
+            <PatientSearchProvider>
+              <LocalisationProvider store={store}>
+                {children}
+              </LocalisationProvider>
+            </PatientSearchProvider>
+          </LabRequestProvider>
+        </ImagingRequestsProvider>
+      </ReferralProvider>
+    </AuthProvider>
   </EncounterProvider>
 );
 

--- a/packages/desktop/app/RoutingApp.js
+++ b/packages/desktop/app/RoutingApp.js
@@ -19,6 +19,7 @@ import {
 } from './routes';
 import { Sidebar, FACILITY_MENU_ITEMS, SYNC_MENU_ITEMS } from './components/Sidebar';
 import { TopBar, Notification } from './components';
+import { useAuth } from './contexts/Auth';
 
 export const RoutingApp = () => {
   const isSyncServer = useSelector(state => state.auth?.server?.type === SERVER_TYPES.SYNC);
@@ -60,12 +61,12 @@ export const RoutingAdminApp = React.memo(() => (
 ));
 
 export const AdminPlaceholder = React.memo(() => {
-  const user = useSelector(state => state.auth?.user);
+  const { currentUser } = useAuth();
 
   return (
     <>
       <TopBar title="New sync admin panel" />
-      <Notification message={`Successfully logged in as ${user.displayName}`} />
+      <Notification message={`Successfully logged in as ${currentUser.displayName}`} />
     </>
   );
 });

--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -1,21 +1,37 @@
+import React, { useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { logout } from '../store';
 
-// This is just a redux selector for now.
-// This should become its own proper context once the auth stuff
-// is refactored out of redux.
+const AuthContext = React.createContext({
+  currentUser: {},
+  isLoggedIn: false,
+  ability: {},
+  facility: {},
+  centralHost: '',
+  onLogout: () => null,
+});
 
-export const useAuth = () => {
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider = ({ children }) => {
   const dispatch = useDispatch();
 
-  return {
-    ...useSelector(state => ({
-      currentUser: state.auth?.user,
-      isLoggedIn: !!(state.auth?.user),
-      ability: state.auth?.ability,
-      facility: state.auth?.server.facility || {},
-      centralHost: state.auth?.server.centralHost,
-    })),
-    onLogout: () => dispatch(logout()),
-  };
+  const reduxState = useSelector(state => ({
+    currentUser: state.auth?.user,
+    isLoggedIn: !!(state.auth?.user),
+    ability: state.auth?.ability,
+    facility: state.auth?.server?.facility || {},
+    centralHost: state.auth?.server?.centralHost,
+  }));
+
+  return (
+    <AuthContext.Provider
+      value={{
+        ...reduxState,
+        onLogout: () => dispatch(logout()),
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
 };

--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -10,10 +10,11 @@ export const useAuth = () => {
 
   return {
     ...useSelector(state => ({
-      currentUser: state.auth.user,
-      ability: state.auth.ability,
-      facility: state.auth.server?.facility || {},
-      centralHost: state.auth.server?.centralHost,
+      currentUser: state.auth?.user,
+      isLoggedIn: !!(state.auth?.user),
+      ability: state.auth?.ability,
+      facility: state.auth?.server.facility || {},
+      centralHost: state.auth?.server.centralHost,
     })),
     onLogout: () => dispatch(logout()),
   };

--- a/packages/desktop/app/forms/ImmunisationForm.js
+++ b/packages/desktop/app/forms/ImmunisationForm.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -8,7 +7,6 @@ import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { INJECTION_SITE_OPTIONS } from 'shared/constants';
 import { OuterLabelFieldWrapper } from '../components/Field/OuterLabelFieldWrapper';
 import { ConfirmCancelRow } from '../components/ButtonRow';
-import { getCurrentUser } from '../store/auth';
 import {
   Form,
   Field,
@@ -21,6 +19,7 @@ import {
   LocalisedLocationField,
 } from '../components/Field';
 import { Colors } from '../constants';
+import { useAuth } from '../contexts/Auth';
 
 const VaccineScheduleOptions = [
   { value: 'Routine', label: 'Routine' },
@@ -113,7 +112,7 @@ export const ImmunisationForm = React.memo(
       [selectedVaccine],
     );
 
-    const currentUser = useSelector(getCurrentUser);
+    const { currentUser } = useAuth();
 
     const onSubmitWithRecorder = useCallback(
       data =>

--- a/packages/desktop/app/store/auth.js
+++ b/packages/desktop/app/store/auth.js
@@ -78,10 +78,6 @@ export const changePassword = ({ host, ...data }) => async (dispatch, getState, 
   }
 };
 
-// selectors
-export const getCurrentUser = ({ auth }) => auth.user;
-export const checkIsLoggedIn = state => !!getCurrentUser(state);
-
 // reducer
 const defaultState = {
   loading: false,

--- a/packages/desktop/app/utils/useCertificate.js
+++ b/packages/desktop/app/utils/useCertificate.js
@@ -1,7 +1,6 @@
-import { useSelector } from 'react-redux';
 import { useLocalisation } from '../contexts/Localisation';
 import { useAsset } from './useAsset';
-import { getCurrentUser } from '../store';
+import { useAuth } from '../contexts/Auth';
 
 export const useCertificate = () => {
   const { getLocalisation } = useLocalisation();
@@ -13,7 +12,7 @@ export const useCertificate = () => {
   const title = getLocalisation('templates.letterhead.title');
   const subTitle = getLocalisation('templates.letterhead.subTitle');
 
-  const currentUser = useSelector(getCurrentUser);
+  const { currentUser } = useAuth();
 
   return {
     title,

--- a/packages/desktop/app/views/programs/ProgramsView.js
+++ b/packages/desktop/app/views/programs/ProgramsView.js
@@ -6,7 +6,6 @@ import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { SURVEY_TYPES } from 'shared/constants';
 
 import { reloadPatient } from 'desktop/app/store/patient';
-import { getCurrentUser } from 'desktop/app/store/auth';
 
 import { SurveyView } from 'desktop/app/views/programs/SurveyView';
 import { SurveySelector } from 'desktop/app/views/programs/SurveySelector';
@@ -20,6 +19,7 @@ import {
 import { LoadingIndicator } from 'desktop/app/components/LoadingIndicator';
 import { PatientListingView } from 'desktop/app/views';
 import { getAnswersFromData, getActionsFromData } from '../../utils';
+import { useAuth } from '../../contexts/Auth';
 
 const SurveyFlow = ({ patient, currentUser }) => {
   const api = useApi();
@@ -121,7 +121,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
 export const ProgramsView = () => {
   const dispatch = useDispatch();
   const patient = useSelector(state => state.patient);
-  const currentUser = useSelector(getCurrentUser);
+  const { currentUser } = useAuth();
   if (!patient.id) {
     return <PatientListingView onViewPatient={id => dispatch(reloadPatient(id))} />;
   }

--- a/packages/desktop/app/views/referrals/ReferralsView.js
+++ b/packages/desktop/app/views/referrals/ReferralsView.js
@@ -10,8 +10,8 @@ import { SURVEY_TYPES } from 'shared/constants';
 
 import { SurveySelector } from '../programs/SurveySelector';
 import { ProgramsPane, ProgramsPaneHeader, ProgramsPaneHeading } from '../programs/ProgramsPane';
-import { getCurrentUser } from '../../store';
 import { getAnswersFromData, getActionsFromData } from '../../utils';
+import { useAuth } from '../../contexts/Auth';
 
 const ReferralFlow = ({ patient, currentUser }) => {
   const api = useApi();
@@ -82,7 +82,7 @@ const ReferralFlow = ({ patient, currentUser }) => {
 
 export const ReferralsView = () => {
   const patient = useSelector(state => state.patient);
-  const currentUser = useSelector(getCurrentUser);
+  const { currentUser } = useAuth();
   const dispatch = useDispatch();
   if (!patient.id) {
     return (


### PR DESCRIPTION
### Changes

We've had a `useAuth` hook around for a while now to access info about the currently logged-in user, but we had these parallel redux selectors as well. This switches things over to uniformly use `useAuth`, as well as updating `useAuth` itself to be an actual context so that we can replace its redux internals with state hooks in the future more easily.

### Checklist

- [x] Code is finished

