### PR TITLE
SAV-128: Snapshot records in chunks

### DIFF
--- a/packages/sync-server/app/sync/getSnapshotChunkBoundaries.js
+++ b/packages/sync-server/app/sync/getSnapshotChunkBoundaries.js
@@ -1,0 +1,53 @@
+import config from 'config';
+import { Op } from 'sequelize';
+
+const CHUNK_SIZE = config.sync.maxRecordsPerSnapshotChunk;
+
+const getBoundariesForNumberOfChars = async (model, since, minId, maxId, numberOfChars = 1) => {
+  const { sequelize, tableName } = model;
+  const [results] = await sequelize.query(
+    `
+      SELECT substring(id, 1, ${numberOfChars}) as substring, count(*) as count
+      FROM ${tableName}
+      WHERE updated_at_sync_tick > :since
+      AND id >= :minId
+      AND id <= :maxId
+      GROUP BY substring
+    `,
+    {
+      replacements: {
+        since,
+        minId,
+        maxId,
+      },
+    },
+  );
+
+  const boundaries = await Promise.all(
+    results.map(async ({ substring, count }) => {
+      const minChunkId = substring;
+      const maxChunkId = `${substring}x`; // TODO where x is largest character in the charset
+      if (count <= CHUNK_SIZE) {
+        return [minChunkId, maxChunkId];
+      }
+      return getBoundariesForNumberOfChars(model, since, minChunkId, maxChunkId, numberOfChars + 1);
+    }),
+  );
+  return boundaries.flat();
+};
+
+export const getSnapshotChunkBoundaries = async (model, since) => {
+  // if the number of records since the last sync tick is less than the chunk size, just return the min and max ids
+  const where = { updated_at_sync_tick: { [Op.gt]: since } };
+  const minId = await model.min('id', { where });
+  const maxId = await model.max('id', { where });
+  const totalCount = await model.count({
+    where,
+  });
+  if (totalCount <= CHUNK_SIZE) {
+    return [[minId, maxId]];
+  }
+
+  // otherwise, break the records into chunks
+  return getBoundariesForNumberOfChars(model, since, minId, maxId);
+};

--- a/packages/sync-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/sync-server/app/sync/snapshotOutgoingChanges.js
@@ -84,7 +84,7 @@ const snapshotChangesForModel = async (
         }
       ${filter || `WHERE ${table}.updated_at_sync_tick > :since`}
       AND ${table}.id >= :minChunkId
-      AND ${table}.id < :maxChunkId;
+      AND ${table}.id <= :maxChunkId;
     `,
       {
         replacements: {

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -28,7 +28,8 @@
     "persistedCacheBatchSize": 20000,
     "adjustDataBatchSize": 20000,
     "syncAllEncountersForTheseVaccines": [],
-    "numberConcurrentSnapshots": 4
+    "numberConcurrentSnapshots": 4,
+    "maxRecordsPerSnapshotChunk": 1000
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix


### PR DESCRIPTION
### Changes

I realised that we need to understand the distribution of actual ids to do this at all accurately, as if we break it up evenly or any way by guesswork, we will end up with large batches when an import created a whole lot of records around the same time (and so there'd be a mass of records in the chunk that covered that set of ids). This is particularly the case for the patients table.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
