### PR TITLE
WAITM-629: Revert uuid for lab_test_panel id as importable from spreadsheat

### DIFF
--- a/packages/shared-src/src/migrations/1676619492367-AddLabPanelsTable.js
+++ b/packages/shared-src/src/migrations/1676619492367-AddLabPanelsTable.js
@@ -3,7 +3,7 @@ import { DataTypes, Sequelize } from 'sequelize';
 export async function up(query) {
   await query.createTable('lab_test_panels', {
     id: {
-      type: DataTypes.UUID,
+      type: DataTypes.STRING,
       allowNull: false,
       primaryKey: true,
       defaultValue: Sequelize.fn('uuid_generate_v4'),

--- a/packages/shared-src/src/migrations/1677158549224-AddLabPanelRequestsTable.js
+++ b/packages/shared-src/src/migrations/1677158549224-AddLabPanelRequestsTable.js
@@ -23,7 +23,7 @@ export async function up(query) {
       allowNull: true,
     },
     lab_test_panel_id: {
-      type: DataTypes.UUID,
+      type: DataTypes.STRING,
       allowNull: false,
       references: {
         model: 'lab_test_panels',


### PR DESCRIPTION
### Changes

- My bad on pointing this out initially
- Its ohk to default to uuid but actual type should be string due to human readable ids supplied in import data spreadsheats
- I noticed this when trying to import test data and it errored on the id

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [n/a] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
