### PR TITLE
EPI-453: Set lastUpdated to now() on rematerialisation unless keepLastUpdated option is given

### DIFF
--- a/packages/shared-src/src/models/fhir/DiagnosticReport/getValues.js
+++ b/packages/shared-src/src/models/fhir/DiagnosticReport/getValues.js
@@ -9,7 +9,6 @@ import {
   FhirIdentifier,
   FhirReference,
 } from '../../../services/fhirTypes';
-import { latestDateTime } from '../../../utils/dateTime';
 import { formatFhirDate } from '../../../utils/fhir';
 
 export async function getValues(upstream, models) {
@@ -25,16 +24,6 @@ async function getValuesFromLabTest(labTest) {
   const { patient, examiner } = encounter;
 
   return {
-    lastUpdated: latestDateTime(
-      labTest.updatedAt,
-      labRequest.updatedAt,
-      labTestType.updatedAt,
-      labTestMethod?.updatedAt,
-      encounter.updatedAt,
-      laboratory?.updatedAt,
-      patient.updatedAt,
-      examiner.updatedAt,
-    ),
     extension: extension(labTestMethod),
     identifier: identifiers(labRequest),
     status: status(labRequest),

--- a/packages/shared-src/src/models/fhir/Immunization/getValues.js
+++ b/packages/shared-src/src/models/fhir/Immunization/getValues.js
@@ -6,7 +6,6 @@ import {
   FhirImmunizationPerformer,
   FhirImmunizationProtocolApplied,
 } from '../../../services/fhirTypes';
-import { latestDateTime } from '../../../utils/dateTime';
 import { formatFhirDate } from '../../../utils/fhir';
 
 export async function getValues(upstream, models) {
@@ -21,14 +20,6 @@ async function getValuesFromAdministeredVaccine(administeredVaccine) {
   const { patient } = encounter;
 
   return {
-    lastUpdated: latestDateTime(
-      administeredVaccine?.updatedAt,
-      encounter?.updatedAt,
-      scheduledVaccine?.updatedAt,
-      recorder?.updatedAt,
-      scheduledVaccine?.vaccine?.updatedAt,
-      patient?.updatedAt,
-    ),
     status: status(administeredVaccine.status),
     vaccineCode: vaccineCode(scheduledVaccine),
     patient: patientReference(patient),

--- a/packages/shared-src/src/models/fhir/Patient/getValues.js
+++ b/packages/shared-src/src/models/fhir/Patient/getValues.js
@@ -2,7 +2,6 @@ import config from 'config';
 import { identity } from 'lodash';
 
 import { activeFromVisibility } from '../utils';
-import { latestDateTime } from '../../../utils/dateTime';
 import { FHIR_DATETIME_PRECISION } from '../../../constants';
 import {
   FhirAddress,
@@ -38,7 +37,6 @@ async function getValuesFromPatient(upstream) {
     deceasedDateTime: formatFhirDate(upstream.dateOfDeath, FHIR_DATETIME_PRECISION.DAYS),
     address: addresses(upstream),
     link: await mergeLinks(upstream),
-    lastUpdated: latestDateTime(upstream.updatedAt, upstream.additionalData?.updatedAt),
   };
 }
 

--- a/packages/shared-src/src/models/fhir/Resource.js
+++ b/packages/shared-src/src/models/fhir/Resource.js
@@ -89,7 +89,15 @@ export class FhirResource extends Model {
       });
     }
 
+    const { lastUpdated } = resource;
     await resource.updateMaterialisation();
+
+    if (options?.keepLastUpdated) {
+      resource.set({ lastUpdated });
+    } else {
+      resource.set({ lastUpdated: Sequelize.fn('NOW') });
+    }
+
     await resource.save();
 
     // don't look up related records if we're already in the process of doing so

--- a/packages/shared-src/src/models/fhir/Resource.js
+++ b/packages/shared-src/src/models/fhir/Resource.js
@@ -74,7 +74,7 @@ export class FhirResource extends Model {
 
   // set upstream_id, call updateMaterialisation
   // do not set relatedToId when calling this, it's for internal use only.
-  static async materialiseFromUpstream(id, relatedToId = null) {
+  static async materialiseFromUpstream(id, options = {}, relatedToId = null) {
     let resource = await this.findOne({
       where: {
         upstreamId: id,
@@ -100,7 +100,7 @@ export class FhirResource extends Model {
       for (const relatedId of await resource.getRelatedUpstreamIds()) {
         if (relatedId === id) continue;
         if (relatedId === relatedToId) continue;
-        await this.materialiseFromUpstream(relatedId, id);
+        await this.materialiseFromUpstream(relatedId, options, id);
       }
     }
 

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
@@ -1,6 +1,5 @@
 import config from 'config';
 
-import { latestDateTime } from '../../../utils/dateTime';
 import {
   FhirAnnotation,
   FhirCodeableConcept,
@@ -42,16 +41,6 @@ async function getValuesFromImagingRequest(upstream, models) {
   );
 
   return {
-    lastUpdated: latestDateTime(
-      upstream.updatedAt,
-      upstream.requestedBy?.updatedAt,
-      upstream.encounter?.updatedAt,
-      upstream.encounter?.patient?.updatedAt,
-      upstream.location?.updatedAt,
-      upstream.location?.facility?.updatedAt,
-      ...upstream.areas.map(area => area.updatedAt),
-      ...[...areaExtCodes.values()].map(ext => ext.updatedAt),
-    ),
     identifier: [
       new FhirIdentifier({
         system: config.hl7.dataDictionaries.serviceRequestImagingId,
@@ -110,18 +99,6 @@ async function getValuesFromImagingRequest(upstream, models) {
 
 async function getValuesFromLabRequest(upstream) {
   return {
-    lastUpdated: latestDateTime(
-      upstream.updatedAt,
-      upstream.requestedBy?.updatedAt,
-      upstream.encounter?.updatedAt,
-      upstream.encounter?.patient?.updatedAt,
-      upstream.labTestPanelRequest?.labTestPanel?.updatedAt,
-      ...upstream.tests.map(test => test.updatedAt),
-      ...upstream.notePages.map(notePage => notePage.updatedAt),
-      ...upstream.notePages.flatMap(notePage =>
-        notePage.noteItems.map(noteItem => noteItem.updatedAt),
-      ),
-    ),
     contained: labContained(upstream),
     identifier: [
       new FhirIdentifier({

--- a/packages/shared-src/src/utils/dateTime.js
+++ b/packages/shared-src/src/utils/dateTime.js
@@ -125,12 +125,6 @@ export function ageInYears(dob) {
   return differenceInYears(new Date(), new Date(dob));
 }
 
-export function latestDateTime(...args) {
-  const times = args.filter(x => x);
-  times.sort(compareDesc);
-  return times[0];
-}
-
 /*
  * date-fns wrappers
  * Wrapper functions around date-fns functions that parse date_string and date_time_string types

--- a/packages/sync-server/app/hl7fhir/materialised/bundle.js
+++ b/packages/sync-server/app/hl7fhir/materialised/bundle.js
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { latestDateTime } from 'shared/utils/dateTime';
 import { formatFhirDate } from 'shared/utils/fhir/datetime';
 
 import { getBaseUrl, getHL7Link } from '../utils';
@@ -18,19 +17,18 @@ export class Bundle {
   }
 
   asFhir() {
+    const timestamp = formatFhirDate(new Date());
     const fields = {
       resourceType: 'Bundle',
       id: uuidv4(),
       type: this.type,
-      timestamp: formatFhirDate(new Date()),
+      timestamp,
+      meta: {
+        // LEGACY: not explicitly required in the spec, and redundant with timestamp.
+        // Candidate for removal at next version.
+        lastUpdated: timestamp,
+      },
     };
-
-    const latestUpdated = latestDateTime(...this.resources.map(r => new Date(r.lastUpdated)));
-    if (latestUpdated) {
-      fields.meta = {
-        lastUpdated: formatFhirDate(latestUpdated),
-      };
-    }
 
     if (typeof this.options.total === 'number') {
       fields.total = this.options.total;

--- a/packages/sync-server/app/tasks/fhir/refresh/allFromUpstream.js
+++ b/packages/sync-server/app/tasks/fhir/refresh/allFromUpstream.js
@@ -5,7 +5,7 @@ import { resourcesThatCanDo } from 'shared/utils/fhir/resources';
 const materialisableResources = resourcesThatCanDo(FHIR_INTERACTIONS.INTERNAL.MATERIALISE);
 
 export async function allFromUpstream({ payload }, { log, sequelize }) {
-  const { table, op, id, deletedRow = null } = payload;
+  const { table, op, id, deletedRow = null, options = {} } = payload;
   const [schema, tableName] = table.toLowerCase().split('.', 2);
 
   const resources = materialisableResources.filter(resource =>
@@ -64,7 +64,8 @@ export async function allFromUpstream({ payload }, { log, sequelize }) {
             'resource', $resource::text,
             'upstreamId', upstreams.id,
             'table', $table::text,
-            'op', $op::text
+            'op', $op::text,
+            'options', $options::jsonb
           )
         FROM upstreams
         ON CONFLICT (discriminant) DO NOTHING
@@ -77,6 +78,7 @@ export async function allFromUpstream({ payload }, { log, sequelize }) {
           resource: Resource.fhirName,
           table,
           op,
+          options,
         },
       });
       if (!results) {

--- a/packages/sync-server/app/tasks/fhir/refresh/entireResource.js
+++ b/packages/sync-server/app/tasks/fhir/refresh/entireResource.js
@@ -3,7 +3,7 @@ import { resourcesThatCanDo } from 'shared/utils/fhir/resources';
 
 const materialisableResources = resourcesThatCanDo(FHIR_INTERACTIONS.INTERNAL.MATERIALISE);
 
-export async function entireResource({ payload: { resource } }, { log, sequelize }) {
+export async function entireResource({ payload: { resource, options = {} } }, { log, sequelize }) {
   log.debug('Finding resource by name', { resource });
   const Resource = materialisableResources.find(({ fhirName }) => fhirName === resource);
   if (!Resource) {
@@ -27,13 +27,15 @@ export async function entireResource({ payload: { resource } }, { log, sequelize
           $topic::text as topic,
           json_build_object(
             'resource', $resource::text,
-            'upstreamId', id
+            'upstreamId', id,
+            'options', $options::jsonb
           ) as payload
         FROM ${UpstreamModel.tableName}`,
       {
         bind: {
           topic: JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM,
           resource,
+          options,
         },
       },
     );

--- a/packages/sync-server/app/tasks/fhir/refresh/fromUpstream.js
+++ b/packages/sync-server/app/tasks/fhir/refresh/fromUpstream.js
@@ -4,7 +4,7 @@ import { resourcesThatCanDo } from 'shared/utils/fhir/resources';
 const materialisableResources = resourcesThatCanDo(FHIR_INTERACTIONS.INTERNAL.MATERIALISE);
 
 export async function fromUpstream(
-  { payload: { resource, upstreamId } },
+  { payload: { resource, upstreamId, options = {} } },
   { log, models: { FhirJob } },
 ) {
   log.debug('Finding resource by name', { resource });
@@ -14,12 +14,13 @@ export async function fromUpstream(
   }
 
   log.debug('Starting materialise', { resource, upstreamId });
-  const result = await Resource.materialiseFromUpstream(upstreamId);
+  const result = await Resource.materialiseFromUpstream(upstreamId, options);
   log.debug('Done materialising', {
     resource,
     upstreamId,
     resourceId: result.id,
     versionId: result.versionId,
+    options,
   });
 
   await FhirJob.submit(


### PR DESCRIPTION
### Changes

- Add an `options` field to the payloads of rematerialisation jobs
- Pass through that field's value to "child jobs" (i.e. `fhir.refresh.fromUpstream` jobs created from `fhir.refresh.allFromUpstream` and `fhir.refresh.entireResource` jobs)
- Always set the `lastUpdated` when rematerialising:
  - By default, to `NOW()`;
  - When the `keepLastUpdated` job option is `true`, to the existing value.
- Cleanups from those changes.

### Checklist

- [x] Code is finished
- [ ] Subcommand is adjusted (to provide the option)
- [ ] Tests are written
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)