### PR TITLE
EPI-276-277: Fix imaging request status typo

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 
+import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants/statuses';
 import { Table, useSelectableColumn } from '../../Table';
 import { OuterLabelFieldWrapper } from '../../Field';
 import { ConfirmCancelRow } from '../../ButtonRow';
@@ -21,7 +22,7 @@ export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter
         `encounter/${encodeURIComponent(encounter.id)}/imagingRequests`,
         {
           includeNotePages: 'true',
-          status: 'reception_pending',
+          status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
           orderBy: 'requestedDate',
           order: 'ASC',
         },

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 
+import { LAB_REQUEST_STATUSES } from 'shared/constants/labs';
 import { Table, useSelectableColumn } from '../../Table';
 import { OuterLabelFieldWrapper } from '../../Field';
 import { ConfirmCancelRow } from '../../ButtonRow';
@@ -62,7 +63,7 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
     async () => {
       const result = await api.get(`encounter/${encodeURIComponent(encounter.id)}/labRequests`, {
         includeNotePages: 'true',
-        status: 'reception_pending',
+        status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
         order: 'asc',
         orderBy: 'requestedDate',
       });


### PR DESCRIPTION
### Changes

We were using plain strings and missed the actual value for imaging requests. Changing both to use constants now for a more solid approach.