### PR TITLE
SAV-232: Only open one instance of the app

### DIFF
--- a/packages/desktop/app/main.dev.js
+++ b/packages/desktop/app/main.dev.js
@@ -14,7 +14,7 @@ import installExtension, {
   REACT_DEVELOPER_TOOLS,
 } from 'electron-devtools-installer';
 
-import {findCountryLocales} from 'iso-lang-codes'
+import { findCountryLocales } from 'iso-lang-codes';
 
 // production only
 import sourceMapSupport from 'source-map-support';
@@ -52,6 +52,12 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', async () => {
+  const isFirstInstance = app.requestSingleInstanceLock();
+  if (!isFirstInstance) {
+    app.quit();
+    return;
+  }
+
   mainWindow = new BrowserWindow({
     show: false,
     // width: 1024,
@@ -67,7 +73,7 @@ app.on('ready', async () => {
 
   // The most accurate method of getting locale in electron is getLocaleCountryCode
   // which unlike getLocale is determined by native os settings
-  const osLocales = findCountryLocales(app.getLocaleCountryCode())
+  const osLocales = findCountryLocales(app.getLocaleCountryCode());
   global.osLocales = osLocales;
 
   const htmlLocation =
@@ -108,6 +114,18 @@ app.on('ready', async () => {
 
   const menuBuilder = new MenuBuilder(mainWindow);
   menuBuilder.buildMenu();
+});
+
+app.on('second-instance', () => {
+  // This is called when a second instance of the app is attempted to be run (i.e., when it calls
+  // requestSingleInstanceLock and fails)
+  // Focus the existing mainWindow, that other instance will take care of quitting itself (see above)
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.focus();
+  }
 });
 
 // if (isDebug) {

--- a/packages/desktop/app/main.dev.js
+++ b/packages/desktop/app/main.dev.js
@@ -52,6 +52,8 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', async () => {
+  // Check if there's already an instance of the app running. If there is, we can quit this one, and
+  // the other will receive a 'second-instance' event telling it to focus its window (see below)
   const isFirstInstance = app.requestSingleInstanceLock();
   if (!isFirstInstance) {
     app.quit();


### PR DESCRIPTION
### Changes

If a user double clicks the executable a second time, it will fail to take the "single app lock", and quit. The first instance of the app will be notified that a second attempted to start, and will bring its window into focus.

Credit to GPT-4 and Github Copilot.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
