### PR TITLE
SAV-134: Allow disabling discovery

### DIFF
--- a/packages/lan/app/discovery.js
+++ b/packages/lan/app/discovery.js
@@ -7,10 +7,14 @@ import { DISCOVERY_MAGIC_STRING, DISCOVERY_PORT } from 'shared/constants';
 import { version } from './serverInfo';
 
 export function listenForServerQueries() {
+  const serverPort = config.port;
+  const { enabled, overrideAddress, overridePort, protocol } = config.discovery;
+  if (!enabled) {
+    return;
+  }
+
   const socket = dgram.createSocket('udp4');
   let address = '';
-  const serverPort = config.port;
-  const { overrideAddress, overridePort, protocol } = config.discovery;
 
   socket.on('message', (msg, rinfo) => {
     if (`${msg}`.trim() !== DISCOVERY_MAGIC_STRING) {

--- a/packages/lan/config/default.json
+++ b/packages/lan/config/default.json
@@ -3,6 +3,7 @@
     "allowAdminRoutes": false
   },
   "discovery": {
+    "enabled": true,
     "overrideAddress": "",
     "overridePort": null,
     "protocol": "https"


### PR DESCRIPTION
### Changes

Adds a config flag to disable discovery, so that devs can run multiple facility servers locally without running into the same discovery listen port being used

See https://github.com/beyondessential/tamanu/pull/3577/files#r1115157093 for some discussion

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
