### PR TITLE
Fix yarn lockfile being different before and after shared build

### DIFF
--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -127,7 +127,6 @@
     "semver-compare": "^1.0.0",
     "semver-diff": "^3.1.1",
     "sequelize": "^6.21.3",
-    "shared": "*",
     "shortid": "^2.2.13",
     "tiny-async-pool": "^1.2.0",
     "transliteration": "^2.2.0",


### PR DESCRIPTION
### Changes

This was a temporary change I'd made while trying out things that I forgot to remove before merging #3667.

Because shared is in the dependency list, before it's built yarn pulls it from registry, and after it's built, yarn pulls it from local, and as that's different packages the lockfile doesn't work anymore.

### Checklist

- [x] Code is finished