### PR TITLE
NASS-767: Support --multi-window flag for testers

### DIFF
--- a/packages/desktop/app/main.dev.js
+++ b/packages/desktop/app/main.dev.js
@@ -52,12 +52,17 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', async () => {
+  // testers can run multiple instances of the app mode by passing the --multi-window flag
+  const singleInstanceOnly = !process.argv.includes('--multi-window');
+
   // Check if there's already an instance of the app running. If there is, we can quit this one, and
   // the other will receive a 'second-instance' event telling it to focus its window (see below)
-  const isFirstInstance = app.requestSingleInstanceLock();
-  if (!isFirstInstance) {
-    app.quit();
-    return;
+  if (singleInstanceOnly) {
+    const isFirstInstance = app.requestSingleInstanceLock();
+    if (!isFirstInstance && !multiWindow) {
+      app.quit();
+      return;
+    }
   }
 
   mainWindow = new BrowserWindow({


### PR DESCRIPTION
### Changes

Allows testers (or others) to run Tamanu desktop multiple times. Very useful for testing when comparing changes between versions, and was broken by the new requirement to explicitly _not_ allow multiple instances by default.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
