### PR TITLE
TAN-2036: Fix test case that showed a recently viewed inpatient in the outpatients view

### DIFF
--- a/packages/desktop/app/components/RecentlyViewedPatientsList.js
+++ b/packages/desktop/app/components/RecentlyViewedPatientsList.js
@@ -160,7 +160,7 @@ export const RecentlyViewedPatientsList = ({ encounterType }) => {
   const api = useApi();
 
   const { data: { data: recentlyViewedPatients = [] } = {} } = useQuery(
-    ['recentlyViewedPatients'],
+    ['recentlyViewedPatients', encounterType],
     () => api.get('user/recently-viewed-patients', { encounterType }),
   );
 


### PR DESCRIPTION
### Changes

When switching from the inpatients view to the outpatients view, the latest inpatient still showed as the first item in the list of outpatients. [Link to video](https://linear.app/bes/issue/NASS-777#comment-075e3a20)

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
