### PR TITLE
SAV-65: Encounter record table tweaks

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -150,7 +150,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
   }
 
   const medications = encounter.medications.filter(medication => {
-    return !medication.discontinued
+    return !medication.discontinued;
   });
 
   const dishchargeQuery = useEncounterDischarge(encounter);

--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -149,6 +149,10 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
     });
   }
 
+  const medications = encounter.medications.filter(medication => {
+    return !medication.discontinued
+  });
+
   const dishchargeQuery = useEncounterDischarge(encounter);
   const discharge = dishchargeQuery.data;
 
@@ -256,6 +260,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
           discharge={discharge}
           village={village}
           pad={padData}
+          medications={medications}
         />
       )}
     </Modal>

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -14,7 +14,6 @@ import { CertificateLabel } from './reusable/CertificateLabels';
 import {
   noteTypes,
   DRUG_ROUTE_VALUE_TO_LABEL,
-  CERTAINTY_OPTIONS_BY_VALUE,
   ENCOUNTER_OPTIONS_BY_VALUE,
 } from '../../../constants';
 
@@ -296,6 +295,7 @@ export const EncounterRecord = React.memo(
     discharge,
     village,
     pad,
+    medications,
   }) => {
     const { firstName, lastName, dateOfBirth, sex, displayId } = patient;
     const { department, location, examiner, reasonForEncounter, startDate, endDate } = encounter;
@@ -404,10 +404,10 @@ export const EncounterRecord = React.memo(
             </>
           ) : null}
 
-          {encounter.medications.length > 0 ? (
+          {medications.length > 0 ? (
             <>
               <TableHeading>Medications</TableHeading>
-              <CompactListTable data={encounter.medications} columns={COLUMNS.medications} />
+              <CompactListTable data={medications} columns={COLUMNS.medications} />
             </>
           ) : null}
 

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -3,10 +3,11 @@ import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 
 import { startCase } from 'lodash';
+import { parseDate } from 'shared/utils/dateTime';
 
 import { LocalisedLabel } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
-import { DateDisplay } from '../../DateDisplay';
+import { DateDisplay, formatTime, formatShort } from '../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../utils/capitalise';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
@@ -111,7 +112,13 @@ export const ShiftedCertificateWrapper = styled(CertificateWrapper)`
   }
 `;
 
-// COLUMN LAYOUTSs
+const customDateFormat = ({ date }) => {
+  const dateObj = parseDate(date);
+  return `${formatShort(dateObj)} ${formatTime(dateObj)
+    .split(' ')
+    .join('')}`;
+};
+
 const COLUMNS = {
   encounterTypes: [
     {
@@ -123,7 +130,7 @@ const COLUMNS = {
     {
       key: 'dateMoved',
       title: 'Date & time moved',
-      accessor: ({ date }) => <DateDisplay date={date} showDate showTime />,
+      accessor: customDateFormat,
       style: { width: '30%' },
     },
   ],
@@ -144,7 +151,7 @@ const COLUMNS = {
     {
       key: 'dateMoved',
       title: 'Date & time moved',
-      accessor: ({ date }) => <DateDisplay date={date} showDate showTime />,
+      accessor: customDateFormat,
       style: { width: '30%' },
     },
   ],

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -158,9 +158,9 @@ const COLUMNS = {
       style: { width: '60%' },
     },
     {
-      key: 'certainty',
-      title: 'Certainty',
-      accessor: ({ certainty }) => CERTAINTY_OPTIONS_BY_VALUE[certainty].label || '',
+      key: 'type',
+      title: 'Type',
+      accessor: ({ isPrimary }) => (isPrimary ? 'Primary' : 'Secondary'),
       style: { width: '20%' },
     },
     {

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -153,7 +153,7 @@ const COLUMNS = {
     {
       key: 'diagnoses',
       title: 'Diagnoses',
-      accessor: ({ diagnosis }) => diagnosis?.name,
+      accessor: ({ diagnosis }) => `${diagnosis?.name} (${diagnosis?.code})`,
       style: { width: '60%' },
     },
     {
@@ -174,7 +174,7 @@ const COLUMNS = {
     {
       key: 'procedure',
       title: 'Procedure',
-      accessor: ({ procedureType }) => procedureType?.name,
+      accessor: ({ procedureType }) => `${procedureType?.name} (${procedureType?.code})`,
       style: { width: '80%' },
     },
     {

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -15,6 +15,7 @@ import {
   noteTypes,
   DRUG_ROUTE_VALUE_TO_LABEL,
   CERTAINTY_OPTIONS_BY_VALUE,
+  ENCOUNTER_OPTIONS_BY_VALUE,
 } from '../../../constants';
 
 import { ImagingRequestData } from './reusable/ImagingRequestData';
@@ -117,7 +118,7 @@ const COLUMNS = {
     {
       key: 'encounterType',
       title: 'Type',
-      accessor: ({ newEncounterType }) => startCase(newEncounterType),
+      accessor: ({ newEncounterType }) => ENCOUNTER_OPTIONS_BY_VALUE[newEncounterType].label,
       style: { width: '70%' },
     },
     {

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -75,7 +75,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
           View discharge summary
         </Button>
         <br />
-        <TypographyLink onClick={onViewEncounterRecord}>Encounter Record</TypographyLink>
+        <TypographyLink onClick={onViewEncounterRecord}>Encounter record</TypographyLink>
       </div>
     );
   }


### PR DESCRIPTION
### Changes

Various small tweaks to Encounter Record based on testing results.

- [x] No space after “am” and “pm” as per figma design like "10:07am" not "10:07 am"
- [x] Don’t show discontinued medications
- [x] Filter out cancelled, deleted and entered in error lab requests/imaging requests
- [x] Shouldn't it be "Route of administration" as per testing notes?
- [x] Diagnosis should have column “Type” instead of “Certainty”
- [x] Based on what we need to order the rows in tables?
- [x] “Hospital admission” instead of “Admission”
- [x] Encounter Record” button should be “Encounter record” as per figma design
- [x] Filter out cancelled/entered-in-error lab/imaging requests
- [x] Filter out discontinued medications 

