### PR TITLE
SAV-106: Show unknown when no date for vax cert

### DIFF
--- a/packages/shared-src/src/utils/patientCertificates/VaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/VaccineCertificate.js
@@ -42,7 +42,8 @@ const columns = [
   {
     key: 'date',
     title: 'Date',
-    accessor: ({ date }, getLocalisation) => getDisplayDate(date, undefined, getLocalisation),
+    accessor: ({ date }, getLocalisation) =>
+      date ? getDisplayDate(date, undefined, getLocalisation) : 'Unknown',
   },
   {
     key: 'batch',


### PR DESCRIPTION
### Changes

The vaccination certificate was inserting todays date when there is no date value saved for the vaccine in the DB. I just made a small adjustment to show the word "Unknown" which it also does on the front end table

Vaccine table
<img width="920" alt="image" src="https://github.com/beyondessential/tamanu/assets/58054247/1dd51996-d77e-44f9-a946-363c247e0263">
Certificate
<img width="931" alt="image" src="https://github.com/beyondessential/tamanu/assets/58054247/0a8d56bf-5d43-403d-ac79-dc335b5fe9ab">
