### PR TITLE
TAN-2184: Mobile input color adjustments

### DIFF
--- a/packages/mobile/App/ui/components/DateField/DateField.tsx
+++ b/packages/mobile/App/ui/components/DateField/DateField.tsx
@@ -115,6 +115,7 @@ export const DateField = React.memo(
               flexDirection="row"
               justifyContent="space-between"
               paddingLeft={screenPercentageToDP(2.82, Orientation.Width)}
+              backgroundColor={theme.colors.WHITE}
             >
               <StyledText
                 fontSize={screenPercentageToDP(2.18, Orientation.Height)}

--- a/packages/mobile/App/ui/components/Forms/ResetPasswordForm/ResetPasswordFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/ResetPasswordForm/ResetPasswordFields.tsx
@@ -35,6 +35,7 @@ export const ResetPasswordFields = ({
         name="email"
         keyboardType="email-address"
         component={TextField}
+        labelColor={theme.colors.WHITE}
         label="Email"
       />
       <Field name="server" component={ServerSelector} label="Select a country" />

--- a/packages/mobile/App/ui/components/Forms/SignInForm.tsx
+++ b/packages/mobile/App/ui/components/Forms/SignInForm.tsx
@@ -109,6 +109,7 @@ export const SignInForm: FunctionComponent<any> = ({ onError, onSuccess }) => {
                 label="Email"
                 blurOnSubmit={false}
                 returnKeyType="next"
+                labelColor={theme.colors.WHITE}
                 onSubmitEditing={(): void => {
                   passwordRef.current.focus();
                 }}
@@ -120,6 +121,7 @@ export const SignInForm: FunctionComponent<any> = ({ onError, onSuccess }) => {
               autoCapitalize="none"
               component={TextField}
               label="Password"
+              labelColor={theme.colors.WHITE}
               secure
               onSubmitEditing={handleSubmit}
             />

--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -58,7 +58,7 @@ export const ServerSelector = ({ onChange, label, value }): ReactElement => {
   return (
     <>
       <StyledView marginBottom={10} height={screenPercentageToDP(4.86, Orientation.Height)}>
-        <InputContainer>
+        <InputContainer background={theme.colors.WHITE}>
           <StyledText
             color={theme.colors.TEXT_DARK}
             paddingTop={screenPercentageToDP(0.66, Orientation.Height)}

--- a/packages/mobile/App/ui/components/TextField/TextField.tsx
+++ b/packages/mobile/App/ui/components/TextField/TextField.tsx
@@ -37,6 +37,7 @@ export interface TextFieldProps extends BaseInputProps {
   blurOnSubmit?: boolean;
   inputRef?: RefObject<TextInput>;
   onSubmitEditing?: () => void;
+  labelColor?: string;
 }
 
 const styles = StyleSheet.create({
@@ -50,6 +51,7 @@ export const TextField = React.memo(
     value,
     onChange,
     label,
+    labelColor,
     error,
     keyboardType,
     multiline = false,
@@ -111,6 +113,7 @@ export const TextField = React.memo(
               focus={focused}
               onFocus={onFocusLabel}
               isValueEmpty={value !== ''}
+              labelColor={labelColor}
             >
               {label}
             </TextFieldLabel>

--- a/packages/mobile/App/ui/components/TextField/TextFieldLabel.tsx
+++ b/packages/mobile/App/ui/components/TextField/TextFieldLabel.tsx
@@ -16,7 +16,6 @@ interface AnimatedText {
 }
 
 const StyledAnimatedLabel = styled(StyledText) <AnimatedText>`
-  color: ${theme.colors.TEXT_SUPER_DARK};
   font-size: ${screenPercentageToDP(2.1, Orientation.Height)};
   font-weight: 600;
   padding-left: ${screenPercentageToDP(1, Orientation.Width)};
@@ -37,6 +36,7 @@ export const TextFieldLabel = ({
   onFocus,
   isValueEmpty,
   error,
+  labelColor,
 }: LabelProps): JSX.Element => {
 
   return (
@@ -44,6 +44,7 @@ export const TextFieldLabel = ({
       as={AnimatedLabel}
       onPress={(): void => onFocus(!focus)}
       pose="open"
+      style={{color: labelColor || theme.colors.TEXT_SUPER_DARK}}
     >
       {children}
     </StyledAnimatedLabel>

--- a/packages/mobile/App/ui/components/TextField/TextFieldLabel.tsx
+++ b/packages/mobile/App/ui/components/TextField/TextFieldLabel.tsx
@@ -28,6 +28,7 @@ interface LabelProps {
   isValueEmpty: boolean;
   error: string;
   onFocus: Function;
+  labelColor?: string;
 }
 
 export const TextFieldLabel = ({

--- a/packages/mobile/App/ui/navigation/screens/signup/FacilitySelectField.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/FacilitySelectField.tsx
@@ -62,6 +62,7 @@ export const FacilitySelectField = ({ options, onChange, value }): ReactElement 
           label="Filter facilities"
           value={currentFilter}
           onChange={setCurrentFilter}
+          labelColor={theme.colors.WHITE}
         />
       </StyledView>
       <ScrollView showsVerticalScrollIndicator>


### PR DESCRIPTION
### Changes

This issue was raised on the support channel where the text colour was black on the login screen for the "Email" and "Password" labels making them difficult to read. The background colour for the date input was also the same as the background which needed to be tweaked to match the rest of the inputs.

This PR adds a prop to the textfield that allows you to choose the colour of the label when declaring the input field

### Checklist

- [x] Code is finished
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
