### PR TITLE
EPI-344: Log FHIR creates to the database

### DIFF
--- a/packages/shared-src/src/migrations/1679999671335-fhirLogging.js
+++ b/packages/shared-src/src/migrations/1679999671335-fhirLogging.js
@@ -14,7 +14,7 @@ export async function up(query) {
     created_at: {
       type: DataTypes.DATE,
       allowNull: false,
-      defaultValue: Sequelize.fn('current_timestamp'),
+      defaultValue: Sequelize.fn('current_timestamp', 6),
     },
     verb: {
       type: DataTypes.TEXT,
@@ -27,12 +27,12 @@ export async function up(query) {
     body: {
       type: DataTypes.JSONB,
       allowNull: false,
-      defaultValue: '{}',
+      defaultValue: {},
     },
     headers: {
       type: DataTypes.JSONB,
       allowNull: false,
-      defaultValue: '{}',
+      defaultValue: {},
     },
     user_id: {
       type: DataTypes.STRING,
@@ -44,9 +44,9 @@ export async function up(query) {
     },
   });
 
-  await query.addIndex(TABLE, ['verb']);
-  await query.addIndex(TABLE, ['url']);
-  await query.addIndex(TABLE, ['headers'], { using: 'gin' });
+  await query.addIndex(TABLE, { fields: ['headers'], using: 'gin' });
+  await query.addIndex(TABLE, { fields: ['url'] });
+  await query.addIndex(TABLE, { fields: ['verb'] });
 }
 
 export async function down(query) {

--- a/packages/shared-src/src/migrations/1679999671335-fhirLogging.js
+++ b/packages/shared-src/src/migrations/1679999671335-fhirLogging.js
@@ -1,0 +1,60 @@
+import { Sequelize, DataTypes } from 'sequelize';
+
+const TABLE = { tableName: 'fhir_writes', schema: 'logs' };
+
+export async function up(query) {
+  await query.createSchema(TABLE.schema);
+  await query.createTable(TABLE, {
+    id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('uuid_generate_v4'),
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('current_timestamp'),
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('current_timestamp'),
+    },
+    verb: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    body: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: '{}',
+    },
+    headers: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: '{}',
+    },
+    user_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      references: {
+        model: { tableName: 'users', schema: 'public' },
+        key: 'id',
+      },
+    },
+  });
+
+  await query.addIndex(TABLE, ['verb']);
+  await query.addIndex(TABLE, ['url']);
+  await query.addIndex(TABLE, ['headers'], { using: 'gin' });
+}
+
+export async function down(query) {
+  await query.dropTable(TABLE);
+  await query.dropSchema(TABLE.schema);
+}

--- a/packages/shared-src/src/migrations/1679999671335-fhirLogging.js
+++ b/packages/shared-src/src/migrations/1679999671335-fhirLogging.js
@@ -16,11 +16,6 @@ export async function up(query) {
       allowNull: false,
       defaultValue: Sequelize.fn('current_timestamp'),
     },
-    updated_at: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: Sequelize.fn('current_timestamp'),
-    },
     verb: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/packages/shared-src/src/models/ImagingRequest.js
+++ b/packages/shared-src/src/models/ImagingRequest.js
@@ -18,7 +18,7 @@ const ALL_IMAGING_REQUEST_STATUS_TYPES = Object.values(IMAGING_REQUEST_STATUS_TY
 const ALL_IMAGING_TYPES = Object.values(IMAGING_TYPES);
 
 export class ImagingRequest extends Model {
-  static init({ primaryKey, ...options }) {
+  static init(options) {
     super.init(
       {
         id: {

--- a/packages/shared-src/src/models/fhir/Resource.js
+++ b/packages/shared-src/src/models/fhir/Resource.js
@@ -15,7 +15,7 @@ import { Model } from '../Model';
 const missingRecordsPrivateMethod = Symbol('missingRecords');
 
 export class FhirResource extends Model {
-  static init(attributes, options) {
+  static init(attributes, { primaryKey, ...options }) {
     super.init(
       {
         id: {

--- a/packages/shared-src/src/models/fhir/WriteLog.js
+++ b/packages/shared-src/src/models/fhir/WriteLog.js
@@ -10,7 +10,7 @@ export class FhirWriteLog extends Model {
         id: {
           type: Sequelize.UUID,
           allowNull: false,
-          default: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('uuid_generate_v4'),
           primaryKey: true,
         },
         createdAt: {

--- a/packages/shared-src/src/models/fhir/WriteLog.js
+++ b/packages/shared-src/src/models/fhir/WriteLog.js
@@ -1,0 +1,57 @@
+import { Sequelize } from 'sequelize';
+
+import { SYNC_DIRECTIONS } from '../../constants';
+import { Model } from '../Model';
+
+export class FhirWriteLog extends Model {
+  static init({ primaryKey, ...options }) {
+    super.init(
+      {
+        id: {
+          type: Sequelize.UUID,
+          allowNull: false,
+          default: Sequelize.fn('uuid_generate_v4'),
+          primaryKey: true,
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW,
+        },
+        verb: {
+          type: Sequelize.TEXT,
+          allowNull: false,
+        },
+        url: {
+          type: Sequelize.TEXT,
+          allowNull: false,
+        },
+        body: {
+          type: Sequelize.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+        headers: {
+          type: Sequelize.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+      },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC,
+        schema: 'logs',
+        tableName: 'fhir_writes',
+        timestamps: false,
+      },
+    );
+  }
+
+  static initRelations(models) {
+    this.belongsTo(models.User, {
+      as: 'user',
+      foreignKey: 'userId',
+      allowNull: true,
+    });
+  }
+}

--- a/packages/shared-src/src/models/fhir/WriteLog.js
+++ b/packages/shared-src/src/models/fhir/WriteLog.js
@@ -63,8 +63,22 @@ export class FhirWriteLog extends Model {
       verb: req.method,
       url: req.originalUrl,
       body: req.body,
-      headers: req.headers,
+      headers: filterHeaders(req.headers),
       userId: req.user?.id,
     });
   }
+}
+
+/**
+ * @param {import('express').Request['headers']} headers
+ */
+function filterHeaders(headers) {
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      ([key]) =>
+        key.startsWith('if-') ||
+        key.startsWith('x-') ||
+        ['accept', 'client-timezone', 'content-type', 'prefer', 'user-agent'].includes(key),
+    ),
+  );
 }

--- a/packages/shared-src/src/models/fhir/WriteLog.js
+++ b/packages/shared-src/src/models/fhir/WriteLog.js
@@ -54,4 +54,17 @@ export class FhirWriteLog extends Model {
       allowNull: true,
     });
   }
+
+  /**
+   * @param {import('express').Request} req
+   */
+  static fromRequest(req) {
+    return this.create({
+      verb: req.method,
+      url: req.originalUrl,
+      body: req.body,
+      headers: req.headers,
+      userId: req.user?.id,
+    });
+  }
 }

--- a/packages/shared-src/src/models/fhir/index.js
+++ b/packages/shared-src/src/models/fhir/index.js
@@ -6,3 +6,5 @@ export * from './ServiceRequest';
 
 export * from './Job';
 export * from './JobWorker';
+
+export * from './WriteLog';

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -332,14 +332,14 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               reference: `ServiceRequest/${mat.id}`,
             },
           ],
-          note: [{ text: 'This is a note' }, { text: 'This is another note' }],
+          note: [{ text: 'This is a good note' }, { text: 'This is another note' }],
         });
 
         // assert
         expect(response).toHaveSucceeded();
         expect(response.status).toBe(201);
         await ires.reload();
-        expect(ires.description).toEqual('This is a note\n\nThis is another note');
+        expect(ires.description).toEqual('This is a good note\n\nThis is another note');
       }));
 
     describe('errors', () => {

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -94,12 +94,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
     it('creates a result from an ImagingStudy with FHIR ID', () =>
       showError(async () => {
         // arrange
-        const {
-          FhirServiceRequest,
-          FhirWriteLog,
-          ImagingRequest,
-          ImagingResult,
-        } = ctx.store.models;
+        const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
         const ir = await ImagingRequest.create(
           fake(ImagingRequest, {
             requestedById: resources.practitioner.id,
@@ -132,7 +127,8 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
             },
           ],
           note: [{ text: 'This is a note' }, { text: 'This is another note' }],
-        });
+        };
+        const response = await app.post(PATH).send(body);
 
         // assert
         expect(response).toHaveSucceeded();
@@ -198,7 +194,12 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
     it('creates a result from an ImagingStudy with upstream UUID', () =>
       showError(async () => {
         // arrange
-        const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
+        const {
+          FhirServiceRequest,
+          FhirWriteLog,
+          ImagingRequest,
+          ImagingResult,
+        } = ctx.store.models;
         const ir = await ImagingRequest.create(
           fake(ImagingRequest, {
             requestedById: resources.practitioner.id,

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -233,7 +233,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               },
             },
           ],
-          note: [{ text: 'This is a note' }, { text: 'This is another note' }],
+          note: [{ text: 'This is a nice note' }, { text: 'This is another note' }],
         };
         const response = await app.post(PATH).send(body);
 
@@ -244,7 +244,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           where: { externalCode: 'ACCESSION' },
         });
         expect(ires).toBeTruthy();
-        expect(ires.description).toEqual('This is a note\n\nThis is another note');
+        expect(ires.description).toEqual('This is a nice note\n\nThis is another note');
         const flog = await FhirWriteLog.findOne({
           where: { url: { [Op.like]: '%ImagingStudy%' } },
         });
@@ -276,7 +276,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               },
             },
           ],
-          note: [{ text: 'This is a note' }, { text: 'This is another note' }],
+          note: [{ text: 'This is a bad note' }, { text: 'This is another note' }],
         };
         const response = await app.post(PATH).send(body);
 

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -249,7 +249,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           where: { url: { [Op.like]: '%ImagingStudy%' } },
         });
         expect(flog).toBeTruthy();
-        expect(flog.verb).toEqual('post');
+        expect(flog.verb).toEqual('POST');
         expect(flog.body).toMatchObject(body);
       }));
 
@@ -286,7 +286,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           where: { url: { [Op.like]: '%ImagingStudy%' } },
         });
         expect(flog).toBeTruthy();
-        expect(flog.verb).toEqual('post');
+        expect(flog.verb).toEqual('POST');
         expect(flog.body).toMatchObject(body);
       }));
 

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -215,7 +215,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
         await FhirServiceRequest.resolveUpstreams();
 
         // act
-        const response = await app.post(PATH).send({
+        const body = {
           resourceType: 'ImagingStudy',
           status: 'final',
           identifier: [
@@ -233,7 +233,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               },
             },
           ],
-          note: [{ text: 'This is a nice note' }, { text: 'This is another note' }],
+          note: [{ text: 'This is a good note' }, { text: 'This is another note' }],
         };
         const response = await app.post(PATH).send(body);
 
@@ -244,7 +244,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           where: { externalCode: 'ACCESSION' },
         });
         expect(ires).toBeTruthy();
-        expect(ires.description).toEqual('This is a nice note\n\nThis is another note');
+        expect(ires.description).toEqual('This is a good note\n\nThis is another note');
         const flog = await FhirWriteLog.findOne({
           where: { url: { [Op.like]: '%ImagingStudy%' } },
         });

--- a/packages/sync-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -9,6 +9,7 @@ const INTEGRATION_ROUTE = 'fhir/mat';
 describe(`Materialised FHIR - WriteLog`, () => {
   let ctx;
   let app;
+  let FhirWriteLog;
 
   beforeAll(async () => {
     ctx = await createTestContext();
@@ -17,15 +18,12 @@ describe(`Materialised FHIR - WriteLog`, () => {
   afterAll(() => ctx.close());
 
   beforeEach(async () => {
-    const { FhirWriteLog } = ctx.store.models;
+    ({ FhirWriteLog } = ctx.store.models);
     await FhirWriteLog.destroy({ where: {} });
   });
 
   it('logs a request for a non-existent resource', () =>
     showError(async () => {
-      const { FhirWriteLog } = ctx.store.models;
-
-      // act
       const body = {
         resourceType: 'FooBarBaz',
         status: 'final',
@@ -47,7 +45,6 @@ describe(`Materialised FHIR - WriteLog`, () => {
       };
       const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
 
-      // assert
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
         where: { url: { [Op.like]: '%FooBarBaz%' } },
@@ -59,9 +56,6 @@ describe(`Materialised FHIR - WriteLog`, () => {
 
   it('logs a request for a malformed resource', () =>
     showError(async () => {
-      const { FhirWriteLog } = ctx.store.models;
-
-      // act
       const body = {
         resourceType: 'NotTheSame',
         status: 'final',
@@ -83,7 +77,6 @@ describe(`Materialised FHIR - WriteLog`, () => {
       };
       const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
 
-      // assert
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
         where: { url: { [Op.like]: '%FooBarBaz%' } },
@@ -95,9 +88,6 @@ describe(`Materialised FHIR - WriteLog`, () => {
 
   it('logs the headers', () =>
     showError(async () => {
-      const { FhirWriteLog } = ctx.store.models;
-
-      // act
       const body = {
         resourceType: 'HeadMeOff',
         at: 'the pass',
@@ -105,15 +95,14 @@ describe(`Materialised FHIR - WriteLog`, () => {
       const response = await app
         .post(`/v1/integration/${INTEGRATION_ROUTE}/HeadMeOff`)
         .set('X-Forwarded-For', '123.45.67.89')
-        .set('Authorization', 'lmao')
-        .set('X-Tamanu-Version', '1.23.4')
+        .set('Authz', 'lmao')
+        .set('X-Tamanu-Field', 'it me')
         .set('If-Match', 'is met')
         .set('Prefer', 'pretty')
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/fhir+json; fhirVersion=4.0')
         .send(body);
 
-      // assert
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
         where: { url: { [Op.like]: '%HeadMeOff%' } },
@@ -123,7 +112,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
       expect(flog.body).toMatchObject(body);
       expect(flog.headers).toMatchObject({
         'x-forwarded-for': '123.45.67.89',
-        'x-tamanu-version': '1.23.4',
+        'x-tamanu-field': 'it me',
         'if-match': 'is met',
         prefer: 'pretty',
         'content-type': 'application/json',

--- a/packages/sync-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -1,0 +1,135 @@
+import { Op } from 'sequelize';
+
+import { showError } from 'shared/test-helpers';
+
+import { createTestContext } from '../../utilities';
+
+const INTEGRATION_ROUTE = 'fhir/mat';
+
+describe(`Materialised FHIR - WriteLog`, () => {
+  let ctx;
+  let app;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    app = await ctx.baseApp.asRole('practitioner');
+  });
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    const { FhirWriteLog } = ctx.store.models;
+    await FhirWriteLog.destroy({ where: {} });
+  });
+
+  it('logs a request for a non-existent resource', () =>
+    showError(async () => {
+      const { FhirWriteLog } = ctx.store.models;
+
+      // act
+      const body = {
+        resourceType: 'FooBarBaz',
+        status: 'final',
+        nope: [
+          {
+            system: 'http://example.com',
+            value: 'ACCESSION',
+          },
+        ],
+        burger: [
+          {
+            type: 'ServiceRequest',
+            identifier: {
+              system: 'http://example.com',
+              value: '123',
+            },
+          },
+        ],
+      };
+      const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
+
+      // assert
+      expect(response.status).not.toBe(201);
+      const flog = await FhirWriteLog.findOne({
+        where: { url: { [Op.like]: '%FooBarBaz%' } },
+      });
+      expect(flog).toBeTruthy();
+      expect(flog.verb).toEqual('POST');
+      expect(flog.body).toMatchObject(body);
+    }));
+
+  it('logs a request for a malformed resource', () =>
+    showError(async () => {
+      const { FhirWriteLog } = ctx.store.models;
+
+      // act
+      const body = {
+        resourceType: 'NotTheSame',
+        status: 'final',
+        nope: [
+          {
+            system: 'http://example.com',
+            value: 'ACCESSION',
+          },
+        ],
+        burger: [
+          {
+            type: 'ServiceRequest',
+            identifier: {
+              system: 'http://example.com',
+              value: '123',
+            },
+          },
+        ],
+      };
+      const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
+
+      // assert
+      expect(response.status).not.toBe(201);
+      const flog = await FhirWriteLog.findOne({
+        where: { url: { [Op.like]: '%FooBarBaz%' } },
+      });
+      expect(flog).toBeTruthy();
+      expect(flog.verb).toEqual('POST');
+      expect(flog.body).toMatchObject(body);
+    }));
+
+  it('logs the headers', () =>
+    showError(async () => {
+      const { FhirWriteLog } = ctx.store.models;
+
+      // act
+      const body = {
+        resourceType: 'HeadMeOff',
+        at: 'the pass',
+      };
+      const response = await app
+        .post(`/v1/integration/${INTEGRATION_ROUTE}/HeadMeOff`)
+        .set('X-Forwarded-For', '123.45.67.89')
+        .set('Authorization', 'lmao')
+        .set('X-Tamanu-Version', '1.23.4')
+        .set('If-Match', 'is met')
+        .set('Prefer', 'pretty')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/fhir+json; fhirVersion=4.0')
+        .send(body);
+
+      // assert
+      expect(response.status).not.toBe(201);
+      const flog = await FhirWriteLog.findOne({
+        where: { url: { [Op.like]: '%HeadMeOff%' } },
+      });
+      expect(flog).toBeTruthy();
+      expect(flog.verb).toEqual('POST');
+      expect(flog.body).toMatchObject(body);
+      expect(flog.headers).toMatchObject({
+        'x-forwarded-for': '123.45.67.89',
+        'x-tamanu-version': '1.23.4',
+        'if-match': 'is met',
+        prefer: 'pretty',
+        'content-type': 'application/json',
+        accept: 'application/fhir+json; fhirVersion=4.0',
+        'user-agent': expect.any(String),
+      });
+      expect(flog.headers).not.toHaveProperty('authorization');
+    }));
+});

--- a/packages/sync-server/app/hl7fhir/materialised/create.js
+++ b/packages/sync-server/app/hl7fhir/materialised/create.js
@@ -14,9 +14,11 @@ async function mapErr(promise, fn) {
 
 export function createHandler(FhirResource) {
   return asyncHandler(async (req, res) => {
-    const { FhirMaterialiseJob } = req.store.models;
+    const { FhirMaterialiseJob, FhirWriteLog } = req.store.models;
 
     try {
+      await FhirWriteLog.fromRequest(req);
+
       const validated = await mapErr(
         FhirResource.INTAKE_SCHEMA.shape({
           resourceType: yup

--- a/packages/sync-server/app/hl7fhir/materialised/create.js
+++ b/packages/sync-server/app/hl7fhir/materialised/create.js
@@ -14,11 +14,9 @@ async function mapErr(promise, fn) {
 
 export function createHandler(FhirResource) {
   return asyncHandler(async (req, res) => {
-    const { FhirMaterialiseJob, FhirWriteLog } = req.store.models;
+    const { FhirMaterialiseJob } = req.store.models;
 
     try {
-      await FhirWriteLog.fromRequest(req);
-
       const validated = await mapErr(
         FhirResource.INTAKE_SCHEMA.shape({
           resourceType: yup


### PR DESCRIPTION
### Changes

- New schema and table
- Log all requests to the `create` FHIR handler
- Filtering of headers to include only tamanu and fhir ones (and exclude e.g. auth tokens, cookies)

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any db schema or other changes that could impact downstream data analysis