### PR TITLE
NASS-682: completed imaging requests initial sort and null order

### DIFF
--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -99,7 +99,13 @@ export const ImagingRequestsTable = React.memo(({ encounterId, status = '' }) =>
       onRowClick={selectImagingRequest}
       fetchOptions={{ ...searchParameters, ...statusFilter }}
       elevated={false}
-      initialSort={{ order: 'desc', orderBy: 'requestedDate' }}
+      initialSort={{
+        order: 'desc',
+        orderBy:
+          status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED
+            ? 'results.completedAt'
+            : 'requestedDate',
+      }}
     />
   );
 });

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -303,6 +303,11 @@ globalImagingRequests.get(
     const { models, query } = req;
     const { order = 'ASC', orderBy, rowsPerPage = 10, page = 0, ...filterParams } = query;
 
+    const orderDirection = order.toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+    const nullPosition =
+      orderBy === 'results.completedAt' &&
+      (orderDirection === 'ASC' ? 'NULLS FIRST' : 'NULLS LAST');
+
     const patientFilters = mapQueryFilters(filterParams, [
       { key: 'firstName', mapFn: caseInsensitiveStartsWithFilter },
       { key: 'lastName', mapFn: caseInsensitiveStartsWithFilter },
@@ -409,7 +414,9 @@ globalImagingRequests.get(
           },
         },
       },
-      order: orderBy ? [[...orderBy.split('.'), order.toUpperCase()]] : undefined,
+      order: orderBy
+        ? [[...orderBy.split('.'), `${orderDirection}${nullPosition ? ` ${nullPosition}` : ''}`]]
+        : undefined,
       include: [requestedBy, encounter, areas, results],
       limit: rowsPerPage,
       offset: page * rowsPerPage,


### PR DESCRIPTION
### Changes
- Completed tab ordered by completed at by default, also this table needs to invert null order to basically treat imaging requests with no imaging result - and no completed date as oldest

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
