### PR TITLE
SAV-188 & SAV-141: Add padding

### DIFF
--- a/packages/desktop/app/components/EditAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/EditAdministeredVaccineModal.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import styled from 'styled-components';
 import { VACCINE_STATUS, VACCINE_RECORDING_TYPES } from 'shared/constants';
 import { useDispatch } from 'react-redux';
 import { Modal } from './Modal';
@@ -6,6 +7,11 @@ import { useApi, useSuggester } from '../api';
 import { reloadPatient } from '../store/patient';
 import { ViewAdministeredVaccineContent } from './ViewAdministeredVaccineModal';
 import { VaccineForm } from '../forms/VaccineForm';
+
+const Separator = styled.div`
+  height: 20px;
+  width: 100%;
+`;
 
 export const EditAdministeredVaccineModal = ({ open, onClose, patientId, vaccineRecord }) => {
   const api = useApi();
@@ -42,6 +48,7 @@ export const EditAdministeredVaccineModal = ({ open, onClose, patientId, vaccine
   return (
     <Modal title="Edit vaccine record" open={open} onClose={onClose}>
       <ViewAdministeredVaccineContent vaccineRecord={vaccineRecord} editMode />
+      <Separator />
       <VaccineForm
         onSubmit={handleUpdateVaccine}
         onCancel={onClose}

--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -23,6 +23,7 @@ const Container = styled.div`
 
 const DisplayField = styled.div`
   width: 50%;
+  padding-right: 15px;
   padding-bottom: 20px;
   color: ${Colors.darkestText};
   font-weight: 500;

--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -27,6 +27,10 @@ const DisplayField = styled.div`
   padding-bottom: 20px;
   color: ${Colors.darkestText};
   font-weight: 500;
+  &:nth-child(2n) {
+    ${props => (props.$editMode ? `border-left: 1px solid ${Colors.outline};` : '')}
+    ${props => (props.$editMode ? `padding-left: 15px;` : '')}
+  }
 `;
 
 const Label = styled.div`
@@ -41,16 +45,17 @@ const FieldGroup = styled.div`
   border-bottom: 1px solid ${Colors.outline};
   &:last-of-type {
     border-bottom: none;
+    padding-bottom: 20px;
   }
   padding-top: 20px;
 `;
 
-const FieldsViewer = ({ labelValueFieldGroups }) => (
+const FieldsViewer = ({ editMode, labelValueFieldGroups }) => (
   <Container>
     {labelValueFieldGroups.map(fieldGroup => (
       <FieldGroup>
         {fieldGroup.map(({ label, value }) => (
-          <DisplayField>
+          <DisplayField $editMode={editMode}>
             <Label>{label}</Label>
             {value}
           </DisplayField>
@@ -294,7 +299,7 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
   const modalVersion = modalVersions.find(modalType => modalType.condition === true);
 
   return modalVersion ? (
-    <FieldsViewer labelValueFieldGroups={modalVersion.fields} />
+    <FieldsViewer editMode={editMode} labelValueFieldGroups={modalVersion.fields} />
   ) : (
     <ErrorMessage />
   );

--- a/packages/desktop/app/forms/VaccineGivenForm.js
+++ b/packages/desktop/app/forms/VaccineGivenForm.js
@@ -156,7 +156,7 @@ export const VaccineGivenForm = ({
 
       {values.givenElsewhere ? <GivenByCountryField /> : <GivenByField />}
 
-      {values.givenElsewhere && <StyledDivider />}
+      {values.givenElsewhere && !editMode && <StyledDivider />}
 
       {!editMode && <RecordedByField />}
 
@@ -171,6 +171,8 @@ export const VaccineGivenForm = ({
       />
 
       <ConsentGivenByField />
+
+      <StyledDivider />
 
       <ConfirmCancelRowField
         onConfirm={submitForm}

--- a/packages/desktop/app/forms/VaccineNotGivenForm.js
+++ b/packages/desktop/app/forms/VaccineNotGivenForm.js
@@ -88,6 +88,8 @@ export const VaccineNotGivenForm = ({
 
     {!editMode && <RecordedByField />}
 
+    <StyledDivider />
+
     <ConfirmCancelRowField
       onConfirm={submitForm}
       category={category}


### PR DESCRIPTION
### Changes

Added padding between the view and the form in the edit vaccination modal as per figma
Added padding between the fields in the view as per Felicity comment (there was no padding at all which was visible for long texts)

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
