### PR TITLE
SAV-274: Stop from setting to null when clearing appointment autocomplete

### DIFF
--- a/packages/desktop/app/components/Field/AutocompleteField.js
+++ b/packages/desktop/app/components/Field/AutocompleteField.js
@@ -234,7 +234,7 @@ export class AutocompleteInput extends Component {
   };
 
   handleClearValue = () => {
-    const { onChange, onClear, name, required, form } = this.props;
+    const { onChange, name, required, form } = this.props;
     const formType = form?.status?.formType;
     // As our autocomplete is in a bunch of places over the app we actually need to be able to set a range of "empty" values
     // based on the situation the field is in.
@@ -251,9 +251,6 @@ export class AutocompleteInput extends Component {
 
     onChange({ target: { value: clearValue, name } });
     this.setState({ selectedOption: { value: '', tag: null } });
-    if (onClear) {
-      onClear();
-    }
   };
 
   clearOptions = () => {

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -77,16 +77,13 @@ export const LocationInput = React.memo(
 
     const handleChangeCategory = event => {
       setGroupId(event.target.value);
+      setLocationId('');
+      onChange({ target: { value: '', name } });
     };
 
     const handleChange = async event => {
       setLocationId(event.target.value);
       onChange({ target: { value: event.target.value, name } });
-    };
-
-    const clearLocationField = () => {
-      setLocationId('');
-      onChange({ target: { value: '', name } });
     };
 
     // Disable the location and location group fields if:
@@ -109,7 +106,6 @@ export const LocationInput = React.memo(
           value={groupId}
           disabled={locationGroupSelectIsDisabled || disabled}
           autofill={!value} // do not autofill if there is a pre-filled value
-          onClear={clearLocationField}
         />
         <AutocompleteInput
           label={label}

--- a/packages/desktop/app/components/Field/SearchField.js
+++ b/packages/desktop/app/components/Field/SearchField.js
@@ -36,7 +36,6 @@ export const SearchField = ({ keepLetterCase = false, ...props }) => {
     field: { value, name },
     form: { setFieldValue } = {},
     label,
-    onClear,
   } = props;
   const [searchValue, setSearchValue] = useState(value);
 
@@ -48,9 +47,6 @@ export const SearchField = ({ keepLetterCase = false, ...props }) => {
     setSearchValue('');
     if (setFieldValue) {
       setFieldValue(name, '');
-    }
-    if (onClear) {
-      onClear();
     }
   };
 

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -96,7 +96,6 @@ export const SelectInput = ({
   name,
   helperText,
   inputRef,
-  onClear,
   form,
   ...props
 }) => {
@@ -109,14 +108,11 @@ export const SelectInput = ({
       const userClickedClear = !changedOption;
       if (userClickedClear) {
         onChange({ target: { value: clearValue, name } });
-        if (onClear) {
-          onClear();
-        }
         return;
       }
       onChange({ target: { value: changedOption.value, name } });
     },
-    [onChange, name, onClear, form],
+    [onChange, name, form],
   );
 
   const customStyles = {

--- a/packages/desktop/app/views/scheduling/AppointmentsCalendar.js
+++ b/packages/desktop/app/views/scheduling/AppointmentsCalendar.js
@@ -86,7 +86,7 @@ export const AppointmentsCalendar = () => {
   const updateCalendar = () => {
     setRefreshCount(refreshCount + 1);
   };
-  const updateFilterValue = e => setFilterValue(e.target.value);
+  const updateFilterValue = e => setFilterValue(e.target.value || '');
 
   const filters = {
     locationGroup: {


### PR DESCRIPTION
### Changes

The appointment calendar has some custom logic for searching as the input changes so we had a suggester error pop up here. I solved this by setting to an empty string when the value it is being changed to is null to make it an empty string. This allows for the proper suggester logic to run as an empty input without throwing errors.