### PR TITLE
TAN-2166: Fix cultural name search

### DIFF
--- a/packages/lan/app/utils/patientFilters.js
+++ b/packages/lan/app/utils/patientFilters.js
@@ -31,7 +31,7 @@ export const createPatientFilters = filterParams => {
     makeFilter(
       filterParams.culturalName,
       `UPPER(patients.cultural_name) LIKE UPPER(:culturalName)`,
-      ({ culturalName }) => ({ culturalName: `${culturalName}%` }),
+      ({ culturalName }) => ({ culturalName: `%${culturalName}%` }),
     ),
     makeFilter(
       !filterParams.deceased || filterParams.deceased === 'false',


### PR DESCRIPTION
### Changes
- Enables the user to search for part of the text for the cultural name


Fix for the issue reported [here](https://linear.app/bes/issue/TAN-2166#comment-a4b5b325).

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
