### PR TITLE
SAV-107: Fix broken sort for vaccination certificate UVCI

### DIFF
--- a/packages/shared-src/src/utils/dateTime.js
+++ b/packages/shared-src/src/utils/dateTime.js
@@ -131,7 +131,7 @@ export function latestDateTime(...args) {
   return times[0];
 }
 
-export function compareByDateString(key = 'desc') {
+export function compareDateStrings(key = 'desc') {
   if (key.toLowerCase() === 'asc') {
     return (a, b) => parseISO(a.date) - parseISO(b.date);
   }

--- a/packages/shared-src/src/utils/dateTime.js
+++ b/packages/shared-src/src/utils/dateTime.js
@@ -138,7 +138,7 @@ export function compareDateStrings(key = 'desc') {
   if (key.toLowerCase() === 'desc') {
     return (a, b) => parseISO(b.date) - parseISO(a.date);
   }
-  return null;
+  return 0;
 }
 
 /*

--- a/packages/shared-src/src/utils/dateTime.js
+++ b/packages/shared-src/src/utils/dateTime.js
@@ -131,6 +131,16 @@ export function latestDateTime(...args) {
   return times[0];
 }
 
+export function compareByDateString(key = 'desc') {
+  if (key.toLowerCase() === 'asc') {
+    return (a, b) => parseISO(a.date) - parseISO(b.date);
+  }
+  if (key.toLowerCase() === 'desc') {
+    return (a, b) => parseISO(b.date) - parseISO(a.date);
+  }
+  return null;
+}
+
 /*
  * date-fns wrappers
  * Wrapper functions around date-fns functions that parse date_string and date_time_string types

--- a/packages/shared-src/src/utils/dateTime.js
+++ b/packages/shared-src/src/utils/dateTime.js
@@ -132,13 +132,11 @@ export function latestDateTime(...args) {
 }
 
 export function compareDateStrings(key = 'desc') {
-  if (key.toLowerCase() === 'asc') {
-    return (a, b) => parseISO(a.date) - parseISO(b.date);
-  }
-  if (key.toLowerCase() === 'desc') {
-    return (a, b) => parseISO(b.date) - parseISO(a.date);
-  }
-  return null;
+  return (a, b) => {
+    if (key.toLowerCase() === 'asc') return parseISO(a.date) - parseISO(b.date);
+    if (key.toLowerCase() === 'desc') return parseISO(b.date) - parseISO(a.date);
+    return 0;
+  };
 }
 
 /*

--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -10,6 +10,7 @@ import { SigningSection } from './SigningSection';
 import { H3, P } from './Typography';
 import { CovidLetterheadSection } from './CovidLetterheadSection';
 import { getDisplayDate } from './getDisplayDate';
+import { compareByDateString } from '../dateTime';
 
 const columns = [
   {
@@ -74,7 +75,7 @@ export const CovidVaccineCertificate = ({
   const uvciFormat = getLocalisation('previewUvciFormat');
 
   const data = vaccinations.map(vaccination => ({ ...vaccination, countryName, healthFacility }));
-  const vaxes = vaccinations.filter(v => v.certifiable).sort((a, b) => +a.date - +b.date);
+  const vaxes = vaccinations.filter(v => v.certifiable).sort(compareByDateString('desc'));
   const actualUvci = vaccinations.length
     ? uvci || generateUVCI((vaxes[0] || {}).id, { format: uvciFormat, countryCode })
     : null;

--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -10,7 +10,7 @@ import { SigningSection } from './SigningSection';
 import { H3, P } from './Typography';
 import { CovidLetterheadSection } from './CovidLetterheadSection';
 import { getDisplayDate } from './getDisplayDate';
-import { compareByDateString } from '../dateTime';
+import { compareDateStrings } from '../dateTime';
 
 const columns = [
   {
@@ -75,7 +75,7 @@ export const CovidVaccineCertificate = ({
   const uvciFormat = getLocalisation('previewUvciFormat');
 
   const data = vaccinations.map(vaccination => ({ ...vaccination, countryName, healthFacility }));
-  const vaxes = vaccinations.filter(v => v.certifiable).sort(compareByDateString('desc'));
+  const vaxes = vaccinations.filter(v => v.certifiable).sort(compareDateStrings('desc'));
   const actualUvci = vaccinations.length
     ? uvci || generateUVCI((vaxes[0] || {}).id, { format: uvciFormat, countryCode })
     : null;


### PR DESCRIPTION
### Changes

After changing to the new date-string format the sort function that is used to decide which vaccine the preview UCVI code is generated from was broken. I have extracted this out into a date util that can be used when we need to sort by date on the front end.
