### PR TITLE
SAV-266: Allow for null discharger

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/EncounterRecord.js
@@ -341,7 +341,7 @@ export const EncounterRecord = React.memo(
               {examiner.displayName}
             </DisplayValue>
             <DisplayValue name="Discharging clinician" size="10px">
-              {discharge?.discharger.displayName}
+              {discharge?.discharger?.displayName}
             </DisplayValue>
             <DisplayValue name="Reason for encounter" size="10px">
               {reasonForEncounter}


### PR DESCRIPTION
### Changes

The Encounter record printout was causing the app to crash if an encounter was discharged without a discharger recorded. I think this happens whenever it's an automatically discharged encounter (ie vaccinations, survey responses, clinics etc, probably anything other than admission?).

Just add a null check to leave that field blank. I think it's fine anyway as users are likely not bringing up encounter records for non-admission encounters.

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
