### PR TITLE
TAN-1996: Desktop notes pane bugfix

### DIFF
--- a/packages/desktop/app/forms/NotePageForm.js
+++ b/packages/desktop/app/forms/NotePageForm.js
@@ -92,6 +92,8 @@ export const NotePageForm = ({
   const { currentUser } = useAuth();
   const { getLocalisation } = useLocalisation();
 
+  const creatingNewNotePage = isEmpty(notePage);
+
   const lastNoteItemRef = useCallback(node => {
     if (node !== null) {
       node.scrollIntoView({ behavior: 'smooth' });
@@ -100,7 +102,7 @@ export const NotePageForm = ({
 
   const renderForm = ({ submitForm }) => (
     <>
-      {!isEmpty(notePage) && (
+      {!creatingNewNotePage && (
         <>
           <StyledFormGrid columns={1}>
             <NoteItemList
@@ -121,8 +123,8 @@ export const NotePageForm = ({
           label="Type"
           required
           component={SelectField}
-          options={isEmpty(notePage) ? getSelectableNoteTypes(noteTypeCountByType) : noteTypes}
-          disabled={!isEmpty(notePage)}
+          options={creatingNewNotePage ? getSelectableNoteTypes(noteTypeCountByType) : noteTypes}
+          disabled={!creatingNewNotePage}
           formatOptionLabel={option => renderOptionLabel(option, noteTypeCountByType)}
         />
         <Field

--- a/packages/desktop/app/forms/NotePageForm.js
+++ b/packages/desktop/app/forms/NotePageForm.js
@@ -121,7 +121,7 @@ export const NotePageForm = ({
           label="Type"
           required
           component={SelectField}
-          options={getSelectableNoteTypes(noteTypeCountByType)}
+          options={isEmpty(notePage) ? getSelectableNoteTypes(noteTypeCountByType) : noteTypes}
           disabled={!isEmpty(notePage)}
           formatOptionLabel={option => renderOptionLabel(option, noteTypeCountByType)}
         />

--- a/packages/shared-src/src/constants/notes.js
+++ b/packages/shared-src/src/constants/notes.js
@@ -22,7 +22,7 @@ export const NOTE_TYPES = {
   RESULT_DESCRIPTION: 'resultDescription',
   SYSTEM: 'system',
   OTHER: 'other',
-  CLINICAL_MOBILE: 'clininicalMobile',
+  CLINICAL_MOBILE: 'clinicalMobile',
   HANDOVER: 'handover',
 };
 


### PR DESCRIPTION
### Changes

Card: https://linear.app/bes/issue/TAN-1996/add-ability-to-add-notes-on-mobile-that-reflect-in-desktop-and-overall

There were 2 separate issues
- A typo in the definition of the NOTE_TYPES constant
- The "hideFromDropdown" key also gives the clinical mobile note type a visual bug on the edit screen.

Originally here: https://github.com/beyondessential/tamanu/pull/4062

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [x] any config/settings changes and manual deployment steps
  - [x] any db schema or other changes that could impact downstream data analysis
- [x] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [x] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
