### PR TITLE
SAV-111: Remove not null constraint for date in Administered Vaccine

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/lan/__tests__/apiv1/PatientVaccine.test.js
@@ -346,5 +346,20 @@ describe('PatientVaccine', () => {
       expect(encounter.startDate).toBeDefined();
       expect(encounter.endDate).toBeDefined();
     });
+
+    it('Should not generate current date as vaccine date if no date is provided', async () => {
+      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+        status: VACCINE_STATUS.GIVEN,
+        scheduledVaccineId: scheduled1.id,
+        recorderId: clinician.id,
+        givenBy: 'Clinician',
+        givenElsewhere: true,
+      });
+
+      expect(result).toHaveSucceeded();
+
+      const vaccine = await models.AdministeredVaccine.findByPk(result.body.id);
+      expect(vaccine.date).toBe(null);
+    });
   });
 });

--- a/packages/lan/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/lan/__tests__/apiv1/PatientVaccine.test.js
@@ -347,7 +347,7 @@ describe('PatientVaccine', () => {
       expect(encounter.endDate).toBeDefined();
     });
 
-    it('Should not generate current date as vaccine date if no date is provided', async () => {
+    it('Should not have current date as default', async () => {
       const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_STATUS.GIVEN,
         scheduledVaccineId: scheduled1.id,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -202,7 +202,6 @@ patientVaccineRoutes.post(
 
       return req.models.AdministeredVaccine.create({
         ...vaccineData,
-        date: vaccineData.date || currentDate,
         encounterId,
       });
     });

--- a/packages/shared-src/src/migrations/1683091064150-removeNotNullConstraintForDateInAdministeredVaccines.js
+++ b/packages/shared-src/src/migrations/1683091064150-removeNotNullConstraintForDateInAdministeredVaccines.js
@@ -8,7 +8,12 @@ export async function up(query) {
 }
 
 export async function down(query) {
-  await query.bulkDelete('administered_vaccines', { date: null });
+  const UNKNOWN_DATE = '1990-01-01 00:00:00';
+  await query.sequelize.query(`
+    UPDATE administered_vaccines
+    SET date = '${UNKNOWN_DATE}'
+    WHERE date IS NULL
+  `);
   await query.changeColumn('administered_vaccines', 'date', {
     type: DataTypes.DATETIMESTRING,
     allowNull: false,

--- a/packages/shared-src/src/migrations/1683091064150-removeNotNullConstraintForDateInAdministeredVaccines.js
+++ b/packages/shared-src/src/migrations/1683091064150-removeNotNullConstraintForDateInAdministeredVaccines.js
@@ -1,0 +1,16 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.changeColumn('administered_vaccines', 'date', {
+    type: DataTypes.DATETIMESTRING,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.bulkDelete('administered_vaccines', { date: null });
+  await query.changeColumn('administered_vaccines', 'date', {
+    type: DataTypes.DATETIMESTRING,
+    allowNull: false,
+  });
+}

--- a/packages/shared-src/src/models/AdministeredVaccine.js
+++ b/packages/shared-src/src/models/AdministeredVaccine.js
@@ -26,9 +26,7 @@ export class AdministeredVaccine extends Model {
         vaccineName: Sequelize.TEXT,
         disease: Sequelize.TEXT,
         circumstanceIds: Sequelize.ARRAY(Sequelize.STRING),
-        date: dateTimeType('date', {
-          allowNull: false,
-        }),
+        date: dateTimeType('date'),
       },
       {
         ...options,


### PR DESCRIPTION
### Changes
- Remove not null constraint for date in Administered Vaccine as this is now optional for vaccine given elsewhere

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
