### PR TITLE
WAITM-700: staging-fix: deviceId optional for external api consumers

### DIFF
--- a/packages/sync-server/__tests__/middleware/auth.test.js
+++ b/packages/sync-server/__tests__/middleware/auth.test.js
@@ -98,6 +98,18 @@ describe('Auth', () => {
       expect(bcrypt.compare(contents.refreshId, refreshTokenRecord.refreshId)).resolves.toBe(true);
     });
 
+    it('Should not issue a refresh token for external client', async () => {
+      const response = await baseApp
+        .post('/v1/login')
+        .set({ 'X-Tamanu-Client': 'FHIR' })
+        .send({
+          email: TEST_EMAIL,
+          password: TEST_PASSWORD,
+        });
+      expect(response).toHaveSucceeded();
+      expect(response.body.refreshToken).toBeUndefined();
+    });
+
     it('Should respond with user details with correct credentials', async () => {
       const response = await baseApp.post('/v1/login').send({
         email: TEST_EMAIL,
@@ -232,6 +244,22 @@ describe('Auth', () => {
       expect(
         bcrypt.compare(newRefreshTokenContents.refreshId, refreshTokenRecord.refreshId),
       ).resolves.toBe(true);
+    });
+    it('Should reject if external client', async () => {
+      const loginResponse = await baseApp.post('/v1/login').send({
+        email: TEST_EMAIL,
+        password: TEST_PASSWORD,
+        deviceId: TEST_DEVICE_ID,
+      });
+      expect(loginResponse).toHaveSucceeded();
+      const refreshResponse = await baseApp
+        .post('/v1/refresh')
+        .set('X-Tamanu-Client', 'FHIR')
+        .send({
+          refreshToken: loginResponse.refreshToken,
+          deviceId: TEST_DEVICE_ID,
+        });
+      expect(refreshResponse).toHaveRequestError();
     });
     it('Should reject invalid refresh token', async () => {
       const loginResponse = await baseApp.post('/v1/login').send({

--- a/packages/sync-server/__tests__/utilities.js
+++ b/packages/sync-server/__tests__/utilities.js
@@ -121,9 +121,11 @@ export async function createTestContext() {
   const expressApp = createApp(ctx);
   const appServer = http.createServer(expressApp);
   const baseApp = supertest.agent(appServer);
+  baseApp.set('X-Tamanu-Client', 'Tamanu Desktop');
 
   baseApp.asUser = async user => {
     const agent = supertest.agent(expressApp);
+    agent.set('X-Tamanu-Client', 'Tamanu Desktop');
     const token = await getToken({ userId: user.id }, DEFAULT_JWT_SECRET, {
       expiresIn: '1d',
       audience: JWT_TOKEN_TYPES.ACCESS,

--- a/packages/sync-server/app/auth/login.js
+++ b/packages/sync-server/app/auth/login.js
@@ -7,15 +7,21 @@ import { BadAuthenticationError } from 'shared/errors';
 import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
 import { getLocalisation } from '../localisation';
 import { convertFromDbRecord } from '../convertDbRecord';
-import { getToken, stripUser, findUser, getRandomBase64String, getRandomU32 } from './utils';
+import {
+  getToken,
+  stripUser,
+  findUser,
+  getRandomBase64String,
+  getRandomU32,
+  isInternalClient,
+} from './utils';
 
 export const login = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {
-    const { store, body, header } = req;
+    const { store, body } = req;
     const { email, password, facilityId, deviceId } = body;
 
-    const client = header('X-Tamanu-Client');
-    const internalClient = ['Tamanu Mobile', 'Tamanu Desktop', 'Tamanu LAN Server'].includes(client);
+    const internalClient = isInternalClient(req.header('X-Tamanu-Client'));
 
     if (!email || !password) {
       throw new BadAuthenticationError('Missing credentials');

--- a/packages/sync-server/app/auth/refresh.js
+++ b/packages/sync-server/app/auth/refresh.js
@@ -4,7 +4,14 @@ import { BadAuthenticationError } from 'shared/errors';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { JWT_TOKEN_TYPES } from 'shared/constants/auth';
-import { getToken, verifyToken, findUserById, getRandomU32, getRandomBase64String } from './utils';
+import {
+  getToken,
+  verifyToken,
+  findUserById,
+  getRandomU32,
+  getRandomBase64String,
+  isInternalClient,
+} from './utils';
 
 export const refresh = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {
@@ -17,6 +24,10 @@ export const refresh = ({ secret, refreshSecret }) =>
       saltRounds,
       refreshToken: { refreshIdLength, tokenDuration: refreshTokenDuration, absoluteExpiration },
     } = auth;
+
+    if (!isInternalClient(req.header('X-Tamanu-Client'))) {
+      throw new BadAuthenticationError('Invalid client');
+    }
 
     let contents = null;
     try {

--- a/packages/sync-server/app/auth/utils.js
+++ b/packages/sync-server/app/auth/utils.js
@@ -47,3 +47,6 @@ export const findUserById = async (models, id) => {
   }
   return user.get({ plain: true });
 };
+
+export const isInternalClient = client =>
+  ['Tamanu Mobile', 'Tamanu Desktop', 'Tamanu LAN Server'].includes(client);


### PR DESCRIPTION
### Changes
To avoid confusion after discussion with Kurt 
With this change

- External api consumers not issued refresh token and do not fail authentication for having no device id
- This just means that to an external consumer authentication is unchanged and login endpoint just wont return a refresh token

### Checklist
- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
