### PR TITLE
SAV-248: Add new encounter note type called 'Admission'

### DIFF
--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -162,6 +162,7 @@ export const nonEmergencyDiagnosisCertaintyOptions = diagnosisCertaintyOptions.f
 // Treatment plan first and alphabetical after that
 export const noteTypes = [
   { value: NOTE_TYPES.TREATMENT_PLAN, label: 'Treatment plan' },
+  { value: NOTE_TYPES.ADMISSION, label: 'Admission' },
   { value: NOTE_TYPES.CLINICAL_MOBILE, label: 'Clinical note (mobile)', hideFromDropdown: true },
   { value: NOTE_TYPES.DIETARY, label: 'Dietary' },
   { value: NOTE_TYPES.DISCHARGE, label: 'Discharge planning' },

--- a/packages/shared-src/src/constants/notes.js
+++ b/packages/shared-src/src/constants/notes.js
@@ -10,6 +10,7 @@ export const NOTE_RECORD_TYPES = {
 
 export const NOTE_TYPES = {
   TREATMENT_PLAN: 'treatmentPlan',
+  ADMISSION: 'admission',
   MEDICAL: 'medical',
   SURGICAL: 'surgical',
   NURSING: 'nursing',


### PR DESCRIPTION
### Changes
- Add new encounter note type called 'Admission'

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
