### PR TITLE
EPI-360: Create lab test panel external code table

### DIFF
--- a/packages/shared-src/src/constants/importable.js
+++ b/packages/shared-src/src/constants/importable.js
@@ -30,6 +30,7 @@ export const GENERAL_IMPORTABLE_DATA_TYPES = [
   'labTestCategory',
   'labTestLaboratory',
   'labTestMethod',
+  'labTestPanelExternalCode',
   'labTestPriority',
   'labTestType',
   'labTestPanel',

--- a/packages/shared-src/src/migrations/1679350403608-labTestPanelsExternalCodesTable.js
+++ b/packages/shared-src/src/migrations/1679350403608-labTestPanelsExternalCodesTable.js
@@ -1,0 +1,58 @@
+import { DataTypes, Sequelize } from 'sequelize';
+
+export async function up(query) {
+  await query.createTable('lab_test_panel_external_codes', {
+    id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('uuid_generate_v4'),
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      defaultValue: Sequelize.NOW,
+      allowNull: false,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      defaultValue: Sequelize.NOW,
+      allowNull: false,
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+
+    pulled_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    visibility_status: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      defaultValue: 'current',
+    },
+
+    lab_test_panel_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      references: {
+        model: 'lab_test_panels',
+        key: 'id',
+      },
+    },
+    code: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+  });
+}
+
+export async function down(query) {
+  await query.dropTable('lab_test_panel_external_codes');
+}

--- a/packages/shared-src/src/migrations/1679350403608-labTestPanelsExternalCodesTable.js
+++ b/packages/shared-src/src/migrations/1679350403608-labTestPanelsExternalCodesTable.js
@@ -48,7 +48,7 @@ export async function up(query) {
     },
   });
 
-  await query.dropColumn('imaging_area_external_codes', 'pulled_at');
+  await query.removeColumn('imaging_area_external_codes', 'pulled_at');
 }
 
 export async function down(query) {

--- a/packages/shared-src/src/migrations/1679350403608-labTestPanelsExternalCodesTable.js
+++ b/packages/shared-src/src/migrations/1679350403608-labTestPanelsExternalCodesTable.js
@@ -23,10 +23,6 @@ export async function up(query) {
       allowNull: true,
     },
 
-    pulled_at: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
     visibility_status: {
       type: DataTypes.TEXT,
       allowNull: false,
@@ -51,8 +47,14 @@ export async function up(query) {
       allowNull: true,
     },
   });
+
+  await query.dropColumn('imaging_area_external_codes', 'pulled_at');
 }
 
 export async function down(query) {
   await query.dropTable('lab_test_panel_external_codes');
+  await query.addColumn('imaging_area_external_codes', 'pulled_at', {
+    type: DataTypes.DATE,
+    allowNull: true,
+  });
 }

--- a/packages/shared-src/src/models/LabTestPanel.js
+++ b/packages/shared-src/src/models/LabTestPanel.js
@@ -33,5 +33,10 @@ export class LabTestPanel extends Model {
       as: 'labTestTypes',
       foreignKey: 'labTestPanelId',
     });
+
+    this.hasOne(models.LabTestPanelExternalCode, {
+      as: 'labTestPanelExternalCode',
+      foreignKey: 'labTestPanelId',
+    });
   }
 }

--- a/packages/shared-src/src/models/LabTestPanelExternalCode.js
+++ b/packages/shared-src/src/models/LabTestPanelExternalCode.js
@@ -1,0 +1,48 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from 'shared/constants';
+import { InvalidOperationError } from 'shared/errors';
+import { Model } from './Model';
+
+export class LabTestPanelExternalCode extends Model {
+  static init({ primaryKey, ...options }) {
+    super.init(
+      {
+        id: primaryKey,
+        visibilityStatus: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          defaultValue: 'current',
+        },
+
+        code: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+        description: DataTypes.TEXT,
+      },
+      {
+        ...options,
+        // This is reference/imported data
+        syncDirection: SYNC_DIRECTIONS.PULL_FROM_CENTRAL,
+        validate: {
+          mustHaveVaccine() {
+            if (!this.deletedAt && !this.labTestPanelId) {
+              throw new InvalidOperationError('A lab test panel external code must have an area.');
+            }
+          },
+        },
+      },
+    );
+  }
+
+  static getListReferenceAssociations() {
+    return ['labTestPanel'];
+  }
+
+  static initRelations(models) {
+    this.belongsTo(models.LabTestPanel, {
+      foreignKey: 'labTestPanelId',
+      as: 'labTestPanel',
+    });
+  }
+}

--- a/packages/shared-src/src/models/index.js
+++ b/packages/shared-src/src/models/index.js
@@ -34,6 +34,7 @@ export * from './EncounterMedication';
 export * from './LabRequest';
 export * from './LabTest';
 export * from './LabRequestLog';
+export * from './LabTestPanelExternalCode';
 export * from './LabTestType';
 export * from './LabTestPanel';
 export * from './LabTestPanelRequest';

--- a/packages/sync-server/app/admin/referenceDataImporter/dependencies.js
+++ b/packages/sync-server/app/admin/referenceDataImporter/dependencies.js
@@ -66,5 +66,7 @@ export default {
   },
 
   imagingAreaExternalCode: {},
-  labTestPanelExternalCode: {},
+  labTestPanelExternalCode: {
+    needs: ['labTestPanel'],
+  },
 };

--- a/packages/sync-server/app/admin/referenceDataImporter/dependencies.js
+++ b/packages/sync-server/app/admin/referenceDataImporter/dependencies.js
@@ -66,4 +66,5 @@ export default {
   },
 
   imagingAreaExternalCode: {},
+  labTestPanelExternalCode: {},
 };


### PR DESCRIPTION
### Changes

Notice this is against branch `create-lab-request-panels-epic`.
Will conflict when merging to dev given that some files were refactored:

`packages/desktop/app/views/administration/ReferenceDataAdminView.js` had some content moved to `packages/shared-src/src/constants/importable.js`
`packages/sync-server/app/admin/refdataImporter/dependencies.js` was refactored to `packages/sync-server/app/admin/referenceDataImporter/dependencies.js`