### PR TITLE
WAITM-605: Ensure device ids are passed to lan centralServerLogin

### DIFF
--- a/packages/lan/app/createApp.js
+++ b/packages/lan/app/createApp.js
@@ -12,7 +12,7 @@ import { versionCompatibility } from './middleware/versionCompatibility';
 
 import { version } from './serverInfo';
 
-export function createApp({ sequelize, models, syncManager }) {
+export function createApp({ sequelize, models, syncManager, deviceId }) {
   // Init our app
   const app = express();
   app.use(compression());
@@ -33,6 +33,7 @@ export function createApp({ sequelize, models, syncManager }) {
     req.models = models;
     req.db = sequelize;
     req.syncManager = syncManager;
+    req.deviceId = deviceId;
 
     next();
   });


### PR DESCRIPTION
### Changes
Testing the epic branch I found A login that wasn't sending deviceId to sync login
This pr fixes this by making sure the deviceId is available on the request

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [n/a] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
