### PR TITLE
NASS-773: Fix ExpandedMultiSelectField

### DIFF
--- a/packages/desktop/app/components/Field/ExpandedMultiSelectField.js
+++ b/packages/desktop/app/components/Field/ExpandedMultiSelectField.js
@@ -56,7 +56,7 @@ export const ExpandedMultiSelectField = ({
         <MultiSelectItem key="select_all">
           <CheckInput
             label="Select all"
-            checked={currentList.length === options.length}
+            value={currentList.length === options.length}
             onChange={e => {
               const { checked } = e.target;
               const newList = checked ? options.map(option => option.value) : [];
@@ -74,7 +74,7 @@ export const ExpandedMultiSelectField = ({
                   name={value}
                   key={value}
                   label={optionLabel}
-                  checked={currentList.includes(value)}
+                  value={currentList.includes(value)}
                   onChange={toggle}
                 />
               </MultiSelectItem>


### PR DESCRIPTION
### Changes

This field isn't using the latest update :)

BUT I know you might not know what it was: so we updated formik to v2 and this broke our checkboxes which used MUI checkbox component. Won't go into much details but we had to change our custom checkbox components to fixate `value` and `checked` props. However this component still relied on setting its own `checked`, which should now be derived!