### PR TITLE
EPI-270: Update FHIR NZ ethnicity extension mapping

### DIFF
--- a/packages/shared-src/src/models/fhir/extensions.js
+++ b/packages/shared-src/src/models/fhir/extensions.js
@@ -3,7 +3,7 @@ import { withConfig } from 'shared/utils/withConfig';
 
 function getEthnicity(ethnicityId) {
   switch (ethnicityId) {
-    case 'ethnicity-Fiji':
+    case 'ethnicity-ITaukei':
       return { code: '36111', display: 'Fijian/iTaukei' };
     case 'ethnicity-FID':
       return { code: '43112', display: 'Fijian Indian' };


### PR DESCRIPTION
### Changes

It was noticed that one of the IDs was off, this is solving that problem. There is a broader discussion regarding having reference data IDs hardcoded but it's out of scope to bring this into a configurable value (by any means).