### PR TITLE
EPI-396: Fix connection pool exhaustion during sync

### DIFF
--- a/packages/shared-src/src/services/database.js
+++ b/packages/shared-src/src/services/database.js
@@ -57,6 +57,7 @@ async function connectToDatabase(dbOptions) {
     host = null,
     port = null,
     verbose = false,
+    pool,
   } = dbOptions;
   let { name } = dbOptions;
 
@@ -84,6 +85,7 @@ async function connectToDatabase(dbOptions) {
     host,
     port,
     logging,
+    pool,
   });
   setupQuote(sequelize);
   await sequelize.authenticate();

--- a/packages/sync-server/app/subCommands/serve.js
+++ b/packages/sync-server/app/subCommands/serve.js
@@ -29,11 +29,12 @@ export const serve = async ({ skipMigrationCheck }) => {
     config,
   });
 
+  const minConnectionPoolSnapshotHeadroom = 4;
   const connectionPoolSnapshotHeadroom =
     config.db?.pool?.max - config?.sync?.numberConcurrentPullSnapshots;
-  if (connectionPoolSnapshotHeadroom < 4) {
+  if (connectionPoolSnapshotHeadroom < minConnectionPoolSnapshotHeadroom) {
     log.warn(
-      'WARNING: config.db.pool.max is dangerously close to config.sync.numberConcurrentPullSnapshots (within 4 connections)',
+      `WARNING: config.db.pool.max is dangerously close to config.sync.numberConcurrentPullSnapshots (within ${minConnectionPoolSnapshotHeadroom} connections)`,
       {
         'config.db.pool.max': config.db?.pool?.max,
         'config.sync.numberConcurrentPullSnapshots': config.sync?.numberConcurrentPullSnapshots,

--- a/packages/sync-server/app/subCommands/serve.js
+++ b/packages/sync-server/app/subCommands/serve.js
@@ -29,6 +29,19 @@ export const serve = async ({ skipMigrationCheck }) => {
     config,
   });
 
+  const connectionPoolSnapshotHeadroom =
+    config.db?.pool?.max - config?.sync?.numberConcurrentPullSnapshots;
+  if (connectionPoolSnapshotHeadroom < 4) {
+    log.warn(
+      'WARNING: config.db.pool.max is dangerously close to config.sync.numberConcurrentPullSnapshots (within 4 connections)',
+      {
+        'config.db.pool.max': config.db?.pool?.max,
+        'config.sync.numberConcurrentPullSnapshots': config.sync?.numberConcurrentPullSnapshots,
+        connectionPoolSnapshotHeadroom,
+      },
+    );
+  }
+
   const server = app.listen(port, () => {
     log.info(`Server is running on port ${port}!`);
   });

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -8,7 +8,14 @@
     "verbose": false,
     "username": "",
     "password": "",
-    "migrateOnStartup": false
+    "migrateOnStartup": false,
+    "pool": {
+      "max": 10
+      // "min": 5,
+      // "idle": 10000,
+      // "acquire": 60000,
+      // "evict": 1000
+    }
   },
   "updateUrls": {
     "mobile": ""


### PR DESCRIPTION
### Changes

In staging at the moment we're seeing connection pool exhaustion with long-running syncs, because `numberConcurrentPullSnapshots` is 4 but the Sequelize default connection pool is only 5. This PR lets you configure the connection pool through config, ups the default to 10, and warns on startup if the two are too close together.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
