### PR TITLE
No-Issue: Fix simple get list count

### DIFF
--- a/packages/lan/__tests__/apiv1/Encounter.test.js
+++ b/packages/lan/__tests__/apiv1/Encounter.test.js
@@ -167,6 +167,93 @@ describe('Encounter', () => {
       ).toBe(true);
     });
 
+    it('Should not include lab requests with a status of deleted or entered in error', async () => {
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient.id,
+      });
+
+      await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+        })),
+      });
+      await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+        })),
+      });
+      await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.CANCELLED,
+        })),
+      });
+      await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.DELETED,
+        })),
+      });
+      await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.ENTERED_IN_ERROR,
+        })),
+      });
+
+      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests`);
+      expect(result).toHaveSucceeded();
+      expect(result.body.count).toEqual(3);
+      expect(result.body.data.length).toEqual(3);
+    });
+
+    it('should get the correct count for a list of lab requests', async () => {
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient.id,
+      });
+
+      const labRequest1 = await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+        })),
+      });
+      await models.LabRequest.create({
+        ...(await randomLabRequest(models, {
+          patientId: patient.id,
+          encounterId: encounter.id,
+          status: LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+        })),
+      });
+
+      // Ensure that the count of results is correct even if Lab Lab Requests have many LabTests
+      // to ensure that count is not flattening the count results
+      await models.LabTest.create({
+        labRequestId: labRequest1.id,
+      });
+      await models.LabTest.create({
+        labRequestId: labRequest1.id,
+      });
+      await models.LabTest.create({
+        labRequestId: labRequest1.id,
+      });
+
+      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests`);
+      expect(result).toHaveSucceeded();
+      expect(result.body.count).toEqual(2);
+      expect(result.body.data.length).toEqual(2);
+    });
+
     it('should get a list of lab requests filtered by status query parameter', async () => {
       const encounter = await models.Encounter.create({
         ...(await createDummyEncounter(models)),
@@ -476,9 +563,7 @@ describe('Encounter', () => {
         const noteItems = (await Promise.all(notePages.map(np => np.getNoteItems()))).flat();
         const check = x => x.content.includes('triage') && x.content.includes('admission');
         expect(noteItems.some(check)).toEqual(true);
-        expect(noteItems[0].authorId).toEqual(
-          app.user.id,
-        );
+        expect(noteItems[0].authorId).toEqual(app.user.id);
       });
 
       it('should fail to change encounter type to an invalid type', async () => {
@@ -516,9 +601,7 @@ describe('Encounter', () => {
         const check = x =>
           x.content.includes(departments[0].name) && x.content.includes(departments[1].name);
         expect(noteItems.some(check)).toEqual(true);
-        expect(noteItems[0].authorId).toEqual(
-          app.user.id,
-        );
+        expect(noteItems[0].authorId).toEqual(app.user.id);
       });
 
       it('should change encounter location and add a note', async () => {
@@ -540,9 +623,7 @@ describe('Encounter', () => {
         const check = x =>
           x.content.includes(fromLocation.name) && x.content.includes(toLocation.name);
         expect(noteItems.some(check)).toEqual(true);
-        expect(noteItems[0].authorId).toEqual(
-          app.user.id,
-        );
+        expect(noteItems[0].authorId).toEqual(app.user.id);
       });
 
       it('should include comma separated location_group and location name in created note on updating encounter location', async () => {
@@ -608,9 +689,7 @@ describe('Encounter', () => {
         expect(noteItems[0].content).toEqual(
           `Changed supervising clinician from ${fromClinician.displayName} to ${toClinician.displayName}`,
         );
-        expect(noteItems[0].authorId).toEqual(
-          app.user.id,
-        );
+        expect(noteItems[0].authorId).toEqual(app.user.id);
       });
 
       it('should discharge a patient', async () => {
@@ -649,9 +728,7 @@ describe('Encounter', () => {
         const noteItems = (await Promise.all(notePages.map(np => np.getNoteItems()))).flat();
         const check = x => x.content.includes('Discharged');
         expect(noteItems.some(check)).toEqual(true);
-        expect(noteItems[0].authorId).toEqual(
-          app.user.id,
-        );
+        expect(noteItems[0].authorId).toEqual(app.user.id);
       });
 
       it('should only update medications marked for discharge', async () => {

--- a/packages/lan/app/routes/apiv1/crudHelpers.js
+++ b/packages/lan/app/routes/apiv1/crudHelpers.js
@@ -97,6 +97,7 @@ export const getResourceList = async (req, modelName, foreignKey = '', options =
 
   const count = await models[modelName].count({
     ...baseQueryOptions,
+    distinct: true,
   });
 
   const objects = await models[modelName].findAll({

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -126,18 +126,9 @@ encounterRelations.get(
   '/:id/labRequests',
   getLabRequestList('encounterId', {
     additionalFilters: {
-      [Op.and]: [
-        {
-          status: {
-            [Op.ne]: LAB_REQUEST_STATUSES.DELETED,
-          },
-        },
-        {
-          status: {
-            [Op.ne]: LAB_REQUEST_STATUSES.ENTERED_IN_ERROR,
-          },
-        },
-      ],
+      status: {
+        [Op.notIn]: [LAB_REQUEST_STATUSES.DELETED, LAB_REQUEST_STATUSES.ENTERED_IN_ERROR],
+      },
     },
   }),
 );


### PR DESCRIPTION
### Changes

There was an issue where the number of records being returned was less than the count being returned when fetching Lab Request records. It was caused by the difference in how the  sequelize findAll and count method works. The findAll method returns the labRequest records with the associated tests included as an array while the count method returns the raw sql query results which have has multiple rows for a single lab request if there are multiple lab tests associated with it. Fixed it by adding distinct to the count query.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
