### PR TITLE
Bump staging version to 1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "description": "This repo contains all the packages for Tamanu",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csca",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "private": true,
   "description": "CSCA tooling for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/app/package.json
+++ b/packages/desktop/app/package.json
@@ -3,7 +3,7 @@
   "main": "./dist/main.prod.js",
   "name": "Tamanu",
   "productName": "Tamanu",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Tamanu",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/lan/app/middleware/versionCompatibility.js
+++ b/packages/lan/app/middleware/versionCompatibility.js
@@ -4,8 +4,8 @@ import { buildVersionCompatibilityCheck } from 'shared/utils';
 // server, set MIN_CLIENT_VERSION to reflect that, and desktop users will be logged out until they
 // have updated.
 
-export const MIN_CLIENT_VERSION = '1.25.0';
-export const MAX_CLIENT_VERSION = '1.25.2'; // note that higher patch versions will be allowed to connect
+export const MIN_CLIENT_VERSION = '1.26.0';
+export const MAX_CLIENT_VERSION = '1.26.0'; // note that higher patch versions will be allowed to connect
 
 export const versionCompatibility = (req, res, next) =>
   buildVersionCompatibilityCheck(MIN_CLIENT_VERSION, MAX_CLIENT_VERSION)(req, res, next);

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lan",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "private": true,
   "description": "Lan server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-server",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "private": true,
   "description": "Meta server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/qr-tester/package.json
+++ b/packages/qr-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-tester",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "private": true,
   "description": "BES QR Code Tester App / Website",
   "author": "",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "main": "index.js",
   "license": "SEE LICENSE IN license",
   "scripts": {

--- a/packages/shared-src/package.json
+++ b/packages/shared-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-src",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "description": "Common code across Tamanu packages",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -7,16 +7,16 @@ import { InvalidClientHeadersError } from 'shared/errors';
 // not supported.
 export const SUPPORTED_CLIENT_VERSIONS = {
   'Tamanu LAN Server': {
-    min: '1.25.0',
-    max: '1.25.2', // note that higher patch versions will be allowed to connect
+    min: '1.26.0',
+    max: '1.26.0', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Desktop': {
-    min: '1.25.0',
-    max: '1.25.2', // note that higher patch versions will be allowed to connect
+    min: '1.26.0',
+    max: '1.26.0', // note that higher patch versions will be allowed to connect
   },
   'Tamanu Mobile': {
-    min: '1.25.0',
-    max: '1.25.0', // note that higher patch versions will be allowed to connect
+    min: '1.26.0',
+    max: '1.26.0', // note that higher patch versions will be allowed to connect
   },
   'fiji-vps': {
     min: null,

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-server",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "private": true,
   "description": "Sync server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",


### PR DESCRIPTION
### Changes
Because of abnormal 1.26.0 situ - as a selective cherrypick from 1.25.2 to remove first iteration of labs epic (and all the code depending upon it 😭) 
It needs to have its version bumped directly into staging