### PR TITLE
SAV-167: Show discharge summary on all facilities fix

### DIFF
--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -136,7 +136,7 @@ export const EncounterView = () => {
         subTitle={encounter.location?.facility?.name}
         encounter={encounter}
       >
-        {facility.id === encounter.location.facilityId && (
+        {(facility.id === encounter.location.facilityId || encounter.endDate) && (
           <EncounterActions encounter={encounter} />
         )}
       </EncounterTopBar>


### PR DESCRIPTION
### Changes

This card hides the encounter actions for encounters not on the current facility. This also had the side effect of hiding the discharge summary from other facilities too which should still be present. This fix adds a check that will show the encounter actions on any facility as long as it is complete

