### PR TITLE
NASS-727 Refresh lab req notes on print modal

### DIFF
--- a/packages/desktop/app/forms/LabRequestNoteForm.js
+++ b/packages/desktop/app/forms/LabRequestNoteForm.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 import * as yup from 'yup';
 import { NOTE_TYPES } from 'shared/constants';
@@ -38,6 +39,7 @@ const ReadOnlyNotesField = ({ notes }) => {
 
 export const LabRequestNoteForm = React.memo(({ labRequest, isReadOnly }) => {
   const api = useApi();
+  const queryClient = useQueryClient();
   const [notes, setNotes] = useState([]);
 
   useEffect(() => {
@@ -55,6 +57,7 @@ export const LabRequestNoteForm = React.memo(({ labRequest, isReadOnly }) => {
     });
     setNotes([...notes, newNote]);
     resetForm();
+    queryClient.invalidateQueries(['labRequestNotes']);
   };
 
   if (isReadOnly) {

--- a/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
@@ -25,7 +25,7 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
     },
   );
   const { data: notes, isLoading: areNotesLoading } = useQuery(
-    ['labRequestNotes', labRequest.id, open],
+    ['labRequestNotes', labRequest.id, open], // Refresh notes each time we open the modal
     async () => {
       const notesRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/notes`);
       return notesRes.data;

--- a/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
@@ -20,15 +20,15 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
   const { data: tests, isLoading: areTestsLoading } = useQuery(
     ['labRequestTests', labRequest.id],
     async () => {
-      const notesRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/tests`);
-      return notesRes.data;
+      const testsRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/tests`);
+      return testsRes.data;
     },
   );
   const { data: notes, isLoading: areNotesLoading } = useQuery(
     ['labRequestNotes', labRequest.id],
     async () => {
-      const testsRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/notes`);
-      return testsRes.data;
+      const notesRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/notes`);
+      return notesRes.data;
     },
   );
   const { data: additionalData, isLoading: isAdditionalDataLoading } = useQuery(

--- a/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
@@ -25,7 +25,7 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
     },
   );
   const { data: notes, isLoading: areNotesLoading } = useQuery(
-    ['labRequestNotes', labRequest.id],
+    ['labRequestNotes', labRequest.id, open],
     async () => {
       const notesRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/notes`);
       return notesRes.data;

--- a/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestPrintModal.js
@@ -25,7 +25,7 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
     },
   );
   const { data: notes, isLoading: areNotesLoading } = useQuery(
-    ['labRequestNotes', labRequest.id, open], // Refresh notes each time we open the modal
+    ['labRequestNotes', labRequest.id],
     async () => {
       const notesRes = await api.get(`labRequest/${encodeURIComponent(labRequest.id)}/notes`);
       return notesRes.data;


### PR DESCRIPTION
### Changes

- Refresh the request for lab req notes each time we open the print modal

### Checklist

- [X] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
