### PR TITLE
SAV-237: (Refactor) Desktop vaccine modal updates to include 'Circumstance' field

### DIFF
--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -1,12 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import { Box } from '@material-ui/core';
+import { useQuery } from '@tanstack/react-query';
 import { VACCINE_STATUS, VACCINE_STATUS_LABELS } from 'shared/constants';
 import { Modal } from './Modal';
 import { ModalActionRow } from './ModalActionRow';
 import { Colors } from '../constants';
-import { useSuggester } from '../api';
+import { useApi } from '../api';
 
 import { DateDisplay } from './DateDisplay';
 
@@ -78,9 +79,11 @@ const ErrorMessage = () => {
 
 export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
   const {
+    id: vaccineRecordId,
     status,
     injectionSite,
     scheduledVaccine: { label: vaccineLabel, schedule },
+    encounter: { patientId },
     recorder,
     givenBy,
     location,
@@ -99,24 +102,14 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
   const routine = !vaccineName;
   const notGiven = VACCINE_STATUS.NOT_GIVEN === status;
 
-  const vaccineCircumstanceSuggester = useSuggester('vaccineCircumstance');
-  const [vaccineCircumstances, setVaccineCircumstances] = useState();
-
-  useEffect(() => {
+  const api = useApi();
+  const { data: { data: vaccineCircumstances } = {} } = useQuery({
+    queryKey: ['administeredVaccine', patientId, vaccineRecordId],
+    queryFn: () =>
+      api.get(`patient/${patientId}/administeredVaccine/${vaccineRecordId}/circumstances`),
     // to avoid unnecessary API calls, these are the conditions that will show circumstance
-    if (!editMode && givenElsewhere && circumstanceIds) {
-      const circumstanceIdValues = Array.isArray(circumstanceIds)
-        ? circumstanceIds
-        : String(circumstanceIds)?.split(',') || [];
-      Promise.all(
-        circumstanceIdValues.map(circumstanceId =>
-          vaccineCircumstanceSuggester.fetchCurrentOption(circumstanceId),
-        ),
-      ).then(circumstances => {
-        setVaccineCircumstances(circumstances?.map(circumstance => circumstance?.label));
-      });
-    }
-  }, [vaccineCircumstanceSuggester, circumstanceIds, editMode, givenElsewhere]);
+    enabled: Boolean(!editMode && givenElsewhere && circumstanceIds),
+  });
 
   if (!vaccineRecord) return null;
 
@@ -146,7 +139,13 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
     },
     country: { label: 'Country', value: givenBy || '-' },
     reason: { label: 'Reason', value: notGivenReason?.name || '-' },
-    circumstance: { label: 'Circumstance', value: vaccineCircumstances?.join(', ') || '-' },
+    circumstance: {
+      label: 'Circumstance',
+      value:
+        vaccineCircumstances?.length > 0
+          ? vaccineCircumstances?.map(circumstance => circumstance?.name)?.join(', ')
+          : '-',
+    },
   };
 
   const modalVersions = [

--- a/packages/desktop/app/views/patients/panes/VaccinesPane.js
+++ b/packages/desktop/app/views/patients/panes/VaccinesPane.js
@@ -45,8 +45,8 @@ export const VaccinesPane = React.memo(({ patient, readonly }) => {
     setVaccineData(row);
   }, []);
 
-  const { data: vaccine } = useAdministeredVaccines(patient.id);
-  const vaccinations = vaccine?.data || [];
+  const { data: vaccines } = useAdministeredVaccines(patient.id);
+  const vaccinations = vaccines?.data || [];
   const certifiable = vaccinations.some(v => v.certifiable);
 
   return (

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -286,3 +286,25 @@ patientVaccineRoutes.get(
     res.send({ count: results.count, data: results.data });
   }),
 );
+
+patientVaccineRoutes.get(
+  '/:id/administeredVaccine/:vaccineId/circumstances',
+  asyncHandler(async (req, res) => {
+    req.checkPermission('read', 'PatientVaccine');
+    const { models, params } = req;
+    const administeredVaccine = await models.AdministeredVaccine.findByPk(params.vaccineId);
+    if (!administeredVaccine) throw new NotFoundError();
+    if (
+      !Array.isArray(administeredVaccine.circumstanceIds) ||
+      administeredVaccine.circumstanceIds.length === 0
+    )
+      res.send({ count: 0, data: [] });
+    const results = await models.ReferenceData.findAll({
+      where: {
+        id: administeredVaccine.circumstanceIds,
+      },
+    });
+
+    res.send({ count: results.count, data: results?.map(({ id, name }) => ({ id, name })) });
+  }),
+);


### PR DESCRIPTION
### Changes

Change how circumstances are obtained in the vaccine record view modal from fetching each circumstance individually via the suggester to calling an endpoint with the corresponding vaccine record ID and obtaining its circumstances

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
