### PR TITLE
WAITM-686: staging-fix: remove sidebar links with corresponding routes removed

### DIFF
--- a/packages/desktop/app/components/Sidebar/config.js
+++ b/packages/desktop/app/components/Sidebar/config.js
@@ -79,21 +79,6 @@ export const FACILITY_MENU_ITEMS = [
         path: '/medication-requests/all',
         ability: { action: 'read' },
       },
-      {
-        label: 'Completed',
-        path: '/medication-requests/completed',
-        ability: { action: 'read' },
-      },
-      {
-        label: 'New request',
-        path: '/medication-requests/new',
-        ability: { action: 'create' },
-      },
-      {
-        label: 'Dispense',
-        path: '/medication-requests/dispense',
-        ability: { action: 'create' },
-      },
     ],
   },
   {


### PR DESCRIPTION
### Changes
**Staging fix:**
missed these ones when cleaning up unimplemented routes

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
