### PR TITLE
SAV-117: Run sync cleanup task in tasks process

### DIFF
--- a/packages/shared-src/src/sync/completeSyncSession.js
+++ b/packages/shared-src/src/sync/completeSyncSession.js
@@ -1,23 +1,10 @@
-import { Op } from 'sequelize';
 import { dropSnapshotTable } from './manageSnapshotTable';
 
-export const completeSyncSession = async (store, sessionId) => {
+export const completeSyncSession = async (store, sessionId, error) => {
   // just drop the snapshots, leaving sessions themselves as an artefact that forms a paper trail
   await store.models.SyncSession.update({ completedAt: new Date() }, { where: { id: sessionId } });
   await dropSnapshotTable(store.sequelize, sessionId);
-};
-
-export const completeInactiveSyncSessions = async (store, lapsedSessionSeconds) => {
-  const { SyncSession } = store.models;
-  const lapsedSessions = await SyncSession.findAll({
-    where: {
-      lastConnectionTime: { [Op.lt]: Date.now() - lapsedSessionSeconds * 1000 },
-      completedAt: { [Op.is]: null },
-    },
-    select: ['id'],
-    raw: true,
-  });
-  for (const { id: sessionId } of lapsedSessions) {
-    await completeSyncSession(store, sessionId);
+  if (error) {
+    await store.models.SyncSession.update({ error }, { where: { id: sessionId } });
   }
 };

--- a/packages/sync-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/sync-server/__tests__/sync/CentralSyncManager.test.js
@@ -18,9 +18,6 @@ import { CentralSyncManager } from '../../app/sync/CentralSyncManager';
         },
         onClose: () => {},
       });
-
-      // Also if using this mock remember to call .close() on the instance. i.e.:
-      syncManager.close();
 */
 
 describe('CentralSyncManager', () => {

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -6,7 +6,6 @@ import {
   createSnapshotTable,
   insertSnapshotRecords,
   updateSnapshotRecords,
-  completeInactiveSyncSessions,
   completeSyncSession,
   countSyncSnapshotRecords,
   findSyncSnapshotRecords,
@@ -40,21 +39,10 @@ class CentralSyncManager {
 
   constructor(ctx) {
     this.store = ctx.store;
-    this.purgeInterval = setInterval(
-      this.purgeLapsedSessions,
-      this.constructor.config.sync.lapsedSessionCheckFrequencySeconds * 1000,
-    );
     ctx.onClose(this.close);
   }
 
   close = () => clearInterval(this.purgeInterval);
-
-  purgeLapsedSessions = async () => {
-    await completeInactiveSyncSessions(
-      this.store,
-      this.constructor.config.sync.lapsedSessionSeconds,
-    );
-  };
 
   async tickTockGlobalClock() {
     // rather than just incrementing by one tick, we "tick, tock" the clock so we guarantee the

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -151,6 +151,8 @@ class CentralSyncManager {
 
   // set pull filter begins creating a snapshot of changes to pull at this point in time
   async initiatePull(sessionId, params) {
+    await this.connectToSession(sessionId);
+
     // first check if the snapshot is already being processed, to throw a sane error if (for some
     // reason) the client managed to kick off the pull twice (ran into this in v1.24.0 and v1.24.1)
     const isAlreadyProcessing = await this.checkSnapshotIsProcessing(sessionId);
@@ -283,6 +285,7 @@ class CentralSyncManager {
   }
 
   async checkSessionReady(sessionId) {
+    await this.connectToSession(sessionId);
     const session = await this.connectToSession(sessionId);
     if (session.startedAtTick === null) {
       return false;
@@ -292,6 +295,8 @@ class CentralSyncManager {
   }
 
   async checkPullReady(sessionId) {
+    await this.connectToSession(sessionId);
+
     // if this snapshot still processing, return false to tell the client to keep waiting
     const snapshotIsProcessing = await this.checkSnapshotIsProcessing(sessionId);
     if (snapshotIsProcessing) {

--- a/packages/sync-server/app/tasks/StaleSyncSessionCleaner.js
+++ b/packages/sync-server/app/tasks/StaleSyncSessionCleaner.js
@@ -1,0 +1,44 @@
+import config from 'config';
+import { Op } from 'sequelize';
+import { InvalidConfigError } from 'shared/errors';
+import { ScheduledTask } from 'shared/tasks';
+import { log } from 'shared/services/logging';
+import { completeSyncSession } from 'shared/sync/completeSyncSession';
+
+export class StaleSyncSessionCleaner extends ScheduledTask {
+  getName() {
+    return 'StaleSyncSessionCleaner';
+  }
+
+  constructor(context) {
+    const conf = config.schedules.staleSyncSessionCleaner;
+    super(conf.schedule, log);
+    this.config = conf;
+    this.store = context.store;
+  }
+
+  async run() {
+    const { SyncSession } = this.store.models;
+
+    const { staleSessionSeconds } = this.config;
+    if (!staleSessionSeconds) {
+      throw new InvalidConfigError(`staleSessionSeconds must be set for ${this.getName()}`);
+    }
+
+    const staleSessions = await SyncSession.findAll({
+      where: {
+        lastConnectionTime: { [Op.lt]: Date.now() - staleSessionSeconds * 1000 },
+        completedAt: { [Op.is]: null },
+      },
+      select: ['id'],
+      raw: true,
+    });
+    for (const { id: sessionId } of staleSessions) {
+      await completeSyncSession(
+        this.store,
+        sessionId,
+        'Session marked as completed due to inactivity',
+      );
+    }
+  }
+}

--- a/packages/sync-server/app/tasks/StaleSyncSessionCleaner.js
+++ b/packages/sync-server/app/tasks/StaleSyncSessionCleaner.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { Op } from 'sequelize';
-import { InvalidConfigError } from 'shared/errors';
 import { ScheduledTask } from 'shared/tasks';
 import { log } from 'shared/services/logging';
 import { completeSyncSession } from 'shared/sync/completeSyncSession';
@@ -17,7 +16,7 @@ export class StaleSyncSessionCleaner extends ScheduledTask {
     this.store = context.store;
   }
 
-  async getWhere() {
+  getWhere() {
     const { staleSessionSeconds } = this.config;
     return {
       lastConnectionTime: { [Op.lt]: Date.now() - staleSessionSeconds * 1000 },

--- a/packages/sync-server/app/tasks/index.js
+++ b/packages/sync-server/app/tasks/index.js
@@ -52,7 +52,7 @@ export async function startScheduledTasks(context) {
     taskClasses.push(PlannedMoveTimeout);
   }
 
-  if (config.schedules.staleSessionCleaner.enabled) {
+  if (config.schedules.staleSyncSessionCleaner.enabled) {
     taskClasses.push(StaleSyncSessionCleaner);
   }
 

--- a/packages/sync-server/app/tasks/index.js
+++ b/packages/sync-server/app/tasks/index.js
@@ -16,6 +16,7 @@ import { AutomaticLabTestResultPublisher } from './AutomaticLabTestResultPublish
 import { CovidClearanceCertificatePublisher } from './CovidClearanceCertificatePublisher';
 import { FhirMaterialiser } from './FhirMaterialiser';
 import { PlannedMoveTimeout } from './PlannedMoveTimeout';
+import { StaleSyncSessionCleaner } from './StaleSyncSessionCleaner';
 
 export async function startScheduledTasks(context) {
   const taskClasses = [
@@ -49,6 +50,10 @@ export async function startScheduledTasks(context) {
 
   if (config.schedules.plannedMoveTimeout.enabled) {
     taskClasses.push(PlannedMoveTimeout);
+  }
+
+  if (config.schedules.staleSessionCleaner.enabled) {
+    taskClasses.push(StaleSyncSessionCleaner);
   }
 
   const reportSchedulers = await getReportSchedulers(context);

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -27,8 +27,6 @@
     "readOnly": false,
     "persistedCacheBatchSize": 20000,
     "adjustDataBatchSize": 20000,
-    "lapsedSessionSeconds": 3600,
-    "lapsedSessionCheckFrequencySeconds": 60,
     "syncAllEncountersForTheseVaccines": []
   },
   "loadshedder": {
@@ -174,6 +172,11 @@
       "timeoutHours": 24,
       "batchSize": 100,
       "batchSleepAsyncDurationInMilliseconds": 50
+    },
+    "staleSyncSessionCleaner": {
+      "enabled": true,
+      "schedule": "* * * * *",
+      "staleSessionSeconds": 3600
     }
   },
   "integrations": {
@@ -559,12 +562,12 @@
         },
         "prescriber": {
           "shortLabel": "Prescriber",
-          "longLabel":  "Prescriber",
+          "longLabel": "Prescriber",
           "hidden": false
         },
         "prescriberId": {
           "shortLabel": "Prescriber ID",
-          "longLabel":  "Prescriber ID",
+          "longLabel": "Prescriber ID",
           "hidden": false
         },
         "facility": {


### PR DESCRIPTION
### Changes

Move cleanup task from a setInterval to a scheduled task, so it doesn't run in every node process on the central server. Also adds an error message for transparency/debuggability 

### Manual release steps (copy to release PR)
- Any central server that has been using either `lapsedSessionSeconds` or `lapsedSessionCheckFrequencySeconds` needs to move that config to the `schedules` area:
```
    "staleSyncSessionCleaner": {
      "enabled": true,
      "schedule": "* * * * *",
      "staleSessionSeconds": 3600
    }
```

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
