### PR TITLE
NASS-661: break spaces on print multiple table head cells

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleSelectionTable.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleSelectionTable.js
@@ -15,6 +15,9 @@ const StyledSelectionTable = styled(Table)`
   }
   thead tr th {
     color: ${Colors.midText};
+    span {
+      white-space: break-spaces;
+    }
   }
 `;
 


### PR DESCRIPTION
### Changes
Imaging print multiple select table has some long head cells like `Request date & time` and `Area to be imaged` so needs to have `white-space: break-spaces` to not go scroll mode 😎 🛹 
### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
