### PR TITLE
WAITM-602: staging fix: mobile auto logout styles and text change

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
@@ -32,7 +32,12 @@ export const IntroScreen: FunctionComponent<any> = ({ navigation, route }: Intro
         <CenterView>
           <StyledView height={19} marginTop={screenPercentageToDP(12.32, Orientation.Height)}>
             {signedOutFromInactivity && (
-              <StyledText color={theme.colors.ALERT}>Signed out from inactivity</StyledText>
+              <StyledText
+                fontSize={`${screenPercentageToDP('1.94', Orientation.Height)}px`}
+                color={theme.colors.MAIN_SUPER_DARK}
+              >
+                You have been logged out due to inactivity.
+              </StyledText>
             )}
           </StyledView>
         </CenterView>


### PR DESCRIPTION
### Changes
Change style and text as this was done without designs originally

Changes look like this:
![Screenshot_20230321_123301_Tamanu Mobile](https://user-images.githubusercontent.com/38335330/226488143-4481ec6b-f268-4cf9-ad0c-53caa4bbf629.jpg)

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
