### PR TITLE
SAV-131: Vaccine view modal fixes

### DIFF
--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -149,7 +149,7 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
       name: 'routineOverseas',
       condition: routine && !notGiven && givenElsewhere,
       fields: [
-        ...(editMode ? [] : [fieldObjects.status]),
+        ...(editMode ? [] : [[fieldObjects.status]]),
         [
           fieldObjects.vaccine,
           fieldObjects.schedule,

--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -196,7 +196,7 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
       name: 'otherOverseas',
       condition: !routine && !notGiven && givenElsewhere,
       fields: [
-        ...(editMode ? [] : [fieldObjects.status]),
+        ...(editMode ? [] : [[fieldObjects.status]]),
         [
           fieldObjects.vaccineName,
           ...(editMode

--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -87,6 +87,7 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
     disease,
     givenElsewhere,
     notGivenReason,
+    encounter,
   } = vaccineRecord;
 
   const routine = !vaccineName;
@@ -102,7 +103,10 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
     area: { label: 'Area', value: location?.locationGroup?.name || '-' },
     location: { label: 'Location', value: location?.name || '-' },
     department: { label: 'Department', value: department?.name || '-' },
-    facility: { label: 'Facility', value: location?.facility.name || '-' },
+    facility: {
+      label: 'Facility',
+      value: location?.facility.name || encounter.location.facility.name || '-',
+    },
     givenBy: { label: 'Given by', value: givenBy || '-' },
     supervisingClinician: { label: 'Supervising clincian', value: givenBy || '-' },
     recordedBy: { label: 'Recorded by', value: recorder?.displayName || '-' },


### PR DESCRIPTION
### Changes

This is a small bug fix for an issue that was throwing an error whenever you opened an elsewhere vaccine.

I have also added some logic to fetch the facility of the encounter for the vaccine if no location exists (if the user adds an other vaccine) as this was previously showing up with an empty value when viewing the vaccine modal