### PR TITLE
EPI-451: Add notes to FHIR (RISPACs) ServiceRequest

### DIFF
--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -12,7 +12,7 @@ import {
 } from 'shared/constants';
 import { NotFoundError } from 'shared/errors';
 import { toDateTimeString } from 'shared/utils/dateTime';
-import { getNoteWithType } from 'shared/utils/notePages';
+import { getNotePageWithType } from 'shared/utils/notePages';
 import { mapQueryFilters } from '../../database/utils';
 import { permissionCheckingRouter } from './crudHelpers';
 import { getImagingProvider } from '../../integrations/imaging';
@@ -163,8 +163,8 @@ imagingRequest.put(
       where: { visibilityStatus: VISIBILITY_STATUSES.CURRENT },
     });
 
-    const otherNotePage = getNoteWithType(relatedNotePages, NOTE_TYPES.OTHER);
-    const areaNotePage = getNoteWithType(relatedNotePages, NOTE_TYPES.AREA_TO_BE_IMAGED);
+    const otherNotePage = getNotePageWithType(relatedNotePages, NOTE_TYPES.OTHER);
+    const areaNotePage = getNotePageWithType(relatedNotePages, NOTE_TYPES.AREA_TO_BE_IMAGED);
 
     const notes = {
       note: '',

--- a/packages/shared-src/src/models/ImagingRequest.js
+++ b/packages/shared-src/src/models/ImagingRequest.js
@@ -7,7 +7,7 @@ import {
   NOTE_TYPES,
   VISIBILITY_STATUSES,
 } from 'shared/constants';
-import { getNoteWithType } from 'shared/utils/notePages';
+import { getNotePageWithType } from 'shared/utils/notePages';
 
 import { Model } from './Model';
 import { buildEncounterLinkedSyncFilter } from './buildEncounterLinkedSyncFilter';
@@ -85,7 +85,7 @@ export class ImagingRequest extends Model {
         include: [{ association: 'noteItems' }],
       }));
     const extractWithType = async type => {
-      const notePage = getNoteWithType(notePages, type);
+      const notePage = getNotePageWithType(notePages, type);
       if (!notePage) {
         return '';
       }

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getQueryOptions.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getQueryOptions.js
@@ -56,6 +56,16 @@ export function getQueryOptions(models) {
           },
         ],
       },
+      {
+        model: NotePage,
+        as: 'notePages',
+        include: [
+          {
+            model: NoteItem,
+            as: 'noteItems',
+          },
+        ],
+      },
     ],
   };
 

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getQueryToFindUpstreamIds.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getQueryToFindUpstreamIds.js
@@ -9,7 +9,6 @@ export function fromImagingRequests(models, table, id) {
     Facility,
     Location,
     LocationGroup,
-    Patient,
     ReferenceData,
     User,
   } = models;
@@ -23,16 +22,6 @@ export function fromImagingRequests(models, table, id) {
           {
             model: ImagingRequestArea,
             as: 'areas',
-            where: { id },
-          },
-        ],
-      };
-    case Encounter.tableName:
-      return {
-        include: [
-          {
-            model: Encounter,
-            as: 'encounter',
             where: { id },
           },
         ],
@@ -85,22 +74,6 @@ export function fromImagingRequests(models, table, id) {
               {
                 model: LocationGroup,
                 as: 'locationGroup',
-                where: { id },
-              },
-            ],
-          },
-        ],
-      };
-    case Patient.tableName:
-      return {
-        include: [
-          {
-            model: Encounter,
-            as: 'encounter',
-            include: [
-              {
-                model: Patient,
-                as: 'patient',
                 where: { id },
               },
             ],
@@ -162,23 +135,12 @@ export function fromImagingRequests(models, table, id) {
         },
       };
     default:
-      return null;
+      return fromBoth(models, table, id);
   }
 }
 
 export function fromLabRequests(models, table, id) {
-  const {
-    LabRequest,
-    LabTest,
-    LabTestType,
-    LabTestPanelRequest,
-    LabTestPanel,
-    NotePage,
-    NoteItem,
-    Encounter,
-    Patient,
-    User,
-  } = models;
+  const { LabRequest, LabTest, LabTestType, LabTestPanelRequest, LabTestPanel, User } = models;
 
   switch (table) {
     case LabRequest.tableName:
@@ -235,6 +197,25 @@ export function fromLabRequests(models, table, id) {
           },
         ],
       };
+    case User.tableName:
+      return {
+        include: [
+          {
+            model: User,
+            as: 'requestedBy',
+            where: { id },
+          },
+        ],
+      };
+    default:
+      return fromBoth(models, table, id);
+  }
+}
+
+function fromBoth(models, table, id) {
+  const { NotePage, NoteItem, Encounter, Patient } = models;
+
+  switch (table) {
     case NotePage.tableName:
       return {
         include: [
@@ -284,16 +265,6 @@ export function fromLabRequests(models, table, id) {
                 where: { id },
               },
             ],
-          },
-        ],
-      };
-    case User.tableName:
-      return {
-        include: [
-          {
-            model: User,
-            as: 'requestedBy',
-            where: { id },
           },
         ],
       };

--- a/packages/shared-src/src/utils/notePages.js
+++ b/packages/shared-src/src/utils/notePages.js
@@ -1,10 +1,20 @@
 /*
-Returns the first note (Sequelize Model) with the specified
-noteType or undefined.
+Returns the first NotePage (Sequelize model instance) with the specified noteType, or undefined.
 
 notes: Array<SequelizeModel>
 noteType: string
 */
-export const getNoteWithType = (notes, noteType) => {
-  return notes.filter(note => note.noteType === noteType)[0];
+export const getNotePageWithType = (notes, noteType) => {
+  return getNotePagesWithType(notes, noteType)[0];
+};
+
+/*
+Returns all NotePages (Sequelize model instances) with the specified noteType, which may be an empty
+array.
+
+notes: Array<SequelizeModel>
+noteType: string
+*/
+export const getNotePagesWithType = (notes, noteType) => {
+  return notes.filter(note => note.noteType === noteType);
 };


### PR DESCRIPTION
### Changes

Populates the `note` field in a `FhirServiceRequest` when the upstream is an `ImagingRequest`. Turns out we can mostly reuse the `LabRequest` work and there's no workaround necessary to include a `NotePage` 😬 

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
