### PR TITLE
SAV-131: Disable header "x" button for vaccine modals

### DIFF
--- a/packages/desktop/app/components/ConfirmModal.js
+++ b/packages/desktop/app/components/ConfirmModal.js
@@ -23,7 +23,7 @@ export const ConfirmModal = ({
   cancelButtonText = 'Cancel',
   customContent,
 }) => (
-  <Modal width={width} title={title} open={open} onClose={onCancel}>
+  <Modal width={width} title={title} open={open} onClose={onCancel} disableHeaderCloseIcon>
     {customContent || (
       <Content>
         <h3>{text}</h3>

--- a/packages/desktop/app/components/ConfirmModal.js
+++ b/packages/desktop/app/components/ConfirmModal.js
@@ -23,7 +23,7 @@ export const ConfirmModal = ({
   cancelButtonText = 'Cancel',
   customContent,
 }) => (
-  <Modal width={width} title={title} open={open} onClose={onCancel} disableHeaderCloseIcon>
+  <Modal width={width} title={title} open={open} onClose={onCancel} cornerExitButton={false}>
     {customContent || (
       <Content>
         <h3>{text}</h3>

--- a/packages/desktop/app/components/EditAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/EditAdministeredVaccineModal.js
@@ -41,7 +41,7 @@ export const EditAdministeredVaccineModal = ({ open, onClose, patientId, vaccine
   const notGiven = VACCINE_STATUS.NOT_GIVEN === vaccineRecord?.status;
 
   return (
-    <Modal title="Edit vaccine record" open={open} onClose={onClose} disableHeaderCloseIcon>
+    <Modal title="Edit vaccine record" open={open} onClose={onClose} cornerExitButton={false}>
       <ViewAdministeredVaccineContent vaccineRecord={vaccineRecord} editMode />
       <VaccineForm
         onSubmit={handleUpdateVaccine}

--- a/packages/desktop/app/components/EditAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/EditAdministeredVaccineModal.js
@@ -41,7 +41,7 @@ export const EditAdministeredVaccineModal = ({ open, onClose, patientId, vaccine
   const notGiven = VACCINE_STATUS.NOT_GIVEN === vaccineRecord?.status;
 
   return (
-    <Modal title="Edit vaccine record" open={open} onClose={onClose}>
+    <Modal title="Edit vaccine record" open={open} onClose={onClose} disableHeaderCloseIcon>
       <ViewAdministeredVaccineContent vaccineRecord={vaccineRecord} editMode />
       <VaccineForm
         onSubmit={handleUpdateVaccine}

--- a/packages/desktop/app/components/Modal.js
+++ b/packages/desktop/app/components/Modal.js
@@ -97,7 +97,7 @@ export const Modal = memo(
     additionalActions,
     color = Colors.background,
     overrideContentPadding = false,
-    disableHeaderCloseIcon = false,
+    cornerExitButton = true,
     ...props
   }) => {
     const { printPage } = useElectron();
@@ -150,7 +150,7 @@ export const Modal = memo(
                 Print
               </StyledButton>
             )}
-            {!disableHeaderCloseIcon && (
+            {cornerExitButton && (
               <IconButton onClick={onClose}>
                 <CloseIcon />
               </IconButton>

--- a/packages/desktop/app/components/VaccineModal.js
+++ b/packages/desktop/app/components/VaccineModal.js
@@ -79,7 +79,7 @@ export const VaccineModal = ({ open, onClose, patientId }) => {
   ];
 
   return (
-    <Modal title="Record vaccine" open={open} onClose={onClose}>
+    <Modal title="Record vaccine" open={open} onClose={onClose} disableHeaderCloseIcon>
       <SegmentTabDisplay tabs={TABS} currentTabKey={currentTabKey} onTabSelect={setCurrentTabKey} />
     </Modal>
   );

--- a/packages/desktop/app/components/VaccineModal.js
+++ b/packages/desktop/app/components/VaccineModal.js
@@ -79,7 +79,7 @@ export const VaccineModal = ({ open, onClose, patientId }) => {
   ];
 
   return (
-    <Modal title="Record vaccine" open={open} onClose={onClose} disableHeaderCloseIcon>
+    <Modal title="Record vaccine" open={open} onClose={onClose} cornerExitButton={false}>
       <SegmentTabDisplay tabs={TABS} currentTabKey={currentTabKey} onTabSelect={setCurrentTabKey} />
     </Modal>
   );

--- a/packages/desktop/app/components/ViewAdministeredVaccineModal.js
+++ b/packages/desktop/app/components/ViewAdministeredVaccineModal.js
@@ -307,7 +307,7 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
 export const ViewAdministeredVaccineModal = ({ open, onClose, vaccineRecord }) => {
   if (!vaccineRecord) return null;
   return (
-    <Modal title="View vaccine record" open={open} onClose={onClose} disableHeaderCloseIcon>
+    <Modal title="View vaccine record" open={open} onClose={onClose} cornerExitButton={false}>
       <ViewAdministeredVaccineContent vaccineRecord={vaccineRecord} />
       <ModalActionRow confirmText="Close" onConfirm={onClose} />
     </Modal>


### PR DESCRIPTION
### Changes

We are moving away from having an x button in the corner of all of our modals. I made a new prop (disableHeaderCloseIcon) for disabling this when doing the vaccination work but Ethan did the same thing with a more suitably named prop (cornerExitButton) on dev which was overwritten by the feature branch merge. 

This fix essentially removes all of the x buttons from the vaccination modals while using the new prop created by Ethan instead. This should hopefully stop any merge problems :)