### PR TITLE
[NASS-725] Updates to new lab request modal

### DIFF
--- a/packages/desktop/app/components/Field/RadioField.js
+++ b/packages/desktop/app/components/Field/RadioField.js
@@ -19,6 +19,7 @@ const DEFAULT_LABEL_THEME = {
 const StyledFormControl = styled(FormControl)`
   display: flex;
   flex-direction: column;
+  margin-top: 2px;
 `;
 
 const StyledRadioGroup = styled(RadioGroup)`

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import * as yup from 'yup';
 import { LAB_REQUEST_FORM_TYPES, LAB_REQUEST_STATUSES } from 'shared/constants/labs';
-import { getCurrentDateTimeString } from 'shared/utils/dateTime';
+import { Heading3, BodyText } from '../../components/Typography';
 import {
   AutocompleteField,
   DateTimeField,
@@ -40,13 +40,18 @@ export const screen1ValidationSchema = yup.object().shape({
 const OPTIONS = {
   INDIVIDUAL: {
     label: 'Individual',
-    description: 'Select any individual or range of individual test types',
+    description: 'Select an individual or multiple individual tests',
     value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
   },
   PANEL: {
     label: 'Panel',
     description: 'Select from a list of test panels',
     value: LAB_REQUEST_FORM_TYPES.PANEL,
+  },
+  SUPERSET: {
+    label: 'Superset',
+    description: 'Select from a list of supersets',
+    value: LAB_REQUEST_FORM_TYPES.SUPERSET,
   },
 };
 
@@ -69,28 +74,20 @@ const useLabRequestFormTypeOptions = setFieldValue => {
 };
 
 export const LabRequestFormScreen1 = ({
-  values,
   setFieldValue,
-  handleChange,
   practitionerSuggester,
   departmentSuggester,
 }) => {
   const { options } = useLabRequestFormTypeOptions(setFieldValue);
 
-  const handleToggleSampleCollected = event => {
-    handleChange(event);
-    const isSampleCollected = event.target.value === 'yes';
-    if (isSampleCollected) {
-      setFieldValue('sampleTime', getCurrentDateTimeString());
-      setFieldValue('status', LAB_REQUEST_STATUSES.RECEPTION_PENDING);
-    } else {
-      setFieldValue('sampleTime', null);
-      setFieldValue('status', LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED);
-    }
-  };
-
   return (
     <>
+      <div style={{ gridColumn: '1 / -1' }}>
+        <Heading3 mb="12px">Creating a new lab request</Heading3>
+        <BodyText mb="28px" color="textTertiary">
+          Please complete the details below and select the lab request type
+        </BodyText>
+      </div>
       <Field
         name="requestedById"
         label="Requesting clinician"
@@ -117,34 +114,6 @@ export const LabRequestFormScreen1 = ({
         component={SuggesterSelectField}
         endpoint="labTestPriority"
       />
-      <FormSeparatorLine />
-      <div style={{ gridColumn: '1 / -1' }}>
-        <Field
-          name="specimenAttached"
-          label="Sample collected"
-          required
-          component={RadioField}
-          onChange={handleToggleSampleCollected}
-          options={binaryOptions}
-        />
-      </div>
-      {values.specimenAttached === 'yes' && (
-        <>
-          <Field
-            name="sampleTime"
-            label="Sample date & time"
-            required
-            component={DateTimeField}
-            saveDateAsString
-          />
-          <Field
-            name="labSampleSiteId"
-            label="Site"
-            component={SuggesterSelectField}
-            endpoint="labSampleSite"
-          />
-        </>
-      )}
       <FormSeparatorLine />
       <div style={{ gridColumn: '1 / -1' }}>
         <Field


### PR DESCRIPTION
### Changes
Updated layout for new lab request modal to match figma:
https://www.figma.com/file/sy6gyLBPoSXuJNq5lEEOL8/Tamanu---UI-Pattern-(Updated-2022)?type=design&node-id=9205-173601&t=uCU2ZtqQS6e1DKNg-0

### Card:
https://linear.app/bes/issue/NASS-725/desktop-lab-requests-updates-to-new-lab-request-modal


### Screenshot
<img width="920" alt="image" src="https://user-images.githubusercontent.com/17033058/236002971-2b39ae16-4e1d-4f63-b7b4-43684ea75137.png">


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
