### PR TITLE
TAN-2165: disabling sort for Sync, sex and status

### DIFF
--- a/packages/desktop/app/views/patients/columns.js
+++ b/packages/desktop/app/views/patients/columns.js
@@ -12,6 +12,7 @@ export const markedForSync = {
   key: 'markedForSync',
   minWidth: 26,
   CellComponent: SyncedCell,
+  sortable: false,
 };
 
 export const displayId = {
@@ -39,6 +40,7 @@ export const sex = {
   key: 'sex',
   minWidth: 80,
   CellComponent: SexCell,
+  sortable: false,
 };
 
 export const dateOfBirth = {
@@ -68,6 +70,7 @@ export const department = {
 export const status = {
   key: 'patientStatus',
   title: 'Status',
+  sortable: false,
   minWidth: 100,
   accessor: ({ dateOfDeath: dod, encounterType }) =>
     dod ? <strong>Deceased</strong> : getPatientStatus(encounterType),


### PR DESCRIPTION
### Changes

- Disabled sort for sync, sex, and status
- Fix for this [comment](https://linear.app/bes/issue/TAN-2165#comment-a8ced86e).


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
