### PR TITLE
SAV-141: Fix vaccinebrand and disease fields not shown on edit vaccine

### DIFF
--- a/packages/desktop/app/forms/VaccineForm.js
+++ b/packages/desktop/app/forms/VaccineForm.js
@@ -82,7 +82,7 @@ export const VaccineForm = ({
   vaccineRecordingType,
 }) => {
   const [vaccineOptions, setVaccineOptions] = useState([]);
-  const [category, setCategory] = useState(VACCINE_CATEGORIES.ROUTINE);
+  const [category, setCategory] = useState(currentVaccineRecordValues?.vaccineName ? VACCINE_CATEGORIES.OTHER : VACCINE_CATEGORIES.ROUTINE);
   const [vaccineLabel, setVaccineLabel] = useState();
 
   const {
@@ -155,7 +155,7 @@ export const VaccineForm = ({
       initialValues={
         !editMode
           ? {
-              category: VACCINE_CATEGORIES.ROUTINE,
+              category,
               date: getCurrentDateTimeString(),
               locationGroupId: !currentEncounter
                 ? vaccinationDefaults.data?.locationGroupId
@@ -212,11 +212,13 @@ const VaccineFormComponent = ({
   patientId,
   ...props
 }) => {
-  const { setCategory, setVaccineLabel } = props;
+  const { setCategory, setVaccineLabel, editMode } = props;
   useEffect(() => {
     // Reset the entire form values when switching between GIVEN and NOT_GIVEN tab
     resetForm();
-    setCategory(null);
+    if (!editMode) {
+      setCategory(null);
+    }
     setVaccineLabel(null);
     // we strictly only want to reset the form values when vaccineRecordingType is changed
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/desktop/app/forms/VaccineForm.js
+++ b/packages/desktop/app/forms/VaccineForm.js
@@ -82,7 +82,9 @@ export const VaccineForm = ({
   vaccineRecordingType,
 }) => {
   const [vaccineOptions, setVaccineOptions] = useState([]);
-  const [category, setCategory] = useState(currentVaccineRecordValues?.vaccineName ? VACCINE_CATEGORIES.OTHER : VACCINE_CATEGORIES.ROUTINE);
+  const [category, setCategory] = useState(
+    currentVaccineRecordValues?.vaccineName ? VACCINE_CATEGORIES.OTHER : VACCINE_CATEGORIES.ROUTINE,
+  );
   const [vaccineLabel, setVaccineLabel] = useState();
 
   const {


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
