### PR TITLE
[TAN-2135] Adding handover notes type

### DIFF
--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -151,15 +151,16 @@ export const nonEmergencyDiagnosisCertaintyOptions = diagnosisCertaintyOptions.f
 
 export const noteTypes = [
   { value: NOTE_TYPES.TREATMENT_PLAN, label: 'Treatment plan' },
-  { value: NOTE_TYPES.MEDICAL, label: 'Medical' },
-  { value: NOTE_TYPES.SURGICAL, label: 'Surgical' },
-  { value: NOTE_TYPES.NURSING, label: 'Nursing' },
   { value: NOTE_TYPES.DIETARY, label: 'Dietary' },
+  { value: NOTE_TYPES.DISCHARGE, label: 'Discharge planning' },
+  { value: NOTE_TYPES.HANDOVER, label: 'Handover Notes' },
+  { value: NOTE_TYPES.MEDICAL, label: 'Medical' },
+  { value: NOTE_TYPES.NURSING, label: 'Nursing' },
+  { value: NOTE_TYPES.OTHER, label: 'Other' },
   { value: NOTE_TYPES.PHARMACY, label: 'Pharmacy' },
   { value: NOTE_TYPES.PHYSIOTHERAPY, label: 'Physiotherapy' },
   { value: NOTE_TYPES.SOCIAL, label: 'Social welfare' },
-  { value: NOTE_TYPES.DISCHARGE, label: 'Discharge planning' },
-  { value: NOTE_TYPES.OTHER, label: 'Other' },
+  { value: NOTE_TYPES.SURGICAL, label: 'Surgical' },
   { value: NOTE_TYPES.SYSTEM, label: 'System', hideFromDropdown: true },
 ];
 

--- a/packages/shared-src/src/constants/notes.js
+++ b/packages/shared-src/src/constants/notes.js
@@ -22,6 +22,7 @@ export const NOTE_TYPES = {
   RESULT_DESCRIPTION: 'resultDescription',
   SYSTEM: 'system',
   OTHER: 'other',
+  HANDOVER: 'handover',
 };
 
 export const NOTE_RECORD_TYPE_VALUES = Object.values(NOTE_RECORD_TYPES);


### PR DESCRIPTION
### Changes

- Added new Handover notes type
- Sorted options alphabetically as asked [here](https://linear.app/bes/issue/TAN-2135#comment-b08fae6e)

Ticket:
https://linear.app/bes/issue/TAN-2135/create-a-new-note-type-called-handover-notes
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
