### PR TITLE
SAV-100: Header scroll behaviour tweak

### DIFF
--- a/packages/mobile/App/ui/components/Table/index.tsx
+++ b/packages/mobile/App/ui/components/Table/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyledView, RowView } from '/styled/common';
+import { StyledView, RowView, StyledScrollView } from '/styled/common';
 import { ScrollView } from 'react-native-gesture-handler';
 import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
@@ -43,11 +43,19 @@ export const Table = ({
   scrollHandler,
 }: TableProps): JSX.Element => (
   <RowView>
-    <StyledView>
+    <StyledView paddingTop={60}>
       {Title && <Title />}
       {rows.map((r, i) => r.rowHeader(i))}
     </StyledView>
-    <ScrollView bounces={false} showsHorizontalScrollIndicator onScroll={scrollHandler} horizontal>
+    <StyledScrollView
+      bounces={false}
+      showsHorizontalScrollIndicator
+      onScroll={scrollHandler}
+      horizontal
+      paddingTop={60}
+      bottom={60}
+      position="relative"
+    >
       <RowView>
         {columns.map((column: any) => (
           <StyledView key={`${column}`}>
@@ -62,6 +70,6 @@ export const Table = ({
           </StyledView>
         ))}
       </RowView>
-    </ScrollView>
+    </StyledScrollView>
   </RowView>
 );

--- a/packages/mobile/App/ui/components/Table/index.tsx
+++ b/packages/mobile/App/ui/components/Table/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyledView, RowView } from '/styled/common';
 import { ScrollView } from 'react-native-gesture-handler';
 import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
@@ -41,13 +41,20 @@ export const Table = ({
   tableHeader = null,
   onPressItem,
   scrollHandler,
+  scrollOffset,
 }: TableProps): JSX.Element => (
   <RowView>
     <StyledView>
       {Title && <Title />}
       {rows.map((r, i) => r.rowHeader(i))}
     </StyledView>
-    <ScrollView bounces={false} showsHorizontalScrollIndicator onScroll={scrollHandler} horizontal>
+    <ScrollView
+      contentOffset={{ x: scrollOffset }}
+      bounces={false}
+      showsHorizontalScrollIndicator
+      onScroll={scrollHandler}
+      horizontal
+    >
       <RowView>
         {columns.map((column: any) => (
           <StyledView key={`${column}`}>

--- a/packages/mobile/App/ui/components/Table/index.tsx
+++ b/packages/mobile/App/ui/components/Table/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { StyledView, RowView } from '/styled/common';
 import { ScrollView } from 'react-native-gesture-handler';
 import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
@@ -41,20 +41,13 @@ export const Table = ({
   tableHeader = null,
   onPressItem,
   scrollHandler,
-  scrollOffset,
 }: TableProps): JSX.Element => (
   <RowView>
     <StyledView>
       {Title && <Title />}
       {rows.map((r, i) => r.rowHeader(i))}
     </StyledView>
-    <ScrollView
-      contentOffset={{ x: scrollOffset }}
-      bounces={false}
-      showsHorizontalScrollIndicator
-      onScroll={scrollHandler}
-      horizontal
-    >
+    <ScrollView bounces={false} showsHorizontalScrollIndicator onScroll={scrollHandler} horizontal>
       <RowView>
         {columns.map((column: any) => (
           <StyledView key={`${column}`}>

--- a/packages/mobile/App/ui/components/Table/index.tsx
+++ b/packages/mobile/App/ui/components/Table/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyledView, RowView, StyledScrollView } from '/styled/common';
+import { StyledView, RowView } from '/styled/common';
 import { ScrollView } from 'react-native-gesture-handler';
 import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
@@ -43,18 +43,15 @@ export const Table = ({
   scrollHandler,
 }: TableProps): JSX.Element => (
   <RowView>
-    <StyledView paddingTop={60}>
+    <StyledView>
       {Title && <Title />}
       {rows.map((r, i) => r.rowHeader(i))}
     </StyledView>
-    <StyledScrollView
+    <ScrollView
       bounces={false}
       showsHorizontalScrollIndicator
       onScroll={scrollHandler}
       horizontal
-      paddingTop={60}
-      bottom={60}
-      position="relative"
     >
       <RowView>
         {columns.map((column: any) => (
@@ -70,6 +67,6 @@ export const Table = ({
           </StyledView>
         ))}
       </RowView>
-    </StyledScrollView>
+    </ScrollView>
   </RowView>
 );

--- a/packages/mobile/App/ui/components/VaccinesTable/index.tsx
+++ b/packages/mobile/App/ui/components/VaccinesTable/index.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, { useRef, useState } from 'react';
 import { useIsFocused } from '@react-navigation/native';
 import { uniqBy } from 'lodash';
 import { useBackendEffect } from '~/ui/hooks';
@@ -24,13 +24,21 @@ export const VaccinesTable = ({
   categoryName,
   selectedPatient,
 }: VaccinesTableProps): JSX.Element => {
-  const scrollViewRef = useRef(null);
+  const [scrollOffsetTable, setScrollOffsetTable] = useState(0);
+  const [scrollOffsetHeader, setScrollOffsetHeader] = useState(0);
 
   // This manages the horizontal scroll of the header. This handler is passed down
   // to the scrollview in the generic table. That gets the horizontal scroll coordinate
   // of the table and feeds this back up to position the header appropriately.
-  const handleScroll = (event: any) => {
-    scrollViewRef.current.scrollTo({x: event.nativeEvent.contentOffset.x, animated: false})
+  const handleScrollHeader = (event: any) => {
+    // scrollViewRef.current.scrollTo({x: event.nativeEvent.contentOffset.x, animated: false})
+    console.log(event);
+    setScrollOffsetTable(event.nativeEvent.contentOffset.x);
+  };
+  const handleScrollTable = (event: any) => {
+    // scrollViewRef.current.scrollTo({x: event.nativeEvent.contentOffset.x, animated: false})
+    console.log(event);
+    setScrollOffsetHeader(event.nativeEvent.contentOffset.x);
   };
 
   const isFocused = useIsFocused();
@@ -102,7 +110,11 @@ export const VaccinesTable = ({
     <ScrollView bounces={false} stickyHeaderIndices={[0]}>
       <StyledView flexDirection="row">
         <VaccinesTableTitle />
-        <ScrollView ref={scrollViewRef} horizontal scrollEnabled={false}>
+        <ScrollView
+          contentOffset={{ x: scrollOffsetHeader }}
+          horizontal
+          onScroll={handleScrollHeader}
+        >
           {columns.map((column: any) => (
             <StyledView key={`${column}`}>
               {vaccineTableHeader.accessor(column, onPressItem)}
@@ -115,7 +127,8 @@ export const VaccinesTable = ({
         rows={rows}
         columns={columns}
         cells={cells}
-        scrollHandler={handleScroll}
+        scrollHandler={handleScrollTable}
+        scrollOffset={scrollOffsetTable}
       />
     </ScrollView>
   );

--- a/packages/mobile/App/ui/components/VaccinesTable/index.tsx
+++ b/packages/mobile/App/ui/components/VaccinesTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, {useRef} from 'react';
 import { useIsFocused } from '@react-navigation/native';
 import { uniqBy } from 'lodash';
 import { useBackendEffect } from '~/ui/hooks';
@@ -24,21 +24,13 @@ export const VaccinesTable = ({
   categoryName,
   selectedPatient,
 }: VaccinesTableProps): JSX.Element => {
-  const [scrollOffsetTable, setScrollOffsetTable] = useState(0);
-  const [scrollOffsetHeader, setScrollOffsetHeader] = useState(0);
+  const scrollViewRef = useRef(null);
 
   // This manages the horizontal scroll of the header. This handler is passed down
   // to the scrollview in the generic table. That gets the horizontal scroll coordinate
   // of the table and feeds this back up to position the header appropriately.
-  const handleScrollHeader = (event: any) => {
-    // scrollViewRef.current.scrollTo({x: event.nativeEvent.contentOffset.x, animated: false})
-    console.log(event);
-    setScrollOffsetTable(event.nativeEvent.contentOffset.x);
-  };
-  const handleScrollTable = (event: any) => {
-    // scrollViewRef.current.scrollTo({x: event.nativeEvent.contentOffset.x, animated: false})
-    console.log(event);
-    setScrollOffsetHeader(event.nativeEvent.contentOffset.x);
+  const handleScroll = (event: any) => {
+    scrollViewRef.current.scrollTo({x: event.nativeEvent.contentOffset.x, animated: false})
   };
 
   const isFocused = useIsFocused();
@@ -110,11 +102,7 @@ export const VaccinesTable = ({
     <ScrollView bounces={false} stickyHeaderIndices={[0]}>
       <StyledView flexDirection="row">
         <VaccinesTableTitle />
-        <ScrollView
-          contentOffset={{ x: scrollOffsetHeader }}
-          horizontal
-          onScroll={handleScrollHeader}
-        >
+        <ScrollView ref={scrollViewRef} horizontal scrollEnabled={false}>
           {columns.map((column: any) => (
             <StyledView key={`${column}`}>
               {vaccineTableHeader.accessor(column, onPressItem)}
@@ -127,8 +115,7 @@ export const VaccinesTable = ({
         rows={rows}
         columns={columns}
         cells={cells}
-        scrollHandler={handleScrollTable}
-        scrollOffset={scrollOffsetTable}
+        scrollHandler={handleScroll}
       />
     </ScrollView>
   );

--- a/packages/mobile/App/ui/navigation/stacks/VaccineTableTabs.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/VaccineTableTabs.tsx
@@ -20,6 +20,7 @@ export const VaccineTableTabs = (): ReactElement => {
       tabBarOptions={{
         labelStyle: { textTransform: 'none' },
       }}
+      swipeEnabled={false}
     >
       <Tabs.Screen
         options={{


### PR DESCRIPTION
### Changes

Klaus discovered some more weird behaviour with how the vaccine table scrolls on mobile where you can swipe between tables on the header. In order to resolve this I removed the ability to swipe between tables (which was never really useful for this table in the first place, in fact I think it was probably annoying). This means it now works in a much more predictable way although not as ideal as I would like due to technical limitations due to the layering of the scrollviews for this table (ideally the whole table will scroll when the header is scrolled but I could not get that to work in a reasonable amount of time).

Before:

https://github.com/beyondessential/tamanu/assets/58054247/0a9cd93c-2043-4d29-9cce-fdfd357e0db3

After

https://github.com/beyondessential/tamanu/assets/58054247/a9a68778-665c-4f6c-afd0-152bc569449d

