### PR TITLE
EPI-164: Add missing spots

### DIFF
--- a/packages/shared-src/src/migrations/1682638735334-removeConstraintFromServiceRequests.js
+++ b/packages/shared-src/src/migrations/1682638735334-removeConstraintFromServiceRequests.js
@@ -1,0 +1,17 @@
+const TABLE = { schema: 'fhir', tableName: 'service_requests' };
+
+export async function up(query) {
+  await query.removeConstraint(TABLE, 'service_requests_imaging_request_id_fkey');
+}
+
+export async function down(query) {
+  await query.addConstraint(TABLE, {
+    type: 'foreign key',
+    name: 'service_requests_imaging_request_id_fkey',
+    fields: ['upstream_id'],
+    references: {
+      table: 'imaging_requests',
+      field: 'id',
+    },
+  });
+}

--- a/packages/shared-src/src/models/fhir/ServiceRequest/FhirServiceRequest.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/FhirServiceRequest.js
@@ -51,6 +51,13 @@ export class FhirServiceRequest extends FhirResource {
       models.Patient,
       models.ReferenceData,
       models.User,
+      models.LabRequest,
+      models.LabTest,
+      models.LabTestType,
+      models.LabTestPanelRequest,
+      models.LabTestPanel,
+      models.NotePage,
+      models.NoteItem,
     ];
   }
 

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
@@ -269,8 +269,9 @@ function labContained(upstream) {
 
 function labOrderDetails(upstream) {
   return upstream.tests.map(test => {
-    const labTestType = test?.labTestType || {};
-    const { externalCode, name } = labTestType;
+    if (!test) throw new Exception('Received a null test');
+    
+    const { externalCode, name } = test.labTestType;
     if (!externalCode) throw new Error('No external code specified for this lab test type.');
 
     return new FhirCodeableConcept({

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
@@ -241,7 +241,8 @@ function statusFromLabRequest(upstream) {
 }
 
 function labCode(upstream) {
-  const { externalCode, name } = upstream?.labTestPanelRequest?.labTestPanel;
+  const labTestPanel = upstream?.labTestPanelRequest?.labTestPanel || {};
+  const { externalCode, name } = labTestPanel;
   if (!externalCode) throw new Error('No external code specified for this lab test panel.');
 
   return new FhirCodeableConcept({
@@ -268,7 +269,8 @@ function labContained(upstream) {
 
 function labOrderDetails(upstream) {
   return upstream.tests.map(test => {
-    const { externalCode, name } = test?.labTestType;
+    const labTestType = test?.labTestType || {};
+    const { externalCode, name } = labTestType;
     if (!externalCode) throw new Error('No external code specified for this lab test type.');
 
     return new FhirCodeableConcept({

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
@@ -270,7 +270,7 @@ function labContained(upstream) {
 function labOrderDetails(upstream) {
   return upstream.tests.map(test => {
     if (!test) throw new Exception('Received a null test');
-    
+
     const { externalCode, name } = test.labTestType;
     if (!externalCode) throw new Error('No external code specified for this lab test type.');
 

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getValues.js
@@ -241,8 +241,9 @@ function statusFromLabRequest(upstream) {
 }
 
 function labCode(upstream) {
-  const labTestPanel = upstream?.labTestPanelRequest?.labTestPanel || {};
-  const { externalCode, name } = labTestPanel;
+  const { labTestPanelRequest } = upstream;
+  if (!labTestPanelRequest) throw new Error('No lab test panel request specified.');
+  const { externalCode, name } = labTestPanelRequest.labTestPanel;
   if (!externalCode) throw new Error('No external code specified for this lab test panel.');
 
   return new FhirCodeableConcept({


### PR DESCRIPTION
### Changes

Checking why the lab requests were not being materialised I noticed that:

- Model upstreams were missing (the ones that are new because of lab requests).
- Not possible to de-structure stuff created errors
- Currently the service requests table has a foreign key relation in upstream ID, this needs to be undone in order for us to save lab requests IDs there too.