### PR TITLE
NASS-678: Select state fix for forms and searchbar

### DIFF
--- a/packages/desktop/app/components/Field/Field.js
+++ b/packages/desktop/app/components/Field/Field.js
@@ -6,9 +6,19 @@ import { TextField } from './TextField';
 import { FORM_STATUSES } from '../../constants';
 
 export const Field = formikConnect(
-  ({ formik: { errors, status }, name, component = TextField, onChange, helperText, ...props }) => {
+  ({
+    formik: {
+      errors,
+      status: { submitStatus },
+    },
+    name,
+    component = TextField,
+    onChange,
+    helperText,
+    ...props
+  }) => {
     // Only show error messages once the user has attempted to submit the form
-    const error = status === FORM_STATUSES.SUBMIT_ATTEMPTED && !!getIn(errors, name);
+    const error = submitStatus === FORM_STATUSES.SUBMIT_ATTEMPTED && !!getIn(errors, name);
     const message = error ? getIn(errors, name) : helperText;
 
     const [field] = useField(name);

--- a/packages/desktop/app/components/Field/Form.js
+++ b/packages/desktop/app/components/Field/Form.js
@@ -73,6 +73,7 @@ export class Form extends React.PureComponent {
     setSubmitting,
     getValues,
     setStatus,
+    status,
     ...rest
   }) => async (event, submissionParameters, componentsToValidate) => {
     event.preventDefault();
@@ -80,7 +81,7 @@ export class Form extends React.PureComponent {
 
     // Use formik status prop to track if the user has attempted to submit the form. This is used in
     // Field.js to only show error messages once the user has attempted to submit the form
-    setStatus(FORM_STATUSES.SUBMIT_ATTEMPTED);
+    setStatus({ ...status, submitStatus: FORM_STATUSES.SUBMIT_ATTEMPTED });
 
     // avoid multiple submissions
     if (isSubmitting) {

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -7,7 +7,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import { IconButton } from '@material-ui/core';
 import { ClearIcon } from '../Icons/ClearIcon';
 import { ChevronIcon } from '../Icons/ChevronIcon';
-import { Colors } from '../../constants';
+import { Colors, FORM_TYPES } from '../../constants';
 import { OuterLabelFieldWrapper } from './OuterLabelFieldWrapper';
 import { StyledTextField } from './TextField';
 import { FormFieldTag } from '../Tag';
@@ -102,12 +102,8 @@ export const SelectInput = ({
   const handleChange = useCallback(
     changedOption => {
       // changedOption is empty if Clear indicator is clicked
-      const {
-        form: {
-          initialValues: { isSearchForm },
-        },
-      } = props;
-      const clearValue = isSearchForm ? undefined : null;
+      const { status } = props.form;
+      const clearValue = status.formType === FORM_TYPES.SEARCH_FORM ? undefined : null;
       if (!changedOption) {
         // Send undefined if search bar as we dont want to filter by empty string
         onChange({ target: { value: clearValue, name } });
@@ -118,7 +114,7 @@ export const SelectInput = ({
       }
       onChange({ target: { value: changedOption.value, name } });
     },
-    [onChange, name, onClear, props],
+    [onChange, name, onClear, props.form],
   );
 
   const customStyles = {

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -104,12 +104,13 @@ export const SelectInput = ({
       // changedOption is empty if Clear indicator is clicked
       const {
         form: {
-          initialValues: { search },
+          initialValues: { isSearchForm },
         },
       } = props;
+      const clearValue = isSearchForm ? undefined : null;
       if (!changedOption) {
         // Send undefined if search bar as we dont want to filter by empty string
-        onChange({ target: { value: search ? undefined : null, name } });
+        onChange({ target: { value: clearValue, name } });
         if (onClear) {
           onClear();
         }

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -102,8 +102,14 @@ export const SelectInput = ({
   const handleChange = useCallback(
     changedOption => {
       // changedOption is empty if Clear indicator is clicked
+      const {
+        form: {
+          initialValues: { search },
+        },
+      } = props;
       if (!changedOption) {
-        onChange({ target: { value: null, name } });
+        // Send undefined if search bar as we dont want to filter by empty string
+        onChange({ target: { value: search ? undefined : null, name } });
         if (onClear) {
           onClear();
         }
@@ -111,7 +117,7 @@ export const SelectInput = ({
       }
       onChange({ target: { value: changedOption.value, name } });
     },
-    [onChange, name, onClear],
+    [onChange, name, onClear, props],
   );
 
   const customStyles = {

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -123,7 +123,7 @@ export const CustomisableSearchBar = ({
           {isExpanded && <CustomisableSearchBarGrid>{hiddenFields}</CustomisableSearchBarGrid>}
         </Container>
       )}
-      initialValues={initialValues}
+      initialValues={{ ...initialValues, search: true }}
       enableReinitialize
     />
   );

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -6,7 +6,7 @@ import doubleDown from '../../assets/images/double_down.svg';
 import doubleUp from '../../assets/images/double_up.svg';
 import { Button, TextButton } from '../Button';
 import { Form } from '../Field';
-import { Colors } from '../../constants';
+import { Colors, FORM_TYPES } from '../../constants';
 
 const Container = styled.div`
   border: 1px solid ${Colors.outline};
@@ -123,7 +123,8 @@ export const CustomisableSearchBar = ({
           {isExpanded && <CustomisableSearchBarGrid>{hiddenFields}</CustomisableSearchBarGrid>}
         </Container>
       )}
-      initialValues={{ ...initialValues, isSearchForm: true }}
+      initialValues={initialValues}
+      initialStatus={{ formType: FORM_TYPES.SEARCH_FORM }}
       enableReinitialize
     />
   );

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -123,7 +123,7 @@ export const CustomisableSearchBar = ({
           {isExpanded && <CustomisableSearchBarGrid>{hiddenFields}</CustomisableSearchBarGrid>}
         </Container>
       )}
-      initialValues={{ ...initialValues, search: true }}
+      initialValues={{ ...initialValues, isSearchForm: true }}
       enableReinitialize
     />
   );

--- a/packages/desktop/app/components/Surveys/SurveyScreen.js
+++ b/packages/desktop/app/components/Surveys/SurveyScreen.js
@@ -67,6 +67,7 @@ export const SurveyScreen = ({
   validateForm,
   setErrors,
   errors,
+  status,
   setStatus,
 }) => {
   const { setQuestionToRef, scrollToQuestion } = useScrollToFirstError(errors);
@@ -90,7 +91,7 @@ export const SurveyScreen = ({
     } else {
       // Use formik status prop to track if the user has attempted to submit the form. This is used in
       // Field.js to only show error messages once the user has attempted to submit the form
-      setStatus(FORM_STATUSES.SUBMIT_ATTEMPTED);
+      setStatus({ ...status, submitStatus: FORM_STATUSES.SUBMIT_ATTEMPTED });
 
       const firstErroredQuestion = components.find(({ dataElementId }) =>
         pageErrors.includes(dataElementId),

--- a/packages/desktop/app/components/Surveys/SurveyScreenPaginator.js
+++ b/packages/desktop/app/components/Surveys/SurveyScreenPaginator.js
@@ -46,6 +46,7 @@ export const SurveyScreenPaginator = ({
   validateForm,
   setErrors,
   errors,
+  status,
   setStatus,
 }) => {
   const { components } = survey;
@@ -69,6 +70,7 @@ export const SurveyScreenPaginator = ({
         validateForm={validateForm}
         setErrors={setErrors}
         errors={errors}
+        status={status}
         setStatus={setStatus}
       />
     );

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -452,3 +452,7 @@ export const SUPPORTED_DOCUMENT_TYPES = {
 };
 
 export const REQUIRED_INLINE_ERROR_MESSAGE = '*Required';
+
+export const FORM_TYPES = {
+  SEARCH_FORM: 'searchForm',
+};

--- a/packages/desktop/app/views/programs/SurveyView.js
+++ b/packages/desktop/app/views/programs/SurveyView.js
@@ -36,6 +36,7 @@ export const SurveyView = ({ survey, onSubmit, onCancel, patient, currentUser })
       setErrors,
       errors,
       setStatus,
+      status
     } = props;
 
     // 1. get a list of visible fields
@@ -67,6 +68,7 @@ export const SurveyView = ({ survey, onSubmit, onCancel, patient, currentUser })
         setErrors={setErrors}
         errors={errors}
         setStatus={setStatus}
+        status={status}
       />
     );
   };

--- a/packages/desktop/app/views/programs/SurveyView.js
+++ b/packages/desktop/app/views/programs/SurveyView.js
@@ -36,7 +36,7 @@ export const SurveyView = ({ survey, onSubmit, onCancel, patient, currentUser })
       setErrors,
       errors,
       setStatus,
-      status
+      status,
     } = props;
 
     // 1. get a list of visible fields


### PR DESCRIPTION
### Changes

Another weird interaction has been discovered during testing today related to the clearing of select fields. When pressing the "x" button on the select component to clear, we need to set a value for the field state to reset to.  We discovered that if we set this to null, search fields won't work properly as they try to search for an empty string in the searchParamaters. However if we set this to undefined, search will work properly but we no longer have the option to edit existing records through forms to null as undefined takes it completely out of the edit object sent to the backend.

In order to solve this I needed to set an undefined value when clearing a select field on a search bar and null when clearing a select field on the form. I achieved this by adding an initialValue to the CustomisableSearchBar component `isSearchForm: true` which is checked on the component level and will change the field clear value accordingly

My my main concern for this fix is around the setting of initialValues with my new custom isSearchForm value but I couldn't figure out any other way of setting a value on the searchbar level that can flow down and be checked on the field level. Very open to ideas! :)
