### PR TITLE
SAV-139 + SAV-140: Allow configuring filters in manually emailed COVID-19 clearance certificate

### DIFF
--- a/packages/lan/__tests__/apiv1/Patient.test.js
+++ b/packages/lan/__tests__/apiv1/Patient.test.js
@@ -337,7 +337,7 @@ describe('Patient', () => {
     });
   });
 
-  describe.only('Get patient covid lab tests', () => {
+  describe('Get patient covid lab tests', () => {
     let user;
     let lab;
     let category;

--- a/packages/lan/__tests__/apiv1/Patient.test.js
+++ b/packages/lan/__tests__/apiv1/Patient.test.js
@@ -1,4 +1,6 @@
+import { subDays, startOfDay } from 'date-fns';
 import config from 'config';
+
 import {
   createDummyEncounter,
   createDummyEncounterMedication,
@@ -7,6 +9,10 @@ import {
 } from 'shared/demoData/patients';
 import { PATIENT_FIELD_DEFINITION_TYPES } from 'shared/constants/patientFields';
 import { fake } from 'shared/test-helpers/fake';
+import { randomLabRequest } from 'shared/demoData/labRequests';
+import { LAB_REQUEST_STATUSES, REFERENCE_TYPES } from 'shared/constants';
+import { getCurrentDateString, toDateTimeString } from 'shared-src/src/utils/dateTime';
+
 import { createTestContext } from '../utilities';
 
 describe('Patient', () => {
@@ -21,6 +27,11 @@ describe('Patient', () => {
     baseApp = ctx.baseApp;
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
+    await models.Facility.upsert({
+      id: config.serverFacilityId,
+      name: config.serverFacilityId,
+      code: config.serverFacilityId,
+    });
     patient = await models.Patient.create(await createDummyPatient(models));
   });
   afterAll(() => ctx.close());
@@ -323,6 +334,183 @@ describe('Patient', () => {
         where: { value: oldDisplayId },
       });
       expect(secondaryId.typeId).toBe('secondaryIdType-nhn');
+    });
+  });
+
+  describe.only('Get patient covid lab tests', () => {
+    let user;
+    let lab;
+    let category;
+    let labTestType1;
+    let labTestType2;
+    let method;
+
+    beforeAll(async () => {
+      user = await models.User.create({
+        displayName: 'Test User',
+        email: 'testuser@test.test',
+      });
+      lab = await models.ReferenceData.create({
+        type: REFERENCE_TYPES.LAB_TEST_LABORATORY,
+        name: 'Test Laboratory',
+        code: 'TESTLABORATORY',
+      });
+
+      category = await models.ReferenceData.create({
+        type: REFERENCE_TYPES.LAB_TEST_CATEGORY,
+        name: 'Test Category',
+        code: 'testLabTestCategory',
+      });
+
+      labTestType1 = await models.LabTestType.create({
+        labTestCategoryId: category.id,
+        name: 'Test Test Type 1',
+        code: 'TESTTESTTYPE1',
+      });
+
+      labTestType2 = await models.LabTestType.create({
+        labTestCategoryId: category.id,
+        name: 'Test Test Type2',
+        code: 'TESTTESTTYPE2',
+      });
+
+      method = await models.ReferenceData.create({
+        type: REFERENCE_TYPES.LAB_TEST_METHOD,
+        name: 'Test Method',
+        code: 'testLabTestMethod',
+      });
+    });
+
+    it('includes lab requests after {daysSinceSampleTime} days', async () => {
+      await models.Setting.set('certifications.covidClearanceCertificate', {
+        labTestResults: ['Positive'],
+        daysSinceSampleTime: 10,
+      });
+
+      const patient1 = await models.Patient.create(await createDummyPatient(models));
+
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient1.id,
+      });
+
+      const labRequest = await models.LabRequest.create({
+        ...(await randomLabRequest(models)),
+        encounterId: encounter.id,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
+        requestedById: user.id,
+        labTestLaboratoryId: lab.id,
+        sampleTime: toDateTimeString(subDays(startOfDay(new Date()), 11)), // 1 day AFTER daysSinceSampleTime
+      });
+
+      await models.LabTest.create({
+        result: 'Positive',
+        labTestTypeId: labTestType1.id,
+        labRequestId: labRequest.id,
+        labTestMethodId: method.id,
+        completedDate: getCurrentDateString(),
+      });
+
+      await models.LabTest.create({
+        result: 'Positive',
+        labTestTypeId: labTestType2.id,
+        labRequestId: labRequest.id,
+        labTestMethodId: method.id,
+        completedDate: getCurrentDateString(),
+      });
+
+      const result = await app.get(`/v1/patient/${patient1.id}/covidLabTests`);
+
+      expect(result).toHaveSucceeded();
+      expect(result.body.data.length).toEqual(2);
+    });
+
+    it('excludes lab requests before {daysSinceSampleTime} days', async () => {
+      await models.Setting.set('certifications.covidClearanceCertificate', {
+        labTestResults: ['Positive'],
+        daysSinceSampleTime: 10,
+      });
+
+      const patient2 = await models.Patient.create(await createDummyPatient(models));
+
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient2.id,
+      });
+      const labRequest = await models.LabRequest.create({
+        ...(await randomLabRequest(models)),
+        encounterId: encounter.id,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
+        requestedById: user.id,
+        labTestLaboratoryId: lab.id,
+        sampleTime: toDateTimeString(subDays(startOfDay(new Date()), 9)), // 1 day BEFORE daysSinceSampleTime
+      });
+
+      await models.LabTest.create({
+        result: 'Positive',
+        labTestTypeId: labTestType1.id,
+        labRequestId: labRequest.id,
+        labTestMethodId: method.id,
+        completedDate: getCurrentDateString(),
+      });
+
+      await models.LabTest.create({
+        result: 'Positive',
+        labTestTypeId: labTestType2.id,
+        labRequestId: labRequest.id,
+        labTestMethodId: method.id,
+        completedDate: getCurrentDateString(),
+      });
+
+      const result = await app.get(`/v1/patient/${patient2.id}/covidLabTests`);
+
+      expect(result).toHaveSucceeded();
+      expect(result.body.data.length).toEqual(0);
+    });
+
+    it('includes lab requests that is in configured "labTestResults"', async () => {
+      await models.Setting.set('certifications.covidClearanceCertificate', {
+        labTestResults: ['Positive'],
+        daysSinceSampleTime: 10,
+      });
+
+      const patient1 = await models.Patient.create(await createDummyPatient(models));
+
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient1.id,
+      });
+
+      const labRequest = await models.LabRequest.create({
+        ...(await randomLabRequest(models)),
+        encounterId: encounter.id,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
+        requestedById: user.id,
+        labTestLaboratoryId: lab.id,
+        sampleTime: toDateTimeString(subDays(startOfDay(new Date()), 11)), // 1 day AFTER daysSinceSampleTime
+      });
+
+      await models.LabTest.create({
+        result: 'Positive',
+        labTestTypeId: labTestType1.id,
+        labRequestId: labRequest.id,
+        labTestMethodId: method.id,
+        completedDate: getCurrentDateString(),
+      });
+
+      await models.LabTest.create({
+        result: 'Negative',
+        labTestTypeId: labTestType2.id,
+        labRequestId: labRequest.id,
+        labTestMethodId: method.id,
+        completedDate: getCurrentDateString(),
+      });
+
+      const result = await app.get(`/v1/patient/${patient1.id}/covidLabTests`);
+
+      expect(result).toHaveSucceeded();
+      expect(result.body.data.length).toEqual(1);
+      expect(result.body.data[0].result).toEqual('Positive');
     });
   });
 });

--- a/packages/shared-src/src/models/Patient.js
+++ b/packages/shared-src/src/models/Patient.js
@@ -1,5 +1,6 @@
 import { Sequelize, Op } from 'sequelize';
-import { SYNC_DIRECTIONS, LAB_REQUEST_STATUSES } from 'shared/constants';
+import { SYNC_DIRECTIONS } from 'shared/constants';
+import { getCovidClearanceCertificateFilter } from 'shared/utils';
 import { Model } from './Model';
 import { dateType, dateTimeType } from './dateTimeTypes';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
@@ -156,12 +157,11 @@ export class Patient extends Model {
       raw: true,
       nest: true,
       ...queryOptions,
-      where: { status: LAB_REQUEST_STATUSES.PUBLISHED },
+      where: await getCovidClearanceCertificateFilter(this.sequelize.models),
       include: [
         { association: 'requestedBy' },
         {
           association: 'category',
-          where: { name: Sequelize.literal("UPPER(category.name) LIKE ('%COVID%')") },
         },
         {
           association: 'tests',

--- a/packages/shared-src/src/utils/getCovidClearanceCertificateFilter.js
+++ b/packages/shared-src/src/utils/getCovidClearanceCertificateFilter.js
@@ -1,0 +1,40 @@
+import { subDays, startOfDay } from 'date-fns';
+import { Op } from 'sequelize';
+
+import { LAB_REQUEST_STATUSES } from 'shared/constants';
+
+export const getCovidClearanceCertificateFilter = async models => {
+  const {
+    after = '2022-09-01',
+    daysSinceSampleTime = 13,
+    labTestCategories = [],
+    labTestTypes = [],
+    labTestResults = ['Positive'],
+  } = await models.Setting.get('covidClearanceCertificate');
+
+  const labRequestsWhere = {
+    status: LAB_REQUEST_STATUSES.PUBLISHED,
+  };
+
+  labRequestsWhere.sampleTime = {
+    [Op.lt]: subDays(startOfDay(new Date()), daysSinceSampleTime),
+    [Op.gt]: after,
+    '$tests.result$': {
+      [Op.in]: labTestResults,
+    }
+  };
+
+  if (labTestCategories.length) {
+    labRequestsWhere.labTestCategoryId = {
+      [Op.in]: labTestCategories,
+    };
+  }
+
+  if (labTestTypes.length) {
+    labRequestsWhere['$tests.lab_test_type_id$'] = {
+      [Op.in]: labTestTypes,
+    };
+  }
+
+  return labRequestsWhere;
+};

--- a/packages/shared-src/src/utils/getCovidClearanceCertificateFilter.js
+++ b/packages/shared-src/src/utils/getCovidClearanceCertificateFilter.js
@@ -12,7 +12,7 @@ export const getCovidClearanceCertificateFilter = async models => {
     labTestCategories = [],
     labTestTypes = [],
     labTestResults = ['Positive'],
-  } = await models.Setting.get('certifications.covidClearanceCertificate');
+  } = (await models.Setting.get('certifications.covidClearanceCertificate')) || {};
 
   // mandatory filters
   const labRequestsWhere = {

--- a/packages/shared-src/src/utils/getCovidClearanceCertificateFilter.js
+++ b/packages/shared-src/src/utils/getCovidClearanceCertificateFilter.js
@@ -3,6 +3,8 @@ import { Op } from 'sequelize';
 
 import { LAB_REQUEST_STATUSES } from 'shared/constants';
 
+import { toDateTimeString } from './dateTime';
+
 export const getCovidClearanceCertificateFilter = async models => {
   const {
     after = '2022-09-01',
@@ -10,18 +12,18 @@ export const getCovidClearanceCertificateFilter = async models => {
     labTestCategories = [],
     labTestTypes = [],
     labTestResults = ['Positive'],
-  } = await models.Setting.get('covidClearanceCertificate');
+  } = await models.Setting.get('certifications.covidClearanceCertificate');
 
+  // mandatory filters
   const labRequestsWhere = {
     status: LAB_REQUEST_STATUSES.PUBLISHED,
-  };
-
-  labRequestsWhere.sampleTime = {
-    [Op.lt]: subDays(startOfDay(new Date()), daysSinceSampleTime),
-    [Op.gt]: after,
+    sampleTime: {
+      [Op.lt]: toDateTimeString(subDays(startOfDay(new Date()), daysSinceSampleTime)),
+      [Op.gt]: after,
+    },
     '$tests.result$': {
       [Op.in]: labTestResults,
-    }
+    },
   };
 
   if (labTestCategories.length) {

--- a/packages/shared-src/src/utils/index.js
+++ b/packages/shared-src/src/utils/index.js
@@ -13,3 +13,4 @@ export * from './uvci';
 export * from './valueIndex';
 export * from './withConfig';
 export * from './dischargeOutpatientEncounters';
+export * from './getCovidClearanceCertificateFilter';

--- a/packages/sync-server/__tests__/importers/patient/patientImporter.test.js
+++ b/packages/sync-server/__tests__/importers/patient/patientImporter.test.js
@@ -40,8 +40,15 @@ describe('Patients import', () => {
     expect(didntSendReason).toEqual('dryRun');
     expect(errors).toBeEmpty();
     expect(stats).toEqual({
-      Patient: { created: 1, updated: 0, errored: 0 },
-      PatientAdditionalData: { created: 1, updated: 0, errored: 0 },
+      Patient: { created: 1, updated: 0, errored: 0, deleted: 0, restored: 0, skipped: 0 },
+      PatientAdditionalData: {
+        created: 1,
+        updated: 0,
+        errored: 0,
+        deleted: 0,
+        restored: 0,
+        skipped: 0,
+      },
     });
   });
 
@@ -97,8 +104,15 @@ describe('Patients import', () => {
     expect(didntSendReason).toEqual('dryRun');
     expect(errors).toBeEmpty();
     expect(stats).toEqual({
-      Patient: { created: 1, updated: 0, errored: 0 },
-      PatientAdditionalData: { created: 1, updated: 0, errored: 0 },
+      Patient: { created: 1, updated: 0, errored: 0, deleted: 0, restored: 0, skipped: 0 },
+      PatientAdditionalData: {
+        created: 1,
+        updated: 0,
+        errored: 0,
+        deleted: 0,
+        restored: 0,
+        skipped: 0,
+      },
     });
   });
 
@@ -111,7 +125,7 @@ describe('Patients import', () => {
     expect(didntSendReason).toEqual('dryRun');
     expect(errors).toBeEmpty();
     expect(stats).toEqual({
-      Patient: { created: 1, updated: 0, errored: 0 },
+      Patient: { created: 1, updated: 0, errored: 0, deleted: 0, restored: 0, skipped: 0 },
     });
   });
 
@@ -124,7 +138,7 @@ describe('Patients import', () => {
     expect(didntSendReason).toEqual('dryRun');
     expect(errors).toBeEmpty();
     expect(stats).toEqual({
-      Patient: { created: 1, updated: 0, errored: 0 },
+      Patient: { created: 1, updated: 0, errored: 0, deleted: 0, restored: 0, skipped: 0 },
     });
   });
 });

--- a/packages/sync-server/__tests__/models/Patient.test.js
+++ b/packages/sync-server/__tests__/models/Patient.test.js
@@ -1,7 +1,9 @@
-import { add } from 'date-fns';
+import { add, subDays, startOfDay } from 'date-fns';
+
 import { fake, fakeUser, fakeReferenceData } from 'shared/test-helpers/fake';
 import { fakeUUID } from 'shared/utils/generateId';
 
+import { getCurrentDateString, toDateTimeString } from 'shared-src/src/utils/dateTime';
 import { createTestContext } from '../utilities';
 
 async function prepopulate(models) {
@@ -77,25 +79,64 @@ async function prepopulate(models) {
     code: 'testLabTestCategory',
   });
 
-  await LabRequest.create({
+  const method = await models.ReferenceData.create({
+    type: 'labTestMethod',
+    name: 'Random',
+    code: 'testLabTestMethod',
+  });
+
+  const labRequest1 = await LabRequest.create({
     ...fake(LabRequest),
     encounterId,
     labTestCategoryId: covidCategory.id,
     status: 'published',
+    sampleTime: toDateTimeString(subDays(startOfDay(new Date()), 15)),
   });
 
-  await LabRequest.create({
+  const labRequest2 = await LabRequest.create({
     ...fake(LabRequest),
     encounterId,
     labTestCategoryId: covidCategory.id,
     status: 'published',
+    sampleTime: toDateTimeString(subDays(startOfDay(new Date()), 15)),
   });
 
-  await LabRequest.create({
+  const labRequest3 = await LabRequest.create({
     ...fake(LabRequest),
     encounterId,
     labTestCategoryId: category.id,
     status: 'published',
+    sampleTime: toDateTimeString(subDays(startOfDay(new Date()), 15)),
+  });
+
+  const labTestType = await models.LabTestType.create({
+    labTestCategoryId: category.id,
+    name: 'LabTest111',
+    code: 'LabTest111',
+  });
+
+  await models.LabTest.create({
+    result: 'Positive',
+    labTestTypeId: labTestType.id,
+    labRequestId: labRequest1.id,
+    labTestMethodId: method.id,
+    completedDate: getCurrentDateString(),
+  });
+
+  await models.LabTest.create({
+    result: 'Positive',
+    labTestTypeId: labTestType.id,
+    labRequestId: labRequest2.id,
+    labTestMethodId: method.id,
+    completedDate: getCurrentDateString(),
+  });
+
+  await models.LabTest.create({
+    result: 'Positive',
+    labTestTypeId: labTestType.id,
+    labRequestId: labRequest3.id,
+    labTestMethodId: method.id,
+    completedDate: getCurrentDateString(),
   });
 
   const scheduledVaccineId = fakeUUID();
@@ -150,7 +191,7 @@ describe('Patient', () => {
       const patient = await Patient.findByPk(patientId);
       const results = await patient.getCovidLabTests();
       // Assert
-      expect(results.length).toEqual(2);
+      expect(results.length).toEqual(3);
     });
   });
 

--- a/packages/sync-server/app/tasks/CovidClearanceCertificatePublisher.js
+++ b/packages/sync-server/app/tasks/CovidClearanceCertificatePublisher.js
@@ -1,11 +1,8 @@
 import config from 'config';
 
-import { subDays, startOfDay } from 'date-fns';
-import { Op } from 'sequelize';
 import { ScheduledTask } from 'shared/tasks';
-import { getPatientSurveyResponseAnswer } from 'shared/utils';
+import { getPatientSurveyResponseAnswer, getCovidClearanceCertificateFilter } from 'shared/utils';
 import {
-  LAB_REQUEST_STATUSES,
   COVID_19_CLEARANCE_CERTIFICATE,
   CERTIFICATE_NOTIFICATION_STATUSES,
 } from 'shared/constants';
@@ -23,36 +20,13 @@ export class CovidClearanceCertificatePublisher extends ScheduledTask {
   }
 
   async run() {
-    const {
-      after,
-      labTestCategories,
-      labTestTypes,
-      daysSinceSampleTime,
-      labTestResults = [],
-    } = config.schedules.covidClearanceCertificatePublisher;
     const { LabRequest, LabTest, CertificateNotification, Encounter } = this.models;
     const questionId = config.questionCodeIds?.email;
 
     const labRequestsWhere = {
-      status: LAB_REQUEST_STATUSES.PUBLISHED,
-      sampleTime: {
-        [Op.lt]: subDays(startOfDay(new Date()), daysSinceSampleTime),
-        [Op.gt]: after,
-      },
-      labTestCategoryId: {
-        [Op.in]: labTestCategories,
-      },
-      '$tests.lab_test_type_id$': {
-        [Op.in]: labTestTypes,
-      },
+      ...(await getCovidClearanceCertificateFilter(this.models)),
       '$certificate_notification.id$': null,
     };
-
-    if (labTestResults.length) {
-      labRequestsWhere['$tests.result$'] = {
-        [Op.in]: labTestResults,
-      };
-    }
 
     // Get lab requests that were sampled 13 days before the start
     // of today, and with configured lab test categories
@@ -63,11 +37,6 @@ export class CovidClearanceCertificatePublisher extends ScheduledTask {
           model: LabTest,
           as: 'tests',
           required: true,
-          // We only want to generate clearance notifications for patients who had positive tests
-          // Note that LabTest.status is not a used field so we don't need to filter on it
-          where: {
-            result: 'Positive',
-          },
         },
         {
           model: CertificateNotification,

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -158,12 +158,7 @@
     },
     "covidClearanceCertificatePublisher": {
       "enabled": false,
-      "schedule": "*/30 * * * *",
-      "daysSinceSampleTime": 13,
-      "after": "2022-09-01",
-      "labTestCategories": [],
-      "labTestTypes": [],
-      "labTestResults": []
+      "schedule": "*/30 * * * *"
     },
     "fhirMaterialiser": {
       "enabled": true, // only when integrations.fhir is on

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -162,7 +162,8 @@
       "daysSinceSampleTime": 13,
       "after": "2022-09-01",
       "labTestCategories": [],
-      "labTestTypes": []
+      "labTestTypes": [],
+      "labTestResults": []
     },
     "fhirMaterialiser": {
       "enabled": true, // only when integrations.fhir is on


### PR DESCRIPTION
### Changes
**Problem**: At the moment, all the configured filters (daysSinceSampleTime, labTestTypes, etc...) are only applied to automated covid clearance certificate, but not when manually emailed the certificate (by hitting send email in the Covid Clearance Cert modal)

**Fix**: I've moved all the configured filters into Settings table so that it can be used in both central and facility. And apply those filters to the manual emailed certificate

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
