### PR TITLE
SAV-119: Sync logging + manual sync endpoint improvement

### DIFF
--- a/packages/desktop/app/views/NotActiveView.js
+++ b/packages/desktop/app/views/NotActiveView.js
@@ -31,9 +31,13 @@ const InvisibleSyncButton = () => {
 
     toast.info('Starting manual sync...');
     try {
-      const result = await api.post(`sync/run`, {}, {
-        timeout: 30000,
-      });
+      const result = await api.post(
+        `sync/run`,
+        {},
+        {
+          timeout: 30000,
+        },
+      );
       toast.success(result.message);
     } catch (error) {
       toast.error(<Error errorMessage={error.message} />);

--- a/packages/desktop/app/views/NotActiveView.js
+++ b/packages/desktop/app/views/NotActiveView.js
@@ -31,8 +31,8 @@ const InvisibleSyncButton = () => {
 
     toast.info('Starting manual sync...');
     try {
-      await api.post(`sync/run`);
-      toast.success('Manual sync complete');
+      const result = await api.post(`sync/run`);
+      toast.success(result.message);
     } catch (error) {
       toast.error(<Error errorMessage={error.message} />);
     } finally {

--- a/packages/desktop/app/views/NotActiveView.js
+++ b/packages/desktop/app/views/NotActiveView.js
@@ -31,7 +31,9 @@ const InvisibleSyncButton = () => {
 
     toast.info('Starting manual sync...');
     try {
-      const result = await api.post(`sync/run`);
+      const result = await api.post(`sync/run`, {}, {
+        timeout: 30000,
+      });
       toast.success(result.message);
     } catch (error) {
       toast.error(<Error errorMessage={error.message} />);

--- a/packages/lan/app/routes/apiv1/patientFacility.js
+++ b/packages/lan/app/routes/apiv1/patientFacility.js
@@ -26,7 +26,7 @@ patientFacility.post('/$', async (req, res) => {
   });
 
   // trigger a sync to immediately start pulling data for this patient
-  syncManager.triggerSync(`synced patient ${patient.displayId}`);
+  syncManager.triggerSync(`marked patient ${patient.displayId} for sync`);
 
   res.send(record);
 });

--- a/packages/lan/app/routes/apiv1/patientFacility.js
+++ b/packages/lan/app/routes/apiv1/patientFacility.js
@@ -26,7 +26,7 @@ patientFacility.post('/$', async (req, res) => {
   });
 
   // trigger a sync to immediately start pulling data for this patient
-  syncManager.triggerSync();
+  syncManager.triggerSync(`synced patient ${patient.displayId}`);
 
   res.send(record);
 });

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -6,12 +6,16 @@ export const sync = express.Router();
 sync.post(
   '/run',
   asyncHandler(async (req, res) => {
-    const { syncManager } = req;
+    const { syncManager, user } = req;
 
     req.flagPermissionChecked(); // no particular permission check for triggering a sync
 
-    await syncManager.triggerSync();
-
-    res.send({ message: 'Sync completed' });
+    if (syncManager.isSyncRunning()) {
+      res.send({ message: 'Sync already underway' });
+      return;
+    } 
+    
+    syncManager.triggerSync(`requested by ${user.email}`);
+    res.send({ message: 'Sync started' });
   }),
 );

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -13,8 +13,8 @@ sync.post(
     if (syncManager.isSyncRunning()) {
       res.send({ message: 'Sync already underway' });
       return;
-    } 
-    
+    }
+
     syncManager.triggerSync(`requested by ${user.email}`);
     res.send({ message: 'Sync started' });
   }),

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -15,7 +15,20 @@ sync.post(
       return;
     }
 
-    syncManager.triggerSync(`requested by ${user.email}`);
-    res.send({ message: 'Sync started' });
+    const completeSync = async () => {
+      await syncManager.triggerSync(`requested by ${user.email}`);
+      return 'Completed sync'
+    };
+
+    const timeoutAfter = (seconds) => new Promise(resolve => {
+      setTimeout(() => resolve('Sync started'), seconds * 1000)
+    });
+
+    const message = await Promise.race([
+      completeSync(),
+      timeoutAfter(10),
+    ]);
+
+    res.send({ message });
   }),
 );

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -22,7 +22,10 @@ sync.post(
 
     const timeoutAfter = seconds =>
       new Promise(resolve => {
-        setTimeout(() => resolve('Sync is taking a while, continuing in the background...'), seconds * 1000);
+        setTimeout(
+          () => resolve('Sync is taking a while, continuing in the background...'),
+          seconds * 1000,
+        );
       });
 
     const message = await Promise.race([completeSync(), timeoutAfter(10)]);

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -22,7 +22,7 @@ sync.post(
 
     const timeoutAfter = seconds =>
       new Promise(resolve => {
-        setTimeout(() => resolve('Sync started'), seconds * 1000);
+        setTimeout(() => resolve('Sync is taking a while, continuing in the background...'), seconds * 1000);
       });
 
     const message = await Promise.race([completeSync(), timeoutAfter(10)]);

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -17,17 +17,15 @@ sync.post(
 
     const completeSync = async () => {
       await syncManager.triggerSync(`requested by ${user.email}`);
-      return 'Completed sync'
+      return 'Completed sync';
     };
 
-    const timeoutAfter = (seconds) => new Promise(resolve => {
-      setTimeout(() => resolve('Sync started'), seconds * 1000)
-    });
+    const timeoutAfter = seconds =>
+      new Promise(resolve => {
+        setTimeout(() => resolve('Sync started'), seconds * 1000);
+      });
 
-    const message = await Promise.race([
-      completeSync(),
-      timeoutAfter(10),
-    ]);
+    const message = await Promise.race([completeSync(), timeoutAfter(10)]);
 
     res.send({ message });
   }),

--- a/packages/lan/app/subCommands/index.js
+++ b/packages/lan/app/subCommands/index.js
@@ -1,4 +1,5 @@
 export { migrateCommand } from './migrate';
 export { reportCommand } from './report';
 export { serveCommand } from './serve';
+export { syncCommand } from './sync';
 export * from './migrateAppointmentsToLocationGroups';

--- a/packages/lan/app/subCommands/sync.js
+++ b/packages/lan/app/subCommands/sync.js
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import { initDatabase } from '../database';
 import { FacilitySyncManager, CentralServerConnection } from '../sync';
 
-async function sync({ }) {
+async function sync() {
   const context = await initDatabase();
 
   context.centralServer = new CentralServerConnection(context);
@@ -13,6 +13,4 @@ async function sync({ }) {
   await context.syncManager.triggerSync('subcommand');
 }
 
-export const syncCommand = new Command('sync')
-  .description('Sync to central server')
-  .action(sync);
+export const syncCommand = new Command('sync').description('Sync to central server').action(sync);

--- a/packages/lan/app/subCommands/sync.js
+++ b/packages/lan/app/subCommands/sync.js
@@ -1,0 +1,18 @@
+import { Command } from 'commander';
+
+import { initDatabase } from '../database';
+import { FacilitySyncManager, CentralServerConnection } from '../sync';
+
+async function sync({ }) {
+  const context = await initDatabase();
+
+  context.centralServer = new CentralServerConnection(context);
+  context.centralServer.connect(); // preemptively connect central server to speed up sync
+  context.syncManager = new FacilitySyncManager(context);
+
+  await context.syncManager.triggerSync('subcommand');
+}
+
+export const syncCommand = new Command('sync')
+  .description('Sync to central server')
+  .action(sync);

--- a/packages/lan/app/subCommands/sync.js
+++ b/packages/lan/app/subCommands/sync.js
@@ -13,4 +13,4 @@ async function sync() {
   await context.syncManager.triggerSync('subcommand');
 }
 
-export const syncCommand = new Command('sync').description('Sync to central server').action(sync);
+export const syncCommand = new Command('sync').description('Sync with central server').action(sync);

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -83,7 +83,7 @@ class FacilitySyncManager {
       startedAtTick: newSyncClockTime,
     } = await this.centralServer.startSyncSession();
 
-    log.info(`Sync: Session started`, { 
+    log.info('Sync: Session started', {
       sessionId,
       startedAtTick: newSyncClockTime,
     });

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -115,7 +115,7 @@ class FacilitySyncManager {
       await pushOutgoingChanges(this.centralServer, sessionId, outgoingChanges);
     }
     await this.models.LocalSystemFact.set('lastSuccessfulSyncPush', currentSyncClockTime);
-    log.debug('Sync: Updating last successful push', { currentSyncClockTime });
+    log.debug('Sync: Updated last successful push', { currentSyncClockTime });
 
     // ~~~ Pull phase ~~~ //
 

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -69,6 +69,8 @@ class FacilitySyncManager {
       );
     }
 
+    log.info(`Sync: Initiating session`, { reason: this.reason });
+
     // clear previous temp data, in case last session errored out or server was restarted
     await dropAllSnapshotTables(this.sequelize);
 
@@ -81,8 +83,7 @@ class FacilitySyncManager {
       startedAtTick: newSyncClockTime,
     } = await this.centralServer.startSyncSession();
 
-    log.info(`Sync: Began sync`, { 
-      reason: this.reason,
+    log.info(`Sync: Session started`, { 
       sessionId,
       startedAtTick: newSyncClockTime,
     });

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -125,7 +125,6 @@ class FacilitySyncManager {
 
     // pull incoming changes also returns the sync tick that the central server considers this
     // session to have synced up to
-    log.info('Sync: Pulling changes', { pullSince });
     await createSnapshotTable(this.sequelize, sessionId);
     const { totalPulled, pullUntil } = await pullIncomingChanges(
       this.centralServer,

--- a/packages/lan/app/sync/FacilitySyncManager.js
+++ b/packages/lan/app/sync/FacilitySyncManager.js
@@ -25,13 +25,19 @@ class FacilitySyncManager {
 
   syncPromise = null;
 
+  reason = '';
+
   constructor({ models, sequelize, centralServer }) {
     this.models = models;
     this.sequelize = sequelize;
     this.centralServer = centralServer;
   }
 
-  async triggerSync() {
+  isSyncRunning() {
+    return !!this.syncPromise;
+  }
+
+  async triggerSync(reason) {
     if (!this.constructor.config.sync.enabled) {
       log.warn('FacilitySyncManager.triggerSync: sync is disabled');
       return;
@@ -44,6 +50,7 @@ class FacilitySyncManager {
     }
 
     // set up a common sync promise to avoid double sync
+    this.reason = reason;
     this.syncPromise = this.runSync();
 
     // make sure sync promise gets cleared when finished, even if there's an error
@@ -51,6 +58,7 @@ class FacilitySyncManager {
       await this.syncPromise;
     } finally {
       this.syncPromise = null;
+      this.reason = '';
     }
   }
 

--- a/packages/lan/app/sync/pullIncomingChanges.js
+++ b/packages/lan/app/sync/pullIncomingChanges.js
@@ -11,8 +11,10 @@ const { persistedCacheBatchSize } = config.sync;
 export const pullIncomingChanges = async (centralServer, sequelize, sessionId, since) => {
   // initiating pull also returns the sync tick (or point on the sync timeline) that the
   // central server considers this session will be up to after pulling all changes
+  log.info('Sync: Waiting for central server to prepare records to pull');
   const { totalToPull, pullUntil } = await centralServer.initiatePull(sessionId, since);
 
+  log.info('Sync: Pulling changes', { since, totalToPull });
   let fromId;
   let limit = calculatePageLimit();
   let totalPulled = 0;

--- a/packages/lan/app/sync/pullIncomingChanges.js
+++ b/packages/lan/app/sync/pullIncomingChanges.js
@@ -16,12 +16,10 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
   let fromId;
   let limit = calculatePageLimit();
   let totalPulled = 0;
-  log.debug(`pullIncomingChanges: syncing`, { sessionId });
 
   // pull changes a page at a time
   while (totalPulled < totalToPull) {
-    log.debug(`pullIncomingChanges: pulling records`, {
-      sessionId,
+    log.debug('Sync: Pulling page of records', {
       fromId,
       limit,
     });
@@ -35,11 +33,11 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
     const pullTime = Date.now() - startTime;
 
     if (!records.length) {
-      log.debug(`pullIncomingChanges: Pull returned no more changes, finishing`);
+      log.debug(`Sync: Pull returned no more changes, finishing`);
       break;
     }
 
-    log.debug(`pullIncomingChanges: Pulled ${records.length} changes, saving to local cache`);
+    log.info('Sync: Saving changes to cache', { count: records.length });
 
     const recordsToSave = records.map(r => ({
       ...r,

--- a/packages/lan/app/tasks/SyncTask.js
+++ b/packages/lan/app/tasks/SyncTask.js
@@ -17,6 +17,6 @@ export class SyncTask extends ScheduledTask {
   }
 
   async run() {
-    return this.context.syncManager.triggerSync();
+    return this.context.syncManager.triggerSync('scheduled');
   }
 }

--- a/packages/lan/index.js
+++ b/packages/lan/index.js
@@ -7,6 +7,7 @@ import { log } from 'shared/services/logging';
 
 import {
   serveCommand,
+  syncCommand,
   migrateCommand,
   reportCommand,
   migrateAppointmentsToLocationGroupsCommand,
@@ -20,6 +21,7 @@ async function run() {
 
   program.addCommand(serveCommand, { isDefault: true });
   program.addCommand(reportCommand);
+  program.addCommand(syncCommand);
   program.addCommand(migrateCommand);
   program.addCommand(migrateAppointmentsToLocationGroupsCommand);
 


### PR DESCRIPTION
### Changes

- Updates manual sync endpoint to return better information + immediately
- Track why a sync started
- Log parameters in parameter object rather than interpolating into string
- Explicitly flag when the "waiting for central server" phase starts
- Promote some `debug` logs to `info`s
- Add a subcommand to just run a sync and exit

Other thoughts:
- would be nice to have some "current step" parameter that gets logged alongside the regular "still syncing (duration xxxx)" message
- there's a lot of sync specific stuff in CentralServerConnection that really should be in FacilitySyncManager but I want to keep a light touch

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
