### PR TITLE
SAV-106: Server printing date fix for vax certificate

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 
 import { VACCINATION_CERTIFICATE } from 'shared/constants';
 import { VaccineCertificate } from 'shared/utils/patientCertificates';
+import { getCurrentDateString } from 'shared/utils/dateTime';
 
 import { Modal } from '../../Modal';
 import { useApi } from '../../../api';
@@ -33,7 +34,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
         patientId: patient.id,
         forwardAddress: data.email,
         createdBy: printedBy,
-        createdAt: new Date(),
+        createdAt: getCurrentDateString(),
       });
     },
     [api, patient.id, printedBy],
@@ -60,7 +61,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
           logoSrc={logo}
           signingSrc={footerImg}
           printedBy={printedBy}
-          printedDate={new Date()}
+          printedDate={getCurrentDateString()}
           getLocalisation={getLocalisation}
         />
       </PDFViewer>


### PR DESCRIPTION
### Changes

I applied a fix for the printing date on the Covid Vaccine Certificate in another PR but forgot to apply it to the General Vaccine Certificate. This is just adding in use of the getCurrentDateString to post a date string to the certificate which later gets sent over email
