### PR TITLE
WAITM-600: Turn off idle timeout for admin panel

### DIFF
--- a/packages/desktop/app/App.js
+++ b/packages/desktop/app/App.js
@@ -9,7 +9,6 @@ import { LoginView } from './views';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
-import { UserActivityMonitor } from './components/UserActivityMonitor';
 
 const AppContainer = styled.div`
   display: flex;
@@ -39,7 +38,6 @@ export function App({ sidebar, children }) {
           <AppContentsContainer>
             {children}
             <ForbiddenErrorModal />
-            <UserActivityMonitor />
           </AppContentsContainer>
         </ErrorBoundary>
       </PromiseErrorBoundary>

--- a/packages/desktop/app/RoutingApp.js
+++ b/packages/desktop/app/RoutingApp.js
@@ -18,7 +18,7 @@ import {
   PatientsRoutes,
 } from './routes';
 import { Sidebar, FACILITY_MENU_ITEMS, SYNC_MENU_ITEMS } from './components/Sidebar';
-import { TopBar, Notification } from './components';
+import { UserActivityMonitor } from './components/UserActivityMonitor';
 
 export const RoutingApp = () => {
   const isSyncServer = useSelector(state => state.auth?.server?.type === SERVER_TYPES.SYNC);
@@ -27,6 +27,7 @@ export const RoutingApp = () => {
 
 export const RoutingFacilityApp = React.memo(() => (
   <App sidebar={<Sidebar items={FACILITY_MENU_ITEMS} />}>
+    <UserActivityMonitor />
     <Switch>
       <Redirect exact path="/" to="/patients/all" />
       <Route path="/patients" component={PatientsRoutes} />
@@ -58,14 +59,3 @@ export const RoutingAdminApp = React.memo(() => (
     </Switch>
   </App>
 ));
-
-export const AdminPlaceholder = React.memo(() => {
-  const user = useSelector(state => state.auth?.user);
-
-  return (
-    <>
-      <TopBar title="New sync admin panel" />
-      <Notification message={`Successfully logged in as ${user.displayName}`} />
-    </>
-  );
-});


### PR DESCRIPTION
### Changes

- Turn off idle timeout for admin panel

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
