### PR TITLE
SAV-65: Fix toasts for encounters without discharge

### DIFF
--- a/packages/desktop/app/api/queries/useEncounterDischarge.js
+++ b/packages/desktop/app/api/queries/useEncounterDischarge.js
@@ -1,10 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
-import { useApi } from '../useApi';
+import { useApi, isErrorUnknownAllow404s } from '../index';
 
-export const useEncounterDischarge = encounterId => {
+export const useEncounterDischarge = encounter => {
   const api = useApi();
 
-  return useQuery(['encounterDischarge', encounterId], () =>
-    api.get(`encounter/${encodeURIComponent(encounterId)}/discharge`),
+  return useQuery(
+    ['encounterDischarge', encounter.id],
+    () =>
+      api.get(
+        `encounter/${encodeURIComponent(encounter.id)}/discharge`,
+        {},
+        { isErrorUnknown: isErrorUnknownAllow404s },
+      ),
+    { enabled: !!encounter.endDate },
   );
 };

--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -122,7 +122,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
     imagingName: imagingTypes[imagingRequest.imagingType],
   }));
 
-  const dishchargeQuery = useEncounterDischarge(encounter.id);
+  const dishchargeQuery = useEncounterDischarge(encounter);
   const discharge = dishchargeQuery.data;
 
   const villageQuery = useReferenceData(patient?.villageId);


### PR DESCRIPTION
### Changes

Fix for the error toasts showing up on any old encounter without a discharge record + open encounters that don't have a discharge record yet.
