### PR TITLE
WAITM-687: Add unique constraint to Location.code

### DIFF
--- a/packages/shared-src/src/migrations/1679627805922-uniqueLocationCodes.js
+++ b/packages/shared-src/src/migrations/1679627805922-uniqueLocationCodes.js
@@ -1,18 +1,23 @@
 import Sequelize, { QueryTypes } from 'sequelize';
 
 export async function up(query) {
-  const dupes = await query.sequelize.query(`
+  const dupes = await query.sequelize.query(
+    `
     SELECT COUNT(*), code 
     FROM locations
     GROUP BY code
     HAVING COUNT(*) > 1
-  `, {
-    type: QueryTypes.SELECT,
-  });
+  `,
+    {
+      type: QueryTypes.SELECT,
+    },
+  );
 
   if (dupes.length > 0) {
     const codes = dupes.map(d => `"${d.code}" (x${d.count})`).join(',');
-    throw new Error(`Found some Locations in the db that have the same code as each other. Please resolve the duplication before proceeding.\nThe duplicated codes are: ${codes}`);
+    throw new Error(
+      `Found some Locations in the db that have the same code as each other. Please resolve the duplication before proceeding.\nThe duplicated codes are: ${codes}`,
+    );
   }
 
   await query.changeColumn('locations', 'code', {

--- a/packages/shared-src/src/migrations/1679627805922-uniqueLocationCodes.js
+++ b/packages/shared-src/src/migrations/1679627805922-uniqueLocationCodes.js
@@ -1,0 +1,31 @@
+import Sequelize, { QueryTypes } from 'sequelize';
+
+export async function up(query) {
+  const dupes = await query.sequelize.query(`
+    SELECT COUNT(*), code 
+    FROM locations
+    GROUP BY code
+    HAVING COUNT(*) > 1
+  `, {
+    type: QueryTypes.SELECT,
+  });
+
+  if (dupes.length > 0) {
+    const codes = dupes.map(d => `"${d.code}" (x${d.count})`).join(',');
+    throw new Error(`Found some Locations in the db that have the same code as each other. Please resolve the duplication before proceeding.\nThe duplicated codes are: ${codes}`);
+  }
+
+  await query.changeColumn('locations', 'code', {
+    type: Sequelize.STRING,
+    allowNull: false,
+    unique: true,
+  });
+}
+
+export async function down(query) {
+  await query.changeColumn('locations', 'code', {
+    type: Sequelize.STRING,
+    allowNull: false,
+    unique: false,
+  });
+}

--- a/packages/shared-src/src/models/Location.js
+++ b/packages/shared-src/src/models/Location.js
@@ -22,6 +22,7 @@ export class Location extends Model {
         code: {
           type: Sequelize.STRING,
           allowNull: false,
+          unique: true,
         },
         name: {
           type: Sequelize.STRING,


### PR DESCRIPTION
### Changes

Just an oversight, seems like a unique index was added in the sequelize model definition but not in the migration. This fixes that.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)