### PR TITLE
EPI-310: Imaging ID regression fixes

### DIFF
--- a/packages/desktop/app/forms/ImagingRequestForm.js
+++ b/packages/desktop/app/forms/ImagingRequestForm.js
@@ -99,7 +99,7 @@ export const ImagingRequestForm = React.memo(
       <Form
         onSubmit={onSubmit}
         initialValues={{
-          id: generateId(),
+          displayId: generateId(),
           requestedDate: getCurrentDateTimeString(),
           ...editedObject,
         }}
@@ -111,7 +111,7 @@ export const ImagingRequestForm = React.memo(
           const imagingAreas = getAreasForImagingType(values.imagingType);
           return (
             <FormGrid>
-              <Field name="id" label="Imaging request code" disabled component={TextField} />
+              <Field name="displayId" label="Imaging request code" disabled component={TextField} />
               <Field
                 name="requestedDate"
                 label="Order date and time"

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -87,7 +87,7 @@ const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imag
 
   return (
     <FormGrid columns={3}>
-      <TextInput value={imagingRequest.displayId} label="Request ID" disabled />
+      <TextInput value={imagingRequest.id} label="Request ID" disabled />
       <TextInput
         value={imagingTypes[imagingRequest.imagingType]?.label || 'Unknown'}
         label="Request type"

--- a/packages/shared-src/src/reports/imaging-requests-line-list.js
+++ b/packages/shared-src/src/reports/imaging-requests-line-list.js
@@ -71,7 +71,7 @@ select
   f.name as "Facility",
   d.name as "Department",
   locationGroup.name as "Area",
-  ir.id as "Request ID",
+  ir.display_id as "Request ID",
   to_char(ir.requested_date::timestamp, 'DD/MM/YYYY HH12:MI AM') as "Request date and time",
   u_supervising.display_name as "Supervising clinician",
   u_requesting.display_name as "Requesting clinician",


### PR DESCRIPTION
### Changes

- Two missing ID field changes in a view and a report
- A missing change in the request creation form meant that short IDs were getting written to the `id` field and a random UUID was getting generated for the `display_id` field database-side.
- A manual database query was applied to staging to correct the records created wrongly from that last missed change: `update imaging_requests set display_id = id, id = display_id where length(display_id) = 36;`

### Checklist

- [x] Code is finished
