### PR TITLE
NASS-678: Add missing search components + select sizing

### DIFF
--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -4,6 +4,7 @@ import { Tooltip, InputAdornment, Checkbox } from '@material-ui/core';
 import SpellcheckIcon from '@material-ui/icons/Spellcheck';
 import { LocalisedField } from './LocalisedField';
 import { Field } from './Field';
+import { SearchField } from './SearchField';
 
 const FieldContainer = styled(LocalisedField)`
   .MuiOutlinedInput-adornedEnd {
@@ -34,6 +35,7 @@ export const DisplayIdField = props => (
     {...props}
     name="displayId"
     className="display-field"
+    component={SearchField}
     InputProps={{
       endAdornment: (
         <InputAdornment position="end">

--- a/packages/desktop/app/components/SearchBar/AppointmentsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AppointmentsSearchBar.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { startOfDay } from 'date-fns';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
-import { DateTimeField, AutocompleteField, LocalisedField, SelectField, SearchField } from '../Field';
+import {
+  DateTimeField,
+  AutocompleteField,
+  LocalisedField,
+  SelectField,
+  SearchField,
+} from '../Field';
 import { appointmentTypeOptions, appointmentStatusOptions } from '../../constants';
 import { useSuggester } from '../../api';
 

--- a/packages/desktop/app/components/SearchBar/AppointmentsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AppointmentsSearchBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { startOfDay } from 'date-fns';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
-import { DateTimeField, AutocompleteField, LocalisedField, SelectField } from '../Field';
+import { DateTimeField, AutocompleteField, LocalisedField, SelectField, SearchField } from '../Field';
 import { appointmentTypeOptions, appointmentStatusOptions } from '../../constants';
 import { useSuggester } from '../../api';
 
@@ -29,8 +29,8 @@ export const AppointmentsSearchBar = ({ onSearch }) => {
         displayIdExact: true,
       }}
     >
-      <LocalisedField name="firstName" />
-      <LocalisedField name="lastName" />
+      <LocalisedField name="firstName" component={SearchField} />
+      <LocalisedField name="lastName" component={SearchField} />
       <LocalisedField
         name="clinicianId"
         defaultLabel="Clinician"
@@ -48,12 +48,14 @@ export const AppointmentsSearchBar = ({ onSearch }) => {
         defaultLabel="Appointment Type"
         component={SelectField}
         options={appointmentTypeOptions}
+        size="small"
       />
       <LocalisedField
         name="status"
         defaultLabel="Appointment Status"
         component={SelectField}
         options={appointmentStatusOptions}
+        size="small"
       />
       <LocalisedField
         saveDateAsString
@@ -67,7 +69,7 @@ export const AppointmentsSearchBar = ({ onSearch }) => {
         defaultLabel="Until"
         component={DateTimeField}
       />
-      <LocalisedField name="displayId" />
+      <LocalisedField name="displayId" component={SearchField} />
     </CustomisableSearchBar>
   );
 };

--- a/packages/desktop/app/components/SearchBar/CovidPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CovidPatientsSearchBar.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
-import { AutocompleteField, Field, LocalisedField, DisplayIdField, DOBFields } from '../Field';
+import {
+  AutocompleteField,
+  Field,
+  LocalisedField,
+  DisplayIdField,
+  DOBFields,
+  SearchField,
+} from '../Field';
 import { useSuggester } from '../../api';
 import { SearchBarCheckField } from './SearchBarCheckField';
 
@@ -13,12 +20,12 @@ export const CovidPatientsSearchBar = React.memo(({ onSearch }) => {
       onSearch={onSearch}
       staticValues={{ displayIdExact: true }}
     >
-      <LocalisedField name="firstName" />
-      <LocalisedField name="lastName" />
+      <LocalisedField name="firstName" component={SearchField} />
+      <LocalisedField name="lastName" component={SearchField} />
       <LocalisedField name="villageId" component={AutocompleteField} suggester={villageSuggester} />
       <DisplayIdField />
       <DOBFields />
-      <Field name="clinicalStatus" label="Clinical status" />
+      <Field name="clinicalStatus" label="Clinical status" component={SearchField} />
       <SearchBarCheckField name="deceased" label="Include deceased patients" />
     </CustomisableSearchBar>
   );

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -146,6 +146,7 @@ export const ImagingRequestsSearchBar = ({ status = '' }) => {
           defaultLabel="Priority"
           component={SelectField}
           options={imagingPriorities}
+          size="small"
         />
       )}
       {status && (


### PR DESCRIPTION
### Changes

Some of our search fields in the lesser used search tabs didn't have a proper search component implemented. There were also some select components that didn't have the proper size prop set so this PR just adds those in