### PR TITLE
SAV-168: Fix flaky lab test

### DIFF
--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -164,6 +164,7 @@ describe('Labs', () => {
         ...fake(models.LabRequest),
         encounterId: encounter.id,
         requestedById: app.user.id,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
       });
     };
 

--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -1,11 +1,19 @@
-import {
-  LAB_TEST_STATUSES,
-  LAB_REQUEST_STATUSES,
-} from 'shared/constants';
+import { LAB_TEST_STATUSES, LAB_REQUEST_STATUSES } from 'shared/constants';
 import config from 'config';
+import Chance from 'chance';
 import { createDummyPatient, createDummyEncounter, randomLabRequest } from 'shared/demoData';
 import { fake } from 'shared/test-helpers/fake';
 import { createTestContext } from '../utilities';
+
+const chance = new Chance();
+const VALID_LAB_REQUEST_STATUSES = [
+  LAB_REQUEST_STATUSES.RECEPTION_PENDING,
+  LAB_REQUEST_STATUSES.RESULTS_PENDING,
+  LAB_REQUEST_STATUSES.TO_BE_VERIFIED,
+  LAB_REQUEST_STATUSES.VERIFIED,
+  LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
+  LAB_REQUEST_STATUSES.PUBLISHED,
+];
 
 describe('Labs', () => {
   let patientId = null;
@@ -164,7 +172,7 @@ describe('Labs', () => {
         ...fake(models.LabRequest),
         encounterId: encounter.id,
         requestedById: app.user.id,
-        status: LAB_REQUEST_STATUSES.PUBLISHED,
+        status: chance.pickone(VALID_LAB_REQUEST_STATUSES),
       });
     };
 


### PR DESCRIPTION
### Changes

There was a lab test that was failing sometimes due to the status being assigned randomly. This meant sometimes it was assigned as an error or cancelled lab which means it wouldn't be fetched by the query which filters these out automatically. (at least i think this was the cause. It happens quite rarely and this makes sense to me as the cause)

