### PR TITLE
WAITM-608: Fix Labs Table Filter 2

### DIFF
--- a/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
+++ b/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
@@ -26,7 +26,7 @@ const columns = [
 export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
   const { patientId, category } = useParams();
   const dispatch = useDispatch();
-  const { loadLabRequest, searchParameters } = useLabRequest();
+  const { loadLabRequest } = useLabRequest();
 
   const selectLab = async lab => {
     if (lab.patientId) await dispatch(reloadPatient(lab.patientId));
@@ -42,7 +42,6 @@ export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
       columns={columns}
       noDataMessage="No lab requests found"
       onRowClick={selectLab}
-      fetchOptions={searchParameters}
       initialSort={{ order: 'desc', orderBy: 'requestedDate' }}
     />
   );


### PR DESCRIPTION
### Changes

This PR is a missing line from the original PR that actually removes the saved search filters from the labs pane 😬 

original PR https://github.com/beyondessential/tamanu/pull/3814

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
