### PR TITLE
No issue: staging fix - solve encounter view desktop error

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -133,7 +133,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
           updatedLabRequests.push({
             testType: test.labTestType.name,
             testCategory: labRequest.category.name,
-            requestingClinician: labRequest.requestedBy.displayName,
+            requestingClinician: labRequest.requestedBy?.displayName,
             requestDate: labRequest.requestedDate,
             completedDate: test.completedDate,
           });


### PR DESCRIPTION
### Changes

This is probably caused by the procedurally generated data: lab requests are expected to have a `requested_by_id`, I think that we currently only create lab requests via the lab request form, and that is a mandatory field. However, at database level we do not enforce this, so I think that it's OK to not expect it all the time.

Also no need for card or release notes given that this is a new component created for this release.