### PR TITLE
Sync mobile refresh token cherrypick => staging 1-25-0

### DIFF
--- a/packages/desktop/app/App.js
+++ b/packages/desktop/app/App.js
@@ -9,7 +9,6 @@ import { LoginView } from './views';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
-import { UserActivityMonitor } from './components/UserActivityMonitor';
 
 const AppContainer = styled.div`
   display: flex;
@@ -39,7 +38,6 @@ export function App({ sidebar, children }) {
           <AppContentsContainer>
             {children}
             <ForbiddenErrorModal />
-            <UserActivityMonitor />
           </AppContentsContainer>
         </ErrorBoundary>
       </PromiseErrorBoundary>

--- a/packages/desktop/app/RoutingApp.js
+++ b/packages/desktop/app/RoutingApp.js
@@ -18,7 +18,7 @@ import {
   PatientsRoutes,
 } from './routes';
 import { Sidebar, FACILITY_MENU_ITEMS, SYNC_MENU_ITEMS } from './components/Sidebar';
-import { TopBar, Notification } from './components';
+import { UserActivityMonitor } from './components/UserActivityMonitor';
 
 export const RoutingApp = () => {
   const isSyncServer = useSelector(state => state.auth?.server?.type === SERVER_TYPES.SYNC);
@@ -27,6 +27,7 @@ export const RoutingApp = () => {
 
 export const RoutingFacilityApp = React.memo(() => (
   <App sidebar={<Sidebar items={FACILITY_MENU_ITEMS} />}>
+    <UserActivityMonitor />
     <Switch>
       <Redirect exact path="/" to="/patients/all" />
       <Route path="/patients" component={PatientsRoutes} />
@@ -58,14 +59,3 @@ export const RoutingAdminApp = React.memo(() => (
     </Switch>
   </App>
 ));
-
-export const AdminPlaceholder = React.memo(() => {
-  const user = useSelector(state => state.auth?.user);
-
-  return (
-    <>
-      <TopBar title="New sync admin panel" />
-      <Notification message={`Successfully logged in as ${user.displayName}`} />
-    </>
-  );
-});

--- a/packages/desktop/app/components/HiddenSyncAvatar.js
+++ b/packages/desktop/app/components/HiddenSyncAvatar.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { toast } from 'react-toastify';
+import { Avatar, CircularProgress } from '@material-ui/core';
+import { useApi } from '../api';
+
+const StyledAvatar = styled(Avatar)`
+  background: #e7b091;
+  font-weight: 500;
+  font-size: 16px;
+  margin-right: 12px;
+  margin-top: 5px;
+  text-transform: uppercase;
+  position: relative;
+`;
+
+const ErrorMessage = styled.div`
+  word-break: break-word;
+`;
+
+const CustomCircularProgress = styled(CircularProgress)`
+  color: #ffffff;
+`;
+
+const Error = ({ errorMessage }) => (
+  <div>
+    <b>Manual sync failed</b>
+    <ErrorMessage>{errorMessage}</ErrorMessage>
+  </div>
+);
+
+export const HiddenSyncAvatar = ({ children }) => {
+  const [loading, setLoading] = useState(false);
+  const api = useApi();
+
+  const handleClick = async event => {
+    if (!event.shiftKey || loading) return;
+    setLoading(true);
+
+    toast.info('Starting manual sync...');
+    try {
+      await api.post(`sync/run`);
+      toast.success('Manual sync complete');
+    } catch (error) {
+      toast.error(<Error errorMessage={error.message} />);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <StyledAvatar onClick={handleClick}>
+      {loading ? <CustomCircularProgress size={20} /> : children}
+    </StyledAvatar>
+  );
+};

--- a/packages/desktop/app/components/Sidebar/Sidebar.js
+++ b/packages/desktop/app/components/Sidebar/Sidebar.js
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
-import { List, Divider, Box, Typography, Avatar, Button } from '@material-ui/core';
+import { List, Divider, Box, Typography, Button } from '@material-ui/core';
 import { TamanuLogoWhite } from '../TamanuLogo';
 import { Colors } from '../../constants';
 import { Translated } from '../Translated';
+import { HiddenSyncAvatar } from '../HiddenSyncAvatar';
 import { TopLevelSidebarItem } from './TopLevelSidebarItem';
 import { PrimarySidebarItem } from './PrimarySidebarItem';
 import { SecondarySidebarItem } from './SecondarySidebarItem';
@@ -58,15 +59,6 @@ const ConnectedTo = styled(Typography)`
   font-weight: 400;
   font-size: 11px;
   line-height: 15px;
-`;
-
-const StyledAvatar = styled(Avatar)`
-  background: #e7b091;
-  font-weight: 500;
-  font-size: 16px;
-  margin-right: 12px;
-  margin-top: 5px;
-  text-transform: uppercase;
 `;
 
 const Version = styled.div`
@@ -173,7 +165,7 @@ export const Sidebar = React.memo(({ items }) => {
       <Footer>
         <StyledDivider />
         <Box display="flex" color="white">
-          <StyledAvatar>{initials}</StyledAvatar>
+          <HiddenSyncAvatar>{initials}</HiddenSyncAvatar>
           <Box flex={1}>
             <UserName>{currentUser?.displayName}</UserName>
             <ConnectedTo>{facility?.name ? facility.name : centralHost}</ConnectedTo>

--- a/packages/desktop/app/components/Sidebar/config.js
+++ b/packages/desktop/app/components/Sidebar/config.js
@@ -108,16 +108,6 @@ export const FACILITY_MENU_ITEMS = [
         path: '/imaging-requests/all',
         ability: { action: 'read' },
       },
-      {
-        label: 'Completed',
-        path: '/imaging-requests/completed',
-        ability: { action: 'read' },
-      },
-      {
-        label: 'New request',
-        path: '/imaging-requests/new',
-        ability: { action: 'create' },
-      },
     ],
   },
   {
@@ -132,16 +122,6 @@ export const FACILITY_MENU_ITEMS = [
         path: '/lab-requests/all',
         ability: { action: 'read' },
       },
-      {
-        label: 'Completed',
-        path: '/lab-requests/completed',
-        ability: { action: 'read' },
-      },
-      {
-        label: 'New request',
-        path: '/lab-requests/new',
-        ability: { action: 'create' },
-      },
     ],
   },
   {
@@ -154,10 +134,6 @@ export const FACILITY_MENU_ITEMS = [
       {
         label: 'Immunisation register',
         path: `/immunisations/all`,
-      },
-      {
-        label: 'COVID campaign',
-        path: `/immunisations/covid-campaign`,
       },
     ],
   },

--- a/packages/desktop/app/routes/ImagingRoutes.js
+++ b/packages/desktop/app/routes/ImagingRoutes.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { NotActiveView } from '../views';
 import { ImagingRequestListingView } from '../views/ImagingRequestListingView';
 
 export const ImagingRoutes = React.memo(({ match }) => (
   <div>
     <Switch>
       <Route path={`${match.path}/all`} component={ImagingRequestListingView} />
-      <Route path={`${match.path}/new`} component={NotActiveView} />
-      <Route path={`${match.path}/completed`} component={NotActiveView} />
       <Redirect to={`${match.path}/all`} />
     </Switch>
   </div>

--- a/packages/desktop/app/routes/LabsRoutes.js
+++ b/packages/desktop/app/routes/LabsRoutes.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { NotActiveView } from '../views';
 import { LabRequestListingView } from '../views/LabRequestListingView';
 
 export const LabsRoutes = React.memo(({ match }) => (
   <Switch>
     <Route path={`${match.path}/all`} component={LabRequestListingView} />
-    <Route path={`${match.path}/completed`} component={NotActiveView} />
-    <Route path={`${match.path}/new`} component={NotActiveView} />
     <Redirect to={`${match.path}/all`} />
   </Switch>
 ));

--- a/packages/desktop/app/routes/MedicationRoutes.js
+++ b/packages/desktop/app/routes/MedicationRoutes.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { NotActiveView } from '../views';
 import { MedicationListingView } from '../views/MedicationListingView';
 
 export const MedicationRoutes = React.memo(({ match }) => (
   <div>
     <Switch>
       <Route path={`${match.path}/all`} component={MedicationListingView} />
-      <Route path={`${match.path}/new`} component={NotActiveView} />
-      <Route path={`${match.path}/completed`} component={NotActiveView} />
-      <Route path={`${match.path}/dispense`} component={NotActiveView} />
       <Redirect to={`${match.path}/all`} />
     </Switch>
   </div>

--- a/packages/desktop/app/views/NotActiveView.js
+++ b/packages/desktop/app/views/NotActiveView.js
@@ -1,57 +1,9 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
-import { toast } from 'react-toastify';
-import MuiButton from '@material-ui/core/Button';
-import { useApi } from '../api';
+import React from 'react';
 import { TopBar, Notification } from '../components';
-
-// adding an invisible button as a hack to allow manually triggering a sync
-const InvisibleButton = styled(MuiButton)`
-  height: 200px;
-  width: 300px;
-`;
-
-const ErrorMessage = styled.div`
-  word-break: break-word;
-`;
-
-const Error = ({ errorMessage }) => (
-  <div>
-    <b>Manual sync failed</b>
-    <ErrorMessage>{errorMessage}</ErrorMessage>
-  </div>
-);
-
-const InvisibleSyncButton = () => {
-  const [loading, setLoading] = useState(false);
-  const api = useApi();
-
-  const onClick = async () => {
-    setLoading(true);
-
-    toast.info('Starting manual sync...');
-    try {
-      const result = await api.post(
-        `sync/run`,
-        {},
-        {
-          timeout: 30000,
-        },
-      );
-      toast.success(result.message);
-    } catch (error) {
-      toast.error(<Error errorMessage={error.message} />);
-    } finally {
-      setLoading(false);
-    }
-  };
-  return <InvisibleButton onClick={onClick} disabled={loading} />;
-};
 
 export const NotActiveView = React.memo(() => (
   <>
     <TopBar title="Not active yet" />
     <Notification message="This section is not activated yet." />
-    <InvisibleSyncButton />
   </>
 ));

--- a/packages/mobile/App/services/auth/AuthService.test.ts
+++ b/packages/mobile/App/services/auth/AuthService.test.ts
@@ -1,0 +1,44 @@
+import { CentralServerConnection } from '../sync';
+import { AuthService } from './AuthService';
+import { MODELS_MAP } from '~/models/modelsMap';
+
+jest.mock('../sync/CentralServerConnection', () => ({
+  CentralServerConnection: jest.fn().mockImplementation(() => ({
+    emitter: {
+      on: jest.fn(),
+    },
+    setToken: jest.fn(),
+    setRefreshToken: jest.fn(),
+    clearToken: jest.fn(),
+    clearRefreshToken: jest.fn(),
+  })),
+}));
+
+describe('AuthService', () => {
+  let authService;
+  let centralServerConnection;
+
+  beforeEach(() => {
+    centralServerConnection = new CentralServerConnection();
+    authService = new AuthService(MODELS_MAP, centralServerConnection);
+    (CentralServerConnection as jest.Mock<CentralServerConnection>).mockClear();
+    jest.clearAllMocks();
+  });
+
+  describe('startSession', () => {
+    it('should start a session', () => {
+      const mockToken = 'test-token';
+      const mockRefreshToken = 'test-refresh-token';
+      authService.startSession(mockToken, mockRefreshToken);
+      expect(centralServerConnection.setToken).toHaveBeenCalledWith(mockToken);
+      expect(centralServerConnection.setRefreshToken).toHaveBeenCalledWith(mockRefreshToken);
+    });
+  });
+  describe('endSession', () => {
+    it('should end a session', () => {
+      authService.endSession();
+      expect(centralServerConnection.clearToken).toHaveBeenCalled();
+      expect(centralServerConnection.clearRefreshToken).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/mobile/App/services/auth/AuthService.ts
+++ b/packages/mobile/App/services/auth/AuthService.ts
@@ -1,7 +1,7 @@
 import mitt from 'mitt';
 
 import { MODELS_MAP } from '~/models/modelsMap';
-import { CentralConnectionStatus, IUser, SyncConnectionParameters } from '~/types';
+import { IUser, SyncConnectionParameters } from '~/types';
 import { compare, hash } from './bcrypt';
 import { CentralServerConnection } from '~/services/sync';
 import { readConfig, writeConfig } from '~/services/config';
@@ -20,15 +20,9 @@ export class AuthService {
     this.models = models;
     this.centralServer = centralServer;
 
-    this.centralServer.emitter.on('centralConnectionStatusChange', (status) => {
-      this.emitter.emit('centralConnectionStatusChange', status)
-    });
-
     this.centralServer.emitter.on('error', (err) => {
       if (err instanceof AuthenticationError || err instanceof OutdatedVersionError) {
         this.emitter.emit('authError', err);
-      } else {
-        this.emitter.emit('centralConnectionStatusChange', CentralConnectionStatus.Error);
       }
     });
   }

--- a/packages/mobile/App/services/sync/CentralServerConnection.test.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.test.ts
@@ -169,7 +169,6 @@ describe('CentralServerConnection', () => {
     it('should set new token and refreshToken', async () => {
       const setTokenSpy = jest.spyOn(centralServerConnection, 'setToken');
       const setRefreshTokenSpy = jest.spyOn(centralServerConnection, 'setRefreshToken');
-      const setStatusSpy = jest.spyOn(centralServerConnection, 'setStatus');
       const mockToken = 'test-token';
       const mockRefreshToken = 'test-refresh-token';
       const mockNewRefreshToken = 'test-new-refresh-token';
@@ -194,7 +193,7 @@ describe('CentralServerConnection', () => {
           skipAttemptRefresh: true,
         },
       );
-      expect(setStatusSpy).toBeCalledWith(CentralConnectionStatus.Connected)
+      expect(centralServerConnection.emitter.emit).toBeCalledWith('statusChange', CentralConnectionStatus.Connected)
       expect(setTokenSpy).toBeCalledWith(mockToken);
       expect(setRefreshTokenSpy).toBeCalledWith(mockNewRefreshToken);
     });
@@ -233,7 +232,6 @@ describe('CentralServerConnection', () => {
     it('should invoke itself after invalid token and refresh endpoint', async () => {
       const refreshSpy = jest.spyOn(centralServerConnection, 'refresh');
       const fetchSpy = jest.spyOn(centralServerConnection, 'fetch');
-      const setStatusSpy = jest.spyOn(centralServerConnection, 'setStatus');
       const mockToken = 'test-token';
       const mockRefreshToken = 'test-refresh-token';
       const mockNewToken = 'test-new-token';
@@ -271,7 +269,7 @@ describe('CentralServerConnection', () => {
       expect(fetchWithTimeout).toHaveBeenNthCalledWith(1, `${mockHost}/v1/${mockPath}`, {
         headers: getHeadersWithToken(mockToken),
       });
-      expect(setStatusSpy).toHaveBeenNthCalledWith(1, CentralConnectionStatus.Disconnected)
+      expect(centralServerConnection.emitter.emit).toHaveBeenNthCalledWith(1, 'statusChange', CentralConnectionStatus.Disconnected)
       expect(fetchWithTimeout).toHaveBeenNthCalledWith(2, `${mockHost}/v1/refresh`, {
         headers: { ...getHeadersWithToken(mockToken), 'Content-Type': 'application/json' },
         method: 'POST',
@@ -280,7 +278,7 @@ describe('CentralServerConnection', () => {
           deviceId: 'mobile-test-device-id',
         }),
       });
-      expect(setStatusSpy).toHaveBeenNthCalledWith(2, CentralConnectionStatus.Connected)
+      expect(centralServerConnection.emitter.emit).toHaveBeenNthCalledWith(2, 'statusChange',  CentralConnectionStatus.Connected)
       expect(fetchWithTimeout).toHaveBeenNthCalledWith(3, `${mockHost}/v1/${mockPath}`, {
         headers: getHeadersWithToken(mockNewToken),
       });

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -58,8 +58,6 @@ export class CentralServerConnection {
   token: string | null;
   refreshToken: string | null;
 
-  status: CentralConnectionStatus = CentralConnectionStatus.Disconnected;
-
   emitter = mitt();
 
   connect(host: string): void {
@@ -98,7 +96,7 @@ export class CentralServerConnection {
       } catch(err) {
           // Handle sync disconnection and attempt refresh if possible
           if (err instanceof AuthenticationError && !isLogin) {
-            this.setStatus(CentralConnectionStatus.Disconnected)
+            this.emitter.emit('statusChange', CentralConnectionStatus.Disconnected);
             if (this.refreshToken && !skipAttemptRefresh) {
               await this.refresh();
               // Ensure that we don't get stuck in a loop of refreshes if the refresh token is invalid
@@ -215,10 +213,6 @@ export class CentralServerConnection {
     throw new Error(`Could not fetch if push has been completed after ${maxAttempts} attempts`);
   }
 
-  setStatus(status: CentralConnectionStatus) {
-    this.status = status;
-  }
-
   setToken(token: string): void {
     this.token = token;
   }
@@ -257,7 +251,7 @@ export class CentralServerConnection {
     }
     this.setRefreshToken(data.refreshToken);
     this.setToken(data.token);
-    this.setStatus(CentralConnectionStatus.Connected);
+    this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
   }
 
   async login(email: string, password: string): Promise<LoginResponse> {
@@ -274,7 +268,7 @@ export class CentralServerConnection {
         console.warn('Auth failed with an inexplicable error', data);
         throw new AuthenticationError(generalErrorMessage);
       }
-      this.setStatus(CentralConnectionStatus.Connected);
+      this.emitter.emit('statusChange', CentralConnectionStatus.Connected);
       return data;
     } catch (err) {
       this.throwError(err);

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -58,6 +58,8 @@ export class CentralServerConnection {
   token: string | null;
   refreshToken: string | null;
 
+  status: CentralConnectionStatus = CentralConnectionStatus.Disconnected;
+
   emitter = mitt();
 
   connect(host: string): void {
@@ -96,7 +98,7 @@ export class CentralServerConnection {
       } catch(err) {
           // Handle sync disconnection and attempt refresh if possible
           if (err instanceof AuthenticationError && !isLogin) {
-            this.emitter.emit('centralConnectionStatusChange', CentralConnectionStatus.Disconnected);
+            this.setStatus(CentralConnectionStatus.Disconnected)
             if (this.refreshToken && !skipAttemptRefresh) {
               await this.refresh();
               // Ensure that we don't get stuck in a loop of refreshes if the refresh token is invalid
@@ -213,6 +215,10 @@ export class CentralServerConnection {
     throw new Error(`Could not fetch if push has been completed after ${maxAttempts} attempts`);
   }
 
+  setStatus(status: CentralConnectionStatus) {
+    this.status = status;
+  }
+
   setToken(token: string): void {
     this.token = token;
   }
@@ -251,6 +257,7 @@ export class CentralServerConnection {
     }
     this.setRefreshToken(data.refreshToken);
     this.setToken(data.token);
+    this.setStatus(CentralConnectionStatus.Connected);
   }
 
   async login(email: string, password: string): Promise<LoginResponse> {
@@ -267,7 +274,7 @@ export class CentralServerConnection {
         console.warn('Auth failed with an inexplicable error', data);
         throw new AuthenticationError(generalErrorMessage);
       }
-
+      this.setStatus(CentralConnectionStatus.Connected);
       return data;
     } catch (err) {
       this.throwError(err);

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -48,7 +48,6 @@ export class MobileSyncManager {
   emitter = mitt();
 
   models: typeof MODELS_MAP;
-
   centralServer: CentralServerConnection;
 
   constructor(centralServer: CentralServerConnection) {

--- a/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
+++ b/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
@@ -6,10 +6,7 @@ import { theme } from '~/ui/styled/theme';
 import { Alert, AlertSeverity } from './Alert';
 import { CrossIcon } from './Icons';
 import { useSelector } from 'react-redux';
-import {
-  authCentralConnectionStatusSelector,
-  authUserSelector,
-} from '~/ui/helpers/selectors';
+import { authUserSelector } from '~/ui/helpers/selectors';
 import * as Yup from 'yup';
 import { Form } from './Forms/Form';
 import { Field } from './Forms/FormField';
@@ -18,6 +15,7 @@ import { Button } from './Button';
 import { useAuth } from '~/ui/contexts/AuthContext';
 import { useNetInfo } from '@react-native-community/netinfo';
 import { CentralConnectionStatus } from '~/types';
+import { useBackend } from '../hooks';
 
 interface AuthenticationModelProps {
   open: boolean;
@@ -150,7 +148,7 @@ export const SyncInactiveAlert = (): JSX.Element => {
   const [open, setOpen] = useState(false);
 
   const netInfo = useNetInfo();
-  const centralConnectionStatus = useSelector(authCentralConnectionStatusSelector);
+  const { centralServer } = useBackend();
 
   const handleClose = (): void => setOpen(false);
   const handleOpen = (): void => setOpen(true);
@@ -159,7 +157,7 @@ export const SyncInactiveAlert = (): JSX.Element => {
 
   useEffect(() => {
     if (
-      centralConnectionStatus === CentralConnectionStatus.Disconnected
+      centralServer.status === CentralConnectionStatus.Disconnected
       // Reconnection with central is not possible if there is no internet connection
     ) {
       if (netInfo.isInternetReachable) {
@@ -168,10 +166,10 @@ export const SyncInactiveAlert = (): JSX.Element => {
         handleClose();
       }
     }
-    if (centralConnectionStatus === CentralConnectionStatus.Connected && open) {
+    if (centralServer.status === CentralConnectionStatus.Connected && open) {
       handleClose();
     }
-  }, [centralConnectionStatus, netInfo.isInternetReachable]);
+  }, [centralServer.status, netInfo.isInternetReachable]);
 
   return (
     <>

--- a/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
+++ b/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
@@ -155,21 +155,29 @@ export const SyncInactiveAlert = (): JSX.Element => {
   const handleOpenModal = (): void => setOpenAuthenticationModel(true);
   const handleCloseModal = (): void => setOpenAuthenticationModel(false);
 
-  useEffect(() => {
+  const handleStatusChange = (status: CentralConnectionStatus, isInternetReachable: boolean): void => {
     if (
-      centralServer.status === CentralConnectionStatus.Disconnected
+      status === CentralConnectionStatus.Disconnected
       // Reconnection with central is not possible if there is no internet connection
     ) {
-      if (netInfo.isInternetReachable) {
+      if (isInternetReachable) {
         handleOpen();
       } else if (open) {
         handleClose();
       }
     }
-    if (centralServer.status === CentralConnectionStatus.Connected && open) {
+    if (status === CentralConnectionStatus.Connected && open) {
       handleClose();
     }
-  }, [centralServer.status, netInfo.isInternetReachable]);
+  };
+
+  useEffect(() => {
+    const handler = status => handleStatusChange(status, netInfo.isInternetReachable);
+    centralServer.emitter.on('statusChange', handler);
+    return () => {
+      centralServer.emitter.off('statusChange', handler);
+    };
+  }, [netInfo.isInternetReachable]);
 
   return (
     <>

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -29,6 +29,7 @@ type AuthProviderProps = WithAuthStoreProps & {
 interface AuthContextData {
   user: IUser;
   ability: PureAbility;
+  signedIn: boolean;
   signIn: (params: SyncConnectionParameters) => Promise<void>;
   signOut: () => void;
   reconnectWithPassword: (params: ReconnectWithPasswordParameters) => Promise<void>;
@@ -48,6 +49,7 @@ const Provider = ({
   setRefreshToken,
   setUser,
   setSignedInStatus,
+  signedIn,
   children,
   signOutUser,
   navRef,
@@ -203,6 +205,7 @@ const Provider = ({
         isUserAuthenticated,
         checkFirstSession,
         user,
+        signedIn,
         ability,
         requestResetPassword,
         resetPasswordLastEmailUsed,

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -16,7 +16,7 @@ import { withAuth } from '~/ui/containers/Auth';
 import { WithAuthStoreProps } from '~/ui/store/ducks/auth';
 import { Routes } from '~/ui/helpers/routes';
 import { BackendContext } from '~/ui/contexts/BackendContext';
-import { CentralConnectionStatus, IUser, ReconnectWithPasswordParameters, SyncConnectionParameters } from '~/types';
+import { IUser, ReconnectWithPasswordParameters, SyncConnectionParameters } from '~/types';
 import { ResetPasswordFormModel } from '/interfaces/forms/ResetPasswordFormProps';
 import { ChangePasswordFormModel } from '/interfaces/forms/ChangePasswordFormProps';
 import { buildAbility } from '~/ui/helpers/ability';
@@ -35,7 +35,6 @@ interface AuthContextData {
   signOutClient: (signedOutFromInactivity: boolean) => void;
   isUserAuthenticated: () => boolean;
   setUserFirstSignIn: () => void;
-  setCentralConnectionStatus: (status: CentralConnectionStatus) => void;
   checkFirstSession: () => boolean;
   requestResetPassword: (params: ResetPasswordFormModel) => void;
   resetPasswordLastEmailUsed: string;
@@ -49,7 +48,6 @@ const Provider = ({
   setRefreshToken,
   setUser,
   setSignedInStatus,
-  setCentralConnectionStatus,
   children,
   signOutUser,
   navRef,
@@ -164,9 +162,7 @@ const Provider = ({
 
     if (props.token && props.user) {
       backend.auth.startSession(props.token, props.refreshToken);
-      setCentralConnectionStatus(CentralConnectionStatus.Connected);
     } else {
-      setCentralConnectionStatus(CentralConnectionStatus.Disconnected);
       backend.auth.endSession();
     }
   }, [backend, props.token, props.user]);
@@ -190,14 +186,9 @@ const Provider = ({
         signOut();
       }
     };
-    const centralStatusChangeHandler = (status: CentralConnectionStatus) => {
-      setCentralConnectionStatus(status)
-    }
     backend.auth.emitter.on('authError', errHandler);
-    backend.auth.emitter.on('centralConnectionStatusChange', centralStatusChangeHandler)
     return () => {
       backend.auth.emitter.off('authError', errHandler);
-      backend.auth.emitter.off('centralConnectionStatusChange', centralStatusChangeHandler)
     };
   }, [backend, props.token, preventSignOutOnFailure]);
 
@@ -205,7 +196,6 @@ const Provider = ({
     <AuthContext.Provider
       value={{
         setUserFirstSignIn,
-        setCentralConnectionStatus,
         signIn,
         signOut,
         reconnectWithPassword,

--- a/packages/mobile/App/ui/helpers/selectors.ts
+++ b/packages/mobile/App/ui/helpers/selectors.ts
@@ -11,11 +11,6 @@ export const authUserSelector = createSelector(
   user => user,
 );
 
-export const authCentralConnectionStatusSelector = createSelector(
-  (state: ReduxStoreProps) => state.auth.centralConnectionStatus,
-  centralConnectionStatus => centralConnectionStatus,
-);
-
 export const authSignedInSelector = createSelector(
   (state: ReduxStoreProps) => state.auth.signedIn,
   signedIn => signedIn,

--- a/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
@@ -5,6 +5,7 @@ import {
   CenterView,
   StyledText,
   StyledSafeAreaView,
+  StyledView,
 } from '../../../styled/common';
 import { theme } from '../../../styled/theme';
 import { LogoV1Icon } from '../../../components/Icons';
@@ -15,10 +16,7 @@ import { Routes } from '../../../helpers/routes';
 // Screen
 import { IntroScreenProps } from '../../../interfaces/Screens/SignUpStack/Intro';
 
-export const IntroScreen: FunctionComponent<any> = ({
-  navigation,
-  route,
-}: IntroScreenProps) => {
+export const IntroScreen: FunctionComponent<any> = ({ navigation, route }: IntroScreenProps) => {
   const onNavigateToSignIn = useCallback(() => {
     navigation.navigate(Routes.SignUpStack.SignIn);
   }, []);
@@ -32,16 +30,13 @@ export const IntroScreen: FunctionComponent<any> = ({
           <LogoV1Icon />
         </CenterView>
         <CenterView>
-          {signedOutFromInactivity && (
-            <StyledText
-              color={theme.colors.ALERT}
-              marginTop={screenPercentageToDP(15.32, Orientation.Height)}
-            >
-              Signed out from inactivity
-            </StyledText>
-          )}
+          <StyledView height={19} marginTop={screenPercentageToDP(12.32, Orientation.Height)}>
+            {signedOutFromInactivity && (
+              <StyledText color={theme.colors.ALERT}>Signed out from inactivity</StyledText>
+            )}
+          </StyledView>
         </CenterView>
-        <CenterView marginTop={screenPercentageToDP(26.36, Orientation.Height)}>
+        <CenterView marginTop={screenPercentageToDP(11.5, Orientation.Height)}>
           <StyledText
             color={theme.colors.PRIMARY_MAIN}
             fontSize={`${screenPercentageToDP('3.4', Orientation.Height)}px`}

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -14,9 +14,9 @@ import { SelectFacilityScreen } from '~/ui/navigation/screens/signup/SelectFacil
 const Stack = createStackNavigator();
 
 function getSignInFlowRoute(): string {
-  const authCtx = useAuth();
+  const { signedIn } = useAuth();
   const { facilityId } = useFacility();
-  if (!authCtx.isUserAuthenticated()) {
+  if (!signedIn) {
     return Routes.SignUpStack.Index;
   } else if (!facilityId) {
     return Routes.SignUpStack.SelectFacility;
@@ -28,15 +28,13 @@ export const Core: FunctionComponent<any> = () => {
   const initialRouteName = getSignInFlowRoute();
 
   return (
-    <Stack.Navigator
-      headerMode="none"
-      initialRouteName={initialRouteName}
-    >
+    <Stack.Navigator headerMode="none" initialRouteName={initialRouteName}>
       <Stack.Screen name={Routes.Autocomplete.Modal} component={AutocompleteModalScreen} />
       <Stack.Screen
         name={Routes.SignUpStack.Index}
         component={SignUpStack}
-        initialParams={{ signedOutFromInactivity: false }} />
+        initialParams={{ signedOutFromInactivity: false }}
+      />
       <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
       <Stack.Screen
         options={noSwipeGestureOnNavigator}

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -1,5 +1,13 @@
 import { debounce } from 'lodash';
-import React, { ReactElement, ReactNode, useCallback, useRef, useEffect, useState } from 'react';
+import React, {
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useRef,
+  useEffect,
+  useState,
+  ReactChildren,
+} from 'react';
 import { Keyboard, PanResponder } from 'react-native';
 import { useSelector } from 'react-redux';
 import { authSignedInSelector } from '~/ui/helpers/selectors';
@@ -13,24 +21,18 @@ interface DetectIdleLayerProps {
 const ONE_MINUTE = 1000 * 60;
 const UI_EXPIRY_TIME = ONE_MINUTE * 30;
 
-export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElement => {
+export const PanResponderView = ({ children }: DetectIdleLayerProps): ReactElement => {
   const [idle, setIdle] = useState(0);
-  const signedIn = useSelector(authSignedInSelector);
   const { signOutClient } = useAuth();
 
   const resetIdle = (): void => {
     setIdle(0);
   };
 
-  const debouncedResetIdle = useCallback(
-    debounce(resetIdle, 300),
-    [],
-  );
+  const debouncedResetIdle = useCallback(debounce(resetIdle, 300), []);
 
   const handleResetIdle = (): boolean => {
-    if (signedIn) {
-      debouncedResetIdle();
-    }
+    debouncedResetIdle();
     // Returns false to indicate that this component
     // shouldn't block native components from becoming the JS responder
     return false;
@@ -41,33 +43,26 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
   };
 
   useEffect(() => {
-    let hideEvent;
-    let showEvent;
-    if (signedIn) {
-      hideEvent = Keyboard.addListener('keyboardDidHide', handleResetIdle);
-      showEvent = Keyboard.addListener('keyboardDidShow', handleResetIdle);
-    }
+    const hideEvent = Keyboard.addListener('keyboardDidHide', handleResetIdle);
+    const showEvent = Keyboard.addListener('keyboardDidShow', handleResetIdle);
     return () => {
       hideEvent?.remove();
       showEvent?.remove();
     };
-  }, [signedIn]);
+  }, []);
 
   useEffect(() => {
-    let timer;
-    if (signedIn) {
-      timer = setInterval(() => {
-        const newIdle = idle + ONE_MINUTE;
-        setIdle(newIdle);
-        if (newIdle >= UI_EXPIRY_TIME) {
-          handleIdleLogout();
-        }
-      }, ONE_MINUTE);
-    }
+    const timer = setInterval(() => {
+      const newIdle = idle + ONE_MINUTE;
+      setIdle(newIdle);
+      if (newIdle >= UI_EXPIRY_TIME) {
+        handleIdleLogout();
+      }
+    }, ONE_MINUTE);
     return () => {
       clearInterval(timer);
     };
-  }, [idle, signedIn]);
+  }, [idle]);
 
   const panResponder = useRef(
     PanResponder.create({
@@ -82,4 +77,9 @@ export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElemen
       {children}
     </StyledView>
   );
+};
+
+export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElement | ReactNode => {
+  const signedIn = useSelector(authSignedInSelector);
+  return signedIn ? <PanResponderView>{children}</PanResponderView> : children;
 };

--- a/packages/mobile/App/ui/store/ducks/auth.ts
+++ b/packages/mobile/App/ui/store/ducks/auth.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { CentralConnectionStatus, IUser } from '~/types';
+import { IUser } from '~/types';
 
 export type WithAuthStoreProps = WithAuthActions & AuthStateProps;
 export interface WithAuthActions {
@@ -9,9 +9,6 @@ export interface WithAuthActions {
   setRefreshToken: (payload: string) => PayloadAction<string>;
   setFirstSignIn: (value: boolean) => PayloadAction<boolean>;
   setSignedInStatus: (payload: boolean) => PayloadAction<boolean>;
-  setCentralConnectionStatus: (
-    payload: CentralConnectionStatus,
-  ) => PayloadAction<CentralConnectionStatus>;
   signOutUser(): () => PayloadAction<void>;
 }
 
@@ -21,7 +18,6 @@ export interface AuthStateProps {
   user: IUser;
   signedIn: boolean;
   isFirstTime: boolean;
-  centralConnectionStatus: CentralConnectionStatus;
 }
 
 const initialState: AuthStateProps = {
@@ -30,7 +26,6 @@ const initialState: AuthStateProps = {
   user: null,
   signedIn: false,
   isFirstTime: true,
-  centralConnectionStatus: CentralConnectionStatus.Disconnected,
 };
 
 export const PatientSlice = createSlice({
@@ -76,15 +71,6 @@ export const PatientSlice = createSlice({
         ...state,
         token: null,
         refreshToken: null,
-      };
-    },
-    setCentralConnectionStatus(
-      state,
-      { payload: centralConnectionStatus }: PayloadAction<CentralConnectionStatus>,
-    ): AuthStateProps {
-      return {
-        ...state,
-        centralConnectionStatus,
       };
     },
   },

--- a/packages/sync-server/app/auth/login.js
+++ b/packages/sync-server/app/auth/login.js
@@ -18,6 +18,10 @@ export const login = ({ secret, refreshSecret }) =>
       throw new BadAuthenticationError('Missing credentials');
     }
 
+    if (!deviceId) {
+      throw new BadAuthenticationError('Missing deviceId');
+    }
+
     const user = await findUser(store.models, email);
 
     if (!user && config.auth.reportNoUserError) {

--- a/packages/sync-server/app/auth/login.js
+++ b/packages/sync-server/app/auth/login.js
@@ -4,10 +4,10 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { getPermissionsForRoles } from 'shared/permissions/rolesToPermissions';
 import { BadAuthenticationError } from 'shared/errors';
+import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
 import { getLocalisation } from '../localisation';
 import { convertFromDbRecord } from '../convertDbRecord';
 import { getToken, stripUser, findUser, getRandomBase64String, getRandomU32 } from './utils';
-import { JWT_TOKEN_TYPES } from '../../../shared-src/src/constants/auth';
 
 export const login = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {

--- a/packages/sync-server/app/auth/refresh.js
+++ b/packages/sync-server/app/auth/refresh.js
@@ -3,8 +3,8 @@ import asyncHandler from 'express-async-handler';
 import { BadAuthenticationError } from 'shared/errors';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
 import { getToken, verifyToken, findUserById, getRandomU32, getRandomBase64String } from './utils';
-import { JWT_TOKEN_TYPES } from '../../../shared-src/src/constants/auth';
 
 export const refresh = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {

--- a/packages/sync-server/app/auth/userMiddleware.js
+++ b/packages/sync-server/app/auth/userMiddleware.js
@@ -2,8 +2,8 @@ import asyncHandler from 'express-async-handler';
 import config from 'config';
 
 import { ForbiddenError, BadAuthenticationError } from 'shared/errors';
+import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
 import { verifyToken, stripUser, findUser, findUserById } from './utils';
-import { JWT_TOKEN_TYPES } from '../../../shared-src/src/constants/auth';
 
 const FAKE_TOKEN = 'fake-token';
 


### PR DESCRIPTION
### Changes
Add prs tested in dev for refresh token and mobile sync inactive alert

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
