### PR TITLE
SAV-168: Filter labs by facility

### DIFF
--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -1,8 +1,15 @@
 import React from 'react';
+import styled from 'styled-components';
 import { LAB_REQUEST_STATUS_OPTIONS } from '../../constants';
-import { DateField, SelectField, LocalisedField } from '../Field';
+import { DateField, SelectField, LocalisedField, Field, CheckField } from '../Field';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLabRequest } from '../../contexts/LabRequest';
+
+const FacilityCheckbox = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 20px;
+`;
 
 export const LabRequestsSearchBar = () => {
   const { searchParameters, setSearchParameters } = useLabRequest();
@@ -37,6 +44,9 @@ export const LabRequestsSearchBar = () => {
         saveDateAsString
         component={DateField}
       />
+      <FacilityCheckbox>
+        <Field name="allFacilities" label="Include all facilities" component={CheckField} />
+      </FacilityCheckbox>
     </CustomisableSearchBar>
   );
 };

--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -6,6 +6,7 @@ import {
 } from 'shared/constants';
 import config from 'config';
 import { createDummyPatient, createDummyEncounter, randomLabRequest } from 'shared/demoData';
+import { fake } from 'shared/test-helpers/fake';
 
 import { createTestContext } from '../utilities';
 
@@ -132,9 +133,9 @@ describe('Labs', () => {
         patientId,
       });
       await models.LabRequest.create({
+        ...fake(models.LabRequest),
         encounterId: encounter.id,
         requestedById: app.user.id,
-        displayId: '12345',
       });
     };
 
@@ -157,12 +158,14 @@ describe('Labs', () => {
 
     it('should include all requests when allFacilities  is true', async () => {
       const result = await app.get(`/v1/labRequest?allFacilities=true`);
+      expect(result).toHaveSucceeded();
+
       const hasConfigFacility = result.body.data.some(
         lr => lr.facilityId === config.serverFacilityId,
       );
-      const hasOtherFacility = result.body.data.some(lr => lr.facilityId === otherFacilityId);
-      expect(result).toHaveSucceeded();
       expect(hasConfigFacility).toBe(true);
+
+      const hasOtherFacility = result.body.data.some(lr => lr.facilityId === otherFacilityId);
       expect(hasOtherFacility).toBe(true);
     });
   });

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -105,7 +105,7 @@ labRequest.get(
         }),
       ),
       makeFilter(
-        !JSON.parse(filterParams.allFacilities),
+        !JSON.parse(filterParams.allFacilities || false),
         `location.facility_id = :facilityId`,
         () => ({ facilityId: config.serverFacilityId }),
       ),

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import config from 'config';
 import { startOfDay, endOfDay } from 'date-fns';
 import { QueryTypes } from 'sequelize';
 
@@ -103,6 +104,11 @@ labRequest.get(
           requestedDateTo: toDateTimeString(endOfDay(new Date(requestedDateTo))),
         }),
       ),
+      makeFilter(
+        !JSON.parse(filterParams.allFacilities),
+        `location.facility_id = :facilityId`,
+        () => ({ facilityId: config.serverFacilityId }),
+      ),
     ].filter(f => f);
 
     const whereClauses = filters.map(f => f.sql).join(' AND ');
@@ -123,6 +129,8 @@ labRequest.get(
           ON (examiner.id = encounter.examiner_id)
         LEFT JOIN users AS requester
           ON (requester.id = lab_requests.requested_by_id)
+        LEFT JOIN locations AS location
+          ON (location.id = encounter.location_id)
       ${whereClauses && `WHERE ${whereClauses}`}
     `;
 

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -173,7 +173,8 @@ labRequest.get(
           priority.id AS priority_id,
           priority.name AS priority_name,
           laboratory.id AS laboratory_id,
-          laboratory.name AS laboratory_name
+          laboratory.name AS laboratory_name,
+          location.facility_id AS facility_id
         ${from}
 
         LIMIT :limit


### PR DESCRIPTION
### Changes


The lab requests table shows all imaging requests that are synced to the facility server regardless of which facility the lab request was generated under. In order to reduce confusion in the upcoming aspen facility we are adding a checkbox to let the user change between all vs current facility view of lab requests. The list will default to filtering lab requests by the current facility and they can check the "include all facilities" checkbox if they want to view all lab requests synced down.

For this I have filtered by the location of the encounter that the lab request was created on as that is the only link to a location that the lab request table has.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
