### PR TITLE
Add Scheduled task as a tracing entrypoint

### DIFF
--- a/packages/shared-src/src/tasks/ScheduledTask.js
+++ b/packages/shared-src/src/tasks/ScheduledTask.js
@@ -39,7 +39,7 @@ export class ScheduledTask {
       if (!outcome) {
         // We expect the subtask will have caught & logged all its own errors
         this.log.info(`ScheduledTask: ${name}: Not running (subtask failed)`);
-        span.addEvent('skip');
+        span.addEvent('Skip: subtask failed');
         return false;
       }
     }
@@ -49,7 +49,7 @@ export class ScheduledTask {
       this.log.info(`ScheduledTask: ${name}: Not running (previous task still running)`, {
         durationMs,
       });
-      span.addEvent('skip');
+      span.addEvent('Skip: previous task still running');
       return false;
     }
 
@@ -62,7 +62,7 @@ export class ScheduledTask {
       } else if (queueCount === 0) {
         // Nothing to do, don't even run
         this.log.info(`ScheduledTask: ${name}: Nothing to do`, { queueCount });
-        span.addEvent('skip');
+        span.addEvent('Skip: nothing to do');
         return true;
       } else {
         this.log.info(`Queue status: ${name}`, { queueCount });

--- a/packages/shared-src/src/tasks/ScheduledTask.js
+++ b/packages/shared-src/src/tasks/ScheduledTask.js
@@ -1,5 +1,7 @@
+import { SpanStatusCode } from '@opentelemetry/api';
 import shortid from 'shortid';
 import { scheduleJob } from 'node-schedule';
+import { getTracer, spanWrapFn } from '../services/logging';
 
 export class ScheduledTask {
   getName() {
@@ -16,7 +18,7 @@ export class ScheduledTask {
     this.schedule = schedule;
     this.job = null;
     this.log = log;
-    this.currentlyRunningTask = null;
+    this.currentlyRunningTask = false;
     this.start = null;
     this.subtasks = [];
   }
@@ -32,59 +34,101 @@ export class ScheduledTask {
   }
 
   async runImmediately() {
-    const name = this.getName();
+    async function inner(name, span) {
+      for (const subtask of this.subtasks) {
+        const outcome = await subtask.runImmediately();
+        if (!outcome) {
+          // We expect the subtask will have caught & logged all its own errors
+          this.log.info(`ScheduledTask: ${name}: Not running (subtask failed)`);
+          span.addEvent('skip');
+          return false;
+        }
+      }
 
-    for (const subtask of this.subtasks) {
-      const outcome = await subtask.runImmediately();
-      if (!outcome) {
-        // We expect the subtask will have caught & logged all its own errors
-        this.log.info(`ScheduledTask: ${name}: Not running (subtask failed)`);
+      if (this.currentlyRunningTask) {
+        const durationMs = Date.now() - this.start;
+        this.log.info(`ScheduledTask: ${name}: Not running (previous task still running)`, {
+          durationMs,
+        });
+        span.addEvent('skip');
         return false;
       }
-    }
 
-    if (this.currentlyRunningTask) {
-      const durationMs = Date.now() - this.start;
-      this.log.info(`ScheduledTask: ${name}: Not running (previous task still running)`, {
-        durationMs,
-      });
-      return false;
-    }
-
-    try {
-      const queueCount = await this.countQueue();
-      if (queueCount === null) {
-        // Not a queue-based task (countQueue was not overridden)
-      } else if (queueCount === 0) {
-        // Nothing to do, don't even run
-        this.log.info(`ScheduledTask: ${name}: Nothing to do`, { queueCount });
-        return true;
-      } else {
-        this.log.info(`Queue status: ${name}`, { queueCount });
+      try {
+        span.addEvent('checkQueue');
+        // eslint-disable-next-line no-shadow
+        const queueCount = await spanWrapFn('countQueue', span => this.countQueue(span));
+        if (queueCount === null) {
+          // Not a queue-based task (countQueue was not overridden)
+        } else if (queueCount === 0) {
+          // Nothing to do, don't even run
+          this.log.info(`ScheduledTask: ${name}: Nothing to do`, { queueCount });
+          span.addEvent('skip');
+          return true;
+        } else {
+          this.log.info(`Queue status: ${name}`, { queueCount });
+          span.setAttribute('task.queueCount', queueCount);
+        }
+      } catch (e) {
+        this.log.error(`Error counting queue: ${name}`, e);
+        span.recordException(e);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        return false;
       }
-    } catch (e) {
-      this.log.error(`Error counting queue: ${name}`, e);
-      return false;
+
+      span.addEvent('pre-start');
+      const runId = shortid();
+      span.setAttribute('task.runId', runId);
+
+      this.log.info(`ScheduledTask: ${name}: Running`, { id: runId });
+      span.addEvent('start');
+      this.start = Date.now();
+
+      try {
+        // eslint-disable-next-line no-shadow
+        await spanWrapFn('run', async span => {
+          this.currentlyRunningTask = true;
+          await this.run(span);
+        });
+
+        const durationMs = Date.now() - this.start;
+        this.log.info(`ScheduledTask: ${name}: Succeeded`, { id: runId, durationMs });
+
+        span.addEvent('success');
+        span.setStatus({ code: SpanStatusCode.OK });
+
+        return true;
+      } catch (e) {
+        const durationMs = Date.now() - this.start;
+        this.log.error(`ScheduledTask: ${name}: Failed`, { id: runId, durationMs });
+        this.log.error(e.stack);
+
+        span.recordException(e);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+
+        return false;
+      } finally {
+        this.start = null;
+        this.currentlyRunningTask = false;
+        span.addEvent('end');
+      }
     }
 
-    const runId = shortid();
-    this.log.info(`ScheduledTask: ${name}: Running`, { id: runId });
-    this.start = Date.now();
-    try {
-      this.currentlyRunningTask = this.run();
-      await this.currentlyRunningTask;
-      const durationMs = Date.now() - this.start;
-      this.log.info(`ScheduledTask: ${name}: Succeeded`, { id: runId, durationMs });
-      return true;
-    } catch (e) {
-      const durationMs = Date.now() - this.start;
-      this.log.error(`ScheduledTask: ${name}: Failed`, { id: runId, durationMs });
-      this.log.error(e.stack);
-      return false;
-    } finally {
-      this.start = null;
-      this.currentlyRunningTask = null;
-    }
+    const name = this.getName();
+
+    return getTracer().startActiveSpan(`ScheduledTask/${name}`, async span => {
+      span.setAttribute('code.function', name);
+      try {
+        span.addEvent('call');
+        return await inner.call(this, name, span);
+      } catch (e) {
+        span.recordException(e);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        return false;
+      } finally {
+        span.end();
+      }
+    });
   }
 
   beginPolling() {

--- a/packages/shared-src/src/tasks/ScheduledTask.js
+++ b/packages/shared-src/src/tasks/ScheduledTask.js
@@ -18,7 +18,7 @@ export class ScheduledTask {
     this.schedule = schedule;
     this.job = null;
     this.log = log;
-    this.currentlyRunningTask = false;
+    this.isRunning = false;
     this.start = null;
     this.subtasks = [];
   }
@@ -45,7 +45,7 @@ export class ScheduledTask {
         }
       }
 
-      if (this.currentlyRunningTask) {
+      if (this.isRunning) {
         const durationMs = Date.now() - this.start;
         this.log.info(`ScheduledTask: ${name}: Not running (previous task still running)`, {
           durationMs,
@@ -87,7 +87,7 @@ export class ScheduledTask {
       try {
         // eslint-disable-next-line no-shadow
         await spanWrapFn('run', async span => {
-          this.currentlyRunningTask = true;
+          this.isRunning = true;
           await this.run(span);
         });
 
@@ -109,7 +109,7 @@ export class ScheduledTask {
         return false;
       } finally {
         this.start = null;
-        this.currentlyRunningTask = false;
+        this.isRunning = false;
         span.addEvent('end');
       }
     }


### PR DESCRIPTION
### Changes

Re-adds the manual instrumentation of ScheduledTask, this makes each run of a scheduled task a new trace, completing the Tamanu picture. Notably this makes it possible to get a complete trace for a sync session.

### Checklist

- [x] Code is finished
