### PR TITLE
NASS-748: TestSelector panel re-design as multi-select

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -81,7 +81,7 @@ const useLabRequestFormTypeOptions = setFieldValue => {
     }
   }, [defaultOption, setFieldValue, isSuccess]);
 
-  return { options, panelData: data };
+  return { options };
 };
 
 export const LabRequestFormScreen1 = ({

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -81,7 +81,7 @@ const useLabRequestFormTypeOptions = setFieldValue => {
     }
   }, [defaultOption, setFieldValue, isSuccess]);
 
-  return { options };
+  return { options, panelData: data };
 };
 
 export const LabRequestFormScreen1 = ({

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -1,15 +1,9 @@
 import React, { useMemo } from 'react';
 import * as yup from 'yup';
 import { LAB_REQUEST_FORM_TYPES } from 'shared/constants/labs';
-import styled from 'styled-components';
 import { Field, TextField } from '../../components';
 import { TestSelectorField } from '../../views/labRequest/TestSelector';
-import { Heading3, BodyText } from '../../components/Typography';
-
-const StyledBodyText = styled(BodyText)`
-  margin-bottom: 28px;
-  white-space: pre-line;
-`;
+import { BodyText, Heading3 } from '../../components/Typography';
 
 export const screen2ValidationSchema = yup.object().shape({
   labTestTypeIds: yup
@@ -75,9 +69,9 @@ export const LabRequestFormScreen2 = props => {
     <>
       <div style={{ gridColumn: '1 / -1' }}>
         <Heading3 mb="12px">{subheading}</Heading3>
-        <StyledBodyText width="500px" mb="28px" color="textTertiary">
+        <BodyText width="500px" mb="28px" color="textTertiary">
           {instructions}
-        </StyledBodyText>
+        </BodyText>
         <Field
           name={
             requestFormType === LAB_REQUEST_FORM_TYPES.INDIVIDUAL ? 'labTestTypeIds' : 'panelIds'

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -6,8 +6,22 @@ import { TestSelectorField } from '../../views/labRequest/TestSelector';
 import { BodyText, Heading3 } from '../../components/Typography';
 
 export const screen2ValidationSchema = yup.object().shape({
-  labTestTypeIds: yup.array().of(yup.string()),
-  panelIds: yup.array().of(yup.string()),
+  labTestTypeIds: yup.array().when('panelIds', {
+    is: panelIds => !!panelIds,
+    then: yup
+      .array()
+      .of(yup.string())
+      .min(1, 'Please select at least one test type'),
+    otherwise: yup.array().nullable(),
+  }),
+  panelIds: yup.array().when('labTestTypeIds', {
+    is: labTestTypeIds => !!labTestTypeIds,
+    then: yup
+      .array()
+      .of(yup.string())
+      .min(1, 'Please select at least one panel'),
+    otherwise: yup.array().nullable(),
+  }),
   notes: yup.string(),
 });
 

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -8,7 +8,6 @@ import { BodyText, Heading3 } from '../../components/Typography';
 export const screen2ValidationSchema = yup.object().shape({
   labTestTypeIds: yup.array().of(yup.string()),
   panelIds: yup.array().of(yup.string()),
-  labTestPanelId: yup.string(),
   notes: yup.string(),
 });
 

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -6,30 +6,8 @@ import { TestSelectorField } from '../../views/labRequest/TestSelector';
 import { BodyText, Heading3 } from '../../components/Typography';
 
 export const screen2ValidationSchema = yup.object().shape({
-  labTestTypeIds: yup
-    .array()
-    .of(yup.string())
-    .when('requestFormType', {
-      is: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
-      then: yup
-        .array()
-        .of(yup.string())
-        .min(1, 'Please select at least one test')
-        .required(),
-      otherwise: yup.array().of(yup.string()),
-    }),
-  panelIds: yup
-    .array()
-    .of(yup.string())
-    .when('requestFormType', {
-      is: LAB_REQUEST_FORM_TYPES.PANEL,
-      then: yup
-        .array()
-        .of(yup.string())
-        .min(1, 'Please select at least one panel')
-        .required(),
-      otherwise: yup.array().of(yup.string()),
-    }),
+  labTestTypeIds: yup.array().of(yup.string()),
+  panelIds: yup.array().of(yup.string()),
   labTestPanelId: yup.string(),
   notes: yup.string(),
 });
@@ -64,6 +42,8 @@ export const LabRequestFormScreen2 = props => {
 
   const labelConfig = useMemo(() => SECTION_LABELS[requestFormType], [requestFormType]);
   const { subheading, instructions } = labelConfig;
+
+  console.log(props);
 
   return (
     <>

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -68,7 +68,7 @@ export const LabRequestFormScreen2 = props => {
           <Heading3 mb="12px">{formTypeToLabelConfig.subheading}</Heading3>
         )}
         {formTypeToLabelConfig.instructions && (
-          <StyledBodyText mb="28px" color="textTertiary">
+          <StyledBodyText width="500px" mb="28px" color="textTertiary">
             {formTypeToLabelConfig.instructions}
           </StyledBodyText>
         )}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -43,8 +43,6 @@ export const LabRequestFormScreen2 = props => {
   const labelConfig = useMemo(() => SECTION_LABELS[requestFormType], [requestFormType]);
   const { subheading, instructions } = labelConfig;
 
-  console.log(props);
-
   return (
     <>
       <div style={{ gridColumn: '1 / -1' }}>

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -5,25 +5,26 @@ import { Field, TextField } from '../../components';
 import { TestSelectorField } from '../../views/labRequest/TestSelector';
 import { BodyText, Heading3 } from '../../components/Typography';
 
-export const screen2ValidationSchema = yup.object().shape({
-  labTestTypeIds: yup.array().when('panelIds', {
-    is: panelIds => !!panelIds,
-    then: yup
-      .array()
-      .of(yup.string())
-      .min(1, 'Please select at least one test type'),
-    otherwise: yup.array().nullable(),
-  }),
-  panelIds: yup.array().when('labTestTypeIds', {
-    is: labTestTypeIds => !!labTestTypeIds,
-    then: yup
-      .array()
-      .of(yup.string())
-      .min(1, 'Please select at least one panel'),
-    otherwise: yup.array().nullable(),
-  }),
-  notes: yup.string(),
-});
+export const screen2ValidationSchema = yup.object().shape(
+  {
+    labTestTypeIds: yup.array().when('panelIds', {
+      is: '',
+      then: yup
+        .array()
+        .of(yup.string())
+        .min(1, 'Please select at least one test type'),
+    }),
+    panelIds: yup.array().when('labTestTypeIds', {
+      is: '',
+      then: yup
+        .array()
+        .of(yup.string())
+        .min(1, 'Please select at least one panel'),
+    }),
+    notes: yup.string(),
+  },
+  ['labTestTypeIds', 'panelIds'],
+);
 
 const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -5,32 +5,29 @@ import { Field, TextField } from '../../components';
 import { TestSelectorField } from '../../views/labRequest/TestSelector';
 import { BodyText, Heading3 } from '../../components/Typography';
 
-export const screen2ValidationSchema = yup.object().shape(
-  {
-    labTestTypeIds: yup
-      .array()
-      .nullable()
-      .when('panelIds', {
-        is: '',
-        then: yup
-          .array()
-          .of(yup.string())
-          .min(1, 'Please select at least one test type'),
-      }),
-    panelIds: yup
-      .array()
-      .nullable()
-      .when('labTestTypeIds', {
-        is: '',
-        then: yup
-          .array()
-          .of(yup.string())
-          .min(1, 'Please select at least one panel'),
-      }),
-    notes: yup.string(),
-  },
-  ['labTestTypeIds', 'panelIds'],
-);
+export const screen2ValidationSchema = yup.object().shape({
+  labTestTypeIds: yup
+    .array()
+    .nullable()
+    .when('requestFormType', {
+      is: val => val === LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
+      then: yup
+        .array()
+        .of(yup.string())
+        .min(1, 'Please select at least one test type'),
+    }),
+  panelIds: yup
+    .array()
+    .nullable()
+    .when('requestFormType', {
+      is: val => val === LAB_REQUEST_FORM_TYPES.PANEL,
+      then: yup
+        .array()
+        .of(yup.string())
+        .min(1, 'Please select at least one panel'),
+    }),
+  notes: yup.string(),
+});
 
 const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -11,12 +11,13 @@ export const screen2ValidationSchema = yup.object().shape({
   notes: yup.string(),
 });
 
-const SECTION_LABELS = {
+const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
     subheading: 'Select tests',
     instructions:
       'Please select the test or tests you would like to request below and add any relevant notes. \nYou can filter test by category using the field below.',
     selectableName: 'test',
+    fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
     subheading: 'Select panel',
@@ -25,6 +26,7 @@ const SECTION_LABELS = {
     label: 'Select the test panel or panels',
     selectableName: 'panel',
     searchFieldPlaceholder: 'Search panel or category',
+    fieldName: 'panelIds',
   },
   [LAB_REQUEST_FORM_TYPES.SUPERSET]: {
     subheading: 'Select superset',
@@ -39,8 +41,8 @@ export const LabRequestFormScreen2 = props => {
     values: { requestFormType },
   } = props;
 
-  const labelConfig = useMemo(() => SECTION_LABELS[requestFormType], [requestFormType]);
-  const { subheading, instructions } = labelConfig;
+  const fieldConfig = useMemo(() => FORM_TYPE_TO_FIELD_CONFIG[requestFormType], [requestFormType]);
+  const { subheading, instructions, fieldName } = fieldConfig;
 
   return (
     <>
@@ -50,10 +52,8 @@ export const LabRequestFormScreen2 = props => {
           {instructions}
         </BodyText>
         <Field
-          name={
-            requestFormType === LAB_REQUEST_FORM_TYPES.INDIVIDUAL ? 'labTestTypeIds' : 'panelIds'
-          }
-          labelConfig={labelConfig}
+          name={fieldName}
+          labelConfig={fieldConfig}
           component={TestSelectorField}
           requestFormType={requestFormType}
           required

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -7,20 +7,26 @@ import { BodyText, Heading3 } from '../../components/Typography';
 
 export const screen2ValidationSchema = yup.object().shape(
   {
-    labTestTypeIds: yup.array().when('panelIds', {
-      is: '',
-      then: yup
-        .array()
-        .of(yup.string())
-        .min(1, 'Please select at least one test type'),
-    }),
-    panelIds: yup.array().when('labTestTypeIds', {
-      is: '',
-      then: yup
-        .array()
-        .of(yup.string())
-        .min(1, 'Please select at least one panel'),
-    }),
+    labTestTypeIds: yup
+      .array()
+      .nullable()
+      .when('panelIds', {
+        is: '',
+        then: yup
+          .array()
+          .of(yup.string())
+          .min(1, 'Please select at least one test type'),
+      }),
+    panelIds: yup
+      .array()
+      .nullable()
+      .when('labTestTypeIds', {
+        is: '',
+        then: yup
+          .array()
+          .of(yup.string())
+          .min(1, 'Please select at least one panel'),
+      }),
     notes: yup.string(),
   },
   ['labTestTypeIds', 'panelIds'],

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as yup from 'yup';
 import { getCurrentDateString, getCurrentDateTimeString } from 'shared/utils/dateTime';
 import { LAB_REQUEST_STATUSES, LAB_REQUEST_FORM_TYPES } from 'shared/constants/labs';
 import { useAuth } from '../../contexts/Auth';

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -9,10 +9,7 @@ import { MultiStepForm, FormStep } from '../MultiStepForm';
 import { LabRequestFormScreen1, screen1ValidationSchema } from './LabRequestFormScreen1';
 import { LabRequestFormScreen2, screen2ValidationSchema } from './LabRequestFormScreen2';
 
-const combinedValidationSchema = yup.object().shape({
-  ...screen1ValidationSchema.fields,
-  ...screen2ValidationSchema.fields,
-});
+const combinedValidationSchema = screen1ValidationSchema.concat(screen2ValidationSchema);
 
 export const LabRequestMultiStepForm = ({
   isSubmitting,

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -40,6 +40,7 @@ export const LabRequestMultiStepForm = ({
         specimenAttached: 'no',
         status: LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
         labTestTypeIds: [],
+        panelIds: [],
         notes: '',
         // LabTest date
         date: getCurrentDateString(),

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -123,7 +123,7 @@ const useTestTypes = (labTestPanelId, placeholderData, onSuccess) => {
 
 const usePanels = (placeholderData, onSuccess) => {
   const api = useApi();
-  return useQuery(['labTestTypes'], () => api.get(`suggestions/labTestPanel/all`), {
+  return useQuery(['suggestions/labTestPanel/all'], () => api.get(`suggestions/labTestPanel/all`), {
     placeholderData,
     onSuccess,
   });

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -121,6 +121,14 @@ const useTestTypes = (labTestPanelId, placeholderData, onSuccess) => {
   );
 };
 
+const usePanels = (placeholderData, onSuccess) => {
+  const api = useApi();
+  return useQuery(['labTestTypes'], () => api.get(`suggestions/labTestPanel/all`), {
+    placeholderData,
+    onSuccess,
+  });
+};
+
 const filterByTestTypeQuery = (testTypes = [], { labTestCategoryId, search }) =>
   testTypes
     // Filter out tests that don't match the search query or category
@@ -142,7 +150,6 @@ export const TestSelectorInput = ({
   onClearPanel,
   isLoading,
   onChange,
-  required,
   helperText,
   error,
 }) => {
@@ -150,6 +157,10 @@ export const TestSelectorInput = ({
     labTestCategoryId: '',
     search: '',
   });
+
+  const { data: panelData } = usePanels();
+
+  console.log(panelData);
 
   const handleChange = newSelected => onChange({ target: { name, value: newSelected } });
 
@@ -228,27 +239,33 @@ export const TestSelectorInput = ({
           </Box>
           <FormSeparatorLine />
           <SelectorTable>
-            {showLoadingText && <BodyText>Loading tests</BodyText>}
-            {!showLoadingText &&
-              (queriedTypes.length > 0 ? (
-                queriedTypes.map(type => (
-                  <SelectableTestItem
-                    key={`${type.id}-checkbox`}
-                    label={type.name}
-                    name={type.id}
-                    category={type.category.name}
-                    checked={isSelected(type)}
-                    onChange={handleCheck}
-                  />
-                ))
-              ) : (
-                <BodyText>No tests found.</BodyText>
-              ))}
+            {requestFormType === LAB_REQUEST_FORM_TYPES.INDIVIDUAL && (
+              <>
+                {showLoadingText && <BodyText>Loading tests</BodyText>}
+                {!showLoadingText &&
+                  (queriedTypes.length > 0 ? (
+                    queriedTypes.map(type => (
+                      <SelectableTestItem
+                        key={`${type.id}-checkbox`}
+                        label={type.name}
+                        name={type.id}
+                        category={type.category.name}
+                        checked={isSelected(type)}
+                        onChange={handleCheck}
+                      />
+                    ))
+                  ) : (
+                    <BodyText>No tests found.</BodyText>
+                  ))}
+              </>
+            )}
           </SelectorTable>
         </SelectorContainer>
         <SelectorContainer>
           <Box display="flex" justifyContent="space-between">
-            <SectionHeader>Selected tests</SectionHeader>
+            <SectionHeader>
+              Selected {requestFormType === LAB_REQUEST_FORM_TYPES.PANEL ? 'panels' : 'tests'}
+            </SectionHeader>
             {value.length > 0 && <ClearAllButton onClick={handleClear}>Clear all</ClearAllButton>}
           </Box>
           <FormSeparatorLine />

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -122,15 +122,13 @@ const useSelectable = formType => {
 };
 
 const queryBySearch = (formType, data, { search, labTestCategoryId }) =>
-  formType === LAB_REQUEST_FORM_TYPES.PANEL
-    ? data.filter(
-        result => subStrSearch(search, result.name) || subStrSearch(search, result.category.name),
-      )
-    : data.filter(
-        result =>
-          subStrSearch(search, result.name) &&
-          (!labTestCategoryId || result.category.id === labTestCategoryId),
-      );
+  data.filter(result => {
+    const nameMatch = subStrSearch(search, result.name);
+    if (formType === LAB_REQUEST_FORM_TYPES.PANEL) {
+      return nameMatch || subStrSearch(search, result.category.name);
+    }
+    return nameMatch && (!labTestCategoryId || result.category.id === labTestCategoryId);
+  });
 
 const sortByCategoryAndName = (a, b) =>
   a.category.name.localeCompare(b.category.name) || a.name.localeCompare(b.name);

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -108,17 +108,6 @@ const StyledSearchField = styled(SearchField)`
   }
 `;
 
-const StyledSuggesterSelectField = styled(SuggesterSelectField)`
-  .MuiInputBase-input.Mui-disabled {
-    background: #f3f5f7;
-  }
-`;
-
-const RequiredLabel = styled.span`
-  color: ${Colors.alert};
-  padding-left: 3px;
-`;
-
 const useTestTypes = (labTestPanelId, placeholderData, onSuccess) => {
   const api = useApi();
   return useQuery(
@@ -197,10 +186,7 @@ export const TestSelectorInput = ({
 
   return (
     <Container>
-      <LabelText>
-        {label}
-        {required && <RequiredLabel>*</RequiredLabel>}
-      </LabelText>
+      <LabelText>{label}</LabelText>
       <Wrapper>
         <SelectorContainer>
           {requestFormType === LAB_REQUEST_FORM_TYPES.INDIVIDUAL && (
@@ -215,18 +201,14 @@ export const TestSelectorInput = ({
               name="labTestCategoryId"
             />
           )}
-          {requestFormType === LAB_REQUEST_FORM_TYPES.PANEL && (
-            <Field
-              name="labTestPanelId"
-              label="Test panel"
-              component={StyledSuggesterSelectField}
-              endpoint="labTestPanel"
-              disabled={!!labTestPanelId}
-            />
-          )}
-          <FormSeparatorLine />
           {requestFormType === LAB_REQUEST_FORM_TYPES.INDIVIDUAL && (
-            <TextTypeLabel>Test type</TextTypeLabel>
+            <>
+              <FormSeparatorLine />
+              <TextTypeLabel>Test type</TextTypeLabel>
+            </>
+          )}
+          {requestFormType === LAB_REQUEST_FORM_TYPES.PANEL && (
+            <TextTypeLabel>Panels</TextTypeLabel>
           )}
           <Box display="flex" alignItems="center">
             <SelectableTestItem
@@ -240,7 +222,7 @@ export const TestSelectorInput = ({
                 value: testFilters.search,
                 onChange: handleChangeTestFilters,
               }}
-              placeholder="Search"
+              placeholder="Search panel or category"
               name="search"
             />
           </Box>

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -394,25 +394,7 @@ export const labTestPanel = express.Router();
 
 labTestPanel.get('/', async (req, res) => {
   req.checkPermission('list', 'LabTestPanel');
-  const { models, query } = req;
-  const { search } = query;
-  // Get all panels that match search by name or joined category name from reference data
-  const where = search
-    ? {
-        [Op.or]: [
-          {
-            name: {
-              [Op.iLike]: `%${search}%`,
-            },
-          },
-          {
-            '$category.name$': {
-              [Op.iLike]: `%${search}%`,
-            },
-          },
-        ],
-      }
-    : {};
+  const { models } = req;
   const response = await models.LabTestPanel.findAll({
     include: [
       {
@@ -420,7 +402,6 @@ labTestPanel.get('/', async (req, res) => {
         as: 'category',
       },
     ],
-    where,
   });
   res.send(response);
 });

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -413,8 +413,7 @@ labTestPanel.get(
   asyncHandler(async (req, res) => {
     const { models, params } = req;
     const panelId = params.id;
-    req.checkPermission('read', 'LabTestPanel');
-    req.checkPermission('list', 'LabTestType');
+    req.checkPermission('list', 'LabTest');
     const panel = await models.LabTestPanel.findByPk(panelId);
     if (!panel) {
       throw new NotFoundError();

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -416,6 +416,9 @@ labTestPanel.get(
     req.checkPermission('read', 'LabTestPanel');
     req.checkPermission('list', 'LabTestType');
     const panel = await models.LabTestPanel.findByPk(panelId);
+    if (!panel) {
+      throw new NotFoundError();
+    }
     const response = await panel.getLabTestTypes({
       include: [
         {

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -392,6 +392,7 @@ labTestType.get(
 
 export const labTestPanel = express.Router();
 
+labTestPanel.get('/', simpleGetList('LabTestPanel'));
 labTestPanel.get('/:id', simpleGet('LabTestPanel'));
 labTestPanel.get(
   '/:id/labTestTypes',

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -407,14 +407,14 @@ labTestPanel.get('/', async (req, res) => {
 });
 
 labTestPanel.get('/:id', simpleGet('LabTestPanel'));
+
 labTestPanel.get(
   '/:id/labTestTypes',
   asyncHandler(async (req, res) => {
     const { models, params } = req;
     const panelId = params.id;
-
-    req.checkPermission('list', 'LabTests');
-
+    req.checkPermission('read', 'LabTestPanel');
+    req.checkPermission('list', 'LabTestType');
     const panel = await models.LabTestPanel.findByPk(panelId);
     const response = await panel.getLabTestTypes({
       include: [

--- a/packages/shared-src/src/migrations/1684808590868-addCategoryToLabTestPanel.js
+++ b/packages/shared-src/src/migrations/1684808590868-addCategoryToLabTestPanel.js
@@ -1,0 +1,16 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('lab_test_panels', 'category_id', {
+    type: DataTypes.TEXT,
+    allowNull: true,
+    references: {
+      model: 'reference_data',
+      key: 'id',
+    },
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('lab_test_panels', 'category_id');
+}

--- a/packages/shared-src/src/migrations/1684808590868-addCategoryToLabTestPanel.js
+++ b/packages/shared-src/src/migrations/1684808590868-addCategoryToLabTestPanel.js
@@ -2,7 +2,7 @@ import { DataTypes } from 'sequelize';
 
 export async function up(query) {
   await query.addColumn('lab_test_panels', 'category_id', {
-    type: DataTypes.TEXT,
+    type: DataTypes.STRING,
     allowNull: true,
     references: {
       model: 'reference_data',

--- a/packages/shared-src/src/models/LabTestPanel.js
+++ b/packages/shared-src/src/models/LabTestPanel.js
@@ -28,6 +28,10 @@ export class LabTestPanel extends Model {
     );
   }
 
+  static getListReferenceAssociations() {
+    return ['category'];
+  }
+
   static initRelations(models) {
     this.belongsToMany(models.LabTestType, {
       through: models.LabTestPanelLabTestTypes,

--- a/packages/shared-src/src/models/LabTestPanel.js
+++ b/packages/shared-src/src/models/LabTestPanel.js
@@ -34,5 +34,10 @@ export class LabTestPanel extends Model {
       as: 'labTestTypes',
       foreignKey: 'labTestPanelId',
     });
+
+    this.belongsTo(models.ReferenceData, {
+      foreignKey: 'categoryId',
+      as: 'category',
+    });
   }
 }


### PR DESCRIPTION
### Changes
Into epic branch for Lab test updates

- Implement new behavior for panel version of lab request flow
- Previously panels where selected from a dropdown and determined which lab tests where displayed
- Now you select panels in place of lab requests - see example pic
- Add category to lab panels

**Video of new flow for selecting panels**
https://github.com/beyondessential/tamanu/assets/38335330/bb2e5297-5236-42aa-b79d-d36c3a5fb478


### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
