### PR TITLE
Tests: Create facility from config if not already seeded

### DIFF
--- a/packages/lan/__tests__/utilities.js
+++ b/packages/lan/__tests__/utilities.js
@@ -1,6 +1,7 @@
 import 'jest-expect-message';
 import supertest from 'supertest';
 import Chance from 'chance';
+import config from 'config';
 import http from 'http';
 
 import {
@@ -124,6 +125,17 @@ export async function createTestContext() {
   await seedDepartments(models);
   await seedLocations(models);
   await seedLocationGroups(models);
+
+  // Create the facility for the current config if it doesn't exist
+  await models.Facility.findOrCreate({
+    where: {
+      id: config.serverFacilityId,
+    },
+    defaults: {
+      code: 'TEST',
+      name: 'Test Facility',
+    },
+  });
 
   const expressApp = createApp(dbResult);
   const appServer = http.createServer(expressApp);


### PR DESCRIPTION
### Changes

Something frustrating to debug: when running tests for `lan` locally, you needed to make sure that your `serverFacilityId` line in `lan`'s `local.json` was commented out, otherwise you'd get foreign key errors on the `patient_facilities` table on every test.

This creates the facility if it wasn't already seeded, dropping the requirement for the above.

### Checklist

- [x] Code is finished