### PR TITLE
NASS-678: Autocomplete form state + search fix

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -234,8 +234,10 @@ export class AutocompleteInput extends Component {
   };
 
   handleClearValue = () => {
-    const { onChange, onClear, name } = this.props;
-    onChange({ target: { value: null, name } });
+    const { onChange, onClear, name, required } = this.props;
+    // use correct error message for required fields by setting to "" but otherwise set to null value to prevent FK errors
+    const clearValue = required ? '' : null;
+    onChange({ target: { value: clearValue, name } });
     this.setState({ selectedOption: { value: '', tag: null } });
     if (onClear) {
       onClear();

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -235,7 +235,7 @@ export class AutocompleteInput extends Component {
 
   handleClearValue = () => {
     const { onChange, onClear, name } = this.props;
-    onChange({ target: { value: '', name } });
+    onChange({ target: { value: null, name } });
     this.setState({ selectedOption: { value: '', tag: null } });
     if (onClear) {
       onClear();

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -234,9 +234,11 @@ export class AutocompleteInput extends Component {
   };
 
   handleClearValue = () => {
-    const { onChange, onClear } = this.props;
+    const { onChange, onClear, name } = this.props;
     this.setState({ selectedOption: { value: '', tag: null } });
-    onChange({ target: { value: undefined, name: null } });
+    // TODO: need to resolve this. When I add the name to the onChange it it will properly save the form state however when pressing "clear"
+    // it will not clear the value. If I remove the name from the onChange it will clear the value properly but the form state is out of sync
+    onChange({ target: { value: undefined, name } });
     if (onClear) {
       onClear();
     }

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -235,10 +235,7 @@ export class AutocompleteInput extends Component {
 
   handleClearValue = () => {
     const { onChange, onClear, name } = this.props;
-    this.setState({ selectedOption: { value: '', tag: null } });
-    // TODO: need to resolve this. When I add the name to the onChange it it will properly save the form state however when pressing "clear"
-    // it will not clear the value. If I remove the name from the onChange it will clear the value properly but the form state is out of sync
-    onChange({ target: { value: undefined, name } });
+    onChange({ target: { value: '', name } });
     if (onClear) {
       onClear();
     }

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -236,7 +236,7 @@ export class AutocompleteInput extends Component {
   handleClearValue = () => {
     const { onChange, onClear, name } = this.props;
     onChange({ target: { value: '', name } });
-    this.setState({ selectedOption: { value: '', tag: undefined } });
+    this.setState({ selectedOption: { value: '', tag: null } });
     if (onClear) {
       onClear();
     }

--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -236,6 +236,7 @@ export class AutocompleteInput extends Component {
   handleClearValue = () => {
     const { onChange, onClear, name } = this.props;
     onChange({ target: { value: '', name } });
+    this.setState({ selectedOption: { value: '', tag: undefined } });
     if (onClear) {
       onClear();
     }

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -110,8 +110,10 @@ export const CustomisableSearchBar = ({
                 onClick={() => {
                   // Cant check for dirty as form is reinitialized with persisted values
                   if (Object.keys(values).length === 0) return;
-                  clearForm();
                   onSearch({});
+                  // ClearForm needed to be deferred in order ensure that it re-initializes to an empty
+                  // state rather than the previous state
+                  setTimeout(() => clearForm(), 0);
                 }}
               >
                 Clear


### PR DESCRIPTION
### Changes

We discovered a couple of issues with state not tracking properly with the new clear button for autocomplete fields. I discovered this was a result of me overcomplicating things and calling to multiple of the built in methods causing weird behaviour. When I just use the single built in method properly to change the form/input state everything works smoothly as I would expect :)
