### PR TITLE
Staging SAV-147: Make imaging result description optional

### DIFF
--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -202,15 +202,20 @@ const ImagingResultsSection = ({ values, practitionerSuggester }) => {
       <FormGrid columns={2}>
         <Field
           label="Completed by"
-          name="newResultCompletedBy"
+          name="newResult.completedById"
           placeholder="Search"
           component={AutocompleteField}
           suggester={practitionerSuggester}
         />
-        <Field label="Completed" name="newResultDate" saveDateAsString component={DateTimeField} />
+        <Field
+          label="Completed"
+          name="newResult.completedAt"
+          saveDateAsString
+          component={DateTimeField}
+        />
         <Field
           label="Result description"
-          name="newResultDescription"
+          name="newResult.description"
           placeholder="Result description..."
           multiline
           component={TextField}
@@ -236,18 +241,17 @@ const ImagingRequestInfoPane = React.memo(
             'status',
             'completedById',
             'locationGroupId',
-            'newResultCompletedBy',
-            'newResultDate',
-            'newResultDescription',
+            'newResult',
           );
           onSubmit(updateValues);
         }}
         enableReinitialize // Updates form to reflect changes in initialValues
         initialValues={{
           ...imagingRequest,
-          newResultCompletedBy: null,
-          newResultDate: getCurrentDateTimeString(),
-          newResultDescription: '',
+          newResult: {
+            completedAt: getCurrentDateTimeString(),
+            description: '',
+          },
         }}
       >
         {({ values, dirty, handleChange }) => {

--- a/packages/lan/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/lan/__tests__/apiv1/ImagingRequests.test.js
@@ -284,6 +284,33 @@ describe('Imaging requests', () => {
     expect(results[1].description).toBe('new result description 2');
   });
 
+  it('should create imaging result with description as optional', async () => {
+    // arrange
+    const ir = await models.ImagingRequest.create({
+      encounterId: encounter.id,
+      imagingType: IMAGING_TYPES.CT_SCAN,
+      requestedById: app.user.id,
+    });
+
+    const newResultDate = new Date().toISOString();
+    // act
+    const result1 = await app.put(`/v1/imagingRequest/${ir.id}`).send({
+      status: 'completed',
+      newResultDate,
+      newResultCompletedById: app.user.dataValues.id,
+    });
+
+    // assert
+    expect(result1).toHaveSucceeded();
+
+    const results = await models.ImagingResult.findAll({
+      where: { imagingRequestId: ir.id },
+    });
+    expect(results.length).toBe(1);
+    expect(results[0].completedById).toBe(app.user.dataValues.id);
+    expect(results[0].completedAt).toBe(newResultDate);
+  });
+
   it('should query an external provider for imaging results if configured so', async () => {
     // arrange
     const ir = await models.ImagingRequest.create({

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -215,7 +215,7 @@ imagingRequest.put(
       }
     }
 
-    if (newResultDescription?.length > 0) {
+    if (newResultCompletedBy) {
       const newResult = await ImagingResult.create({
         description: newResultDescription,
         completedAt: newResultDate,

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -141,15 +141,7 @@ imagingRequest.put(
       models: { ImagingRequest, ImagingResult },
       params: { id },
       user,
-      body: {
-        areas,
-        note,
-        areaNote,
-        newResultCompletedBy,
-        newResultDate,
-        newResultDescription,
-        ...imagingRequestData
-      },
+      body: { areas, note, areaNote, newResult, ...imagingRequestData },
     } = req;
     req.checkPermission('read', 'ImagingRequest');
 
@@ -215,18 +207,16 @@ imagingRequest.put(
       }
     }
 
-    if (newResultCompletedBy) {
-      const newResult = await ImagingResult.create({
-        description: newResultDescription,
-        completedAt: newResultDate,
-        completedById: newResultCompletedBy,
+    if (newResult?.completedById) {
+      const imagingResult = await ImagingResult.create({
+        ...newResult,
         imagingRequestId: imagingRequestObject.id,
       });
 
       if (imagingRequestObject.results) {
-        imagingRequestObject.results.push(newResult);
+        imagingRequestObject.results.push(imagingResult);
       } else {
-        imagingRequestObject.results = [newResult];
+        imagingRequestObject.results = [imagingResult];
       }
     }
 


### PR DESCRIPTION
### Changes
- Make imaging result description optional

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
