### PR TITLE
SAV-134: Allow configuring listening port for facility server discovery

### DIFF
--- a/packages/lan/app/discovery.js
+++ b/packages/lan/app/discovery.js
@@ -10,7 +10,8 @@ export function listenForServerQueries() {
   const socket = dgram.createSocket('udp4');
   let address = '';
   const serverPort = config.port;
-  const { overrideAddress, overridePort, protocol } = config.discovery;
+  const { overrideAddress, overridePort, overrideListeningPort, protocol } = config.discovery;
+  const listeningPort = overrideListeningPort || DISCOVERY_PORT;
 
   socket.on('message', (msg, rinfo) => {
     if (`${msg}`.trim() !== DISCOVERY_MAGIC_STRING) {
@@ -35,10 +36,10 @@ export function listenForServerQueries() {
 
   socket.on('listening', () => {
     address = socket.address().address;
-    log.info(`Server locator listening on ${address}:${DISCOVERY_PORT}`);
+    log.info(`Server locator listening on ${address}:${listeningPort}`);
   });
 
-  socket.bind(DISCOVERY_PORT);
+  socket.bind(listeningPort);
 
   process.once('SIGTERM', () => {
     log.info('Received SIGTERM, closing UDP discovery server');

--- a/packages/lan/config/default.json
+++ b/packages/lan/config/default.json
@@ -5,6 +5,7 @@
   "discovery": {
     "overrideAddress": "",
     "overridePort": null,
+    "overrideListeningPort": null,
     "protocol": "https"
   },
   "log": {


### PR DESCRIPTION
### Changes
- Allow configuring listening port for facility server discovery
- This is just to enable running multiple facility servers in the same instance if needed (eg: for testing), so that we can configure different port for different facility
 
### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
