### PR TITLE
TAN-2034: Adjust column width when having no QR code

### DIFF
--- a/packages/shared-src/src/utils/patientCertificates/PatientDetailsSection.js
+++ b/packages/shared-src/src/utils/patientCertificates/PatientDetailsSection.js
@@ -30,7 +30,7 @@ export const PatientDetailsSection = ({
   ];
   return (
     <Row>
-      <Col style={{ width: '68%' }}>
+      <Col style={{ width: vdsSrc ? '68%' : '80%' }}>
         <Row>
           {detailsToDisplay.map(({ key, label: defaultLabel, accessor }) => {
             const value = (accessor ? accessor(patient, getLocalisation) : patient[key]) || '';
@@ -53,7 +53,7 @@ export const PatientDetailsSection = ({
           </Row>
         )}
       </Col>
-      <Col style={{ width: '32%' }}>{vdsSrc && <VDSImage src={vdsSrc} />}</Col>
+      <Col style={{ width: vdsSrc ? '32%' : '20%' }}>{vdsSrc && <VDSImage src={vdsSrc} />}</Col>
     </Row>
   );
 };


### PR DESCRIPTION
### Changes

- Adjusted Column width for the scenario when it has no QR Code
Related to this issue below:
https://linear.app/bes/issue/TAN-2034#comment-41058d3e

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
