### PR TITLE
EPI-276 + EPI-277: More bugfixes to multiple imaging request printing

### DIFF
--- a/packages/desktop/app/components/DateDisplay.js
+++ b/packages/desktop/app/components/DateDisplay.js
@@ -8,9 +8,13 @@ import styled from 'styled-components';
 
 import { Colors } from '../constants';
 
-const SoftText = styled(Typography)`
+const Text = styled(Typography)`
   font-size: inherit;
   line-height: inherit;
+  margin-top: -2px;
+`;
+
+const SoftText = styled(Text)`
   color: ${Colors.softText};
 `;
 
@@ -131,13 +135,16 @@ export const DateDisplay = React.memo(
   },
 );
 
-export const MultilineDatetimeDisplay = React.memo(({ date, showExplicitDate }) => {
-  return (
-    <Box>
-      <DateDisplay date={date} showExplicitDate={showExplicitDate} />
-      <SoftText>{formatTime(date)}</SoftText>
-    </Box>
-  );
-});
+export const MultilineDatetimeDisplay = React.memo(
+  ({ date, showExplicitDate, isTimeSoft = true }) => {
+    const TimeText = isTimeSoft ? SoftText : Text;
+    return (
+      <Box>
+        <DateDisplay date={date} showExplicitDate={showExplicitDate} />
+        <TimeText>{formatTime(date)}</TimeText>
+      </Box>
+    );
+  },
+);
 
 DateDisplay.rawFormat = formatShort;

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -25,8 +25,11 @@ const ControlLabel = styled(FormControlLabel)`
     font-size: 16px;
     line-height: 18px;
   }
-  i {
+  i.fa-check-square {
     color: ${Colors.primary};
+  }
+  i.fa-square {
+    color: ${Colors.softText};
   }
 `;
 

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionModal.js
@@ -6,7 +6,7 @@ import { PrintMultipleImagingRequestsSelectionForm } from './PrintMultipleImagin
 
 export const PrintMultipleImagingRequestsSelectionModal = ({ encounter, open, onClose }) => {
   return (
-    <Modal title="Print imaging requests" width="md" open={open} onClose={onClose}>
+    <Modal title="Print imaging request/s" width="md" open={open} onClose={onClose}>
       <PrintMultipleImagingRequestsSelectionForm encounter={encounter} onClose={onClose} />
     </Modal>
   );

--- a/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { startCase } from 'lodash';
 
-import { DateDisplay, MultilineDatetimeDisplay } from '../../DateDisplay';
+import { MultilineDatetimeDisplay } from '../../DateDisplay';
 import { getImagingRequestType } from '../../../utils/getImagingRequestType';
 import { getAreaNote } from '../../../utils/areaNote';
 import { useLocalisation } from '../../../contexts/Localisation';
@@ -38,7 +38,9 @@ const COMMON_COLUMNS = [
     },
     printout: {
       widthProportion: 4,
-      accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
+      accessor: ({ requestedDate }) => (
+        <MultilineDatetimeDisplay date={requestedDate} isTimeSoft={false} />
+      ),
     },
   },
   {

--- a/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
@@ -31,7 +31,7 @@ const COMMON_COLUMNS = [
   },
   {
     key: COLUMN_KEYS.REQUESTED_DATE,
-    title: 'Requested date and time',
+    title: 'Requested date & time',
     sortable: false,
     form: {
       accessor: ({ requestedDate }) => <MultilineDatetimeDisplay date={requestedDate} />,

--- a/packages/desktop/app/components/PatientPrinting/printouts/DeathCertificate.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/DeathCertificate.js
@@ -4,10 +4,7 @@ import { Typography, Box } from '@material-ui/core';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { DateDisplay } from '../../DateDisplay';
-import {
-  LocalisedCertificateLabel as LocalisedLabel,
-  CertificateLabel as Label,
-} from './reusable/CertificateLabels';
+import { LocalisedCertificateLabel, CertificateLabel } from './reusable/CertificateLabels';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 
 const Grid = styled(Box)`
@@ -72,6 +69,16 @@ const FormFieldUnderline = styled(Text)`
 
 const UnderlinedFormHelper = styled(Text)`
   font-weight: 500;
+`;
+
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  font-size: 12px;
+  margin-bottom: 20px;
+`;
+
+const Label = styled(CertificateLabel)`
+  font-size: 12px;
+  margin-bottom: 20px;
 `;
 
 const FormLine = ({ children, helperText }) => {

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -4,13 +4,12 @@ import { Typography } from '@material-ui/core';
 
 import { startCase } from 'lodash';
 
-import { LocalisedLabel } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { DateDisplay } from '../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../utils/capitalise';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
-import { CertificateLabel } from './reusable/CertificateLabels';
+import { CertificateLabel, LocalisedCertificateLabel } from './reusable/CertificateLabels';
 import {
   noteTypes,
   DRUG_ROUTE_VALUE_TO_LABEL,
@@ -78,7 +77,7 @@ const TableHeading = styled(SummaryHeading)`
   margin-bottom: 5px;
 `;
 
-const LocalisedDisplayValue = styled(LocalisedLabel)`
+const LocalisedDisplayValue = styled(LocalisedCertificateLabel)`
   font-size: 10px;
   line-height: 12px;
   margin-bottom: 5px;

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -4,12 +4,13 @@ import { Typography } from '@material-ui/core';
 
 import { startCase } from 'lodash';
 
+import { LocalisedLabel } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { DateDisplay } from '../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../utils/capitalise';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
-import { LocalisedCertificateLabel, CertificateLabel } from './reusable/CertificateLabels';
+import { CertificateLabel } from './reusable/CertificateLabels';
 import {
   noteTypes,
   DRUG_ROUTE_VALUE_TO_LABEL,
@@ -77,7 +78,7 @@ const TableHeading = styled(SummaryHeading)`
   margin-bottom: 5px;
 `;
 
-const LocalisedDisplayValue = styled(LocalisedCertificateLabel)`
+const LocalisedDisplayValue = styled(LocalisedLabel)`
   font-size: 10px;
   line-height: 12px;
   margin-bottom: 5px;

--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -4,13 +4,12 @@ import { Typography } from '@material-ui/core';
 
 import { startCase } from 'lodash';
 
-import { LocalisedLabel } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { DateDisplay } from '../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../utils/capitalise';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
-import { CertificateLabel } from './reusable/CertificateLabels';
+import { LocalisedCertificateLabel, CertificateLabel } from './reusable/CertificateLabels';
 import {
   noteTypes,
   DRUG_ROUTE_VALUE_TO_LABEL,
@@ -78,7 +77,7 @@ const TableHeading = styled(SummaryHeading)`
   margin-bottom: 5px;
 `;
 
-const LocalisedDisplayValue = styled(LocalisedLabel)`
+const LocalisedDisplayValue = styled(LocalisedCertificateLabel)`
   font-size: 10px;
   line-height: 12px;
   margin-bottom: 5px;

--- a/packages/desktop/app/components/PatientPrinting/printouts/ImagingRequestPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/ImagingRequestPrintout.js
@@ -6,7 +6,7 @@ import { DateDisplay } from '../../DateDisplay';
 import { getFullLocationName } from '../../../utils/location';
 
 export const ImagingRequestPrintout = React.memo(
-  ({ imagingRequestData, patientData, encounterData, certificateData }) => {
+  ({ imagingRequest, patient, encounter, certificate, village, additionalData }) => {
     const {
       displayId,
       requestedDate,
@@ -16,22 +16,24 @@ export const ImagingRequestPrintout = React.memo(
       areas,
       areaNote,
       note,
-    } = imagingRequestData;
+    } = imagingRequest;
     const { getLocalisation } = useLocalisation();
     const imagingTypes = getLocalisation('imagingTypes') || {};
     const imagingPriorities = getLocalisation('imagingPriorities') || [];
 
     return (
       <SimplePrintout
-        patientData={patientData}
+        patient={patient}
+        village={village}
+        additionalData={additionalData}
         notes={[{ content: note }]}
-        certificateData={{ ...certificateData, pageTitle: 'Imaging Request' }}
+        certificate={{ ...certificate, pageTitle: 'Imaging Request' }}
         tableData={{
           'Request ID': displayId,
           'Request date': requestedDate ? <DateDisplay date={requestedDate} /> : null,
-          Facility: encounterData?.location?.facility?.name,
-          Department: encounterData?.department?.name,
-          Location: getFullLocationName(encounterData?.location),
+          Facility: encounter?.location?.facility?.name,
+          Department: encounter?.department?.name,
+          Location: getFullLocationName(encounter?.location),
           'Requested by': requestedBy?.displayName,
           Priority: imagingPriorities.find(p => p.value === priority)?.label || '',
           'Imaging type': imagingTypes[imagingType]?.label || 'Unknown',

--- a/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintout.js
@@ -5,7 +5,7 @@ import { DateDisplay } from '../../DateDisplay';
 import { getFullLocationName } from '../../../utils/location';
 
 export const LabRequestPrintout = React.memo(
-  ({ labRequestData, patientData, encounterData, certificateData }) => {
+  ({ labRequest, patient, village, additionalData, encounter, certificate }) => {
     const {
       displayId,
       requestedDate,
@@ -15,19 +15,21 @@ export const LabRequestPrintout = React.memo(
       category,
       tests,
       notes,
-    } = labRequestData;
+    } = labRequest;
 
     return (
       <SimplePrintout
-        patientData={patientData}
+        patient={patient}
+        village={village}
+        additionalData={additionalData}
         notes={notes}
-        certificateData={{ ...certificateData, pageTitle: 'Lab Request' }}
+        certificate={{ ...certificate, pageTitle: 'Lab Request' }}
         tableData={{
           'Test ID': displayId,
           'Request date': requestedDate ? <DateDisplay date={requestedDate} showTime /> : null,
-          Facility: encounterData?.location?.facility?.name,
-          Department: encounterData?.department?.name,
-          Location: getFullLocationName(encounterData?.location),
+          Facility: encounter?.location?.facility?.name,
+          Department: encounter?.department?.name,
+          Location: getFullLocationName(encounter?.location),
           'Requested by': requestedBy?.displayName,
           'Sample time': sampleTime ? <DateDisplay date={sampleTime} showTime /> : null,
           Priority: priority?.name,

--- a/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
@@ -11,11 +11,11 @@ import { useAuth } from '../../../contexts/Auth';
 import { Colors, DRUG_ROUTE_VALUE_TO_LABEL } from '../../../constants';
 
 import { PatientDetailPrintout } from './reusable/PatientDetailPrintout';
-import { NotesSection, LocalisedLabel } from './reusable/SimplePrintout';
+import { NotesSection } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
-import { CertificateLabel } from './reusable/CertificateLabels';
+import { CertificateLabel, LocalisedCertificateLabel } from './reusable/CertificateLabels';
 
 const RowContainer = styled.div`
   display: flex;
@@ -51,6 +51,9 @@ const StyledNotesSectionWrapper = styled.div`
 const StyledDiv = styled.div`
   ${props => (props.$marginLeft ? `margin-left: ${props.$marginLeft}px;` : '')}
 `;
+
+const LocalisedLabel = props => <LocalisedCertificateLabel size="14px" margin="9px" {...props} />;
+const Label = props => <CertificateLabel size="14px" margin="9px" {...props} />;
 
 const columns = [
   {
@@ -106,20 +109,14 @@ export const MultiplePrescriptionPrintout = React.memo(
 
         <RowContainer>
           <StyledDiv>
-            <CertificateLabel margin="9px" name="Date" size="14px">
+            <Label name="Date">
               <DateDisplay date={getCurrentDateString()} />
-            </CertificateLabel>
-            <LocalisedLabel name="prescriber" size="14px">
-              {prescriber?.displayName}
-            </LocalisedLabel>
+            </Label>
+            <LocalisedLabel name="prescriber">{prescriber?.displayName}</LocalisedLabel>
           </StyledDiv>
           <StyledDiv $marginLeft="150">
-            <LocalisedLabel name="prescriberId" size="14px">
-              {prescriber?.displayId}
-            </LocalisedLabel>
-            <LocalisedLabel name="facility" size="14px">
-              {facility.name}
-            </LocalisedLabel>
+            <LocalisedLabel name="prescriberId">{prescriber?.displayId}</LocalisedLabel>
+            <LocalisedLabel name="facility">{facility.name}</LocalisedLabel>
           </StyledDiv>
         </RowContainer>
 

--- a/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
@@ -11,11 +11,15 @@ import { useAuth } from '../../../contexts/Auth';
 import { Colors, DRUG_ROUTE_VALUE_TO_LABEL } from '../../../constants';
 
 import { PatientDetailPrintout } from './reusable/PatientDetailPrintout';
-import { NotesSection, LocalisedLabel } from './reusable/SimplePrintout';
+import { NotesSection } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
-import { CertificateLabel } from './reusable/CertificateLabels';
+import { CertificateLabel, LocalisedCertificateLabel } from './reusable/CertificateLabels';
+
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  margin-bottom: 9px;
+`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
@@ -52,8 +52,15 @@ const StyledDiv = styled.div`
   ${props => (props.$marginLeft ? `margin-left: ${props.$marginLeft}px;` : '')}
 `;
 
-const LocalisedLabel = props => <LocalisedCertificateLabel size="14px" margin="9px" {...props} />;
-const Label = props => <CertificateLabel size="14px" margin="9px" {...props} />;
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  font-size: 14px;
+  margin-bottom: 9px;
+`;
+
+const Label = styled(CertificateLabel)`
+  font-size: 14px;
+  margin-bottom: 9px;
+`;
 
 const columns = [
   {

--- a/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/MultiplePrescriptionPrintout.js
@@ -11,15 +11,11 @@ import { useAuth } from '../../../contexts/Auth';
 import { Colors, DRUG_ROUTE_VALUE_TO_LABEL } from '../../../constants';
 
 import { PatientDetailPrintout } from './reusable/PatientDetailPrintout';
-import { NotesSection } from './reusable/SimplePrintout';
+import { NotesSection, LocalisedLabel } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { ListTable } from './reusable/ListTable';
-import { CertificateLabel, LocalisedCertificateLabel } from './reusable/CertificateLabels';
-
-const LocalisedLabel = styled(LocalisedCertificateLabel)`
-  margin-bottom: 9px;
-`;
+import { CertificateLabel } from './reusable/CertificateLabels';
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/PrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/PrescriptionPrintout.js
@@ -5,11 +5,16 @@ import { Typography, Box } from '@material-ui/core';
 import { DateDisplay } from '../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../utils/capitalise';
 
-import { NotesSection, LocalisedLabel } from './reusable/SimplePrintout';
+import { NotesSection } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { PatientBarcode } from './reusable/PatientBarcode';
 import { GridTable } from './reusable/GridTable';
+import { LocalisedCertificateLabel } from './reusable/CertificateLabels';
+
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  margin-bottom: 9px;
+`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/PrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/PrescriptionPrintout.js
@@ -3,18 +3,12 @@ import styled from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 
 import { DateDisplay } from '../../DateDisplay';
-import { capitaliseFirstLetter } from '../../../utils/capitalise';
 
-import { NotesSection, LocalisedLabel } from './reusable/SimplePrintout';
+import { NotesSection } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
-import { PatientBarcode } from './reusable/PatientBarcode';
 import { GridTable } from './reusable/GridTable';
-
-const RowContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
+import { PatientDetailPrintout } from './reusable/PatientDetailPrintout';
 
 const Text = styled(Typography)`
   font-size: 14px;
@@ -27,17 +21,7 @@ const SignatureBox = styled(Box)`
 
 export const PrescriptionPrintout = React.memo(
   ({ patientData, prescriptionData, encounterData, certificateData }) => {
-    const {
-      firstName,
-      lastName,
-      dateOfBirth,
-      sex,
-      displayId,
-      additionalData,
-      village,
-    } = patientData;
-    const { streetVillage } = additionalData;
-    const { name: villageName } = village;
+    const { additionalData, village } = patientData;
     const { title, subTitle, logo } = certificateData;
     const { prescriber, medication, route, prescription, quantity, date, note } = prescriptionData;
 
@@ -49,22 +33,11 @@ export const PrescriptionPrintout = React.memo(
           logoSrc={logo}
           pageTitle="Prescription"
         />
-        <RowContainer>
-          <div>
-            <LocalisedLabel name="firstName">{firstName}</LocalisedLabel>
-            <LocalisedLabel name="lastName">{lastName}</LocalisedLabel>
-            <LocalisedLabel name="dateOfBirth">
-              <DateDisplay date={dateOfBirth} showDate={false} showExplicitDate />
-            </LocalisedLabel>
-            <LocalisedLabel name="sex">{capitaliseFirstLetter(sex)}</LocalisedLabel>
-            <LocalisedLabel name="streetVillage">{streetVillage}</LocalisedLabel>
-          </div>
-          <div>
-            <LocalisedLabel name="villageName">{villageName}</LocalisedLabel>
-            <LocalisedLabel name="displayId">{displayId}</LocalisedLabel>
-            <PatientBarcode patient={patientData} barWidth={2} barHeight={60} margin={0} />
-          </div>
-        </RowContainer>
+        <PatientDetailPrintout
+          patient={patientData}
+          additionalData={additionalData}
+          village={village}
+        />
         <GridTable
           data={{
             Date: date ? <DateDisplay date={date} /> : null,

--- a/packages/desktop/app/components/PatientPrinting/printouts/PrescriptionPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/PrescriptionPrintout.js
@@ -5,16 +5,11 @@ import { Typography, Box } from '@material-ui/core';
 import { DateDisplay } from '../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../utils/capitalise';
 
-import { NotesSection } from './reusable/SimplePrintout';
+import { NotesSection, LocalisedLabel } from './reusable/SimplePrintout';
 import { PrintLetterhead } from './reusable/PrintLetterhead';
 import { CertificateWrapper } from './reusable/CertificateWrapper';
 import { PatientBarcode } from './reusable/PatientBarcode';
 import { GridTable } from './reusable/GridTable';
-import { LocalisedCertificateLabel } from './reusable/CertificateLabels';
-
-const LocalisedLabel = styled(LocalisedCertificateLabel)`
-  margin-bottom: 9px;
-`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/CertificateLabels.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/CertificateLabels.js
@@ -1,33 +1,24 @@
 import React from 'react';
-import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { LocalisedText } from '../../../LocalisedText';
 
-// TODO: can we style these normally instead of passing them around?
-const Text = styled(Typography)`
-  font-size: ${props => props.$size};
-  margin-bottom: ${props => props.$margin};
-`;
-
-export const CertificateLabel = ({ name, children, margin = '20px', size = '12px', className }) => (
-  <Text $margin={margin} $size={size} className={className}>
+export const CertificateLabel = ({ name, children, className }) => (
+  <Typography className={className}>
     <strong>{name}: </strong>
     {children}
-  </Text>
+  </Typography>
 );
 
 export const LocalisedCertificateLabel = ({
   name,
   children,
-  margin = '20px',
-  size = '12px',
   className,
   path = `fields.${name}.longLabel`,
 }) => (
-  <Text $margin={margin} $size={size} className={className}>
+  <Typography className={className}>
     <strong>
       <LocalisedText path={path} />:{' '}
     </strong>
     {children}
-  </Text>
+  </Typography>
 );

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/CertificateLabels.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/CertificateLabels.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { LocalisedText } from '../../../LocalisedText';
 
+// TODO: can we style these normally instead of passing them around?
 const Text = styled(Typography)`
   font-size: ${props => props.$size};
   margin-bottom: ${props => props.$margin};

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
@@ -8,11 +8,6 @@ import { DateDisplay } from '../../../DateDisplay';
 
 import { LocalisedLabel } from './SimplePrintout';
 import { CertificateLabel } from './CertificateLabels';
-import { CertificateLabel, LocalisedCertificateLabel } from './CertificateLabels';
-
-const LocalisedLabel = styled(LocalisedCertificateLabel)`
-  margin-bottom: 9px;
-`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
@@ -19,6 +19,7 @@ const Item = styled.div`
   margin-right: 36px;
   p {
     margin-bottom: 0px;
+    font-size: 14px;
   }
 `;
 
@@ -26,17 +27,17 @@ export const DateFacilitySection = ({ encounter }) => {
   return (
     <RowContainer>
       <Item>
-        <CertificateLabel name="Print date" size="14px">
+        <CertificateLabel name="Print date">
           <DateDisplay date={getCurrentDateString()} />
         </CertificateLabel>
       </Item>
       <Item>
-        <LocalisedCertificateLabel name="facility" size="14px">
+        <LocalisedCertificateLabel name="facility">
           {encounter?.location?.facility?.name}
         </LocalisedCertificateLabel>
       </Item>
       <Item>
-        <LocalisedCertificateLabel name="locationId" size="14px">
+        <LocalisedCertificateLabel name="locationId">
           {getFullLocationName(encounter?.location)}
         </LocalisedCertificateLabel>
       </Item>

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
@@ -17,29 +17,33 @@ const RowContainer = styled.div`
 
 const Item = styled.div`
   margin-right: 36px;
-  p {
-    margin-bottom: 0px;
-    font-size: 14px;
-  }
+`;
+
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  font-size: 14px;
+  margin-bottom: 0px;
+`;
+
+const Label = styled(CertificateLabel)`
+  font-size: 14px;
+  margin-bottom: 0px;
 `;
 
 export const DateFacilitySection = ({ encounter }) => {
   return (
     <RowContainer>
       <Item>
-        <CertificateLabel name="Print date">
+        <Label name="Print date">
           <DateDisplay date={getCurrentDateString()} />
-        </CertificateLabel>
+        </Label>
       </Item>
       <Item>
-        <LocalisedCertificateLabel name="facility">
-          {encounter?.location?.facility?.name}
-        </LocalisedCertificateLabel>
+        <LocalisedLabel name="facility">{encounter?.location?.facility?.name}</LocalisedLabel>
       </Item>
       <Item>
-        <LocalisedCertificateLabel name="locationId">
+        <LocalisedLabel name="locationId">
           {getFullLocationName(encounter?.location)}
-        </LocalisedCertificateLabel>
+        </LocalisedLabel>
       </Item>
     </RowContainer>
   );

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
@@ -6,34 +6,40 @@ import { getCurrentDateString } from 'shared/utils/dateTime';
 import { getFullLocationName } from '../../../../utils/location';
 import { DateDisplay } from '../../../DateDisplay';
 
-import { LocalisedLabel } from './SimplePrintout';
-import { CertificateLabel } from './CertificateLabels';
+import { CertificateLabel, LocalisedCertificateLabel } from './CertificateLabels';
 
 const RowContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: start;
   flex-wrap: wrap;
   padding: 0 20px;
+`;
+
+const Item = styled.div`
+  margin-right: 36px;
+  p {
+    margin-bottom: 0px;
+  }
 `;
 
 export const DateFacilitySection = ({ encounter }) => {
   return (
     <RowContainer>
-      <div>
+      <Item>
         <CertificateLabel name="Print date" size="14px">
           <DateDisplay date={getCurrentDateString()} />
         </CertificateLabel>
-      </div>
-      <div>
-        <LocalisedLabel name="facility" size="14px">
+      </Item>
+      <Item>
+        <LocalisedCertificateLabel name="facility" size="14px">
           {encounter?.location?.facility?.name}
-        </LocalisedLabel>
-      </div>
-      <div>
-        <LocalisedLabel name="locationId" size="14px">
+        </LocalisedCertificateLabel>
+      </Item>
+      <Item>
+        <LocalisedCertificateLabel name="locationId" size="14px">
           {getFullLocationName(encounter?.location)}
-        </LocalisedLabel>
-      </div>
+        </LocalisedCertificateLabel>
+      </Item>
     </RowContainer>
   );
 };

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/DateFacilitySection.js
@@ -8,6 +8,11 @@ import { DateDisplay } from '../../../DateDisplay';
 
 import { LocalisedLabel } from './SimplePrintout';
 import { CertificateLabel } from './CertificateLabels';
+import { CertificateLabel, LocalisedCertificateLabel } from './CertificateLabels';
+
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  margin-bottom: 9px;
+`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
@@ -5,8 +5,12 @@ import styled from 'styled-components';
 import { DateDisplay } from '../../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../../utils/capitalise';
 
-import { LocalisedLabel } from './SimplePrintout';
+import { LocalisedCertificateLabel } from './CertificateLabels';
 import { PatientBarcode } from './PatientBarcode';
+
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  margin-bottom: 9px;
+`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
@@ -17,8 +17,8 @@ const LocalisedLabel = props => <LocalisedCertificateLabel margin="0" {...props}
 
 export const PatientDetailPrintout = React.memo(({ patient, village, additionalData }) => {
   const { firstName, lastName, dateOfBirth, sex, displayId } = patient;
-  const { streetVillage } = additionalData;
-  const { name: villageName } = village;
+  const { streetVillage } = additionalData || {};
+  const { name: villageName } = village || {};
 
   return (
     <RowContainer>
@@ -29,10 +29,10 @@ export const PatientDetailPrintout = React.memo(({ patient, village, additionalD
           <DateDisplay date={dateOfBirth} />
         </LocalisedLabel>
         <LocalisedLabel name="sex">{capitaliseFirstLetter(sex)}</LocalisedLabel>
-        <LocalisedLabel name="streetVillage">{streetVillage}</LocalisedLabel>
+        {streetVillage ? <LocalisedLabel name="streetVillage">{streetVillage}</LocalisedLabel> : ''}
       </div>
       <div>
-        <LocalisedLabel name="villageName">{villageName}</LocalisedLabel>
+        {villageName ? <LocalisedLabel name="villageName">{villageName}</LocalisedLabel> : ''}
         <LocalisedLabel path="fields.displayId.shortLabel">{displayId}</LocalisedLabel>
         <PatientBarcode patient={patient} barWidth={2} barHeight={60} margin={0} />
       </div>

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
@@ -5,13 +5,15 @@ import styled from 'styled-components';
 import { DateDisplay } from '../../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../../utils/capitalise';
 
-import { LocalisedLabel } from './SimplePrintout';
+import { LocalisedCertificateLabel } from './CertificateLabels';
 import { PatientBarcode } from './PatientBarcode';
 
 const RowContainer = styled.div`
   display: flex;
   justify-content: space-between;
 `;
+
+const LocalisedLabel = props => <LocalisedCertificateLabel margin="0" {...props} />;
 
 export const PatientDetailPrintout = React.memo(({ patient, village, additionalData }) => {
   const { firstName, lastName, dateOfBirth, sex, displayId } = patient;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
@@ -5,12 +5,8 @@ import styled from 'styled-components';
 import { DateDisplay } from '../../../DateDisplay';
 import { capitaliseFirstLetter } from '../../../../utils/capitalise';
 
-import { LocalisedCertificateLabel } from './CertificateLabels';
+import { LocalisedLabel } from './SimplePrintout';
 import { PatientBarcode } from './PatientBarcode';
-
-const LocalisedLabel = styled(LocalisedCertificateLabel)`
-  margin-bottom: 9px;
-`;
 
 const RowContainer = styled.div`
   display: flex;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
@@ -13,7 +13,10 @@ const RowContainer = styled.div`
   justify-content: space-between;
 `;
 
-const LocalisedLabel = props => <LocalisedCertificateLabel margin="0" {...props} />;
+const LocalisedLabel = styled(LocalisedCertificateLabel)`
+  font-size: 12px;
+  margin-bottom: 0px;
+`;
 
 export const PatientDetailPrintout = React.memo(({ patient, village, additionalData }) => {
   const { firstName, lastName, dateOfBirth, sex, displayId } = patient;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
@@ -4,7 +4,6 @@ import { Typography, Box } from '@material-ui/core';
 
 import { PrintLetterhead } from './PrintLetterhead';
 import { CertificateWrapper } from './CertificateWrapper';
-import { LocalisedCertificateLabel } from './CertificateLabels';
 import { GridTable } from './GridTable';
 import { PatientDetailPrintout } from './PatientDetailPrintout';
 
@@ -42,20 +41,6 @@ export const NotesSection = ({
     </>
   );
 };
-
-// TODO: kill this off and/or get rid of default margin from LocalisedCertificateLabel
-export const LocalisedLabel = ({ name, children, size, className, length, path }) => (
-  <LocalisedCertificateLabel
-    margin="9px"
-    name={name}
-    size={size}
-    className={className}
-    length={length}
-    path={path}
-  >
-    {children}
-  </LocalisedCertificateLabel>
-);
 
 export const SimplePrintout = React.memo(({ patientData, tableData, notes, certificateData }) => {
   const { pageTitle, title, subTitle, logo } = certificateData;

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
@@ -2,23 +2,15 @@ import React from 'react';
 import styled from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 
-import { DateDisplay } from '../../../DateDisplay';
-import { capitaliseFirstLetter } from '../../../../utils/capitalise';
-
 import { PrintLetterhead } from './PrintLetterhead';
 import { CertificateWrapper } from './CertificateWrapper';
 import { LocalisedCertificateLabel } from './CertificateLabels';
-import { PatientBarcode } from './PatientBarcode';
 import { GridTable } from './GridTable';
+import { PatientDetailPrintout } from './PatientDetailPrintout';
 
 const Text = styled(Typography)`
   ${props => (props.$boldTitle ? 'font-weight: 500;' : '')}
   font-size: 14px;
-`;
-
-const RowContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
 `;
 
 const NotesBox = styled(Box)`
@@ -51,6 +43,7 @@ export const NotesSection = ({
   );
 };
 
+// TODO: kill this off and/or get rid of default margin from LocalisedCertificateLabel
 export const LocalisedLabel = ({ name, children, size, className, length, path }) => (
   <LocalisedCertificateLabel
     margin="9px"
@@ -65,26 +58,12 @@ export const LocalisedLabel = ({ name, children, size, className, length, path }
 );
 
 export const SimplePrintout = React.memo(({ patientData, tableData, notes, certificateData }) => {
-  const { firstName, lastName, dateOfBirth, sex, displayId } = patientData;
   const { pageTitle, title, subTitle, logo } = certificateData;
-
   return (
     <CertificateWrapper>
       <PrintLetterhead title={title} subTitle={subTitle} logoSrc={logo} pageTitle={pageTitle} />
-      <RowContainer>
-        <div>
-          <LocalisedLabel name="firstName">{firstName}</LocalisedLabel>
-          <LocalisedLabel name="lastName">{lastName}</LocalisedLabel>
-          <LocalisedLabel name="dateOfBirth">
-            <DateDisplay date={dateOfBirth} showDate={false} showExplicitDate />
-          </LocalisedLabel>
-          <LocalisedLabel name="sex">{capitaliseFirstLetter(sex)}</LocalisedLabel>
-        </div>
-        <div>
-          <LocalisedLabel name="displayId">{displayId}</LocalisedLabel>
-          <PatientBarcode patient={patientData} barWidth={2} barHeight={60} margin={0} />
-        </div>
-      </RowContainer>
+      {/* TODO: village and additionalData */}
+      <PatientDetailPrintout patient={patientData} />
       <GridTable data={tableData} />
       <NotesSection notes={notes} />
     </CertificateWrapper>

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
@@ -51,13 +51,14 @@ export const NotesSection = ({
   );
 };
 
-export const LocalisedLabel = ({ name, children, size, className, length }) => (
+export const LocalisedLabel = ({ name, children, size, className, length, path }) => (
   <LocalisedCertificateLabel
     margin="9px"
     name={name}
     size={size}
     className={className}
     length={length}
+    path={path}
   >
     {children}
   </LocalisedCertificateLabel>

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
@@ -42,15 +42,20 @@ export const NotesSection = ({
   );
 };
 
-export const SimplePrintout = React.memo(({ patientData, tableData, notes, certificateData }) => {
-  const { pageTitle, title, subTitle, logo } = certificateData;
-  return (
-    <CertificateWrapper>
-      <PrintLetterhead title={title} subTitle={subTitle} logoSrc={logo} pageTitle={pageTitle} />
-      {/* TODO: village and additionalData */}
-      <PatientDetailPrintout patient={patientData} />
-      <GridTable data={tableData} />
-      <NotesSection notes={notes} />
-    </CertificateWrapper>
-  );
-});
+export const SimplePrintout = React.memo(
+  ({ patient, village, additionalData, tableData, notes, certificate }) => {
+    const { pageTitle, title, subTitle, logo } = certificate;
+    return (
+      <CertificateWrapper>
+        <PrintLetterhead title={title} subTitle={subTitle} logoSrc={logo} pageTitle={pageTitle} />
+        <PatientDetailPrintout
+          patient={patient}
+          village={village}
+          additionalData={additionalData}
+        />
+        <GridTable data={tableData} />
+        <NotesSection notes={notes} />
+      </CertificateWrapper>
+    );
+  },
+);

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
@@ -51,14 +51,13 @@ export const NotesSection = ({
   );
 };
 
-export const LocalisedLabel = ({ name, children, size, className, length, path }) => (
+const LocalisedLabel = ({ name, children, size, className, length }) => (
   <LocalisedCertificateLabel
     margin="9px"
     name={name}
     size={size}
     className={className}
     length={length}
-    path={path}
   >
     {children}
   </LocalisedCertificateLabel>

--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/SimplePrintout.js
@@ -51,13 +51,14 @@ export const NotesSection = ({
   );
 };
 
-const LocalisedLabel = ({ name, children, size, className, length }) => (
+export const LocalisedLabel = ({ name, children, size, className, length, path }) => (
   <LocalisedCertificateLabel
     margin="9px"
     name={name}
     size={size}
     className={className}
     length={length}
+    path={path}
   >
     {children}
   </LocalisedCertificateLabel>


### PR DESCRIPTION
### Changes

Has the following changes:
- [PDF] Path is broken
- [Modal] "Print imaging request\s"
- [PDF] Show time (not greyed out)
- [PDF for single IR] SimplePrintout uses the old design
- [PDF] Justify content to start instead of using space-between for date/facility/location section
- [PDF] Reduce padding of patient details fields
- [Checkbox] Should be grey when not selected
- [Code] Fix margin/size in props
- [Code] Refactor all the printout headers

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

