### PR TITLE
NASS-717: Dynamic selection field

### DIFF
--- a/packages/desktop/.storybook/__mocks__/defaultEndpoints.js
+++ b/packages/desktop/.storybook/__mocks__/defaultEndpoints.js
@@ -59,5 +59,7 @@ export const defaultEndpoints = {
   },
   'suggestions/labTestLaboratory/all': () => Array.from({ length: 10 }, fakeLabTestLaboratory),
   'suggestions/labTestPriority/all': () => Array.from({ length: 10 }, fakeLabTestPriority),
-  'suggestions/labTestCategory/all': () => Array.from({ length: 10 }, fakeLabTestCategory)
+  'suggestions/labTestCategory/all': () => Array.from({ length: 10 }, fakeLabTestCategory),
+  'suggestions/lessThanSevenCities': () => Array.from({ length: 6 }, fakeCity),
+  'suggestions/moreThanSevenCities': () => Array.from({ length: 10 }, fakeCity),
 };

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -3,9 +3,10 @@ import React, { useEffect, useState } from 'react';
 import { SelectInput } from './SelectField';
 import { AutocompleteInput } from './AutocompleteField';
 
+const SELECT_OPTIONS_LIMIT = 7;
+
 export const DynamicSelectField = ({ field, options, suggester, name, ...props }) => {
   const [selectOptions, setSelectOptions] = useState([]);
-  const SELECT_OPTIONS_LIMIT = 7;
 
   useEffect(() => {
     async function setInputOptions() {
@@ -16,21 +17,8 @@ export const DynamicSelectField = ({ field, options, suggester, name, ...props }
   }, [options, suggester]);
 
   return selectOptions.length > SELECT_OPTIONS_LIMIT ? (
-    <AutocompleteInput
-      name={field.name}
-      onChange={field.onChange}
-      value={field.value}
-      suggester={suggester}
-      options={selectOptions}
-      {...props}
-    />
+    <AutocompleteInput suggester={suggester} options={selectOptions} {...props} {...field} />
   ) : (
-    <SelectInput
-      name={field.name}
-      onChange={field.onChange}
-      value={field.value}
-      options={selectOptions}
-      {...props}
-    />
+    <SelectInput options={selectOptions} {...props} {...field} />
   );
 };

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -14,6 +14,7 @@ export const DynamicSelectField = ({ field, options, suggester, name, ...props }
     async function setInputOptions() {
       const optionsList = suggester ? await suggester.fetchSuggestions() : options;
       if (optionsList.length > SELECT_OPTIONS_LIMIT) {
+        if (suggester) {
           setAutocompleteSuggester(suggester);
         } else {
           setAutocompleteOptions(optionsList);

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -8,15 +8,18 @@ export const DynamicSelectField = ({ field, options, suggester, name, ...props }
   const [autocompleteOptions, setAutocompleteOptions] = useState([]);
   const [autocompleteSuggester, setAutocompleteSuggester] = useState(null);
 
+  const SELECT_OPTIONS_LIMIT = 7;
+
   useEffect(() => {
     async function setInputOptions() {
       const optionsList = suggester ? await suggester.fetchSuggestions() : options;
-      if (optionsList.length <= 7) {
-        setSelectOptions(optionsList);
-      } else if (optionsList.length > 7 && !suggester) {
-        setAutocompleteOptions(optionsList);
+      if (optionsList.length > SELECT_OPTIONS_LIMIT) {
+          setAutocompleteSuggester(suggester);
+        } else {
+          setAutocompleteOptions(optionsList);
+        }
       } else {
-        setAutocompleteSuggester(suggester);
+        setSelectOptions(optionsList);
       }
     }
     setInputOptions();

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -1,27 +1,33 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { SelectField } from './SelectField';
-import { AutocompleteField } from './AutocompleteField';
+import { SelectInput } from './SelectField';
+import { AutocompleteInput } from './AutocompleteField';
 
-export const DynamicSelectField = ({ field, options, ...props }) => {
-  let resultLength = 0;
-  if (Array.isArray(options)) {
-    resultLength = options.length;
-  } else {
-    const results = options.fetchSuggestions();
-    resultLength = results.length;
-  }
+export const DynamicSelectField = ({ field, options, suggester, ...props }) => {
+  const [resultLength, setResultLength] = React.useState(0);
+  useEffect(() => {
+    async function findDataLength() {
+      if (options) {
+        setResultLength(options.length);
+      }
+      if (suggester) {
+        const results = await suggester.fetchSuggestions();
+        setResultLength(results.length);
+      }
+    }
+    findDataLength();
+  });
 
   return resultLength > 7 ? (
-    <AutocompleteField
+    <AutocompleteInput
       name={field.name}
       onChange={field.onChange}
       value={field.value}
-      options={options}
+      suggester={suggester}
       {...props}
     />
   ) : (
-    <SelectField
+    <SelectInput
       name={field.name}
       onChange={field.onChange}
       value={field.value}

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -5,42 +5,31 @@ import { AutocompleteInput } from './AutocompleteField';
 
 export const DynamicSelectField = ({ field, options, suggester, name, ...props }) => {
   const [selectOptions, setSelectOptions] = useState([]);
-  const [autocompleteOptions, setAutocompleteOptions] = useState([]);
-  const [autocompleteSuggester, setAutocompleteSuggester] = useState(null);
-
   const SELECT_OPTIONS_LIMIT = 7;
 
   useEffect(() => {
     async function setInputOptions() {
       const optionsList = suggester ? await suggester.fetchSuggestions() : options;
-      if (optionsList.length > SELECT_OPTIONS_LIMIT) {
-        if (suggester) {
-          setAutocompleteSuggester(suggester);
-        } else {
-          setAutocompleteOptions(optionsList);
-        }
-      } else {
-        setSelectOptions(optionsList);
-      }
+      setSelectOptions(optionsList);
     }
     setInputOptions();
   }, [options, suggester]);
 
-  return selectOptions.length > 0 ? (
+  return selectOptions.length > SELECT_OPTIONS_LIMIT ? (
+    <AutocompleteInput
+      name={field.name}
+      onChange={field.onChange}
+      value={field.value}
+      suggester={suggester}
+      options={selectOptions}
+      {...props}
+    />
+  ) : (
     <SelectInput
       name={field.name}
       onChange={field.onChange}
       value={field.value}
       options={selectOptions}
-      {...props}
-    />
-  ) : (
-    <AutocompleteInput
-      name={field.name}
-      onChange={field.onChange}
-      value={field.value}
-      suggester={autocompleteSuggester}
-      options={autocompleteOptions}
       {...props}
     />
   );

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { SelectField } from './SelectField';
+import { AutocompleteField } from './AutocompleteField';
+
+export const DynamicSelectField = ({ field, options, ...props }) => {
+  let resultLength = 0;
+  if (Array.isArray(options)) {
+    resultLength = options.length;
+  } else {
+    const results = options.fetchSuggestions();
+    resultLength = results.length;
+  }
+
+  return resultLength > 7 ? (
+    <AutocompleteField
+      name={field.name}
+      onChange={field.onChange}
+      value={field.value}
+      options={options}
+      {...props}
+    />
+  ) : (
+    <SelectField
+      name={field.name}
+      onChange={field.onChange}
+      value={field.value}
+      options={options}
+      {...props}
+    />
+  );
+};

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -1,12 +1,12 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { SelectInput } from './SelectField';
 import { AutocompleteInput } from './AutocompleteField';
 
 export const DynamicSelectField = ({ field, options, suggester, name, ...props }) => {
-  const [selectOptions, setSelectOptions] = React.useState([]);
-  const [autocompleteOptions, setAutocompleteOptions] = React.useState([]);
-  const [autocompleteSuggester, setAutocompleteSuggester] = React.useState(null);
+  const [selectOptions, setSelectOptions] = useState([]);
+  const [autocompleteOptions, setAutocompleteOptions] = useState([]);
+  const [autocompleteSuggester, setAutocompleteSuggester] = useState(null);
 
   useEffect(() => {
     async function setInputOptions() {

--- a/packages/desktop/app/components/Field/DynamicSelectField.js
+++ b/packages/desktop/app/components/Field/DynamicSelectField.js
@@ -3,35 +3,40 @@ import React, { useEffect } from 'react';
 import { SelectInput } from './SelectField';
 import { AutocompleteInput } from './AutocompleteField';
 
-export const DynamicSelectField = ({ field, options, suggester, ...props }) => {
-  const [resultLength, setResultLength] = React.useState(0);
+export const DynamicSelectField = ({ field, options, suggester, name, ...props }) => {
+  const [selectOptions, setSelectOptions] = React.useState([]);
+  const [autocompleteOptions, setAutocompleteOptions] = React.useState([]);
+  const [autocompleteSuggester, setAutocompleteSuggester] = React.useState(null);
+
   useEffect(() => {
-    async function findDataLength() {
-      if (options) {
-        setResultLength(options.length);
-      }
-      if (suggester) {
-        const results = await suggester.fetchSuggestions();
-        setResultLength(results.length);
+    async function setInputOptions() {
+      const optionsList = suggester ? await suggester.fetchSuggestions() : options;
+      if (optionsList.length <= 7) {
+        setSelectOptions(optionsList);
+      } else if (optionsList.length > 7 && !suggester) {
+        setAutocompleteOptions(optionsList);
+      } else {
+        setAutocompleteSuggester(suggester);
       }
     }
-    findDataLength();
-  });
+    setInputOptions();
+  }, [options, suggester]);
 
-  return resultLength > 7 ? (
-    <AutocompleteInput
-      name={field.name}
-      onChange={field.onChange}
-      value={field.value}
-      suggester={suggester}
-      {...props}
-    />
-  ) : (
+  return selectOptions.length > 0 ? (
     <SelectInput
       name={field.name}
       onChange={field.onChange}
       value={field.value}
-      options={options}
+      options={selectOptions}
+      {...props}
+    />
+  ) : (
+    <AutocompleteInput
+      name={field.name}
+      onChange={field.onChange}
+      value={field.value}
+      suggester={autocompleteSuggester}
+      options={autocompleteOptions}
       {...props}
     />
   );

--- a/packages/desktop/app/components/Field/index.js
+++ b/packages/desktop/app/components/Field/index.js
@@ -23,6 +23,7 @@ export * from './AutocompleteField';
 export * from './DisplayIdField';
 export * from './DOBFields';
 export * from './LocationField';
+export * from './DynamicSelectField';
 
 // form helpers
 export * from './Form';

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -3,7 +3,14 @@ import { getCurrentDateString } from 'shared/utils/dateTime';
 import Box from '@material-ui/core/Box';
 import styled from 'styled-components';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
-import { Field, LocalisedField, DOBFields, SearchField, DynamicSelectField } from '../Field';
+import {
+  Field,
+  LocalisedField,
+  DOBFields,
+  SearchField,
+  AutocompleteField,
+  SelectField,
+} from '../Field';
 import { useSuggester } from '../../api';
 import { DateField } from '../Field/DateField';
 import { useSexOptions } from '../../hooks';
@@ -43,14 +50,14 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             <DOBFields showExactBirth={false} />
             <SexLocalisedField
               name="sex"
-              component={DynamicSelectField}
+              component={SelectField}
               options={sexOptions}
               size="small"
             />
           </TwoColumnsField>
           <VillageLocalisedField
             name="villageId"
-            component={DynamicSelectField}
+            component={AutocompleteField}
             suggester={villageSuggester}
             size="small"
           />

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -58,7 +58,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
           </TwoColumnsField>
           <VillageLocalisedField
             name="villageId"
-            component={AutocompleteField}
+            component={DynamicSelectField}
             suggester={villageSuggester}
             size="small"
           />

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -3,15 +3,7 @@ import { getCurrentDateString } from 'shared/utils/dateTime';
 import Box from '@material-ui/core/Box';
 import styled from 'styled-components';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
-import {
-  AutocompleteField,
-  Field,
-  LocalisedField,
-  DOBFields,
-  SearchField,
-  SelectField,
-  DynamicSelectField
-} from '../Field';
+import { Field, LocalisedField, DOBFields, SearchField, DynamicSelectField } from '../Field';
 import { useSuggester } from '../../api';
 import { DateField } from '../Field/DateField';
 import { useSexOptions } from '../../hooks';

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -10,6 +10,7 @@ import {
   DOBFields,
   SearchField,
   SelectField,
+  DynamicSelectField
 } from '../Field';
 import { useSuggester } from '../../api';
 import { DateField } from '../Field/DateField';
@@ -50,7 +51,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             <DOBFields showExactBirth={false} />
             <SexLocalisedField
               name="sex"
-              component={SelectField}
+              component={DynamicSelectField}
               options={sexOptions}
               size="small"
             />

--- a/packages/desktop/stories/dynamicSelectField.stories.js
+++ b/packages/desktop/stories/dynamicSelectField.stories.js
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { DynamicSelectField } from '../app/components';
+
+const FRUITS = [
+  { value: 'apples', label: 'Apples' },
+  { value: 'oranges', label: 'Oranges' },
+  { value: 'bananas', label: 'Bananas' },
+];
+
+const FURNITURE = [
+  { label: 'Sofa', value: 'sofa' },
+  { label: 'Armchair', value: 'armchair' },
+  { label: 'Coffee Table', value: 'coffeeTable' },
+  { label: 'End Table', value: 'endTable' },
+  { label: 'Dining Table', value: 'diningTable' },
+  { label: 'Dining Chair', value: 'diningChair' },
+  { label: 'Bed', value: 'bed' },
+  { label: 'Dresser', value: 'dresser' },
+  { label: 'Nightstand', value: 'nightstand' },
+  { label: 'Bookshelf', value: 'bookshelf' },
+];
+
+export default {
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+  },
+  title: 'FormControls/DynamicSelectField',
+  component: DynamicSelectField,
+};
+
+const Template = args => {
+  const [value, setValue] = useState(null);
+  const handleChange = e => {
+    setValue(e.target.value);
+  };
+  return <DynamicSelectField field={{ name: 'name', onChange: handleChange, value }} {...args} />;
+};
+
+export const SevenOrLessItems = Template.bind({});
+SevenOrLessItems.args = {
+  options: FRUITS,
+};
+
+export const MoreThanSevenItems = Template.bind({});
+MoreThanSevenItems.args = {
+  options: FURNITURE,
+};

--- a/packages/desktop/stories/dynamicSelectField.stories.js
+++ b/packages/desktop/stories/dynamicSelectField.stories.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { DynamicSelectField } from '../app/components';
-import { useApi, useSuggester } from '../app/api';
-import { MockedApi } from './utils/mockedApi';
+import { useSuggester } from '../app/api';
 
 const FRUITS = [
   { value: 'apples', label: 'Apples' },
@@ -39,8 +38,7 @@ export default {
 };
 
 const Template = ({ name, suggesterEndpoint, ...args }) => {
-  const testSuggester = useSuggester(suggesterEndpoint);
-  const suggester = testSuggester.endpoint.includes('undefined') ? null : testSuggester;
+  const suggester = useSuggester(suggesterEndpoint);
   const [value, setValue] = useState(null);
   const handleChange = e => {
     setValue(e.target.value);
@@ -48,7 +46,7 @@ const Template = ({ name, suggesterEndpoint, ...args }) => {
   return (
     <DynamicSelectField
       field={{ name, onChange: handleChange, value }}
-      suggester={suggester}
+      suggester={suggesterEndpoint ? suggester : null}
       {...args}
     />
   );

--- a/packages/desktop/stories/dynamicSelectField.stories.js
+++ b/packages/desktop/stories/dynamicSelectField.stories.js
@@ -33,20 +33,22 @@ export default {
   component: DynamicSelectField,
 };
 
-const Template = args => {
+const Template = ({ name, ...args }) => {
   const [value, setValue] = useState(null);
   const handleChange = e => {
     setValue(e.target.value);
   };
-  return <DynamicSelectField field={{ name: 'name', onChange: handleChange, value }} {...args} />;
+  return <DynamicSelectField field={{ name, onChange: handleChange, value }} {...args} />;
 };
 
 export const SevenOrLessItems = Template.bind({});
 SevenOrLessItems.args = {
+  name: 'fruit',
   options: FRUITS,
 };
 
 export const MoreThanSevenItems = Template.bind({});
 MoreThanSevenItems.args = {
+  name: 'furniture',
   options: FURNITURE,
 };

--- a/packages/desktop/stories/dynamicSelectField.stories.js
+++ b/packages/desktop/stories/dynamicSelectField.stories.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { DynamicSelectField } from '../app/components';
+import { useApi, useSuggester } from '../app/api';
+import { MockedApi } from './utils/mockedApi';
 
 const FRUITS = [
   { value: 'apples', label: 'Apples' },
@@ -22,6 +24,9 @@ const FURNITURE = [
 
 export default {
   argTypes: {
+    name: {
+      control: 'text',
+    },
     label: {
       control: 'text',
     },
@@ -33,12 +38,20 @@ export default {
   component: DynamicSelectField,
 };
 
-const Template = ({ name, ...args }) => {
+const Template = ({ name, suggesterEndpoint, ...args }) => {
+  const testSuggester = useSuggester(suggesterEndpoint);
+  const suggester = testSuggester.endpoint.includes('undefined') ? null : testSuggester;
   const [value, setValue] = useState(null);
   const handleChange = e => {
     setValue(e.target.value);
   };
-  return <DynamicSelectField field={{ name, onChange: handleChange, value }} {...args} />;
+  return (
+    <DynamicSelectField
+      field={{ name, onChange: handleChange, value }}
+      suggester={suggester}
+      {...args}
+    />
+  );
 };
 
 export const SevenOrLessItems = Template.bind({});
@@ -51,4 +64,16 @@ export const MoreThanSevenItems = Template.bind({});
 MoreThanSevenItems.args = {
   name: 'furniture',
   options: FURNITURE,
+};
+
+export const SevenOrLessItemsWithSuggester = Template.bind({});
+SevenOrLessItemsWithSuggester.args = {
+  name: 'lessThanSevenCities',
+  suggesterEndpoint: 'lessThanSevenCities',
+};
+
+export const MoreThanSevenItemsWithSuggester = Template.bind({});
+MoreThanSevenItemsWithSuggester.args = {
+  name: 'moreThanSevenCities',
+  suggesterEndpoint: 'moreThanSevenCities',
 };

--- a/packages/desktop/stories/dynamicSelectField.stories.js
+++ b/packages/desktop/stories/dynamicSelectField.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { DynamicSelectField } from '../app/components';
 import { useSuggester } from '../app/api';
 
@@ -20,6 +21,11 @@ const FURNITURE = [
   { label: 'Nightstand', value: 'nightstand' },
   { label: 'Bookshelf', value: 'bookshelf' },
 ];
+
+const Container = styled.div`
+  padding: 1rem;
+  max-width: 500px;
+`;
 
 export default {
   argTypes: {
@@ -44,11 +50,13 @@ const Template = ({ name, suggesterEndpoint, ...args }) => {
     setValue(e.target.value);
   };
   return (
-    <DynamicSelectField
-      field={{ name, onChange: handleChange, value }}
-      suggester={suggesterEndpoint ? suggester : null}
-      {...args}
-    />
+    <Container>
+      <DynamicSelectField
+        field={{ name, onChange: handleChange, value }}
+        suggester={suggesterEndpoint ? suggester : null}
+        {...args}
+      />
+    </Container>
   );
 };
 


### PR DESCRIPTION
### Changes

We are introducing a new type of select field to the app that dynamically changes based on the number of available options to select. This will take either an array of objects as options or a suggester. If the options array is <= 7 we will display the input as a select field and if above we will display as an autocomplete field. Same goes for if a suggester is passed, we query it and if the first page of results is less then 7 we will display those as the select options otherwise we will display as an autocomplete field like usual with suggester logic.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)

