### PR TITLE
WAITM-602: staging-fix: mobile trigger sync on re-login with password from sync inactive alert

### DIFF
--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -96,8 +96,8 @@ const Provider = ({
       password: params.password,
     };
     setPreventSignOutOnFailure(true);
-
     await remoteSignIn(payload);
+    backend.syncManager.triggerSync();
   };
 
   const remoteSignIn = async (params: SyncConnectionParameters): Promise<void> => {


### PR DESCRIPTION
### Changes
**Staging-fix**
- This avoids confusion of expired token error persisting on sync screen if automatic sync hasn't triggered after re-login through sync inactive model
- This mimics initial logins triggering of sync

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
