### PR TITLE
NASS-643: Status workflow fixes for cancelled request fixes

### DIFF
--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -16,7 +16,7 @@ const ModalBody = styled.div`
 `;
 
 const Wrapper = styled.div`
-  margin: 0 auto 50px;
+  margin: 30px auto 50px;
   max-width: 350px;
 `;
 const isReasonForDelete = reason => reason === 'duplicate' || reason === 'entered-in-error';
@@ -34,6 +34,7 @@ export const CancelModal = React.memo(
             <BodyText>{bodyText}</BodyText>
             <Wrapper>
               <Field
+                required
                 component={SelectField}
                 label="Reason for cancellation"
                 name="reasonForCancellation"

--- a/packages/desktop/app/components/MenuButton.js
+++ b/packages/desktop/app/components/MenuButton.js
@@ -37,62 +37,64 @@ const List = styled(MenuList)`
   }
 `;
 
-export const MenuButton = React.memo(({ actions, className, iconDirection, iconColor }) => {
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef(null);
+export const MenuButton = React.memo(
+  ({ actions, className, iconDirection, iconColor, disabled = false }) => {
+    const [open, setOpen] = useState(false);
+    const anchorRef = useRef(null);
 
-  const handleClick = (event, action) => {
-    setOpen(false);
-    action(event);
-  };
+    const handleClick = (event, action) => {
+      setOpen(false);
+      action(event);
+    };
 
-  const handleToggle = () => {
-    setOpen(prevOpen => !prevOpen);
-  };
+    const handleToggle = () => {
+      setOpen(prevOpen => !prevOpen);
+    };
 
-  const handleClose = event => {
-    if (anchorRef.current && anchorRef.current.contains(event.target)) {
-      return;
-    }
-    setOpen(false);
-  };
+    const handleClose = event => {
+      if (anchorRef.current && anchorRef.current.contains(event.target)) {
+        return;
+      }
+      setOpen(false);
+    };
 
-  const Icon = iconDirection === 'vertical' ? MoreVertIcon : MoreHorizIcon;
+    const Icon = iconDirection === 'vertical' ? MoreVertIcon : MoreHorizIcon;
 
-  return (
-    <div className={className}>
-      <OpenButton onClick={handleToggle} ref={anchorRef}>
-        <Icon style={{ color: iconColor, cursor: 'pointer' }} />
-      </OpenButton>
-      <Popper
-        open={open}
-        anchorEl={anchorRef.current}
-        transition
-        disablePortal
-        placement="bottom-end"
-        style={{ zIndex: 10 }}
-      >
-        {() => (
-          <Paper id="menu-list-grow" variant="outlined">
-            <ClickAwayListener onClickAway={handleClose}>
-              <List>
-                {Object.entries(actions).map(([label, action]) => (
-                  <Item
-                    key={label}
-                    disabled={!action}
-                    onClick={event => handleClick(event, action)}
-                  >
-                    {label}
-                  </Item>
-                ))}
-              </List>
-            </ClickAwayListener>
-          </Paper>
-        )}
-      </Popper>
-    </div>
-  );
-});
+    return (
+      <div className={className}>
+        <OpenButton disabled={disabled} onClick={handleToggle} ref={anchorRef}>
+          <Icon style={{ color: iconColor, cursor: 'pointer' }} />
+        </OpenButton>
+        <Popper
+          open={open}
+          anchorEl={anchorRef.current}
+          transition
+          disablePortal
+          placement="bottom-end"
+          style={{ zIndex: 10 }}
+        >
+          {() => (
+            <Paper id="menu-list-grow" variant="outlined">
+              <ClickAwayListener onClickAway={handleClose}>
+                <List>
+                  {Object.entries(actions).map(([label, action]) => (
+                    <Item
+                      key={label}
+                      disabled={!action}
+                      onClick={event => handleClick(event, action)}
+                    >
+                      {label}
+                    </Item>
+                  ))}
+                </List>
+              </ClickAwayListener>
+            </Paper>
+          )}
+        </Popper>
+      </div>
+    );
+  },
+);
 
 MenuButton.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -71,19 +71,19 @@ const MODALS = {
   [MODAL_IDS.CANCEL]: LabRequestCancelModal,
 };
 
-const Menu = ({ setModal, status }) => {
+const Menu = ({ setModal, status, disabled }) => {
   const menuActions = {
     'Print label': () => {
-      setModal(MODALS.LABEL_PRINT);
+      setModal(MODAL_IDS.LABEL_PRINT);
     },
   };
 
   if (status !== LAB_REQUEST_STATUSES.PUBLISHED) {
     menuActions['Cancel request'] = () => {
-      setModal(MODALS.CANCEL);
+      setModal(MODAL_IDS.CANCEL);
     };
   }
-  return <MenuButton status={status} actions={menuActions} />;
+  return <MenuButton disabled={disabled} status={status} actions={menuActions} />;
 };
 
 export const LabRequestView = () => {
@@ -135,13 +135,14 @@ export const LabRequestView = () => {
         actions={
           <Box display="flex" alignItems="center">
             <OutlinedButton
+              disabled={isReadOnly}
               onClick={() => {
                 handleChangeModalId(MODAL_IDS.PRINT);
               }}
             >
               Print request
             </OutlinedButton>
-            <Menu setModal={handleChangeModalId} status={labRequest.status} />
+            <Menu setModal={handleChangeModalId} status={labRequest.status} disabled={isReadOnly} />
           </Box>
         }
       />
@@ -160,11 +161,12 @@ export const LabRequestView = () => {
               {LAB_REQUEST_STATUS_CONFIG[displayStatus]?.label || 'Unknown'}
             </TileTag>
           }
-          isReadOnly={isReadOnly}
           actions={{
-            'Change status': () => {
-              handleChangeModalId(MODAL_IDS.CHANGE_STATUS);
-            },
+            ...(!isReadOnly && {
+              'Change status': () => {
+                handleChangeModalId(MODAL_IDS.CHANGE_STATUS);
+              },
+            }),
             'View status log': () => {
               handleChangeModalId(MODAL_IDS.VIEW_STATUS_LOG);
             },
@@ -173,6 +175,7 @@ export const LabRequestView = () => {
         <Tile
           Icon={() => <img src={BeakerIcon} alt="beaker" />}
           text="Sample collected"
+          isReadOnly={isReadOnly}
           main={
             <>
               <DateDisplay date={labRequest.sampleTime} showTime />


### PR DESCRIPTION
### Changes
- Disable menu and print after cancelling a lab request
- Make so status log is still viewable after cancel
- Fix spacing of cancel modal and make field required
- Fix mistake with Modal id

Disabled actions with status log available
![Screenshot 2023-04-13 at 2 09 18 PM](https://user-images.githubusercontent.com/38335330/231628930-c7f35c50-0db9-49dd-8401-360c40507444.png)

Fixed spacing
![Screenshot 2023-04-13 at 2 09 12 PM](https://user-images.githubusercontent.com/38335330/231628957-c4da9652-fcfa-4e70-918a-951174c6beb3.png)

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
