### PR TITLE
SAV-236: Update vax history immunisation register

### DIFF
--- a/packages/desktop/app/components/ImmunisationsTable.js
+++ b/packages/desktop/app/components/ImmunisationsTable.js
@@ -113,6 +113,7 @@ export const ImmunisationsTable = React.memo(
         columns={COLUMNS}
         optionRow={viewOnly ? null : notGivenCheckBox}
         noDataMessage="No vaccinations found"
+        {...(viewOnly ? { allowExport: false, page: null, rowsPerPage: null } : {})}
       />
     );
   },

--- a/packages/desktop/app/components/ImmunisationsTable.js
+++ b/packages/desktop/app/components/ImmunisationsTable.js
@@ -72,7 +72,7 @@ const TableHeaderCheckbox = styled(CheckInput)`
 `;
 
 export const ImmunisationsTable = React.memo(
-  ({ patient, onItemClick, onItemEditClick, onItemDeleteClick, viewOnly }) => {
+  ({ patient, onItemClick, onItemEditClick, onItemDeleteClick, viewOnly, allRows }) => {
     const [includeNotGiven, setIncludeNotGiven] = useState(false);
 
     const notGivenCheckBox = (
@@ -111,9 +111,9 @@ export const ImmunisationsTable = React.memo(
         initialSort={{ orderBy: 'date', order: 'desc' }}
         fetchOptions={{ includeNotGiven }}
         columns={COLUMNS}
-        optionRow={viewOnly ? null : notGivenCheckBox}
         noDataMessage="No vaccinations found"
-        {...(viewOnly ? { allowExport: false, page: null, rowsPerPage: null } : {})}
+        {...(viewOnly ? { allowExport: false, optionRow: null } : { optionRow: notGivenCheckBox })}
+        {...(allRows ? { page: null, allRows: true } : {})}
       />
     );
   },

--- a/packages/desktop/app/components/ImmunisationsTable.js
+++ b/packages/desktop/app/components/ImmunisationsTable.js
@@ -72,7 +72,7 @@ const TableHeaderCheckbox = styled(CheckInput)`
 `;
 
 export const ImmunisationsTable = React.memo(
-  ({ patient, onItemClick, onItemEditClick, onItemDeleteClick }) => {
+  ({ patient, onItemClick, onItemEditClick, onItemDeleteClick, viewOnly }) => {
     const [includeNotGiven, setIncludeNotGiven] = useState(false);
 
     const notGivenCheckBox = (
@@ -90,15 +90,19 @@ export const ImmunisationsTable = React.memo(
         { key: 'date', title: 'Date', accessor: getDate },
         { key: 'givenBy', title: 'Given by', accessor: getGiver, sortable: false },
         { key: 'displayLocation', title: 'Facility/Country', accessor: getFacility },
-        {
-          key: 'action',
-          title: 'Action',
-          accessor: getActionButtons({ onItemClick, onItemEditClick, onItemDeleteClick }),
-          sortable: false,
-          isExportable: false,
-        },
+        ...(!viewOnly
+          ? [
+              {
+                key: 'action',
+                title: 'Action',
+                accessor: getActionButtons({ onItemClick, onItemEditClick, onItemDeleteClick }),
+                sortable: false,
+                isExportable: false,
+              },
+            ]
+          : []),
       ],
-      [onItemClick, onItemEditClick, onItemDeleteClick],
+      [onItemClick, onItemEditClick, onItemDeleteClick, viewOnly],
     );
 
     return (
@@ -107,7 +111,7 @@ export const ImmunisationsTable = React.memo(
         initialSort={{ orderBy: 'date', order: 'desc' }}
         fetchOptions={{ includeNotGiven }}
         columns={COLUMNS}
-        optionRow={notGivenCheckBox}
+        optionRow={viewOnly ? null : notGivenCheckBox}
         noDataMessage="No vaccinations found"
       />
     );

--- a/packages/desktop/app/components/ImmunisationsTable.js
+++ b/packages/desktop/app/components/ImmunisationsTable.js
@@ -72,7 +72,7 @@ const TableHeaderCheckbox = styled(CheckInput)`
 `;
 
 export const ImmunisationsTable = React.memo(
-  ({ patient, onItemClick, onItemEditClick, onItemDeleteClick, viewOnly, allRows }) => {
+  ({ patient, onItemClick, onItemEditClick, onItemDeleteClick, viewOnly, disablePagination }) => {
     const [includeNotGiven, setIncludeNotGiven] = useState(false);
 
     const notGivenCheckBox = (
@@ -112,8 +112,9 @@ export const ImmunisationsTable = React.memo(
         fetchOptions={{ includeNotGiven }}
         columns={COLUMNS}
         noDataMessage="No vaccinations found"
-        {...(viewOnly ? { allowExport: false, optionRow: null } : { optionRow: notGivenCheckBox })}
-        {...(allRows ? { page: null, allRows: true } : {})}
+        allowExport={!viewOnly}
+        optionRow={!viewOnly && notGivenCheckBox}
+        disablePagination={disablePagination}
       />
     );
   },

--- a/packages/desktop/app/components/Table/DataFetchingTable.js
+++ b/packages/desktop/app/components/Table/DataFetchingTable.js
@@ -14,6 +14,7 @@ export const DataFetchingTable = memo(
     initialSort = DEFAULT_SORT,
     refreshCount = 0,
     onDataFetched,
+    allRows = false,
     ...props
   }) => {
     const [page, setPage] = useState(0);
@@ -53,11 +54,13 @@ export const DataFetchingTable = memo(
             endpoint,
             {
               page,
-              rowsPerPage,
+              ...(!allRows ? { rowsPerPage } : {}),
               ...sorting,
               ...fetchOptions,
             },
-            { showUnknownErrorToast: false },
+            {
+              showUnknownErrorToast: false,
+            },
           );
           const transformedData = transformRow ? data.map(transformRow) : data;
           updateFetchState({
@@ -90,6 +93,7 @@ export const DataFetchingTable = memo(
       transformRow,
       onDataFetched,
       updateFetchState,
+      allRows,
     ]);
 
     useEffect(() => setPage(0), [fetchOptions]);

--- a/packages/desktop/app/components/Table/DataFetchingTable.js
+++ b/packages/desktop/app/components/Table/DataFetchingTable.js
@@ -14,7 +14,7 @@ export const DataFetchingTable = memo(
     initialSort = DEFAULT_SORT,
     refreshCount = 0,
     onDataFetched,
-    allRows = false,
+    disablePagination = false,
     ...props
   }) => {
     const [page, setPage] = useState(0);
@@ -54,7 +54,7 @@ export const DataFetchingTable = memo(
             endpoint,
             {
               page,
-              ...(!allRows ? { rowsPerPage } : {}),
+              ...(!disablePagination ? { rowsPerPage } : {}),
               ...sorting,
               ...fetchOptions,
             },
@@ -93,7 +93,7 @@ export const DataFetchingTable = memo(
       transformRow,
       onDataFetched,
       updateFetchState,
-      allRows,
+      disablePagination,
     ]);
 
     useEffect(() => setPage(0), [fetchOptions]);
@@ -106,7 +106,7 @@ export const DataFetchingTable = memo(
         data={data}
         errorMessage={errorMessage}
         rowsPerPage={rowsPerPage}
-        page={page}
+        page={disablePagination ? null : page}
         count={count}
         onChangePage={setPage}
         onChangeRowsPerPage={setRowsPerPage}

--- a/packages/desktop/app/components/index.js
+++ b/packages/desktop/app/components/index.js
@@ -10,6 +10,7 @@ export * from './FormGrid';
 export * from './FormTooltip';
 export * from './Layout';
 export * from './Modal';
+export * from './ModalActionRow';
 export * from './MenuButton';
 export * from './Notification';
 export * from './PageContainer';

--- a/packages/desktop/app/views/patients/ImmunisationsView.js
+++ b/packages/desktop/app/views/patients/ImmunisationsView.js
@@ -7,28 +7,10 @@ import {
   SearchTableTitle,
   SearchTable,
 } from '../../components';
-import {
-  displayId,
-  firstName,
-  lastName,
-  culturalName,
-  village,
-  sex,
-  dateOfBirth,
-  vaccinationStatus,
-} from './columns';
+import { displayId, firstName, lastName, culturalName, village, sex, dateOfBirth } from './columns';
 import { PatientImmunisationsModal } from './components';
 
-const COLUMNS = [
-  displayId,
-  firstName,
-  lastName,
-  culturalName,
-  village,
-  sex,
-  dateOfBirth,
-  vaccinationStatus,
-];
+const COLUMNS = [displayId, firstName, lastName, culturalName, village, sex, dateOfBirth];
 
 export const ImmunisationsView = () => {
   const [searchParameters, setSearchParameters] = useState({});

--- a/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
+++ b/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
@@ -9,6 +9,6 @@ export const PatientImmunisationsModal = React.memo(({ open, patient, onClose, .
     onClose={onClose}
     {...props}
   >
-    <ImmunisationsTable patient={patient} />
+    <ImmunisationsTable patient={patient} viewOnly />
   </Modal>
 ));

--- a/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
+++ b/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
@@ -10,7 +10,7 @@ export const PatientImmunisationsModal = React.memo(({ open, patient, onClose, .
     disableHeaderCloseIcon
     {...props}
   >
-    <ImmunisationsTable patient={patient} viewOnly allRows />
+    <ImmunisationsTable patient={patient} viewOnly disablePagination />
     <ModalActionRow confirmText="Close" onConfirm={onClose} />
   </Modal>
 ));

--- a/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
+++ b/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
@@ -1,14 +1,16 @@
 import React from 'react';
 
-import { ImmunisationsTable, Modal } from '../../../components';
+import { ImmunisationsTable, Modal, ModalActionRow } from '../../../components';
 
 export const PatientImmunisationsModal = React.memo(({ open, patient, onClose, ...props }) => (
   <Modal
     title={`${patient.firstName} ${patient.lastName} Immunisation History`}
     open={open}
     onClose={onClose}
+    disableHeaderCloseIcon
     {...props}
   >
     <ImmunisationsTable patient={patient} viewOnly />
+    <ModalActionRow confirmText="Close" onConfirm={onClose} />
   </Modal>
 ));

--- a/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
+++ b/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
@@ -10,7 +10,7 @@ export const PatientImmunisationsModal = React.memo(({ open, patient, onClose, .
     disableHeaderCloseIcon
     {...props}
   >
-    <ImmunisationsTable patient={patient} viewOnly />
+    <ImmunisationsTable patient={patient} viewOnly allRows />
     <ModalActionRow confirmText="Close" onConfirm={onClose} />
   </Modal>
 ));


### PR DESCRIPTION
### Changes

After some vaccination updates we discovered a few issues with the "Immunisation Register" tab that needed to be addressed.

- Remove table footer for patient immunisation history when viewed from register
- Remove checkbox row for patient immunisation history when viewed from register
- Remove action column for patient immunisation history when viewed from register
- Remove "Vaccination status" column of immunisation register

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
