### PR TITLE
NASS-678: staging-fix: old lab flow clear tests on category change

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm.js
+++ b/packages/desktop/app/forms/LabRequestForm.js
@@ -94,7 +94,7 @@ export const LabRequestForm = ({
     api.get('suggestions/labTestType/all'),
   );
 
-  const renderForm = ({ values, submitForm }) => {
+  const renderForm = ({ values, submitForm, setFieldValue }) => {
     const { examiner = {} } = encounter;
     const examinerLabel = examiner.displayName;
     const encounterLabel = getEncounterLabel(encounter);
@@ -141,6 +141,11 @@ export const LabRequestForm = ({
           name="labTestCategoryId"
           label="Test category"
           required
+          onChange={event => {
+            // Reset selected test types when category changes
+            setFieldValue('labTestCategoryId', event.target.value);
+            setFieldValue('labTestTypeIds', []);
+          }}
           component={SuggesterSelectField}
           endpoint="labTestCategory"
         />


### PR DESCRIPTION
### Changes
A rare fix appropriate for merge directly into staging
development has long removed this depreciated lab flow since merge of lab epic.
**Fix:**
- Test ids persist across different categories
- Clearing did not reset test type id list

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
