### PR TITLE
WAITM-602: Mobile idle detection and central server disconnected alert fixes

### DIFF
--- a/packages/mobile/App/services/sync/CentralServerConnection.test.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.test.ts
@@ -169,7 +169,6 @@ describe('CentralServerConnection', () => {
     it('should set new token and refreshToken', async () => {
       const setTokenSpy = jest.spyOn(centralServerConnection, 'setToken');
       const setRefreshTokenSpy = jest.spyOn(centralServerConnection, 'setRefreshToken');
-      const setStatusSpy = jest.spyOn(centralServerConnection, 'setStatus');
       const mockToken = 'test-token';
       const mockRefreshToken = 'test-refresh-token';
       const mockNewRefreshToken = 'test-new-refresh-token';
@@ -194,7 +193,7 @@ describe('CentralServerConnection', () => {
           skipAttemptRefresh: true,
         },
       );
-      expect(setStatusSpy).toBeCalledWith(CentralConnectionStatus.Connected)
+      expect(centralServerConnection.emitter.emit).toBeCalledWith('statusChange', CentralConnectionStatus.Connected)
       expect(setTokenSpy).toBeCalledWith(mockToken);
       expect(setRefreshTokenSpy).toBeCalledWith(mockNewRefreshToken);
     });
@@ -233,7 +232,6 @@ describe('CentralServerConnection', () => {
     it('should invoke itself after invalid token and refresh endpoint', async () => {
       const refreshSpy = jest.spyOn(centralServerConnection, 'refresh');
       const fetchSpy = jest.spyOn(centralServerConnection, 'fetch');
-      const setStatusSpy = jest.spyOn(centralServerConnection, 'setStatus');
       const mockToken = 'test-token';
       const mockRefreshToken = 'test-refresh-token';
       const mockNewToken = 'test-new-token';
@@ -271,7 +269,7 @@ describe('CentralServerConnection', () => {
       expect(fetchWithTimeout).toHaveBeenNthCalledWith(1, `${mockHost}/v1/${mockPath}`, {
         headers: getHeadersWithToken(mockToken),
       });
-      expect(setStatusSpy).toHaveBeenNthCalledWith(1, CentralConnectionStatus.Disconnected)
+      expect(centralServerConnection.emitter.emit).toHaveBeenNthCalledWith(1, 'statusChange', CentralConnectionStatus.Disconnected)
       expect(fetchWithTimeout).toHaveBeenNthCalledWith(2, `${mockHost}/v1/refresh`, {
         headers: { ...getHeadersWithToken(mockToken), 'Content-Type': 'application/json' },
         method: 'POST',
@@ -280,7 +278,7 @@ describe('CentralServerConnection', () => {
           deviceId: 'mobile-test-device-id',
         }),
       });
-      expect(setStatusSpy).toHaveBeenNthCalledWith(2, CentralConnectionStatus.Connected)
+      expect(centralServerConnection.emitter.emit).toHaveBeenNthCalledWith(2, 'statusChange',  CentralConnectionStatus.Connected)
       expect(fetchWithTimeout).toHaveBeenNthCalledWith(3, `${mockHost}/v1/${mockPath}`, {
         headers: getHeadersWithToken(mockNewToken),
       });

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -58,8 +58,6 @@ export class CentralServerConnection {
   token: string | null;
   refreshToken: string | null;
 
-  status: CentralConnectionStatus = CentralConnectionStatus.Disconnected;
-
   emitter = mitt();
 
   connect(host: string): void {
@@ -98,7 +96,7 @@ export class CentralServerConnection {
       } catch(err) {
           // Handle sync disconnection and attempt refresh if possible
           if (err instanceof AuthenticationError && !isLogin) {
-            this.setStatus(CentralConnectionStatus.Disconnected)
+            this.emitter.emit('statusChange', CentralConnectionStatus.Disconnected);
             if (this.refreshToken && !skipAttemptRefresh) {
               await this.refresh();
               // Ensure that we don't get stuck in a loop of refreshes if the refresh token is invalid
@@ -215,10 +213,6 @@ export class CentralServerConnection {
     throw new Error(`Could not fetch if push has been completed after ${maxAttempts} attempts`);
   }
 
-  setStatus(status: CentralConnectionStatus) {
-    this.status = status;
-  }
-
   setToken(token: string): void {
     this.token = token;
   }
@@ -257,7 +251,7 @@ export class CentralServerConnection {
     }
     this.setRefreshToken(data.refreshToken);
     this.setToken(data.token);
-    this.setStatus(CentralConnectionStatus.Connected);
+    this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
   }
 
   async login(email: string, password: string): Promise<LoginResponse> {
@@ -274,7 +268,7 @@ export class CentralServerConnection {
         console.warn('Auth failed with an inexplicable error', data);
         throw new AuthenticationError(generalErrorMessage);
       }
-      this.setStatus(CentralConnectionStatus.Connected);
+      this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
       return data;
     } catch (err) {
       this.throwError(err);

--- a/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
+++ b/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
@@ -155,21 +155,29 @@ export const SyncInactiveAlert = (): JSX.Element => {
   const handleOpenModal = (): void => setOpenAuthenticationModel(true);
   const handleCloseModal = (): void => setOpenAuthenticationModel(false);
 
-  useEffect(() => {
+  const handleStatusChange = (status: CentralConnectionStatus, isInternetReachable: boolean): void => {
     if (
-      centralServer.status === CentralConnectionStatus.Disconnected
+      status === CentralConnectionStatus.Disconnected
       // Reconnection with central is not possible if there is no internet connection
     ) {
-      if (netInfo.isInternetReachable) {
+      if (isInternetReachable) {
         handleOpen();
       } else if (open) {
         handleClose();
       }
     }
-    if (centralServer.status === CentralConnectionStatus.Connected && open) {
+    if (status === CentralConnectionStatus.Connected && open) {
       handleClose();
     }
-  }, [centralServer.status, netInfo.isInternetReachable]);
+  };
+
+  useEffect(() => {
+    const handler = status => handleStatusChange(status, netInfo.isInternetReachable);
+    centralServer.emitter.on('statusChange', handler);
+    return () => {
+      centralServer.emitter.off('statusChange', handler);
+    };
+  }, [netInfo.isInternetReachable]);
 
   return (
     <>

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -29,6 +29,7 @@ type AuthProviderProps = WithAuthStoreProps & {
 interface AuthContextData {
   user: IUser;
   ability: PureAbility;
+  signedIn: boolean;
   signIn: (params: SyncConnectionParameters) => Promise<void>;
   signOut: () => void;
   reconnectWithPassword: (params: ReconnectWithPasswordParameters) => Promise<void>;
@@ -48,6 +49,7 @@ const Provider = ({
   setRefreshToken,
   setUser,
   setSignedInStatus,
+  signedIn,
   children,
   signOutUser,
   navRef,
@@ -203,6 +205,7 @@ const Provider = ({
         isUserAuthenticated,
         checkFirstSession,
         user,
+        signedIn,
         ability,
         requestResetPassword,
         resetPasswordLastEmailUsed,

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -14,9 +14,9 @@ import { SelectFacilityScreen } from '~/ui/navigation/screens/signup/SelectFacil
 const Stack = createStackNavigator();
 
 function getSignInFlowRoute(): string {
-  const authCtx = useAuth();
+  const { signedIn } = useAuth();
   const { facilityId } = useFacility();
-  if (!authCtx.isUserAuthenticated()) {
+  if (!signedIn) {
     return Routes.SignUpStack.Index;
   } else if (!facilityId) {
     return Routes.SignUpStack.SelectFacility;
@@ -28,15 +28,13 @@ export const Core: FunctionComponent<any> = () => {
   const initialRouteName = getSignInFlowRoute();
 
   return (
-    <Stack.Navigator
-      headerMode="none"
-      initialRouteName={initialRouteName}
-    >
+    <Stack.Navigator headerMode="none" initialRouteName={initialRouteName}>
       <Stack.Screen name={Routes.Autocomplete.Modal} component={AutocompleteModalScreen} />
       <Stack.Screen
         name={Routes.SignUpStack.Index}
         component={SignUpStack}
-        initialParams={{ signedOutFromInactivity: false }} />
+        initialParams={{ signedOutFromInactivity: false }}
+      />
       <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
       <Stack.Screen
         options={noSwipeGestureOnNavigator}

--- a/packages/sync-server/app/auth/login.js
+++ b/packages/sync-server/app/auth/login.js
@@ -4,10 +4,10 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { getPermissionsForRoles } from 'shared/permissions/rolesToPermissions';
 import { BadAuthenticationError } from 'shared/errors';
+import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
 import { getLocalisation } from '../localisation';
 import { convertFromDbRecord } from '../convertDbRecord';
 import { getToken, stripUser, findUser, getRandomBase64String, getRandomU32 } from './utils';
-import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
 
 export const login = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {

--- a/packages/sync-server/app/auth/refresh.js
+++ b/packages/sync-server/app/auth/refresh.js
@@ -3,8 +3,8 @@ import asyncHandler from 'express-async-handler';
 import { BadAuthenticationError } from 'shared/errors';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { getToken, verifyToken, findUserById, getRandomU32, getRandomBase64String } from './utils';
 import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
+import { getToken, verifyToken, findUserById, getRandomU32, getRandomBase64String } from './utils';
 
 export const refresh = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {

--- a/packages/sync-server/app/auth/userMiddleware.js
+++ b/packages/sync-server/app/auth/userMiddleware.js
@@ -3,8 +3,8 @@ import asyncHandler from 'express-async-handler';
 import config from 'config';
 
 import { ForbiddenError, BadAuthenticationError } from 'shared/errors';
-import { verifyToken, stripUser, findUser, findUserById } from './utils';
 import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
+import { verifyToken, stripUser, findUser, findUserById } from './utils';
 
 const FAKE_TOKEN = 'fake-token';
 


### PR DESCRIPTION
### Changes
- Conditional rendering of idle detection view wrapper caused a discrepancy with nav router ref and would flash logout but stay on same route
- Due to backendManager being a class passed directly to context value (not observable) - status change would not properly cause a re-render - change back to event - but listen from component and avoid passing upwards through AuthService -> AuthContext -> Redux state

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [n/a] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
