### PR TITLE
SAV-198: Exclude imaging and survey response encounter types for current patients count

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patient.js
+++ b/packages/lan/app/routes/apiv1/patient/patient.js
@@ -5,7 +5,7 @@ import { QueryTypes, Op } from 'sequelize';
 import { snakeCase } from 'lodash';
 
 import { NotFoundError } from 'shared/errors';
-import { PATIENT_REGISTRY_TYPES, VISIBILITY_STATUSES, ENCOUNTER_TYPES } from 'shared/constants';
+import { PATIENT_REGISTRY_TYPES, VISIBILITY_STATUSES } from 'shared/constants';
 import { isGeneratedDisplayId } from 'shared/utils/generateId';
 
 import { renameObjectKeys } from '../../../utils/renameObjectKeys';
@@ -375,10 +375,6 @@ patientRoute.get(
         filterParams,
       );
     filterReplacements.facilityId = config.serverFacilityId;
-    filterReplacements.currentPatientExcludedEncounterTypes = [
-      ENCOUNTER_TYPES.IMAGING,
-      ENCOUNTER_TYPES.SURVEY_RESPONSE,
-    ];
 
     const countResult = await req.db.query(`SELECT COUNT(1) AS count ${from}`, {
       replacements: filterReplacements,

--- a/packages/lan/app/routes/apiv1/patient/patient.js
+++ b/packages/lan/app/routes/apiv1/patient/patient.js
@@ -375,7 +375,7 @@ patientRoute.get(
         filterParams,
       );
     filterReplacements.facilityId = config.serverFacilityId;
-    filterReplacements.currentPatientExcludeEncounterTypes = [
+    filterReplacements.currentPatientExcludedEncounterTypes = [
       ENCOUNTER_TYPES.IMAGING,
       ENCOUNTER_TYPES.SURVEY_RESPONSE,
     ];

--- a/packages/lan/app/routes/apiv1/patient/patient.js
+++ b/packages/lan/app/routes/apiv1/patient/patient.js
@@ -5,7 +5,7 @@ import { QueryTypes, Op } from 'sequelize';
 import { snakeCase } from 'lodash';
 
 import { NotFoundError } from 'shared/errors';
-import { PATIENT_REGISTRY_TYPES, VISIBILITY_STATUSES } from 'shared/constants';
+import { PATIENT_REGISTRY_TYPES, VISIBILITY_STATUSES, ENCOUNTER_TYPES } from 'shared/constants';
 import { isGeneratedDisplayId } from 'shared/utils/generateId';
 
 import { renameObjectKeys } from '../../../utils/renameObjectKeys';
@@ -375,6 +375,10 @@ patientRoute.get(
         filterParams,
       );
     filterReplacements.facilityId = config.serverFacilityId;
+    filterReplacements.currentPatientExcludeEncounterTypes = [
+      ENCOUNTER_TYPES.IMAGING,
+      ENCOUNTER_TYPES.SURVEY_RESPONSE,
+    ];
 
     const countResult = await req.db.query(`SELECT COUNT(1) AS count ${from}`, {
       replacements: filterReplacements,

--- a/packages/lan/app/utils/patientFilters.js
+++ b/packages/lan/app/utils/patientFilters.js
@@ -63,7 +63,7 @@ export const createPatientFilters = filterParams => {
     makeFilter(filterParams.sex, `patients.sex = :sex`),
     makeFilter(
       filterParams.currentPatient,
-      `recent_encounter_by_patient IS NOT NULL AND encounters.encounter_type NOT IN (:currentPatientExcludeEncounterTypes)`,
+      `recent_encounter_by_patient IS NOT NULL AND encounters.encounter_type NOT IN (:currentPatientExcludedEncounterTypes)`,
     ),
   ].filter(f => f);
 

--- a/packages/lan/app/utils/patientFilters.js
+++ b/packages/lan/app/utils/patientFilters.js
@@ -1,6 +1,8 @@
 import config from 'config';
 import { sub } from 'date-fns';
 import { toDateString } from 'shared/utils/dateTime';
+import { ENCOUNTER_TYPES } from 'shared/constants';
+
 import { makeFilter } from './query';
 
 export const createPatientFilters = filterParams => {
@@ -63,7 +65,13 @@ export const createPatientFilters = filterParams => {
     makeFilter(filterParams.sex, `patients.sex = :sex`),
     makeFilter(
       filterParams.currentPatient,
-      `recent_encounter_by_patient IS NOT NULL AND encounters.encounter_type NOT IN (:currentPatientExcludedEncounterTypes)`,
+      `recent_encounter_by_patient IS NOT NULL AND encounters.encounter_type NOT IN (:currentPatientExcludeEncounterTypes)`,
+      () => ({
+        currentPatientExcludeEncounterTypes: [
+          ENCOUNTER_TYPES.IMAGING,
+          ENCOUNTER_TYPES.SURVEY_RESPONSE,
+        ],
+      }),
     ),
   ].filter(f => f);
 

--- a/packages/lan/app/utils/patientFilters.js
+++ b/packages/lan/app/utils/patientFilters.js
@@ -61,7 +61,10 @@ export const createPatientFilters = filterParams => {
     makeFilter(filterParams.outpatient, `encounters.encounter_type = 'clinic'`),
     makeFilter(filterParams.clinicianId, `encounters.examiner_id = :clinicianId`),
     makeFilter(filterParams.sex, `patients.sex = :sex`),
-    makeFilter(filterParams.currentPatient, `recent_encounter_by_patient IS NOT NULL`),
+    makeFilter(
+      filterParams.currentPatient,
+      `recent_encounter_by_patient IS NOT NULL AND encounters.encounter_type NOT IN (:currentPatientExcludeEncounterTypes)`,
+    ),
   ].filter(f => f);
 
   return filters;


### PR DESCRIPTION
### Changes
- Exclude imaging and survey response encounter types

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
