### PR TITLE
SAV-131: Fix wrong fields showing on vax modal

### DIFF
--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -177,9 +177,8 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
         ...(editMode ? [] : [[fieldObjects.circumstance, fieldObjects.status]]),
         [
           fieldObjects.vaccine,
-          fieldObjects.schedule,
           ...(editMode
-            ? [fieldObjects.status, fieldObjects.recordedBy]
+            ? [fieldObjects.schedule, fieldObjects.status, fieldObjects.recordedBy]
             : [fieldObjects.batch, fieldObjects.dateGiven, fieldObjects.injectionSite]),
         ],
         ...(editMode


### PR DESCRIPTION
### Changes

When edit mode logic was added to the view vaccine modal, the wrong field was added to the "always showing" section when it should have been conditionally only shown in edit mode. This PR is just a small tweak moving it to the right place
