### PR TITLE
EPI-355: Add visibility status to notes and patient death data

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientDeath.test.js
+++ b/packages/lan/__tests__/apiv1/PatientDeath.test.js
@@ -1,3 +1,4 @@
+import { VISIBILITY_STATUSES } from 'shared/constants/importable';
 import { fake } from 'shared/test-helpers/fake';
 import { toDateString } from 'shared/utils/dateTime';
 import { createTestContext } from '../utilities';
@@ -338,7 +339,9 @@ describe('PatientDeath', () => {
 
       const result = await app.post(`/v1/patient/${id}/revertDeath`).send({});
       expect(result).toHaveSucceeded();
-      const deathData = await PatientDeathData.findAll({ where: { patientId: id } });
+      const deathData = await PatientDeathData.findAll({
+        where: { patientId: id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      });
       expect(deathData.length).toBe(0);
     });
 
@@ -357,7 +360,9 @@ describe('PatientDeath', () => {
 
       const result = await app.post(`/v1/patient/${id}/revertDeath`).send({});
       expect(result).not.toHaveSucceeded();
-      const deathData = await PatientDeathData.findAll({ where: { patientId: id } });
+      const deathData = await PatientDeathData.findAll({
+        where: { patientId: id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      });
       expect(deathData.length).toBe(1);
     });
 

--- a/packages/lan/app/routeHandlers/labs/getLabRequestList.js
+++ b/packages/lan/app/routeHandlers/labs/getLabRequestList.js
@@ -1,4 +1,5 @@
 import asyncHandler from 'express-async-handler';
+import { VISIBILITY_STATUSES } from 'shared/constants/importable';
 
 import { NOTE_RECORD_TYPES } from 'shared/constants/notes';
 
@@ -60,7 +61,11 @@ export const getLabRequestList = (foreignKey = '', options = {}) =>
             as: 'noteItems',
           },
         ],
-        where: { recordId: labRequest.id, recordType: NOTE_RECORD_TYPES.LAB_REQUEST },
+        where: {
+          recordId: labRequest.id,
+          recordType: NOTE_RECORD_TYPES.LAB_REQUEST,
+          visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        },
       });
 
       labRequest.notePages = notePages;

--- a/packages/lan/app/routeHandlers/notes/notePageListHandler.js
+++ b/packages/lan/app/routeHandlers/notes/notePageListHandler.js
@@ -1,4 +1,5 @@
 import asyncHandler from 'express-async-handler';
+import { VISIBILITY_STATUSES } from 'shared/constants/importable';
 
 import { checkNotePermission } from '../../utils/checkNotePermission';
 
@@ -27,7 +28,7 @@ export const notePageListHandler = recordType =>
           ],
         },
       ],
-      where: { recordType, recordId },
+      where: { recordType, recordId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
       order: orderBy ? [[orderBy, order.toUpperCase()]] : undefined,
     });
 
@@ -55,6 +56,7 @@ export const notePagesWithSingleItemListHandler = recordType =>
       where: {
         recordId,
         recordType,
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
       },
       order: [['createdAt', 'ASC']],
     });

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -7,6 +7,7 @@ import {
   AREA_TYPE_TO_IMAGING_TYPE,
   IMAGING_AREA_TYPES,
   IMAGING_REQUEST_STATUS_TYPES,
+  VISIBILITY_STATUSES,
 } from 'shared/constants';
 import { NotFoundError } from 'shared/errors';
 import { toDateTimeString } from 'shared/utils/dateTime';
@@ -131,7 +132,9 @@ imagingRequest.get(
     };
 
     // Get related notes (general, area to be imaged)
-    const relatedNotePages = await imagingRequestObject.getNotePages();
+    const relatedNotePages = await imagingRequestObject.getNotePages({
+      where: { visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    });
 
     const otherNotePage = getNoteWithType(relatedNotePages, NOTE_TYPES.OTHER);
     const areaNotePage = getNoteWithType(relatedNotePages, NOTE_TYPES.AREA_TO_BE_IMAGED);
@@ -192,7 +195,9 @@ imagingRequest.put(
     }
 
     // Get related notes (general, area to be imaged)
-    const relatedNotePages = await imagingRequestObject.getNotePages();
+    const relatedNotePages = await imagingRequestObject.getNotePages({
+      where: { visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    });
 
     const otherNotePage = getNoteWithType(relatedNotePages, NOTE_TYPES.OTHER);
     const areaNotePage = getNoteWithType(relatedNotePages, NOTE_TYPES.AREA_TO_BE_IMAGED);

--- a/packages/lan/app/routes/apiv1/note/noteItems.js
+++ b/packages/lan/app/routes/apiv1/note/noteItems.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
+import { VISIBILITY_STATUSES } from 'shared/constants';
 
 import { checkNotePermission } from '../../../utils/checkNotePermission';
 
@@ -19,7 +20,9 @@ noteItemRoute.post(
       req.checkPermission('write', 'OtherPractitionerEncounterNote');
     }
 
-    const notePage = await models.NotePage.findByPk(notePageId);
+    const notePage = await models.NotePage.findOne({
+      where: { id: notePageId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    });
     await checkNotePermission(req, notePage, 'create');
 
     await models.NoteItem.create({
@@ -55,7 +58,9 @@ noteItemRoute.get(
     const { models, params } = req;
     const { notePageId } = params;
 
-    const notePage = await models.NotePage.findByPk(notePageId);
+    const notePage = await models.NotePage.findOne({
+      where: { id: notePageId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    });
     await checkNotePermission(req, notePage, 'list');
 
     const noteItems = await models.NoteItem.findAll({

--- a/packages/lan/app/routes/apiv1/note/notePages.js
+++ b/packages/lan/app/routes/apiv1/note/notePages.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { NotFoundError, ForbiddenError } from 'shared/errors';
-import { NOTE_RECORD_TYPES } from 'shared/constants';
+import { NOTE_RECORD_TYPES, VISIBILITY_STATUSES } from 'shared/constants';
 
 import { noteItems } from './noteItems';
 import { checkNotePermission } from '../../../utils/checkNotePermission';
@@ -126,16 +126,7 @@ notePageRoute.delete(
 
     req.checkPermission('write', notePageToDelete.recordType);
 
-    await req.models.NoteItem.destroy({
-      where: {
-        notePageId: req.params.id,
-      },
-    });
-    await req.models.NotePage.destroy({
-      where: {
-        id: req.params.id,
-      },
-    });
+    await notePageToDelete.update({ visibilityStatus: VISIBILITY_STATUSES.HISTORICAL });
 
     res.send({});
   }),

--- a/packages/lan/app/routes/apiv1/note/notePages.js
+++ b/packages/lan/app/routes/apiv1/note/notePages.js
@@ -114,7 +114,9 @@ notePageRoute.delete(
   '/:id',
   asyncHandler(async (req, res) => {
     const { models } = req;
-    const notePageToDelete = await models.NotePage.findByPk(req.params.id);
+    const notePageToDelete = await models.NotePage.findOne({
+      where: { id: req.params.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+    });
 
     if (!notePageToDelete) {
       throw new NotFoundError();

--- a/packages/lan/app/routes/apiv1/note/notePages.js
+++ b/packages/lan/app/routes/apiv1/note/notePages.js
@@ -62,7 +62,7 @@ notePageRoute.get(
           ],
         },
       ],
-      where: { id: notePageId },
+      where: { id: notePageId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
     });
 
     await checkNotePermission(req, notePage, 'read');
@@ -87,7 +87,7 @@ notePageRoute.put(
           ],
         },
       ],
-      where: { id: params.id },
+      where: { id: params.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
     });
 
     if (!editedNotePage) {

--- a/packages/lan/app/routes/apiv1/patient/patientCarePlan.js
+++ b/packages/lan/app/routes/apiv1/patient/patientCarePlan.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { NOTE_TYPES, NOTE_RECORD_TYPES } from 'shared/constants';
+import { NOTE_TYPES, NOTE_RECORD_TYPES, VISIBILITY_STATUSES } from 'shared/constants';
 import { InvalidParameterError } from 'shared/errors';
 
 import { simpleGet, simplePut } from '../crudHelpers';
@@ -55,6 +55,7 @@ patientCarePlan.get(
         recordId: params.id,
         recordType: NOTE_RECORD_TYPES.PATIENT_CARE_PLAN,
         noteType: NOTE_TYPES.TREATMENT_PLAN,
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
       },
       // TODO add test to verify this order
       order: [['createdAt', 'ASC']],

--- a/packages/lan/app/routes/apiv1/patient/patientDeath.js
+++ b/packages/lan/app/routes/apiv1/patient/patientDeath.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import { VISIBILITY_STATUSES } from 'shared/constants';
 import { InvalidOperationError, NotFoundError } from 'shared/errors';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import * as yup from 'yup';
@@ -310,7 +311,7 @@ patientDeath.post(
         revertedById: req.user.id,
       });
       await patient.update({ dateOfDeath: null });
-      await deathData.destroy();
+      await deathData.update({ visibilityStatus: VISIBILITY_STATUSES.HISTORICAL });
     });
 
     res.send({

--- a/packages/lan/app/routes/apiv1/patient/patientDeath.js
+++ b/packages/lan/app/routes/apiv1/patient/patientDeath.js
@@ -38,7 +38,8 @@ patientDeath.get(
     }
 
     const deathData = await PatientDeathData.findOne({
-      where: { patientId },
+      where: { patientId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      order: [['createdAt', 'DESC']],
       include: [
         {
           model: User,
@@ -213,7 +214,8 @@ patientDeath.post(
     if (!doc) throw new NotFoundError('Discharge clinician not found');
 
     const existingDeathData = await PatientDeathData.findOne({
-      where: { patientId: patient.id },
+      where: { patientId: patient.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      order: [['createdAt', 'DESC']],
     });
 
     await transactionOnPostgres(db, async () => {
@@ -297,7 +299,8 @@ patientDeath.post(
     if (!patient) throw new NotFoundError('Patient not found');
 
     const deathData = await PatientDeathData.findOne({
-      where: { patientId: patient.id },
+      where: { patientId: patient.id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+      order: [['createdAt', 'DESC']],
     });
     if (!deathData) throw new NotFoundError('Death data not found');
     if (deathData.isFinal)

--- a/packages/shared-src/src/migrations/1676591314361-addVisibilityStatusToNotesAndDeathData.js
+++ b/packages/shared-src/src/migrations/1676591314361-addVisibilityStatusToNotesAndDeathData.js
@@ -1,0 +1,18 @@
+import { DataTypes } from 'sequelize';
+
+const tables = ['patient_death_data', 'note_pages', 'note_items'];
+
+export async function up(query) {
+  for (const table of tables) {
+    await query.addColumn(table, 'visibility_status', {
+      type: DataTypes.TEXT,
+      defaultValue: 'current',
+    });
+  }
+}
+
+export async function down(query) {
+  for (const table of tables) {
+    await query.removeColumn(table, 'visibility_status');
+  }
+}

--- a/packages/shared-src/src/migrations/1676591314361-addVisibilityStatusToNotesAndDeathData.js
+++ b/packages/shared-src/src/migrations/1676591314361-addVisibilityStatusToNotesAndDeathData.js
@@ -1,6 +1,6 @@
 import { DataTypes } from 'sequelize';
 
-const tables = ['patient_death_data', 'note_pages', 'note_items'];
+const tables = ['patient_death_data', 'note_pages'];
 
 export async function up(query) {
   for (const table of tables) {

--- a/packages/shared-src/src/models/NoteItem.js
+++ b/packages/shared-src/src/models/NoteItem.js
@@ -1,5 +1,5 @@
 import { DataTypes } from 'sequelize';
-import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from 'shared/constants';
+import { SYNC_DIRECTIONS } from 'shared/constants';
 
 import { Model } from './Model';
 import { dateTimeType } from './dateTimeTypes';
@@ -27,10 +27,6 @@ export class NoteItem extends Model {
           allowNull: false,
           defaultValue: getCurrentDateTimeString,
         }),
-        visibilityStatus: {
-          type: DataTypes.TEXT,
-          defaultValue: VISIBILITY_STATUSES.CURRENT,
-        },
       },
       {
         ...options,

--- a/packages/shared-src/src/models/NoteItem.js
+++ b/packages/shared-src/src/models/NoteItem.js
@@ -1,5 +1,5 @@
 import { DataTypes } from 'sequelize';
-import { SYNC_DIRECTIONS } from 'shared/constants';
+import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from 'shared/constants';
 
 import { Model } from './Model';
 import { dateTimeType } from './dateTimeTypes';
@@ -27,6 +27,10 @@ export class NoteItem extends Model {
           allowNull: false,
           defaultValue: getCurrentDateTimeString,
         }),
+        visibilityStatus: {
+          type: DataTypes.TEXT,
+          defaultValue: VISIBILITY_STATUSES.CURRENT,
+        },
       },
       {
         ...options,

--- a/packages/shared-src/src/models/NotePage.js
+++ b/packages/shared-src/src/models/NotePage.js
@@ -1,6 +1,11 @@
 import { DataTypes } from 'sequelize';
 import { log } from 'shared/services/logging';
-import { NOTE_RECORD_TYPE_VALUES, NOTE_TYPE_VALUES, SYNC_DIRECTIONS } from 'shared/constants';
+import {
+  NOTE_RECORD_TYPE_VALUES,
+  NOTE_TYPE_VALUES,
+  SYNC_DIRECTIONS,
+  VISIBILITY_STATUSES,
+} from 'shared/constants';
 
 import { Model } from './Model';
 import { NoteItem } from './NoteItem';
@@ -28,6 +33,10 @@ export class NotePage extends Model {
           allowNull: false,
           defaultValue: getCurrentDateTimeString,
         }),
+        visibilityStatus: {
+          type: DataTypes.TEXT,
+          defaultValue: VISIBILITY_STATUSES.CURRENT,
+        },
       },
       {
         ...options,

--- a/packages/shared-src/src/models/PatientDeathData.js
+++ b/packages/shared-src/src/models/PatientDeathData.js
@@ -1,5 +1,5 @@
 import { Sequelize } from 'sequelize';
-import { SYNC_DIRECTIONS } from 'shared/constants';
+import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from 'shared/constants';
 import { InvalidOperationError } from 'shared/errors';
 import { dateType } from './dateTimeTypes';
 import { Model } from './Model';
@@ -31,6 +31,7 @@ export class PatientDeathData extends Model {
         antecedentCause1TimeAfterOnset: Sequelize.INTEGER, // minutes
         antecedentCause2TimeAfterOnset: Sequelize.INTEGER, // minutes
         isFinal: Sequelize.BOOLEAN,
+        visibilityStatus: { type: Sequelize.TEXT, defaultValue: VISIBILITY_STATUSES.CURRENT },
       },
       {
         ...options,

--- a/packages/shared-src/src/reports/admissions.js
+++ b/packages/shared-src/src/reports/admissions.js
@@ -1,7 +1,12 @@
 import { Op } from 'sequelize';
 import { Location } from 'shared/models/Location';
 import { subDays, startOfDay, endOfDay, parseISO } from 'date-fns';
-import { ENCOUNTER_TYPES, DIAGNOSIS_CERTAINTY, NOTE_TYPES } from 'shared/constants';
+import {
+  ENCOUNTER_TYPES,
+  DIAGNOSIS_CERTAINTY,
+  NOTE_TYPES,
+  VISIBILITY_STATUSES,
+} from 'shared/constants';
 import upperFirst from 'lodash/upperFirst';
 import { ageInYears } from 'shared/utils/dateTime';
 import { generateReportFromQueryData } from './utilities';
@@ -85,6 +90,7 @@ const getAllNotes = async (models, encounterIds) => {
     where: {
       recordId: encounterIds,
       noteType: NOTE_TYPES.SYSTEM,
+      visibilityStatus: VISIBILITY_STATUSES.CURRENT,
     },
   });
 
@@ -103,6 +109,7 @@ const getAllNotes = async (models, encounterIds) => {
     where: {
       recordId: encounterIds,
       noteType: NOTE_TYPES.SYSTEM,
+      visibilityStatus: VISIBILITY_STATUSES.CURRENT,
     },
   });
 


### PR DESCRIPTION
### Changes

Avoid hard deleting records in facility server, instead setting a visibility status field to remove them.

There are a couple of unit tests that use `getNotePages` and `findX` methods, I'm not sure they need to be updated with the where clause as in [7c2156c](https://github.com/beyondessential/tamanu/pull/3550/commits/7c2156c8be4c7fe4aa26dd7cec2c472e1fa871da) because they would essentially be current notes anyway, plus that's not what is being tested.