### PR TITLE
Enable babel-loader caching

### DIFF
--- a/common.webpack.config.mjs
+++ b/common.webpack.config.mjs
@@ -13,6 +13,7 @@ export default {
         use: {
           loader: 'babel-loader',
           options: {
+            cacheDirectory: true,
             rootMode: 'upward',
           },
         },


### PR DESCRIPTION
### Changes

This makes (local) builds of sync-server source up to 300% faster.

### Checklist

- [x] Code is finished