### PR TITLE
NASS-661: Print-multiple imaging request using string of 'id' instead of same named variable

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/printouts/reusable/NotesPagesSection.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/reusable/NotesPagesSection.js
@@ -26,7 +26,7 @@ export const NotesPagesSection = ({ idsAndNotePages }) => {
       return {
         content: (
           <BodyText key={id} mb={2}>
-            {idsAndNotePages.length > 1 && <StyledId>id</StyledId>}
+            {idsAndNotePages.length > 1 && <StyledId>{id}</StyledId>}
             {content}
           </BodyText>
         ),


### PR DESCRIPTION
### Changes

- simple mistake of putting id in as string instead of variable as child of Id text element

<img width="781" alt="Screenshot 2023-04-13 at 10 09 58 AM" src="https://user-images.githubusercontent.com/38335330/231597408-ffbb535a-9399-4fa4-a8c7-b08f4fc28ce6.png">


### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
