### PR TITLE
SAV-130: Make "Not given" vaccines viewable

### DIFF
--- a/packages/desktop/app/components/VaccineCommonFields.js
+++ b/packages/desktop/app/components/VaccineCommonFields.js
@@ -198,9 +198,9 @@ export const DiseaseField = () => (
   <Field name="disease" label="Disease" component={TextField} required />
 );
 
-export const ConfirmCancelRowField = ({ submitForm, category, scheduleOptions, onCancel }) => (
+export const ConfirmCancelRowField = ({ onConfirm, category, scheduleOptions, onCancel }) => (
   <ConfirmCancelRow
-    onConfirm={submitForm}
+    onConfirm={onConfirm}
     confirmDisabled={category !== VACCINE_CATEGORIES.OTHER && scheduleOptions.length === 0}
     onCancel={onCancel}
   />

--- a/packages/lan/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/lan/__tests__/apiv1/PatientVaccine.test.js
@@ -1,7 +1,7 @@
 import config from 'config';
 
 import { createDummyEncounter, createDummyPatient, randomVitals } from 'shared/demoData/patients';
-import { VACCINE_CATEGORIES, VACCINE_RECORDING_TYPES } from 'shared/constants';
+import { VACCINE_CATEGORIES, VACCINE_RECORDING_TYPES, VACCINE_STATUS } from 'shared/constants';
 import { fake } from 'shared/test-helpers/fake';
 import { createAdministeredVaccine, createScheduledVaccine } from 'shared/demoData/vaccines';
 import { createTestContext } from '../utilities';
@@ -19,6 +19,8 @@ describe('PatientVaccine', () => {
   let location = null;
   let department = null;
   let facility = null;
+  let givenVaccine1 = null;
+  let notGivenVaccine1 = null;
   let ctx;
 
   beforeAll(async () => {
@@ -78,10 +80,27 @@ describe('PatientVaccine', () => {
     await models.Vitals.create({ encounterId: encounter.id, ...randomVitals() });
     await models.Vitals.create({ encounterId: encounter.id, ...randomVitals() });
 
+    givenVaccine1 = await models.AdministeredVaccine.create(
+      await createAdministeredVaccine(models, {
+        scheduledVaccineId: scheduled2.id,
+        encounterId: encounter.id,
+        status: VACCINE_STATUS.GIVEN,
+      }),
+    );
+
+    notGivenVaccine1 = await models.AdministeredVaccine.create(
+      await createAdministeredVaccine(models, {
+        scheduledVaccineId: scheduled2.id,
+        encounterId: encounter.id,
+        status: VACCINE_STATUS.NOT_GIVEN,
+      }),
+    );
+
     await models.AdministeredVaccine.create(
       await createAdministeredVaccine(models, {
         scheduledVaccineId: scheduled2.id,
         encounterId: encounter.id,
+        status: VACCINE_STATUS.UNKNOWN,
       }),
     );
   });
@@ -136,8 +155,13 @@ describe('PatientVaccine', () => {
     it('Should get administered vaccines', async () => {
       const result = await app.get(`/v1/patient/${patient.id}/administeredVaccines`);
       expect(result).toHaveSucceeded();
-      expect(result.body.count).toEqual(1);
-      expect(result.body.data[0].status).toEqual('GIVEN');
+      expect(result.body.count).toEqual(2);
+      expect(result.body.data.find(v => v.status === VACCINE_STATUS.GIVEN)?.id).toEqual(
+        givenVaccine1.id,
+      );
+      expect(result.body.data.find(v => v.status === VACCINE_STATUS.NOT_GIVEN)?.id).toEqual(
+        notGivenVaccine1.id,
+      );
     });
 
     it('Should mark an administered vaccine as recorded in error', async () => {

--- a/packages/shared-src/src/models/Patient.js
+++ b/packages/shared-src/src/models/Patient.js
@@ -4,6 +4,7 @@ import { getCovidClearanceCertificateFilter } from 'shared/utils';
 import { Model } from './Model';
 import { dateType, dateTimeType } from './dateTimeTypes';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
+import { VACCINE_STATUS } from '../constants';
 
 export class Patient extends Model {
   static init({ primaryKey, ...options }) {
@@ -137,7 +138,7 @@ export class Patient extends Model {
       where: {
         ...optWhere,
         '$encounter.patient_id$': this.id,
-        status: 'GIVEN',
+        status: { [Op.in]: [VACCINE_STATUS.GIVEN, VACCINE_STATUS.NOT_GIVEN] },
       },
     });
 


### PR DESCRIPTION
### Changes
- Make "Not given" vaccines viewable

### Checklist
- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
