### PR TITLE
SAV-142: Allow the modal to update on editing not given vax

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
+++ b/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
@@ -51,8 +51,10 @@ export const NewVaccineTabComponent = ({
         date,
         scheduledVaccine,
         encounter,
+        notGivenReasonId,
         ...otherValues
       } = values;
+
       const vaccineEncounter = await models.Encounter.getOrCreateCurrentEncounter(
         selectedPatient.id,
         user.id,
@@ -65,7 +67,10 @@ export const NewVaccineTabComponent = ({
         scheduledVaccine: scheduledVaccineId,
         recorder: recorderId,
         encounter: vaccineEncounter.id,
+        notGivenReasonId,
       });
+
+      const notGivenReason = await models.ReferenceData.findOne({ id: notGivenReasonId });
 
       if (values.administeredVaccine) {
         navigation.navigate(Routes.HomeStack.VaccineStack.VaccineModalScreen, {
@@ -75,7 +80,9 @@ export const NewVaccineTabComponent = ({
               ...updatedVaccine,
               encounter,
               scheduledVaccine,
+              notGivenReason,
             },
+            status: updatedVaccine.status,
           },
         });
       } else {


### PR DESCRIPTION
### Changes

This card was about fixing the mobile vaccine modal to update with the new details after submitting the edit form. Previously it would use navigation to go back and show the previous details from before the edit. 

This was fixed for vaccines with status "Given" but not the "Not given" vaccines. This pr just extends the logic to work when changing a vaccine to "Not given" and vice versa.
