### PR TITLE
NASS-661: Print multiple imaging & lab requests select style updates

### DIFF
--- a/packages/desktop/app/components/DateDisplay.js
+++ b/packages/desktop/app/components/DateDisplay.js
@@ -15,7 +15,7 @@ const Text = styled(Typography)`
 `;
 
 const SoftText = styled(Text)`
-  color: ${Colors.softText};
+  color: ${Colors.midText};
 `;
 
 const getLocale = () => remote.getGlobal('osLocales') || remote.app.getLocale() || 'default';

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 
 import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants/statuses';
@@ -11,6 +12,23 @@ import { Colors } from '../../../constants';
 
 import { MultipleImagingRequestsPrintoutModal } from './MultipleImagingRequestsPrintoutModal';
 import { COLUMN_KEYS, FORM_COLUMNS } from './multipleImagingRequestsColumns';
+
+const StyledTable = styled(Table)`
+  border: none;
+  box-shadow: 2px 2px 25px rgba(0, 0, 0, 0.1);
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  tbody tr td:first-child {
+    border-bottom: none;
+  }
+}`;
+
+const StyledLabelFieldWrapper = styled(OuterLabelFieldWrapper)`
+  .label-field {
+    margin-bottom: 15px;
+  }
+`;
 
 export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter, onClose }) => {
   const [openPrintoutModal, setOpenPrintoutModal] = useState(false);
@@ -52,8 +70,8 @@ export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter
         onClose={() => setOpenPrintoutModal(false)}
       />
 
-      <OuterLabelFieldWrapper label="Select the imaging requests you would like to print">
-        <Table
+      <StyledLabelFieldWrapper label="Select the imaging requests you would like to print">
+        <StyledTable
           headerColor={Colors.white}
           columns={columns}
           data={imagingRequestsData || []}
@@ -63,7 +81,7 @@ export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter
           noDataMessage="No imaging requests found"
           allowExport={false}
         />
-      </OuterLabelFieldWrapper>
+      </StyledLabelFieldWrapper>
       <ConfirmCancelRow
         cancelText="Close"
         confirmText="Print"

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
@@ -15,12 +15,15 @@ import { COLUMN_KEYS, FORM_COLUMNS } from './multipleImagingRequestsColumns';
 
 const StyledTable = styled(Table)`
   border: none;
-  box-shadow: 2px 2px 25px rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
   tbody tr:last-child td {
     border-bottom: none;
   }
   tbody tr td:first-child {
     border-bottom: none;
+  }
+  thead tr th {
+    color: ${Colors.midText};
   }
 }`;
 
@@ -28,6 +31,16 @@ const StyledLabelFieldWrapper = styled(OuterLabelFieldWrapper)`
   .label-field {
     margin-bottom: 15px;
   }
+  padding: 25px 30px;
+`;
+
+const Rule = styled.div`
+  margin: 15px 0 30px 0;
+  width: calc(100% + 64px);
+  height: 1px;
+  background-color: ${Colors.outline};
+  position: relative;
+  left: -32px;
 `;
 
 export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter, onClose }) => {
@@ -82,6 +95,7 @@ export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter
           allowExport={false}
         />
       </StyledLabelFieldWrapper>
+      <Rule />
       <ConfirmCancelRow
         cancelText="Close"
         confirmText="Print"

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
@@ -1,47 +1,16 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 
 import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants/statuses';
-import { Table, useSelectableColumn } from '../../Table';
-import { OuterLabelFieldWrapper } from '../../Field';
+import { useSelectableColumn } from '../../Table';
 import { ConfirmCancelRow } from '../../ButtonRow';
 import { useApi } from '../../../api';
 import { Colors } from '../../../constants';
 
 import { MultipleImagingRequestsPrintoutModal } from './MultipleImagingRequestsPrintoutModal';
 import { COLUMN_KEYS, FORM_COLUMNS } from './multipleImagingRequestsColumns';
-
-const StyledTable = styled(Table)`
-  border: none;
-  border-radius: 5px;
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-  tbody tr td:first-child {
-    border-bottom: none;
-  }
-  thead tr th {
-    color: ${Colors.midText};
-  }
-}`;
-
-const StyledLabelFieldWrapper = styled(OuterLabelFieldWrapper)`
-  .label-field {
-    margin-bottom: 15px;
-  }
-  padding: 25px 30px;
-`;
-
-export const Rule = styled.div`
-  margin: 15px 0 30px 0;
-  width: calc(100% + 64px);
-  height: 1px;
-  background-color: ${Colors.outline};
-  position: relative;
-  left: -32px;
-`;
+import { FormDivider, PrintMultipleSelectionTable } from './PrintMultipleSelectionTable';
 
 export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter, onClose }) => {
   const [openPrintoutModal, setOpenPrintoutModal] = useState(false);
@@ -82,20 +51,18 @@ export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter
         open={openPrintoutModal}
         onClose={() => setOpenPrintoutModal(false)}
       />
-
-      <StyledLabelFieldWrapper label="Select the imaging requests you would like to print">
-        <StyledTable
-          headerColor={Colors.white}
-          columns={columns}
-          data={imagingRequestsData || []}
-          elevated={false}
-          isLoading={isLoading}
-          errorMessage={error?.message}
-          noDataMessage="No imaging requests found"
-          allowExport={false}
-        />
-      </StyledLabelFieldWrapper>
-      <Rule />
+      <PrintMultipleSelectionTable
+        label="Select the imaging requests you would like to print"
+        headerColor={Colors.white}
+        columns={columns}
+        data={imagingRequestsData || []}
+        elevated={false}
+        isLoading={isLoading}
+        errorMessage={error?.message}
+        noDataMessage="No imaging requests found"
+        allowExport={false}
+      />
+      <FormDivider />
       <ConfirmCancelRow
         cancelText="Close"
         confirmText="Print"

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
@@ -34,7 +34,7 @@ const StyledLabelFieldWrapper = styled(OuterLabelFieldWrapper)`
   padding: 25px 30px;
 `;
 
-const Rule = styled.div`
+export const Rule = styled.div`
   margin: 15px 0 30px 0;
   width: calc(100% + 64px);
   height: 1px;

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 
 import { LAB_REQUEST_STATUSES } from 'shared/constants/labs';
+import styled from 'styled-components';
 import { Table, useSelectableColumn } from '../../Table';
 import { OuterLabelFieldWrapper } from '../../Field';
 import { ConfirmCancelRow } from '../../ButtonRow';
@@ -11,6 +12,36 @@ import { useApi } from '../../../api';
 import { Colors } from '../../../constants';
 
 import { MultipleLabRequestsPrintoutModal } from './MultipleLabRequestsPrintoutModal';
+
+const StyledTable = styled(Table)`
+  border: none;
+  border-radius: 5px;
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  tbody tr td:first-child {
+    border-bottom: none;
+  }
+  thead tr th {
+    color: ${Colors.midText};
+  }
+}`;
+
+const StyledLabelFieldWrapper = styled(OuterLabelFieldWrapper)`
+  .label-field {
+    margin-bottom: 15px;
+  }
+  padding: 25px 30px;
+`;
+
+export const Rule = styled.div`
+  margin: 15px 0 30px 0;
+  width: calc(100% + 64px);
+  height: 1px;
+  background-color: ${Colors.outline};
+  position: relative;
+  left: -32px;
+`;
 
 const COLUMN_KEYS = {
   SELECTED: 'selected',
@@ -90,8 +121,8 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
         onClose={() => setOpenPrintoutModal(false)}
       />
 
-      <OuterLabelFieldWrapper label="Select the lab requests you would like to print">
-        <Table
+      <StyledLabelFieldWrapper label="Select the lab requests you would like to print">
+        <StyledTable
           headerColor={Colors.white}
           columns={[selectableColumn, ...COLUMNS]}
           data={labRequestsData || []}
@@ -101,7 +132,8 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
           noDataMessage="No lab requests found"
           allowExport={false}
         />
-      </OuterLabelFieldWrapper>
+      </StyledLabelFieldWrapper>
+      <Rule />
       <ConfirmCancelRow
         cancelText="Close"
         confirmText="Print"

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
@@ -3,45 +3,15 @@ import PropTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 
 import { LAB_REQUEST_STATUSES } from 'shared/constants/labs';
-import styled from 'styled-components';
-import { Table, useSelectableColumn } from '../../Table';
-import { OuterLabelFieldWrapper } from '../../Field';
+import { useSelectableColumn } from '../../Table';
+
 import { ConfirmCancelRow } from '../../ButtonRow';
 import { DateDisplay } from '../../DateDisplay';
 import { useApi } from '../../../api';
 import { Colors } from '../../../constants';
 
 import { MultipleLabRequestsPrintoutModal } from './MultipleLabRequestsPrintoutModal';
-
-const StyledTable = styled(Table)`
-  border: none;
-  border-radius: 5px;
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-  tbody tr td:first-child {
-    border-bottom: none;
-  }
-  thead tr th {
-    color: ${Colors.midText};
-  }
-}`;
-
-const StyledLabelFieldWrapper = styled(OuterLabelFieldWrapper)`
-  .label-field {
-    margin-bottom: 15px;
-  }
-  padding: 25px 30px;
-`;
-
-export const Rule = styled.div`
-  margin: 15px 0 30px 0;
-  width: calc(100% + 64px);
-  height: 1px;
-  background-color: ${Colors.outline};
-  position: relative;
-  left: -32px;
-`;
+import { FormDivider, PrintMultipleSelectionTable } from './PrintMultipleSelectionTable';
 
 const COLUMN_KEYS = {
   SELECTED: 'selected',
@@ -120,20 +90,18 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
         open={openPrintoutModal}
         onClose={() => setOpenPrintoutModal(false)}
       />
-
-      <StyledLabelFieldWrapper label="Select the lab requests you would like to print">
-        <StyledTable
-          headerColor={Colors.white}
-          columns={[selectableColumn, ...COLUMNS]}
-          data={labRequestsData || []}
-          elevated={false}
-          isLoading={isLoading}
-          errorMessage={error?.message}
-          noDataMessage="No lab requests found"
-          allowExport={false}
-        />
-      </StyledLabelFieldWrapper>
-      <Rule />
+      <PrintMultipleSelectionTable
+        label="Select the lab requests you would like to print"
+        headerColor={Colors.white}
+        columns={[selectableColumn, ...COLUMNS]}
+        data={labRequestsData || []}
+        elevated={false}
+        isLoading={isLoading}
+        errorMessage={error?.message}
+        noDataMessage="No lab requests found"
+        allowExport={false}
+      />
+      <FormDivider />
       <ConfirmCancelRow
         cancelText="Close"
         confirmText="Print"

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleSelectionTable.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleSelectionTable.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Table } from '../../Table';
+import { Colors } from '../../../constants';
+import { OuterLabelFieldWrapper } from '../../Field';
+
+const StyledSelectionTable = styled(Table)`
+  border: none;
+  border-radius: 5px;
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  tbody tr td:first-child {
+    border-bottom: none;
+  }
+  thead tr th {
+    color: ${Colors.midText};
+  }
+`;
+
+const StyledOuterLayerFieldWrapper = styled(OuterLabelFieldWrapper)`
+  .label-field {
+    margin-bottom: 15px;
+  }
+  padding: 25px 30px;
+`;
+
+export const FormDivider = styled.div`
+  margin: 15px 0 30px 0;
+  width: calc(100% + 64px);
+  height: 1px;
+  background-color: ${Colors.outline};
+  position: relative;
+  left: -32px;
+`;
+
+export const PrintMultipleSelectionTable = ({ label, ...props }) => {
+  return (
+    <StyledOuterLayerFieldWrapper label={label}>
+      <StyledSelectionTable {...props} />
+    </StyledOuterLayerFieldWrapper>
+  );
+};

--- a/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { startCase } from 'lodash';
 
+import styled from 'styled-components';
 import { MultilineDatetimeDisplay } from '../../DateDisplay';
 import { getImagingRequestType } from '../../../utils/getImagingRequestType';
 import { getAreaNote } from '../../../utils/areaNote';
@@ -22,6 +23,11 @@ const ImagingType = ({ imagingType }) => {
   return getImagingRequestType(imagingTypes)({ imagingType });
 };
 
+const StyledDateTitle = styled.div`
+  width: 83px;
+  white-space: break-spaces;
+`;
+
 const COMMON_COLUMNS = [
   {
     key: COLUMN_KEYS.ID,
@@ -31,7 +37,7 @@ const COMMON_COLUMNS = [
   },
   {
     key: COLUMN_KEYS.REQUESTED_DATE,
-    title: 'Requested date & time',
+    title: <StyledDateTitle>Request date & time</StyledDateTitle>,
     sortable: false,
     form: {
       accessor: ({ requestedDate }) => <MultilineDatetimeDisplay date={requestedDate} />,

--- a/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { startCase } from 'lodash';
 
-import styled from 'styled-components';
 import { MultilineDatetimeDisplay } from '../../DateDisplay';
 import { getImagingRequestType } from '../../../utils/getImagingRequestType';
 import { getAreaNote } from '../../../utils/areaNote';

--- a/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/multipleImagingRequestsColumns.js
@@ -23,11 +23,6 @@ const ImagingType = ({ imagingType }) => {
   return getImagingRequestType(imagingTypes)({ imagingType });
 };
 
-const StyledDateTitle = styled.div`
-  width: 83px;
-  white-space: break-spaces;
-`;
-
 const COMMON_COLUMNS = [
   {
     key: COLUMN_KEYS.ID,
@@ -37,7 +32,7 @@ const COMMON_COLUMNS = [
   },
   {
     key: COLUMN_KEYS.REQUESTED_DATE,
-    title: <StyledDateTitle>Request date & time</StyledDateTitle>,
+    title: 'Request date & time',
     sortable: false,
     form: {
       accessor: ({ requestedDate }) => <MultilineDatetimeDisplay date={requestedDate} />,


### PR DESCRIPTION
### Changes
- Update styles for print multiple select for labs and imaging requests

**Before**
![Screenshot 2023-05-15 at 10 22 59 AM](https://github.com/beyondessential/tamanu/assets/38335330/03631f13-835d-4ed6-b530-9c98889f4961)

**After**
<img width="1062" alt="Screenshot 2023-05-15 at 10 14 32 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/27f31d65-9fe8-44d2-bb4c-673aa0715c42">


### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
