### PR TITLE
TAN-2071: hot-fix adjusting styles for auto complete component

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -22,13 +22,15 @@ const SuggestionsContainer = styled(Popper)`
   .react-autosuggest__suggestions-container {
     max-height: 210px;
     overflow-y: auto;
+    border-color: ${Colors.primary};
   }
 `;
 
 const SuggestionsList = styled(Paper)`
+  margin-top: 1px;
   box-shadow: none;
   border: 1px solid ${Colors.outline};
-  border-radius: 0 0 3px 3px;
+  border-radius: 3px;
 
   .react-autosuggest__suggestions-list {
     margin: 0;
@@ -37,11 +39,12 @@ const SuggestionsList = styled(Paper)`
 
     .MuiButtonBase-root {
       padding: 12px 12px 12px 20px;
+      padding: ${props => (props.size === 'small' ? '8px 12px 8px 20px' : '12px 12px 12px 20px')};
       white-space: normal;
 
       .MuiTypography-root {
-        font-size: 14px;
-        line-height: 18px;
+        font-size: ${props => (props.size === 'small' ? '11px' : '14px')};
+        line-height: 1.3em;
       }
 
       &:hover {
@@ -213,22 +216,27 @@ class BaseAutocomplete extends Component {
     );
   };
 
-  renderContainer = option => (
-    <SuggestionsContainer
-      anchorEl={this.anchorEl}
-      open={!!option.children}
-      placement="bottom-start"
-    >
-      <SuggestionsList {...option.containerProps}>{option.children}</SuggestionsList>
-    </SuggestionsContainer>
-  );
+  renderContainer = option => {
+    const { size = 'medium' } = this.props;
+    return (
+      <SuggestionsContainer
+        anchorEl={this.anchorEl}
+        open={!!option.children}
+        placement="bottom-start"
+      >
+        <SuggestionsList {...option.containerProps} size={size}>
+          {option.children}
+        </SuggestionsList>
+      </SuggestionsContainer>
+    );
+  };
 
   setAnchorRefForPopper = ref => {
     this.anchorEl = ref;
   };
 
   renderInputComponent = inputProps => {
-    const { label, required, className, infoTooltip, tag, value, ...other } = inputProps;
+    const { label, required, className, infoTooltip, tag, value, size, ...other } = inputProps;
     const { suggestions } = this.state;
     return (
       <OuterLabelFieldWrapper
@@ -236,9 +244,11 @@ class BaseAutocomplete extends Component {
         required={required}
         className={className}
         infoTooltip={infoTooltip}
+        size={size}
       >
         <StyledTextField
           variant="outlined"
+          size={size}
           InputProps={{
             ref: this.setAnchorRefForPopper,
             endAdornment: (
@@ -270,6 +280,7 @@ class BaseAutocomplete extends Component {
       name,
       infoTooltip,
       disabled,
+      size,
       error,
       helperText,
       placeholder = 'Search...',
@@ -296,6 +307,7 @@ class BaseAutocomplete extends Component {
             name,
             placeholder,
             infoTooltip,
+            size,
             value: selectedOption?.value,
             tag: selectedOption?.tag,
             onKeyDown: this.onKeyDown,

--- a/packages/desktop/app/components/Field/OuterLabelFieldWrapper.js
+++ b/packages/desktop/app/components/Field/OuterLabelFieldWrapper.js
@@ -9,7 +9,7 @@ const OuterLabel = styled.div`
   margin-bottom: 4px;
   color: ${Colors.darkText};
   font-weight: 500;
-  font-size: 14px;
+  font-size: ${props => (props.size === 'small' ? '11px' : '14px')};
   line-height: 16px;
   letter-spacing: 0;
 `;
@@ -50,10 +50,10 @@ const StyledTooltip = styled(props => (
 `;
 
 export const OuterLabelFieldWrapper = React.memo(
-  React.forwardRef(({ children, required, label, infoTooltip, style, className }, ref) => (
+  React.forwardRef(({ children, required, label, infoTooltip, style, className, size }, ref) => (
     <div style={style} className={className} ref={ref}>
       {label && (
-        <OuterLabel className="label-field">
+        <OuterLabel className="label-field" size={size}>
           {label}
           {required && <OuterLabelRequired>*</OuterLabelRequired>}
         </OuterLabel>

--- a/packages/desktop/app/components/Field/TextField.js
+++ b/packages/desktop/app/components/Field/TextField.js
@@ -15,10 +15,11 @@ export const StyledTextField = styled(MuiTextField)`
     ${props =>
       props.style?.color ? `color: ${props.style.color}` : `color: ${Colors.darkestText}`};
     padding: 13px 12px 13px 15px;
-    ${props => (props.style?.fontSize ? `font-size: ${props.style.fontSize}` : `font-size: 15px`)};
     line-height: 18px;
     ${props => (props.style?.minHeight ? `min-height: ${props.style.minHeight}` : '')};
     ${props => (props.style?.padding ? `padding: ${props.style.padding}` : '')};
+
+    font-size: ${props => (props.size === 'small' ? '11px' : '15px')};
 
     &::placeholder {
       color: ${Colors.softText};

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -30,7 +30,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
         name="villageId"
         component={AutocompleteField}
         suggester={villageSuggester}
-        style={{ fontSize: '11px' }}
+        size="small"
       />
       <DisplayIdField />
       <DOBFields />

--- a/packages/desktop/app/components/SearchBar/PatientSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/PatientSearchBar.js
@@ -45,11 +45,13 @@ export const PatientSearchBar = React.memo(
           name="locationGroupId"
           defaultLabel="Location"
           component={AutocompleteField}
+          size="small"
           suggester={locationGroupSuggester}
         />
         <LocalisedField
           name="departmentId"
           defaultLabel="Department"
+          size="small"
           component={AutocompleteField}
           suggester={departmentSuggester}
         />
@@ -57,6 +59,7 @@ export const PatientSearchBar = React.memo(
           name="clinicianId"
           defaultLabel="Clinician"
           component={AutocompleteField}
+          size="small"
           suggester={practitionerSuggester}
         />
       </CustomisableSearchBar>

--- a/packages/desktop/stories/fields.stories.js
+++ b/packages/desktop/stories/fields.stories.js
@@ -257,6 +257,15 @@ const dummySuggester = {
 addStories('Autocomplete', props => (
   <StoryControlWrapper Component={AutocompleteInput} label="Fruit" options={FRUITS} {...props} />
 ))
+  .add('Small', () => (
+    <StoryControlWrapper
+      Component={AutocompleteInput}
+      value="pomegranates"
+      label="Fruit"
+      size="small"
+      suggester={dummySuggester}
+    />
+  ))
   .add('Asynchronous options', () => (
     <StoryControlWrapper Component={AutocompleteInput} label="Fruit" suggester={dummySuggester} />
   ))


### PR DESCRIPTION
### Changes
- Decrease suggestions font size to match Figma
- Fix this issue mentioned [here](https://linear.app/bes/issue/TAN-2071#comment-c70fb459)
- Changed auto-complete component suggestions style to match figma:
1. Border Color
2. Border radius
3. Margin

Figma:
https://www.figma.com/file/sy6gyLBPoSXuJNq5lEEOL8/Tamanu---UI-Pattern-(Updated-2022)?node-id=7208-114526&t=G7jKvNoUyYHMcZgO-0

### Screnshoots
<img width="309" alt="image" src="https://user-images.githubusercontent.com/17033058/223866422-8bdddc03-0154-486b-b818-7eaffed6d41a.png">

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
