### PR TITLE
NAS-716: db-defined-reports gui common

### DIFF
--- a/packages/desktop/app/components/Sidebar/config.js
+++ b/packages/desktop/app/components/Sidebar/config.js
@@ -181,4 +181,9 @@ export const SYNC_MENU_ITEMS = [
     label: 'Sync status',
     path: '/admin/sync',
   },
+  {
+    key: 'reports',
+    label: 'Reports',
+    path: '/admin/reports',
+  },
 ];

--- a/packages/desktop/app/views/administration/index.js
+++ b/packages/desktop/app/views/administration/index.js
@@ -5,3 +5,4 @@ export { PermissionsAdminView } from './PermissionsAdminView';
 export { ReferenceDataAdminView } from './ReferenceDataAdminView';
 export { PatientMergeView } from './patientMerge';
 export { SyncView } from './SyncView';
+export { ReportsAdminView } from './reports/ReportsAdminView';

--- a/packages/desktop/app/views/administration/reports/ReportsAdminView.js
+++ b/packages/desktop/app/views/administration/reports/ReportsAdminView.js
@@ -28,7 +28,7 @@ const REPORT_TABS = {
 };
 
 export const ReportsAdminView = () => {
-  const [currentTab, setCurrentTab] = useState(REPORT_TABS.EXPORT);
+  const [currentTab, setCurrentTab] = useState(REPORT_TABS.EDIT);
 
   const tabs = [
     {

--- a/packages/desktop/app/views/administration/reports/ReportsAdminView.js
+++ b/packages/desktop/app/views/administration/reports/ReportsAdminView.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { TopBar } from '../../../components';
+import { TabDisplay } from '../../../components/TabDisplay';
+import { Colors } from '../../../constants';
+
+const OuterContainer = styled.div`
+  position: relative;
+  background-color: ${Colors.white};
+  min-height: 100%;
+`;
+
+const StyledTabDisplay = styled(TabDisplay)`
+  .MuiTabs-root {
+    padding: 0px 20px;
+    border-bottom: 1px solid ${Colors.outline};
+  }
+`;
+
+const TabContainer = styled.div`
+  padding: 20px;
+`;
+
+const REPORT_TABS = {
+  EDIT: 'edit',
+  IMPORT: 'import',
+  EXPORT: 'export',
+};
+
+export const ReportsAdminView = () => {
+  const [currentTab, setCurrentTab] = useState(REPORT_TABS.EXPORT);
+
+  const tabs = [
+    {
+      label: 'Edit',
+      key: REPORT_TABS.EDIT,
+      icon: 'fa fa-file-export',
+      render: () => <TabContainer>Coming soon</TabContainer>,
+    },
+  ];
+
+  return (
+    <OuterContainer>
+      <TopBar title="Reports" />
+      <StyledTabDisplay
+        tabs={tabs}
+        currentTab={currentTab}
+        onTabSelect={setCurrentTab}
+        scrollable={false}
+      />
+    </OuterContainer>
+  );
+};

--- a/packages/shared-src/src/models/ReportDefinitionVersion.js
+++ b/packages/shared-src/src/models/ReportDefinitionVersion.js
@@ -103,6 +103,7 @@ export class ReportDefinitionVersion extends Model {
 
     this.belongsTo(models.User, {
       foreignKey: { name: 'userId', allowNull: false },
+      as: 'createdBy',
     });
 
     this.hasMany(models.ReportRequest);

--- a/packages/sync-server/__tests__/admin/reports.test.js
+++ b/packages/sync-server/__tests__/admin/reports.test.js
@@ -58,9 +58,9 @@ describe('reports', () => {
       const res = await adminApp.get('/v1/admin/reports');
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(1);
-      expect(res.body[0]).toMatchObject({ 
+      expect(res.body[0]).toMatchObject({
         id: testReport.id,
-        name: testReport.name
+        name: testReport.name,
       });
     });
     it('should return version count and last updated', async () => {

--- a/packages/sync-server/__tests__/admin/reports.test.js
+++ b/packages/sync-server/__tests__/admin/reports.test.js
@@ -100,6 +100,7 @@ describe('reports', () => {
         'status',
         'notes',
         'queryOptions',
+        'createdBy',
       ];
       const additionalKeys = Object.keys(res.body[0]).filter(k => !allowedKeys.includes(k));
       expect(additionalKeys).toHaveLength(0);

--- a/packages/sync-server/__tests__/admin/reports.test.js
+++ b/packages/sync-server/__tests__/admin/reports.test.js
@@ -89,18 +89,18 @@ describe('reports', () => {
       await ReportDefinitionVersion.create(getMockReportVersion(1));
       const res = await adminApp.get(`/v1/admin/reports/${testReport.id}/versions`);
       expect(res).toHaveSucceeded();
-      expect(Object.keys(res.body[0])).toEqual(
-        expect.arrayContaining([
-          'id',
-          'versionNumber',
-          'query',
-          'createdAt',
-          'updatedAt',
-          'status',
-          'notes',
-          'queryOptions',
-        ]),
-      );
+      const allowedKeys = [
+        'id',
+        'versionNumber',
+        'query',
+        'createdAt',
+        'updatedAt',
+        'status',
+        'notes',
+        'queryOptions',
+      ];
+      const additionalKeys = Object.keys(res.body[0]).filter(k => !allowedKeys.includes(k));
+      expect(additionalKeys).toHaveLength(0);
     });
   });
 });

--- a/packages/sync-server/__tests__/admin/reports.test.js
+++ b/packages/sync-server/__tests__/admin/reports.test.js
@@ -1,0 +1,105 @@
+import { User } from 'shared/models/User';
+import { createTestContext, withDate } from '../utilities';
+
+describe('reports', () => {
+  let ctx;
+  let models;
+  let baseApp;
+  let adminApp;
+  let testReport;
+  let user;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
+    adminApp = await baseApp.asRole('admin');
+    testReport = await models.ReportDefinition.create({
+      name: 'Test Report',
+    });
+    user = await User.create({
+      displayName: 'Test User',
+      email: 'db@dreportsuser.com',
+    });
+  });
+
+  afterAll(async () => {
+    await ctx.close();
+  });
+
+  afterEach(async () => {
+    await models.ReportDefinitionVersion.destroy({
+      where: {
+        reportDefinitionId: testReport.id,
+      },
+    });
+  });
+
+  const getMockReportVersion = (versionNumber, query = 'select bark from dog') => ({
+    versionNumber,
+    query,
+    reportDefinitionId: testReport.id,
+    queryOptions: {
+      defaultDateRange: '30days',
+      parameters: [
+        {
+          parameterField: 'test-field',
+          name: 'test-name',
+        },
+      ],
+    },
+    status: 'draft',
+    notes: 'test',
+    userId: user.id,
+  });
+
+  describe('GET /reports', () => {
+    it('should return a list of reports', async () => {
+      const res = await adminApp.get('/v1/admin/reports');
+      expect(res).toHaveSucceeded();
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].id).toBe(testReport.id);
+    });
+    it('should return version count and last updated', async () => {
+      const { ReportDefinitionVersion } = models;
+      await ReportDefinitionVersion.create(getMockReportVersion(1));
+      const latestVersion = await withDate(new Date(Date.now() + 10000), () =>
+        ReportDefinitionVersion.create(getMockReportVersion(2)),
+      );
+      const res = await adminApp.get('/v1/admin/reports');
+      expect(res).toHaveSucceeded();
+      expect(res.body[0].versionCount).toBe(2);
+      expect(new Date(res.body[0].lastUpdated)).toEqual(latestVersion.updatedAt);
+    });
+  });
+
+  describe('GET /reports/:id/versions', () => {
+    it('should return a list of versions', async () => {
+      const { ReportDefinitionVersion } = models;
+      const v1 = await ReportDefinitionVersion.create(getMockReportVersion(1));
+      const v2 = await ReportDefinitionVersion.create(getMockReportVersion(2));
+      const res = await adminApp.get(`/v1/admin/reports/${testReport.id}/versions`);
+      expect(res).toHaveSucceeded();
+      expect(res.body).toHaveLength(2);
+      expect(res.body.map(x => x.id)).toEqual(expect.arrayContaining([v1.id, v2.id]));
+    });
+    it('shouldnt return unnecessary metadata', async () => {
+      const { ReportDefinitionVersion } = models;
+      await ReportDefinitionVersion.create(getMockReportVersion(1));
+      const res = await adminApp.get(`/v1/admin/reports/${testReport.id}/versions`);
+      expect(res).toHaveSucceeded();
+      expect(Object.keys(res.body[0])).toEqual(
+        expect.arrayContaining([
+          'id',
+          'versionNumber',
+          'query',
+          'createdAt',
+          'updatedAt',
+          'status',
+          'notes',
+          'queryOptions',
+        ]),
+      );
+    });
+  });
+});

--- a/packages/sync-server/__tests__/admin/reports.test.js
+++ b/packages/sync-server/__tests__/admin/reports.test.js
@@ -59,6 +59,7 @@ describe('reports', () => {
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(1);
       expect(res.body[0].id).toBe(testReport.id);
+      expect(res.body[0].name).toBe(testReport.name);
     });
     it('should return version count and last updated', async () => {
       const { ReportDefinitionVersion } = models;

--- a/packages/sync-server/__tests__/admin/reports.test.js
+++ b/packages/sync-server/__tests__/admin/reports.test.js
@@ -58,8 +58,10 @@ describe('reports', () => {
       const res = await adminApp.get('/v1/admin/reports');
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(1);
-      expect(res.body[0].id).toBe(testReport.id);
-      expect(res.body[0].name).toBe(testReport.name);
+      expect(res.body[0]).toMatchObject({ 
+        id: testReport.id,
+        name: testReport.name
+      });
     });
     it('should return version count and last updated', async () => {
       const { ReportDefinitionVersion } = models;

--- a/packages/sync-server/app/admin/index.js
+++ b/packages/sync-server/app/admin/index.js
@@ -10,6 +10,7 @@ import { referenceDataImporter, PERMISSIONS as REFDATA_PERMISSIONS } from './ref
 
 import { mergePatientHandler } from './patientMerge';
 import { syncLastCompleted } from './sync';
+import { reportsRouter } from './reports/reportRoutes';
 
 export const adminRoutes = express.Router();
 
@@ -30,6 +31,7 @@ adminRoutes.use(
   }),
 );
 
+adminRoutes.use('/reports', reportsRouter);
 adminRoutes.post('/mergePatient', mergePatientHandler);
 
 // A temporary lookup-patient-by-displayId endpoint, just to

--- a/packages/sync-server/app/admin/reports/reportRoutes.js
+++ b/packages/sync-server/app/admin/reports/reportRoutes.js
@@ -1,0 +1,61 @@
+import express from 'express'
+import asyncHandler from 'express-async-handler';
+import { QueryTypes } from 'sequelize';
+
+export const reportsRouter = express.Router();
+
+reportsRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const { store } = req;
+    const result = await store.sequelize.query(
+      `SELECT rd.id,
+        rd.name,
+        rd.created_at AS "createdAt",
+        max(rdv.updated_at) AS "lastUpdated",
+        max(rdv.version_number) AS "versionCount"
+    FROM report_definitions rd
+        LEFT JOIN report_definition_versions rdv ON rd.id = rdv.report_definition_id
+    GROUP BY rd.id
+    ORDER BY rd.name
+        `,
+      {
+        type: QueryTypes.SELECT,
+      },
+    );
+    res.send(result);
+  }),
+);
+
+reportsRouter.get(
+  '/:reportId/versions',
+  asyncHandler(async (req, res) => {
+    const { store, params } = req;
+    const {
+      models: { ReportDefinitionVersion },
+    } = store;
+    const { reportId } = params;
+    const versions = await ReportDefinitionVersion.findAll({
+      where: { reportDefinitionId: reportId },
+      attributes: [
+        'id',
+        'versionNumber',
+        'query',
+        'createdAt',
+        'updatedAt',
+        'status',
+        'notes',
+        'queryOptions',
+      ],
+      order: [['versionNumber', 'DESC']],
+      include: [
+        {
+          model: store.models.User,
+          as: 'createdBy',
+          attributes: ['displayName'],
+        },
+      ],
+    });
+    res.send(versions);
+  }),
+);

--- a/packages/sync-server/app/admin/reports/reportRoutes.js
+++ b/packages/sync-server/app/admin/reports/reportRoutes.js
@@ -1,4 +1,4 @@
-import express from 'express'
+import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { QueryTypes } from 'sequelize';
 


### PR DESCRIPTION
### Changes
Fixing up branch strat for db defined reports GUI into epic branch with common functionality seperated into this pr. 

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
