### PR TITLE
SAV-1: Age with months formatting tweaks

### DIFF
--- a/packages/desktop/app/utils/survey.js
+++ b/packages/desktop/app/utils/survey.js
@@ -194,14 +194,17 @@ function transformPatientData(patient, config) {
     end: new Date(),
   });
 
+  const yearPlural = years !== 1 ? 's' : '';
+  const monthPlural = months !== 1 ? 's' : '';
+
   switch (column) {
     case 'age':
       return years.toString();
     case 'ageWithMonths':
       if (!years) {
-        return `${months} month${months !== 1 ? 's' : ''}`;
+        return `${months} month${monthPlural}`;
       }
-      return `${years} years, ${months} month${months !== 1 ? 's' : ''}`;
+      return `${years} year${yearPlural}, ${months} month${monthPlural}`;
     case 'fullName':
       return joinNames({ firstName, lastName });
     default:

--- a/packages/desktop/app/utils/survey.js
+++ b/packages/desktop/app/utils/survey.js
@@ -198,7 +198,10 @@ function transformPatientData(patient, config) {
     case 'age':
       return years.toString();
     case 'ageWithMonths':
-      return `${years} years, ${months} months`;
+      if (!years) {
+        return `${months} month${months !== 1 ? 's' : ''}`;
+      }
+      return `${years} years, ${months} month${months !== 1 ? 's' : ''}`;
     case 'fullName':
       return joinNames({ firstName, lastName });
     default:

--- a/packages/mobile/App/ui/helpers/date.ts
+++ b/packages/mobile/App/ui/helpers/date.ts
@@ -13,7 +13,10 @@ export function getAgeWithMonthsFromDate(date: string): string {
     start: parseISO(date),
     end: new Date(),
   });
-  return `${years} years, ${months} months`;
+  if (!years) {
+    return `${months} month${months !== 1 ? 's' : ''}`;
+  }
+  return `${years} years, ${months} month${months !== 1 ? 's' : ''}`;
 }
 
 export function formatStringDate(date: string, dateFormat: string): string {

--- a/packages/mobile/App/ui/helpers/date.ts
+++ b/packages/mobile/App/ui/helpers/date.ts
@@ -13,10 +13,14 @@ export function getAgeWithMonthsFromDate(date: string): string {
     start: parseISO(date),
     end: new Date(),
   });
+
+  const yearPlural = years !== 1 ? 's' : '';
+  const monthPlural = months !== 1 ? 's' : '';
+
   if (!years) {
-    return `${months} month${months !== 1 ? 's' : ''}`;
+    return `${months} month${monthPlural}`;
   }
-  return `${years} years, ${months} month${months !== 1 ? 's' : ''}`;
+  return `${years} year${yearPlural}, ${months} month${monthPlural}`;
 }
 
 export function formatStringDate(date: string, dateFormat: string): string {


### PR DESCRIPTION
### Changes

Some small formatting alterations to the new "Age with months" field for surveys. This will only show months if the patient is less than a year old and will also not show a plural if there is only one month or year
