### PR TITLE
WAITM-695: Update lab request labels to be more consistent

### DIFF
--- a/packages/desktop/app/components/LabRequestsTable.js
+++ b/packages/desktop/app/components/LabRequestsTable.js
@@ -18,7 +18,6 @@ import {
   getPriority,
   getDateTime,
   getRequestId,
-  getLaboratory,
 } from '../utils/lab';
 
 const encounterColumns = [
@@ -37,7 +36,6 @@ const globalColumns = [
     accessor: getPatientDisplayId,
     sortable: false,
   },
-  { key: 'laboratory', title: 'Laboratory', accessor: getLaboratory },
   ...encounterColumns,
 ];
 

--- a/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintout.js
@@ -31,8 +31,8 @@ export const LabRequestPrintout = React.memo(
           'Requested by': requestedBy?.displayName,
           'Sample time': sampleTime ? <DateDisplay date={sampleTime} showTime /> : null,
           Priority: priority?.name,
-          'Test type': category?.name,
-          'Test requested': tests.map(test => test.labTestType?.name).join(', '),
+          'Test category': category?.name,
+          Test: tests.map(test => test.labTestType?.name).join(', '),
         }}
       />
     );

--- a/packages/desktop/app/components/PatientPrinting/printouts/MultipleLabRequestsPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/MultipleLabRequestsPrintout.js
@@ -50,7 +50,7 @@ const columns = [
   },
   {
     key: 'testType',
-    title: 'Test type',
+    title: 'Test',
     accessor: ({ tests }) => tests?.map(test => test.labTestType?.name).join(', ') || '',
     widthProportion: 3,
   },

--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -15,8 +15,8 @@ export const LabRequestsSearchBar = () => {
       <LocalisedField name="firstName" />
       <LocalisedField name="lastName" />
       <LocalisedField name="displayId" />
-      <LocalisedField name="requestId" defaultLabel="Request ID" />
-      <LocalisedField name="category" defaultLabel="Type" />
+      <LocalisedField name="requestId" defaultLabel="Test ID" />
+      <LocalisedField name="category" defaultLabel="Test category" />
       <LocalisedField
         name="status"
         defaultLabel="Status"

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -110,10 +110,10 @@ export const LabRequestView = () => {
       </SimpleTopBar>
       <ContentPane>
         <FormGrid columns={3}>
-          <TextInput value={labRequest.displayId} label="Request ID" disabled={isReadOnly} />
+          <TextInput value={labRequest.displayId} label="Test ID" disabled={isReadOnly} />
           <TextInput
             value={(labRequest.category || {}).name}
-            label="Request type"
+            label="Test category"
             disabled={isReadOnly}
           />
           <TextInput


### PR DESCRIPTION
### Changes

- We're making the language around requests/tests more coherent
- Update references to `Request ID` to instead use `Test ID`
- Update references to `Request Type` to instead use `Test category`
- Also remove the laboratory column from the lab requests view (this was meant to be removed next release, but bringing it forward slightly to avoid more frequent smaller changes

### Checklist

- [X] Code is finished
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue