### PR TITLE
SAV-108: Hide button rather than disable it

### DIFF
--- a/packages/desktop/app/views/patients/panes/VaccinesPane.js
+++ b/packages/desktop/app/views/patients/panes/VaccinesPane.js
@@ -50,14 +50,15 @@ export const VaccinesPane = React.memo(({ patient, readonly }) => {
       />
       <ContentPane>
         <TableButtonRow variant="small">
-          <CovidCertificateButton
-            onClick={() => setIsCovidCertificateModalOpen(true)}
-            variant="text"
-            disabled={!certifiable}
-          >
-            <CovidCertificateIcon style={{ marginRight: 4 }} className="fa fa-clipboard-list" />
-            COVID-19 certificate
-          </CovidCertificateButton>
+          {certifiable && (
+            <CovidCertificateButton
+              onClick={() => setIsCovidCertificateModalOpen(true)}
+              variant="text"
+            >
+              <CovidCertificateIcon style={{ marginRight: 4 }} className="fa fa-clipboard-list" />
+              COVID-19 certificate
+            </CovidCertificateButton>
+          )}
           <Button
             onClick={() => setIsCertificateModalOpen(true)}
             variant="outlined"


### PR DESCRIPTION
### Changes

I initially designed the new covid-19 vaccine certificate button to be greyed out when no certifiable vaccines have been administered on the patient. We actually want it to not even show if there are no certifiable vaccines.
