### PR TITLE
Set postgres application_name

### DIFF
--- a/packages/shared-src/src/services/database.js
+++ b/packages/shared-src/src/services/database.js
@@ -4,6 +4,7 @@ import pg from 'pg';
 import util from 'util';
 
 import { log } from './logging';
+import { serviceContext, serviceName } from './logging/context';
 
 import { migrate, assertUpToDate, NON_SYNCING_TABLES } from './migrations';
 import * as models from '../models';
@@ -77,7 +78,12 @@ async function connectToDatabase(dbOptions) {
           `${util.inspect(query)}; -- ${util.inspect(obj.bind || [], { breakLength: Infinity })}`,
         )
     : null;
-  const options = { dialect: 'postgres' };
+
+  const options = {
+    dialect: 'postgres',
+    dialectOptions: { application_name: serviceName(serviceContext()) ?? 'tamanu' },
+  };
+
   const sequelize = new Sequelize(name, username, password, {
     ...options,
     host,


### PR DESCRIPTION
### Changes

The `application_name` of a connection shows up in postgres stats and activity views. For our deployment pattern of a database per application, most connections will be from tamanu, but this may be useful to e.g. differentiate from backups, psql, and any other connections.

### Checklist

- [x] Code is finished