### PR TITLE
NASS-678: fix select change event when not a child of form

### DIFF
--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -97,15 +97,15 @@ export const SelectInput = ({
   helperText,
   inputRef,
   onClear,
+  form,
   ...props
 }) => {
   const handleChange = useCallback(
     changedOption => {
-      // changedOption is empty if Clear indicator is clicked
-      const { status } = props.form;
-      const clearValue = status.formType === FORM_TYPES.SEARCH_FORM ? undefined : null;
+      // Send undefined if search bar as we dont want to filter by empty string
+      const clearValue = form?.status.formType === FORM_TYPES.SEARCH_FORM ? undefined : null;
       if (!changedOption) {
-        // Send undefined if search bar as we dont want to filter by empty string
+        // Change option is empty if the user clicks the clear button
         onChange({ target: { value: clearValue, name } });
         if (onClear) {
           onClear();
@@ -114,7 +114,7 @@ export const SelectInput = ({
       }
       onChange({ target: { value: changedOption.value, name } });
     },
-    [onChange, name, onClear, props.form],
+    [onChange, name, onClear, form],
   );
 
   const customStyles = {

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -102,7 +102,9 @@ export const SelectInput = ({
 }) => {
   const handleChange = useCallback(
     changedOption => {
-      // Send undefined if search bar as we dont want to filter by empty string
+      // As the select field is in a few places on the site we need to account for a range of "empty" values for state
+      // 1. Search fields should be undefined when cleared as they need to be completely detached from the form object when submitted
+      // 2. Form fields should be null as we need to be able to save them as null in the database if we are trying to remove a value when editing a record
       const clearValue = form?.status.formType === FORM_TYPES.SEARCH_FORM ? undefined : null;
       if (!changedOption) {
         // Change option is empty if the user clicks the clear button

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -106,8 +106,8 @@ export const SelectInput = ({
       // 1. Search fields should be undefined when cleared as they need to be completely detached from the form object when submitted
       // 2. Form fields should be null as we need to be able to save them as null in the database if we are trying to remove a value when editing a record
       const clearValue = form?.status.formType === FORM_TYPES.SEARCH_FORM ? undefined : null;
-      if (!changedOption) {
-        // Change option is empty if the user clicks the clear button
+      const userClickedClear = !changedOption;
+      if (userClickedClear) {
         onChange({ target: { value: clearValue, name } });
         if (onClear) {
           onClear();


### PR DESCRIPTION
### Changes
- Inputs do not always receive the form prop as is a product of form wrapper logic
- However if form is received status will always be at minimum `{}`

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
