### PR TITLE
No issue: Add special lint:fix command to csca

### DIFF
--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "swc --delete-dir-on-start -D -d build/ src/",
     "cli": "yarn build && node build",
-    "lint": "eslint src/**/*.ts && tsc --noEmit"
+    "lint": "eslint src/**/*.ts && tsc --noEmit",
+    "lint:fix": "eslint src/**/*.ts --fix"
   },
   "devDependencies": {
     "@beyondessential/eslint-config-beyondessential": "^2.6.0",

--- a/scripts/lint-all.mjs
+++ b/scripts/lint-all.mjs
@@ -8,6 +8,15 @@ doWithAllPackages((name, pkg) => {
   }
 
   console.log(`Linting ${name}...`);
+
+  // Some packages require special handling for lint --fix
+  if (process.argv.includes('--fix') && pkg?.scripts?.['lint:fix']) {
+    execFileSync('yarn', ['workspace', pkg.name, 'run', 'lint:fix', ...process.argv.slice(2).filter(arg => arg !== '--fix')], {
+      stdio: 'inherit',
+    });
+    return;
+  }
+
   execFileSync('yarn', ['workspace', pkg.name, 'run', 'lint', ...process.argv.slice(2)], {
     stdio: 'inherit',
   });


### PR DESCRIPTION
### Changes

This is the behavior on dev:
![image](https://github.com/beyondessential/tamanu/assets/32168886/5d01c2e8-4341-428d-b4f6-f3ae83027fbc)

Fixed:
<img width="398" alt="image" src="https://github.com/beyondessential/tamanu/assets/32168886/e7e210bf-5a00-4157-9e40-cd589626013b">

It might be better to also run `tsc --noEmit`, but since it doesn't actually automatically fix anything I didn't think it was worth it.

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
