### PR TITLE
TAN-1996: Staging fix desktop notes pane displaying mobile notes

### DIFF
--- a/packages/desktop/app/forms/NotePageForm.js
+++ b/packages/desktop/app/forms/NotePageForm.js
@@ -121,7 +121,7 @@ export const NotePageForm = ({
           label="Type"
           required
           component={SelectField}
-          options={getSelectableNoteTypes(noteTypeCountByType)}
+          options={isEmpty(notePage) ? getSelectableNoteTypes(noteTypeCountByType) : noteTypes}
           disabled={!isEmpty(notePage)}
           formatOptionLabel={option => renderOptionLabel(option, noteTypeCountByType)}
         />

--- a/packages/shared-src/src/constants/notes.js
+++ b/packages/shared-src/src/constants/notes.js
@@ -22,7 +22,7 @@ export const NOTE_TYPES = {
   RESULT_DESCRIPTION: 'resultDescription',
   SYSTEM: 'system',
   OTHER: 'other',
-  CLINICAL_MOBILE: 'clininicalMobile',
+  CLINICAL_MOBILE: 'clinicalMobile',
   HANDOVER: 'handover',
 };
 


### PR DESCRIPTION
### Changes

There were 2 separate issues
- A typo in the definition of the NOTE_TYPES constant
- The "hideFromDropdown" key also gives the clinical mobile note type a visual bug on the edit screen.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
