### PR TITLE
SAV-100: Stop allowing the user to scroll only the header

### DIFF
--- a/packages/mobile/App/ui/components/VaccinesTable/index.tsx
+++ b/packages/mobile/App/ui/components/VaccinesTable/index.tsx
@@ -102,7 +102,7 @@ export const VaccinesTable = ({
     <ScrollView bounces={false} stickyHeaderIndices={[0]}>
       <StyledView flexDirection="row">
         <VaccinesTableTitle />
-        <ScrollView ref={scrollViewRef} horizontal>
+        <ScrollView ref={scrollViewRef} horizontal scrollEnabled={false}>
           {columns.map((column: any) => (
             <StyledView key={`${column}`}>
               {vaccineTableHeader.accessor(column, onPressItem)}


### PR DESCRIPTION
### Changes

We discovered a bug with the mobile vaccination table header where the user was able to scroll the header independently from the rest of the table. This is due to the slightly roundabout logic that we needed to do to allow the header to act sticky and also scroll horizontally.

The fix I did was to simply add the prop that disables the ability to scroll the header row. The scroll still works as expected when the table is scrolled horizontally