### PR TITLE
SAV-229: Allow disable procedure code in discharge summary

### DIFF
--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -89,13 +89,23 @@ const DiagnosesList = ({ diagnoses }) => {
 };
 
 const ProceduresList = ({ procedures }) => {
+  const { getLocalisation } = useLocalisation();
+
   if (!procedures || procedures.length === 0) {
     return <span>N/A</span>;
   }
 
+  const displayProcedureCodes = getLocalisation('features.displayProcedureCodesInDischargeSummary');
+
   return procedures.map(procedure => (
     <li>
-      {procedure.procedureType.name} (<Label>CPT Code: </Label> {procedure.procedureType.code})
+      {procedure.procedureType.name}
+      {displayProcedureCodes && (
+        <span>
+          {' '}
+          (<Label>CPT Code: </Label> {procedure.procedureType.code})
+        </span>
+      )}
     </li>
   ));
 };

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -424,6 +424,7 @@ const rootLocalisationSchema = yup
           .required(),
         fhirNewZealandEthnicity: yup.boolean().required(),
         onlyAllowLabPanels: yup.boolean().required(),
+        displayProcedureCodesInDischargeSummary: yup.boolean().required(),
       })
       .required()
       .noUnknown(),

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -629,7 +629,8 @@
           "refreshInterval": 150
         },
         "fhirNewZealandEthnicity": false,
-        "onlyAllowLabPanels": false
+        "onlyAllowLabPanels": false,
+        "displayProcedureCodesInDischargeSummary": true
       },
       "templates": {
         "letterhead": {


### PR DESCRIPTION
### Changes
- Allow disable procedure code in discharge summary

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
