### PR TITLE
Make versioning script read package.json

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -8,7 +8,7 @@ if [ -z "$VERSION" ]; then
 This script sets all the relevant version numbers in the repo
 
 Usage:
-$ ./scripts/version.sh 1.2.3
+$ $0 1.2.3
 EOF
   exit 1
 fi
@@ -21,17 +21,12 @@ version() {
 }
 
 echo "Bumping package.jsons to $VERSION"
+for package in $(jq -r .workspaces.packages[] package.json); do
+  version $package/package.json
+done
 version package.json
-version packages/desktop/package.json
 version packages/desktop/app/package.json
-version packages/sync-server/package.json
-version packages/lan/package.json
-version packages/shared-src/package.json
 version packages/shared-src/shared.package.json
-version packages/meta-server/package.json
-version packages/scripts/package.json
-version packages/qr-tester/package.json
-version packages/csca/package.json
 
 cat << EOF
 


### PR DESCRIPTION
### Changes

This makes the versioning script read from the workspaces package list except for special cases so that if there's new packages it doesn't need changing.

### Checklist

- [x] Code is finished