### PR TITLE
no-issue: remove reliance on success of death data fetch when displaying record death button

### DIFF
--- a/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
+++ b/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
@@ -147,13 +147,13 @@ export const PatientInfoPane = () => {
   const { getLocalisation } = useLocalisation();
   const patient = useSelector(state => state.patient);
   const api = useApi();
-  const { data: deathData, isSuccess } = useQuery(['patientDeathSummary', patient.id], () =>
+  const { data: deathData, isLoading } = useQuery(['patientDeathSummary', patient.id], () =>
     api.get(`patient/${patient.id}/death`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
   );
 
   const readonly = !!patient.death;
   const patientDeathsEnabled = getLocalisation('features.enablePatientDeaths');
-  const showRecordDeathActions = isSuccess && patientDeathsEnabled && !deathData?.isFinal;
+  const showRecordDeathActions = !isLoading && patientDeathsEnabled && !deathData?.isFinal;
   const showCauseOfDeathButton = showRecordDeathActions && Boolean(deathData);
 
   return (


### PR DESCRIPTION
### Changes
Issue that has only gone as far as dev

![Screenshot 2023-04-18 at 10 03 37 AM](https://user-images.githubusercontent.com/38335330/232621059-5ad841bf-23bb-4acf-a237-04a666257f3f.png)


### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
