### PR TITLE
EPI-378: Add GIN and B-tree indexes to all current FHIR tables

### DIFF
--- a/packages/shared-src/src/migrations/1678747519206-fhirIndexes.js
+++ b/packages/shared-src/src/migrations/1678747519206-fhirIndexes.js
@@ -43,6 +43,8 @@ export async function up(query) {
           fields: [field],
           using: 'gin',
           operator: 'jsonb_path_ops',
+          // we only use this index for @? queries, so we can use the more
+          // efficient jsonb_path_ops operator class instead of the default
         },
       );
     }

--- a/packages/shared-src/src/migrations/1678747519206-fhirIndexes.js
+++ b/packages/shared-src/src/migrations/1678747519206-fhirIndexes.js
@@ -1,0 +1,71 @@
+const BTREE_INDEXES = {
+  diagnostic_reports: ['last_updated', 'status', 'effective_date_time', 'issued'],
+  immunizations: ['last_updated', 'status', 'occurrence_date_time', 'lot_number'],
+  patients: ['last_updated', 'active', 'gender', 'birth_date', 'deceased_date_time'],
+  service_requests: ['last_updated', 'status', 'intent', 'priority', 'occurrence_date_time'],
+};
+
+const GIN_INDEXES = {
+  diagnostic_reports: ['identifier', 'code', 'subject', 'performer', 'result', 'extension'],
+  immunizations: ['vaccine_code', 'patient', 'encounter', 'site', 'performer', 'protocol_applied'],
+  patients: ['identifier', 'telecom', 'address', 'link', 'extension'],
+  service_requests: [
+    'identifier',
+    'category',
+    'order_detail',
+    'location_code',
+    'code',
+    'subject',
+    'requester',
+  ],
+};
+
+export async function up(query) {
+  for (const [tableName, fields] of Object.entries(BTREE_INDEXES)) {
+    for (const field of fields) {
+      await query.addIndex(
+        { schema: 'fhir', tableName },
+        {
+          name: `${tableName}_${field}_idx`,
+          fields: [field],
+          using: 'btree',
+        },
+      );
+    }
+  }
+
+  for (const [tableName, fields] of Object.entries(GIN_INDEXES)) {
+    for (const field of fields) {
+      await query.addIndex(
+        { schema: 'fhir', tableName },
+        {
+          name: `${tableName}_${field}_ginp`,
+          fields: [field],
+          using: 'gin',
+          operator: 'jsonb_path_ops',
+        },
+      );
+    }
+  }
+}
+
+export async function down(query) {
+  await query.sequelize.query(
+    Object.entries(BTREE_INDEXES)
+      .flatMap(([tableName, fields]) =>
+        fields.map(field => `DROP INDEX IF EXISTS fhir.${tableName}_${field}_idx;`),
+      )
+      .join(' '),
+  );
+
+  await query.sequelize.query(
+    Object.entries(GIN_INDEXES)
+      .flatMap(([tableName, fields]) =>
+        fields.map(
+          field =>
+            `DROP INDEX IF EXISTS fhir.${tableName}_${field}_gin; DROP INDEX IF EXISTS fhir.${tableName}_${field}_ginp;`,
+        ),
+      )
+      .join(' '),
+  );
+}


### PR DESCRIPTION
### Changes

- Adds B-tree (forward, single item) and GIN (inverse, in-document lookups) indexes to cover all fields of FHIR tables
- Adjusts the FHIR query builder to add "cover queries" which guide the query builder to use the GIN indexes where appropriate

### Checklist

- [x] Code is finished
- [x] Tests pass

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any db schema or other changes that could impact downstream data analysis