### PR TITLE
EPI-463: Fix undefined FHIR default limit fetching all patients

### DIFF
--- a/packages/sync-server/app/hl7fhir/materialised/search/query.js
+++ b/packages/sync-server/app/hl7fhir/materialised/search/query.js
@@ -5,7 +5,7 @@ import * as yup from 'yup';
 import {
   FHIR_SEARCH_PARAMETERS,
   FHIR_SEARCH_PREFIXES,
-  MAX_RESOURCES_PER_PAGE,
+  FHIR_MAX_RESOURCES_PER_PAGE,
   FHIR_SEARCH_TOKEN_TYPES,
   FHIR_DATETIME_PRECISION,
 } from 'shared/constants';
@@ -19,7 +19,7 @@ export function pushToQuery(query, param, value) {
 
 export function buildSearchQuery(query, parameters, FhirResource) {
   const sql = {
-    limit: MAX_RESOURCES_PER_PAGE,
+    limit: FHIR_MAX_RESOURCES_PER_PAGE,
   };
 
   if (query.has('_sort')) {


### PR DESCRIPTION
### Changes

Because `MAX_RESOURCES_PER_PAGE` was undefined, queries without a limit had _no_ limit.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
