### PR TITLE
WAITM-670: Fix mobile dropdown overlay on surveys

### DIFF
--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -57,14 +57,12 @@ interface FormFieldsProps {
   note: string;
 }
 
-export const FormFields = ({
-  components,
-  note,
-  patient,
-}: FormFieldsProps): ReactElement => {
+export const FormFields = ({ components, note, patient }: FormFieldsProps): ReactElement => {
   const [currentScreenIndex, setCurrentScreenIndex] = useState(0);
   const scrollViewRef = useRef(null);
-  const { errors, validateForm, setStatus, submitForm, values, resetForm } = useFormikContext<GenericFormValues>();
+  const { errors, validateForm, setStatus, submitForm, values, resetForm } = useFormikContext<
+    GenericFormValues
+  >();
   const { setQuestionPosition, scrollToQuestion } = useScrollToFirstError();
 
   const maxIndex = components
@@ -155,6 +153,7 @@ export const FormFields = ({
                   key={component.id}
                   component={component}
                   patient={patient}
+                  zIndex={components.length - index}
                   setPosition={setQuestionPosition(component.dataElement.code)}
                 />
               </ErrorBoundary>

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -9,6 +9,8 @@ interface SurveyQuestionProps {
   component: ISurveyScreenComponent;
   setPosition: (pos: string) => void;
   patient: IPatient;
+  // Dropdown components will overlap if there are 2 in a row if a z-index is not explicitly set
+  zIndex: number;
 }
 
 function getField(type: string, { writeToPatient: { fieldType = '' } = {} } = {}): Element {
@@ -26,6 +28,7 @@ export const SurveyQuestion = ({
   component,
   patient,
   setPosition,
+  zIndex,
 }: SurveyQuestionProps): ReactElement => {
   const { dataElement } = component;
   const config = component && component.getConfigObject();
@@ -37,7 +40,7 @@ export const SurveyQuestion = ({
   return (
     <StyledView
       marginTop={10}
-      zIndex={1}
+      zIndex={zIndex}
       onLayout={({ nativeEvent }): void => {
         setPosition(nativeEvent.layout.y);
       }}


### PR DESCRIPTION
### Changes

There is an issue where the menu in dropdowns on mobile surveys is hidden behind the next dropdown if there are 2 in a row. This is actually an issue that is existing everywhere as far as I can tell but has never come up because we don't have any examples of multiple dropdowns in a form anywhere outside of surveys.

I spent more than a couple of hours trying to find a good solution for this but manually setting the z-index in the survey form is the best I could come up with. The library that we use for the dropdowns is quite basic and doesn't support portals which would probably be the proper solution to this issue. Changing out the library for a more established one could be a long term solution but I didn't consider it in scope for this ticket.

Screenshot of fix
![Screen Shot 2023-03-14 at 3 34 04 PM](https://user-images.githubusercontent.com/12807916/224877988-f048a6de-c3ae-4cf9-8029-27bef6084f30.png)


### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
