### PR TITLE
EPI-350: Discharge records are not being created

### DIFF
--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -42,10 +42,9 @@ encounter.put(
     await db.transaction(async () => {
       if (req.body.discharge) {
         req.checkPermission('write', 'Discharge');
-        await models.Discharge.create({
-          ...req.body.discharge,
-          encounterId: id,
-        });
+        if (!req.body.discharge.dischargerId) {
+          throw new Error('A discharge must have a discharger.');
+        }
 
         // Update medications that were marked for discharge and ensure
         // only isDischarge, quantity and repeats fields are edited

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -35,9 +35,9 @@ encounter.put(
     const { db, models, user, params } = req;
     const { referralId, id } = params;
     req.checkPermission('read', 'Encounter');
-    const object = await models.Encounter.findByPk(id);
-    if (!object) throw new NotFoundError();
-    req.checkPermission('write', object);
+    const encounterObject = await models.Encounter.findByPk(id);
+    if (!encounterObject) throw new NotFoundError();
+    req.checkPermission('write', encounterObject);
 
     await db.transaction(async () => {
       if (req.body.discharge) {
@@ -63,10 +63,10 @@ encounter.put(
         const referral = await models.Referral.findByPk(referralId);
         await referral.update({ encounterId: id });
       }
-      await object.update(req.body, user);
+      await encounterObject.update(req.body, user);
     });
 
-    res.send(object);
+    res.send(encounterObject);
   }),
 );
 

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -43,6 +43,7 @@ encounter.put(
       if (req.body.discharge) {
         req.checkPermission('write', 'Discharge');
         if (!req.body.discharge.dischargerId) {
+          // Only automatic discharges can have a null discharger ID
           throw new Error('A discharge must have a discharger.');
         }
 

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { Op, QueryTypes } from 'sequelize';
-import { NotFoundError } from 'shared/errors';
+import { NotFoundError, InvalidParameterError } from 'shared/errors';
 import {
   LAB_REQUEST_STATUSES,
   DOCUMENT_SIZE_LIMIT,
@@ -44,7 +44,7 @@ encounter.put(
         req.checkPermission('write', 'Discharge');
         if (!req.body.discharge.dischargerId) {
           // Only automatic discharges can have a null discharger ID
-          throw new Error('A discharge must have a discharger.');
+          throw new InvalidParameterError('A discharge must have a discharger.');
         }
 
         // Update medications that were marked for discharge and ensure

--- a/packages/lan/app/routes/apiv1/patient/patientDeath.js
+++ b/packages/lan/app/routes/apiv1/patient/patientDeath.js
@@ -274,7 +274,10 @@ patientDeath.post(
         for (const encounter of activeEncounters) {
           await encounter.update({
             endDate: body.timeOfDeath,
-            discharge: { dischargerId: doc.id },
+            discharge: {
+              dischargerId: doc.id,
+              note: 'Automatically discharged by registering patient death',
+            },
           });
         }
       }

--- a/packages/lan/app/routes/apiv1/patient/patientDeath.js
+++ b/packages/lan/app/routes/apiv1/patient/patientDeath.js
@@ -272,7 +272,10 @@ patientDeath.post(
           },
         });
         for (const encounter of activeEncounters) {
-          await encounter.dischargeWithDischarger(doc, body.timeOfDeath);
+          await encounter.update({
+            endDate: body.timeOfDeath,
+            discharge: { dischargerId: doc.id },
+          });
         }
       }
     });

--- a/packages/shared-src/src/migrations/1678918010271-removeNotNullConstraintFromDischarges.js
+++ b/packages/shared-src/src/migrations/1678918010271-removeNotNullConstraintFromDischarges.js
@@ -1,0 +1,19 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  // Given that the foreign key constraint is already added,
+  // no need to put references in here. In some Sequelize versions
+  // it breaks, in others it creates a duplicate foreign key.
+  await query.changeColumn('discharges', 'discharger_id', {
+    type: DataTypes.STRING,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.bulkDelete('discharges', { discharger_id: null });
+  await query.changeColumn('discharges', 'discharger_id', {
+    type: DataTypes.STRING,
+    allowNull: false,
+  });
+}

--- a/packages/shared-src/src/models/Discharge.js
+++ b/packages/shared-src/src/models/Discharge.js
@@ -12,11 +12,6 @@ export class Discharge extends Model {
           throw new InvalidOperationError('A discharge must have an encounter.');
         }
       },
-      mustHaveDischarger() {
-        if (!this.deletedAt && !this.dischargerId) {
-          throw new InvalidOperationError('A discharge must have a discharger.');
-        }
-      },
     };
     super.init(
       {

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -330,6 +330,8 @@ export class Encounter extends Model {
   }
 
   async onDischarge({ endDate, submittedTime, systemNote, discharge }, user) {
+    if (this.endDate) throw new Error(`Encounter ${this.id} already discharged`);
+
     const { Discharge } = this.sequelize.models;
     await Discharge.create({
       ...discharge,
@@ -356,17 +358,6 @@ export class Encounter extends Model {
         closedTime: endDate,
       });
     }
-  }
-
-  async dischargeWithDischarger(discharger, endDate) {
-    if (this.endDate) throw new Error(`Encounter ${this.id} already discharged`);
-
-    const { Discharge } = this.sequelize.models;
-    await Discharge.create({
-      encounterId: this.id,
-      dischargerId: discharger.id,
-    });
-    await this.update({ endDate });
   }
 
   async updateClinician(data, user) {

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -333,10 +333,12 @@ export class Encounter extends Model {
     if (this.endDate) throw new Error(`Encounter ${this.id} already discharged`);
 
     const { Discharge } = this.sequelize.models;
-    await Discharge.create({
-      ...discharge,
-      encounterId: this.id,
-    });
+    if (discharge.dischargerId) {
+      await Discharge.create({
+        ...discharge,
+        encounterId: this.id,
+      });
+    }
 
     await this.addSystemNote(systemNote || `Discharged patient.`, submittedTime, user);
     await this.closeTriage(endDate);

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -331,12 +331,10 @@ export class Encounter extends Model {
 
   async onDischarge({ endDate, submittedTime, systemNote, discharge }, user) {
     const { Discharge } = this.sequelize.models;
-    if (discharge.dischargerId) {
-      await Discharge.create({
-        ...discharge,
-        encounterId: this.id,
-      });
-    }
+    await Discharge.create({
+      ...discharge,
+      encounterId: this.id,
+    });
 
     await this.addSystemNote(systemNote || `Discharged patient.`, submittedTime, user);
     await this.closeTriage(endDate);

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -330,8 +330,6 @@ export class Encounter extends Model {
   }
 
   async onDischarge({ endDate, submittedTime, systemNote, discharge }, user) {
-    if (this.endDate) throw new Error(`Encounter ${this.id} already discharged`);
-
     const { Discharge } = this.sequelize.models;
     if (discharge.dischargerId) {
       await Discharge.create({

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -329,8 +329,14 @@ export class Encounter extends Model {
     });
   }
 
-  async onDischarge(endDate, submittedTime, note, user) {
-    await this.addSystemNote(note || `Discharged patient.`, submittedTime, user);
+  async onDischarge({ endDate, submittedTime, systemNote, discharge }, user) {
+    const { Discharge } = this.sequelize.models;
+    await Discharge.create({
+      ...discharge,
+      encounterId: this.id,
+    });
+
+    await this.addSystemNote(systemNote || `Discharged patient.`, submittedTime, user);
     await this.closeTriage(endDate);
   }
 
@@ -385,7 +391,7 @@ export class Encounter extends Model {
     const updateEncounter = async () => {
       const additionalChanges = {};
       if (data.endDate && !this.endDate) {
-        await this.onDischarge(data.endDate, data.submittedTime, data.dischargeNote, user);
+        await this.onDischarge(data, user);
       }
 
       if (data.patientId && data.patientId !== this.patientId) {

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -336,7 +336,7 @@ export class Encounter extends Model {
       encounterId: this.id,
     });
 
-    await this.addSystemNote(systemNote || `Discharged patient.`, submittedTime, user);
+    await this.addSystemNote(systemNote || 'Discharged patient.', submittedTime, user);
     await this.closeTriage(endDate);
   }
 

--- a/packages/shared-src/src/utils/dischargeOutpatientEncounters.js
+++ b/packages/shared-src/src/utils/dischargeOutpatientEncounters.js
@@ -42,7 +42,7 @@ export const dischargeOutpatientEncounters = async (
       const justBeforeMidnight = sub(endOfDay(parseISO(oldEncounter.startDate)), { minutes: 1 });
       await oldEncounter.update({
         endDate: justBeforeMidnight,
-        dischargeNote: 'Automatically discharged',
+        systemNote: 'Automatically discharged',
       });
       log.info(`Auto-closed encounter with id ${oldEncounter.id}`);
     }

--- a/packages/shared-src/src/utils/dischargeOutpatientEncounters.js
+++ b/packages/shared-src/src/utils/dischargeOutpatientEncounters.js
@@ -43,6 +43,9 @@ export const dischargeOutpatientEncounters = async (
       await oldEncounter.update({
         endDate: justBeforeMidnight,
         systemNote: 'Automatically discharged',
+        discharge: {
+          note: 'Automatically discharged by outpatient discharger',
+        },
       });
       log.info(`Auto-closed encounter with id ${oldEncounter.id}`);
     }

--- a/packages/sync-server/app/tasks/DeceasedPatientDischarger.js
+++ b/packages/sync-server/app/tasks/DeceasedPatientDischarger.js
@@ -73,7 +73,10 @@ export class DeceasedPatientDischarger extends ScheduledTask {
         }
 
         const discharger = await patientDeathData.getClinician();
-        await encounter.dischargeWithDischarger(discharger, patient.dateOfDeath);
+        await encounter.update({
+          endDate: patient.dateOfDeath,
+          discharge: { dischargerId: discharger.id },
+        });
         log.info(
           `Auto-closed encounter with id ${encounter.id} (discharger=${discharger.id}, dod=${patient.dateOfDeath})`,
         );

--- a/packages/sync-server/app/tasks/DeceasedPatientDischarger.js
+++ b/packages/sync-server/app/tasks/DeceasedPatientDischarger.js
@@ -75,7 +75,10 @@ export class DeceasedPatientDischarger extends ScheduledTask {
         const discharger = await patientDeathData.getClinician();
         await encounter.update({
           endDate: patient.dateOfDeath,
-          discharge: { dischargerId: discharger.id },
+          discharge: {
+            dischargerId: discharger.id,
+            note: 'Automatically discharged by deceased patient discharger',
+          },
         });
         log.info(
           `Auto-closed encounter with id ${encounter.id} (discharger=${discharger.id}, dod=${patient.dateOfDeath})`,


### PR DESCRIPTION
### Changes

Main change is to refactor the way we create `Discharge` records: currently it's just one single place and it happens inside `onDischarge` method of an encounter, which ends up being a side effect of updating said encounter.

After a brief chat with McLean, we concluded that the `Discharge` record is supposed to be just extra information about a discharge and an encounter's `endDate` is what tells us if its actually discharged. Still, including a note (aside from a system note) is enough "additional information" to have.