### PR TITLE
SAV-159: Reverse where null dates show when sorting vaccine route

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -249,12 +249,10 @@ patientVaccineRoutes.get(
       },
     };
 
-    const orderWithNulls =
-      orderBy === 'date'
-        ? order.toLowerCase() === 'asc'
-          ? 'ASC NULLS FIRST'
-          : 'DESC NULLS LAST'
-        : order;
+    let orderWithNulls = order;
+    if (orderBy === 'date') {
+      orderWithNulls = order.toLowerCase() === 'asc' ? 'ASC NULLS FIRST' : 'DESC NULLS LAST';
+    }
 
     const results = await patient.getAdministeredVaccines({
       ...rest,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -252,7 +252,17 @@ patientVaccineRoutes.get(
     const results = await patient.getAdministeredVaccines({
       ...rest,
       ...customSortingColumns,
-      order: [[...orderBy.split('.'), order]],
+      order: [
+        [
+          ...orderBy.split('.'),
+          // We want the date for vaccine listing to behave a little differently to standard SQL sorting for dates. When
+          // Sorting from oldest to newest we want the null values to show at the start of the list, and when sorting
+          // from newest to oldest we want the null values to show at the end of the list
+          orderBy === 'date'
+            ? `${order} NULLS ${order.toLowerCase() === 'asc' ? 'FIRST' : 'LAST'}`
+            : order,
+        ],
+      ],
       where,
       limit: rowsPerPage,
       offset: page * rowsPerPage,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -259,7 +259,7 @@ patientVaccineRoutes.get(
           // Sorting from oldest to newest we want the null values to show at the start of the list, and when sorting
           // from newest to oldest we want the null values to show at the end of the list
           orderBy === 'date'
-            ? `${order} NULLS ${order.toLowerCase() === 'asc' ? 'FIRST' : 'LAST'}`
+            ? order.toLowerCase() === 'asc' ? 'ASC NULLS FIRST' : 'DESC NULLS LAST'
             : order,
         ],
       ],

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -249,6 +249,10 @@ patientVaccineRoutes.get(
       },
     };
 
+    const orderWithNulls = orderBy === 'date'
+      ? (order.toLowerCase() === 'asc' ? 'ASC NULLS FIRST' : 'DESC NULLS LAST')
+      : order;
+      
     const results = await patient.getAdministeredVaccines({
       ...rest,
       ...customSortingColumns,
@@ -258,9 +262,7 @@ patientVaccineRoutes.get(
           // We want the date for vaccine listing to behave a little differently to standard SQL sorting for dates. When
           // Sorting from oldest to newest we want the null values to show at the start of the list, and when sorting
           // from newest to oldest we want the null values to show at the end of the list
-          orderBy === 'date'
-            ? order.toLowerCase() === 'asc' ? 'ASC NULLS FIRST' : 'DESC NULLS LAST'
-            : order,
+          orderWithNulls,
         ],
       ],
       where,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -249,10 +249,13 @@ patientVaccineRoutes.get(
       },
     };
 
-    const orderWithNulls = orderBy === 'date'
-      ? (order.toLowerCase() === 'asc' ? 'ASC NULLS FIRST' : 'DESC NULLS LAST')
-      : order;
-      
+    const orderWithNulls =
+      orderBy === 'date'
+        ? order.toLowerCase() === 'asc'
+          ? 'ASC NULLS FIRST'
+          : 'DESC NULLS LAST'
+        : order;
+
     const results = await patient.getAdministeredVaccines({
       ...rest,
       ...customSortingColumns,


### PR DESCRIPTION
### Changes

Felicity wanted vaccines with a NULL date to act as if they are the "oldest" date when sorting. Currently they show up at the start when sorting new to old and at the end when sorting old to new and we want the reverse behaviour.