### PR TITLE
SAV-128: Reinstate chunking

### DIFF
--- a/packages/sync-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/sync-server/app/sync/snapshotOutgoingChanges.js
@@ -15,11 +15,13 @@ const snapshotChangesForModel = async (
   sessionId,
   facilityId,
   sessionConfig,
+  config,
 ) => {
   log.debug(
     `snapshotChangesForModel: Beginning snapshot for model ${model.tableName} since ${since}, in session ${sessionId}`,
   );
 
+  const CHUNK_SIZE = config.sync.maxRecordsPerPullSnapshotChunk;
   const modelHasSyncFilter = !!model.buildSyncFilter;
   const filter = modelHasSyncFilter ? model.buildSyncFilter(patientIds, sessionConfig) : '';
   if (modelHasSyncFilter && filter === null) {
@@ -35,65 +37,85 @@ const snapshotChangesForModel = async (
 
   const snapshotTableName = getSnapshotTableName(sessionId);
 
-  const [, count] = await model.sequelize.query(
-    `
-      INSERT INTO ${snapshotTableName} (
-        direction,
-        is_deleted,
-        record_type,
-        record_id,
-        saved_at_sync_tick,
-        updated_at_by_field_sum,
-        data
-      )
-      SELECT
-        '${SYNC_SESSION_DIRECTION.OUTGOING}',
-        ${table}.deleted_at IS NOT NULL,
-        '${table}',
-        ${table}.id,
-        ${table}.updated_at_sync_tick,
-        ${useUpdatedAtByFieldSum ? 'updated_at_by_field_summary.sum ,' : 'NULL,'}
-        json_build_object(
-          ${Object.keys(attributes)
-            .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))
-            .map(a => `'${a}', ${table}.${snake(a)}`)}
+  let fromId = '';
+  let totalCount = 0;
+
+  while (fromId != null) {
+    const [[{ maxId, count }]] = await model.sequelize.query(
+      `
+      WITH inserted as (
+        INSERT INTO ${snapshotTableName} (
+          direction,
+          is_deleted,
+          record_type,
+          record_id,
+          saved_at_sync_tick,
+          updated_at_by_field_sum,
+          data
         )
-      FROM
-        ${table}
-        ${
-          useUpdatedAtByFieldSum
-            ? `
-      LEFT JOIN (
         SELECT
-          ${table}.id, sum(value::text::bigint) sum
+          '${SYNC_SESSION_DIRECTION.OUTGOING}',
+          ${table}.deleted_at IS NOT NULL,
+          '${table}',
+          ${table}.id,
+          ${table}.updated_at_sync_tick,
+          ${useUpdatedAtByFieldSum ? 'updated_at_by_field_summary.sum ,' : 'NULL,'}
+          json_build_object(
+            ${Object.keys(attributes)
+              .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))
+              .map(a => `'${a}', ${table}.${snake(a)}`)}
+          )
         FROM
-          ${table}, json_each(${table}.updated_at_by_field)
-        GROUP BY
-          ${table}.id
-      ) updated_at_by_field_summary
-      ON
-        ${table}.id = updated_at_by_field_summary.id`
-            : ''
-        }
-      ${filter || `WHERE ${table}.updated_at_sync_tick > :since`};
+          ${table}
+          ${
+            useUpdatedAtByFieldSum
+              ? `
+        LEFT JOIN (
+          SELECT
+            ${table}.id, sum(value::text::bigint) sum
+          FROM
+            ${table}, json_each(${table}.updated_at_by_field)
+          GROUP BY
+            ${table}.id
+        ) updated_at_by_field_summary
+        ON
+          ${table}.id = updated_at_by_field_summary.id`
+              : ''
+          }
+        ${filter || `WHERE ${table}.updated_at_sync_tick > :since`}
+        ${fromId ? `AND ${table}.id > :fromId` : ''}
+        ORDER BY ${table}.id
+        LIMIT :limit
+        RETURNING record_id
+      )
+      SELECT MAX(record_id) as "maxId", 
+        count(*) as "count" 
+      FROM inserted;
     `,
-    {
-      replacements: {
-        sessionId,
-        since,
-        // include replacement params used in some model specific sync filters outside of this file
-        // see e.g. Referral.buildSyncFilter
-        patientIds,
-        facilityId,
+      {
+        replacements: {
+          sessionId,
+          since,
+          // include replacement params used in some model specific sync filters outside of this file
+          // see e.g. Referral.buildSyncFilter
+          patientIds,
+          facilityId,
+          limit: CHUNK_SIZE,
+          fromId,
+        },
       },
-    },
-  );
+    );
+
+    const chunkCount = parseInt(count, 10); // count should always be default to '0'
+    fromId = maxId;
+    totalCount += chunkCount;
+  }
 
   log.debug(
-    `snapshotChangesForModel: Found ${count} for model ${model.tableName} since ${since}, in session ${sessionId}`,
+    `snapshotChangesForModel: Found ${totalCount} for model ${model.tableName} since ${since}, in session ${sessionId}`,
   );
 
-  return count;
+  return totalCount;
 };
 
 export const snapshotOutgoingChanges = withConfig(
@@ -128,6 +150,7 @@ export const snapshotOutgoingChanges = withConfig(
           sessionId,
           facilityId,
           sessionConfig,
+          config,
         );
 
         changesCount += modelChangesCount || 0;

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -28,8 +28,10 @@
     "persistedCacheBatchSize": 20000,
     "adjustDataBatchSize": 20000,
     "syncAllEncountersForTheseVaccines": [],
-    "numberConcurrentPullSnapshots": 4,
-    "maxRecordsPerPullSnapshotChunk": 10000
+    "numberConacurrentPullSnapshots": 4,
+    // at its very large default, maxRecordsPerPullSnapshotChunk is essentially "off"
+    // can be turned on by lowering to some amount that seems appropriate if snapshot performance is an issue
+    "maxRecordsPerPullSnapshotChunk": 1000000000
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -28,7 +28,8 @@
     "persistedCacheBatchSize": 20000,
     "adjustDataBatchSize": 20000,
     "syncAllEncountersForTheseVaccines": [],
-    "numberConcurrentPullSnapshots": 4
+    "numberConcurrentPullSnapshots": 4,
+    "maxRecordsPerPullSnapshotChunk": 10000
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix


### PR DESCRIPTION
Reverts beyondessential/tamanu#3614, as the performance of snapshot time on Aspen Clone was exactly the same with it out (1 hour), as with it on but tuned to a value so high it has no effect. This also sets the default to a very high value.