### PR TITLE
No issue: Extend loadshedder timeout

### DIFF
--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -51,7 +51,7 @@
         ],
         "maxActiveRequests": 4,
         "maxQueuedRequests": 8,
-        "queueTimeout": 500
+        "queueTimeout": 7500
       },
       // global queue for non-sync non-attachment requests
       // (defaults to queueing more requests than sync/attachments and them shedding much later)
@@ -62,7 +62,7 @@
         ],
         "maxActiveRequests": 8,
         "maxQueuedRequests": 32,
-        "queueTimeout": 2000
+        "queueTimeout": 7500
       }
     ]
   },


### PR DESCRIPTION
### Changes

In staging (which doesn't run in cluster mode), when syncing 5 devices, we have been seeing an issue where one or more devices will get an error relating to acquiring a spot in the load shedder.

With @stretchkennedy worked through the probable cause:
- Defaults to 4 active tasks in a single process deployment
- The 5th device ends up in the queue
- Defaults to 500ms waiting timeout before getting kicked off the queue
- If the other requests take more than that half second, the 5th device will retry after a backoff
- Because the other devices are actively syncing, and immediately sending another request for the next batch of changes after each batch of changes, it's most likely the 5th will be back on the queue after waiting and retrying with its backoff
- This keeps happening throughout its backoff, until the request ultimately fails after 15 attempts

This PR simply extends the time the 5th is allowed to wait in the queue, so the other 4 devices can take up to 7.5 seconds ~(intentionally less than the nginx 10 second timeout)~ [edit: there was no basis for thinking the nginx timeout was 10 seconds, so the loadshedder timeout can probably go up further in future if required] before the 5th will get kicked out.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
