### PR TITLE
SAV-150: staging-fix: UVCI hidden under QR code

### DIFF
--- a/packages/shared-src/src/utils/patientCertificates/Layout.js
+++ b/packages/shared-src/src/utils/patientCertificates/Layout.js
@@ -60,12 +60,11 @@ export const styles = StyleSheet.create({
   vds: {
     position: 'relative',
     top: -30,
-    left: -30,
     width: 140,
   },
 });
 
-export const Row = props => <View {...props} style={styles.row} />;
+export const Row = props => <View style={styles.row} {...props} />;
 export const Col = props => <View style={styles.col} {...props} />;
 export const Box = ({ mt, mb, ...props }) => (
   <View style={[styles.box, { marginTop: mt, marginBottom: mb }]} {...props} />


### PR DESCRIPTION
### Changes
Some positioning tweaks form earlier date causes this - `the margin-left: -30px`.
After fix: *note this is just me mucking around with mock data in storybook*
![Screenshot 2023-03-14 at 1 48 11 PM](https://user-images.githubusercontent.com/38335330/224865659-c8d57b53-958e-492a-9a8c-e317391794f5.png)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
