### PR TITLE
NASS-678: Set value to null when pressing clear in SelectField

### DIFF
--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -101,6 +101,7 @@ export const SelectInput = ({
 }) => {
   const handleChange = useCallback(
     changedOption => {
+      // changedOption is empty if Clear indicator is clicked
       if (!changedOption) {
         onChange({ target: { value: null, name } });
         if (onClear) {

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -102,7 +102,7 @@ export const SelectInput = ({
   const handleChange = useCallback(
     changedOption => {
       if (!changedOption) {
-        onChange({ target: { value: '', name } });
+        onChange({ target: { value: null, name } });
         if (onClear) {
           onClear();
         }


### PR DESCRIPTION
### Changes
- Set value to null when pressing clear in SelectField

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
