### PR TITLE
WAITM-670: Fix mobile dropdown height

### DIFF
--- a/packages/mobile/App/ui/components/Dropdown/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/index.tsx
@@ -64,9 +64,6 @@ export const Dropdown = React.memo(
     return (
       <StyledView
         width="100%"
-        // when items are selected, let the height be auto calculated so that
-        // the selected items view doesn't cause overlapping with any component below
-        height={selectedItems?.length ? undefined : screenPercentageToDP(6.68, Orientation.Height)}
         marginBottom={error ? screenPercentageToDP(2, Orientation.Height) : 0}
       >
         <MultiSelect


### PR DESCRIPTION
### Changes

There is a fixed height on the dropdown and the scroll on the flat list doesn't work so some of the options are cut off and aren't usable. After a lot of effort I can't get the scrolling to work so I have just removed the fixed height as a work around to make sure the options are functional.

It would be good to re-do the multi select component from scratch based on a more reliable package but since we are about to release I've gone with the lighter tough fix.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
