### PR TITLE
EPI-376: DB-defined reports should use ISO 9075 dates

### DIFF
--- a/packages/lan/app/routes/apiv1/reports.js
+++ b/packages/lan/app/routes/apiv1/reports.js
@@ -46,6 +46,7 @@ reports.get(
         id: version.id,
         name: r.name,
         dataSourceOptions: version.queryOptions.dataSources,
+        filterDateRangeAsStrings: true,
         dateRangeLabel:
           version.queryOptions.dateRangeLabel ||
           REPORT_DATE_RANGE_LABELS[version.queryOptions.defaultDateRange],


### PR DESCRIPTION
### Changes

There's a flag `filterDateRangeAsStrings` that toggles whether reports for the human-readable date "23/01/2023" get dates in the format `2023-01-22T13:00:00.000Z` or `2023-01-23` — no, that's not a typo, the first date has the wrong day. Because the first format can be on the wrong day depending on user timezone, and because there's no way to work out what the right day would have been, we're going to enable `filterDateRangeAsStrings` for all database-defined reports while there are relative few and we've still got control over them.

This is causing bugs in Fiji Aspen, and hotfixing it will allow us to fix them reliably. Our existing reports mean that a release step will have to be added to 1.24.3 to import a new report version without hacky workarounds.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
