### PR TITLE
SAV-227: Add feature flag to disable ICD10 code from displaying on discharge summary

### DIFF
--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -75,15 +75,25 @@ const IdValue = styled.span`
 `;
 
 const DiagnosesList = ({ diagnoses }) => {
+  const { getLocalisation } = useLocalisation();
+
   if (diagnoses.length === 0) {
     return <span>N/A</span>;
   }
+
+  const displayIcd10Codes = getLocalisation('features.displayIcd10CodesInDischargeSummary');
 
   return diagnoses
     .filter(({ certainty }) => !DIAGNOSIS_CERTAINTIES_TO_HIDE.includes(certainty))
     .map(item => (
       <li>
-        {item.diagnosis.name} (<Label>ICD 10 Code: </Label> {item.diagnosis.code})
+        {item.diagnosis.name}
+        {displayIcd10Codes && (
+          <span>
+            {' '}
+            <Label>ICD 10 Code: </Label> {item.diagnosis.code}
+          </span>
+        )}
       </li>
     ));
 };

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -425,6 +425,7 @@ const rootLocalisationSchema = yup
         fhirNewZealandEthnicity: yup.boolean().required(),
         onlyAllowLabPanels: yup.boolean().required(),
         displayProcedureCodesInDischargeSummary: yup.boolean().required(),
+        displayIcd10CodesInDischargeSummary: yup.boolean().required(),
       })
       .required()
       .noUnknown(),

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -631,7 +631,7 @@
         "fhirNewZealandEthnicity": false,
         "onlyAllowLabPanels": false,
         "displayProcedureCodesInDischargeSummary": true,
-        "displayIcd10CodesInDischargeSummary": false
+        "displayIcd10CodesInDischargeSummary": true
       },
       "templates": {
         "letterhead": {

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -630,7 +630,8 @@
         },
         "fhirNewZealandEthnicity": false,
         "onlyAllowLabPanels": false,
-        "displayProcedureCodesInDischargeSummary": true
+        "displayProcedureCodesInDischargeSummary": true,
+        "displayIcd10CodesInDischargeSummary": false
       },
       "templates": {
         "letterhead": {


### PR DESCRIPTION
### Changes
- Add feature flag to disable ICD10 code from displaying on discharge summary

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
