### PR TITLE
WAITM-653: fix manual sync avatar shift-click button

### DIFF
--- a/packages/desktop/app/components/HiddenSyncAvatar.js
+++ b/packages/desktop/app/components/HiddenSyncAvatar.js
@@ -29,22 +29,26 @@ const Error = ({ errorMessage }) => (
   </div>
 );
 
-export const HiddenSyncAvatar = ({ children, ...props }) => {
+export const HiddenSyncAvatar = ({ children, onClick, ...props }) => {
   const [loading, setLoading] = useState(false);
   const api = useApi();
 
   const handleClick = async event => {
-    if (!event.shiftKey || loading) return;
-    setLoading(true);
+    if (event.shiftKey) {
+      if (loading) return;
+      setLoading(true);
 
-    toast.info('Starting manual sync...');
-    try {
-      await api.post(`sync/run`);
-      toast.success('Manual sync complete');
-    } catch (error) {
-      toast.error(<Error errorMessage={error.message} />);
-    } finally {
-      setLoading(false);
+      toast.info('Starting manual sync...');
+      try {
+        await api.post(`sync/run`);
+        toast.success('Manual sync complete');
+      } catch (error) {
+        toast.error(<Error errorMessage={error.message} />);
+      } finally {
+        setLoading(false);
+      }
+    } else if (onClick) {
+      onClick(event);
     }
   };
 

--- a/packages/desktop/app/components/Sidebar/Sidebar.js
+++ b/packages/desktop/app/components/Sidebar/Sidebar.js
@@ -25,7 +25,8 @@ const Container = styled.div`
   padding: 0 15px;
   box-shadow: 1px 0 4px rgba(0, 0, 0, 0.15);
   color: ${Colors.white};
-  overflow: ${props => (props.$retracted ? 'hidden' : 'auto')};
+  overflow-y: auto;
+  overflow-x: hidden;
   height: 100vh;
   transition: ${props => props.theme.transitions.create(['min-width', 'max-width'])};
 
@@ -46,6 +47,10 @@ const HeaderContainer = styled.div`
 const RetractExtendButton = styled(IconButton)`
   padding: 8px;
   background-color: ${Colors.primaryDark};
+
+  &.MuiIconButton-root:hover {
+    background-color: #4e5f71;
+  }
 `;
 
 const RetractButton = styled(RetractExtendButton)``;
@@ -54,11 +59,6 @@ const ExtendButton = styled(RetractExtendButton)`
   position: fixed;
   z-index: 12;
   transform: translate(100%);
-  &.MuiIconButton-root {
-    &:hover {
-      background-color: ${`${Colors.primaryDark}99`};
-    }
-  }
 `;
 
 const ExtendedLogo = styled(TamanuLogoWhite)``;


### PR DESCRIPTION
### Changes
Broken due to changes to sidebar collapsing sidebar logic adding an onclick to avatar which had overridden the components onclick

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
