### PR TITLE
NASS-769: Improve performance of waiting for in-flight transactions when snapshot for pull

### DIFF
--- a/packages/shared-src/src/sync/getSyncTicksOfPendingEdits.js
+++ b/packages/shared-src/src/sync/getSyncTicksOfPendingEdits.js
@@ -1,5 +1,5 @@
-export const getSyncTicksOfPendingEdits = async (sequelize, syncTick) => {
-  // Get the keys (ie: syncTicks) of all the in-flight transaction locks of previously pending edits.
+export const getSyncTicksOfPendingEdits = async sequelize => {
+  // Get the keys (ie: syncTicks) of all the in-flight transaction locks of pending edits.
   // Since advisory locks are global, and:
   // - in-flight transaction locks are 'ShareLock'
   // - sync snapshot locks which are `ExclusiveLock`
@@ -9,12 +9,8 @@ export const getSyncTicksOfPendingEdits = async (sequelize, syncTick) => {
     `
       SELECT objid AS tick FROM pg_locks
       WHERE locktype = 'advisory'
-      AND mode = 'ShareLock' -- filter by
-      AND objid < :syncTick;
+      AND mode = 'ShareLock'
     `,
-    {
-      replacements: { syncTick },
-    },
   );
 
   return results.map(r => r.tick);

--- a/packages/shared-src/src/sync/getSyncTicksOfPendingEdits.js
+++ b/packages/shared-src/src/sync/getSyncTicksOfPendingEdits.js
@@ -1,9 +1,15 @@
 export const getSyncTicksOfPendingEdits = async (sequelize, syncTick) => {
-  // Get the keys (ie: syncTicks) of all the pending locks
+  // Get the keys (ie: syncTicks) of all the in-flight transaction locks of previously pending edits.
+  // Since advisory locks are global, and:
+  // - in-flight transaction locks are 'ShareLock'
+  // - sync snapshot locks which are `ExclusiveLock`
+  // => Only select for in-flight transaction locks by filtering for `ShareLock`
+  // to avoid clashing with the sync snapshot locks
   const [results] = await sequelize.query(
     `
       SELECT objid AS tick FROM pg_locks
       WHERE locktype = 'advisory'
+      AND mode = 'ShareLock' -- filter by
       AND objid < :syncTick;
     `,
     {

--- a/packages/shared-src/src/sync/getSyncTicksOfPendingEdits.js
+++ b/packages/shared-src/src/sync/getSyncTicksOfPendingEdits.js
@@ -1,0 +1,15 @@
+export const getSyncTicksOfPendingEdits = async (sequelize, syncTick) => {
+  // Get the keys (ie: syncTicks) of all the pending locks
+  const [results] = await sequelize.query(
+    `
+      SELECT objid AS tick FROM pg_locks
+      WHERE locktype = 'advisory'
+      AND objid < :syncTick;
+    `,
+    {
+      replacements: { syncTick },
+    },
+  );
+
+  return results.map(r => r.tick);
+};

--- a/packages/shared-src/src/sync/index.js
+++ b/packages/shared-src/src/sync/index.js
@@ -9,3 +9,4 @@ export * from './saveIncomingChanges';
 export * from './adjustDataPostSyncPush';
 export * from './getSyncSnapshotRecordIds';
 export * from './waitForPendingEditsUsingSyncTick';
+export * from './getSyncTicksOfPendingEdits';

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -1,7 +1,6 @@
 import { trace } from '@opentelemetry/api';
 import { Op, Transaction } from 'sequelize';
 import _config from 'config';
-import { range } from 'lodash';
 
 import { SYNC_DIRECTIONS } from 'shared/constants';
 import { CURRENT_SYNC_TIME_KEY } from 'shared/sync/constants';
@@ -18,6 +17,7 @@ import {
   saveIncomingChanges,
   adjustDataPostSyncPush,
   waitForPendingEditsUsingSyncTick,
+  getSyncTicksOfPendingEdits,
   SYNC_SESSION_DIRECTION,
 } from 'shared/sync';
 import { uuidToFairlyUniqueInteger } from 'shared/utils';
@@ -206,10 +206,11 @@ export class CentralSyncManager {
       // process is ongoing, will have a later updated_at_sync_tick)
       const { tick } = await this.tickTockGlobalClock();
 
+      const pendingSyncTicks = await getSyncTicksOfPendingEdits(sequelize, tick);
+
       // wait for any in-flight transactions using a tick within the range we are syncing here, so
       // that we don't miss any changes that are in progress
-      const ticksInRange = range(since, tick);
-      await Promise.all(ticksInRange.map(t => waitForPendingEditsUsingSyncTick(sequelize, t)));
+      await Promise.all(pendingSyncTicks.map(t => waitForPendingEditsUsingSyncTick(sequelize, t)));
 
       await models.SyncSession.update(
         { pullSince: since, pullUntil: tick },

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -208,7 +208,7 @@ export class CentralSyncManager {
 
       const pendingSyncTicks = await getSyncTicksOfPendingEdits(sequelize, tick);
 
-      // wait for any in-flight transactions using a tick within the range we are syncing here, so
+      // wait for any in-flight transactions of pending edits
       // that we don't miss any changes that are in progress
       await Promise.all(pendingSyncTicks.map(t => waitForPendingEditsUsingSyncTick(sequelize, t)));
 

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -206,7 +206,8 @@ export class CentralSyncManager {
       // process is ongoing, will have a later updated_at_sync_tick)
       const { tick } = await this.tickTockGlobalClock();
 
-      const pendingSyncTicks = await getSyncTicksOfPendingEdits(sequelize, tick);
+      // get all the ticks (ie: keys of in-flight transaction advisory locks) of previously pending edits
+      const pendingSyncTicks = (await getSyncTicksOfPendingEdits(sequelize)).filter(t => t < tick);
 
       // wait for any in-flight transactions of pending edits
       // that we don't miss any changes that are in progress


### PR DESCRIPTION
### Changes
- Improve performance of waitForPendingEdits

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
