### PR TITLE
NAS-649: fix clearing of panel in lab request form test select screen

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -18,11 +18,16 @@ export const screen2ValidationSchema = yup.object().shape({
 export const LabRequestFormScreen2 = props => {
   const {
     values: { requestFormType, labTestPanelId },
+    setFieldValue,
   } = props;
   const api = useApi();
   const { data: testTypesData, isLoading } = useQuery(['labTestTypes'], () =>
     api.get('labTestType'),
   );
+
+  const handleClearPanel = () => {
+    setFieldValue('labTestPanelId', undefined);
+  };
 
   return (
     <>
@@ -32,6 +37,7 @@ export const LabRequestFormScreen2 = props => {
           label={`Select the test ${
             requestFormType === LAB_REQUEST_FORM_TYPES.PANEL ? 'panel' : 'category'
           }`}
+          onClearPanel={handleClearPanel}
           component={TestSelectorField}
           requestFormType={requestFormType}
           labTestPanelId={labTestPanelId}

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -144,6 +144,7 @@ export const TestSelectorInput = ({
   value,
   requestFormType,
   labTestPanelId,
+  onClearPanel,
   isLoading,
   onChange,
   required,
@@ -163,6 +164,7 @@ export const TestSelectorInput = ({
   const handleClear = () => {
     setTestFilters(values => ({ ...values, labTestPanelId: '' }));
     handleChange([]);
+    onClearPanel();
   };
 
   const handleChangeTestFilters = event =>


### PR DESCRIPTION
### Changes

- Fix resetting of child field `labTestPanelId`
- This fixes the error when trying to return to form after clearing panel

*Just investigating test failure think unrelated*

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
