### PR TITLE
NASS-654: desktop labs listing view search fields and table columns discrepancy

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -76,8 +76,10 @@ const Item = styled(MenuItem)`
 `;
 
 const iconStyle = css`
-  color: ${Colors.midText};
-  font-size: 24;
+  &.MuiSvgIcon-root {
+    color: ${Colors.midText};
+    font-size: 24px;
+  }
 `;
 
 const StyledExpandLess = styled(ExpandLess)`

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -55,10 +55,6 @@ const ActionsContainer = styled(Box)`
   margin-left: 8px;
 `;
 
-const ExpandButton = styled(IconButton)`
-  padding: 6px 14px;
-`;
-
 const SearchButton = styled(Button)`
   margin-right: 20px;
   margin-left: 6px;
@@ -92,7 +88,7 @@ export const CustomisableSearchBar = ({
             {children}
             <ActionsContainer>
               {showExpandButton && (
-                <ExpandButton
+                <IconButton
                   onClick={() => {
                     switchExpandValue();
                   }}
@@ -102,7 +98,7 @@ export const CustomisableSearchBar = ({
                     src={isExpanded ? doubleUp : doubleDown}
                     alt={`${isExpanded ? 'hide' : 'show'} advanced filters`}
                   />
-                </ExpandButton>
+                </IconButton>
               )}
               <SearchButton type="submit">Search</SearchButton>
               <ClearButton onClick={clearForm}>Clear</ClearButton>

--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -27,7 +27,7 @@ const useAdvancedFields = advancedFields => {
   return { showAdvancedFields, setShowAdvancedFields, searchParameters, setSearchParameters };
 };
 
-const ADVANCED_FIELDS = ['requestedDateFrom', 'requestedDateTo', 'requestedById', 'priority'];
+const ADVANCED_FIELDS = ['locationGroupId', 'departmentId', 'laboratory', 'priority'];
 
 export const LabRequestsSearchBar = () => {
   const {
@@ -36,7 +36,6 @@ export const LabRequestsSearchBar = () => {
     searchParameters,
     setSearchParameters,
   } = useAdvancedFields(ADVANCED_FIELDS);
-  const clinicianSuggester = useSuggester('practitioner');
   const locationGroupSuggester = useSuggester('locationGroup');
   const departmentSuggester = useSuggester('department', {
     baseQueryParameters: { filterByFacility: true },
@@ -50,25 +49,26 @@ export const LabRequestsSearchBar = () => {
       showExpandButton
       hiddenFields={
         <>
-          <LocalisedField
-            name="requestedDateFrom"
-            label="Requested from"
-            saveDateAsString
-            component={DateField}
-            $joined
-          />
-          <LocalisedField
-            name="requestedDateTo"
-            defaultLabel="Requested to"
-            saveDateAsString
-            component={DateField}
+          <Field
+            name="locationGroupId"
+            label="Area"
+            component={AutocompleteField}
+            suggester={locationGroupSuggester}
+            size="small"
           />
           <Field
-            name="requestedById"
-            label="Requested by"
-            size="small"
+            name="departmentId"
+            label="Department"
             component={AutocompleteField}
-            suggester={clinicianSuggester}
+            suggester={departmentSuggester}
+            size="small"
+          />
+          <LocalisedField
+            name="laboratory"
+            defaultLabel="Laboratory"
+            component={SuggesterSelectField}
+            endpoint="labTestLaboratory"
+            size="small"
           />
           <LocalisedField
             name="priority"
@@ -93,25 +93,24 @@ export const LabRequestsSearchBar = () => {
           size="small"
         />
         <Field
-          name="locationGroupId"
-          label="Area"
-          component={AutocompleteField}
-          suggester={locationGroupSuggester}
-          size="small"
-        />
-        <Field
-          name="departmentId"
-          label="Department"
-          component={AutocompleteField}
-          suggester={departmentSuggester}
+          name="labTestPanelId"
+          label="Panel"
+          component={SuggesterSelectField}
+          endpoint="labTestPanel"
           size="small"
         />
         <LocalisedField
-          name="laboratory"
-          defaultLabel="Laboratory"
-          component={SuggesterSelectField}
-          endpoint="labTestLaboratory"
-          size="small"
+          name="requestedDateFrom"
+          label="Requested from"
+          saveDateAsString
+          component={DateField}
+          $joined
+        />
+        <LocalisedField
+          name="requestedDateTo"
+          defaultLabel="Requested to"
+          saveDateAsString
+          component={DateField}
         />
         <LocalisedField
           name="status"

--- a/packages/desktop/app/utils/lab.js
+++ b/packages/desktop/app/utils/lab.js
@@ -26,7 +26,6 @@ export const getRequestedBy = ({ requestedBy }) =>
 export const getPatientName = row => <PatientNameDisplay patient={row} />;
 export const getPatientDisplayId = ({ patientDisplayId }) => patientDisplayId || 'Unknown';
 export const getStatus = ({ status }) => <StatusDisplay status={status} />;
-export const getPanel = ({ labRequestPanel }) => labRequestPanel?.name;
 export const getRequestType = ({ categoryName, category }) =>
   categoryName || (category || {}).name || 'Unknown';
 export const getPriority = ({ priorityName, priority }) =>

--- a/packages/desktop/app/utils/lab.js
+++ b/packages/desktop/app/utils/lab.js
@@ -26,6 +26,7 @@ export const getRequestedBy = ({ requestedBy }) =>
 export const getPatientName = row => <PatientNameDisplay patient={row} />;
 export const getPatientDisplayId = ({ patientDisplayId }) => patientDisplayId || 'Unknown';
 export const getStatus = ({ status }) => <StatusDisplay status={status} />;
+export const getPanel = ({ labRequestPanel }) => labRequestPanel?.name;
 export const getRequestType = ({ categoryName, category }) =>
   categoryName || (category || {}).name || 'Unknown';
 export const getPriority = ({ priorityName, priority }) =>

--- a/packages/desktop/app/views/LabRequestListingView.js
+++ b/packages/desktop/app/views/LabRequestListingView.js
@@ -10,7 +10,7 @@ import { LabRequestsTable } from './LabRequestsTable';
 
 export const LabRequestListingView = React.memo(() => (
   <PageContainer>
-    <TopBar title="Lab requests" />
+    <TopBar title="Active lab requests" />
     <ContentPane>
       <SearchTableTitle>Lab request search</SearchTableTitle>
       <LabRequestsSearchBar />

--- a/packages/desktop/app/views/LabRequestsTable.js
+++ b/packages/desktop/app/views/LabRequestsTable.js
@@ -6,7 +6,7 @@ import { reloadPatient } from '../store/patient';
 import { useEncounter } from '../contexts/Encounter';
 import { useLabRequest } from '../contexts/LabRequest';
 import {
-  getRequestedBy,
+  getPanel,
   getPatientName,
   getPatientDisplayId,
   getStatus,
@@ -29,8 +29,8 @@ const columns = [
   },
   { key: 'requestId', title: 'Test ID', accessor: getRequestId },
   { key: 'testCategory', title: 'Test category', accessor: getRequestType },
+  { key: 'labRequestPanelId', title: 'Panel', accessor: getPanel },
   { key: 'requestedDate', title: 'Requested at time', accessor: getDateTime },
-  { key: 'requestedBy', title: 'Requested by', accessor: getRequestedBy },
   { key: 'priority', title: 'Priority', accessor: getPriority },
   { key: 'status', title: 'Status', accessor: getStatus, maxWidth: 200 },
 ];

--- a/packages/desktop/app/views/LabRequestsTable.js
+++ b/packages/desktop/app/views/LabRequestsTable.js
@@ -6,7 +6,6 @@ import { reloadPatient } from '../store/patient';
 import { useEncounter } from '../contexts/Encounter';
 import { useLabRequest } from '../contexts/LabRequest';
 import {
-  getPanel,
   getPatientName,
   getPatientDisplayId,
   getStatus,
@@ -29,7 +28,7 @@ const columns = [
   },
   { key: 'requestId', title: 'Test ID', accessor: getRequestId },
   { key: 'testCategory', title: 'Test category', accessor: getRequestType },
-  { key: 'labRequestPanelId', title: 'Panel', accessor: getPanel },
+  { key: 'labTestPanelName', title: 'Panel' },
   { key: 'requestedDate', title: 'Requested at time', accessor: getDateTime },
   { key: 'priority', title: 'Priority', accessor: getPriority },
   { key: 'status', title: 'Status', accessor: getStatus, maxWidth: 200 },

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -146,6 +146,7 @@ labRequest.get(
       makeSimpleTextFilter('requestedById', 'lab_requests.requested_by_id'),
       makeSimpleTextFilter('departmentId', 'encounter.department_id'),
       makeSimpleTextFilter('locationGroupId', 'location.location_group_id'),
+      makeSimpleTextFilter('labTestPanelId', 'lab_test_panel.id'),
       makeFilter(
         filterParams.requestedDateFrom,
         `lab_requests.requested_date >= :requestedDateFrom`,
@@ -178,6 +179,10 @@ labRequest.get(
           ON (laboratory.type = 'labTestLaboratory' AND lab_requests.lab_test_laboratory_id = laboratory.id)
         LEFT JOIN reference_data AS site
           ON (site.type = 'labSampleSite' AND lab_requests.lab_sample_site_id = site.id)
+        LEFT JOIN lab_test_panel_requests AS lab_test_panel_requests
+          ON (lab_test_panel_requests.id = lab_requests.lab_test_panel_request_id)
+        LEFT JOIN lab_test_panels AS lab_test_panel
+          ON (lab_test_panel.id = lab_test_panel_requests.lab_test_panel_id)
         LEFT JOIN patients AS patient
           ON (patient.id = encounter.patient_id)
         LEFT JOIN users AS examiner
@@ -215,6 +220,7 @@ labRequest.get(
       patientName: 'UPPER(patient.last_name)',
       requestId: 'display_id',
       testCategory: 'category.name',
+      labRequestPanelId: 'lab_test_panel.id',
       requestedDate: 'requested_date',
       requestedBy: 'examiner.display_name',
       priority: 'priority.name',

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -245,6 +245,7 @@ labRequest.get(
           category.name AS category_name,
           priority.id AS priority_id,
           priority.name AS priority_name,
+          lab_test_panel.name as lab_test_panel_name,
           laboratory.id AS laboratory_id,
           laboratory.name AS laboratory_name
         ${from}


### PR DESCRIPTION
### Changes

- Update title to say `Active lab requests`
- Rearrange expanded search fields, remove `requested by` in table and search fields
- Add search by panel and sortable panel column to table
- Fix padding making weird ripple effect shape on icon button

Filter by panel:
<img width="1180" alt="Screenshot 2023-04-11 at 12 09 25 PM" src="https://user-images.githubusercontent.com/38335330/231022746-7ffe0dc0-f6df-4a72-b301-e14fdcdd135e.png">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
