### PR TITLE
NASS-661: standadize imaging and labs list table date treatment and reduce table width

### DIFF
--- a/packages/desktop/app/utils/lab.js
+++ b/packages/desktop/app/utils/lab.js
@@ -33,5 +33,6 @@ export const getRequestType = ({ categoryName, category }) =>
   categoryName || (category || {}).name || 'Unknown';
 export const getPriority = ({ priorityName, priority }) =>
   priorityName || (priority || {}).name || 'Unknown';
-export const getDate = ({ requestedDate }) => <DateDisplay date={requestedDate} />;
-export const getDateTime = ({ requestedDate }) => <DateDisplay date={requestedDate} showTime />;
+export const getDateWithTimeTooltip = ({ requestedDate }) => (
+  <DateDisplay date={requestedDate} timeOnlyTooltip />
+);

--- a/packages/desktop/app/views/LabRequestsTable.js
+++ b/packages/desktop/app/views/LabRequestsTable.js
@@ -12,7 +12,7 @@ import {
   getPatientDisplayId,
   getRequestType,
   getPriority,
-  getDateTime,
+  getDateWithTimeTooltip,
   getRequestId,
   getPublishedDate,
 } from '../utils/lab';
@@ -36,7 +36,7 @@ export const LabRequestsTable = ({ status = '' }) => {
       { key: 'requestId', title: 'Test ID', accessor: getRequestId, sortable: false },
       { key: 'labTestPanelName', title: 'Panel' },
       { key: 'testCategory', title: 'Test category', accessor: getRequestType },
-      { key: 'requestedDate', title: 'Requested at time', accessor: getDateTime },
+      { key: 'requestedDate', title: 'Requested at time', accessor: getDateWithTimeTooltip },
       publishedStatus
         ? { key: 'publishedDate', title: 'Completed', accessor: getPublishedDate }
         : { key: 'priority', title: 'Priority', accessor: getPriority },

--- a/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
+++ b/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
@@ -10,14 +10,14 @@ import {
   getStatus,
   getRequestType,
   getPriority,
-  getDateTime,
+  getDateWithTimeTooltip,
   getRequestId,
 } from '../../utils/lab';
 
 const columns = [
   { key: 'requestId', title: 'Test ID', sortable: false, accessor: getRequestId },
   { key: 'category.name', title: 'Test category', accessor: getRequestType },
-  { key: 'requestedDate', title: 'Requested at time', accessor: getDateTime },
+  { key: 'requestedDate', title: 'Requested at time', accessor: getDateWithTimeTooltip },
   { key: 'displayName', title: 'Requested by', accessor: getRequestedBy, sortable: false },
   { key: 'priority.name', title: 'Priority', accessor: getPriority },
   { key: 'status', title: 'Status', accessor: getStatus, maxWidth: 200 },


### PR DESCRIPTION
### Changes

Date treatment across similar tables of encounter and labs field `Requested at date` was different which felt unbalanced this just makes it so labs table also uses date with time tooltip. Which also saves on width now that head cells are white-space: no-wrap.

![Screenshot 2023-05-16 at 10 16 12 AM](https://github.com/beyondessential/tamanu/assets/38335330/5804ac47-91ce-433d-b92e-7d20634ce98f)

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
