### PR TITLE
EPI-310: Migrate ImagingRequest.id to UUID

### DIFF
--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -35,7 +35,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, searchParameters 
   const imagingTypes = getLocalisation('imagingTypes') || {};
 
   const encounterColumns = [
-    { key: 'id', title: 'Request ID' },
+    { key: 'displayId', title: 'Request ID' },
     {
       key: 'imagingType',
       title: 'Type',

--- a/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
@@ -6,7 +6,7 @@ import { getAreaNote } from '../../../utils/areaNote';
 import { useLocalisation } from '../../../contexts/Localisation';
 
 export const COLUMN_KEYS = {
-  ID: 'id',
+  ID: 'displayId',
   SELECTED: 'selected',
   REQUESTED_DATE: 'requestedDate',
   REQUESTED_BY: 'requestedBy',

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -80,7 +80,7 @@ const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imag
 
   return (
     <FormGrid columns={3}>
-      <TextInput value={imagingRequest.id} label="Request ID" disabled />
+      <TextInput value={imagingRequest.displayId} label="Request ID" disabled />
       <TextInput
         value={imagingTypes[imagingRequest.imagingType]?.label || 'Unknown'}
         label="Request type"

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -21,6 +21,7 @@ const SNAKE_CASE_COLUMN_NAMES = {
   firstName: 'first_name',
   lastName: 'last_name',
   displayId: 'display_id',
+  requestId: 'ImagingRequest.display_id',
   id: 'ImagingRequest.id',
   name: 'name',
 };

--- a/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
+++ b/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
@@ -8,7 +8,7 @@ export async function up(query) {
 
     ALTER TABLE imaging_requests
     ALTER COLUMN display_id SET NOT NULL,
-    ALTER COLUMN id SET DEFAULT id;
+    ALTER COLUMN display_id SET DEFAULT uuid_generate_v4();
   `);
 
   // add index

--- a/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
+++ b/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
@@ -1,20 +1,19 @@
-//TODO: facility srever
 export async function up(query) {
   // copy id into display_id
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_requests
     ADD COLUMN display_id VARCHAR(255) NOT NULL
     USING (id::VARCHAR);
   `);
 
   // add index
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_requests
     ADD INDEX imaging_requests_display_id (display_id);
   `);
 
   // add cascading to related tables
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_results
     ALTER CONSTRAINT imaging_results_imaging_request_id_fkey
     FOREIGN KEY (imaging_request_id)
@@ -35,7 +34,7 @@ export async function up(query) {
   `);
 
   // assign new UUIDs in a deterministic way
-  query.sequelize.query(`
+  await query.sequelize.query(`
     UPDATE imaging_requests
     SET id = uuid_generate_v5(
       uuid_generate_v5(uuid_nil(), 'imaging_requests'),
@@ -44,7 +43,7 @@ export async function up(query) {
   `);
 
   // rewrite note pages relationship
-  query.sequelize.query(`
+  await query.sequelize.query(`
     UPDATE note_pages
     SET record_id = imaging_requests.id
     FROM imaging_requests
@@ -53,7 +52,7 @@ export async function up(query) {
   `);
 
   // change id to UUID
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_requests
     ALTER COLUMN id TYPE UUID USING id::UUID;
 
@@ -70,7 +69,7 @@ export async function up(query) {
 
 export async function down(query) {
   // rewrite note pages relationship
-  query.sequelize.query(`
+  await query.sequelize.query(`
     UPDATE note_pages
     SET record_id = imaging_requests.display_id
     FROM imaging_requests
@@ -79,7 +78,7 @@ export async function down(query) {
   `);
 
   // change id to varchar
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_requests
     ALTER COLUMN id TYPE VARCHAR(255) USING id::VARCHAR;
 
@@ -94,13 +93,13 @@ export async function down(query) {
   `);
 
   // assign old display IDs
-  query.sequelize.query(`
+  await query.sequelize.query(`
     UPDATE imaging_requests
     SET id = display_id;
   `);
 
   // remove cascading from related tables
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_results
     ALTER CONSTRAINT imaging_results_imaging_request_id_fkey
     FOREIGN KEY (imaging_request_id)
@@ -118,13 +117,13 @@ export async function down(query) {
   `);
 
   // remove index
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_requests
     DROP INDEX imaging_requests_display_id;
   `);
 
   // remove display_id column
-  query.sequelize.query(`
+  await query.sequelize.query(`
     ALTER TABLE imaging_requests
     DROP COLUMN display_id;
   `);

--- a/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
+++ b/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
@@ -3,9 +3,12 @@ export async function up(query) {
   await query.sequelize.query(`
     ALTER TABLE imaging_requests
     ADD COLUMN display_id VARCHAR(255);
+
     UPDATE imaging_requests SET display_id = id;
+
     ALTER TABLE imaging_requests
-    ALTER COLUMN display_id SET NOT NULL;
+    ALTER COLUMN display_id SET NOT NULL,
+    ALTER COLUMN id SET DEFAULT id;
   `);
 
   // add index
@@ -61,7 +64,8 @@ export async function up(query) {
     ALTER TABLE fhir.service_requests DROP CONSTRAINT service_requests_imaging_request_id_fkey;
 
     ALTER TABLE imaging_requests
-    ALTER COLUMN id TYPE UUID USING id::UUID;
+    ALTER COLUMN id SET DATA TYPE UUID USING id::UUID,
+    ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 
     ALTER TABLE imaging_results
     ALTER COLUMN imaging_request_id TYPE UUID USING imaging_request_id::UUID;
@@ -109,7 +113,8 @@ export async function down(query) {
     ALTER TABLE fhir.service_requests DROP CONSTRAINT service_requests_imaging_request_id_fkey;
 
     ALTER TABLE imaging_requests
-    ALTER COLUMN id TYPE VARCHAR(255) USING id::VARCHAR;
+    ALTER COLUMN id SET DATA TYPE VARCHAR(255) USING id::VARCHAR,
+    ALTER COLUMN id DROP DEFAULT;
 
     ALTER TABLE imaging_results
     ALTER COLUMN imaging_request_id TYPE VARCHAR(255) USING imaging_request_id::VARCHAR;

--- a/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
+++ b/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
@@ -1,5 +1,4 @@
-import { DataTypes } from 'sequelize';
-
+//TODO: facility srever
 export async function up(query) {
   // copy id into display_id
   query.sequelize.query(`
@@ -7,7 +6,7 @@ export async function up(query) {
     ADD COLUMN display_id VARCHAR(255) NOT NULL
     USING (id::VARCHAR);
   `);
-  
+
   // add index
   query.sequelize.query(`
     ALTER TABLE imaging_requests
@@ -27,14 +26,20 @@ export async function up(query) {
     FOREIGN KEY (imaging_request_id)
     REFERENCES imaging_requests (id)
     ON UPDATE CASCADE;
+
+    ALTER TABLE fhir.service_requests
+    ADD CONSTRAINT service_requests_imaging_request_id_fkey
+    FOREIGN KEY (upstream_id)
+    REFERENCES imaging_requests (id)
+    ON UPDATE CASCADE;
   `);
-  
+
   // assign new UUIDs
   query.sequelize.query(`
     UPDATE imaging_requests
     SET id = uuid_generate_v4();
   `);
-  
+
   // rewrite note pages relationship
   query.sequelize.query(`
     UPDATE note_pages
@@ -43,11 +48,20 @@ export async function up(query) {
     WHERE note_pages.record_id = imaging_requests.display_id
     AND note_pages.record_type = 'ImagingRequest';
   `);
-  
+
   // change id to UUID
   query.sequelize.query(`
     ALTER TABLE imaging_requests
     ALTER COLUMN id TYPE UUID USING id::UUID;
+
+    ALTER TABLE imaging_results
+    ALTER COLUMN imaging_request_id TYPE UUID USING imaging_request_id::UUID;
+
+    ALTER TABLE imaging_request_areas
+    ALTER COLUMN imaging_request_id TYPE UUID USING imaging_request_id::UUID;
+
+    ALTER TABLE fhir.service_requests
+    ALTER COLUMN upstream_id TYPE UUID USING upstream_id::UUID;
   `);
 }
 
@@ -60,11 +74,20 @@ export async function down(query) {
     WHERE note_pages.record_id = imaging_requests.id
     AND note_pages.record_type = 'ImagingRequest';
   `);
-  
+
   // change id to varchar
   query.sequelize.query(`
     ALTER TABLE imaging_requests
     ALTER COLUMN id TYPE VARCHAR(255) USING id::VARCHAR;
+
+    ALTER TABLE imaging_results
+    ALTER COLUMN imaging_request_id TYPE VARCHAR(255) USING imaging_request_id::VARCHAR;
+
+    ALTER TABLE imaging_request_areas
+    ALTER COLUMN imaging_request_id TYPE VARCHAR(255) USING imaging_request_id::VARCHAR;
+
+    ALTER TABLE fhir.service_requests
+    ALTER COLUMN upstream_id TYPE VARCHAR(255) USING upstream_id::VARCHAR;
   `);
 
   // assign old display IDs
@@ -72,7 +95,7 @@ export async function down(query) {
     UPDATE imaging_requests
     SET id = display_id;
   `);
-  
+
   // remove cascading from related tables
   query.sequelize.query(`
     ALTER TABLE imaging_results
@@ -80,20 +103,23 @@ export async function down(query) {
     FOREIGN KEY (imaging_request_id)
     REFERENCES imaging_requests (id)
     ON UPDATE NO ACTION;
-    
+
     ALTER TABLE imaging_request_areas
     ALTER CONSTRAINT imaging_request_area_imaging_request_id_fkey
     FOREIGN KEY (imaging_request_id)
     REFERENCES imaging_requests (id)
     ON UPDATE NO ACTION;
+
+    ALTER TABLE fhir.service_requests
+    DROP CONSTRAINT service_requests_imaging_request_id_fkey;
   `);
-  
+
   // remove index
   query.sequelize.query(`
     ALTER TABLE imaging_requests
     DROP INDEX imaging_requests_display_id;
   `);
-  
+
   // remove display_id column
   query.sequelize.query(`
     ALTER TABLE imaging_requests

--- a/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
+++ b/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
@@ -1,0 +1,102 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  // copy id into display_id
+  query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    ADD COLUMN display_id VARCHAR(255) NOT NULL
+    USING (id::VARCHAR);
+  `);
+  
+  // add index
+  query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    ADD INDEX imaging_requests_display_id (display_id);
+  `);
+
+  // add cascading to related tables
+  query.sequelize.query(`
+    ALTER TABLE imaging_results
+    ALTER CONSTRAINT imaging_results_imaging_request_id_fkey
+    FOREIGN KEY (imaging_request_id)
+    REFERENCES imaging_requests (id)
+    ON UPDATE CASCADE;
+
+    ALTER TABLE imaging_request_areas
+    ALTER CONSTRAINT imaging_request_area_imaging_request_id_fkey
+    FOREIGN KEY (imaging_request_id)
+    REFERENCES imaging_requests (id)
+    ON UPDATE CASCADE;
+  `);
+  
+  // assign new UUIDs
+  query.sequelize.query(`
+    UPDATE imaging_requests
+    SET id = uuid_generate_v4();
+  `);
+  
+  // rewrite note pages relationship
+  query.sequelize.query(`
+    UPDATE note_pages
+    SET record_id = imaging_requests.id
+    FROM imaging_requests
+    WHERE note_pages.record_id = imaging_requests.display_id
+    AND note_pages.record_type = 'ImagingRequest';
+  `);
+  
+  // change id to UUID
+  query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    ALTER COLUMN id TYPE UUID USING id::UUID;
+  `);
+}
+
+export async function down(query) {
+  // rewrite note pages relationship
+  query.sequelize.query(`
+    UPDATE note_pages
+    SET record_id = imaging_requests.display_id
+    FROM imaging_requests
+    WHERE note_pages.record_id = imaging_requests.id
+    AND note_pages.record_type = 'ImagingRequest';
+  `);
+  
+  // change id to varchar
+  query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    ALTER COLUMN id TYPE VARCHAR(255) USING id::VARCHAR;
+  `);
+
+  // assign old display IDs
+  query.sequelize.query(`
+    UPDATE imaging_requests
+    SET id = display_id;
+  `);
+  
+  // remove cascading from related tables
+  query.sequelize.query(`
+    ALTER TABLE imaging_results
+    ALTER CONSTRAINT imaging_results_imaging_request_id_fkey
+    FOREIGN KEY (imaging_request_id)
+    REFERENCES imaging_requests (id)
+    ON UPDATE NO ACTION;
+    
+    ALTER TABLE imaging_request_areas
+    ALTER CONSTRAINT imaging_request_area_imaging_request_id_fkey
+    FOREIGN KEY (imaging_request_id)
+    REFERENCES imaging_requests (id)
+    ON UPDATE NO ACTION;
+  `);
+  
+  // remove index
+  query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    DROP INDEX imaging_requests_display_id;
+  `);
+  
+  // remove display_id column
+  query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    DROP COLUMN display_id;
+  `);
+}

--- a/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
+++ b/packages/shared-src/src/migrations/1677203077682-imagingRequestsMoveIdToDisplayId.js
@@ -34,10 +34,13 @@ export async function up(query) {
     ON UPDATE CASCADE;
   `);
 
-  // assign new UUIDs
+  // assign new UUIDs in a deterministic way
   query.sequelize.query(`
     UPDATE imaging_requests
-    SET id = uuid_generate_v4();
+    SET id = uuid_generate_v5(
+      uuid_generate_v5(uuid_nil(), 'imaging_requests'),
+      display_id
+    );
   `);
 
   // rewrite note pages relationship

--- a/packages/shared-src/src/migrations/1677708145887-uuidCompareOperators.js
+++ b/packages/shared-src/src/migrations/1677708145887-uuidCompareOperators.js
@@ -1,0 +1,53 @@
+export async function up(query) {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION op_uuid_eq_varchar(lvalue uuid, rvalue varchar)
+    RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    AS $$
+      SELECT lvalue::varchar = rvalue
+    $$;
+
+    CREATE OR REPLACE FUNCTION op_uuid_ne_varchar(lvalue uuid, rvalue varchar)
+    RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    AS $$
+      SELECT lvalue::varchar <> rvalue
+    $$;
+  `);
+
+  await query.sequelize.query(`
+    CREATE OPERATOR = (
+      FUNCTION = op_uuid_eq_varchar,
+      LEFTARG = uuid,
+      RIGHTARG = varchar,
+      NEGATOR = <>,
+      RESTRICT = eqsel,
+      JOIN = eqjoinsel,
+      HASHES, MERGES
+    );
+
+    CREATE OPERATOR <> (
+      FUNCTION = op_uuid_ne_varchar,
+      LEFTARG = uuid,
+      RIGHTARG = varchar,
+      NEGATOR = =,
+      RESTRICT = eqsel,
+      JOIN = eqjoinsel,
+      HASHES, MERGES
+    );
+  `);
+}
+
+export async function down(query) {
+  await query.sequelize.query(`
+    DROP OPERATOR = (uuid, varchar);
+    DROP OPERATOR <> (uuid, varchar);
+  `);
+
+  await query.sequelize.query(`
+    DROP FUNCTION op_uuid_eq_varchar;
+    DROP FUNCTION op_uuid_ne_varchar;
+  `);
+}

--- a/packages/shared-src/src/models/ImagingRequest.js
+++ b/packages/shared-src/src/models/ImagingRequest.js
@@ -24,11 +24,12 @@ export class ImagingRequest extends Model {
         id: {
           type: Sequelize.UUID,
           allowNull: false,
-          default: Sequelize.fn('uuid_generate_v4'),
+          default: Sequelize.UUIDV4,
           primaryKey: true,
         },
         displayId: {
           type: Sequelize.STRING,
+          default: Sequelize.UUIDV4,
           allowNull: false,
         },
 

--- a/packages/shared-src/src/models/ImagingRequest.js
+++ b/packages/shared-src/src/models/ImagingRequest.js
@@ -24,12 +24,12 @@ export class ImagingRequest extends Model {
         id: {
           type: Sequelize.UUID,
           allowNull: false,
-          default: Sequelize.UUIDV4,
+          defaultValue: Sequelize.UUIDV4,
           primaryKey: true,
         },
         displayId: {
           type: Sequelize.STRING,
-          default: Sequelize.UUIDV4,
+          defaultValue: Sequelize.UUIDV4,
           allowNull: false,
         },
 

--- a/packages/shared-src/src/models/ImagingRequest.js
+++ b/packages/shared-src/src/models/ImagingRequest.js
@@ -21,7 +21,16 @@ export class ImagingRequest extends Model {
   static init({ primaryKey, ...options }) {
     super.init(
       {
-        id: primaryKey,
+        id: {
+          type: Sequelize.UUID,
+          allowNull: false,
+          default: Sequelize.fn('uuid_generate_v4'),
+          primaryKey: true,
+        },
+        displayId: {
+          type: Sequelize.STRING,
+          allowNull: false,
+        },
 
         imagingType: {
           type: Sequelize.ENUM(ALL_IMAGING_TYPES),

--- a/packages/shared-src/src/models/fhir/ServiceRequest.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest.js
@@ -23,6 +23,8 @@ import {
 import { Exception } from '../../utils/fhir';
 
 export class FhirServiceRequest extends FhirResource {
+  static UPSTREAM_UUID = true;
+
   static init(options, models) {
     super.init(
       {

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -145,7 +145,7 @@ imaging_info as (
       )
     ) "Imaging requests"
   from imaging_requests ir
-  left join notes_info ni on ni.record_id = ir.id
+  left join notes_info ni on ni.record_id = ir.id::varchar
   left join imaging_areas_by_request iabr on iabr.imaging_request_id = ir.id 
   group by encounter_id
 ),


### PR DESCRIPTION
### Changes

- Copy `id` to `display_id`
- Make new UUIDs for `id`
  - These are made deterministically using `uuid_generate_v5` which takes a "namespace" and a value and creates a new UUID from their SHA1 (unfortunately can't use other hashes, but that's good enough for this). The namespace needs to be a UUID, to create one we make another v5 from the nil UUID and the string `imaging_requests`, which works out to the constant value `5d0f0330-1bd7-59bd-a57e-b3297dd9d86c`.
  - Because the conversion is deterministic from `display_id`, the `id` value will be identical on central and facility
- Migrate all the foreign keys on other tables and the types of those foreign keys
  - imaging results
  - imaging areas
  - notes!
  - FHIR service request
    - which we also make a foreign key
    - this may need undoing at some point to multi-upstream that resource but for now it's good
- Also change some of the lan/ui code to use display ID as needed

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any db schema or other changes that could impact downstream data analysis
