### PR TITLE
SAV-107: Covid certificate printing date fix

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 
 import { ICAO_DOCUMENT_TYPES } from 'shared/constants';
 import { CovidVaccineCertificate } from 'shared/utils/patientCertificates';
+import { getCurrentDateString } from 'shared/utils/dateTime';
 
 import { Modal } from '../../Modal';
 import { useApi } from '../../../api';
@@ -33,7 +34,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
         patientId: patient.id,
         forwardAddress: data.email,
         createdBy: printedBy,
-        createdAt: new Date(),
+        printedDate: getCurrentDateString(),
       });
     },
     [api, patient.id, printedBy],
@@ -60,7 +61,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
           logoSrc={logo}
           signingSrc={footerImg}
           printedBy={printedBy}
-          printedDate={new Date()}
+          printedDate={getCurrentDateString()}
           getLocalisation={getLocalisation}
         />
       </PDFViewer>

--- a/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
@@ -44,7 +44,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
 
   return (
     <Modal
-      title="Vaccination Certificate"
+      title="COVID-19 Vaccine Certificate"
       open={open}
       onClose={onClose}
       width="md"

--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -43,7 +43,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
 
   return (
     <Modal
-      title="Vaccination Certificate"
+      title="Vaccine Certificate"
       open={open}
       onClose={onClose}
       width="md"

--- a/packages/shared-src/src/migrations/1683171222913-addPrintedDateColumnCertificates.js
+++ b/packages/shared-src/src/migrations/1683171222913-addPrintedDateColumnCertificates.js
@@ -1,0 +1,10 @@
+export async function up(query) {
+  await query.addColumn('certificate_notifications', 'printed_date', {
+    type: 'date_string',
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('certificate_notifications', 'printed_date');
+}

--- a/packages/shared-src/src/models/CertificateNotification.js
+++ b/packages/shared-src/src/models/CertificateNotification.js
@@ -2,6 +2,8 @@ import { Sequelize } from 'sequelize';
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { Model } from './Model';
 
+import { dateType } from './dateTimeTypes';
+
 export class CertificateNotification extends Model {
   static init({ primaryKey, ...options }) {
     super.init(
@@ -13,6 +15,7 @@ export class CertificateNotification extends Model {
         requireSigning: Sequelize.BOOLEAN,
         status: Sequelize.STRING,
         error: Sequelize.TEXT,
+        printedDate: dateType,
       },
       {
         ...options,

--- a/packages/shared-src/src/models/CertificateNotification.js
+++ b/packages/shared-src/src/models/CertificateNotification.js
@@ -15,7 +15,7 @@ export class CertificateNotification extends Model {
         requireSigning: Sequelize.BOOLEAN,
         status: Sequelize.STRING,
         error: Sequelize.TEXT,
-        printedDate: dateType,
+        printedDate: dateType('printedDate'),
       },
       {
         ...options,

--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Document, Page } from '@react-pdf/renderer';
 
 import { generateUVCI } from 'shared/utils/uvci';
-import { format, parseISO } from 'date-fns';
 
 import { Table } from './Table';
 import { styles, Col, Box, Row, Watermark } from './Layout';

--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -85,7 +85,7 @@ export const CovidVaccineCertificate = ({
       <Page size="A4" style={styles.page}>
         {watermarkSrc && <Watermark src={watermarkSrc} />}
         <CovidLetterheadSection getLocalisation={getLocalisation} logoSrc={logoSrc} />
-        <H3>Vaccination Certificate</H3>
+        <H3>COVID-19 Vaccine Certificate</H3>
         <CovidPatientDetailsSection
           patient={patient}
           vdsSrc={vdsSrc}

--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -103,7 +103,7 @@ export const CovidVaccineCertificate = ({
               <P>Printed by: {printedBy}</P>
             </Col>
             <Col>
-              <P>Printing date: {format(parseISO(printedDate), 'dd/MM/yyyy')}</P>
+              <P>Printing date: {getDisplayDate(printedDate)}</P>
             </Col>
           </Row>
         </Box>

--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Document, Page } from '@react-pdf/renderer';
 
 import { generateUVCI } from 'shared/utils/uvci';
+import { format, parseISO } from 'date-fns';
 
 import { Table } from './Table';
 import { styles, Col, Box, Row, Watermark } from './Layout';
@@ -102,7 +103,7 @@ export const CovidVaccineCertificate = ({
               <P>Printed by: {printedBy}</P>
             </Col>
             <Col>
-              <P>Printing date: {getDisplayDate(printedDate)}</P>
+              <P>Printing date: {format(parseISO(printedDate), 'dd/MM/yyyy')}</P>
             </Col>
           </Row>
         </Box>

--- a/packages/shared-src/src/utils/patientCertificates/VaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/VaccineCertificate.js
@@ -79,7 +79,7 @@ export const VaccineCertificate = ({
           <LetterheadSection
             getLocalisation={getLocalisation}
             logoSrc={logoSrc}
-            certificateTitle="Vaccination Certificate"
+            certificateTitle="Vaccine Certificate"
           />
           <PatientDetailsSection
             patient={patient}

--- a/packages/sync-server/app/tasks/CertificateNotificationProcessor/index.js
+++ b/packages/sync-server/app/tasks/CertificateNotificationProcessor/index.js
@@ -72,7 +72,7 @@ export class CertificateNotificationProcessor extends ScheduledTask {
         const requireSigning = notification.get('requireSigning');
         const type = notification.get('type');
         const printedBy = notification.get('createdBy');
-        const printedDate = notification.get('createdAt');
+        const printedDate = notification.get('printedDate');
 
         const { country } = await getLocalisation();
         const countryCode = country['alpha-2'];


### PR DESCRIPTION
### Changes

There was another bug with the emailed covid vaccination certificates where the printing date was wrong as it was accidentally fetching from the metadata field. This has now been resolved by creating a new column on the certificate notification with a printing date that can be accessed when sending the certificate