### PR TITLE
SAV-128: Revert chunking to check performance

### DIFF
--- a/packages/sync-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/sync-server/app/sync/snapshotOutgoingChanges.js
@@ -15,13 +15,11 @@ const snapshotChangesForModel = async (
   sessionId,
   facilityId,
   sessionConfig,
-  config,
 ) => {
   log.debug(
     `snapshotChangesForModel: Beginning snapshot for model ${model.tableName} since ${since}, in session ${sessionId}`,
   );
 
-  const CHUNK_SIZE = config.sync.maxRecordsPerPullSnapshotChunk;
   const modelHasSyncFilter = !!model.buildSyncFilter;
   const filter = modelHasSyncFilter ? model.buildSyncFilter(patientIds, sessionConfig) : '';
   if (modelHasSyncFilter && filter === null) {
@@ -37,85 +35,65 @@ const snapshotChangesForModel = async (
 
   const snapshotTableName = getSnapshotTableName(sessionId);
 
-  let fromId = '';
-  let totalCount = 0;
-
-  while (fromId != null) {
-    const [[{ maxId, count }]] = await model.sequelize.query(
-      `
-      WITH inserted as (
-        INSERT INTO ${snapshotTableName} (
-          direction,
-          is_deleted,
-          record_type,
-          record_id,
-          saved_at_sync_tick,
-          updated_at_by_field_sum,
-          data
-        )
-        SELECT
-          '${SYNC_SESSION_DIRECTION.OUTGOING}',
-          ${table}.deleted_at IS NOT NULL,
-          '${table}',
-          ${table}.id,
-          ${table}.updated_at_sync_tick,
-          ${useUpdatedAtByFieldSum ? 'updated_at_by_field_summary.sum ,' : 'NULL,'}
-          json_build_object(
-            ${Object.keys(attributes)
-              .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))
-              .map(a => `'${a}', ${table}.${snake(a)}`)}
-          )
-        FROM
-          ${table}
-          ${
-            useUpdatedAtByFieldSum
-              ? `
-        LEFT JOIN (
-          SELECT
-            ${table}.id, sum(value::text::bigint) sum
-          FROM
-            ${table}, json_each(${table}.updated_at_by_field)
-          GROUP BY
-            ${table}.id
-        ) updated_at_by_field_summary
-        ON
-          ${table}.id = updated_at_by_field_summary.id`
-              : ''
-          }
-        ${filter || `WHERE ${table}.updated_at_sync_tick > :since`}
-        ${fromId ? `AND ${table}.id > :fromId` : ''}
-        ORDER BY ${table}.id
-        LIMIT :limit
-        RETURNING record_id
+  const [, count] = await model.sequelize.query(
+    `
+      INSERT INTO ${snapshotTableName} (
+        direction,
+        is_deleted,
+        record_type,
+        record_id,
+        saved_at_sync_tick,
+        updated_at_by_field_sum,
+        data
       )
-      SELECT MAX(record_id) as "maxId", 
-        count(*) as "count" 
-      FROM inserted;
+      SELECT
+        '${SYNC_SESSION_DIRECTION.OUTGOING}',
+        ${table}.deleted_at IS NOT NULL,
+        '${table}',
+        ${table}.id,
+        ${table}.updated_at_sync_tick,
+        ${useUpdatedAtByFieldSum ? 'updated_at_by_field_summary.sum ,' : 'NULL,'}
+        json_build_object(
+          ${Object.keys(attributes)
+            .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))
+            .map(a => `'${a}', ${table}.${snake(a)}`)}
+        )
+      FROM
+        ${table}
+        ${
+          useUpdatedAtByFieldSum
+            ? `
+      LEFT JOIN (
+        SELECT
+          ${table}.id, sum(value::text::bigint) sum
+        FROM
+          ${table}, json_each(${table}.updated_at_by_field)
+        GROUP BY
+          ${table}.id
+      ) updated_at_by_field_summary
+      ON
+        ${table}.id = updated_at_by_field_summary.id`
+            : ''
+        }
+      ${filter || `WHERE ${table}.updated_at_sync_tick > :since`};
     `,
-      {
-        replacements: {
-          sessionId,
-          since,
-          // include replacement params used in some model specific sync filters outside of this file
-          // see e.g. Referral.buildSyncFilter
-          patientIds,
-          facilityId,
-          limit: CHUNK_SIZE,
-          fromId,
-        },
+    {
+      replacements: {
+        sessionId,
+        since,
+        // include replacement params used in some model specific sync filters outside of this file
+        // see e.g. Referral.buildSyncFilter
+        patientIds,
+        facilityId,
       },
-    );
-
-    const chunkCount = parseInt(count, 10); // count should always be default to '0'
-    fromId = maxId;
-    totalCount += chunkCount;
-  }
-
-  log.debug(
-    `snapshotChangesForModel: Found ${totalCount} for model ${model.tableName} since ${since}, in session ${sessionId}`,
+    },
   );
 
-  return totalCount;
+  log.debug(
+    `snapshotChangesForModel: Found ${count} for model ${model.tableName} since ${since}, in session ${sessionId}`,
+  );
+
+  return count;
 };
 
 export const snapshotOutgoingChanges = withConfig(
@@ -150,7 +128,6 @@ export const snapshotOutgoingChanges = withConfig(
           sessionId,
           facilityId,
           sessionConfig,
-          config,
         );
 
         changesCount += modelChangesCount || 0;

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -28,8 +28,7 @@
     "persistedCacheBatchSize": 20000,
     "adjustDataBatchSize": 20000,
     "syncAllEncountersForTheseVaccines": [],
-    "numberConcurrentPullSnapshots": 4,
-    "maxRecordsPerPullSnapshotChunk": 10000
+    "numberConcurrentPullSnapshots": 4
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix


### PR DESCRIPTION
### Changes

On the Aspen clone instance, we found that the snapshotting process took more than 50% longer with the chunk size set to 10,000 compared with 100,000,000 (1hr 40 vs. 1hr). Because the latter is essentially "off", I'd like to check whether it's even faster with the ordering etc. removed entirely. So, this reverts https://github.com/beyondessential/tamanu/pull/3568

That would leave us with just the concurrent snapshots config switch, but that may be enough. 

Will revert this if the performance doesn't significantly improve.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
