### PR TITLE
SAV-133: Stop trying to export a button

### DIFF
--- a/packages/desktop/app/components/ImmunisationsTable.js
+++ b/packages/desktop/app/components/ImmunisationsTable.js
@@ -95,6 +95,7 @@ export const ImmunisationsTable = React.memo(
           title: 'Action',
           accessor: getActionButtons({ onItemClick, onItemEditClick, onItemDeleteClick }),
           sortable: false,
+          isExportable: false,
         },
       ],
       [onItemClick, onItemEditClick, onItemDeleteClick],


### PR DESCRIPTION
### Changes

We added a button to a data fetching table that was causing errors when trying to export. In order to stop this I added an isExportable: false flag to the column definition for the button
