### PR TITLE
NASS-682: Only require results when filter is applied

### DIFF
--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -392,8 +392,7 @@ globalImagingRequests.get(
       association: 'results',
       where: resultFilters,
       required:
-        query.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED &&
-        Object.getOwnPropertySymbols(resultFilters).length > 0,
+        query.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED && !!filterParams.completedAt,
     };
 
     // Query database

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -391,7 +391,9 @@ globalImagingRequests.get(
     const results = {
       association: 'results',
       where: resultFilters,
-      required: query.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED,
+      required:
+        query.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED &&
+        Object.getOwnPropertySymbols(resultFilters).length > 0,
     };
 
     // Query database


### PR DESCRIPTION
### Changes

We currently were only including imaging requests with a corresponding result in the new completed table. This means that the completed table was excluding imaging requests without a saved result. This should be impossible now with the creation workflow but there are records like this in prod so we want to make sure they still show up in the completed table. 

I have added in a line so that it will show all completed imaging requests (including those with no result) unless a result filter is applied and then it will only return results with that date
