### PR TITLE
WAITM-677: Add visibility status filter to mobile suggesters that are missing it

### DIFF
--- a/packages/mobile/App/models/BaseModel.ts
+++ b/packages/mobile/App/models/BaseModel.ts
@@ -11,6 +11,9 @@ import {
   Repository,
 } from 'typeorm/browser';
 import { getSyncTick } from '../services/sync/utils';
+import { ObjectType } from 'typeorm/browser/common/ObjectType';
+import { FindManyOptions } from 'typeorm/browser/find-options/FindManyOptions';
+import { VisibilityStatus } from '../visibilityStatuses';
 
 export type ModelPojo = {
   id: string;
@@ -121,6 +124,21 @@ export abstract class BaseModel extends BaseEntity {
     const thisModel = this.constructor as typeof BaseModel;
     const syncTick = await getSyncTick(thisModel.allModels, 'currentSyncTick');
     this.updatedAtSyncTick = syncTick;
+  }
+
+  static findVisible<T extends BaseEntity>(
+    this: ObjectType<T>,
+    options?: FindManyOptions<T>,
+  ): Promise<T[]> {
+    const repo = this.getRepository<T>();
+
+    if (repo.metadata.columns.find(col => col.propertyName === 'visibilityStatus')) {
+      return repo.find({
+        ...options,
+        where: { ...options.where, visibilityStatus: VisibilityStatus.Current },
+      });
+    }
+    return repo.find(options);
   }
 
   /*

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
@@ -9,22 +9,17 @@ import { Routes } from '~/ui/helpers/routes';
 import { ReferenceDataType } from '~/types';
 import { Suggester } from '~/ui/helpers/suggester';
 import { useBackend } from '~/ui/hooks';
-import { VisibilityStatus } from '~/visibilityStatuses';
 
 export const LocationDetailsSection = (): ReactElement => {
   const navigation = useNavigation();
   const { models } = useBackend();
   const { getString } = useLocalisation();
 
-  const villageSuggester = new Suggester(
-    models.ReferenceData,
-    {
-      where: {
-        type: ReferenceDataType.Village,
-        visibilityStatus: VisibilityStatus.Current,
-      },
+  const villageSuggester = new Suggester(models.ReferenceData, {
+    where: {
+      type: ReferenceDataType.Village,
     },
-  );
+  });
 
   return (
     <FormGroup sectionName="LOCATION DETAILS" marginTop>

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
@@ -9,6 +9,7 @@ import { Routes } from '~/ui/helpers/routes';
 import { ReferenceDataType } from '~/types';
 import { Suggester } from '~/ui/helpers/suggester';
 import { useBackend } from '~/ui/hooks';
+import { VisibilityStatus } from '~/visibilityStatuses';
 
 export const LocationDetailsSection = (): ReactElement => {
   const navigation = useNavigation();
@@ -20,6 +21,7 @@ export const LocationDetailsSection = (): ReactElement => {
     {
       where: {
         type: ReferenceDataType.Village,
+        visibilityStatus: VisibilityStatus.Current,
       },
     },
   );

--- a/packages/mobile/App/ui/helpers/constants.ts
+++ b/packages/mobile/App/ui/helpers/constants.ts
@@ -204,12 +204,12 @@ export const LabRequestStatus = {
 
 // also update /packages/lan/app/routes/apiv1/surveyResponse.js when this changes
 export const AutocompleteSourceToColumnMap = {
-  User: 'displayName',
   Department: 'name',
   Facility: 'name',
   Location: 'name',
   LocationGroup: 'name',
   ReferenceData: 'name',
+  User: 'displayName',
 };
 
 export const VitalsDataElements = {

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -30,19 +30,13 @@ export class Suggester<ModelType extends BaseModelSubclass> {
   }
 
   async fetch(options): Promise<BaseModel[]> {
-    const data = await this.model
-      .getRepository()
-      .find(options);
-
-    return data;
+    return this.model.findVisible(options);
   }
 
   fetchCurrentOption = async (value: string | null): Promise<OptionType> => {
     if (!value) return undefined;
     try {
-      const data = await this.model
-        .getRepository()
-        .findOne(value);
+      const data = await this.model.getRepository().findOne(value);
 
       return this.formatter(data);
     } catch (e) {
@@ -51,10 +45,7 @@ export class Suggester<ModelType extends BaseModelSubclass> {
   };
 
   fetchSuggestions = async (search: string): Promise<OptionType[]> => {
-    const {
-      where = {},
-      column = 'name',
-    } = this.options;
+    const { where = {}, column = 'name' } = this.options;
 
     try {
       const data = await this.fetch({

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
@@ -13,6 +13,7 @@ import { Routes } from '~/ui/helpers/routes';
 import { ReferenceDataType } from '~/types';
 import { Suggester } from '~/ui/helpers/suggester';
 import { useBackend } from '~/ui/hooks';
+import { VisibilityStatus } from '~/visibilityStatuses';
 
 export const VillageSection = (): ReactElement => {
   const navigation = useNavigation();
@@ -24,6 +25,7 @@ export const VillageSection = (): ReactElement => {
     {
       where: {
         type: ReferenceDataType.Village,
+        visibilityStatus: VisibilityStatus.Current,
       },
     },
   );

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
@@ -13,22 +13,17 @@ import { Routes } from '~/ui/helpers/routes';
 import { ReferenceDataType } from '~/types';
 import { Suggester } from '~/ui/helpers/suggester';
 import { useBackend } from '~/ui/hooks';
-import { VisibilityStatus } from '~/visibilityStatuses';
 
 export const VillageSection = (): ReactElement => {
   const navigation = useNavigation();
   const { models } = useBackend();
   const { getString } = useLocalisation();
 
-  const villageSuggester = new Suggester(
-    models.ReferenceData,
-    {
-      where: {
-        type: ReferenceDataType.Village,
-        visibilityStatus: VisibilityStatus.Current,
-      },
+  const villageSuggester = new Suggester(models.ReferenceData, {
+    where: {
+      type: ReferenceDataType.Village,
     },
-  );
+  });
 
   // uses new IdRelation decorator on model, so the field is `villageId` and not `village`
   return (

--- a/packages/mobile/App/ui/navigation/screens/sickOrInjured/AddIllnessDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/sickOrInjured/AddIllnessDetails.tsx
@@ -24,6 +24,7 @@ import { Dropdown } from '~/ui/components/Dropdown';
 import { authUserSelector } from '~/ui/helpers/selectors';
 import { CurrentUserField } from '~/ui/components/CurrentUserField/CurrentUserField';
 import { getCurrentDateTimeString } from '~/ui/helpers/date';
+import { VisibilityStatus } from '~/visibilityStatuses';
 
 const IllnessFormSchema = Yup.object().shape({
   certainty: Yup.mixed()
@@ -72,6 +73,7 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
   const icd10Suggester = new Suggester(models.ReferenceData, {
     where: {
       type: ReferenceDataType.ICD10,
+      visibilityStatus: VisibilityStatus.Current,
     },
   });
 

--- a/packages/mobile/App/ui/navigation/screens/sickOrInjured/AddIllnessDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/sickOrInjured/AddIllnessDetails.tsx
@@ -24,7 +24,6 @@ import { Dropdown } from '~/ui/components/Dropdown';
 import { authUserSelector } from '~/ui/helpers/selectors';
 import { CurrentUserField } from '~/ui/components/CurrentUserField/CurrentUserField';
 import { getCurrentDateTimeString } from '~/ui/helpers/date';
-import { VisibilityStatus } from '~/visibilityStatuses';
 
 const IllnessFormSchema = Yup.object().shape({
   certainty: Yup.mixed()
@@ -73,7 +72,6 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
   const icd10Suggester = new Suggester(models.ReferenceData, {
     where: {
       type: ReferenceDataType.ICD10,
-      visibilityStatus: VisibilityStatus.Current,
     },
   });
 

--- a/packages/mobile/App/ui/navigation/screens/sickOrInjured/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/sickOrInjured/PrescribeMedication.tsx
@@ -25,6 +25,7 @@ import { ReferenceData } from '~/models/ReferenceData';
 import { NumberField } from '~/ui/components/NumberField';
 import { authUserSelector } from '~/ui/helpers/selectors';
 import { getCurrentDateTimeString } from '~/ui/helpers/date';
+import { VisibilityStatus } from '~/visibilityStatuses';
 
 const styles = StyleSheet.create({
   KeyboardAvoidingViewStyles: { flex: 1 },
@@ -66,6 +67,7 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
     {
       where: {
         type: ReferenceDataType.Drug,
+        visibilityStatus: VisibilityStatus.Current,
       },
     },
   );

--- a/packages/mobile/App/ui/navigation/screens/sickOrInjured/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/sickOrInjured/PrescribeMedication.tsx
@@ -11,10 +11,7 @@ import { TextField } from '/components/TextField/TextField';
 import { Button } from '/components/Button';
 import { theme } from '/styled/theme';
 import { KeyboardAvoidingView, StyleSheet } from 'react-native';
-import {
-  screenPercentageToDP,
-  Orientation,
-} from '/helpers/screen';
+import { screenPercentageToDP, Orientation } from '/helpers/screen';
 import { useBackend } from '~/ui/hooks';
 import { withPatient } from '~/ui/containers/Patient';
 import { Routes } from '~/ui/helpers/routes';
@@ -25,7 +22,6 @@ import { ReferenceData } from '~/models/ReferenceData';
 import { NumberField } from '~/ui/components/NumberField';
 import { authUserSelector } from '~/ui/helpers/selectors';
 import { getCurrentDateTimeString } from '~/ui/helpers/date';
-import { VisibilityStatus } from '~/visibilityStatuses';
 
 const styles = StyleSheet.create({
   KeyboardAvoidingViewStyles: { flex: 1 },
@@ -45,39 +41,30 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
 
   const user = useSelector(authUserSelector);
 
-  const onPrescribeMedication = useCallback(
-    async (values): Promise<any> => {
-      const encounter = await models.Encounter.getOrCreateCurrentEncounter(
-        selectedPatient.id,
-        user.id,
-      );
+  const onPrescribeMedication = useCallback(async (values): Promise<any> => {
+    const encounter = await models.Encounter.getOrCreateCurrentEncounter(
+      selectedPatient.id,
+      user.id,
+    );
 
-      await models.Medication.createAndSaveOne({
-        encounter: encounter.id,
-        date: getCurrentDateTimeString(),
-        ...values,
-      });
+    await models.Medication.createAndSaveOne({
+      encounter: encounter.id,
+      date: getCurrentDateTimeString(),
+      ...values,
+    });
 
-      navigateToHistory();
-    }, [],
-  );
+    navigateToHistory();
+  }, []);
 
-  const medicationSuggester = new Suggester(
-    ReferenceData,
-    {
-      where: {
-        type: ReferenceDataType.Drug,
-        visibilityStatus: VisibilityStatus.Current,
-      },
+  const medicationSuggester = new Suggester(ReferenceData, {
+    where: {
+      type: ReferenceDataType.Drug,
     },
-  );
+  });
 
   return (
     <FullView background={theme.colors.BACKGROUND_GREY}>
-      <Formik
-        onSubmit={onPrescribeMedication}
-        initialValues={{}}
-      >
+      <Formik onSubmit={onPrescribeMedication} initialValues={{}}>
         {({ handleSubmit }): ReactElement => (
           <FullView
             background={theme.colors.BACKGROUND_GREY}
@@ -106,35 +93,16 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                   name="medication"
                 />
                 <StyledView
-                  marginTop={screenPercentageToDP(
-                    2.105,
-                    Orientation.Height,
-                  )}
+                  marginTop={screenPercentageToDP(2.105, Orientation.Height)}
                   height={screenPercentageToDP(21.87, Orientation.Height)}
                   justifyContent="space-between"
                 >
-                  <SectionHeader
-                    h3
-                    marginBottom={screenPercentageToDP(
-                      2.105,
-                      Orientation.Height,
-                    )}>INFO
+                  <SectionHeader h3 marginBottom={screenPercentageToDP(2.105, Orientation.Height)}>
+                    INFO
                   </SectionHeader>
-                  <Field
-                    component={TextField}
-                    name="prescription"
-                    label="Prescription"
-                  />
-                  <Field
-                    component={TextField}
-                    name="indication"
-                    label="Indication"
-                  />
-                  <Field
-                    component={TextField}
-                    name="route"
-                    label="Route"
-                  />
+                  <Field component={TextField} name="prescription" label="Prescription" />
+                  <Field component={TextField} name="indication" label="Indication" />
+                  <Field component={TextField} name="route" label="Route" />
                   <Field
                     component={NumberField}
                     name="quantity"
@@ -143,18 +111,11 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                 </StyledView>
                 <StyledView
                   marginTop={screenPercentageToDP(16.42, Orientation.Height)}
-                  marginBottom={screenPercentageToDP(
-                    0.605,
-                    Orientation.Height,
-                  )}
+                  marginBottom={screenPercentageToDP(0.605, Orientation.Height)}
                 >
                   <SectionHeader h3>Prescription notes</SectionHeader>
                 </StyledView>
-                <Field
-                  component={TextField}
-                  name="note"
-                  multiline
-                />
+                <Field component={TextField} name="note" multiline />
                 <Button
                   marginTop={screenPercentageToDP(1.22, Orientation.Height)}
                   backgroundColor={theme.colors.PRIMARY_MAIN}


### PR DESCRIPTION
### Changes
Discovered by Tim Drown on Samoa server - after marking drug visibility status to historical
Add `visibilityStatus = current` to where clause of mobile reference data suggesters for reference data selectors that are missing it. There are a few that include this already.

Fairly sure we want this logic on mobile but let me know if there is reason for this 🙏 

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
