### PR TITLE
SAV-167: Can only use encounter actions on current facility

### DIFF
--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -25,6 +25,7 @@ import {
 import { Colors, ENCOUNTER_OPTIONS_BY_VALUE } from '../../constants';
 import { ENCOUNTER_TAB_NAMES } from '../../constants/encounterTabNames';
 import { EncounterActions } from './components';
+import { useAuth } from '../../contexts/Auth';
 
 const getIsTriage = encounter => ENCOUNTER_OPTIONS_BY_VALUE[encounter.encounterType].triageFlowOnly;
 
@@ -118,6 +119,7 @@ const StyledTabDisplay = styled(TabDisplay)`
 export const EncounterView = () => {
   const query = useUrlSearchParams();
   const { getLocalisation } = useLocalisation();
+  const { facility } = useAuth();
   const patient = useSelector(state => state.patient);
   const { encounter, isLoadingEncounter } = useEncounter();
   const [currentTab, setCurrentTab] = useState(query.get('tab') || ENCOUNTER_TAB_NAMES.VITALS);
@@ -134,7 +136,9 @@ export const EncounterView = () => {
         subTitle={encounter.location?.facility?.name}
         encounter={encounter}
       >
-        <EncounterActions encounter={encounter} />
+        {facility.id === encounter.location.facilityId && (
+          <EncounterActions encounter={encounter} />
+        )}
       </EncounterTopBar>
       <ContentPane>
         <EncounterInfoPane encounter={encounter} />


### PR DESCRIPTION
### Changes

Currently you can edit the details on an encounter from any facility even if not the in facility where the encounter was created. This can cause issues as the lists for moving location, moving department, changing clinician, etc are filtered by the current facility which could get confusing and cause unwanted behaviour.

Here are a couple examples where it can go wrong:
- A patient triaged in Facility A has their location updated by a user connected to Facility B. This swaps their encounter to be under Facility B and removes them from the Facility A emergency dashboard. Admitting that patient to hospital from Facility A moves the patient back on the Facility A inpatient list but their encounter stills displays the facility as Facility B.
- A patient admitted to Facility A has their department updated by a user connected to Facility B server. Their encounter facility is still listed as Facility A however they are now only viewable on Facility B inpatient listing.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)