### PR TITLE
Change honeycomb sample rate default to 1%

### DIFF
--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -27,7 +27,8 @@
   },
   "honeycomb": {
     "apiKey": "",
-    "sampleRate": 1, // 5 = 1/5 = 20% of traces get sent to honeycomb
+    "sampleRate": 100,  // 100 = 1/100 = 1% of traces get sent to honeycomb
+                        // in contrast, logs are always sent
     "enabled": true
   },
   "sync": {


### PR DESCRIPTION
### Changes

Sending all traces is way too much, and not needed for accurate statistics (sample rate is taken into account at the honeycomb query end). Logs are always sent, so they keep their utility for diagnostics/alerting. Can always set `sampleRate` to `1` locally for detailed trace-assisted debugging if needed. 

This was previously a recommendation in the release notes but let's just make it the default.

### Checklist

- [x] Code is finished