### PR TITLE
SAV-169: Filter imaging requests by facility

### DIFF
--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -56,15 +56,7 @@ export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters
         saveDateAsString
         component={DateField}
       />
-      <Field
-        name="facility"
-        label="Include all facilities"
-        options={[
-          { label: 'This facility', value: facility.id },
-          { label: 'All facilities', value: null },
-        ]}
-        component={SelectField}
-      />
+      <Field name="allFacilities" label="Include all facilities" component={CheckField} />
     </CustomisableSearchBar>
   );
 };

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -1,8 +1,15 @@
 import React from 'react';
+import styled from 'styled-components';
 import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../constants';
 import { DateField, LocalisedField, SelectField, Field, CheckField } from '../Field';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLocalisation } from '../../contexts/Localisation';
+
+const FacilityCheckbox = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 20px;
+`;
 
 export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters }) => {
   const { getLocalisation } = useLocalisation();
@@ -54,7 +61,9 @@ export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters
         saveDateAsString
         component={DateField}
       />
-      <Field name="allFacilities" label="Include all facilities" component={CheckField} />
+      <FacilityCheckbox>
+        <Field name="allFacilities" label="Include all facilities" component={CheckField} />
+      </FacilityCheckbox>
     </CustomisableSearchBar>
   );
 };

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -3,11 +3,9 @@ import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../constants';
 import { DateField, LocalisedField, SelectField, Field, CheckField } from '../Field';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLocalisation } from '../../contexts/Localisation';
-import { useAuth } from '../../contexts/Auth';
 
 export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters }) => {
   const { getLocalisation } = useLocalisation();
-  const { facility } = useAuth();
   const imagingTypes = getLocalisation('imagingTypes') || {};
   const imagingPriorities = getLocalisation('imagingPriorities') || [];
 

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../constants';
-import { DateField, LocalisedField, SelectField } from '../Field';
+import { DateField, LocalisedField, SelectField, Field, CheckField } from '../Field';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLocalisation } from '../../contexts/Localisation';
 
@@ -54,6 +54,7 @@ export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters
         saveDateAsString
         component={DateField}
       />
+      <Field name="allFacilities" label="Include all facilities" component={CheckField} />
     </CustomisableSearchBar>
   );
 };

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -3,9 +3,11 @@ import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../constants';
 import { DateField, LocalisedField, SelectField, Field, CheckField } from '../Field';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLocalisation } from '../../contexts/Localisation';
+import { useAuth } from '../../contexts/Auth';
 
 export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters }) => {
   const { getLocalisation } = useLocalisation();
+  const { facility } = useAuth();
   const imagingTypes = getLocalisation('imagingTypes') || {};
   const imagingPriorities = getLocalisation('imagingPriorities') || [];
 
@@ -54,7 +56,15 @@ export const ImagingRequestsSearchBar = ({ searchParameters, setSearchParameters
         saveDateAsString
         component={DateField}
       />
-      <Field name="allFacilities" label="Include all facilities" component={CheckField} />
+      <Field
+        name="facility"
+        label="Include all facilities"
+        options={[
+          { label: 'This facility', value: facility.id },
+          { label: 'All facilities', value: null },
+        ]}
+        component={SelectField}
+      />
     </CustomisableSearchBar>
   );
 };

--- a/packages/lan/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/lan/__tests__/apiv1/ImagingRequests.test.js
@@ -24,57 +24,6 @@ describe('Imaging requests', () => {
   });
   afterAll(() => ctx.close());
 
-  describe('Filtering by allFacilities', () => {
-    const otherFacilityId = 'kerang';
-    const makeRequestAtFacility = async facilityId => {
-      const testLocation = await models.Location.create({
-        facilityId,
-        name: 'Test Facility Location',
-        code: 'testFacilityLocation',
-      });
-      const testEncounter = await models.Encounter.create({
-        ...(await createDummyEncounter(models)),
-        locationId: testLocation.id,
-        patientId: patient.id,
-      });
-      await models.ImagingRequest.create({
-        encounterId: testEncounter.id,
-        imagingType: IMAGING_TYPES.CT_SCAN,
-        requestedById: app.user.id,
-      });
-    };
-
-    beforeAll(async () => {
-      await makeRequestAtFacility(config.serverFacilityId);
-      await makeRequestAtFacility(config.serverFacilityId);
-      await makeRequestAtFacility(config.serverFacilityId);
-      await makeRequestAtFacility(otherFacilityId);
-      await makeRequestAtFacility(otherFacilityId);
-      await makeRequestAtFacility(otherFacilityId);
-    });
-
-    it('should omit external requests when allFacilities is false', async () => {
-      const result = await app.get(`/v1/imagingRequest?allFacilities=false`);
-      expect(result).toHaveSucceeded();
-      result.body.data.forEach(ir => {
-        expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
-      });
-    });
-
-    it('should include all requests when allFacilities is true', async () => {
-      const result = await app.get(`/v1/imagingRequest?allFacilities=true`);
-      expect(result).toHaveSucceeded();
-      const hasConfigFacility = result.body.data.some(
-        ir => ir.encounter.location.facilityId === config.serverFacilityId,
-      );
-      const hasOtherFacility = result.body.data.some(
-        ir => ir.encounter.location.facilityId === otherFacilityId,
-      );
-      expect(hasConfigFacility).toBe(true);
-      expect(hasOtherFacility).toBe(true);
-    });
-  });
-
   it('should record an imaging request', async () => {
     const result = await app.post('/v1/imagingRequest').send({
       encounterId: encounter.id,
@@ -377,6 +326,60 @@ describe('Imaging requests', () => {
       completedBy: {
         id: app.user.dataValues.id,
       },
+    });
+  });
+
+  describe('Filtering by allFacilities', () => {
+    const otherFacilityId = 'kerang';
+    const makeRequestAtFacility = async facilityId => {
+      const testLocation = await models.Location.create({
+        facilityId,
+        name: 'Test Facility Location',
+        code: 'testFacilityLocation',
+      });
+      const testEncounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        locationId: testLocation.id,
+        patientId: patient.id,
+      });
+      await models.ImagingRequest.create({
+        encounterId: testEncounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+    };
+
+    beforeAll(async () => {
+      await models.ImagingRequest.truncate({ cascade: true });
+      await makeRequestAtFacility(config.serverFacilityId);
+      await makeRequestAtFacility(config.serverFacilityId);
+      await makeRequestAtFacility(config.serverFacilityId);
+      await makeRequestAtFacility(otherFacilityId);
+      await makeRequestAtFacility(otherFacilityId);
+      await makeRequestAtFacility(otherFacilityId);
+    });
+
+    it('should omit external requests when allFacilities is false', async () => {
+      const result = await app.get(`/v1/imagingRequest?allFacilities=false`);
+      expect(result).toHaveSucceeded();
+      result.body.data.forEach(ir => {
+        expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
+      });
+    });
+
+    it('should include all requests when allFacilities is true', async () => {
+      const result = await app.get(`/v1/imagingRequest?allFacilities=true`);
+      expect(result).toHaveSucceeded();
+
+      const hasConfigFacility = result.body.data.some(
+        ir => ir.encounter.location.facilityId === config.serverFacilityId,
+      );
+      expect(hasConfigFacility).toBe(true);
+
+      const hasOtherFacility = result.body.data.some(
+        ir => ir.encounter.location.facilityId === otherFacilityId,
+      );
+      expect(hasOtherFacility).toBe(true);
     });
   });
 });

--- a/packages/lan/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/lan/__tests__/apiv1/ImagingRequests.test.js
@@ -351,7 +351,8 @@ describe('Imaging requests', () => {
     expect(result).toHaveSucceeded();
 
     const result2 = await app.get(`/v1/imagingRequest?allFacilities=false`);
-    result2.body.data.foreach(ir => {
+    expect(result2).toHaveSucceeded();
+    result2.body.data.forEach(ir => {
       expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
     });
   });

--- a/packages/lan/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/lan/__tests__/apiv1/ImagingRequests.test.js
@@ -351,6 +351,8 @@ describe('Imaging requests', () => {
     expect(result).toHaveSucceeded();
 
     const result2 = await app.get(`/v1/imagingRequest?allFacilities=false`);
-    expect(result2.body.data[0].encounter.location.facilityId).toBe(config.serverFacilityId);
+    result2.body.data.foreach(ir => {
+      expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
+    });
   });
 });

--- a/packages/lan/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/lan/__tests__/apiv1/ImagingRequests.test.js
@@ -327,4 +327,33 @@ describe('Imaging requests', () => {
       },
     });
   });
+
+  it('should return with only imaging requests from config facility with allFacilities filter turned off', async () => {
+    // arrange
+    await models.ImagingRequest.create({
+      encounterId: encounter.id,
+      imagingType: IMAGING_TYPES.CT_SCAN,
+      requestedById: app.user.id,
+    });
+    await models.ImagingRequest.create({
+      encounterId: encounter.id,
+      imagingType: IMAGING_TYPES.CT_SCAN,
+      requestedById: app.user.id,
+    });
+    await models.ImagingRequest.create({
+      encounterId: encounter.id,
+      imagingType: IMAGING_TYPES.CT_SCAN,
+      requestedById: app.user.id,
+    });
+    // act
+    const {
+      body: { count: allCount },
+    } = await app.get(`/v1/imagingRequest?allFacilities=true`);
+    const {
+      body: { count: filteredCount },
+    } = await app.get(`/v1/imagingRequest?allFacilities=false`);
+    // assert
+    expect(allCount).toBe(13);
+    expect(filteredCount).toBe(3);
+  });
 });

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -360,7 +360,6 @@ globalImagingRequests.get(
 
     const location = {
       association: 'location',
-
       where: {
         facilityId:
           filterParams.allFacilities === 'true'

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -361,10 +361,9 @@ globalImagingRequests.get(
     const location = {
       association: 'location',
       where: {
-        facilityId:
-          filterParams.allFacilities === 'true'
-            ? { [Op.like]: '%' }
-            : { [Op.eq]: config.serverFacilityId },
+        facilityId: JSON.parse(filterParams.allFacilities)
+          ? { [Op.like]: '%' }
+          : { [Op.eq]: config.serverFacilityId },
       },
     };
 

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -358,13 +358,15 @@ globalImagingRequests.get(
       where: patientFilters,
     };
 
+    const locationWhere = {
+      where: JSON.parse(filterParams.allFacilities)
+        ? {}
+        : { facilityId: { [Op.eq]: config.serverFacilityId } },
+    };
+
     const location = {
       association: 'location',
-      where: {
-        facilityId: JSON.parse(filterParams.allFacilities)
-          ? { [Op.like]: '%' }
-          : { [Op.eq]: config.serverFacilityId },
-      },
+      ...locationWhere,
     };
 
     const encounter = {

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import config from 'config';
 import asyncHandler from 'express-async-handler';
 import { startOfDay, endOfDay } from 'date-fns';
 import { Op } from 'sequelize';
@@ -359,9 +360,13 @@ globalImagingRequests.get(
 
     const location = {
       association: 'location',
-      where: filterParams.facility
-        ? { facilityId: filterParams.facility }
-        : { facilityId: { [Op.like]: '%' } },
+
+      where: {
+        facilityId:
+          filterParams.allFacilities === 'true'
+            ? { [Op.like]: '%' }
+            : { [Op.eq]: config.serverFacilityId },
+      },
     };
 
     const encounter = {

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -356,9 +356,17 @@ globalImagingRequests.get(
       association: 'patient',
       where: patientFilters,
     };
+
+    const location = {
+      association: 'location',
+      where: filterParams.facility
+        ? { facilityId: filterParams.facility }
+        : { facilityId: { [Op.like]: '%' } },
+    };
+
     const encounter = {
       association: 'encounter',
-      include: [patient],
+      include: [patient, location],
       required: true,
     };
 


### PR DESCRIPTION
### Changes

The imaging requests table shows all imaging requests that are synced to the facility server regardless of which facility the imaging request was generated under. In order to reduce confusion in the upcoming aspen facility we are adding a checkbox to let the user change between all vs current facility view of imaging requests. The list will default to filtering imaging requests by the current facility and they can check the "include all facilities" checkbox if they want to view all imaging requests synced down.

For this I have filtered by the location of the encounter that the imaging request was created on. It seemed like the simplest way (as imaging requests could have either a location group or location attached) and I couldn't imagine a situation where the location/location group attached to the imaging request would be in a different facility to the encounter it was created on. Am very open to changing if the reviewer thinks this situation is possible though.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
