### PR TITLE
NASS-767: Support --multi-window flag for testers

### DIFF
--- a/packages/desktop/app/main.dev.js
+++ b/packages/desktop/app/main.dev.js
@@ -52,12 +52,17 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', async () => {
+  // testers can run multiple instances of the app mode by passing the --multi-window flag
+  const singleInstanceOnly = !process.argv.includes('--multi-window');
+
   // Check if there's already an instance of the app running. If there is, we can quit this one, and
   // the other will receive a 'second-instance' event telling it to focus its window (see below)
-  const isFirstInstance = app.requestSingleInstanceLock();
-  if (!isFirstInstance) {
-    app.quit();
-    return;
+  if (singleInstanceOnly) {
+    const isFirstInstance = app.requestSingleInstanceLock();
+    if (!isFirstInstance && !multiWindow) {
+      app.quit();
+      return;
+    }
   }
 
   mainWindow = new BrowserWindow({


### PR DESCRIPTION
### Changes

Allows testers (or others) to run Tamanu desktop multiple times. Very useful for testing when comparing changes between versions, and was broken by the new requirement to explicitly _not_ allow multiple instances by default.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue