### PR TITLE
NASS-678: Clear field bugfixes + tweaks

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -67,6 +67,7 @@ const OptionTag = styled(FormFieldTag)`
 
 const SelectTag = styled(FormFieldTag)`
   position: relative;
+  margin-right: 3px;
 `;
 
 const Item = styled(MenuItem)`
@@ -92,8 +93,6 @@ const StyledExpandMore = styled(ChevronIcon)`
 
 const StyledIconButton = styled(IconButton)`
   padding: 5px;
-  position: absolute;
-  right: 35px;
 `;
 
 const StyledClearIcon = styled(ClearIcon)`

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -235,9 +235,9 @@ export class AutocompleteInput extends Component {
   };
 
   handleClearValue = () => {
-    const { onChange, name } = this.props;
+    const { onChange } = this.props;
     this.setState({ selectedOption: { value: '', tag: null } });
-    onChange({ target: { value: undefined, name } });
+    onChange({ target: { value: undefined, name: null } });
   };
 
   clearOptions = () => {

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -234,9 +234,12 @@ export class AutocompleteInput extends Component {
   };
 
   handleClearValue = () => {
-    const { onChange } = this.props;
+    const { onChange, onClear } = this.props;
     this.setState({ selectedOption: { value: '', tag: null } });
     onChange({ target: { value: undefined, name: null } });
+    if (onClear) {
+      onClear();
+    }
   };
 
   clearOptions = () => {

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -84,6 +84,11 @@ export const LocationInput = React.memo(
       onChange({ target: { value: event.target.value, name } });
     };
 
+    const clearLocationField = () => {
+      setLocationId('');
+      onChange({ target: { value: '', name } });
+    };
+
     // Disable the location and location group fields if:
     // 1. In edit mode (form already is initialised with pre-filled values); and
     // 2. The existing location has a different facility than the current facility
@@ -104,6 +109,7 @@ export const LocationInput = React.memo(
           value={groupId}
           disabled={locationGroupSelectIsDisabled || disabled}
           autofill={!value} // do not autofill if there is a pre-filled value
+          onClear={clearLocationField}
         />
         <AutocompleteInput
           label={label}

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -36,6 +36,7 @@ export const SearchField = ({ keepLetterCase = false, ...props }) => {
     field: { value, name },
     form: { setFieldValue } = {},
     label,
+    onClear,
   } = props;
   const [searchValue, setSearchValue] = useState(value);
 
@@ -47,6 +48,9 @@ export const SearchField = ({ keepLetterCase = false, ...props }) => {
     setSearchValue('');
     if (setFieldValue) {
       setFieldValue(name, '');
+    }
+    if (onClear) {
+      onClear();
     }
   };
 

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -119,8 +119,8 @@ export const SelectInput = ({
         borderColor,
         boxShadow: 'none',
         borderRadius: '3px',
-        paddingTop: '10px',
-        paddingBottom: '8px',
+        paddingTop: '11px',
+        paddingBottom: '9px',
         paddingLeft: '5px',
         fontSize,
       };

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -96,17 +96,21 @@ export const SelectInput = ({
   name,
   helperText,
   inputRef,
+  onClear,
   ...props
 }) => {
   const handleChange = useCallback(
     changedOption => {
       if (!changedOption) {
         onChange({ target: { value: '', name } });
+        if (onClear) {
+          onClear();
+        }
         return;
       }
       onChange({ target: { value: changedOption.value, name } });
     },
-    [onChange, name],
+    [onChange, name, onClear],
   );
 
   const customStyles = {


### PR DESCRIPTION
### Changes

A couple of test fails have come through during regression testing which have been addressed in this PR.

- [x] Fix clear search bug where pressing "clear" was reverting to the previously saved state for saved search parameters
- [x] Tweak padding for input as it was short in some places where it shows up larger
- [x] Fix bug with status tag position that was overlapping with the "x" button (specifically for location availability)
- [x] Able to clear both locations and location group fields when clearing location groups. (to fix this I added a custom onClear function that we can use to add custom functionality to pressing the x on the autocomplete input. As this was a simple and quite helpful fix I added this prop to the other two kinds of input as well.
