### PR TITLE
WAITM-608: Fix Lab request status display

### DIFF
--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -95,6 +95,8 @@ export const LabRequestView = () => {
   if (isLoading) return <LoadingIndicator />;
 
   const isReadOnly = HIDDEN_STATUSES.includes(labRequest.status);
+  // If the value of status is enteredInError or deleted, it should display to the user as Cancelled
+  const displayStatus = isReadOnly ? LAB_REQUEST_STATUSES.CANCELLED : labRequest.status;
 
   return (
     <div>
@@ -125,7 +127,7 @@ export const LabRequestView = () => {
             disabled={isReadOnly}
           />
           <TextInput
-            value={LAB_REQUEST_STATUS_CONFIG[labRequest.status]?.label || 'Unknown'}
+            value={LAB_REQUEST_STATUS_CONFIG[displayStatus]?.label || 'Unknown'}
             label="Status"
             disabled={isReadOnly}
           />


### PR DESCRIPTION
### Changes

- Fix Lab request status display

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
