### PR TITLE
Add index for slow query in PlannedMove task

### DIFF
--- a/packages/shared-src/src/migrations/1678836964160-encountersPlannedMoveIndex.js
+++ b/packages/shared-src/src/migrations/1678836964160-encountersPlannedMoveIndex.js
@@ -1,0 +1,7 @@
+export function up(query) {
+  return query.addIndex('encounters', ['planned_location_start_time']);
+}
+
+export function down(query) {
+  return query.removeIndex('encounters', ['planned_location_start_time']);
+}


### PR DESCRIPTION
### Changes

See [heatmap](https://ui.honeycomb.io/beyond-essential-systems/environments/test/result/wL8HFyNYb8j?hideCompare&tab=traces&useStackedGraphs) and [a representative trace](https://ui.honeycomb.io/beyond-essential-systems/environments/test/result/wL8HFyNYb8j/trace/FgbLbXNsCX5?fields[]=c_name&fields[]=c_service.name&span=622ec954c391647c).

Query plan (with `SET enable_seqscan TO off`):

```
 Aggregate  (cost=10000000021.21..10000000021.22 rows=1 width=8)
   ->  Nested Loop  (cost=10000000000.13..10000000021.21 rows=1 width=37)
         Join Filter: (("Encounter".planned_location_id)::text = ("plannedLocation".id)::text)
         ->  Seq Scan on encounters "Encounter"  (cost=10000000000.00..10000000001.02 rows=1 width=553)
               Filter: ((deleted_at IS NULL) AND ((planned_location_start_time)::bpchar < '2023-03-10 21:50:00'::bpchar))
         ->  Index Scan using locations_pkey on locations "plannedLocation"  (cost=0.13..20.16 rows=2 width=37)
               Filter: (deleted_at IS NULL)
```

You can see the foreign key in use but as there's no index for the condition, it has to seqscan encounters. Putting an index on either of deleted_at or planned_location_start_time would help, I chose the latter as it likely helps this query more.

Query plan with index:

```
 Aggregate  (cost=28.33..28.34 rows=1 width=8)
   ->  Nested Loop  (cost=0.26..28.33 rows=1 width=37)
         Join Filter: (("Encounter".planned_location_id)::text = ("plannedLocation".id)::text)
         ->  Index Scan using encounters_planned_location_start_time_idx on encounters "Encounter"  (cost=0.13..8.14 rows=1 width=553)
               Index Cond: ((planned_location_start_time)::bpchar < '2023-03-10 21:50:00'::bpchar)
               Filter: (deleted_at IS NULL)
         ->  Index Scan using locations_pkey on locations "plannedLocation"  (cost=0.13..20.16 rows=2 width=37)
               Filter: (deleted_at IS NULL)
```

### Checklist

- [x] Code is finished