### PR TITLE
WAITM-394: Migrate document metadata date fields to date_time_string

### DIFF
--- a/packages/shared-src/src/migrations/1679533922049-updateDocumentMetadataDateFields.js
+++ b/packages/shared-src/src/migrations/1679533922049-updateDocumentMetadataDateFields.js
@@ -1,0 +1,70 @@
+import { QueryTypes, DataTypes } from 'sequelize';
+import config from 'config';
+
+const ISO9075_DATE_TIME_FMT = 'YYYY-MM-DD HH24:MI:SS';
+const MIGRATIONS = [
+  { TABLE: 'document_metadata', FIELD: 'document_created_at' },
+  { TABLE: 'document_metadata', FIELD: 'document_uploaded_at' },
+];
+
+const alterSchemaOnly = async (query, table, field) => {
+  // Change column types from of original columns from date to string
+  return query.sequelize.query(`
+      ALTER TABLE ${table}
+      ALTER COLUMN ${field} TYPE date_time_string;
+    `);
+};
+
+const alterSchemaAndBackUpLegacyData = async (query, table, field) => {
+  const COUNTRY_TIMEZONE = config?.countryTimeZone;
+
+  if (!COUNTRY_TIMEZONE) {
+    throw Error('A countryTimeZone must be configured in local.json for this migration to run.');
+  }
+
+  // Copy data to legacy columns for backup
+  await query.sequelize.query(`
+      UPDATE ${table}
+      SET
+          ${field}_legacy = ${field};
+  `);
+
+  // Change column types from of original columns from date to string & convert data to string
+  return query.sequelize.query(`
+    ALTER TABLE ${table}
+    ALTER COLUMN ${field} TYPE date_time_string
+    USING TO_CHAR(${field}::TIMESTAMPTZ AT TIME ZONE '${COUNTRY_TIMEZONE}', '${ISO9075_DATE_TIME_FMT}');
+  `);
+};
+
+export async function up(query) {
+  for (const migration of MIGRATIONS) {
+    // Create legacy columns
+    await query.addColumn(migration.TABLE, `${migration.FIELD}_legacy`, {
+      type: DataTypes.DATE,
+    });
+
+    // Check for legacy data
+    // Check if there is any legacy data in the system
+    // For example, newly deployed instances of tamanu won't have legacy data
+    const legacyDataCount = await query.sequelize.query(
+      `SELECT COUNT(*) FROM ${migration.TABLE} WHERE ${migration.FIELD}_legacy IS NOT NULL;`,
+      {
+        type: QueryTypes.SELECT,
+      },
+    );
+
+    // If there is no legacy column data, then we don't need to run the data migration or check
+    // for the timezone in the config
+    if (legacyDataCount === 0) {
+      await alterSchemaOnly(query, migration.TABLE, migration.FIELD);
+    } else {
+      await alterSchemaAndBackUpLegacyData(query, migration.TABLE, migration.FIELD);
+    }
+  }
+}
+
+export async function down() {
+  // No down as is a data correction
+  return null;
+}

--- a/packages/shared-src/src/migrations/1679533922049-updateDocumentMetadataDateFields.js
+++ b/packages/shared-src/src/migrations/1679533922049-updateDocumentMetadataDateFields.js
@@ -64,7 +64,13 @@ export async function up(query) {
   }
 }
 
-export async function down() {
-  // No down as is a data correction
-  return null;
+export async function down(query) {
+  for (const migration of MIGRATIONS) {
+    await query.sequelize.query(`
+      ALTER TABLE ${migration.TABLE}
+      ALTER COLUMN ${migration.FIELD} TYPE ${migration.LEGACY_TYPE?.postgres ||
+      'timestamp with time zone'} USING ${migration.FIELD}_legacy;
+    `);
+    await query.removeColumn(migration.TABLE, `${migration.FIELD}_legacy`);
+  }
 }

--- a/packages/shared-src/src/models/DocumentMetadata.js
+++ b/packages/shared-src/src/models/DocumentMetadata.js
@@ -1,6 +1,8 @@
 import { Sequelize } from 'sequelize';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
+import { dateTimeType } from './dateTimeTypes';
+import { getCurrentDateTimeString } from '../utils/dateTime';
 import { buildEncounterLinkedSyncFilterJoins } from './buildEncounterLinkedSyncFilter';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 
@@ -17,12 +19,11 @@ export class DocumentMetadata extends Model {
           type: Sequelize.TEXT,
           allowNull: false,
         },
-        documentCreatedAt: Sequelize.DATE,
-        documentUploadedAt: {
-          type: Sequelize.DATE,
+        documentCreatedAt: dateTimeType('documentCreatedAt'),
+        documentUploadedAt: dateTimeType('documentUploadedAt', {
           allowNull: false,
-          defaultValue: Sequelize.NOW,
-        },
+          defaultValue: getCurrentDateTimeString,
+        }),
         documentOwner: Sequelize.TEXT,
         note: Sequelize.STRING,
 


### PR DESCRIPTION
### Changes

- Migrate document metadata date fields to date_time_string
- Update model
- There are no uses of document meta data in reports, front end code or integrations

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
