### PR TITLE
[TAN-2164] Fix advanced fields on patient's page, opened value when opening the page

### DIFF
--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -28,15 +28,14 @@ const Spacer = styled.div`
   width: 100%;
 `;
 
-const ADVANCED_FIELDS_PER_STATUS = {
-  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: [
-    'locationGroupId',
-    'departmentId',
-    'completedAt',
-    'allFacilities',
-  ],
-  all: ['allFacilities'],
-};
+const BASE_ADVANCED_FIELDS = ['allFacilities'];
+const COMPLETED_ADVANCED_FIELDS = [
+  ...BASE_ADVANCED_FIELDS,
+  'locationGroupId',
+  'departmentId',
+  'completedAt',
+];
+const ALL_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS];
 
 export const ImagingRequestsSearchBar = ({ status = '' }) => {
   const { getLocalisation } = useLocalisation();
@@ -52,7 +51,7 @@ export const ImagingRequestsSearchBar = ({ status = '' }) => {
   );
 
   const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
-    ADVANCED_FIELDS_PER_STATUS[status || 'all'],
+    completedStatus ? COMPLETED_ADVANCED_FIELDS : ALL_ADVANCED_FIELDS,
     searchParameters,
   );
   const statusFilter = status ? { status } : {};

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { IMAGING_REQUEST_STATUS_TYPES } from 'shared/constants';
 import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../constants';
@@ -16,6 +16,7 @@ import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLocalisation } from '../../contexts/Localisation';
 import { useSuggester } from '../../api';
 import { useImagingRequests, IMAGING_REQUEST_SEARCH_KEYS } from '../../contexts/ImagingRequests';
+import { useAdvancedFields } from './useAdvancedFields';
 
 const FacilityCheckbox = styled.div`
   display: flex;
@@ -27,20 +28,14 @@ const Spacer = styled.div`
   width: 100%;
 `;
 
-const ADVANCED_FIELDS = ['locationGroupId', 'departmentId', 'completedAt', 'allFacilities'];
-
-const useAdvancedFields = (advancedFields, completedStatus) => {
-  const { searchParameters, setSearchParameters } = useImagingRequests(
-    completedStatus ? IMAGING_REQUEST_SEARCH_KEYS.COMPLETED : IMAGING_REQUEST_SEARCH_KEYS.ALL,
-  );
-
-  // If one of the advanced fields is filled in when landing on the screen,
-  // show the advanced fields section
-  const defaultIsOpen = Object.keys(searchParameters).some(searchKey =>
-    advancedFields.includes(searchKey),
-  );
-  const [showAdvancedFields, setShowAdvancedFields] = useState(defaultIsOpen);
-  return { showAdvancedFields, setShowAdvancedFields, searchParameters, setSearchParameters };
+const ADVANCED_FIELDS_PER_STATUS = {
+  [IMAGING_REQUEST_STATUS_TYPES.COMPLETED]: [
+    'locationGroupId',
+    'departmentId',
+    'completedAt',
+    'allFacilities',
+  ],
+  all: ['allFacilities'],
 };
 
 export const ImagingRequestsSearchBar = ({ status = '' }) => {
@@ -51,12 +46,15 @@ export const ImagingRequestsSearchBar = ({ status = '' }) => {
   const departmentSuggester = useSuggester('department');
   const requesterSuggester = useSuggester('practitioner');
   const completedStatus = status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED;
-  const {
-    showAdvancedFields,
-    setShowAdvancedFields,
+
+  const { searchParameters, setSearchParameters } = useImagingRequests(
+    completedStatus ? IMAGING_REQUEST_SEARCH_KEYS.COMPLETED : IMAGING_REQUEST_SEARCH_KEYS.ALL,
+  );
+
+  const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
+    ADVANCED_FIELDS_PER_STATUS[status || 'all'],
     searchParameters,
-    setSearchParameters,
-  } = useAdvancedFields(ADVANCED_FIELDS, completedStatus);
+  );
   const statusFilter = status ? { status } : {};
 
   const imagingTypeOptions = Object.entries(imagingTypes).map(([key, val]) => ({

--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -18,15 +18,9 @@ import { useLabRequest, LabRequestSearchParamKeys } from '../../contexts/LabRequ
 import { useSuggester } from '../../api';
 import { useAdvancedFields } from './useAdvancedFields';
 
-const ADVANCED_FIELDS_PER_STATUS = {
-  all: ['locationGroupId', 'departmentId', 'laboratory', 'priority', 'allFacilities'],
-  [LAB_REQUEST_STATUSES.PUBLISHED]: [
-    'locationGroupId',
-    'departmentId',
-    'publishedDate',
-    'allFacilities',
-  ],
-};
+const BASE_ADVANCED_FIELDS = ['locationGroupId', 'departmentId', 'allFacilities'];
+const PUBLISHED_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'publishedDate'];
+const ALL_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'priority', 'laboratory'];
 
 const FacilityCheckbox = styled.div`
   display: flex;
@@ -40,7 +34,7 @@ export const LabRequestsSearchBar = ({ status = '' }) => {
     publishedStatus ? LabRequestSearchParamKeys.Published : LabRequestSearchParamKeys.All,
   );
 
-  const advancedFields = ADVANCED_FIELDS_PER_STATUS[status || 'all'];
+  const advancedFields = publishedStatus ? PUBLISHED_ADVANCED_FIELDS : ALL_ADVANCED_FIELDS;
   const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
     advancedFields,
     searchParameters,

--- a/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/LabRequestsSearchBar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { LAB_REQUEST_STATUSES } from 'shared/constants/labs';
 import { LAB_REQUEST_STATUS_OPTIONS } from '../../constants';
@@ -16,23 +16,17 @@ import {
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { useLabRequest, LabRequestSearchParamKeys } from '../../contexts/LabRequest';
 import { useSuggester } from '../../api';
+import { useAdvancedFields } from './useAdvancedFields';
 
-const useAdvancedFields = (advancedFields, publishedStatus) => {
-  const { searchParameters, setSearchParameters } = useLabRequest(
-    publishedStatus ? LabRequestSearchParamKeys.Published : LabRequestSearchParamKeys.All,
-  );
-
-  // If one of the advanced fields is filled in when landing on the screen,
-  // show the advanced fields section
-  const defaultIsOpen = Object.keys(searchParameters).some(searchKey =>
-    advancedFields.includes(searchKey),
-  );
-  const [showAdvancedFields, setShowAdvancedFields] = useState(defaultIsOpen);
-
-  return { showAdvancedFields, setShowAdvancedFields, searchParameters, setSearchParameters };
+const ADVANCED_FIELDS_PER_STATUS = {
+  all: ['locationGroupId', 'departmentId', 'laboratory', 'priority', 'allFacilities'],
+  [LAB_REQUEST_STATUSES.PUBLISHED]: [
+    'locationGroupId',
+    'departmentId',
+    'publishedDate',
+    'allFacilities',
+  ],
 };
-
-const ADVANCED_FIELDS = ['locationGroupId', 'departmentId', 'laboratory', 'priority'];
 
 const FacilityCheckbox = styled.div`
   display: flex;
@@ -42,12 +36,15 @@ const FacilityCheckbox = styled.div`
 
 export const LabRequestsSearchBar = ({ status = '' }) => {
   const publishedStatus = status === LAB_REQUEST_STATUSES.PUBLISHED;
-  const {
-    showAdvancedFields,
-    setShowAdvancedFields,
+  const { searchParameters, setSearchParameters } = useLabRequest(
+    publishedStatus ? LabRequestSearchParamKeys.Published : LabRequestSearchParamKeys.All,
+  );
+
+  const advancedFields = ADVANCED_FIELDS_PER_STATUS[status || 'all'];
+  const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
+    advancedFields,
     searchParameters,
-    setSearchParameters,
-  } = useAdvancedFields(ADVANCED_FIELDS, publishedStatus);
+  );
   const locationGroupSuggester = useSuggester('locationGroup');
   const departmentSuggester = useSuggester('department', {
     baseQueryParameters: {

--- a/packages/desktop/app/components/SearchBar/PatientSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/PatientSearchBar.js
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { AutocompleteField, LocalisedField, SearchField } from '../Field';
 import { useSuggester } from '../../api';
+import { useAdvancedFields } from './useAdvancedFields';
 
+const ADVANCED_FIELDS = ['departmentId', 'clinicianId'];
 export const PatientSearchBar = React.memo(
   ({ onSearch, searchParameters, suggestByFacility = true }) => {
     const locationGroupSuggester = useSuggester('locationGroup', {
@@ -12,7 +14,11 @@ export const PatientSearchBar = React.memo(
       baseQueryParameters: suggestByFacility ? { filterByFacility: true } : {},
     });
 
-    const [showAdvancedFields, setShowAdvancedFields] = useState(false);
+    const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
+      ADVANCED_FIELDS,
+      searchParameters,
+    );
+
     const practitionerSuggester = useSuggester('practitioner');
     return (
       <CustomisableSearchBar
@@ -25,7 +31,13 @@ export const PatientSearchBar = React.memo(
         staticValues={{ displayIdExact: true }}
         hiddenFields={
           <>
-            <LocalisedField useShortLabel component={SearchField} name="displayId" keepLetterCase />
+            <LocalisedField
+              name="departmentId"
+              defaultLabel="Department"
+              size="small"
+              component={AutocompleteField}
+              suggester={departmentSuggester}
+            />
             <LocalisedField
               name="clinicianId"
               defaultLabel="Clinician"
@@ -36,6 +48,7 @@ export const PatientSearchBar = React.memo(
           </>
         }
       >
+        <LocalisedField useShortLabel component={SearchField} name="displayId" keepLetterCase />
         <LocalisedField name="firstName" component={SearchField} />
         <LocalisedField name="lastName" component={SearchField} />
         <LocalisedField
@@ -44,13 +57,6 @@ export const PatientSearchBar = React.memo(
           component={AutocompleteField}
           size="small"
           suggester={locationGroupSuggester}
-        />
-        <LocalisedField
-          name="departmentId"
-          defaultLabel="Department"
-          size="small"
-          component={AutocompleteField}
-          suggester={departmentSuggester}
         />
       </CustomisableSearchBar>
     );

--- a/packages/desktop/app/components/SearchBar/PatientSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/PatientSearchBar.js
@@ -5,6 +5,7 @@ import { useSuggester } from '../../api';
 import { useAdvancedFields } from './useAdvancedFields';
 
 const ADVANCED_FIELDS = ['departmentId', 'clinicianId'];
+
 export const PatientSearchBar = React.memo(
   ({ onSearch, searchParameters, suggestByFacility = true }) => {
     const locationGroupSuggester = useSuggester('locationGroup', {

--- a/packages/desktop/app/components/SearchBar/useAdvancedFields.js
+++ b/packages/desktop/app/components/SearchBar/useAdvancedFields.js
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 
 export const useAdvancedFields = (advancedFields, searchParameters) => {
+  const [showAdvancedFields, setShowAdvancedFields] = useState(false);
   // If one of the advanced fields is filled in when landing on the screen,
   // show the advanced fields section
   const defaultFilterOpen = useCallback(() => {
@@ -14,6 +15,5 @@ export const useAdvancedFields = (advancedFields, searchParameters) => {
     setShowAdvancedFields(defaultFilterOpen());
   }, [defaultFilterOpen]);
 
-  const [showAdvancedFields, setShowAdvancedFields] = useState(false);
   return { showAdvancedFields, setShowAdvancedFields };
 };

--- a/packages/desktop/app/components/SearchBar/useAdvancedFields.js
+++ b/packages/desktop/app/components/SearchBar/useAdvancedFields.js
@@ -1,0 +1,19 @@
+import { useEffect, useState, useCallback } from 'react';
+
+export const useAdvancedFields = (advancedFields, searchParameters) => {
+  // If one of the advanced fields is filled in when landing on the screen,
+  // show the advanced fields section
+  const defaultFilterOpen = useCallback(() => {
+    return Object.keys(searchParameters || {})
+      .filter(key => searchParameters[key])
+      .some(value => advancedFields.includes(value));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [advancedFields]);
+
+  useEffect(() => {
+    setShowAdvancedFields(defaultFilterOpen());
+  }, [defaultFilterOpen]);
+
+  const [showAdvancedFields, setShowAdvancedFields] = useState(false);
+  return { showAdvancedFields, setShowAdvancedFields };
+};

--- a/packages/desktop/app/views/LabRequestListingView.js
+++ b/packages/desktop/app/views/LabRequestListingView.js
@@ -23,7 +23,7 @@ export const LabRequestListingView = React.memo(() => {
         <LabRequestsTable
           loadEncounter={loadEncounter}
           loadLabRequest={loadLabRequest}
-          searchParameter={searchParameters}
+          searchParameters={searchParameters}
         />
       </ContentPane>
     </PageContainer>


### PR DESCRIPTION
### Changes

- Fixed open advanced filters values when opening the patient page (advanced filters should be opened when having and advanced filter selected)
- Fixed search fields order 

Issue: 
https://linear.app/bes/issue/TAN-2164#comment-d5f50ad2
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
