### PR TITLE
WAITM-602: staging-fix: mobile logout from inactivity text cut-off on some screen sizes

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/Intro.tsx
@@ -30,10 +30,13 @@ export const IntroScreen: FunctionComponent<any> = ({ navigation, route }: Intro
           <LogoV1Icon />
         </CenterView>
         <CenterView>
-          <StyledView height={19} marginTop={screenPercentageToDP(12.32, Orientation.Height)}>
+          <StyledView
+            height={screenPercentageToDP(2.9, Orientation.Height)}
+            marginTop={screenPercentageToDP(12.32, Orientation.Height)}
+          >
             {signedOutFromInactivity && (
               <StyledText
-                fontSize={`${screenPercentageToDP('1.94', Orientation.Height)}px`}
+                fontSize={`${screenPercentageToDP(1.94, Orientation.Height)}px`}
                 color={theme.colors.MAIN_SUPER_DARK}
               >
                 You have been logged out due to inactivity.
@@ -44,7 +47,7 @@ export const IntroScreen: FunctionComponent<any> = ({ navigation, route }: Intro
         <CenterView marginTop={screenPercentageToDP(11.5, Orientation.Height)}>
           <StyledText
             color={theme.colors.PRIMARY_MAIN}
-            fontSize={`${screenPercentageToDP('3.4', Orientation.Height)}px`}
+            fontSize={`${screenPercentageToDP(3.4, Orientation.Height)}px`}
             fontWeight="bold"
           >
             eHealth patient record
@@ -53,16 +56,16 @@ export const IntroScreen: FunctionComponent<any> = ({ navigation, route }: Intro
         <StyledText
           marginTop={10}
           color={theme.colors.PRIMARY_MAIN}
-          fontSize={`${screenPercentageToDP('1.94', Orientation.Height)}px`}
+          fontSize={`${screenPercentageToDP(1.94, Orientation.Height)}px`}
           textAlign="center"
-          marginLeft={screenPercentageToDP('14', Orientation.Width)}
-          marginRight={screenPercentageToDP('14', Orientation.Width)}
+          marginLeft={screenPercentageToDP(14, Orientation.Width)}
+          marginRight={screenPercentageToDP(14, Orientation.Width)}
         >
           For Hospitals, Health Centres and clinics around the world
         </StyledText>
         <RowView
           justifyContent="center"
-          marginTop={screenPercentageToDP('13.00', Orientation.Height)}
+          marginTop={screenPercentageToDP(13, Orientation.Height)}
         >
           <Button
             id="intro-sign-in-button"


### PR DESCRIPTION
### Changes
Cut-off due to a mix of screen size relative font size and pixels in height of container

Screenshot from a different sized device than I usually test on
<img width="531" alt="Screenshot 2023-03-23 at 10 32 06 AM" src="https://user-images.githubusercontent.com/38335330/227043772-5651eaff-5d65-4af0-9028-0e98879674cd.png">

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
