### PR TITLE
TAN-2071: Create new Search field and some UI/UX adjustments

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -229,6 +229,7 @@ class BaseAutocomplete extends Component {
 
   renderInputComponent = inputProps => {
     const { label, required, className, infoTooltip, tag, value, ...other } = inputProps;
+    const { suggestions } = this.state;
     return (
       <OuterLabelFieldWrapper
         label={label}
@@ -248,7 +249,7 @@ class BaseAutocomplete extends Component {
                   </SelectTag>
                 )}
                 <Icon position="end">
-                  {className?.includes('open') ? <ExpandLess /> : <ExpandMore />}
+                  {suggestions.length > 0 ? <ExpandLess /> : <ExpandMore />}
                 </Icon>
               </>
             ),

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import Autosuggest from 'react-autosuggest';
 import { debounce } from 'lodash';
 import { MenuItem, Popper, Paper, Typography, InputAdornment } from '@material-ui/core';
-import Search from '@material-ui/icons/Search';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import ExpandLess from '@material-ui/icons/ExpandLess';
 import { OuterLabelFieldWrapper } from './OuterLabelFieldWrapper';
 import { Colors } from '../../constants';
 import { StyledTextField } from './TextField';
@@ -52,7 +53,7 @@ const SuggestionsList = styled(Paper)`
 
 const Icon = styled(InputAdornment)`
   .MuiSvgIcon-root {
-    color: ${props => props.theme.palette.text.secondary};
+    color: ${Colors.softText};
     font-size: 20px;
   }
 `;
@@ -228,7 +229,6 @@ class BaseAutocomplete extends Component {
 
   renderInputComponent = inputProps => {
     const { label, required, className, infoTooltip, tag, value, ...other } = inputProps;
-
     return (
       <OuterLabelFieldWrapper
         label={label}
@@ -248,7 +248,7 @@ class BaseAutocomplete extends Component {
                   </SelectTag>
                 )}
                 <Icon position="end">
-                  <Search />
+                  {className?.includes('open') ? <ExpandLess /> : <ExpandMore />}
                 </Icon>
               </>
             ),

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -32,6 +32,7 @@ const CheckField = ({ field }) => (
 export const DisplayIdField = () => (
   <FieldContainer
     name="displayId"
+    className="display-field"
     InputProps={{
       endAdornment: (
         <InputAdornment position="end">

--- a/packages/desktop/app/components/Field/OuterLabelFieldWrapper.js
+++ b/packages/desktop/app/components/Field/OuterLabelFieldWrapper.js
@@ -53,7 +53,7 @@ export const OuterLabelFieldWrapper = React.memo(
   React.forwardRef(({ children, required, label, infoTooltip, style, className }, ref) => (
     <div style={style} className={className} ref={ref}>
       {label && (
-        <OuterLabel>
+        <OuterLabel className="label-field">
           {label}
           {required && <OuterLabelRequired>*</OuterLabelRequired>}
         </OuterLabel>

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import Search from '@material-ui/icons/Search';
+import { InputAdornment } from '@material-ui/core';
+import styled from 'styled-components';
+import { TextField } from './TextField';
+import { Colors } from '../../constants';
+
+const Icon = styled(InputAdornment)`
+  .MuiSvgIcon-root {
+    color: ${Colors.softText};
+    font-size: 13px;
+  }
+`;
+
+const StyledTextField = styled(TextField)`
+  .MuiInputBase-input {
+    padding-left: 7px;
+  }
+`;
+
+export const SearchField = props => {
+  return (
+    <StyledTextField
+      InputProps={{
+        startAdornment: (
+          <Icon position="start">
+            <Search />
+          </Icon>
+        ),
+      }}
+      placeholder={props?.label ? `Search ${props?.label}` : ''}
+      {...props}
+    />
+  );
+};

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Search from '@material-ui/icons/Search';
 import { InputAdornment } from '@material-ui/core';
 import styled from 'styled-components';
@@ -28,7 +28,7 @@ export const SearchField = props => {
           </Icon>
         ),
       }}
-      placeholder={props?.label ? `search ${props?.label}` : ''}
+      placeholder={props?.label ? `Search ${props?.label.toLowerCase()}` : ''}
       {...props}
     />
   );

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -28,7 +28,7 @@ export const SearchField = props => {
           </Icon>
         ),
       }}
-      placeholder={props?.label ? `Search ${props?.label}` : ''}
+      placeholder={props?.label ? `search ${props?.label}` : ''}
       {...props}
     />
   );

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import Search from '@material-ui/icons/Search';
 import { InputAdornment } from '@material-ui/core';
 import styled from 'styled-components';

--- a/packages/desktop/app/components/Field/TextField.js
+++ b/packages/desktop/app/components/Field/TextField.js
@@ -15,7 +15,7 @@ export const StyledTextField = styled(MuiTextField)`
     ${props =>
       props.style?.color ? `color: ${props.style.color}` : `color: ${Colors.darkestText}`};
     padding: 13px 12px 13px 15px;
-    font-size: 15px;
+    ${props => (props.style?.fontSize ? `font-size: ${props.style.fontSize}` : `font-size: 15px`)};
     line-height: 18px;
     ${props => (props.style?.minHeight ? `min-height: ${props.style.minHeight}` : '')};
     ${props => (props.style?.padding ? `padding: ${props.style.padding}` : '')};
@@ -42,6 +42,11 @@ export const StyledTextField = styled(MuiTextField)`
   // Focused state
   .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
     border: 1px solid ${props => props.theme.palette.primary.main};
+  }
+
+  // Place holder color when focused
+  .MuiInputBase-input:focus::-webkit-input-placeholder {
+    color: ${Colors.midText};
   }
 
   .MuiFormLabel-root.Mui-focused {

--- a/packages/desktop/app/components/Field/index.js
+++ b/packages/desktop/app/components/Field/index.js
@@ -15,6 +15,7 @@ export * from './SurveyResponseSelectField';
 export * from './TextField';
 export * from './UnsupportedPhotoField';
 export * from './ImagingPriorityField';
+export * from './SearchField';
 
 // fancy fields
 export * from './ArrayField';

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -7,6 +7,7 @@ import {
   LocalisedField,
   DisplayIdField,
   DOBFields,
+  SearchField,
 } from '../Field';
 import { useSuggester } from '../../api';
 
@@ -15,16 +16,22 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
   return (
     <CustomisableSearchBar
       title="Search for Patients"
+      variant="small"
       renderCheckField={
         <Field name="deceased" label="Include deceased patients" component={CheckField} />
       }
       onSearch={onSearch}
       initialValues={{ displayIdExact: true, ...searchParameters }}
     >
-      <LocalisedField name="firstName" />
-      <LocalisedField name="lastName" />
-      <LocalisedField name="culturalName" />
-      <LocalisedField name="villageId" component={AutocompleteField} suggester={villageSuggester} />
+      <LocalisedField component={SearchField} name="firstName" />
+      <LocalisedField component={SearchField} name="lastName" />
+      <LocalisedField component={SearchField} name="culturalName" />
+      <LocalisedField
+        name="villageId"
+        component={AutocompleteField}
+        suggester={villageSuggester}
+        style={{ fontSize: '11px' }}
+      />
       <DisplayIdField />
       <DOBFields />
     </CustomisableSearchBar>

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -11,6 +11,22 @@ const Container = styled.div`
   padding: 16px 30px 28px;
 `;
 
+const SmallContainer = styled(Container)`
+  font-size: 11px;
+  .MuiInputBase-input {
+    font-size: 11px;
+  }
+  .label-field {
+    font-size: 11px;
+  }
+
+  .display-field {
+    .MuiSvgIcon-root {
+      font-size: 16px;
+    }
+  }
+`;
+
 const SectionLabel = styled.div`
   font-size: 16px;
   font-weight: 500;
@@ -30,34 +46,39 @@ export const CustomisableSearchBar = ({
   onSearch,
   children,
   renderCheckField,
+  variant = 'normal',
   initialValues = {},
-}) => (
-  <Container>
-    <SectionLabel>{title}</SectionLabel>
-    <Form
-      onSubmit={onSearch}
-      render={({ submitForm, clearForm }) => (
-        <>
-          <SearchInputContainer>{children}</SearchInputContainer>
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="space-between"
-            style={{ marginTop: 20 }}
-          >
-            {renderCheckField}
-            <Box marginLeft="auto">
-              <LargeOutlineButton style={{ marginRight: 12 }} onClick={clearForm}>
-                Clear search
-              </LargeOutlineButton>
-              <LargeButton onClick={submitForm} type="submit">
-                Search
-              </LargeButton>
+}) => {
+  const ParentContainer = variant === 'small' ? SmallContainer : Container;
+
+  return (
+    <ParentContainer>
+      <SectionLabel>{title}</SectionLabel>
+      <Form
+        onSubmit={onSearch}
+        render={({ submitForm, clearForm }) => (
+          <>
+            <SearchInputContainer>{children}</SearchInputContainer>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="space-between"
+              style={{ marginTop: 20 }}
+            >
+              {renderCheckField}
+              <Box marginLeft="auto">
+                <LargeOutlineButton style={{ marginRight: 12 }} onClick={clearForm}>
+                  Clear search
+                </LargeOutlineButton>
+                <LargeButton onClick={submitForm} type="submit">
+                  Search
+                </LargeButton>
+              </Box>
             </Box>
-          </Box>
-        </>
-      )}
-      initialValues={initialValues}
-    />
-  </Container>
-);
+          </>
+        )}
+        initialValues={initialValues}
+      />
+    </ParentContainer>
+  );
+};

--- a/packages/desktop/app/components/SearchBar/PatientSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/PatientSearchBar.js
@@ -8,6 +8,7 @@ import {
   LocalisedField,
   DisplayIdField,
   DateField,
+  SearchField,
 } from '../Field';
 import { useSuggester } from '../../api';
 
@@ -23,14 +24,15 @@ export const PatientSearchBar = React.memo(
     return (
       <CustomisableSearchBar
         title="Search for Patients"
+        variant="small"
         renderCheckField={
           <Field name="deceased" label="Include deceased patients" component={CheckField} />
         }
         onSearch={onSearch}
         initialValues={{ displayIdExact: true, ...searchParameters }}
       >
-        <LocalisedField name="firstName" />
-        <LocalisedField name="lastName" />
+        <LocalisedField name="firstName" component={SearchField} />
+        <LocalisedField name="lastName" component={SearchField} />
         <Field
           name="dateOfBirthExact"
           label="DOB"


### PR DESCRIPTION
### Changes
- Created new Search field
- Changed the Auto complete field to use arrows to open and close
- UI/UX Adjustments on search patient's page


### Related to
https://linear.app/bes/issue/TAN-2071/create-new-search-fields-for-new-patient-search-table

### Screenshots
Smaller font-sizes / Height 
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/17033058/219470081-73d5e752-54dc-423b-b5cb-0d3f82aaf654.png">

Auto Complete with arrows:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/17033058/219470129-c0f34d4c-163f-40d6-b2e4-5ff39ecb80fa.png">

<img width="328" alt="image" src="https://user-images.githubusercontent.com/17033058/219470619-33ecae0e-bc86-4ebe-8b20-406da549a578.png">


New Search field
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/17033058/219470232-c2d9bef3-994f-41f2-9044-3f0fd491c4c4.png">

Fixed Labels
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/17033058/219470309-aa6cee56-78be-4697-9b40-8536f629cb13.png">


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
