### PR TITLE
NASS-654: Lab request listing view exclude published

### DIFF
--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { LAB_REQUEST_STATUSES } from 'shared/constants';
+import { LAB_REQUEST_STATUSES } from 'shared/constants/labs';
 import { LAB_REQUEST_STATUS_OPTIONS } from '../../constants';
 import {
   DateField,
@@ -150,7 +150,9 @@ export const LabRequestsSearchBar = ({ status = '' }) => {
             name="status"
             defaultLabel="Status"
             component={SelectField}
-            options={LAB_REQUEST_STATUS_OPTIONS}
+            options={LAB_REQUEST_STATUS_OPTIONS.filter(
+              option => option.value !== LAB_REQUEST_STATUSES.PUBLISHED,
+            )}
             size="small"
           />
         )}

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -177,6 +177,13 @@ labRequest.get(
           };
         },
       ),
+      makeFilter(
+        JSON.parse(filterParams.status !== LAB_REQUEST_STATUSES.PUBLISHED),
+        `lab_requests.status != :published`,
+        () => ({
+          [LAB_REQUEST_STATUSES.PUBLISHED]: LAB_REQUEST_STATUSES.PUBLISHED,
+        }),
+      ),
     ].filter(f => f);
 
     const whereClauses = filters.map(f => f.sql).join(' AND ');

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -128,10 +128,10 @@ labRequest.get(
     const makeSimpleTextFilter = makeSimpleTextFilterFactory(filterParams);
     const filters = [
       makeFilter(true, `lab_requests.status != :deleted`, () => ({
-        [LAB_REQUEST_STATUSES.DELETED]: LAB_REQUEST_STATUSES.DELETED,
+        deleted: LAB_REQUEST_STATUSES.DELETED,
       })),
       makeFilter(true, `lab_requests.status != :cancelled`, () => ({
-        [LAB_REQUEST_STATUSES.CANCELLED]: LAB_REQUEST_STATUSES.CANCELLED,
+        cancelled: LAB_REQUEST_STATUSES.CANCELLED,
       })),
       makeFilter(true, `lab_requests.status != :enteredInError`, () => ({
         enteredInError: LAB_REQUEST_STATUSES.ENTERED_IN_ERROR,
@@ -178,10 +178,10 @@ labRequest.get(
         },
       ),
       makeFilter(
-        JSON.parse(filterParams.status !== LAB_REQUEST_STATUSES.PUBLISHED),
+        filterParams.status !== LAB_REQUEST_STATUSES.PUBLISHED,
         `lab_requests.status != :published`,
         () => ({
-          [LAB_REQUEST_STATUSES.PUBLISHED]: LAB_REQUEST_STATUSES.PUBLISHED,
+          published: LAB_REQUEST_STATUSES.PUBLISHED,
         }),
       ),
     ].filter(f => f);


### PR DESCRIPTION
### Changes
- Exclude published lab requests on active requests page (They have there own page with table now
- Don't display published as an option on active request status search field dropdown

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
