### PR TITLE
EPI-390: staging-fix: user null prescription printout error

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.js
@@ -30,7 +30,7 @@ export const MultiplePrescriptionPrintoutModal = ({
     () => api.get(`user/${prescriberId}`),
     {
       enabled: !!prescriberId,
-    }
+    },
   );
 
   const { data: additionalData, isLoading: additionalDataLoading } = useQuery(

--- a/packages/desktop/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.js
@@ -28,6 +28,9 @@ export const MultiplePrescriptionPrintoutModal = ({
   const { data: prescriber, isLoading: prescriberLoading } = useQuery(
     ['prescriber', prescriberId],
     () => api.get(`user/${prescriberId}`),
+    {
+      enabled: !!prescriberId,
+    }
   );
 
   const { data: additionalData, isLoading: additionalDataLoading } = useQuery(


### PR DESCRIPTION
### Changes
Fixes this error:
![image (23)](https://user-images.githubusercontent.com/38335330/224853384-79f8d3c9-784d-4fa8-8637-43aae547fb61.png)

Due to endpoint being called with null - it could also be called with undefined if the autocomplete in backspaced into no text causing a similar error

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
