### PR TITLE
Disable autovacuum on temporary snapshot table

### DIFF
--- a/packages/shared-src/src/sync/manageSnapshotTable.js
+++ b/packages/shared-src/src/sync/manageSnapshotTable.js
@@ -25,6 +25,8 @@ export const createSnapshotTable = async (sequelize, sessionId) => {
       data json NOT NULL,
       saved_at_sync_tick bigint, -- saved_at_sync_tick is used to check whether record has been updated between incoming and outgoing phase of a single session
       updated_at_by_field_sum bigint -- updated_at_by_field_sum is used to check whether record has had changes to field during merge and save component of push phase
+    ) WITH (
+      autovacuum_enabled = off
     );
     CREATE INDEX ${tableName
       .replaceAll('.', '_')


### PR DESCRIPTION
### Changes

As we know we’re going to drop that table some minutes later, we can disable autovacuum on it, to avoid unnecessary background processing. See https://www.postgresql.org/docs/12/sql-createtable.html#RELOPTION-AUTOVACUUM-ENABLED

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))