### PR TITLE
EPI-211: Fix materialising after reference data update

### DIFF
--- a/packages/shared-src/src/models/ImagingRequest.js
+++ b/packages/shared-src/src/models/ImagingRequest.js
@@ -142,6 +142,11 @@ export class ImagingRequest extends Model {
       foreignKey: 'imagingRequestId',
     });
 
+    // Used to be able to explicitly include these (hence no alias)
+    this.hasMany(models.ImagingRequestArea, {
+      foreignKey: 'imagingRequestId',
+    });
+
     this.hasMany(models.NotePage, {
       foreignKey: 'recordId',
       as: 'notePages',

--- a/packages/shared-src/src/models/fhir/DiagnosticReport/getQueryToFindUpstreamIds.js
+++ b/packages/shared-src/src/models/fhir/DiagnosticReport/getQueryToFindUpstreamIds.js
@@ -78,7 +78,7 @@ export function fromLabTests(models, table, id) {
           [Op.or]: [
             { '$category.id$': id },
             { '$labTestMethod.id$': id },
-            { '$laboratory.id$': id },
+            { '$labRequest.laboratory.id$': id },
           ],
         },
       };

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getQueryToFindUpstreamIds.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getQueryToFindUpstreamIds.js
@@ -79,15 +79,9 @@ export function fromImagingRequests(models, table, id) {
       return {
         include: [
           {
-            model: Encounter,
-            as: 'encounter',
-            include: [
-              {
-                model: LocationGroup,
-                as: 'locationGroup',
-                where: { id },
-              },
-            ],
+            model: LocationGroup,
+            as: 'locationGroup',
+            where: { id },
           },
         ],
       };

--- a/packages/shared-src/src/models/fhir/ServiceRequest/getQueryToFindUpstreamIds.js
+++ b/packages/shared-src/src/models/fhir/ServiceRequest/getQueryToFindUpstreamIds.js
@@ -22,7 +22,6 @@ export function fromImagingRequests(models, table, id) {
         include: [
           {
             model: ImagingRequestArea,
-            as: 'areas',
             where: { id },
           },
         ],
@@ -106,7 +105,6 @@ export function fromImagingRequests(models, table, id) {
         include: [
           {
             model: ImagingRequestArea,
-            as: 'areas',
             include: [
               {
                 model: ReferenceData,
@@ -122,7 +120,6 @@ export function fromImagingRequests(models, table, id) {
         include: [
           {
             model: ImagingRequestArea,
-            as: 'areas',
             include: [
               {
                 model: ReferenceData,


### PR DESCRIPTION
### Changes

FHIR resources remained the same even after some of their upstreams were updated i.e. reference data update didn't cause a re-materialisation. After a closer look, it was scheduling the jobs properly but was failing when trying to query for the models since it had a couple of wrong spots here and there. Actual changes solved that I found along the way:

- `laboratory` was a nested field from `LabRequest`.
- `LocationGroup` is directly associated with `ImagingRequest`.
- `ImagingRequest` model didn't know about the association with `ImagingRequestArea` which caused it to always throw an error when trying to `include` them in the query options.
- The association aliases need to match.