### PR TITLE
no-issue: staging-fix: encounter view cannot read property trim of undefined

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -70,11 +70,11 @@ const extractEncounterTypeHistory = (notes, encounterData) => {
 const extractLocationHistory = (notes, encounterData) => {
   const history = extractUpdateHistoryFromNoteData(notes, encounterData, locationNoteMatcher);
   const locationHistory = history?.map(location => {
-    const locationArr = location.to?.split(',');
+    const locationArr = location.to?.split(/,\s+/);
     const hasLocationGroup = locationArr.length > 1;
     return {
       newLocationGroup: hasLocationGroup && locationArr[0],
-      newLocation: hasLocationGroup ? locationArr[1].trim() : locationArr[0],
+      newLocation: hasLocationGroup ? locationArr[1] : locationArr[0],
       date: location.date,
     };
   });

--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -70,9 +70,11 @@ const extractEncounterTypeHistory = (notes, encounterData) => {
 const extractLocationHistory = (notes, encounterData) => {
   const history = extractUpdateHistoryFromNoteData(notes, encounterData, locationNoteMatcher);
   const locationHistory = history?.map(location => {
+    const locationArr = location.to?.split(',');
+    const hasLocationGroup = locationArr.length > 1;
     return {
-      newLocationGroup: location.to?.split(',')[0],
-      newLocation: location.to?.split(',')[1].trim(),
+      newLocationGroup: hasLocationGroup && locationArr[0],
+      newLocation: hasLocationGroup ? locationArr[1].trim() : locationArr[0],
       date: location.date,
     };
   });


### PR DESCRIPTION
### Changes
**Staging-fix:**
Not all location move notes have locationGroups - this pr accounts for the split of locationHistory `to` in order to account for both cases.

This fixes `cannot read property trim of undefined` when viewing certain encounters with location history notes without locationGroups

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
