### PR TITLE
TAV-540: Linux-based production container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 
 WORKDIR /app
 ENV NODE_ENV=production
-COPY package.json yarn.lock .yarnrc ./
+COPY package.json yarn.lock .yarnrc common.* babel.config.js license scripts/docker-build-server.sh ./
 
 
 # Build the shared sources only

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@
 ### - the CodeShip containers, at Dockerfile.codeship and Dockerfile.deploy
 ### - the development containers, at packages/*/docker/Dockerfile
 
+## Build the base system and image setup
 FROM node:16-alpine AS base
 RUN apk add --no-cache \
     --virtual .build-deps \
     make \
     gcc \
     g++ \
-    python \
+    python3 \
+    bash \
     jq
 
 WORKDIR /app
@@ -16,67 +18,46 @@ ENV NODE_ENV=production
 COPY package.json yarn.lock .yarnrc common.* babel.config.js license scripts/docker-build-server.sh ./
 
 
-# Build the shared sources only
-FROM base as shared
-RUN mkdir -p packages/shared-src
-COPY packages/shared-src/ packages/shared-src/
-RUN true \
-    && yarn install --non-interactive --frozen-lockfile \
-    && yarn build-shared
-# We don't bother cleaning up, as we're only going to copy the parts we want.
-# This means that other packages can't depend directly on shared-src; they
-# shouldn't anyway but this makes it a hard requirement.
-
-
-# Build the central server
+## Build the central server
 FROM base as central
-LABEL tamanu.product=central
+# this first one is commented to explain, the next two are the same so compacted
+
 # this label makes it possible to build and tag all images in one step
+LABEL tamanu.product=central
 
-# Start with just the package.json and shared packages, for caching purposes
-RUN mkdir -p packages/sync-server
-COPY packages/sync-server/package.json packages/sync-server/
-COPY --from=shared packages/shared packages/
-RUN true \
-    && yarn install --non-interactive --frozen-lockfile \
-    && yarn cache clean
-
-# Actually build now
+# copy sources
+COPY packages/build-tooling/ packages/build-tooling/
+COPY packages/shared/ packages/shared/
 COPY packages/sync-server/ packages/sync-server/
-RUN yarn workspace sync-server build
+
+# do the actual build
+RUN ./docker-build-server.sh sync-server && rm ./docker-build-server.sh
+
+# set the runtime
+WORKDIR /app/packages/sync-server
 ENTRYPOINT ["node", "dist/app.bundle.js"]
-CMD "serve"
+CMD ["serve"]
 
 
-# Build the facility server
+## Build the facility server
 FROM base as facility
 LABEL tamanu.product=facility
-
-RUN mkdir -p packages/lan
-COPY packages/lan/package.json packages/lan/
-COPY --from=shared packages/shared packages/
-RUN true \
-    && yarn install --non-interactive --frozen-lockfile \
-    && yarn cache clean
-
+COPY packages/build-tooling/ packages/build-tooling/
+COPY packages/shared/ packages/shared/
 COPY packages/lan/ packages/lan/
-RUN yarn workspace lan build
+RUN ./docker-build-server.sh lan && rm ./docker-build-server.sh
+WORKDIR /app/packages/lan
 ENTRYPOINT ["node", "dist/app.bundle.js"]
-CMD "serve"
+CMD ["serve"]
 
 
-# Build the meta server
+## Build the meta server
 FROM base as meta
 LABEL tamanu.product=meta
-
-RUN mkdir -p packages/meta-server
-COPY packages/meta-server/package.json packages/meta-server/
-COPY --from=shared packages/shared packages/
-RUN true \
-    && yarn install --non-interactive --frozen-lockfile \
-    && yarn cache clean
-
+COPY packages/build-tooling/ packages/build-tooling/
+COPY packages/shared/ packages/shared/
 COPY packages/meta-server/ packages/meta-server/
-RUN yarn workspace meta-server build
+RUN ./docker-build-server.sh meta-server && rm ./docker-build-server.sh
+WORKDIR /app/packages/meta-server
 ENTRYPOINT ["node", "dist/app.bundle.js"]
-CMD "serve"
+CMD ["serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,82 @@
+### This is the production-grade Linux container. You may be looking for:
+### - the CodeShip containers, at Dockerfile.codeship and Dockerfile.deploy
+### - the development containers, at packages/*/docker/Dockerfile
+
+FROM node:16-alpine AS base
+RUN apk add --no-cache \
+    --virtual .build-deps \
+    make \
+    gcc \
+    g++ \
+    python \
+    jq
+
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json yarn.lock .yarnrc ./
+
+
+# Build the shared sources only
+FROM base as shared
+RUN mkdir -p packages/shared-src
+COPY packages/shared-src/ packages/shared-src/
+RUN true \
+    && yarn install --non-interactive --frozen-lockfile \
+    && yarn build-shared
+# We don't bother cleaning up, as we're only going to copy the parts we want.
+# This means that other packages can't depend directly on shared-src; they
+# shouldn't anyway but this makes it a hard requirement.
+
+
+# Build the central server
+FROM base as central
+LABEL tamanu.product=central
+# this label makes it possible to build and tag all images in one step
+
+# Start with just the package.json and shared packages, for caching purposes
+RUN mkdir -p packages/sync-server
+COPY packages/sync-server/package.json packages/sync-server/
+COPY --from=shared packages/shared packages/
+RUN true \
+    && yarn install --non-interactive --frozen-lockfile \
+    && yarn cache clean
+
+# Actually build now
+COPY packages/sync-server/ packages/sync-server/
+RUN yarn workspace sync-server build
+ENTRYPOINT ["node", "dist/app.bundle.js"]
+CMD "serve"
+
+
+# Build the facility server
+FROM base as facility
+LABEL tamanu.product=facility
+
+RUN mkdir -p packages/lan
+COPY packages/lan/package.json packages/lan/
+COPY --from=shared packages/shared packages/
+RUN true \
+    && yarn install --non-interactive --frozen-lockfile \
+    && yarn cache clean
+
+COPY packages/lan/ packages/lan/
+RUN yarn workspace lan build
+ENTRYPOINT ["node", "dist/app.bundle.js"]
+CMD "serve"
+
+
+# Build the meta server
+FROM base as meta
+LABEL tamanu.product=meta
+
+RUN mkdir -p packages/meta-server
+COPY packages/meta-server/package.json packages/meta-server/
+COPY --from=shared packages/shared packages/
+RUN true \
+    && yarn install --non-interactive --frozen-lockfile \
+    && yarn cache clean
+
+COPY packages/meta-server/ packages/meta-server/
+RUN yarn workspace meta-server build
+ENTRYPOINT ["node", "dist/app.bundle.js"]
+CMD "serve"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN apk add --no-cache \
 COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh ./
 
 FROM base AS run-base
+RUN apk add --no-cache bash
 # set the runtime options
-ENTRYPOINT ["node", "dist/app.bundle.js"]
+COPY scripts/docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["serve"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,7 @@ COPY --from=build-server /app/node_modules/ node_modules/
 
 # set the working directory, which is where the entrypoint will run
 WORKDIR /app/packages/${PACKAGE_PATH}
+
+# explicitly reconfigure the port
+RUN echo '{"port":3000}' > config/local.json
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
 COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh ./
 
 FROM base AS run-base
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash curl jq
 # set the runtime options
 COPY scripts/docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY packages/shared/ packages/shared/
 RUN ./docker-build-server.sh
 
 
-## Build the central server
+## Build the target server
 FROM build-base as build-server
 ARG PACKAGE_PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN ./docker-build-server.sh sync-server
 # restart from a fresh base without the build tools
 FROM run-base as central
 
-# this label makes it possible to build and tag all images in one step
+# this label makes it possible to discover what an image is without relying on tags
 LABEL tamanu.product=central
 
 # copy the built packages and their deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM node:16-alpine AS base
 WORKDIR /app
 ENV NODE_ENV=production
-COPY package.json yarn.lock .yarnrc common.* babel.config.js license scripts/docker-build-server.sh ./
+COPY package.json license ./
 
 FROM base AS build-base
 RUN apk add --no-cache \
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     python3 \
     bash \
     jq
+COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh ./
 
 FROM base AS run-base
 # set the runtime options

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh .
 FROM base AS run-base
 RUN apk add --no-cache bash curl jq
 # set the runtime options
-COPY scripts/docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY scripts/docker-entrypoint.sh /entrypoint
+ENTRYPOINT ["/entrypoint"]
 CMD ["serve"]
 
 

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -3,7 +3,7 @@
 ### This expects to be run in the production docker build in /Dockerfile.
 
 set -euxo pipefail
-package="${1:?package name is required}"
+package="${1:-}"
 
 # save the original package.jsons
 cp package.json{,.orig}
@@ -14,19 +14,26 @@ jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json.orig > package.js
 # install dependencies
 yarn install --non-interactive --frozen-lockfile
 
-# build the shared package
-yarn workspace @tamanu/shared build
-
-# build the server package
-yarn workspace "$package" build
+# if we're building a server package, the shared stage will bring in the builds,
+# so we don't need to build shared here, and in the shared stage we don't build
+# the server packages, hence this neat branching logic here
+if [ -z "$package" ]; then
+  yarn workspace @tamanu/shared build
+else
+  yarn workspace "$package" build
+fi
 
 # restore the top level package.json
 mv package.json{.orig,}
 
-# clear out the build-tooling
-rm -rf node_modules/@tamanu/build-tooling
-rm -rf packages/**/node_modules/@tamanu/build-tooling
-rm -rf packages/build-tooling
+# clear out the build-tooling when building a server package
+# otherwise we assume we're building the shared stage, and want to keep these
+if ! [ -z "$package" ]; then
+  rm -rf node_modules/@tamanu/build-tooling
+  rm -rf packages/**/node_modules/@tamanu/build-tooling
+  rm -rf packages/build-tooling
+fi
 
 # cleanup
 yarn cache clean
+rm $0

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 shopt -s extglob
 package="${1:-}"
 
-is_building_server() {
+is_building_shared() {
   # we use a function instead of a variable as we're relying on the exit value
   # -z = true if the string is empty
   test -z "$package"
@@ -27,7 +27,7 @@ yarn install --non-interactive --frozen-lockfile
 # if we're building a server package, the shared stage will bring in the builds,
 # so we don't need to build shared here, and in the shared stage we don't build
 # the server packages, hence this neat branching logic here
-if is_building_server; then
+if is_building_shared; then
   yarn workspace @tamanu/shared build
 else
   # clear out the tests and files not useful for production
@@ -44,7 +44,7 @@ fi
 # otherwise we assume we're building the shared stage, and we either want to
 # keep some of these, or we don't care to clean up as the multi-staging will
 # take care of skipping the cruft anyway
-if ! is_building_server; then
+if ! is_building_shared; then
   # clear out the build-tooling
   rm -rf node_modules/@tamanu/build-tooling
   rm -rf packages/build-tooling

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+### This expects to be run in the production docker build in /Dockerfile.
+
+set -euxo pipefail
+package="${1:?package name is required}"
+
+# save the original package.jsons
+cp package.json{,.orig}
+
+# let build-tooling be installed in prod mode
+jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json.orig > package.json
+
+# install dependencies
+yarn install --non-interactive --frozen-lockfile
+
+# build the shared package
+yarn workspace @tamanu/shared build
+
+# build the server package
+yarn workspace "$package" build
+
+# restore the top level package.json
+mv package.json{.orig,}
+
+# clear out the build-tooling
+rm -rf node_modules/@tamanu/build-tooling
+rm -rf packages/**/node_modules/@tamanu/build-tooling
+rm -rf packages/build-tooling
+
+# cleanup
+yarn cache clean

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -20,6 +20,12 @@ yarn install --non-interactive --frozen-lockfile
 if [ -z "$package" ]; then
   yarn workspace @tamanu/shared build
 else
+  # clear out the tests and files not useful for production
+  rm -rf packages/*/__tests__ || true
+  rm -rf packages/*/jest.* || true
+  rm -rf packages/*/docker || true
+  rm -rf packages/*/coverage || true
+
   yarn workspace "$package" build
 fi
 
@@ -31,8 +37,11 @@ fi
 if ! [ -z "$package" ]; then
   # clear out the build-tooling
   rm -rf node_modules/@tamanu/build-tooling
-  rm -rf packages/**/node_modules/@tamanu/build-tooling
   rm -rf packages/build-tooling
+  rm -rf packages/**/node_modules/@tamanu/build-tooling
+
+  # clear out the build configs
+  rm -rf packages/*/*.config.* || true
 
   # restore the top level package.json
   mv package.json{.orig,}

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -8,8 +8,11 @@ package="${1:-}"
 # save the original package.jsons
 cp package.json{,.orig}
 
-# let build-tooling be installed in prod mode
+# let build-tooling be installed in production mode
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json.orig > package.json
+
+# put cache in packages/ so it's carried between stages
+yarn config set cache-folder /app/packages/.yarn-cache
 
 # install dependencies
 yarn install --non-interactive --frozen-lockfile
@@ -48,5 +51,7 @@ if ! [ -z "$package" ]; then
 
   # cleanup
   yarn cache clean
+  yarn config delete cache-folder
+  rm -rf packages/.yarn-cache || true
   rm $0
 fi

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -35,6 +35,7 @@ else
   rm -rf packages/*/jest.* || true
   rm -rf packages/*/docker || true
   rm -rf packages/*/coverage || true
+  rm -rf packages/*/config/{local,development,test}.* || true
 
   yarn workspace "$package" build
 fi

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -23,17 +23,21 @@ else
   yarn workspace "$package" build
 fi
 
-# restore the top level package.json
-mv package.json{.orig,}
-
-# clear out the build-tooling when building a server package
-# otherwise we assume we're building the shared stage, and want to keep these
+# clean up when building a server package
+#
+# otherwise we assume we're building the shared stage, and we either want to
+# keep some of these, or we don't care to clean up as the multi-staging will
+# take care of skipping the cruft anyway
 if ! [ -z "$package" ]; then
+  # clear out the build-tooling
   rm -rf node_modules/@tamanu/build-tooling
   rm -rf packages/**/node_modules/@tamanu/build-tooling
   rm -rf packages/build-tooling
-fi
 
-# cleanup
-yarn cache clean
-rm $0
+  # restore the top level package.json
+  mv package.json{.orig,}
+
+  # cleanup
+  yarn cache clean
+  rm $0
+fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -8,7 +8,11 @@ if [[ -d /config ]]; then
   cp -v /config/* ./config/
 fi
 
-if which "$1" >/dev/null; then
+if [[ "$1" == "healthcheck" ]]; then
+  # used as healthcheck command in ECS
+  set -eo pipefail
+  curl http://localhost:3000 | jq '.index == true' | grep -F true
+elif which "$1" >/dev/null; then
   # if the first arg is a binary, run it
   # that provides a convenient way to run arbitrary commands in the container
   exec $*

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -11,7 +11,21 @@ fi
 if [[ "$1" == "healthcheck" ]]; then
   # used as healthcheck command in ECS
   set -eo pipefail
-  curl http://localhost:3000 | jq '.index == true' | grep -F true
+
+  # rest of the arguments are those used to start the container
+  # that can be used to determine what kind of healthcheck to run
+  shift
+
+  case "$1" in
+    serve)
+      curl http://localhost:3000 | jq '.index == true' | grep -F true
+      ;;
+    # TODO: healthcheck for task runner (check process is running?)
+    *)
+      echo "Unknown healthcheck type: $1"
+      exit 0 # assume success
+      ;;
+  esac
 elif which "$1" >/dev/null; then
   # if the first arg is a binary, run it
   # that provides a convenient way to run arbitrary commands in the container

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+### This expects to be run in the production docker container in /Dockerfile.
+# While not strictly required, it is prefered to run with an init process.
+
+if [[ -d /config ]]; then
+  # copy the config file(s) from the configurator into the expected place
+  cp -v /config/* ./config/
+fi
+
+if which "$1" >/dev/null; then
+  # if the first arg is a binary, run it
+  # that provides a convenient way to run arbitrary commands in the container
+  exec $*
+else
+  # otherwise, run the app
+  exec node dist/app.bundle.js $*
+fi


### PR DESCRIPTION
### Changes

Production-focused Dockerfile
- produces Linux container images
- single dockerfile that can produce three separate images (either with `--target` or by tagging post-build via labels)
- only contains the minimal amount of dependencies for each server, so images weigh in at about a half-gig per image, which is pretty nice (for node)

This is _just_ the containers, I'll address CI/CD in another PR (different cards too).

### Checklist

- [x] Containers for servers build
- [x] Optimised Dockerfile for size and speed (in this order)

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)