### PR TITLE
Hotfix v1.24.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "This repo contains all the packages for Tamanu",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csca",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "CSCA tooling for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/desktop/app/package.json
+++ b/packages/desktop/app/package.json
@@ -3,7 +3,7 @@
   "main": "./dist/main.prod.js",
   "name": "Tamanu",
   "productName": "Tamanu",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Tamanu",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/lan/app/middleware/versionCompatibility.js
+++ b/packages/lan/app/middleware/versionCompatibility.js
@@ -5,7 +5,7 @@ import { buildVersionCompatibilityCheck } from 'shared/utils';
 // have updated.
 
 export const MIN_CLIENT_VERSION = '1.24.0';
-export const MAX_CLIENT_VERSION = '1.24.3'; // note that higher patch versions will be allowed to connect
+export const MAX_CLIENT_VERSION = '1.24.5'; // note that higher patch versions will be allowed to connect
 
 export const versionCompatibility = (req, res, next) =>
   buildVersionCompatibilityCheck(MIN_CLIENT_VERSION, MAX_CLIENT_VERSION)(req, res, next);

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lan",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Lan server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-server",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Meta server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "1.24.55",
+  "version": "1.24.57",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/qr-tester/package.json
+++ b/packages/qr-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-tester",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "BES QR Code Tester App / Website",
   "author": "",
   "license": "UNLICENSED",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "main": "index.js",
   "license": "SEE LICENSE IN license",
   "scripts": {

--- a/packages/shared-src/package.json
+++ b/packages/shared-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-src",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Common code across Tamanu packages",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/shared-src/shared.package.json
+++ b/packages/shared-src/shared.package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Common code across Tamanu packages (generated)",
   "main": "index.js",
   "types": "types/",

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -7,16 +7,16 @@ import { InvalidClientHeadersError } from 'shared/errors';
 // not supported.
 export const SUPPORTED_CLIENT_VERSIONS = {
   'Tamanu LAN Server': {
-    min: '1.24.3',
-    max: '1.24.3', // note that higher patch versions will be allowed to connect
+    min: '1.24.3', // intentionally held at v1.24.3 for v1.24.5 release, should be aligned in future
+    max: '1.24.5', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Desktop': {
     min: '1.24.0',
-    max: '1.24.3', // note that higher patch versions will be allowed to connect
+    max: '1.24.5', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Mobile': {
     min: '1.24.46',
-    max: '1.24.55', // note that higher patch versions will be allowed to connect
+    max: '1.24.57', // note that higher patch versions will be allowed to connect
   },
   'fiji-vps': {
     min: null,

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -270,7 +270,7 @@ class CentralSyncManager {
       // time throughout the snapshot process
       await session.update({ snapshotCompletedAt: new Date() });
     } catch (error) {
-      log.error('CentralSyncManager.setupSnapshotForPull encountered an error', error);
+      log.error('CentralSyncManager.setupSnapshotForPull encountered an error', { sessionId, ...error });
       await this.store.models.SyncSession.update(
         { error: error.message },
         { where: { id: sessionId } },

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -270,7 +270,10 @@ class CentralSyncManager {
       // time throughout the snapshot process
       await session.update({ snapshotCompletedAt: new Date() });
     } catch (error) {
-      log.error('CentralSyncManager.setupSnapshotForPull encountered an error', { sessionId, ...error });
+      log.error('CentralSyncManager.setupSnapshotForPull encountered an error', {
+        sessionId,
+        ...error,
+      });
       await this.store.models.SyncSession.update(
         { error: error.message },
         { where: { id: sessionId } },

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -158,15 +158,15 @@ class CentralSyncManager {
     { since, facilityId, tablesToInclude, tablesForFullResync, isMobile },
     unmarkSnapshotAsProcessing,
   ) {
-    const { models, sequelize } = this.store;
-
-    const session = await this.connectToSession(sessionId);
-
-    // will wait for concurrent snapshots to complete if we are currently at capacity, then
-    // set the snapshot_started_at timestamp before we proceed with the heavy work below
-    await startSnapshotWhenCapacityAvailable(sequelize, sessionId);
-
     try {
+      const { models, sequelize } = this.store;
+
+      const session = await this.connectToSession(sessionId);
+
+      // will wait for concurrent snapshots to complete if we are currently at capacity, then
+      // set the snapshot_started_at timestamp before we proceed with the heavy work below
+      await startSnapshotWhenCapacityAvailable(sequelize, sessionId);
+
       // get a sync tick that we can safely consider the snapshot to be up to (because we use the
       // "tick" of the tick-tock, so we know any more changes on the server, even while the snapshot
       // process is ongoing, will have a later updated_at_sync_tick)
@@ -270,8 +270,11 @@ class CentralSyncManager {
       // time throughout the snapshot process
       await session.update({ snapshotCompletedAt: new Date() });
     } catch (error) {
-      log.error('CentralSyncManager.initiatePull encountered an error', error);
-      await session.update({ error: error.message });
+      log.error('CentralSyncManager.setupSnapshotForPull encountered an error', error);
+      await this.store.models.SyncSession.update(
+        { error: error.message },
+        { where: { id: sessionId } },
+      );
     } finally {
       await unmarkSnapshotAsProcessing();
     }

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-server",
-  "version": "1.24.3",
+  "version": "1.24.5",
   "description": "Sync server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",


### PR DESCRIPTION
### Changes

In Nauru, found that db queries were timing out despite not much going on CPU or memory wise. Looking at pg_stat_activity, found a bunch of advisory locks idle in transaction. We use advisory locks to represent when a sync session is actively snapshotting. The corresponding sync sessions weren't actively being connected to though, and there were no active db queries that looked like they were doing snapshotting, so there should be no need to hold an advisory lock. 

Looked in the code and found that there are a few lines sitting outside of the `try/finally`, and if those throw an error, the finally that releases the advisory lock would never be hit. This means any e.g. timeout errors that result from actual resource max out will compound, as they'll leave around an idle transaction that is not doing any work, but is hogging a db connection.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
