### PR TITLE
NASS-649: Lab test panel name suggester

### DIFF
--- a/packages/lan/app/routes/apiv1/suggestions.js
+++ b/packages/lan/app/routes/apiv1/suggestions.js
@@ -322,3 +322,4 @@ createSuggester('patientLabTestPanelTypes', 'LabTestPanel', (search, query) => {
 
 // TODO: Use generic LabTest permissions for this suggester
 createAllRecordsSuggesterRoute('labTestPanel', 'LabTestPanel', VISIBILITY_CRITERIA);
+createNameSuggester('labTestPanel', 'LabTestPanel');


### PR DESCRIPTION
### Changes
- Lab test panels where missing a name suggester and it was possible to throw and error on returning to lab select page when panel was populated previously

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
