### PR TITLE
EPI-394: Move mobile package.json to normal versioning

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -146,7 +146,7 @@ android {
         applicationId "com.tamanuapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode patch.toInteger()
+        versionCode major.toInteger() * 1000000 + minor.toInteger() * 1000 + patch.toInteger()
         versionName getAppVersion()
         multiDexEnabled true
     }

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "1.25.54",
+  "version": "1.25.0",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -15,8 +15,8 @@ export const SUPPORTED_CLIENT_VERSIONS = {
     max: '1.25.0', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Mobile': {
-    min: '1.25.54',
-    max: '1.25.54', // note that higher patch versions will be allowed to connect
+    min: '1.25.0',
+    max: '1.25.0', // note that higher patch versions will be allowed to connect
   },
   'fiji-vps': {
     min: null,

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -27,11 +27,11 @@ done
 version package.json
 version packages/desktop/app/package.json
 version packages/shared-src/shared.package.json
+version packages/mobile/package.json
 
 cat << EOF
 
 Don't forget to manually update:
   - packages/lan/app/middleware/versionCompatibility.js
   - packages/sync-server/app/middleware/versionCompatibility.js
-  - packages/mobile/package.json (the patch version of mobile must monotonically increase)
 EOF


### PR DESCRIPTION
### Changes

This moves mobile from versions like `1.25.55` to `1.25.0`, and `versionCode` (an Android thing; here are the [docs](https://developer.android.com/studio/publish/versioning#versioningsettings)) from `55` to `1025000`. We won't have to manually keep mobile monotonically increasing, and hotfix versions for older releases are now much easier because they won't conflict with newer releases.

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] update the [versioning playbook](https://beyond-essential.slab.com/posts/tamanu-release-workflow-fka-update-playbook-23rhzna1)
