### PR TITLE
No-issue: Add validation to imaging form

### DIFF
--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -97,6 +97,7 @@ export const SelectInput = ({
   helperText,
   inputRef,
   form,
+  isClearable = true,
   ...props
 }) => {
   const handleChange = useCallback(
@@ -202,7 +203,7 @@ export const SelectInput = ({
           styles={customStyles}
           menuShouldBlockScroll="true"
           placeholder="Select"
-          isClearable={value !== ''}
+          isClearable={value !== '' && isClearable}
           isSearchable={false}
           components={{ Option, SingleValue, ClearIndicator, DropdownIndicator: StyledChevronIcon }}
           {...props}

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { Form, Formik } from 'formik';
+import * as yup from 'yup';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
 import { useParams } from 'react-router-dom';
@@ -121,6 +122,7 @@ const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imag
         component={SelectField}
         options={isCancelled ? cancelledOption : IMAGING_REQUEST_STATUS_OPTIONS}
         disabled={isCancelled}
+        required
       />
       <DateTimeInput value={imagingRequest.requestedDate} label="Request date and time" disabled />
       {(values.status === IMAGING_REQUEST_STATUS_TYPES.IN_PROGRESS ||
@@ -251,6 +253,9 @@ const ImagingRequestInfoPane = React.memo(
             completedAt: getCurrentDateTimeString(),
           },
         }}
+        validationSchema={yup.object().shape({
+          status: yup.string().required('Status is required'),
+        })}
       >
         {({ values }) => {
           return (

--- a/packages/desktop/app/views/patients/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/ImagingRequestView.js
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react';
-import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
@@ -29,6 +28,7 @@ import {
   DateTimeInput,
   DateTimeField,
   TextField,
+  Form,
 } from '../../components/Field';
 import { useApi, useSuggester } from '../../api';
 import { useEncounterData } from '../../api/queries';
@@ -122,6 +122,7 @@ const ImagingRequestSection = ({ values, imagingRequest, imagingPriorities, imag
         component={SelectField}
         options={isCancelled ? cancelledOption : IMAGING_REQUEST_STATUS_OPTIONS}
         disabled={isCancelled}
+        isClearable={false}
         required
       />
       <DateTimeInput value={imagingRequest.requestedDate} label="Request date and time" disabled />
@@ -233,7 +234,7 @@ const ImagingRequestInfoPane = React.memo(
     const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
 
     return (
-      <Formik
+      <Form
         // Only submit specific fields for update
         onSubmit={fields => {
           const updateValues = pick(
@@ -256,10 +257,9 @@ const ImagingRequestInfoPane = React.memo(
         validationSchema={yup.object().shape({
           status: yup.string().required('Status is required'),
         })}
-      >
-        {({ values }) => {
+        render={({ values }) => {
           return (
-            <Form>
+            <>
               <ImagingRequestSection
                 {...{
                   values,
@@ -279,10 +279,10 @@ const ImagingRequestInfoPane = React.memo(
               <ButtonRow style={{ marginTop: 20 }}>
                 {!isCancelled && <Button type="submit">Save</Button>}
               </ButtonRow>
-            </Form>
+            </>
           );
         }}
-      </Formik>
+      />
     );
   },
 );


### PR DESCRIPTION
### Changes

Currently when clearing the status field on the imagingRequestView, we can still submit it. This is a result of the new 'x' button used to clear fields. Previously this would be a select with a pre-populated value with no option to clear it so no validation was added to this form. In this card I have added proper validation for the imaging request form and also added a prop for select fields with the option to turn off the "x" if needed and set it on this one field.
![image](https://github.com/beyondessential/tamanu/assets/58054247/826f6fa4-1d1f-4059-a47b-07510e3c3f1e)


- [x] Validation on endpoint
- [x] Add required *
- [x] Add prop to Select field that removes x as option

### Checklist

- [x] Code is finished
