### PR TITLE
SAV-195: Get previous encounters whose end_date falls within past 30 …

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patientLocations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientLocations.js
@@ -100,6 +100,7 @@ patientLocations.get(
               encounter_type,
               end_date
             FROM encounters
+            WHERE end_date::date > now() - '30 days'::interval
           ) previous_encounters
           ON encounters.patient_id = previous_encounters.patient_id
           AND encounters.start_date::date - '30 days'::interval < previous_encounters.end_date::date

--- a/packages/lan/app/routes/apiv1/patient/patientLocations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientLocations.js
@@ -100,9 +100,9 @@ patientLocations.get(
               encounter_type,
               end_date
             FROM encounters
-            WHERE end_date::date > now() - '30 days'::interval
           ) previous_encounters
           ON encounters.patient_id = previous_encounters.patient_id
+          AND encounters.start_date::date - '30 days'::interval < previous_encounters.end_date::date
           LEFT JOIN locations
           ON locations.id = encounters.location_id
           WHERE encounters.end_date IS NULL

--- a/packages/lan/app/routes/apiv1/patient/patientLocations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientLocations.js
@@ -103,10 +103,10 @@ patientLocations.get(
             WHERE end_date::date > now() - '30 days'::interval
           ) previous_encounters
           ON encounters.patient_id = previous_encounters.patient_id
-          AND encounters.start_date::date - '30 days'::interval < previous_encounters.end_date::date
           LEFT JOIN locations
           ON locations.id = encounters.location_id
           WHERE encounters.end_date IS NULL
+          AND encounters.start_date::date > now() - '30 days'::interval
           AND encounters.encounter_type = 'admission'
           AND previous_encounters.encounter_type = 'admission'
           AND previous_encounter_id IS NOT NULL


### PR DESCRIPTION
…days

### Changes

Only get the previous encounters whose start_date falls within the past 30 days for the calculation of readmissions. Requirements: https://linear.app/bes/issue/SAV-195#comment-529e9936

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
