### PR TITLE
EPI-310: Fix imaging study referencing

### DIFF
--- a/packages/shared-src/src/models/fhir/ImagingStudy.js
+++ b/packages/shared-src/src/models/fhir/ImagingStudy.js
@@ -94,8 +94,14 @@ export class FhirImagingStudy extends FhirResource {
 
     if (!serviceRequest) {
       const failedId = serviceRequestFhirId || serviceRequestId || serviceRequestDisplayId;
-      throw new Invalid(`ServiceRequest ${failedId} does not exist in Tamanu`, {
-        code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+      if (failedId) {
+        throw new Invalid(`ServiceRequest ${failedId} does not exist in Tamanu`, {
+          code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+        });
+      }
+
+      throw new Invalid('Need to have basedOn field that includes a Tamanu identifier', {
+        code: FHIR_ISSUE_TYPE.INVALID.STRUCTURE,
       });
     }
 

--- a/packages/shared-src/src/models/fhir/ImagingStudy.js
+++ b/packages/shared-src/src/models/fhir/ImagingStudy.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { DataTypes } from 'sequelize';
 import * as yup from 'yup';
 
@@ -49,11 +50,10 @@ export class FhirImagingStudy extends FhirResource {
     const results = this.note.map(n => n.params.text).join('\n\n');
 
     const imagingAccessCode = this.identifier.find(
-      ({ params: i }) =>
-        i?.system === 'http://data-dictionary.tamanu-fiji.org/ris-accession-number.html',
+      ({ params: i }) => i?.system === config.hl7.dataDictionaries.imagingStudyAccessionId,
     )?.params.value;
     if (!imagingAccessCode) {
-      throw new Invalid('Need to have RIS Accession Number identifier', {
+      throw new Invalid('Need to have Accession Number identifier', {
         code: FHIR_ISSUE_TYPE.INVALID.STRUCTURE,
       });
     }
@@ -61,8 +61,7 @@ export class FhirImagingStudy extends FhirResource {
     const serviceRequestFhirId = this.basedOn.find(
       ({ params: b }) =>
         b?.type === 'ServiceRequest' &&
-        b?.identifier?.params.system ===
-          'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+        b?.identifier?.params.system === config.hl7.dataDictionaries.serviceRequestId,
     )?.params.identifier.params.value;
     if (!serviceRequestFhirId) {
       throw new Invalid('Need to have basedOn field that includes a Tamanu identifier', {

--- a/packages/shared-src/src/models/fhir/ServiceRequest.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest.js
@@ -142,6 +142,10 @@ export class FhirServiceRequest extends FhirResource {
           system: config.hl7.dataDictionaries.serviceRequestId,
           value: upstream.id,
         }),
+        new FhirIdentifier({
+          system: config.hl7.dataDictionaries.serviceRequestDisplayId,
+          value: upstream.displayId,
+        }),
       ],
       status: {
         [IMAGING_REQUEST_STATUS_TYPES.PENDING]: FHIR_REQUEST_STATUS.DRAFT,

--- a/packages/shared-src/src/services/fhirTypes/reference.js
+++ b/packages/shared-src/src/services/fhirTypes/reference.js
@@ -50,14 +50,17 @@ export class FhirReference extends Composite {
   }
 
   fhirTypeAndId() {
-    const TYPE_ID_URL_REGEX = /\/(\w+)\/([0-9a-f-]+)$/i;
+    const TYPE_ID_URL_REGEX = /\/(?<type>\w+)\/(?<id>[0-9a-f-]+)$/i;
 
     const { reference } = this.params;
     if (!reference) return null;
 
-    if (TYPE_ID_URL_REGEX.test()) {
-      const [, type, id] = reference.match(TYPE_ID_URL_REGEX);
-      return { type, id };
+    const match = TYPE_ID_URL_REGEX.exec(reference);
+    if (match) {
+      return {
+        type: match.groups.type,
+        id: match.groups.id,
+      };
     }
 
     return null;

--- a/packages/shared-src/src/services/fhirTypes/reference.js
+++ b/packages/shared-src/src/services/fhirTypes/reference.js
@@ -48,6 +48,20 @@ export class FhirReference extends Composite {
       display: `${fieldName}.${id}`,
     });
   }
+
+  fhirTypeAndId() {
+    const TYPE_ID_URL_REGEX = /\/(\w+)\/([0-9a-f-]+)$/i;
+
+    const { reference } = this.params;
+    if (!reference) return null;
+
+    if (TYPE_ID_URL_REGEX.test()) {
+      const [, type, id] = reference.match(TYPE_ID_URL_REGEX);
+      return { type, id };
+    }
+
+    return null;
+  }
 }
 
 export class FHIR_REFERENCE extends COMPOSITE {

--- a/packages/shared-src/src/services/fhirTypes/reference.js
+++ b/packages/shared-src/src/services/fhirTypes/reference.js
@@ -50,7 +50,7 @@ export class FhirReference extends Composite {
   }
 
   fhirTypeAndId() {
-    const TYPE_ID_URL_REGEX = /\/(?<type>\w+)\/(?<id>[0-9a-f-]+)$/i;
+    const TYPE_ID_URL_REGEX = /\/?(?<type>\w+)\/(?<id>[0-9a-f-]+)$/i;
 
     const { reference } = this.params;
     if (!reference) return null;

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -276,10 +276,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           basedOn: [
             {
               type: 'ServiceRequest',
-              identifier: {
-                system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
-                value: mat.id,
-              },
+              reference: `/ServiceRequest/${mat.id}`,
             },
           ],
           note: [{ text: 'This is a note' }, { text: 'This is another note' }],
@@ -348,10 +345,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           basedOn: [
             {
               type: 'ServiceRequest',
-              identifier: {
-                system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
-                value: mat.id,
-              },
+              reference: `/ServiceRequest/${mat.id}`,
             },
           ],
           note: [{ text: 'A note' }],

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -1,8 +1,8 @@
 import { fake, fakeReferenceData, showError } from 'shared/test-helpers';
 import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
+import { fakeUUID } from 'shared/utils/generateId';
 
 import { createTestContext } from '../../utilities';
-import { fakeUUID } from 'shared/utils/generateId';
 
 const INTEGRATION_ROUTE = 'fhir/mat';
 
@@ -87,7 +87,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
       );
     });
 
-    it('creates a result from an ImagingStudy', () =>
+    it('creates a result from an ImagingStudy with FHIR ID', () =>
       showError(async () => {
         // arrange
         const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
@@ -119,9 +119,108 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           basedOn: [
             {
               type: 'ServiceRequest',
+              reference: `/ServiceRequest/${mat.id}`,
+            },
+          ],
+          note: [{ text: 'This is a note' }, { text: 'This is another note' }],
+        });
+
+        // assert
+        expect(response).toHaveSucceeded();
+        expect(response.status).toBe(201);
+        const ires = await ImagingResult.findOne({
+          where: { externalCode: 'ACCESSION' },
+        });
+        expect(ires).toBeTruthy();
+        expect(ires.description).toEqual('This is a note\n\nThis is another note');
+      }));
+
+    it('creates a result from an ImagingStudy with upstream Display ID', () =>
+      showError(async () => {
+        // arrange
+        const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
+        const ir = await ImagingRequest.create(
+          fake(ImagingRequest, {
+            requestedById: resources.practitioner.id,
+            encounterId: encounter.id,
+            locationId: resources.location.id,
+            status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+            priority: 'routine',
+            requestedDate: '2022-03-04 15:30:00',
+          }),
+        );
+        await ir.setAreas([resources.area1.id, resources.area2.id]);
+        await ir.reload();
+        await FhirServiceRequest.materialiseFromUpstream(ir.id);
+        await FhirServiceRequest.resolveUpstreams();
+
+        // act
+        const response = await app.post(PATH).send({
+          resourceType: 'ImagingStudy',
+          status: 'final',
+          identifier: [
+            {
+              system: 'http://data-dictionary.tamanu-fiji.org/ris-accession-number.html',
+              value: 'ACCESSION',
+            },
+          ],
+          basedOn: [
+            {
+              type: 'ServiceRequest',
               identifier: {
                 system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
-                value: mat.id,
+                value: ir.displayId,
+              },
+            },
+          ],
+          note: [{ text: 'This is a note' }, { text: 'This is another note' }],
+        });
+
+        // assert
+        expect(response).toHaveSucceeded();
+        expect(response.status).toBe(201);
+        const ires = await ImagingResult.findOne({
+          where: { externalCode: 'ACCESSION' },
+        });
+        expect(ires).toBeTruthy();
+        expect(ires.description).toEqual('This is a note\n\nThis is another note');
+      }));
+
+    it('creates a result from an ImagingStudy with upstream UUID', () =>
+      showError(async () => {
+        // arrange
+        const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
+        const ir = await ImagingRequest.create(
+          fake(ImagingRequest, {
+            requestedById: resources.practitioner.id,
+            encounterId: encounter.id,
+            locationId: resources.location.id,
+            status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+            priority: 'routine',
+            requestedDate: '2022-03-04 15:30:00',
+          }),
+        );
+        await ir.setAreas([resources.area1.id, resources.area2.id]);
+        await ir.reload();
+        await FhirServiceRequest.materialiseFromUpstream(ir.id);
+        await FhirServiceRequest.resolveUpstreams();
+
+        // act
+        const response = await app.post(PATH).send({
+          resourceType: 'ImagingStudy',
+          status: 'final',
+          identifier: [
+            {
+              system: 'http://data-dictionary.tamanu-fiji.org/ris-accession-number.html',
+              value: 'ACCESSION',
+            },
+          ],
+          basedOn: [
+            {
+              type: 'ServiceRequest',
+              identifier: {
+                system: 'http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html',
+                value: ir.id,
               },
             },
           ],

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -276,7 +276,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           basedOn: [
             {
               type: 'ServiceRequest',
-              reference: `/ServiceRequest/${mat.id}`,
+              reference: `ServiceRequest/${mat.id}`,
             },
           ],
           note: [{ text: 'This is a note' }, { text: 'This is another note' }],

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -1,11 +1,13 @@
+/* eslint-disable no-unused-expressions */
+
 import { addDays, format, formatRFC7231 } from 'date-fns';
 
 import { fake, fakeReferenceData } from 'shared/test-helpers';
 import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
-
-import { createTestContext } from '../../utilities';
 import { fakeUUID } from 'shared/utils/generateId';
 import { dateTimeStringIntoCountryTimezone } from 'shared/utils/dateTime';
+
+import { createTestContext } from '../../utilities';
 
 const INTEGRATION_ROUTE = 'fhir/mat';
 
@@ -116,6 +118,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
       // normalise for comparison
       response.body?.orderDetail?.sort((a, b) => a.text.localeCompare(b.text));
+      response.body?.identifier?.sort((a, b) => a.system.localeCompare(b.system));
 
       // assert
       expect(response.body).toMatchObject({
@@ -126,8 +129,12 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
         },
         identifier: [
           {
-            system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+            system: 'http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html',
             value: ir.id,
+          },
+          {
+            system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+            value: ir.displayId,
           },
         ],
         status: 'completed',
@@ -210,6 +217,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
       // act
       const response = await app.get(path);
+      response.body?.identifier?.sort((a, b) => a.system.localeCompare(b.system));
 
       // assert
       expect(response.body).toMatchObject({
@@ -217,8 +225,12 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
         id: expect.any(String),
         identifier: [
           {
-            system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+            system: 'http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html',
             value: ir.id,
+          },
+          {
+            system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+            value: ir.displayId,
           },
         ],
         priority: 'routine',
@@ -226,7 +238,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       expect(response).toHaveSucceeded();
     });
 
-    it('searches a single service request by Tamanu ID', async () => {
+    it('searches a single service request by Tamanu UUID', async () => {
       // arrange
       const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
       const ir = await ImagingRequest.create(
@@ -245,12 +257,14 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       await FhirServiceRequest.resolveUpstreams();
 
       const id = encodeURIComponent(
-        `http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html|${ir.id}`,
+        `http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html|${ir.id}`,
       );
       const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${id}`;
 
       // act
       const response = await app.get(path);
+      response.body?.entry?.[0]?.orderDetail?.sort((a, b) => a.text.localeCompare(b.text));
+      response.body?.entry?.[0]?.identifier?.sort((a, b) => a.system.localeCompare(b.system));
 
       // assert
       expect(response.body).toMatchObject({
@@ -278,8 +292,134 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
               },
               identifier: [
                 {
-                  system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+                  system: 'http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html',
                   value: ir.id,
+                },
+                {
+                  system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+                  value: ir.displayId,
+                },
+              ],
+              status: 'completed',
+              intent: 'order',
+              category: [
+                {
+                  coding: [
+                    {
+                      system: 'http://snomed.info/sct',
+                      code: '363679005',
+                    },
+                  ],
+                },
+              ],
+              priority: 'routine',
+              code: {
+                text: 'X-Ray',
+              },
+              orderDetail: [
+                {
+                  text: resources.extCode1.description,
+                  coding: [
+                    {
+                      code: resources.extCode1.code,
+                      system: 'http://data-dictionary.tamanu-fiji.org/rispacs-billing-code.html',
+                    },
+                  ],
+                },
+                {
+                  text: resources.extCode2.description,
+                  coding: [
+                    {
+                      code: resources.extCode2.code,
+                      system: 'http://data-dictionary.tamanu-fiji.org/rispacs-billing-code.html',
+                    },
+                  ],
+                },
+              ],
+              subject: {
+                reference: `Patient/${resources.pat.id}`,
+                type: 'Patient',
+                display: `${resources.patient.firstName} ${resources.patient.lastName}`,
+              },
+              occurrenceDateTime: format(
+                dateTimeStringIntoCountryTimezone('2023-11-12 13:14:15'),
+                "yyyy-MM-dd'T'HH:mm:ssXXX",
+              ),
+              requester: {
+                display: resources.practitioner.displayName,
+              },
+              locationCode: [
+                {
+                  text: resources.facility.name,
+                },
+              ],
+            },
+          },
+        ],
+      });
+      expect(response).toHaveSucceeded();
+    });
+
+    it('searches a single service request by Tamanu Display ID', async () => {
+      // arrange
+      const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
+      const ir = await ImagingRequest.create(
+        fake(ImagingRequest, {
+          requestedById: resources.practitioner.id,
+          encounterId: encounter.id,
+          locationGroupId: resources.locationGroup.id,
+          status: IMAGING_REQUEST_STATUS_TYPES.COMPLETED,
+          priority: 'routine',
+          requestedDate: '2023-11-12 13:14:15',
+        }),
+      );
+      await ir.setAreas([resources.area1.id, resources.area2.id]);
+      await ir.reload();
+      await FhirServiceRequest.materialiseFromUpstream(ir.id);
+      await FhirServiceRequest.resolveUpstreams();
+
+      const id = encodeURIComponent(
+        `http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html|${ir.displayId}`,
+      );
+      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${id}`;
+
+      // act
+      const response = await app.get(path);
+      response.body?.entry?.[0]?.orderDetail?.sort((a, b) => a.text.localeCompare(b.text));
+      response.body?.entry?.[0]?.identifier?.sort((a, b) => a.system.localeCompare(b.system));
+
+      // assert
+      expect(response.body).toMatchObject({
+        resourceType: 'Bundle',
+        id: expect.any(String),
+        timestamp: expect.any(String),
+        meta: {
+          lastUpdated: format(new Date(ir.updatedAt), "yyyy-MM-dd'T'HH:mm:ssXXX"),
+        },
+        type: 'searchset',
+        total: 1,
+        link: [
+          {
+            relation: 'self',
+            url: expect.stringContaining(path),
+          },
+        ],
+        entry: [
+          {
+            resource: {
+              resourceType: 'ServiceRequest',
+              id: expect.any(String),
+              meta: {
+                lastUpdated: format(new Date(ir.updatedAt), "yyyy-MM-dd'T'HH:mm:ssXXX"),
+              },
+              identifier: [
+                {
+                  system: 'http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html',
+                  value: ir.id,
+                },
+                {
+                  system: 'http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html',
+                  value: ir.displayId,
                 },
               ],
               status: 'completed',
@@ -344,7 +484,8 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
   });
 
   describe('search', () => {
-    let encounter, irs;
+    let encounter;
+    let irs;
     beforeAll(async () => {
       const {
         Encounter,

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -788,6 +788,7 @@
       "patientDisplayId": "http://tamanu.io/data-dictionary/application-reference-number.html",
       "labRequestDisplayId": "http://tamanu.io/data-dictionary/labrequest-reference-number.html",
       "areaExternalCode": "http://data-dictionary.tamanu-fiji.org/rispacs-billing-code.html",
+      "serviceRequestDisplayId": "http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html",
       "serviceRequestId": "http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html",
       "imagingStudyAccessionId": "http://data-dictionary.tamanu-fiji.org/ris-accession-number.html",
       "ethnicityId": "http://data-dictionary.tamanu-fiji.org/extensions/ethnic-group-code.html"

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -788,7 +788,8 @@
       "patientDisplayId": "http://tamanu.io/data-dictionary/application-reference-number.html",
       "labRequestDisplayId": "http://tamanu.io/data-dictionary/labrequest-reference-number.html",
       "areaExternalCode": "http://data-dictionary.tamanu-fiji.org/rispacs-billing-code.html",
-      "serviceRequestId": "http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html",
+      "serviceRequestId": "http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html",
+      "imagingStudyAccessionId": "http://data-dictionary.tamanu-fiji.org/ris-accession-number.html",
       "ethnicityId": "http://data-dictionary.tamanu-fiji.org/extensions/ethnic-group-code.html"
     }
   },


### PR DESCRIPTION
### Changes

Critical realisation: we were (correctly!) materialising the ServiceRequests with their `identifier` as the ImagingRequest's `id` (now `displayId`), but when ImagingStudys were being sent to us, we would do the matching assuming that the ServiceRequest's `identifier` (via `basedOn`) was the **FHIR** ID. So it never worked right.

(Impact: this integration isn't live yet, so... not an issue beyond a big scare for me when I realised!)

This PR:
- adds the EPI-310-introduced ImagingRequest **displayID** to the materialised ServiceRequest
  - this is _in addition_ to the UUID, such that it's not a breaking change
  - we should still encourage integrations to use the UUID
- makes the ImagingStudy endpoint accept any of:
  - the FHIR ID, as `{ type: 'ServiceRequest', reference: '/ServiceRequest/<uuid>' }`
  - the ImagingRequest's Display ID
  - the ImagingRequest's UUID
- also moves some hardcoded values to the config

### Checklist

- [x] Code is finished
- [x] Tests are written

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
