### PR TITLE
WAITM-629 Fix duplicates on panel imports

### DIFF
--- a/packages/shared-src/src/migrations/1680147932505-useGeneratedIdForPanelRelations.js
+++ b/packages/shared-src/src/migrations/1680147932505-useGeneratedIdForPanelRelations.js
@@ -1,0 +1,27 @@
+import Sequelize from 'sequelize';
+
+export async function up(query) {
+  await query.sequelize.query(
+    `
+    ALTER TABLE lab_test_panel_lab_test_types DROP CONSTRAINT lab_test_panel_lab_test_types_pkey;
+    ALTER TABLE lab_test_panel_lab_test_types ADD PRIMARY KEY (lab_test_panel_id, lab_test_type_id);
+  `,
+  );
+  await query.removeColumn('lab_test_panel_lab_test_types', 'id');
+  await query.addColumn('lab_test_panel_lab_test_types', 'id', {
+    type: `TEXT GENERATED ALWAYS AS (REPLACE("lab_test_panel_id", ';', ':') || ';' || REPLACE("lab_test_type_id", ';', ':')) STORED`,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('lab_test_panel_lab_test_types', 'id');
+  await query.addColumn('lab_test_panel_lab_test_types', 'id', {
+    type: Sequelize.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('uuid_generate_v4'),
+  });
+  await query.sequelize.query(`
+    ALTER TABLE lab_test_panel_lab_test_types DROP CONSTRAINT lab_test_panel_lab_test_types_pkey;
+    ALTER TABLE lab_test_panel_lab_test_types ADD PRIMARY KEY (id);
+  `);
+}

--- a/packages/sync-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/sync-server/app/admin/referenceDataImporter/loaders.js
@@ -160,6 +160,7 @@ export function labTestPanelLoader(item) {
       rows.push({
         model: 'LabTestPanelLabTestTypes',
         values: {
+          id: `${id};${testType}`,
           labTestPanelId: id,
           labTestTypeId: testType,
         },


### PR DESCRIPTION
### Changes

- Swap the panel relations table to use generated ids so we can detect existing relations during import

### Checklist

- [X] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
