### PR TITLE
WAITM-636: Update labs status colors

### DIFF
--- a/packages/desktop/app/components/LabRequestsTable.js
+++ b/packages/desktop/app/components/LabRequestsTable.js
@@ -23,7 +23,7 @@ import {
 
 const encounterColumns = [
   { key: 'requestId', title: 'Test ID', sortable: false, accessor: getRequestId },
-  { key: 'category.name', title: 'Category', accessor: getRequestType },
+  { key: 'category.name', title: 'Test category', accessor: getRequestType },
   { key: 'requestedDate', title: 'Requested at time', accessor: getDateTime },
   { key: 'displayName', title: 'Requested by', accessor: getRequestedBy, sortable: false },
   { key: 'priority.name', title: 'Priority', accessor: getPriority },

--- a/packages/desktop/app/components/Tag.js
+++ b/packages/desktop/app/components/Tag.js
@@ -5,25 +5,38 @@ const DEFAULTS = {
   background: '#F4F4F4',
 };
 
-export const Tag = styled.div`
+const BaseTag = styled.div`
   position: relative;
-  background: ${p => (p.$background ? p.$background : DEFAULTS.background)};
+  display: inline-block;
+  background: ${({ $background, $color }) => {
+    if ($background) {
+      return $background;
+    }
+    if ($color) {
+      // If no background-color prop was provided then use a semi-transparent version of the color
+      return `${$color}1A`;
+    }
+    return DEFAULTS.background;
+  }};
   color: ${p => (p.$color ? p.$color : DEFAULTS.color)};
+  font-weight: 400;
+`;
+
+export const FormFieldTag = styled(BaseTag)`
   padding: 3px 13px;
   border-radius: 20px;
-  font-weight: 400;
   font-size: 14px;
   line-height: 18px;
 `;
 
-export const StatusTag = styled.div`
-  position: relative;
-  display: inline-block;
-  background: ${p => p.$background || DEFAULTS.background};
-  color: ${p => p.$color || DEFAULTS.color};
-  padding: 6px 13px;
-  border-radius: 20px;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 16px;
+export const TableCellTag = styled(BaseTag)`
+  padding: 5px 10px;
+  border-radius: 25px;
+  font-size: 11px;
+  line-height: 15px;
 `;
+
+// Keep Tag and StatusTag export temporarily for backwards compatibility until the
+// labs epic is merged
+export const Tag = FormFieldTag;
+export const StatusTag = TableCellTag;

--- a/packages/shared-src/src/constants/labs.js
+++ b/packages/shared-src/src/constants/labs.js
@@ -12,48 +12,40 @@ export const LAB_REQUEST_STATUSES = {
 export const LAB_REQUEST_STATUS_CONFIG = {
   [LAB_REQUEST_STATUSES.RECEPTION_PENDING]: {
     label: 'Reception pending',
-    color: '#CB6100',
-    background: '#FAF0E6',
+    color: '#D10580',
   },
   [LAB_REQUEST_STATUSES.RESULTS_PENDING]: {
     label: 'Results pending',
-    color: '#19934E',
-    background: '#DEF0EE',
+    color: '#CB6100',
   },
   [LAB_REQUEST_STATUSES.TO_BE_VERIFIED]: {
     label: 'To be verified',
-    color: '#4101C9;',
-    background: '#ECE6FA',
+    color: '#BD9503',
   },
   [LAB_REQUEST_STATUSES.VERIFIED]: {
     label: 'Verified',
-    color: '#4101C9;',
-    background: '#ECE6FA',
+    color: '#1172D1',
   },
   [LAB_REQUEST_STATUSES.PUBLISHED]: {
     label: 'Published',
-    color: '#4101C9;',
-    background: '#ECE6FA',
+    color: '#19934E',
   },
   [LAB_REQUEST_STATUSES.CANCELLED]: {
     label: 'Cancelled',
-    color: '#444444;',
-    background: '#EDEDED',
+    color: '#444444',
   },
   [LAB_REQUEST_STATUSES.DELETED]: {
     label: 'Deleted',
-    color: '#444444;',
-    background: '#EDEDED',
+    color: '#444444',
   },
   [LAB_REQUEST_STATUSES.ENTERED_IN_ERROR]: {
     label: 'Entered in error',
-    color: '#444444;',
-    background: '#EDEDED',
+    color: '#F76853',
+    background: '#FFCEC7',
   },
   unknown: {
     label: 'Unknown',
-    color: '#444444;',
-    background: '#EDEDED',
+    color: '#444444',
   },
 };
 


### PR DESCRIPTION
### Changes

-  Update labs status colors to match design


Screenshots

![Screen Shot 2023-03-14 at 4 24 03 PM](https://user-images.githubusercontent.com/12807916/224885199-a9bab67c-2c5c-4f70-b6b7-c17c70f786af.png)


### Checklist

- [x] Code is finished
- [ ] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
