### PR TITLE
NASS-645: Lab request form sampleTime use date_time string

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import * as yup from 'yup';
 import { LAB_REQUEST_FORM_TYPES, LAB_REQUEST_STATUSES } from 'shared/constants/labs';
-import { getCurrentDateString } from 'shared/utils/dateTime';
+import { getCurrentDateTimeString } from 'shared/utils/dateTime';
 import {
   AutocompleteField,
   DateTimeField,
@@ -81,7 +81,7 @@ export const LabRequestFormScreen1 = ({
     handleChange(event);
     const isSampleCollected = event.target.value === 'yes';
     if (isSampleCollected) {
-      setFieldValue('sampleTime', getCurrentDateString());
+      setFieldValue('sampleTime', getCurrentDateTimeString());
       setFieldValue('status', LAB_REQUEST_STATUSES.RECEPTION_PENDING);
     } else {
       setFieldValue('sampleTime', null);

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -151,7 +151,7 @@ export const LabRequestView = () => {
         <Tile
           Icon={() => <img src={TestCategoryIcon} alt="test category" />}
           text="Test Category"
-          main={labRequest.category?.name}
+          main={labRequest.category?.name || '-'}
         />
         <Tile
           Icon={Timelapse}
@@ -198,7 +198,7 @@ export const LabRequestView = () => {
         <Tile
           Icon={Business}
           text="Laboratory"
-          main={(labRequest.laboratory || {}).name || 'Unknown'}
+          main={labRequest.laboratory?.name || '-'}
           isReadOnly={isReadOnly}
           actions={{
             'Change laboratory': () => {
@@ -209,7 +209,7 @@ export const LabRequestView = () => {
         <Tile
           Icon={AssignmentLate}
           text="Priority"
-          main={(labRequest.priority || {}).name || 'Unknown'}
+          main={labRequest.priority?.name || '-'}
           isReadOnly={isReadOnly}
           actions={{
             'Change priority': () => {


### PR DESCRIPTION
### Changes
- sampleTime is a `date_time` column so time defaulted to 12:00 when set as `date` only
- replace `unknown` fallback with `-`
### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
