### PR TITLE
EPI-443 Add custom content for revert death modal

### DIFF
--- a/packages/desktop/app/components/Modal.js
+++ b/packages/desktop/app/components/Modal.js
@@ -11,7 +11,8 @@ import { Colors } from '../constants';
 import { useElectron } from '../contexts/Electron';
 import { Button } from './Button';
 
-export const MODAL_PADDING = 32;
+export const MODAL_PADDING_TOP_AND_BOTTOM = 18;
+export const MODAL_PADDING_LEFT_AND_RIGHT = 32;
 export const MODAL_TRANSITION_DURATION = 300;
 
 /*  To keep consistent use of styled-components,
@@ -38,7 +39,8 @@ const Dialog = styled(MuiDialog)`
 
 const ModalContent = styled.div`
   flex: 1 1 auto;
-  padding: 18px ${props => (props.$overrideContentPadding ? 0 : MODAL_PADDING)}px;
+  padding: ${MODAL_PADDING_TOP_AND_BOTTOM}px
+    ${props => (props.$overrideContentPadding ? 0 : MODAL_PADDING_LEFT_AND_RIGHT)}px;
 `;
 
 const ModalContainer = styled.div`
@@ -52,7 +54,7 @@ const ModalContainer = styled.div`
 `;
 
 export const FullWidthRow = styled.div`
-  margin: 0 -${MODAL_PADDING}px;
+  margin: 0 -${MODAL_PADDING_LEFT_AND_RIGHT}px;
   grid-column: 1 / -1;
 `;
 

--- a/packages/desktop/app/components/ModalActionRow.js
+++ b/packages/desktop/app/components/ModalActionRow.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import { MODAL_PADDING, FullWidthRow } from './Modal';
+import { MODAL_PADDING_LEFT_AND_RIGHT, FullWidthRow } from './Modal';
 import { Colors } from '../constants';
 import { ConfirmCancelRow } from './ButtonRow';
 
 const ActionRow = styled(ConfirmCancelRow)`
   border-top: 1px solid ${Colors.outline};
-  padding: 30px ${MODAL_PADDING}px 0 0;
+  padding: 30px ${MODAL_PADDING_LEFT_AND_RIGHT}px 0 0;
   grid-column: 1 / -1;
   display: flex;
   justify-content: flex-end;

--- a/packages/desktop/app/components/RecordDeathSection.js
+++ b/packages/desktop/app/components/RecordDeathSection.js
@@ -26,6 +26,13 @@ const Content = styled.p`
   margin-bottom: 2rem;
 `;
 
+const customContent = (
+  <Content>
+    Are you sure you want to revert the patient death record? This will not reopen any previously
+    closed encounters.
+  </Content>
+);
+
 export const RecordDeathSection = memo(({ patient, openDeathModal }) => {
   const api = useApi();
   const dispatch = useDispatch();
@@ -46,12 +53,6 @@ export const RecordDeathSection = memo(({ patient, openDeathModal }) => {
 
   const isPatientDead = Boolean(patient.dateOfDeath);
   const actionText = isPatientDead ? 'Revert death record' : 'Record death';
-  const customContent = (
-    <Content>
-      Are you sure you want to revert the patient death record? This will not reopen any previously
-      closed encounters.
-    </Content>
-  );
 
   return (
     <>

--- a/packages/desktop/app/components/RecordDeathSection.js
+++ b/packages/desktop/app/components/RecordDeathSection.js
@@ -8,6 +8,7 @@ import { useApi } from '../api';
 import { ConfirmModal } from './ConfirmModal';
 import { usePatientNavigation } from '../utils/usePatientNavigation';
 import { reloadPatient } from '../store/patient';
+import { MODAL_PADDING_LEFT_AND_RIGHT, MODAL_PADDING_TOP_AND_BOTTOM } from './Modal';
 
 const TypographyLink = styled(Typography)`
   color: ${Colors.primary};
@@ -21,21 +22,28 @@ const TypographyLink = styled(Typography)`
   margin-top: auto;
 `;
 
+const marginBottom = 58;
+const marginTop = marginBottom - MODAL_PADDING_TOP_AND_BOTTOM;
+const marginLeftAndRight = 80 - MODAL_PADDING_LEFT_AND_RIGHT;
 const Content = styled.p`
   text-align: left;
-  margin-bottom: 2rem;
+  margin: ${marginTop}px ${marginLeftAndRight}px ${marginBottom}px;
+  font-size: 14px;
+  line-height: 18px;
 `;
 
 const ComponentDivider = styled(Divider)`
-  margin: 56px 0 30px 0px;
+  margin: 0 -${MODAL_PADDING_LEFT_AND_RIGHT}px 30px -${MODAL_PADDING_LEFT_AND_RIGHT}px;
 `;
 
 const customContent = (
-  <Content>
-    Are you sure you want to revert the patient death record? This will not reopen any previously
-    closed encounters.
+  <div>
+    <Content>
+      Are you sure you want to revert the patient death record? This will not reopen any previously
+      closed encounters.
+    </Content>
     <ComponentDivider />
-  </Content>
+  </div>
 );
 
 export const RecordDeathSection = memo(({ patient, openDeathModal }) => {

--- a/packages/desktop/app/components/RecordDeathSection.js
+++ b/packages/desktop/app/components/RecordDeathSection.js
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { Typography } from '@material-ui/core';
+import { Typography, Divider } from '@material-ui/core';
 import { Colors } from '../constants';
 import { useApi } from '../api';
 import { ConfirmModal } from './ConfirmModal';
@@ -26,10 +26,15 @@ const Content = styled.p`
   margin-bottom: 2rem;
 `;
 
+const ComponentDivider = styled(Divider)`
+  margin: 56px 0 30px 0px;
+`;
+
 const customContent = (
   <Content>
     Are you sure you want to revert the patient death record? This will not reopen any previously
     closed encounters.
+    <ComponentDivider />
   </Content>
 );
 

--- a/packages/desktop/app/components/RecordDeathSection.js
+++ b/packages/desktop/app/components/RecordDeathSection.js
@@ -21,6 +21,11 @@ const TypographyLink = styled(Typography)`
   margin-top: auto;
 `;
 
+const Content = styled.p`
+  text-align: left;
+  margin-bottom: 2rem;
+`;
+
 export const RecordDeathSection = memo(({ patient, openDeathModal }) => {
   const api = useApi();
   const dispatch = useDispatch();
@@ -41,6 +46,12 @@ export const RecordDeathSection = memo(({ patient, openDeathModal }) => {
 
   const isPatientDead = Boolean(patient.dateOfDeath);
   const actionText = isPatientDead ? 'Revert death record' : 'Record death';
+  const customContent = (
+    <Content>
+      Are you sure you want to revert the patient death record? This will not reopen any previously
+      closed encounters.
+    </Content>
+  );
 
   return (
     <>
@@ -50,7 +61,7 @@ export const RecordDeathSection = memo(({ patient, openDeathModal }) => {
       <ConfirmModal
         open={isRevertModalOpen}
         title="Revert patient death"
-        subText="Are you sure you want to revert the patient death record? This will not reopen any previously closed encounters."
+        customContent={customContent}
         onConfirm={revertDeath}
         onCancel={closeRevertModal}
       />


### PR DESCRIPTION
### Changes

Add custom content for revert death modal for text alignment.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
