### PR TITLE
NASS-682: fix imaging listing view issue with sequelize limit inside subquery

### DIFF
--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -2,7 +2,7 @@ import express from 'express';
 import config from 'config';
 import asyncHandler from 'express-async-handler';
 import { startOfDay, endOfDay } from 'date-fns';
-import { Op } from 'sequelize';
+import { Op, Sequelize } from 'sequelize';
 import {
   NOTE_TYPES,
   AREA_TYPE_TO_IMAGING_TYPE,
@@ -361,13 +361,6 @@ globalImagingRequests.get(
     const requestedBy = {
       association: 'requestedBy',
     };
-    const areas = {
-      association: 'areas',
-      through: {
-        // Don't include attributes on through table
-        attributes: [],
-      },
-    };
     const patient = {
       association: 'patient',
       where: patientFilters,
@@ -417,10 +410,11 @@ globalImagingRequests.get(
       order: orderBy
         ? [[...orderBy.split('.'), `${orderDirection}${nullPosition ? ` ${nullPosition}` : ''}`]]
         : undefined,
-      include: [requestedBy, encounter, areas, results],
+      include: [requestedBy, encounter, results],
       limit: rowsPerPage,
       offset: page * rowsPerPage,
       distinct: true,
+      subQuery: false,
     });
 
     // Extract and normalize data calling a base model method

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -361,13 +361,6 @@ globalImagingRequests.get(
     const requestedBy = {
       association: 'requestedBy',
     };
-    const areas = {
-      association: 'areas',
-      through: {
-        // Don't include attributes on through table
-        attributes: [],
-      },
-    };
     const patient = {
       association: 'patient',
       where: patientFilters,
@@ -409,7 +402,7 @@ globalImagingRequests.get(
             [Op.notIn]: [
               IMAGING_REQUEST_STATUS_TYPES.DELETED,
               IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
-              IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+              IMAGING_REQUEST_STATUS_TYPES.CANCELLED, 
             ],
           },
         },
@@ -417,10 +410,11 @@ globalImagingRequests.get(
       order: orderBy
         ? [[...orderBy.split('.'), `${orderDirection}${nullPosition ? ` ${nullPosition}` : ''}`]]
         : undefined,
-      include: [requestedBy, encounter, areas, results],
+      include: [requestedBy, encounter, results],
       limit: rowsPerPage,
       offset: page * rowsPerPage,
       distinct: true,
+      // subQuery: false,
     });
 
     // Extract and normalize data calling a base model method


### PR DESCRIPTION
### Changes
Same sequelize issue as these ones:
https://github.com/sequelize/sequelize/issues/12971
https://github.com/sequelize/sequelize/issues/14972

**with default behaviour** => limit section gets placed inside generated subquery (eager loading) - and so the sort behaviour becomes take 10 - then sort them - instead of sort and take first 10

**with the suggested workaround subquery off** => Limit is taken before duplicates are removed when querying with many to many relationship i.e in this case areas.

So its kind of a bricked situation really if we want to achieve our use case

Luckily we only use this endpoint for table and we dont use areas (many to many) in listing or search

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
