### PR TITLE
Staging fix: EPI-276 + EPI-277: Align text with barcode & give modal white bg

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/PatientDetailPrintout.js
@@ -18,6 +18,9 @@ const ColumnContainer = styled.div`
   display: flex;
   justify-content: space-between;
   flex-direction: column;
+  &:first-child *:last-child {
+    padding-bottom: 18px;
+  }
 `;
 
 const LocalisedLabel = styled(LocalisedCertificateLabel)`
@@ -45,7 +48,7 @@ export const PatientDetailPrintout = React.memo(
         <ColumnContainer>
           <LocalisedLabel name="villageName">{villageName}</LocalisedLabel>
           <LocalisedLabel path="fields.displayId.shortLabel">{displayId}</LocalisedLabel>
-          <PatientBarcode patient={patient} barWidth={2} barHeight={50} margin={0} />
+          <PatientBarcode patient={patient} barWidth={2} barHeight={60} margin={0} />
         </ColumnContainer>
       </RowContainer>
     );

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -12,7 +12,7 @@ import { IMAGING_REQUEST_STATUS_TYPES, LAB_REQUEST_STATUS_CONFIG } from 'shared/
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 
 import { CancelModal } from '../../components/CancelModal';
-import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../constants';
+import { IMAGING_REQUEST_STATUS_OPTIONS, Colors } from '../../constants';
 import { useCertificate } from '../../utils/useCertificate';
 import { Button } from '../../components/Button';
 import { ContentPane } from '../../components/ContentPane';
@@ -64,7 +64,14 @@ const PrintButton = ({ imagingRequest, patient }) => {
 
   return (
     <>
-      <Modal title="Imaging Request" open={isModalOpen} onClose={closeModal} width="md" printable>
+      <Modal
+        title="Imaging Request"
+        open={isModalOpen}
+        onClose={closeModal}
+        width="md"
+        color={Colors.white}
+        printable
+      >
         {isLoading ? (
           <LoadingIndicator />
         ) : (

--- a/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
@@ -5,6 +5,7 @@ import { useCertificate } from '../../../utils/useCertificate';
 import { Modal } from '../../../components';
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { LabRequestPrintout } from '../../../components/PatientPrinting/printouts/LabRequestPrintout';
+import { Colors } from '../../../constants';
 
 export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onClose }) => {
   const api = useApi();
@@ -48,7 +49,14 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
     (isVillageEnabled && isVillageLoading);
 
   return (
-    <Modal title="Lab Request" open={open} onClose={onClose} width="md" printable>
+    <Modal
+      title="Lab Request"
+      open={open}
+      onClose={onClose}
+      width="md"
+      color={Colors.white}
+      printable
+    >
       {isLoading ? (
         <LoadingIndicator />
       ) : (


### PR DESCRIPTION
### Changes

- Align PDF header text with barcode, not barcode text
- Give single imaging request and lab request printout modals a white background

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

