### PR TITLE
SAV-199: Hide error and disproven diagnosis and adjust some date format

### DIFF
--- a/packages/lan/app/routes/apiv1/locationGroup.js
+++ b/packages/lan/app/routes/apiv1/locationGroup.js
@@ -87,14 +87,14 @@ locationGroup.get(
             ' (' || 
             CASE 
               WHEN encounter_diagnoses.certainty = 'suspected' THEN 'For investigation'
-              WHEN encounter_diagnoses.certainty = 'error' THEN 'Recorded by error'
               ELSE INITCAP(encounter_diagnoses.certainty)
             END ||
             ')', 
           ', ') AS name 
           FROM encounter_diagnoses 
           LEFT JOIN reference_data ON encounter_diagnoses.diagnosis_id = reference_data.id
-            GROUP BY encounter_id
+          WHERE encounter_diagnoses.certainty NOT IN ('disproven', 'error') 
+          GROUP BY encounter_id
           ) AS diagnosis ON encounters.id = diagnosis.encounter_id
 		    LEFT JOIN (
 		      SELECT record_id, MAX(date) AS date

--- a/packages/shared-src/src/utils/handoverNotes/HandoverPatient.js
+++ b/packages/shared-src/src/utils/handoverNotes/HandoverPatient.js
@@ -6,14 +6,15 @@ import { P } from '../patientCertificates/Typography';
 import { getName, getSex, getDOB } from './accessors';
 
 const PATIENT_FIELDS = [
-  { key: 'name', label: 'Patient Name', accessor: getName },
-  { key: 'displayId', label: 'Patient ID' },
+  { key: 'name', label: 'Patient Name', accessor: getName, width: 40 },
+  { key: 'displayId', label: 'Patient ID', width: 40 },
   {
     key: 'dateOfBirth',
     label: 'DOB',
     accessor: getDOB,
+    width: 20,
   },
-  { key: 'sex', label: 'Sex', accessor: getSex },
+  { key: 'sex', label: 'Sex', accessor: getSex, width: 40 },
 ];
 
 const ValueDisplay = ({ width, title, value }) => (
@@ -44,17 +45,17 @@ export const HandoverPatient = ({
       <Row style={{ width: '100%', marginBottom: 40 }}>
         <Col style={{ width: '100%' }}>
           <Row>
-            {detailsToDisplay.map(({ key, label: defaultLabel, accessor }) => {
+            {detailsToDisplay.map(({ key, label: defaultLabel, accessor, width = 33 }) => {
               const value = (accessor ? accessor(patient, getLocalisation) : patient[key]) || '';
               const label = defaultLabel || getLocalisation(`fields.${key}.shortLabel`);
 
-              return <ValueDisplay key={key} width="33%" title={label} value={value} />;
+              return <ValueDisplay key={key} width={`${width}%`} title={label} value={value} />;
             })}
-            <ValueDisplay width="33%" title="Location" value={location} />
+            <ValueDisplay width="40%" title="Location" value={location} />
             <ValueDisplay
-              width="33%"
+              width="20%"
               title="Arrival date"
-              value={getDisplayDate(arrivalDate, 'dd/MM/yyyy')}
+              value={getDisplayDate(arrivalDate, 'dd/MM/yy')}
             />
           </Row>
           {diagnosis && <ValueDisplay width="100%" title="Diagnosis" value={diagnosis} />}

--- a/packages/shared-src/src/utils/handoverNotes/HandoverPatient.js
+++ b/packages/shared-src/src/utils/handoverNotes/HandoverPatient.js
@@ -6,15 +6,15 @@ import { P } from '../patientCertificates/Typography';
 import { getName, getSex, getDOB } from './accessors';
 
 const PATIENT_FIELDS = [
-  { key: 'name', label: 'Patient Name', accessor: getName, widthPercentage: 40 },
-  { key: 'displayId', label: 'Patient ID', widthPercentage: 40 },
+  { key: 'name', label: 'Patient Name', accessor: getName, percentageWidth: 40 },
+  { key: 'displayId', label: 'Patient ID', percentageWidth: 40 },
   {
     key: 'dateOfBirth',
     label: 'DOB',
     accessor: getDOB,
-    widthPercentage: 20,
+    percentageWidth: 20,
   },
-  { key: 'sex', label: 'Sex', accessor: getSex, widthPercentage: 40 },
+  { key: 'sex', label: 'Sex', accessor: getSex, percentageWidth: 40 },
 ];
 
 const ValueDisplay = ({ width, title, value }) => (
@@ -46,14 +46,14 @@ export const HandoverPatient = ({
         <Col style={{ width: '100%' }}>
           <Row>
             {detailsToDisplay.map(
-              ({ key, label: defaultLabel, accessor, widthPercentage = 33 }) => {
+              ({ key, label: defaultLabel, accessor, percentageWidth = 33 }) => {
                 const value = (accessor ? accessor(patient, getLocalisation) : patient[key]) || '';
                 const label = defaultLabel || getLocalisation(`fields.${key}.shortLabel`);
 
                 return (
                   <ValueDisplay
                     key={key}
-                    width={`${widthPercentage}%`}
+                    width={`${percentageWidth}%`}
                     title={label}
                     value={value}
                   />

--- a/packages/shared-src/src/utils/handoverNotes/HandoverPatient.js
+++ b/packages/shared-src/src/utils/handoverNotes/HandoverPatient.js
@@ -6,15 +6,15 @@ import { P } from '../patientCertificates/Typography';
 import { getName, getSex, getDOB } from './accessors';
 
 const PATIENT_FIELDS = [
-  { key: 'name', label: 'Patient Name', accessor: getName, width: 40 },
-  { key: 'displayId', label: 'Patient ID', width: 40 },
+  { key: 'name', label: 'Patient Name', accessor: getName, widthPercentage: 40 },
+  { key: 'displayId', label: 'Patient ID', widthPercentage: 40 },
   {
     key: 'dateOfBirth',
     label: 'DOB',
     accessor: getDOB,
-    width: 20,
+    widthPercentage: 20,
   },
-  { key: 'sex', label: 'Sex', accessor: getSex, width: 40 },
+  { key: 'sex', label: 'Sex', accessor: getSex, widthPercentage: 40 },
 ];
 
 const ValueDisplay = ({ width, title, value }) => (
@@ -45,12 +45,21 @@ export const HandoverPatient = ({
       <Row style={{ width: '100%', marginBottom: 40 }}>
         <Col style={{ width: '100%' }}>
           <Row>
-            {detailsToDisplay.map(({ key, label: defaultLabel, accessor, width = 33 }) => {
-              const value = (accessor ? accessor(patient, getLocalisation) : patient[key]) || '';
-              const label = defaultLabel || getLocalisation(`fields.${key}.shortLabel`);
+            {detailsToDisplay.map(
+              ({ key, label: defaultLabel, accessor, widthPercentage = 33 }) => {
+                const value = (accessor ? accessor(patient, getLocalisation) : patient[key]) || '';
+                const label = defaultLabel || getLocalisation(`fields.${key}.shortLabel`);
 
-              return <ValueDisplay key={key} width={`${width}%`} title={label} value={value} />;
-            })}
+                return (
+                  <ValueDisplay
+                    key={key}
+                    width={`${widthPercentage}%`}
+                    title={label}
+                    value={value}
+                  />
+                );
+              },
+            )}
             <ValueDisplay width="40%" title="Location" value={location} />
             <ValueDisplay
               width="20%"


### PR DESCRIPTION
### Changes

- Fixed Column sizes
- Hide 'Error' and 'Disproven' diagnosis from handover notes pdf
- Fixed date format for arrival date

Fix for those issues reported:
https://linear.app/bes/issue/SAV-199#comment-f605bfee

### Screenshot
<img width="795" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/dd723b11-906d-4dca-9399-ff884bff224e">


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
