### PR TITLE
Default to no location filter if query param is not passed in

### DIFF
--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -349,9 +349,10 @@ globalImagingRequests.get(
     };
 
     const locationWhere = {
-      where: JSON.parse(filterParams.allFacilities)
-        ? {}
-        : { facilityId: { [Op.eq]: config.serverFacilityId } },
+      where:
+        filterParams?.allFacilities && JSON.parse(filterParams.allFacilities)
+          ? {}
+          : { facilityId: { [Op.eq]: config.serverFacilityId } },
     };
 
     const location = {


### PR DESCRIPTION
### Changes

- If no `allFacilities` query parameter is passed in, it will be `undefined` which is not a valid JSON string for `JSON.parse`
  - If we don't pass in the query parameter, treat it the same as if the query parameter was `false`

### Checklist

- [X] Code is finished