### PR TITLE
SAV-160: "Not given" vaccines should be hidden if there's a corresponding "Given" vaccine on Desktop

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/lan/__tests__/apiv1/PatientVaccine.test.js
@@ -307,7 +307,7 @@ describe('PatientVaccine', () => {
       expect(encounter.departmentId).toEqual(department.id);
     });
 
-    it.only('Should update corresponding NOT_GIVEN vaccine to HISTORICAL if recording GIVEN vaccine', async () => {
+    it('Should update corresponding NOT_GIVEN vaccine to HISTORICAL if recording GIVEN vaccine', async () => {
       patient = await models.Patient.create(await createDummyPatient(models));
       const notGivenVaccine = await recordAdministeredVaccine(patient, scheduled1, {
         status: VACCINE_STATUS.NOT_GIVEN,

--- a/packages/lan/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/lan/__tests__/apiv1/PatientVaccine.test.js
@@ -28,11 +28,11 @@ describe('PatientVaccine', () => {
   let notGivenVaccine1 = null;
   let patient = null;
 
-  const administerVaccine = async (patientObject, vaccine, overrides) => {
+  const recordAdministeredVaccine = async (patientObject, vaccine, overrides) => {
     const encounter = await models.Encounter.create(
       await createDummyEncounter(models, { patientId: patientObject.id }),
     );
-    await models.AdministeredVaccine.create(
+    return models.AdministeredVaccine.create(
       await createAdministeredVaccine(models, {
         scheduledVaccineId: vaccine.id,
         encounterId: encounter.id,
@@ -126,7 +126,7 @@ describe('PatientVaccine', () => {
 
     // set up clinical data
     patient = await models.Patient.create(await createDummyPatient(models));
-    await administerVaccine(patient, scheduled2);
+    await recordAdministeredVaccine(patient, scheduled2);
   });
 
   afterAll(() => ctx.close());
@@ -199,8 +199,10 @@ describe('PatientVaccine', () => {
 
     it('Should include not given vaccines', async () => {
       const freshPatient = await models.Patient.create(await createDummyPatient(models));
-      await administerVaccine(freshPatient, scheduled1);
-      await administerVaccine(freshPatient, scheduled2, { status: VACCINE_STATUS.NOT_GIVEN });
+      await recordAdministeredVaccine(freshPatient, scheduled1);
+      await recordAdministeredVaccine(freshPatient, scheduled2, {
+        status: VACCINE_STATUS.NOT_GIVEN,
+      });
 
       const result = await app.get(
         `/v1/patient/${freshPatient.id}/administeredVaccines?includeNotGiven=true`,
@@ -303,6 +305,29 @@ describe('PatientVaccine', () => {
 
       expect(encounter.locationId).toEqual(location.id);
       expect(encounter.departmentId).toEqual(department.id);
+    });
+
+    it.only('Should update corresponding NOT_GIVEN vaccine to HISTORICAL if recording GIVEN vaccine', async () => {
+      patient = await models.Patient.create(await createDummyPatient(models));
+      const notGivenVaccine = await recordAdministeredVaccine(patient, scheduled1, {
+        status: VACCINE_STATUS.NOT_GIVEN,
+      });
+
+      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+        status: VACCINE_STATUS.GIVEN,
+        scheduledVaccineId: scheduled1.id,
+        recorderId: clinician.id,
+        date: new Date(),
+        givenBy: 'Clinician',
+      });
+
+      expect(result).toHaveSucceeded();
+
+      const givenVaccine = await models.AdministeredVaccine.findByPk(result.body.id);
+      const histocalVaccine = await models.AdministeredVaccine.findByPk(notGivenVaccine.id);
+
+      expect(givenVaccine.status).toEqual(VACCINE_STATUS.GIVEN);
+      expect(histocalVaccine.status).toEqual(VACCINE_STATUS.HISTORICAL);
     });
   });
 });

--- a/packages/lan/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/lan/__tests__/apiv1/PatientVaccine.test.js
@@ -307,7 +307,7 @@ describe('PatientVaccine', () => {
       expect(encounter.departmentId).toEqual(department.id);
     });
 
-    it('Should update corresponding NOT_GIVEN vaccine to HISTORICAL if recording GIVEN vaccine', async () => {
+    it('Should update corresponding NOT_GIVEN vaccine to HISTORICAL when recording GIVEN vaccine', async () => {
       patient = await models.Patient.create(await createDummyPatient(models));
       const notGivenVaccine = await recordAdministeredVaccine(patient, scheduled1, {
         status: VACCINE_STATUS.NOT_GIVEN,


### PR DESCRIPTION
### Changes
- "Not given" vaccines should be hidden if there's a corresponding "Given" vaccine on Desktop

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
