### PR TITLE
Bump mobile to 1.24.58

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "1.24.57",
+  "version": "1.24.58",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -16,7 +16,7 @@ export const SUPPORTED_CLIENT_VERSIONS = {
   },
   'Tamanu Mobile': {
     min: '1.24.46',
-    max: '1.24.57', // note that higher patch versions will be allowed to connect
+    max: '1.24.58', // note that higher patch versions will be allowed to connect
   },
   'fiji-vps': {
     min: null,


### PR DESCRIPTION
### Changes

No functionality changes, just clearing up an ambiguity where another v1.24.57 already exists elsewhere/undeployed in a hotfix branch so bumping this one to disambiguate.

