### PR TITLE
WAITM-671: staging-fix: add missing context to CentralServerConnection initialisation 

### DIFF
--- a/packages/lan/__tests__/uploadAttachment.test.js
+++ b/packages/lan/__tests__/uploadAttachment.test.js
@@ -26,7 +26,7 @@ getUploadedData.mockImplementation(async req => {
 });
 
 describe('UploadAttachment', () => {
-  const mockReq = { name: 'hello world image', type: 'image/jpeg' };
+  const mockReq = { name: 'hello world image', type: 'image/jpeg', deviceId: 'test-device-id' };
 
   it('abort uploading file if its above permitted max file size', async () => {
     await expect(uploadAttachment(mockReq, 1000)).rejects.toThrow(InvalidParameterError);
@@ -54,6 +54,7 @@ describe('UploadAttachment', () => {
     }));
     await expect(uploadAttachment(mockReq)).rejects.toThrow(RemoteCallFailedError);
     expect(CentralServerConnection.mock.calls.length).toBe(1);
+    expect(CentralServerConnection).toBeCalledWith({ deviceId: 'test-device-id' });
   });
 
   it('successfully uploads attachment', async () => {
@@ -82,5 +83,6 @@ describe('UploadAttachment', () => {
       metadata: { name: 'hello world image' },
     });
     expect(CentralServerConnection.mock.calls.length).toBe(2);
+    expect(CentralServerConnection).toBeCalledWith({ deviceId: 'test-device-id' });
   });
 });

--- a/packages/lan/app/middleware/auth.js
+++ b/packages/lan/app/middleware/auth.js
@@ -41,7 +41,7 @@ async function comparePassword(user, password) {
 
 export async function centralServerLogin(models, email, password, deviceId) {
   // try logging in to sync server
-  const centralServer = new CentralServerConnection();
+  const centralServer = new CentralServerConnection({ deviceId });
   const response = await centralServer.fetch('login', {
     awaitConnection: false,
     retryAuth: false,

--- a/packages/lan/app/routes/apiv1/attachment.js
+++ b/packages/lan/app/routes/apiv1/attachment.js
@@ -9,10 +9,10 @@ attachment.get(
   asyncHandler(async (req, res) => {
     req.checkPermission('read', 'Attachment');
 
-    const { query, params } = req;
+    const { query, params, deviceId } = req;
     const { base64 } = query;
     const { id } = params;
-    const centralServer = new CentralServerConnection();
+    const centralServer = new CentralServerConnection({ deviceId });
     const response = await centralServer.fetch(`attachment/${id}?base64=${base64}`, {
       method: 'GET',
     });

--- a/packages/lan/app/routes/apiv1/changePassword.js
+++ b/packages/lan/app/routes/apiv1/changePassword.js
@@ -10,9 +10,9 @@ changePassword.post(
     // no permission needed
     req.flagPermissionChecked();
 
-    const { models } = req;
+    const { models, deviceId } = req;
 
-    const centralServer = new CentralServerConnection();
+    const centralServer = new CentralServerConnection({ deviceId });
     const response = await centralServer.forwardRequest(req, 'changePassword');
 
     // If sync server successful, update password on lan server too

--- a/packages/lan/app/routes/apiv1/patient/patientProfilePicture.js
+++ b/packages/lan/app/routes/apiv1/patient/patientProfilePicture.js
@@ -8,7 +8,7 @@ export const patientProfilePicture = express.Router();
 patientProfilePicture.get(
   '/:id/profilePicture',
   asyncHandler(async (req, res) => {
-    const { params } = req;
+    const { params, deviceId } = req;
 
     // what we want is:
     // - the answer body
@@ -52,7 +52,7 @@ patientProfilePicture.get(
     const attachmentId = result[0].body;
 
     // load the attachment from the central server
-    const centralServer = new CentralServerConnection();
+    const centralServer = new CentralServerConnection({ deviceId });
     const response = await centralServer.fetch(`attachment/${attachmentId}?base64=true`, {
       method: 'GET',
     });

--- a/packages/lan/app/routes/apiv1/resetPassword.js
+++ b/packages/lan/app/routes/apiv1/resetPassword.js
@@ -7,10 +7,11 @@ export const resetPassword = express.Router();
 resetPassword.post(
   '/$',
   asyncHandler(async (req, res) => {
+    const { deviceId } = req;
     // no permission needed
     req.flagPermissionChecked();
 
-    const centralServer = new CentralServerConnection();
+    const centralServer = new CentralServerConnection({ deviceId });
     const response = await centralServer.forwardRequest(req, 'resetPassword');
 
     res.send(response);

--- a/packages/lan/app/routes/apiv1/syncHealth.js
+++ b/packages/lan/app/routes/apiv1/syncHealth.js
@@ -7,8 +7,9 @@ export const syncHealth = express.Router();
 syncHealth.get(
   '/$',
   asyncHandler(async (req, res) => {
+    const { deviceId } = req;
     req.flagPermissionChecked();
-    const centralServer = new CentralServerConnection();
+    const centralServer = new CentralServerConnection({ deviceId });
 
     // The desktop client and lan server should still work without
     // a connected sync server, we just want to notify the user they aren't

--- a/packages/lan/app/utils/uploadAttachment.js
+++ b/packages/lan/app/utils/uploadAttachment.js
@@ -11,6 +11,7 @@ export const uploadAttachment = async (req, maxFileSize) => {
   // req.checkPermission('write', 'Attachment'); ??
 
   // Read request and extract file, stats and metadata
+  const { deviceId } = req;
   const { file, deleteFileAfterImport, type, ...metadata } = await getUploadedData(req);
   const { size } = fs.statSync(file);
   const fileData = await asyncFs.readFile(file, { encoding: 'base64' });
@@ -25,7 +26,7 @@ export const uploadAttachment = async (req, maxFileSize) => {
 
   // Upload file to sync server
   // CentralServerConnection takes care of adding headers and convert body to JSON
-  const centralServer = new CentralServerConnection();
+  const centralServer = new CentralServerConnection({ deviceId });
   const syncResponse = await centralServer.fetch('attachment', {
     method: 'POST',
     body: {


### PR DESCRIPTION
### Changes
Something I missed with refresh token auth changes - there are other places on lan beyond the main context.centralServer in `serve` that also init CentralServerConnection

This fixes document upload

- Some places that init CentralServerConnection did not pass deviceId context

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [n/a] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
