### PR TITLE
WAITM-608: Cancellation workflow fixes

### DIFF
--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -1,8 +1,22 @@
 import React from 'react';
-import { IMAGING_REQUEST_STATUS_OPTIONS } from 'shared/constants';
+import { IMAGING_REQUEST_STATUS_CONFIG, IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
 import { DateField, LocalisedField, SelectField } from '../Field';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLocalisation } from '../../contexts/Localisation';
+
+const IMAGING_REQUEST_STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES)
+  .filter(
+    x =>
+      ![
+        IMAGING_REQUEST_STATUS_TYPES.DELETED,
+        IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
+        IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+      ].includes(x),
+  )
+  .map(x => ({
+    label: IMAGING_REQUEST_STATUS_CONFIG[x].label,
+    value: x,
+  }));
 
 export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters }) => {
   const { getLocalisation } = useLocalisation();

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -6,16 +6,16 @@ import { useLocalisation } from '../../contexts/Localisation';
 
 const IMAGING_REQUEST_STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES)
   .filter(
-    x =>
+    type =>
       ![
         IMAGING_REQUEST_STATUS_TYPES.DELETED,
         IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
         IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
-      ].includes(x),
+      ].includes(type),
   )
-  .map(x => ({
-    label: IMAGING_REQUEST_STATUS_CONFIG[x].label,
-    value: x,
+  .map(type => ({
+    label: IMAGING_REQUEST_STATUS_CONFIG[type].label,
+    value: type,
   }));
 
 export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters }) => {

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -33,16 +33,16 @@ import { SimpleTopBar } from '../../components';
 
 const STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES)
   .filter(
-    x =>
+    type =>
       ![
         IMAGING_REQUEST_STATUS_TYPES.DELETED,
         IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
         IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
-      ].includes(x),
+      ].includes(type),
   )
-  .map(x => ({
-    label: IMAGING_REQUEST_STATUS_CONFIG[x].label,
-    value: x,
+  .map(type => ({
+    label: IMAGING_REQUEST_STATUS_CONFIG[type].label,
+    value: type,
   }));
 
 const PrintButton = ({ imagingRequest, patient }) => {

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import { shell } from 'electron';
 import { pick } from 'lodash';
 import styled from 'styled-components';
-import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
+import { IMAGING_REQUEST_STATUS_TYPES, IMAGING_REQUEST_STATUS_CONFIG } from 'shared/constants';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { CancelModal } from '../../components/CancelModal';
 import { useCertificate } from '../../utils/useCertificate';
@@ -31,11 +31,19 @@ import { useLocalisation } from '../../contexts/Localisation';
 import { ENCOUNTER_TAB_NAMES } from './encounterTabNames';
 import { SimpleTopBar } from '../../components';
 
-const STATUS_OPTIONS = [
-  { value: 'pending', label: 'Pending' },
-  { value: 'in_progress', label: 'In progress' },
-  { value: 'completed', label: 'Completed' },
-];
+const STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES)
+  .filter(
+    x =>
+      ![
+        IMAGING_REQUEST_STATUS_TYPES.DELETED,
+        IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
+        IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+      ].includes(x),
+  )
+  .map(x => ({
+    label: IMAGING_REQUEST_STATUS_CONFIG[x].label,
+    value: x,
+  }));
 
 const PrintButton = ({ imagingRequest, patient }) => {
   const api = useApi();

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -6,8 +6,6 @@ import { usePatientNavigation } from '../../utils/usePatientNavigation';
 import { useLabRequest } from '../../contexts/LabRequest';
 import { useApi, useSuggester } from '../../api';
 import { useCertificate } from '../../utils/useCertificate';
-
-import { DeleteButton } from '../../components/Button';
 import { ContentPane } from '../../components/ContentPane';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { DataFetchingTable } from '../../components/Table';
@@ -21,13 +19,11 @@ import {
   AutocompleteField,
 } from '../../components/Field';
 import { ConfirmCancelRow } from '../../components/ButtonRow';
-import { ConfirmModal } from '../../components/ConfirmModal';
 import { LabRequestPrintout } from '../../components/PatientPrinting/LabRequestPrintout';
 import { DropdownButton } from '../../components/DropdownButton';
 import { Modal } from '../../components/Modal';
 import { LabRequestNoteForm } from '../../forms/LabRequestNoteForm';
 import { LabRequestAuditPane } from '../../components/LabRequestAuditPane';
-
 import { capitaliseFirstLetter } from '../../utils/capitalise';
 import { getCompletedDate, getMethod } from '../../utils/lab';
 import { CancelModal } from '../../components/CancelModal';
@@ -157,32 +153,6 @@ const ChangeLaboratoryModal = ({ laboratory, updateLabReq, open, onClose }) => {
   );
 };
 
-const DeleteRequestModal = ({ updateLabReq, open, onClose }) => {
-  const { navigateToEncounter } = usePatientNavigation();
-  const deleteLabRequest = useCallback(async () => {
-    await updateLabReq({
-      status: 'deleted',
-    });
-    onClose();
-    navigateToEncounter();
-  }, [updateLabReq, onClose, navigateToEncounter]);
-
-  return (
-    <>
-      <ConfirmModal
-        title="Delete lab request"
-        open={open}
-        text="WARNING: This action is irreversible!"
-        subText="Are you sure you want to delete this lab request?"
-        onCancel={onClose}
-        onConfirm={deleteLabRequest}
-        ConfirmButton={DeleteButton}
-        confirmButtonText="Delete"
-      />
-    </>
-  );
-};
-
 const PrintModal = ({ labRequest, patient, open, onClose }) => {
   const api = useApi();
   const certificateData = useCertificate();
@@ -287,7 +257,6 @@ const LabRequestActionDropdown = ({ labRequest, patient, updateLabReq }) => {
   const [printModalOpen, setPrintModalOpen] = useState(modal === 'print');
   const [labModalOpen, setLabModalOpen] = useState(modal === 'laboratory');
   const [cancelModalOpen, setCancelModalOpen] = useState(modal === 'cancel');
-  const [deleteModalOpen, setDeleteModalOpen] = useState(modal === 'delete');
 
   const api = useApi();
   const [hasTests, setHasTests] = useState(true); // default to true to hide delete button at first
@@ -337,12 +306,6 @@ const LabRequestActionDropdown = ({ labRequest, patient, updateLabReq }) => {
         patient={patient}
         open={printModalOpen}
         onClose={() => setPrintModalOpen(false)}
-      />
-      <DeleteRequestModal
-        labRequestId={labRequestId}
-        updateLabReq={updateLabReq}
-        open={deleteModalOpen}
-        onClose={() => setDeleteModalOpen(false)}
       />
       <ChangeLaboratoryModal
         laboratory={labRequest.laboratory}

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -258,20 +258,7 @@ const LabRequestActionDropdown = ({ labRequest, patient, updateLabReq }) => {
   const [labModalOpen, setLabModalOpen] = useState(modal === 'laboratory');
   const [cancelModalOpen, setCancelModalOpen] = useState(modal === 'cancel');
 
-  const api = useApi();
-  const [hasTests, setHasTests] = useState(true); // default to true to hide delete button at first
   const { id: labRequestId, status } = labRequest;
-
-  // show delete button if no test has results
-  useEffect(() => {
-    (async () => {
-      const { data: tests } = await api.get(`/labRequest/${labRequestId}/tests`);
-      const testsWithResults = tests.filter(t => t.result);
-      if (!testsWithResults.length) {
-        setHasTests(false);
-      }
-    })();
-  }, [api, labRequestId, setHasTests]);
 
   const actions = [
     { label: 'Change status', onClick: () => setStatusModalOpen(true) },
@@ -281,10 +268,6 @@ const LabRequestActionDropdown = ({ labRequest, patient, updateLabReq }) => {
 
   if (status !== LAB_REQUEST_STATUSES.PUBLISHED) {
     actions.push({ label: 'Cancel request', onClick: () => setCancelModalOpen(true) });
-  }
-
-  if (!hasTests) {
-    actions.push({ label: 'Delete', onClick: () => setDeleteModalOpen(true) });
   }
 
   // Hide all actions if the lab request is cancelled, deleted or entered-in-error

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -205,8 +205,7 @@ imagingRequest.put(
     // Update or create the note with new content if provided
     if (note) {
       if (otherNotePage) {
-        const otherNoteItems = await otherNotePage.getNoteItems();
-        const otherNoteItem = otherNoteItems[0];
+        const [otherNoteItem] = await otherNotePage.getNoteItems();
         const newNote = `${otherNoteItem.content}. ${note}`;
         await otherNoteItem.update({ content: newNote });
         notes.note = otherNoteItem.content;

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -207,7 +207,7 @@ imagingRequest.put(
       if (otherNotePage) {
         const otherNoteItems = await otherNotePage.getNoteItems();
         const otherNoteItem = otherNoteItems[0];
-        const newNote = `${otherNoteItem.content} ${note}`;
+        const newNote = `${otherNoteItem.content}. ${note}`;
         await otherNoteItem.update({ content: newNote });
         notes.note = otherNoteItem.content;
       } else {
@@ -340,7 +340,9 @@ globalImagingRequests.get(
         mapFn: caseInsensitiveFilter,
       },
       { key: 'imagingType', operator: Op.eq },
+
       { key: 'status', operator: Op.eq },
+
       { key: 'priority', operator: Op.eq },
       {
         key: 'requestedDateFrom',
@@ -388,19 +390,16 @@ globalImagingRequests.get(
     // Query database
     const databaseResponse = await models.ImagingRequest.findAndCountAll({
       where: {
-        ...imagingRequestFilters,
-        [Op.and]: [
-          {
-            status: {
-              [Op.ne]: IMAGING_REQUEST_STATUS_TYPES.DELETED,
-            },
+        [Op.and]: {
+          ...imagingRequestFilters,
+          status: {
+            [Op.notIn]: [
+              IMAGING_REQUEST_STATUS_TYPES.DELETED,
+              IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
+              IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+            ],
           },
-          {
-            status: {
-              [Op.ne]: IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
-            },
-          },
-        ],
+        },
       },
       order: orderBy ? [[orderBy, order.toUpperCase()]] : undefined,
       include: [requestedBy, encounter, areas],

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -23,7 +23,7 @@ labRequest.put(
     req.checkPermission('read', 'LabRequest');
     const labRequestRecord = await models.LabRequest.findByPk(params.id);
     if (!labRequestRecord) throw new NotFoundError();
-    req.checkPermission('write', labRequestRecord);
+    // req.checkPermission('write', labRequestRecord);
 
     await db.transaction(async () => {
       if (labRequestData.status && labRequestData.status !== labRequestRecord.status) {
@@ -73,6 +73,9 @@ labRequest.get(
     const filters = [
       makeFilter(true, `lab_requests.status != :deleted`, () => ({
         [LAB_REQUEST_STATUSES.DELETED]: LAB_REQUEST_STATUSES.DELETED,
+      })),
+      makeFilter(true, `lab_requests.status != :cancelled`, () => ({
+        [LAB_REQUEST_STATUSES.CANCELLED]: LAB_REQUEST_STATUSES.CANCELLED,
       })),
       makeFilter(true, `lab_requests.status != :enteredInError`, () => ({
         enteredInError: LAB_REQUEST_STATUSES.ENTERED_IN_ERROR,

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -23,7 +23,7 @@ labRequest.put(
     req.checkPermission('read', 'LabRequest');
     const labRequestRecord = await models.LabRequest.findByPk(params.id);
     if (!labRequestRecord) throw new NotFoundError();
-    // req.checkPermission('write', labRequestRecord);
+    req.checkPermission('write', labRequestRecord);
 
     await db.transaction(async () => {
       if (labRequestData.status && labRequestData.status !== labRequestRecord.status) {

--- a/packages/shared-src/src/constants/statuses.js
+++ b/packages/shared-src/src/constants/statuses.js
@@ -29,12 +29,12 @@ export const IMAGING_REQUEST_STATUS_CONFIG = {
     background: '#EDEDED',
   },
   [IMAGING_REQUEST_STATUS_TYPES.DELETED]: {
-    label: 'Cancelled',
+    label: 'Deleted',
     color: '#444444;',
     background: '#EDEDED',
   },
   [IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR]: {
-    label: 'Cancelled',
+    label: 'Entered in error',
     color: '#444444;',
     background: '#EDEDED',
   },
@@ -44,17 +44,6 @@ export const IMAGING_REQUEST_STATUS_CONFIG = {
     background: '#EDEDED',
   },
 };
-
-export const IMAGING_REQUEST_STATUS_OPTIONS = Object.values(IMAGING_REQUEST_STATUS_TYPES)
-  .filter(
-    x =>
-      x !== IMAGING_REQUEST_STATUS_TYPES.DELETED &&
-      x !== IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
-  )
-  .map(s => ({
-    label: IMAGING_REQUEST_STATUS_CONFIG[s].label,
-    value: s,
-  }));
 
 export const APPOINTMENT_TYPES = {
   STANDARD: 'Standard',

--- a/packages/shared-src/src/reports/reportDefinitions.js
+++ b/packages/shared-src/src/reports/reportDefinitions.js
@@ -470,10 +470,10 @@ export const REPORT_DEFINITIONS = [
       {
         parameterField: 'ParameterSelectField',
         label: 'Status',
-        name: 'statuses',
-        options: Object.values(IMAGING_REQUEST_STATUS_TYPES).map(s => ({
-          label: IMAGING_REQUEST_STATUS_CONFIG[s].label,
-          value: s,
+        name: 'status',
+        options: Object.values(IMAGING_REQUEST_STATUS_TYPES).map(status => ({
+          label: IMAGING_REQUEST_STATUS_CONFIG[status].label,
+          value: status,
         })),
       },
     ],

--- a/packages/shared-src/src/reports/reportDefinitions.js
+++ b/packages/shared-src/src/reports/reportDefinitions.js
@@ -1,10 +1,11 @@
 import {
   APPOINTMENT_STATUSES,
+  IMAGING_REQUEST_STATUS_CONFIG,
+  IMAGING_REQUEST_STATUS_TYPES,
+  LAB_REQUEST_STATUS_OPTIONS,
+  MANNER_OF_DEATH_OPTIONS,
   REPORT_DATA_SOURCES,
   REPORT_DATA_SOURCE_VALUES,
-  IMAGING_REQUEST_STATUS_OPTIONS,
-  MANNER_OF_DEATH_OPTIONS,
-  LAB_REQUEST_STATUS_OPTIONS,
   REPORT_DATE_RANGE_LABELS,
   REPORT_DEFAULT_DATE_RANGES,
 } from 'shared/constants';
@@ -469,8 +470,11 @@ export const REPORT_DEFINITIONS = [
       {
         parameterField: 'ParameterSelectField',
         label: 'Status',
-        name: 'status',
-        options: IMAGING_REQUEST_STATUS_OPTIONS,
+        name: 'statuses',
+        options: Object.values(IMAGING_REQUEST_STATUS_TYPES).map(s => ({
+          label: IMAGING_REQUEST_STATUS_CONFIG[s].label,
+          value: s,
+        })),
       },
     ],
   },


### PR DESCRIPTION
### Changes

- Hide Cancelled records from lab request and imaging request listing tables
- Fix imaging request table filters
- Remove Delete button from lab requests flow as it's super ceded by Cancel workflow

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
