### PR TITLE
SAV-175: When reviewing the given vaccine in mobile it displays the 'Administer by' as 'Admin' instead of the value as 'Given by'

### DIFF
--- a/packages/mobile/App/ui/components/VaccineCard/GivenOnTimeFields.tsx
+++ b/packages/mobile/App/ui/components/VaccineCard/GivenOnTimeFields.tsx
@@ -10,13 +10,6 @@ import { formatStringDate } from '../../helpers/date';
 import { DateFormats } from '../../helpers/constants';
 
 const GivenOnTimeFields: FC<VaccineDataProps> = ({ administeredVaccine }) => {
-  const administeredBy =
-    typeof administeredVaccine.encounter !== 'string'
-      ? typeof administeredVaccine.encounter.examiner !== 'string'
-        ? administeredVaccine.encounter.examiner.displayName
-        : undefined
-      : undefined ?? 'Unknown';
-
   const location =
     typeof administeredVaccine.encounter !== 'string'
       ? typeof administeredVaccine.encounter.location !== 'string'
@@ -42,7 +35,7 @@ const GivenOnTimeFields: FC<VaccineDataProps> = ({ administeredVaccine }) => {
       <Separator />
       <ModalField label="Injection site" value={administeredVaccine.injectionSite || 'Unknown'} />
       <Separator />
-      <ModalField label="Administered By" value={administeredBy} />
+      <ModalField label="Administered By" value={administeredVaccine.givenBy} />
       <Separator />
       <ModalField label="Location" value={location} />
     </StyledView>

--- a/packages/mobile/App/ui/components/VaccineCard/GivenOnTimeFields.tsx
+++ b/packages/mobile/App/ui/components/VaccineCard/GivenOnTimeFields.tsx
@@ -35,7 +35,7 @@ const GivenOnTimeFields: FC<VaccineDataProps> = ({ administeredVaccine }) => {
       <Separator />
       <ModalField label="Injection site" value={administeredVaccine.injectionSite || 'Unknown'} />
       <Separator />
-      <ModalField label="Administered By" value={administeredVaccine.givenBy} />
+      <ModalField label="Administered By" value={administeredVaccine.givenBy || 'Unknown'} />
       <Separator />
       <ModalField label="Location" value={location} />
     </StyledView>


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
