### PR TITLE
SAV-107: Unknown date in general certificate

### DIFF
--- a/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
+++ b/packages/shared-src/src/utils/patientCertificates/CovidVaccineCertificate.js
@@ -44,7 +44,8 @@ const columns = [
   {
     key: 'date',
     title: 'Date',
-    accessor: ({ date }, getLocalisation) => getDisplayDate(date, undefined, getLocalisation),
+    accessor: ({ date }, getLocalisation) =>
+      date ? getDisplayDate(date, undefined, getLocalisation) : 'Unknown',
   },
   {
     key: 'batch',


### PR DESCRIPTION
### Changes

Another tiny fix that was applied to the general certificate but I forgot to apply it to the covid certificate. It just shows the string "Unknown" when a vaccine has no date
