### PR TITLE
EPI-389: Document release candidate PR creation in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
@@ -1,6 +1,6 @@
-## External 🏡 
+## External Changes 🏡 
 
-### Manual Release Steps
+### Manual Release Steps 🦀
 
 ### Features ⭐
 
@@ -8,7 +8,7 @@
 
 ### Bug fixes 🐛
 
-## Internal 🛋️ 
+## Internal Changes 🛋️ 
 
 ### Infrastructure and maintenance 🛠️
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
@@ -1,6 +1,6 @@
-## External Changes 🏡
+## Manual Release Steps 🦀
 
-### Manual Release Steps 🦀
+## External Changes 🏡
 
 ### Features ⭐
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
@@ -1,5 +1,11 @@
 ## Manual Release Steps 🦀
 
+### Config to update ⚙️
+
+### Db schema or other changes to check against reports 📊
+
+### Other manual release steps 🤏
+
 ## External Changes 🏡
 
 ### Features ⭐

--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate.md
@@ -1,4 +1,4 @@
-## External Changes 🏡 
+## External Changes 🏡
 
 ### Manual Release Steps 🦀
 
@@ -8,8 +8,8 @@
 
 ### Bug fixes 🐛
 
-## Internal Changes 🛋️ 
+## Internal Changes 🛋️
 
 ### Infrastructure and maintenance 🛠️
 
-### Miscellaneous / Config changes 🌊 
+### Miscellaneous / Config changes 🌊

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 
 _Upon merging:_
 
-- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
+- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
   - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
   - [ ] any config/settings changes and manual deployment steps
   - [ ] any db schema or other changes that could impact downstream data analysis

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 
 _Upon merging:_
 
-- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
+- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
   - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
   - [ ] any config/settings changes and manual deployment steps
   - [ ] any db schema or other changes that could impact downstream data analysis


### PR DESCRIPTION
### Changes

This documents when you should create a new release candidate PR, as it's not clear from the PR template. It also fixes the format of the old template and changes the link to release candidates to use `label:release` rather than `in:title release`.

### Checklist

- [x] Documentation is written

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+release+in%3Atitle))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
