### PR TITLE
NASS-733: Staging fix - checkboxes

### DIFF
--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -7,6 +7,11 @@ import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import { Colors } from '../../constants';
 
+/* 
+  Note that the Checkbox value prop only controls what gets sent,
+  not the checkbox state. It's also worth noting that usually forms
+  will send the state value, not the prop value.
+*/
 const CheckControl = React.memo(({ value, ...props }) => (
   <Checkbox
     icon={<i className="far fa-square" />}

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -17,8 +17,8 @@ const CheckControl = React.memo(({ value, ...props }) => (
     icon={<i className="far fa-square" />}
     checkedIcon={<i className="far fa-check-square" />}
     checked={value}
-    value="true"
     {...props}
+    value="true"
   />
 ));
 

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -16,8 +16,8 @@ export const CheckControl = React.memo(({ value, ...props }) => (
   <Checkbox
     icon={<i className="far fa-square" />}
     checkedIcon={<i className="far fa-check-square" />}
-    checked={value}
     {...props}
+    checked={value}
     value="true"
   />
 ));

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -17,7 +17,7 @@ export const CheckControl = React.memo(({ value, ...props }) => (
     icon={<i className="far fa-square" />}
     checkedIcon={<i className="far fa-check-square" />}
     {...props}
-    checked={value}
+    checked={Boolean(value)}
     value="true"
   />
 ));

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -12,7 +12,7 @@ const CheckControl = React.memo(({ value, ...props }) => (
     icon={<i className="far fa-square" />}
     checkedIcon={<i className="far fa-check-square" />}
     checked={value}
-    value="checked"
+    value="true"
     {...props}
   />
 ));

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -60,7 +60,7 @@ export const CheckInput = React.memo(
 );
 
 export const CheckField = React.memo(({ field, ...props }) => (
-  <CheckInput name={field.name} value={field.value || false} onChange={field.onChange} {...props} />
+  <CheckInput name={field.name} value={field.value} onChange={field.onChange} {...props} />
 ));
 
 CheckInput.propTypes = {

--- a/packages/desktop/app/components/Field/CheckField.js
+++ b/packages/desktop/app/components/Field/CheckField.js
@@ -12,7 +12,7 @@ import { Colors } from '../../constants';
   not the checkbox state. It's also worth noting that usually forms
   will send the state value, not the prop value.
 */
-const CheckControl = React.memo(({ value, ...props }) => (
+export const CheckControl = React.memo(({ value, ...props }) => (
   <Checkbox
     icon={<i className="far fa-square" />}
     checkedIcon={<i className="far fa-check-square" />}

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -24,7 +24,7 @@ const CheckField = ({ field }) => (
       name={field.name}
       checked={!!field.value}
       onChange={field.onChange}
-      value="checked"
+      value="true"
       color="primary"
     />
   </Tooltip>

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Tooltip, InputAdornment, Checkbox } from '@material-ui/core';
+import { Tooltip, InputAdornment } from '@material-ui/core';
 import SpellcheckIcon from '@material-ui/icons/Spellcheck';
 import { LocalisedField } from './LocalisedField';
 import { Field } from './Field';
 import { SearchField } from './SearchField';
+import { CheckControl } from './CheckField';
 
 const FieldContainer = styled(LocalisedField)`
   .MuiOutlinedInput-adornedEnd {
@@ -18,7 +19,7 @@ const FieldContainer = styled(LocalisedField)`
 
 const CheckField = ({ field }) => (
   <Tooltip title="Exact term search">
-    <Checkbox
+    <CheckControl
       icon={<SpellcheckIcon color="disabled" />}
       checkedIcon={<SpellcheckIcon />}
       name={field.name}

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -20,12 +20,9 @@ const FieldContainer = styled(LocalisedField)`
 const CheckField = ({ field }) => (
   <Tooltip title="Exact term search">
     <CheckControl
-      icon={<SpellcheckIcon color="disabled" />}
-      checkedIcon={<SpellcheckIcon />}
       name={field.name}
       checked={!!field.value}
       onChange={field.onChange}
-      value="true"
       color="primary"
     />
   </Tooltip>

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -23,7 +23,7 @@ const CheckField = ({ field }) => (
       icon={<SpellcheckIcon color="disabled" />}
       checkedIcon={<SpellcheckIcon />}
       name={field.name}
-      value={!!field.value}
+      value={field.value}
       onChange={field.onChange}
       color="primary"
     />

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -20,6 +20,8 @@ const FieldContainer = styled(LocalisedField)`
 const CheckField = ({ field }) => (
   <Tooltip title="Exact term search">
     <CheckControl
+      icon={<SpellcheckIcon color="disabled" />}
+      checkedIcon={<SpellcheckIcon />}
       name={field.name}
       value={!!field.value}
       onChange={field.onChange}

--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -21,7 +21,7 @@ const CheckField = ({ field }) => (
   <Tooltip title="Exact term search">
     <CheckControl
       name={field.name}
-      checked={!!field.value}
+      value={!!field.value}
       onChange={field.onChange}
       color="primary"
     />

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -3,7 +3,6 @@ import * as yup from 'yup';
 import Select from 'react-select';
 import styled from 'styled-components';
 import { format, getCurrentDateTimeString, toDateTimeString } from 'shared/utils/dateTime';
-import Checkbox from '@material-ui/core/Checkbox';
 import { range } from 'lodash';
 import { isFuture, parseISO, set } from 'date-fns';
 import { Colors } from '../constants';
@@ -20,6 +19,7 @@ import {
   StyledTextField,
   LocalisedField,
   useLocalisedSchema,
+  CheckControl,
 } from '../components/Field';
 import { OuterLabelFieldWrapper } from '../components/Field/OuterLabelFieldWrapper';
 import { DateTimeField, DateTimeInput } from '../components/Field/DateField';
@@ -120,7 +120,7 @@ const NumberFieldWithoutLabel = ({ field, ...props }) => (
 const StyledFlexDiv = styled.div`
   display: flex;
 `;
-const StyledCheckbox = styled(Checkbox)`
+const StyledCheckbox = styled(CheckControl)`
   font-size: 16px;
 `;
 const StyledTextSpan = styled.span`

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -136,7 +136,7 @@ const CustomCheckField = ({ field, lineOne, lineTwo }) => (
   <StyledFlexDiv>
     <StyledCheckbox
       color="primary"
-      checked={field.value || false}
+      value={field.value || false}
       name={field.name}
       onChange={field.onChange}
     />

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -135,10 +135,7 @@ alongside the checkbox with different stylings.
 const CustomCheckField = ({ field, lineOne, lineTwo }) => (
   <StyledFlexDiv>
     <StyledCheckbox
-      icon={<i className="far fa-square" />}
-      checkedIcon={<i className="far fa-check-square" />}
       color="primary"
-      value="true"
       checked={field.value || false}
       name={field.name}
       onChange={field.onChange}

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -136,7 +136,7 @@ const CustomCheckField = ({ field, lineOne, lineTwo }) => (
   <StyledFlexDiv>
     <StyledCheckbox
       color="primary"
-      value={field.value || false}
+      value={field.value}
       name={field.name}
       onChange={field.onChange}
     />

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -138,7 +138,7 @@ const CustomCheckField = ({ field, lineOne, lineTwo }) => (
       icon={<i className="far fa-square" />}
       checkedIcon={<i className="far fa-check-square" />}
       color="primary"
-      value="checked"
+      value="true"
       checked={field.value || false}
       name={field.name}
       onChange={field.onChange}


### PR DESCRIPTION
### Changes

Problem was caused by upgrading library Formik to v2, which changed the way checkboxes work internally. After a long investigation, I believe this is the correct approach to solving it.

The main reasoning being that the `value` **prop** on HTML inputs with type checkbox only control what gets sent over. However we're managing state, and what gets sent is actually the state of the field, which is a different value. Using it as query params will also work because we only check that the key exists, we never care if it's actually `"checked"` - `"true"` reads just as right to me.

A lot of background info found on the card if you're interested.

PS: had a bit of back and forth with McLean, so pretty much all commits co-authored by as well! Thanks again 🙏 