### PR TITLE
NASS-678: Bugfixes for clearing search fields

### DIFF
--- a/packages/desktop/app/components/DocumentsSearchBar.js
+++ b/packages/desktop/app/components/DocumentsSearchBar.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 
-import { Form, Field, TextField } from './Field';
+import { Form, Field, SearchField } from './Field';
 import { FormGrid } from './FormGrid';
 import { LargeButton, LargeOutlineButton } from './Button';
 import { Colors } from '../constants';
@@ -32,9 +32,9 @@ const HeaderBar = styled.div`
 const renderSearchBar = ({ submitForm, clearForm }) => (
   <>
     <FormGrid columns={3}>
-      <Field name="type" placeholder="Type" component={TextField} />
-      <Field name="documentOwner" placeholder="Owner" component={TextField} />
-      <Field name="departmentName" placeholder="Department" component={TextField} />
+      <Field name="type" label="Type" component={SearchField} />
+      <Field name="documentOwner" label="Owner" component={SearchField} />
+      <Field name="departmentName" label="Department" component={SearchField} />
     </FormGrid>
     <Box display="flex" alignItems="center" justifyContent="flex-end" mt={2}>
       <LargeOutlineButton onClick={clearForm} style={{ marginRight: 12 }}>

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -227,7 +227,7 @@ export class AutocompleteInput extends Component {
   handleClearValue = () => {
     const { onChange, name } = this.props;
     this.setState({ selectedOption: { value: '', tag: null } });
-    onChange({ target: { value: '', name } });
+    onChange({ target: { value: undefined, name } });
   };
 
   clearOptions = () => {

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -92,6 +92,8 @@ const StyledExpandMore = styled(ChevronIcon)`
 
 const StyledIconButton = styled(IconButton)`
   padding: 5px;
+  position: absolute;
+  right: 35px;
 `;
 
 const StyledClearIcon = styled(ClearIcon)`

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -32,9 +32,10 @@ const StyledClearIcon = styled(ClearIcon)`
 `;
 
 export const SearchField = ({ keepLetterCase = false, ...props }) => {
-  const { label } = props;
   const {
-    field: { value },
+    field: { value, name },
+    form: { setFieldValue },
+    label,
   } = props;
   const [searchValue, setSearchValue] = useState(value);
 
@@ -44,6 +45,7 @@ export const SearchField = ({ keepLetterCase = false, ...props }) => {
 
   const clearSearch = () => {
     setSearchValue('');
+    setFieldValue(name, '');
   };
 
   return (

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -34,7 +34,9 @@ const OptionTag = styled(FormFieldTag)`
 `;
 
 const StyledIconButton = styled(IconButton)`
-  padding: 0 5px;
+  padding: 5px;
+  position: absolute;
+  right: 35px;
 `;
 
 const StyledClearIcon = styled(ClearIcon)`
@@ -117,7 +119,7 @@ export const SelectInput = ({
         borderColor,
         boxShadow: 'none',
         borderRadius: '3px',
-        paddingTop: '12px',
+        paddingTop: '10px',
         paddingBottom: '8px',
         paddingLeft: '5px',
         fontSize,

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -34,7 +34,7 @@ const OptionTag = styled(FormFieldTag)`
 `;
 
 const StyledIconButton = styled(IconButton)`
-  padding: 5px;
+  padding: 0 5px;
 `;
 
 const StyledClearIcon = styled(ClearIcon)`
@@ -111,14 +111,14 @@ export const SelectInput = ({
     control: (provided, state) => {
       const mainBorderColor = state.isFocused ? Colors.primary : Colors.outline;
       const borderColor = props.error ? Colors.alert : mainBorderColor;
-      const fontSize = props.size === 'small' ? '11px' : '14px';
+      const fontSize = props.size === 'small' ? '11px' : '15px';
       return {
         ...provided,
         borderColor,
         boxShadow: 'none',
         borderRadius: '3px',
-        paddingTop: '5px',
-        paddingBottom: '3px',
+        paddingTop: '12px',
+        paddingBottom: '8px',
         paddingLeft: '5px',
         fontSize,
       };

--- a/packages/desktop/app/views/programs/ProgramsView.js
+++ b/packages/desktop/app/views/programs/ProgramsView.js
@@ -31,6 +31,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
   const [survey, setSurvey] = useState(null);
   const [programs, setPrograms] = useState(null);
   const [selectedProgramId, setSelectedProgramId] = useState(null);
+  const [selectedSurveyId, setSelectedSurveyId] = useState(null);
   const [startTime, setStartTime] = useState(null);
   const [surveys, setSurveys] = useState(null);
 
@@ -58,6 +59,12 @@ const SurveyFlow = ({ patient, currentUser }) => {
 
   const unsetSurvey = useCallback(() => {
     setSurvey(null);
+    setSelectedSurveyId(null);
+  }, []);
+
+  const clearProgram = useCallback(() => {
+    setSelectedProgramId(null);
+    setSurveys(null);
   }, []);
 
   const selectProgram = useCallback(
@@ -69,7 +76,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
       setSelectedProgramId(programId);
 
       if (!programId) {
-        setSurveys(null);
+        handleClearProgram();
         return;
       }
 
@@ -80,7 +87,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
           .map(x => ({ value: x.id, label: x.name })),
       );
     },
-    [api, selectedProgramId],
+    [api, selectedProgramId, handleClearProgram],
   );
 
   const submitSurveyResponse = async data => {
@@ -117,7 +124,9 @@ const SurveyFlow = ({ patient, currentUser }) => {
             label="Select program"
           />
           <SurveySelector
-            onSelectSurvey={setSelectedSurvey}
+            onSubmit={setSelectedSurvey}
+            onChange={setSelectedSurveyId}
+            value={selectedSurveyId}
             surveys={surveys}
             buttonText="Begin survey"
           />

--- a/packages/desktop/app/views/programs/ProgramsView.js
+++ b/packages/desktop/app/views/programs/ProgramsView.js
@@ -76,7 +76,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
       setSelectedProgramId(programId);
 
       if (!programId) {
-        handleClearProgram();
+        clearProgram();
         return;
       }
 
@@ -87,7 +87,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
           .map(x => ({ value: x.id, label: x.name })),
       );
     },
-    [api, selectedProgramId, handleClearProgram],
+    [api, selectedProgramId, clearProgram],
   );
 
   const submitSurveyResponse = async data => {

--- a/packages/desktop/app/views/programs/ProgramsView.js
+++ b/packages/desktop/app/views/programs/ProgramsView.js
@@ -59,11 +59,10 @@ const SurveyFlow = ({ patient, currentUser }) => {
 
   const unsetSurvey = useCallback(() => {
     setSurvey(null);
-    setSelectedSurveyId(null);
   }, []);
 
   const clearProgram = useCallback(() => {
-    setSelectedProgramId(null);
+    setSelectedSurveyId(null);
     setSurveys(null);
   }, []);
 

--- a/packages/desktop/app/views/programs/SurveySelector.js
+++ b/packages/desktop/app/views/programs/SurveySelector.js
@@ -27,7 +27,7 @@ export const SurveySelector = React.memo(({ onSelectSurvey, surveys, buttonText 
     <>
       <SelectInput options={surveys} value={selectedSurveyId} onChange={onChangeSurvey} />
       <StyledButtonRow>
-        <Button onClick={onSubmit} disabled={!selectedSurveyId} variant="contained" color="primary">
+        <Button onClick={onSubmit} disabled={!surveys} variant="contained" color="primary">
           {buttonText}
         </Button>
       </StyledButtonRow>

--- a/packages/desktop/app/views/programs/SurveySelector.js
+++ b/packages/desktop/app/views/programs/SurveySelector.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 
 import { Button } from 'desktop/app/components/Button';
 import { ButtonRow } from 'desktop/app/components/ButtonRow';
@@ -11,29 +11,24 @@ const StyledButtonRow = styled(ButtonRow)`
   margin-top: 24px;
 `;
 
-export const SurveySelector = React.memo(({ onSelectSurvey, surveys, buttonText }) => {
-  const [selectedSurveyId, setSelectedSurveyId] = useState(null);
+export const SurveySelector = React.memo(({ value, onChange, onSubmit, surveys, buttonText }) => {
+  const handleChange = useCallback(
+    event => {
+      const surveyId = event.target.value;
+      onChange(surveyId);
+    },
+    [onChange],
+  );
 
-  const onChangeSurvey = useCallback(event => {
-    const surveyId = event.target.value;
-    setSelectedSurveyId(surveyId);
-  }, []);
-
-  const onSubmit = useCallback(() => {
-    onSelectSurvey(selectedSurveyId);
-  }, [onSelectSurvey, selectedSurveyId]);
-
-  useEffect(() => {
-    if (!surveys) {
-      setSelectedSurveyId(null);
-    }
-  }, [surveys]);
+  const handleSubmit = useCallback(() => {
+    onSubmit(value);
+  }, [onSubmit, value]);
 
   return (
     <>
-      <SelectInput options={surveys} value={selectedSurveyId} onChange={onChangeSurvey} />
+      <SelectInput options={surveys} value={value} onChange={handleChange} />
       <StyledButtonRow>
-        <Button onClick={onSubmit} disabled={!selectedSurveyId} variant="contained" color="primary">
+        <Button onClick={handleSubmit} disabled={!value} variant="contained" color="primary">
           {buttonText}
         </Button>
       </StyledButtonRow>

--- a/packages/desktop/app/views/programs/SurveySelector.js
+++ b/packages/desktop/app/views/programs/SurveySelector.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 
 import { Button } from 'desktop/app/components/Button';
 import { ButtonRow } from 'desktop/app/components/ButtonRow';
@@ -23,11 +23,17 @@ export const SurveySelector = React.memo(({ onSelectSurvey, surveys, buttonText 
     onSelectSurvey(selectedSurveyId);
   }, [onSelectSurvey, selectedSurveyId]);
 
+  useEffect(() => {
+    if (!surveys) {
+      setSelectedSurveyId(null);
+    }
+  }, [surveys]);
+
   return (
     <>
       <SelectInput options={surveys} value={selectedSurveyId} onChange={onChangeSurvey} />
       <StyledButtonRow>
-        <Button onClick={onSubmit} disabled={!surveys} variant="contained" color="primary">
+        <Button onClick={onSubmit} disabled={!selectedSurveyId} variant="contained" color="primary">
           {buttonText}
         </Button>
       </StyledButtonRow>

--- a/packages/desktop/app/views/referrals/ReferralsView.js
+++ b/packages/desktop/app/views/referrals/ReferralsView.js
@@ -20,6 +20,7 @@ const ReferralFlow = ({ patient, currentUser }) => {
   const { navigateToPatient } = usePatientNavigation();
   const [referralSurvey, setReferralSurvey] = useState(null);
   const [referralSurveys, setReferralSurveys] = useState(null);
+  const [selectedSurveyId, setSelectedSurveyId] = useState(null);
   const [startTime, setStartTime] = useState(null);
 
   useEffect(() => {
@@ -63,7 +64,9 @@ const ReferralFlow = ({ patient, currentUser }) => {
         </ProgramsPaneHeader>
         <FormGrid columns={1}>
           <SurveySelector
-            onSelectSurvey={setSelectedReferral}
+            onSubmit={setSelectedReferral}
+            onChange={setSelectedSurveyId}
+            value={selectedSurveyId}
             surveys={referralSurveys}
             buttonText="Begin referral"
           />


### PR DESCRIPTION
### Changes

After a round of tests there were a few edge cases that needed to be resolved:

- [x] Implement proper search fields for documents tab
- [x] Disable "Begin survey" button when survey category is cleared
- [x] After clearing a facility from dropdown for death workflow, it will try to insert a facility id that is an empty string
- [x] "X" doesn't actually clear search inputs for search tables. It will still store the old value that was used last time the user pressed "Search"
- [x] Clearing the area dropdown on the imaging table will "break" the search (always returns nothing afterwards)
- [x] Select dropdown seems to be shorter in many places than other inputs
