### PR TITLE
WAITM-479: Fix document preview scroll

### DIFF
--- a/packages/desktop/app/components/DocumentPreview/PDFPreview.js
+++ b/packages/desktop/app/components/DocumentPreview/PDFPreview.js
@@ -11,9 +11,8 @@ const PDFDocument = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow-y: scroll;
-  height: 75vh;
   text-align: center;
+  min-height: 400px;
 `;
 
 // Calculate which page we're scrolled to "Page X of Y"

--- a/packages/desktop/app/components/Modal.js
+++ b/packages/desktop/app/components/Modal.js
@@ -42,6 +42,8 @@ const ModalContent = styled.div`
 
 const ModalContainer = styled.div`
   background: ${props => props.$color};
+  // Overflow in the modal content ensures that the modal header stays fixed
+  overflow: auto;
 
   @media print {
     background: none;
@@ -55,6 +57,7 @@ export const FullWidthRow = styled.div`
 
 const ModalTitle = styled(DialogTitle)`
   padding: 14px 14px 14px 32px;
+  border-bottom: 1px solid ${Colors.softOutline};
 
   h2 {
     display: flex;


### PR DESCRIPTION
### Changes

- fix document preview scroll by making all modals scroll inside the body component

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

Screenshots

![Screen Shot 2023-02-24 at 10 41 51 AM](https://user-images.githubusercontent.com/12807916/221037072-c13e3252-40b5-4056-b83e-4987a9f64719.png)

![Screen Shot 2023-02-24 at 10 41 35 AM](https://user-images.githubusercontent.com/12807916/221037089-08399d2d-ee41-40d0-9aef-39f10bdf35cc.png)

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
