### PR TITLE
absoluteExpiration refresh token fix cherry-picked => staging 1.25.0

### DIFF
--- a/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
+++ b/packages/mobile/App/ui/components/SyncInactiveAlert.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useState } from 'react';
+import Modal from 'react-native-modal';
+import { useSelector } from 'react-redux';
+import * as Yup from 'yup';
+import { useNetInfo } from '@react-native-community/netinfo';
 import { Orientation, screenPercentageToDP } from '~/ui/helpers/screen';
 import { StyledText, StyledTouchableOpacity, StyledView } from '~/ui/styled/common';
-import Modal from 'react-native-modal';
 import { theme } from '~/ui/styled/theme';
 import { Alert, AlertSeverity } from './Alert';
 import { CrossIcon } from './Icons';
-import { useSelector } from 'react-redux';
 import { authUserSelector } from '~/ui/helpers/selectors';
-import * as Yup from 'yup';
 import { Form } from './Forms/Form';
 import { Field } from './Forms/FormField';
 import { TextField } from './TextField/TextField';
 import { Button } from './Button';
 import { useAuth } from '~/ui/contexts/AuthContext';
-import { useNetInfo } from '@react-native-community/netinfo';
 import { CentralConnectionStatus } from '~/types';
 import { useBackend } from '../hooks';
 
@@ -30,7 +30,7 @@ const AuthenticationModal = ({ open, onClose }: AuthenticationModelProps): JSX.E
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
   const user = useSelector(authUserSelector);
   const authCtx = useAuth();
-  const handleSignIn = async (payload: AuthenticationValues) => {
+  const handleSignIn = async (payload: AuthenticationValues): Promise<void> => {
     try {
       await authCtx.reconnectWithPassword(payload);
       onClose();
@@ -155,7 +155,10 @@ export const SyncInactiveAlert = (): JSX.Element => {
   const handleOpenModal = (): void => setOpenAuthenticationModel(true);
   const handleCloseModal = (): void => setOpenAuthenticationModel(false);
 
-  const handleStatusChange = (status: CentralConnectionStatus, isInternetReachable: boolean): void => {
+  const handleStatusChange = (
+    status: CentralConnectionStatus,
+    isInternetReachable: boolean,
+  ): void => {
     if (
       status === CentralConnectionStatus.Disconnected
       // Reconnection with central is not possible if there is no internet connection
@@ -172,12 +175,14 @@ export const SyncInactiveAlert = (): JSX.Element => {
   };
 
   useEffect(() => {
-    const handler = status => handleStatusChange(status, netInfo.isInternetReachable);
+    const handler = (status: CentralConnectionStatus): void => {
+      handleStatusChange(status, netInfo.isInternetReachable);
+    };
     centralServer.emitter.on('statusChange', handler);
     return () => {
       centralServer.emitter.off('statusChange', handler);
     };
-  }, [netInfo.isInternetReachable]);
+  }, [netInfo.isInternetReachable, open]);
 
   return (
     <>

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -86,6 +86,7 @@
     "refreshToken": {
       "secret": null,
       "tokenDuration": "30d",
+      "absoluteExpiration": false,
       "refreshIdLength": 54
     },
     "resetPassword": {


### PR DESCRIPTION
### Changes
The reason for this strategy is that we are testing this stuff in dev as it involves somewhat disruptive reduction of acess-token  and refresh-token expiry config to unrealistic times like 1 min and 2 min.
Need these last changes from dev into staging.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
