### PR TITLE
EPI-350: Create missing discharge records and notes

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -105,7 +105,6 @@ patientVaccineRoutes.post(
       res.status(400).send({ error: { message: 'scheduledVaccineId is required' } });
     }
 
-    let newAdministeredVaccine;
     const existingEncounter = await req.models.Encounter.findOne({
       where: {
         endDate: {
@@ -115,7 +114,7 @@ patientVaccineRoutes.post(
       },
     });
 
-    await db.transaction(async () => {
+    const newAdministeredVaccine = await db.transaction(async () => {
       let encounterId;
       if (existingEncounter) {
         encounterId = existingEncounter.get('id');
@@ -132,7 +131,7 @@ patientVaccineRoutes.post(
         encounterId = newEncounter.get('id');
       }
 
-      newAdministeredVaccine = await req.models.AdministeredVaccine.create({
+      return req.models.AdministeredVaccine.create({
         status: 'GIVEN',
         ...req.body,
         encounterId,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -99,12 +99,13 @@ patientVaccineRoutes.put(
 patientVaccineRoutes.post(
   '/:id/administeredVaccine',
   asyncHandler(async (req, res) => {
+    const { db } = req;
     req.checkPermission('create', 'PatientVaccine');
     if (!req.body.scheduledVaccineId) {
       res.status(400).send({ error: { message: 'scheduledVaccineId is required' } });
     }
 
-    let encounterId;
+    let newAdministeredVaccine;
     const existingEncounter = await req.models.Encounter.findOne({
       where: {
         endDate: {
@@ -114,27 +115,31 @@ patientVaccineRoutes.post(
       },
     });
 
-    if (existingEncounter) {
-      encounterId = existingEncounter.get('id');
-    } else {
-      const newEncounter = await req.models.Encounter.create({
-        encounterType: ENCOUNTER_TYPES.CLINIC,
-        startDate: req.body.date,
-        endDate: req.body.date,
-        patientId: req.params.id,
-        locationId: req.body.locationId,
-        examinerId: req.body.recorderId,
-        departmentId: req.body.departmentId,
-      });
-      encounterId = newEncounter.get('id');
-    }
+    await db.transaction(async () => {
+      let encounterId;
+      if (existingEncounter) {
+        encounterId = existingEncounter.get('id');
+      } else {
+        const newEncounter = await req.models.Encounter.create({
+          encounterType: ENCOUNTER_TYPES.CLINIC,
+          startDate: req.body.date,
+          endDate: req.body.date,
+          patientId: req.params.id,
+          locationId: req.body.locationId,
+          examinerId: req.body.recorderId,
+          departmentId: req.body.departmentId,
+        });
+        encounterId = newEncounter.get('id');
+      }
 
-    const newRecord = await req.models.AdministeredVaccine.create({
-      status: 'GIVEN',
-      ...req.body,
-      encounterId,
+      newAdministeredVaccine = await req.models.AdministeredVaccine.create({
+        status: 'GIVEN',
+        ...req.body,
+        encounterId,
+      });
     });
-    res.send(newRecord);
+
+    res.send(newAdministeredVaccine);
   }),
 );
 

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -123,12 +123,12 @@ patientVaccineRoutes.post(
         const newEncounter = await req.models.Encounter.create({
           encounterType: ENCOUNTER_TYPES.CLINIC,
           startDate: req.body.date,
-          endDate: req.body.date,
           patientId: req.params.id,
           locationId: req.body.locationId,
           examinerId: req.body.recorderId,
           departmentId: req.body.departmentId,
         });
+        await newEncounter.update({ endDate: req.body.date });
         encounterId = newEncounter.get('id');
       }
 

--- a/packages/shared-src/src/models/SurveyResponse.js
+++ b/packages/shared-src/src/models/SurveyResponse.js
@@ -156,7 +156,7 @@ export class SurveyResponse extends Model {
     const { departmentId, userId, locationId } = responseData;
 
     // need to create a new encounter with examiner set as the user who submitted the survey.
-    return Encounter.create({
+    const newEncounter = Encounter.create({
       patientId,
       encounterType: 'surveyResponse',
       reasonForEncounter,
@@ -166,6 +166,9 @@ export class SurveyResponse extends Model {
       // Survey responses will usually have a startTime and endTime and we prefer to use that
       // for the encounter to ensure the times are set in the browser timezone
       startDate: responseData.startTime ? responseData.startTime : getCurrentDateTimeString(),
+    });
+
+    return newEncounter.update({
       endDate: responseData.endTime ? responseData.endTime : getCurrentDateTimeString(),
     });
   }

--- a/packages/shared-src/src/models/SurveyResponse.js
+++ b/packages/shared-src/src/models/SurveyResponse.js
@@ -156,7 +156,7 @@ export class SurveyResponse extends Model {
     const { departmentId, userId, locationId } = responseData;
 
     // need to create a new encounter with examiner set as the user who submitted the survey.
-    const newEncounter = Encounter.create({
+    const newEncounter = await Encounter.create({
       patientId,
       encounterType: 'surveyResponse',
       reasonForEncounter,

--- a/packages/shared-src/src/models/SurveyResponse.js
+++ b/packages/shared-src/src/models/SurveyResponse.js
@@ -125,6 +125,10 @@ export class SurveyResponse extends Model {
   }
 
   static async getSurveyEncounter({ encounterId, patientId, reasonForEncounter, ...responseData }) {
+    if (!this.sequelize.isInsideTransaction()) {
+      throw new Error('SurveyResponse.getSurveyEncounter must always run inside a transaction!');
+    }
+
     const { Encounter } = this.sequelize.models;
 
     if (encounterId) {


### PR DESCRIPTION
### Changes

After a first round of testing it was found that there were still a couple of places left to track. Specifically, we have some shortcut functionality that allows to give a vaccine or submit a survey response that will create an encounter for you. This encounter will automatically get an `endDate` on creation and it will be missing regular discharge and note records.