### PR TITLE
NASS-723: Updating lab request print label layout

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/LabRequestPrintLabelModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/LabRequestPrintLabelModal.js
@@ -6,6 +6,7 @@ import { Box } from '@material-ui/core';
 import { Modal } from '../../Modal';
 import { LabRequestPrintLabel } from '../printouts/LabRequestPrintLabel';
 import { useLocalisation } from '../../../contexts/Localisation';
+import { getPatientNameAsString } from '../../PatientNameDisplay';
 
 const Container = styled.div`
   display: flex;
@@ -38,6 +39,7 @@ export const LabRequestPrintLabelModal = ({ open, onClose, labRequests }) => {
             <LabRequestPrintLabel
               printWidth={labelWidth}
               data={{
+                patientName: getPatientNameAsString(patient),
                 testId: lab.displayId,
                 patientId: patient.displayId,
                 patientDateOfBirth: patient.dateOfBirth,

--- a/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
@@ -15,7 +15,7 @@ const Container = styled.div`
   }
 `;
 
-const FlexPadding = styled.div`
+const FlexContainer = styled.div`
   // Note: percentage padding is based on the dimensions of the parent element
   padding: 5%;
   display: flex;
@@ -76,7 +76,7 @@ export const LabRequestPrintLabel = React.memo(({ data, printWidth }) => {
   const { patientId, patientName, patientDateOfBirth, testId, labCategory, date } = data;
   return (
     <Container $printWidth={printWidth}>
-      <FlexPadding>
+      <FlexContainer>
         <TextContainer>
           <svg viewBox="0 0 200 120">
             <Item x="0" y="10" label="Patient Name" value={patientName} />
@@ -90,7 +90,7 @@ export const LabRequestPrintLabel = React.memo(({ data, printWidth }) => {
         <BarcodeContainer>
           <Barcode value={testId} width={2} height={57} margin={0} font="Roboto" fontSize={24} />
         </BarcodeContainer>
-      </FlexPadding>
+      </FlexContainer>
     </Container>
   );
 });

--- a/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Barcode from 'react-barcode';
 import { formatShort } from '../../DateDisplay';
-import { getDisplayAge } from '../../../utils/dateTime';
 
 const Container = styled.div`
   position: relative;
@@ -16,12 +15,14 @@ const Container = styled.div`
   }
 `;
 
-const Padding = styled.div`
+const FlexPadding = styled.div`
   // Note: percentage padding is based on the dimensions of the parent element
-  padding: 2.5%;
+  padding: 5%;
+  display: flex;
 `;
 
 const TextContainer = styled.div`
+  width: 70%;
   svg {
     width: 100%;
   }
@@ -51,9 +52,9 @@ const Item = ({ label, value, x, y }) => (
 
 const BarcodeContainer = styled.div`
   margin: 0 auto 0;
+  transform: rotate(270deg);
   padding-top: 1%;
-  max-width: 80%;
-
+  width: 30%;
   svg {
     width: 100%;
     height: 100%;
@@ -72,25 +73,24 @@ const BarcodeContainer = styled.div`
  * why the whole component is made with svgs
  */
 export const LabRequestPrintLabel = React.memo(({ data, printWidth }) => {
-  const { patientId, patientDateOfBirth, testId, date, labCategory } = data;
-  const age = getDisplayAge(patientDateOfBirth);
-
+  const { patientId, patientName, patientDateOfBirth, testId, labCategory, date } = data;
   return (
     <Container $printWidth={printWidth}>
-      <Padding>
+      <FlexPadding>
         <TextContainer>
-          <svg viewBox="0 0 300 60">
-            <Item x="0" y="11" label="Patient ID" value={patientId} />
-            <Item x="50%" y="11" label="Test ID" value={testId} />
-            <Item x="0" y="30" label="Age" value={age} />
-            <Item x="50%" y="30" label="Date collected" value={formatShort(date)} />
-            <Item x="0%" y="50" label="Lab category" value={labCategory} />
+          <svg viewBox="0 0 200 120">
+            <Item x="0" y="10" label="Patient Name" value={patientName} />
+            <Item x="0" y="30" label="Patient ID" value={patientId} />
+            <Item x="0" y="50" label="DOB" value={formatShort(patientDateOfBirth)} />
+            <Item x="0" y="70" label="Test ID" value={testId} />
+            <Item x="0" y="90" label="Date collected" value={formatShort(date)} />
+            <Item x="0" y="110" label="Lab category" value={labCategory} />
           </svg>
         </TextContainer>
         <BarcodeContainer>
-          <Barcode value={testId} width={2} height={57} margin={0} font="Roboto" fontSize={15} />
+          <Barcode value={testId} width={2} height={57} margin={0} font="Roboto" fontSize={24} />
         </BarcodeContainer>
-      </Padding>
+      </FlexPadding>
     </Container>
   );
 });

--- a/packages/desktop/stories/printLabels.stories.js
+++ b/packages/desktop/stories/printLabels.stories.js
@@ -11,6 +11,7 @@ const chance = new Chance();
 
 const mockData = () => {
   return {
+    patientName: chance.name(),
     patientId: chance.hash({ length: 10 }),
     testId: chance.hash({ length: 8 }),
     patientDateOfBirth: chance.birthday({ type: 'child' }),


### PR DESCRIPTION
### Changes
- Some improvements over the Print label for lab requests

### Screenshots
Desktop:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/17033058/231538276-ed01e43c-3e3b-4526-b526-24e55677a50c.png">

Storybook:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/17033058/231538605-1fcfd0b4-3154-496d-b6a5-a304f99683c2.png">


### Task
https://linear.app/bes/issue/NASS-723/desktop-lab-requests-lab-sample-label-updates

_Add a brief description of the changes in this PR to help give the reviewer context._

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
