### PR TITLE
TAN-2066: Fix Patient Navigation

### DIFF
--- a/packages/desktop/app/constants/patientPaths.js
+++ b/packages/desktop/app/constants/patientPaths.js
@@ -27,3 +27,14 @@ export const PATIENT_PATHS = {
   LAB_REQUEST: LAB_REQUEST_PATH,
   IMAGING_REQUEST: IMAGING_REQUEST_PATH,
 };
+
+export const PATIENT_TABS = {
+  HISTORY: 'history',
+  DETAILS: 'details',
+  REFERRALS: 'Referrals',
+  PROGRAMS: 'Programs',
+  DOCUMENTS: 'documents',
+  IMMUNISATION: 'a',
+  MEDICATION: 'medication',
+  INVOICES: 'invoices',
+};

--- a/packages/desktop/app/constants/patientPaths.js
+++ b/packages/desktop/app/constants/patientPaths.js
@@ -31,10 +31,10 @@ export const PATIENT_PATHS = {
 export const PATIENT_TABS = {
   HISTORY: 'history',
   DETAILS: 'details',
-  REFERRALS: 'Referrals',
-  PROGRAMS: 'Programs',
+  REFERRALS: 'referrals',
+  PROGRAMS: 'programs',
   DOCUMENTS: 'documents',
-  IMMUNISATION: 'a',
+  IMMUNISATION: 'immunisation',
   MEDICATION: 'medication',
   INVOICES: 'invoices',
 };

--- a/packages/desktop/app/routes/PatientRoutes.js
+++ b/packages/desktop/app/routes/PatientRoutes.js
@@ -25,7 +25,7 @@ export const usePatientRoutes = () => {
   const { encounter } = useEncounter();
   return [
     {
-      path: `${PATIENT_PATHS.PATIENT}/:modal?/:tab?`,
+      path: `${PATIENT_PATHS.PATIENT}`,
       component: PatientView,
       navigateTo: () => navigateToPatient(patient.id),
       title: getPatientNameAsString(patient || {}),

--- a/packages/desktop/app/routes/PatientRoutes.js
+++ b/packages/desktop/app/routes/PatientRoutes.js
@@ -25,7 +25,7 @@ export const usePatientRoutes = () => {
   const { encounter } = useEncounter();
   return [
     {
-      path: `${PATIENT_PATHS.PATIENT}`,
+      path: PATIENT_PATHS.PATIENT,
       component: PatientView,
       navigateTo: () => navigateToPatient(patient.id),
       title: getPatientNameAsString(patient || {}),

--- a/packages/desktop/app/utils/usePatientNavigation.js
+++ b/packages/desktop/app/utils/usePatientNavigation.js
@@ -24,24 +24,20 @@ export const usePatientNavigation = () => {
     );
   };
 
-  const navigateToPatient = (patientId, modal, tab) => {
+  const navigateToPatient = (patientId, search) => {
     const existingParams = getParams(PATIENT_PATHS.CATEGORY);
-    navigate(
-      generatePath(`${PATIENT_PATHS.PATIENT}/:modal?/:tab?`, {
-        ...existingParams,
-        patientId,
-        modal,
-        tab,
-      }),
-    );
+    const patientRoute = generatePath(PATIENT_PATHS.PATIENT, {
+      ...existingParams,
+      patientId,
+    });
+    navigate(`${patientRoute}${search ? `?${new URLSearchParams(search)}` : ''}`);
   };
 
-  const navigateToEncounter = (encounterId, modal, search) => {
+  const navigateToEncounter = (encounterId, search) => {
     const existingParams = getParams(PATIENT_PATHS.PATIENT);
-    const encounterRoute = generatePath(`${PATIENT_PATHS.ENCOUNTER}/:modal?`, {
+    const encounterRoute = generatePath(PATIENT_PATHS.ENCOUNTER, {
       ...existingParams,
       encounterId,
-      modal,
     });
     navigate(`${encounterRoute}${search ? `?${new URLSearchParams(search)}` : ''}`);
   };
@@ -55,6 +51,7 @@ export const usePatientNavigation = () => {
     );
   };
 
+  // @todo: refactor modal that is used in lab request printing
   const navigateToLabRequest = (labRequestId, modal) => {
     const existingParams = getParams(PATIENT_PATHS.ENCOUNTER);
     navigate(
@@ -66,6 +63,7 @@ export const usePatientNavigation = () => {
     );
   };
 
+  // @todo: refactor modal that is used in imaging request printing
   const navigateToImagingRequest = (imagingRequestId, modal) => {
     const existingParams = getParams(PATIENT_PATHS.ENCOUNTER);
     navigate(

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { Divider, Box } from '@material-ui/core';
@@ -122,7 +122,7 @@ export const EncounterView = () => {
   const { getLocalisation } = useLocalisation();
   const patient = useSelector(state => state.patient);
   const { encounter, isLoadingEncounter } = useEncounter();
-  const [currentTab, setCurrentTab] = React.useState(query.get('tab') || 'vitals');
+  const [currentTab, setCurrentTab] = useState(query.get('tab') || ENCOUNTER_TAB_NAMES.VITALS);
   const disabled = encounter?.endDate || patient.death;
 
   if (!encounter || isLoadingEncounter || patient.loading) return <LoadingIndicator />;

--- a/packages/desktop/app/views/patients/PatientView.js
+++ b/packages/desktop/app/views/patients/PatientView.js
@@ -1,15 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
-
 import { TabDisplay } from '../../components/TabDisplay';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { PatientAlert } from '../../components/PatientAlert';
 import { useLocalisation } from '../../contexts/Localisation';
 import { useApi } from '../../api';
-
 import {
   HistoryPane,
   ImmunisationsPane,
@@ -21,7 +18,9 @@ import {
   PatientDetailsPane,
 } from './panes';
 import { Colors } from '../../constants';
+import { PATIENT_TABS } from '../../constants/patientPaths';
 import { NAVIGATION_CONTAINER_HEIGHT } from '../../components/PatientNavigation';
+import { useUrlSearchParams } from '../../utils/useUrlSearchParams';
 
 const StyledDisplayTabs = styled(TabDisplay)`
   overflow: initial;
@@ -36,25 +35,25 @@ const StyledDisplayTabs = styled(TabDisplay)`
 const TABS = [
   {
     label: 'History',
-    key: 'history',
+    key: PATIENT_TABS.HISTORY,
     icon: 'fa fa-calendar-day',
     render: props => <HistoryPane {...props} />,
   },
   {
     label: 'Details',
-    key: 'details',
+    key: PATIENT_TABS.DETAILS,
     icon: 'fa fa-info-circle',
     render: props => <PatientDetailsPane {...props} />,
   },
   {
     label: 'Referrals',
-    key: 'Referrals',
+    key: PATIENT_TABS.REFERRALS,
     icon: 'fa fa-hospital',
     render: props => <ReferralPane {...props} />,
   },
   {
     label: 'Programs',
-    key: 'Programs',
+    key: PATIENT_TABS.PROGRAMS,
     icon: 'fa fa-hospital',
     render: ({ patient, ...props }) => (
       <PatientProgramsPane endpoint={`patient/${patient.id}/programResponses`} {...props} />
@@ -62,38 +61,35 @@ const TABS = [
   },
   {
     label: 'Documents',
-    key: 'documents',
+    key: PATIENT_TABS.DOCUMENTS,
     icon: 'fa fa-file-medical-alt',
     render: props => <DocumentsPane {...props} />,
   },
   {
     label: 'Immunisation',
-    key: 'a',
+    key: PATIENT_TABS.IMMUNISATION,
     icon: 'fa fa-syringe',
     render: props => <ImmunisationsPane {...props} />,
   },
   {
     label: 'Medication',
-    key: 'medication',
+    key: PATIENT_TABS.MEDICATION,
     icon: 'fa fa-medkit',
     render: props => <PatientMedicationPane {...props} />,
   },
   {
     label: 'Invoices',
-    key: 'invoices',
+    key: PATIENT_TABS.INVOICES,
     icon: 'fa fa-cash-register',
     render: props => <InvoicesPane {...props} />,
-    condition: getLocalisation => getLocalisation('features.enableInvoicing'),
   },
 ];
 
 export const PatientView = () => {
   const { getLocalisation } = useLocalisation();
+  const query = useUrlSearchParams();
   const patient = useSelector(state => state.patient);
-  const { tab } = useParams();
-  const [currentTab, setCurrentTab] = React.useState(
-    TABS.find(t => t.key === tab) ? tab : 'history',
-  );
+  const [currentTab, setCurrentTab] = useState(query.get('tab') || PATIENT_TABS.HISTORY);
   const disabled = !!patient.death;
   const api = useApi();
   const { data: additionalData, isLoading: isLoadingAdditionalData } = useQuery(
@@ -109,7 +105,7 @@ export const PatientView = () => {
     return <LoadingIndicator />;
   }
 
-  const visibleTabs = TABS.filter(t => !t.condition || t.condition(getLocalisation));
+  const visibleTabs = TABS.filter(tab => !tab.condition || tab.condition(getLocalisation));
 
   return (
     <>

--- a/packages/desktop/app/views/programs/ProgramsView.js
+++ b/packages/desktop/app/views/programs/ProgramsView.js
@@ -1,13 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
-
 import { useSelector, useDispatch } from 'react-redux';
 import { useApi } from 'desktop/app/api';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { SURVEY_TYPES } from 'shared/constants';
-
 import { reloadPatient } from 'desktop/app/store/patient';
 import { getCurrentUser } from 'desktop/app/store/auth';
-
 import { SurveyView } from 'desktop/app/views/programs/SurveyView';
 import { SurveySelector } from 'desktop/app/views/programs/SurveySelector';
 import { FormGrid } from 'desktop/app/components/FormGrid';
@@ -20,9 +17,12 @@ import {
 import { LoadingIndicator } from 'desktop/app/components/LoadingIndicator';
 import { PatientListingView } from 'desktop/app/views';
 import { getAnswersFromData, getActionsFromData } from '../../utils';
+import { usePatientNavigation } from '../../utils/usePatientNavigation';
+import { PATIENT_TABS } from '../../constants/patientPaths';
 
 const SurveyFlow = ({ patient, currentUser }) => {
   const api = useApi();
+  const { navigateToPatient } = usePatientNavigation();
   const [survey, setSurvey] = useState(null);
   const [programs, setPrograms] = useState(null);
   const [selectedProgramId, setSelectedProgramId] = useState(null);
@@ -67,18 +67,17 @@ const SurveyFlow = ({ patient, currentUser }) => {
     [api, selectedProgramId],
   );
 
-  const submitSurveyResponse = useCallback(
-    data =>
-      api.post('surveyResponse', {
-        surveyId: survey.id,
-        startTime,
-        patientId: patient.id,
-        endTime: getCurrentDateTimeString(),
-        answers: getAnswersFromData(data, survey),
-        actions: getActionsFromData(data, survey),
-      }),
-    [api, startTime, survey, patient],
-  );
+  const submitSurveyResponse = async data => {
+    navigateToPatient(patient.id, { tab: PATIENT_TABS.PROGRAMS });
+    await api.post('surveyResponse', {
+      surveyId: survey.id,
+      startTime,
+      patientId: patient.id,
+      endTime: getCurrentDateTimeString(),
+      answers: getAnswersFromData(data, survey),
+      actions: getActionsFromData(data, survey),
+    });
+  };
 
   if (!programs) {
     return <LoadingIndicator />;

--- a/packages/desktop/app/views/programs/SurveyView.js
+++ b/packages/desktop/app/views/programs/SurveyView.js
@@ -1,11 +1,10 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { Form } from 'desktop/app/components/Field';
 import { checkVisibility, getFormInitialValues, getValidationSchema } from 'desktop/app/utils';
 import { ProgramsPane, ProgramsPaneHeader, ProgramsPaneHeading } from './ProgramsPane';
 import { Colors } from '../../constants';
 import { SurveyScreenPaginator } from '../../components/Surveys';
-import { usePatientNavigation } from '../../utils/usePatientNavigation';
 
 export const SurveyPaneHeader = styled(ProgramsPaneHeader)`
   background: ${props => props.theme.palette.primary.main};
@@ -22,15 +21,10 @@ export const SurveyView = ({ survey, onSubmit, onCancel, patient, currentUser })
   const { components } = survey;
   const initialValues = getFormInitialValues(components, patient, currentUser);
   const validationSchema = useMemo(() => getValidationSchema(survey), [survey]);
-  const { navigateToPatient } = usePatientNavigation();
 
-  const onSubmitSurvey = useCallback(
-    async data => {
-      await onSubmit(data);
-      navigateToPatient(patient.id, undefined, 'Programs');
-    },
-    [onSubmit, navigateToPatient, patient.id],
-  );
+  const onSubmitSurvey = data => {
+    onSubmit(data);
+  };
 
   const renderSurvey = props => {
     const {
@@ -76,23 +70,19 @@ export const SurveyView = ({ survey, onSubmit, onCancel, patient, currentUser })
     );
   };
 
-  const surveyContents = (
-    <Form
-      initialValues={initialValues}
-      onSubmit={onSubmitSurvey}
-      render={renderSurvey}
-      validationSchema={validationSchema}
-      validateOnChange
-      validateOnBlur
-    />
-  );
-
   return (
     <ProgramsPane>
       <SurveyPaneHeader>
         <SurveyPaneHeading variant="h6">{survey.name}</SurveyPaneHeading>
       </SurveyPaneHeader>
-      {surveyContents}
+      <Form
+        initialValues={initialValues}
+        onSubmit={onSubmitSurvey}
+        render={renderSurvey}
+        validationSchema={validationSchema}
+        validateOnChange
+        validateOnBlur
+      />
     </ProgramsPane>
   );
 };

--- a/packages/desktop/app/views/referrals/ReferralsView.js
+++ b/packages/desktop/app/views/referrals/ReferralsView.js
@@ -12,9 +12,12 @@ import { SurveySelector } from '../programs/SurveySelector';
 import { ProgramsPane, ProgramsPaneHeader, ProgramsPaneHeading } from '../programs/ProgramsPane';
 import { getCurrentUser } from '../../store';
 import { getAnswersFromData, getActionsFromData } from '../../utils';
+import { PATIENT_TABS } from '../../constants/patientPaths';
+import { usePatientNavigation } from '../../utils/usePatientNavigation';
 
 const ReferralFlow = ({ patient, currentUser }) => {
   const api = useApi();
+  const { navigateToPatient } = usePatientNavigation();
   const [referralSurvey, setReferralSurvey] = useState(null);
   const [referralSurveys, setReferralSurveys] = useState(null);
   const [startTime, setStartTime] = useState(null);
@@ -39,19 +42,18 @@ const ReferralFlow = ({ patient, currentUser }) => {
     setReferralSurvey(null);
   }, []);
 
-  const submitReferral = useCallback(
-    data => {
-      api.post('referral', {
-        surveyId: referralSurvey.id,
-        startTime,
-        patientId: patient.id,
-        endTime: getCurrentDateTimeString(),
-        answers: getAnswersFromData(data, referralSurvey),
-        actions: getActionsFromData(data, referralSurvey),
-      });
-    },
-    [api, referralSurvey, startTime, patient],
-  );
+  const submitReferral = async data => {
+    await api.post('referral', {
+      surveyId: referralSurvey.id,
+      startTime,
+      patientId: patient.id,
+      endTime: getCurrentDateTimeString(),
+      answers: getAnswersFromData(data, referralSurvey),
+      actions: getActionsFromData(data, referralSurvey),
+    });
+
+    navigateToPatient(patient.id, { tab: PATIENT_TABS.REFERRALS });
+  };
 
   if (!referralSurvey) {
     return (


### PR DESCRIPTION
### Changes

- Fix the patient routes issue that was found in regression testing (see [Slack](https://beyondessential.slack.com/archives/GE9NHB95F/p1676504083496309thread). The tab url param clashes with other patient routes causing two routes to be rendered at the same time
- Add support for deep linking to patient tabs using a tab query string parameter in the same way as we do for encounter tabs
- Redirect user to Programs and Referrals tab after submitting a Programs or Referrals survey

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
