### PR TITLE
[NASS-657] Fix columns, sort and labels for lab requests

### DIFF
--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -80,7 +80,7 @@ export const LabRequestsSearchBar = ({ status = '' }) => {
             size="small"
           />
           {publishedStatus ? (
-            <Field name="publishedDate" label="Published" saveDateAsString component={DateField} />
+            <Field name="publishedDate" label="Completed" saveDateAsString component={DateField} />
           ) : (
             <>
               <LocalisedField

--- a/packages/desktop/app/views/LabRequestsTable.js
+++ b/packages/desktop/app/views/LabRequestsTable.js
@@ -7,7 +7,7 @@ import { reloadPatient } from '../store/patient';
 import { useEncounter } from '../contexts/Encounter';
 import { useLabRequest, LabRequestSearchParamKeys } from '../contexts/LabRequest';
 import {
-  getRequestedBy,
+  getStatus,
   getPatientName,
   getPatientDisplayId,
   getRequestType,
@@ -31,15 +31,22 @@ export const LabRequestsTable = ({ status = '' }) => {
         title: 'Patient',
         accessor: getPatientName,
         maxWidth: 200,
+        sortable: false,
       },
-      { key: 'requestId', title: 'Test ID', accessor: getRequestId },
-      { key: 'testCategory', title: 'Test category', accessor: getRequestType },
+      { key: 'requestId', title: 'Test ID', accessor: getRequestId, sortable: false },
       { key: 'labTestPanelName', title: 'Panel' },
+      { key: 'testCategory', title: 'Test category', accessor: getRequestType },
       { key: 'requestedDate', title: 'Requested at time', accessor: getDateTime },
-      { key: 'requestedBy', title: 'Requested by', accessor: getRequestedBy },
       publishedStatus
-        ? { key: 'publishedDate', title: 'Published', accessor: getPublishedDate }
+        ? { key: 'publishedDate', title: 'Completed', accessor: getPublishedDate }
         : { key: 'priority', title: 'Priority', accessor: getPriority },
+      {
+        key: 'status',
+        title: 'Status',
+        accessor: getStatus,
+        maxWidth: 200,
+        sortable: !publishedStatus,
+      },
     ];
   }, [publishedStatus]);
   const dispatch = useDispatch();


### PR DESCRIPTION
### Changes

- Fixed issues found https://linear.app/bes/issue/NASS-657/desktop-labs-sidebar-nav-add-tab-for-published-lab-requests

## Screenshots
Published lab requests:
<img width="1712" alt="image" src="https://user-images.githubusercontent.com/17033058/236907037-8726a49e-e2a7-45c8-87bd-9c12ab7606be.png">

Active Lab requests
<img width="1725" alt="image" src="https://user-images.githubusercontent.com/17033058/236907085-c260de21-ae77-4caa-a38c-cf12204850a8.png">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
