### PR TITLE
EPI-368: Create unique index in UserLocalisationCache

### DIFF
--- a/packages/lan/app/middleware/auth.js
+++ b/packages/lan/app/middleware/auth.js
@@ -95,6 +95,7 @@ async function localLogin(models, email, password) {
 
   const localisation = await models.UserLocalisationCache.getLocalisation({
     where: { userId: user.id },
+    order: [['createdAt', 'DESC']],
   });
 
   const token = getToken(user);

--- a/packages/lan/app/middleware/auth.js
+++ b/packages/lan/app/middleware/auth.js
@@ -60,14 +60,11 @@ export async function centralServerLogin(models, email, password) {
   const { id, ...userDetails } = user;
 
   await models.User.sequelize.transaction(async () => {
-    await models.User.upsert(
-      {
-        id,
-        ...userDetails,
-        password,
-      },
-      { where: { id } },
-    );
+    await models.User.upsert({
+      id,
+      ...userDetails,
+      password,
+    });
     await models.UserLocalisationCache.upsert({
       userId: id,
       localisation: JSON.stringify(localisation),

--- a/packages/shared-src/src/migrations/1676414365356-addUserIdIndexToUserLocalisationCache.js
+++ b/packages/shared-src/src/migrations/1676414365356-addUserIdIndexToUserLocalisationCache.js
@@ -1,0 +1,30 @@
+export async function up(query) {
+  // Get rid of all records except one per user ID
+  const temporaryTable = `temp_table_user_localisation_caches_${Date.now()}`;
+  await query.sequelize.query(`
+  CREATE TABLE ${temporaryTable} AS
+    (SELECT *
+    FROM user_localisation_caches
+    WHERE id IN (
+      SELECT DISTINCT ON (user_id) id
+      FROM user_localisation_caches
+      WHERE localisation IS NOT NULL
+      ORDER BY user_id, created_at DESC
+    ));
+  `);
+  await query.sequelize.query(`TRUNCATE TABLE user_localisation_caches`); // this bit destructive, can't be downed
+  await query.sequelize.query(`
+    INSERT INTO user_localisation_caches
+    SELECT * FROM ${temporaryTable};
+  `);
+  await query.sequelize.query(`DROP TABLE ${temporaryTable}`);
+
+  await query.addIndex('user_localisation_caches', {
+    fields: ['user_id'],
+    unique: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeIndex('user_localisation_caches', ['user_id']);
+}

--- a/packages/shared-src/src/models/UserLocalisationCache.js
+++ b/packages/shared-src/src/models/UserLocalisationCache.js
@@ -12,7 +12,11 @@ export class UserLocalisationCache extends Model {
           allowNull: false,
         },
       },
-      { ...options, syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC,
+        indexes: [{ fields: ['user_id'], unique: true }],
+      },
     );
   }
 


### PR DESCRIPTION
### Changes

Doing a local login would bring an out of date localisation and also we were creating new records and piling them up for no reason, this changes that.

I do wonder if we should get rid of the order clause because it's not going to do anything now, but at the same time, it doesn't really hurt?