### PR TITLE
EPI-483: Convert last_updated to timestamp without time zone

### DIFF
--- a/packages/shared-src/src/migrations/1683620093808-fhirLastUpdatedToTimestampWithoutTimeZone.js
+++ b/packages/shared-src/src/migrations/1683620093808-fhirLastUpdatedToTimestampWithoutTimeZone.js
@@ -1,0 +1,45 @@
+import config from 'config';
+import { Sequelize } from 'sequelize';
+
+const SCHEMA = 'fhir';
+const TABLES = ['patients', 'diagnostic_reports', 'immunizations', 'service_requests'];
+
+export async function up(query) {
+  // Central only
+  if (config.serverFacilityId) return;
+
+  const COUNTRY_TIMEZONE = config?.countryTimeZone;
+  if (!COUNTRY_TIMEZONE) {
+    throw Error('A countryTimeZone must be configured in local.json for this migration to run.');
+  }
+
+  await query.sequelize.query(`SET TIME ZONE '${COUNTRY_TIMEZONE}'`);
+
+  for (const tableName of TABLES) {
+    await query.changeColumn({ schema: SCHEMA, tableName }, 'last_updated', {
+      type: 'timestamp',
+      defaultValue: Sequelize.fn('NOW'),
+      allowNull: false,
+    });
+  }
+}
+
+export async function down(query) {
+  // Central only
+  if (config.serverFacilityId) return;
+
+  const COUNTRY_TIMEZONE = config?.countryTimeZone;
+  if (!COUNTRY_TIMEZONE) {
+    throw Error('A countryTimeZone must be configured in local.json for this migration to run.');
+  }
+
+  await query.sequelize.query(`SET TIME ZONE '${COUNTRY_TIMEZONE}'`);
+
+  for (const tableName of TABLES) {
+    await query.changeColumn({ schema: SCHEMA, tableName }, 'last_updated', {
+      type: 'timestamptz',
+      defaultValue: Sequelize.fn('NOW'),
+      allowNull: false,
+    });
+  }
+}

--- a/packages/shared-src/src/models/fhir/Resource.js
+++ b/packages/shared-src/src/models/fhir/Resource.js
@@ -1,5 +1,5 @@
 import { snakeCase } from 'lodash';
-import { Sequelize, Utils, QueryTypes } from 'sequelize';
+import { Sequelize, Utils, DataTypes, QueryTypes } from 'sequelize';
 import * as yup from 'yup';
 
 import {
@@ -19,22 +19,22 @@ export class FhirResource extends Model {
     super.init(
       {
         id: {
-          type: Sequelize.UUID,
+          type: DataTypes.UUID,
           allowNull: false,
           default: Sequelize.fn('uuid_generate_v4'),
           primaryKey: true,
         },
         versionId: {
-          type: Sequelize.UUID,
+          type: DataTypes.UUID,
           allowNull: false,
           default: Sequelize.fn('uuid_generate_v4'),
         },
         upstreamId: {
-          type: this.UPSTREAM_UUID ? Sequelize.UUID : Sequelize.STRING,
+          type: this.UPSTREAM_UUID ? DataTypes.UUID : DataTypes.STRING,
           allowNull: false,
         },
         lastUpdated: {
-          type: Sequelize.DATE,
+          type: DataTypes.TIMESTAMP,
           allowNull: false,
           defaultValue: Sequelize.NOW,
         },

--- a/packages/shared-src/src/services/createDateTypes.js
+++ b/packages/shared-src/src/services/createDateTypes.js
@@ -28,13 +28,20 @@ export function createDateTypes() {
     }
   }
 
+  // TIMESTAMP WITHOUT TIME ZONE
+  const TIMESTAMP = function TIMESTAMP() {};
+  util.inherits(TIMESTAMP, DataTypes.DATE);
+  TIMESTAMP.prototype.toSql = () => 'TIMESTAMP';
+
   // Set the type key
   DATETIMESTRING.prototype.key = 'date_time_string';
   DATESTRING.prototype.key = 'date_string';
+  TIMESTAMP.prototype.key = 'TIMESTAMP';
 
   // Make datatype able to be used directly without having to call `new` on it.
   DataTypes.DATETIMESTRING = Utils.classToInvokable(DATETIMESTRING);
   DataTypes.DATESTRING = Utils.classToInvokable(DATESTRING);
+  DataTypes.TIMESTAMP = Utils.classToInvokable(TIMESTAMP);
 
   // Map the datatype to the postgres type/domain name
   DataTypes.DATETIMESTRING.types.postgres = ['date_time_string'];

--- a/packages/shared-src/src/test-helpers/fake.js
+++ b/packages/shared-src/src/test-helpers/fake.js
@@ -211,7 +211,9 @@ export const fakeBool = () => sample([true, false]);
 
 const FIELD_HANDLERS = {
   'TIMESTAMP WITH TIME ZONE': fakeDate,
+  'TIMESTAMP WITHOUT TIME ZONE': fakeDate,
   DATETIME: fakeDate,
+  TIMESTAMP: fakeDate,
 
   // custom type used for datetime string storage
   date_time_string: fakeDateTimeString,

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -2,7 +2,10 @@ import { QueryTypes } from 'sequelize';
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { upperFirst } from 'lodash';
-import { parseDateTime } from 'shared/utils/fhir/datetime';
+import { parseISO } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
+import { FHIR_DATETIME_PRECISION } from 'shared/constants/fhir';
+import { parseDateTime, formatDateTime } from 'shared/utils/fhir/datetime';
 import config from 'config';
 
 import { requireClientHeaders } from '../../middleware/requireClientHeaders';
@@ -10,6 +13,16 @@ import { requireClientHeaders } from '../../middleware/requireClientHeaders';
 export const routes = express.Router();
 
 const COUNTRY_TIMEZONE = config?.countryTimeZone;
+
+// Workaround for this test changing from a hotfix, see EPI-483/484
+function formatDate(date) {
+  if (!date) return date;
+  return formatInTimeZone(
+    parseISO(formatDateTime(date, FHIR_DATETIME_PRECISION.SECONDS_WITH_TIMEZONE)),
+    '+00:00',
+    "yyyy-MM-dd'T'HH:mm:ssXXX",
+  ).replace(/Z$/, '+00:00');
+}
 
 const reportQuery = `
 with
@@ -419,11 +432,38 @@ routes.get(
       },
     });
 
+    const mapNotes = notes =>
+      notes?.map(note => ({
+        ...note,
+        noteDate: formatDate(note.noteDate),
+      }));
+
     const mappedData = data.map(encounter => ({
       ...encounter,
       age: parseInt(encounter.age),
       weight: parseFloat(encounter.weight),
       sex: upperFirst(encounter.sex),
+      departments: encounter.departments?.map(department => ({
+        ...department,
+        assignedTime: formatDate(department.assignedTime),
+      })),
+      locations: encounter.locations?.map(location => ({
+        ...location,
+        assignedTime: formatDate(location.assignedTime),
+      })),
+      imagingRequests: encounter.imagingRequests?.map(ir => ({
+        ...ir,
+        notes: mapNotes(ir.notes),
+      })),
+      labRequests: encounter.labRequests?.map(lr => ({
+        ...lr,
+        notes: mapNotes(lr.notes),
+      })),
+      procedures: encounter.procedures?.map(procedure => ({
+        ...procedure,
+        date: formatDate(procedure.date),
+      })),
+      notes: mapNotes(encounter.notes),
     }));
 
     res.status(200).send({ data: mappedData });


### PR DESCRIPTION
### Changes

Yet another issue with `timestamp with time zone`, but I'm not comfortable enough to go full on string dates (and we'd want FHIR-style string dates anyway I think) so this:
- [adds the `timestamp without time zone` to sequelize](https://github.com/sequelize/sequelize/issues/2572#issuecomment-786983958)
- migrates the data, setting the time zone for the connection with `countryTimeZone` (otherwise we hit upon sequelize fucking up the times during the migration as well)
- changes the Resource base class to match

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
