### PR TITLE
SAV-251: Set end date of encounter to 11:59 PM when discharging outpatients

### DIFF
--- a/packages/shared-src/src/utils/dischargeOutpatientEncounters.js
+++ b/packages/shared-src/src/utils/dischargeOutpatientEncounters.js
@@ -1,4 +1,4 @@
-import { endOfDay, startOfDay, sub, parseISO } from 'date-fns';
+import { endOfDay, startOfDay, parseISO } from 'date-fns';
 import { Op } from 'sequelize';
 
 import { log } from 'shared/services/logging';
@@ -39,7 +39,7 @@ export const dischargeOutpatientEncounters = async (
     });
 
     for (const oldEncounter of oldEncounters) {
-      const justBeforeMidnight = sub(endOfDay(parseISO(oldEncounter.startDate)), { minutes: 1 });
+      const justBeforeMidnight = endOfDay(parseISO(oldEncounter.startDate));
       await oldEncounter.update({
         endDate: justBeforeMidnight,
         systemNote: 'Automatically discharged',

--- a/packages/sync-server/__tests__/tasks/outpatientDischarger.test.js
+++ b/packages/sync-server/__tests__/tasks/outpatientDischarger.test.js
@@ -1,30 +1,32 @@
-import { OutpatientDischarger } from "../../app/tasks/OutpatientDischarger";
-import { createTestContext } from "../utilities";
-import { sub, isSameDay, startOfDay, parseISO } from 'date-fns';
-import { ENCOUNTER_TYPES } from "shared/constants/encounters";
+import { sub, isSameDay, startOfDay, endOfDay, parseISO } from 'date-fns';
+import { ENCOUNTER_TYPES } from 'shared/constants/encounters';
 import { fake, fakeUser } from 'shared/test-helpers/fake';
+import { toDateTimeString } from 'shared/utils/dateTime';
+
+import { OutpatientDischarger } from '../../app/tasks/OutpatientDischarger';
+import { createTestContext } from '../utilities';
 
 describe('Outpatient discharger', () => {
-
   let ctx;
   let models;
   let createEncounter;
 
   const runDischarger = () => {
-    const discharger = new OutpatientDischarger(ctx, { 
+    const discharger = new OutpatientDischarger(ctx, {
       schedule: '',
       suppressInitialRun: true,
       batchSleepAsyncDurationInMilliseconds: 1,
     });
     return discharger.run();
-  }
+  };
 
-  const expectEndsOnSameDay = (encounter) => {
+  const expectEndsOnSameDayBeforeMidnight = encounter => {
     const { startDate, endDate } = encounter;
     expect(startDate).toBeTruthy();
     expect(endDate).toBeTruthy();
     expect(isSameDay(parseISO(startDate), parseISO(endDate))).toEqual(true);
-  }
+    expect(toDateTimeString(endOfDay(parseISO(startDate)))).toEqual(endDate);
+  };
 
   beforeAll(async () => {
     ctx = await createTestContext();
@@ -41,26 +43,26 @@ describe('Outpatient discharger', () => {
       facilityId: facility.id,
     });
 
-    createEncounter = (options = {}) => models.Encounter.create({
-      patientId: patient.id,
-      departmentId: department.id,
-      encounterType: ENCOUNTER_TYPES.CLINIC,
-      locationId: location.id,
-      examinerId: examiner.id,
-      ...options,
-    });
-    
+    createEncounter = (options = {}) =>
+      models.Encounter.create({
+        patientId: patient.id,
+        departmentId: department.id,
+        encounterType: ENCOUNTER_TYPES.CLINIC,
+        locationId: location.id,
+        examinerId: examiner.id,
+        ...options,
+      });
   });
 
   afterAll(() => ctx.close());
 
   it('Should discharge a patient that was left open a few days ago', async () => {
-    const enc = await createEncounter({ 
-      startDate: sub(new Date(), { days: 2 }), 
+    const enc = await createEncounter({
+      startDate: sub(new Date(), { days: 2 }),
     });
     await runDischarger();
     await enc.reload();
-    expectEndsOnSameDay(enc);
+    expectEndsOnSameDayBeforeMidnight(enc);
   });
 
   // A timezone issue on my dev machine means that this one doesn't run correctly.
@@ -68,19 +70,19 @@ describe('Outpatient discharger', () => {
   // so I'm just disabling it for now. Would be good to reinstate at some point but
   // probably not critical.
   xit('Should discharge a patient that was left open at 11:58pm last night', async () => {
-    const enc = await createEncounter({ 
-      startDate: sub(startOfDay(new Date()), { minutes: 2 }), 
+    const enc = await createEncounter({
+      startDate: sub(startOfDay(new Date()), { minutes: 2 }),
     });
-    console.log("enc starting at", enc.startDate);
+    console.log('enc starting at', enc.startDate);
     await runDischarger();
-    console.log("discharger done");
+    console.log('discharger done');
     await enc.reload();
-    expectEndsOnSameDay(enc);
+    expectEndsOnSameDayBeforeMidnight(enc);
   });
 
   it('Should not discharge a patient whose encounter opened today', async () => {
     const enc = await createEncounter({
-      startDate: sub(new Date(), { minutes: 2 }), 
+      startDate: sub(new Date(), { minutes: 2 }),
     });
     await runDischarger();
     await enc.reload();
@@ -89,8 +91,8 @@ describe('Outpatient discharger', () => {
 
   it('Should not discharge a patient on a non-clinic encounter', async () => {
     const enc = await createEncounter({
-      startDate: sub(new Date(), { minutes: 2 }), 
-      encounterType: ENCOUNTER_TYPES.ADMISSION 
+      startDate: sub(new Date(), { minutes: 2 }),
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
     });
     await runDischarger();
     await enc.reload();
@@ -99,11 +101,10 @@ describe('Outpatient discharger', () => {
 
   it('Should discharge a patient to the same day as their startDate', async () => {
     const enc = await createEncounter({
-      startDate: sub(new Date(), { days: 6 }), 
+      startDate: sub(new Date(), { days: 6 }),
     });
     await runDischarger();
-    await enc.reload();   
-    expectEndsOnSameDay(enc);
+    await enc.reload();
+    expectEndsOnSameDayBeforeMidnight(enc);
   });
-
 });

--- a/packages/sync-server/__tests__/tasks/outpatientDischarger.test.js
+++ b/packages/sync-server/__tests__/tasks/outpatientDischarger.test.js
@@ -25,6 +25,8 @@ describe('Outpatient discharger', () => {
     expect(startDate).toBeTruthy();
     expect(endDate).toBeTruthy();
     expect(isSameDay(parseISO(startDate), parseISO(endDate))).toEqual(true);
+
+    // verify if endDate is set to be 11:59PM of the same day as startDate
     expect(toDateTimeString(endOfDay(parseISO(startDate)))).toEqual(endDate);
   };
 


### PR DESCRIPTION
### Changes
- Set end date of encounter to 11:59 PM when discharging outpatients

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
