### PR TITLE
NASS-682: Fix incorrect pagination on ImagingRequest table

### DIFF
--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -28,9 +28,7 @@ const getPatientName = ({ encounter }) => <PatientNameDisplay patient={encounter
 const getPatientDisplayId = ({ encounter }) => encounter.patient.displayId;
 const getStatus = ({ status }) => <StatusDisplay status={status} />;
 const getDate = ({ requestedDate }) => <DateDisplay date={requestedDate} timeOnlyTooltip />;
-const getCompletedDate = ({ results }) => (
-  <DateDisplay date={results[0]?.completedAt} timeOnlyTooltip />
-);
+const getCompletedDate = ({ completedAt }) => <DateDisplay date={completedAt} timeOnlyTooltip />;
 
 export const ImagingRequestsTable = React.memo(({ encounterId, status = '' }) => {
   const dispatch = useDispatch();
@@ -56,7 +54,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, status = '' }) =>
     ...(status
       ? [
           {
-            key: 'results.completedAt',
+            key: 'completedAt',
             title: 'Completed',
             accessor: getCompletedDate,
           },
@@ -106,7 +104,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, status = '' }) =>
       elevated={false}
       initialSort={{
         order: 'desc',
-        orderBy: completedStatus ? 'results.completedAt' : 'requestedDate',
+        orderBy: completedStatus ? 'completedAt' : 'requestedDate',
       }}
     />
   );

--- a/packages/lan/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/lan/__tests__/apiv1/ImagingRequests.test.js
@@ -34,48 +34,38 @@ describe('Imaging requests', () => {
   });
   afterAll(() => ctx.close());
 
-  it('should record an imaging request', async () => {
-    const result = await app.post('/v1/imagingRequest').send({
-      encounterId: encounter.id,
-      imagingType: IMAGING_TYPES.CT_SCAN,
-      requestedById: app.user.id,
+  describe('Creating an imaging request', () => {
+    it('should record an imaging request', async () => {
+      const result = await app.post('/v1/imagingRequest').send({
+        encounterId: encounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+      expect(result).toHaveSucceeded();
+      expect(result.body.requestedDate).toBeTruthy();
     });
-    expect(result).toHaveSucceeded();
-    expect(result.body.requestedDate).toBeTruthy();
+  
+    it('should require a valid status', async () => {
+      const result = await app.post('/v1/imagingRequest').send({
+        encounterId: encounter.id,
+        status: 'invalid',
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+      expect(result).toHaveRequestError();
+    });
+  
+    it('should require a valid status', async () => {
+      const result = await app.post('/v1/imagingRequest').send({
+        encounterId: encounter.id,
+        status: 'invalid',
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+      expect(result).toHaveRequestError();
+    });  
   });
 
-  it('should return note content when providing note or areaNote', async () => {
-    const result = await app.post('/v1/imagingRequest').send({
-      encounterId: encounter.id,
-      imagingType: IMAGING_TYPES.CT_SCAN,
-      requestedById: app.user.id,
-      note: 'test-note',
-      areaNote: 'test-area-note',
-    });
-    expect(result).toHaveSucceeded();
-    expect(result.body.note).toEqual('test-note');
-    expect(result.body.areaNote).toEqual('test-area-note');
-  });
-
-  it('should require a valid status', async () => {
-    const result = await app.post('/v1/imagingRequest').send({
-      encounterId: encounter.id,
-      status: 'invalid',
-      imagingType: IMAGING_TYPES.CT_SCAN,
-      requestedById: app.user.id,
-    });
-    expect(result).toHaveRequestError();
-  });
-
-  it('should require a valid status', async () => {
-    const result = await app.post('/v1/imagingRequest').send({
-      encounterId: encounter.id,
-      status: 'invalid',
-      imagingType: IMAGING_TYPES.CT_SCAN,
-      requestedById: app.user.id,
-    });
-    expect(result).toHaveRequestError();
-  });
 
   it('should get imaging requests for an encounter', async () => {
     const createdImagingRequest = await models.ImagingRequest.create({
@@ -94,95 +84,110 @@ describe('Imaging requests', () => {
     expect(body.data[0]).toHaveProperty('imagingType', createdImagingRequest.imagingType);
   });
 
-  it('should get relevant notes for an imagingRequest', async () => {
-    const createdImagingRequest = await models.ImagingRequest.create({
-      encounterId: encounter.id,
-      imagingType: IMAGING_TYPES.CT_SCAN,
-      requestedById: app.user.id,
+  describe('Notes', () => {
+    it('should get relevant notes for an imagingRequest', async () => {
+      const createdImagingRequest = await models.ImagingRequest.create({
+        encounterId: encounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+  
+      await models.NotePage.createForRecord(
+        createdImagingRequest.id,
+        NOTE_RECORD_TYPES.IMAGING_REQUEST,
+        NOTE_TYPES.AREA_TO_BE_IMAGED,
+        'test-area-note',
+        app.user.id,
+      );
+  
+      await models.NotePage.createForRecord(
+        createdImagingRequest.id,
+        NOTE_RECORD_TYPES.IMAGING_REQUEST,
+        NOTE_TYPES.OTHER,
+        'test-note',
+        app.user.id,
+      );
+  
+      const result = await app.get(`/v1/imagingRequest/${createdImagingRequest.id}`);
+  
+      expect(result).toHaveSucceeded();
+  
+      const { body } = result;
+      expect(body).toHaveProperty('note', 'test-note');
+      expect(body).toHaveProperty('areaNote', 'test-area-note');
+    });
+  
+    it('should get relevant notes for an imagingRequest under an encounter', async () => {
+      // Arrange
+      const createdImagingRequest = await models.ImagingRequest.create({
+        encounterId: encounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+      });
+      const n1 = await models.NotePage.createForRecord(
+        createdImagingRequest.id,
+        NOTE_RECORD_TYPES.IMAGING_REQUEST,
+        NOTE_TYPES.AREA_TO_BE_IMAGED,
+        'test-area-note',
+        app.user.id,
+      );
+      const n2 = await models.NotePage.createForRecord(
+        createdImagingRequest.id,
+        NOTE_RECORD_TYPES.IMAGING_REQUEST,
+        NOTE_TYPES.OTHER,
+        'test-note',
+        app.user.id,
+      );
+  
+      // Act
+      const result = await app.get(
+        `/v1/encounter/${encounter.id}/imagingRequests?includeNotePages=true`,
+      );
+  
+      // Assert
+      expect(result).toHaveSucceeded();
+      const { body } = result;
+      expect(body.count).toBeGreaterThan(0);
+      const retrievedImgReq = body.data.find(ir => ir.id === createdImagingRequest.id);
+      expect(retrievedImgReq).toMatchObject({
+        note: 'test-note',
+        areaNote: 'test-area-note',
+      });
+      expect(
+        retrievedImgReq.notePages
+          .map(np => np.id)
+          .sort()
+          .join(','),
+      ).toBe([n1.id, n2.id].sort().join(','));
+    });
+  
+    it('should get imaging request reference info when listing imaging requests', async () => {
+      await models.ImagingRequest.create({
+        encounterId: encounter.id,
+        requestedById: app.user.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+      });
+      const result = await app.get(`/v1/encounter/${encounter.id}/imagingRequests`);
+      expect(result).toHaveSucceeded();
+      const { body } = result;
+      expect(body.count).toBeGreaterThan(0);
+  
+      const record = body.data[0];
+      expect(record).toHaveProperty('requestedBy.displayName');
     });
 
-    await models.NotePage.createForRecord(
-      createdImagingRequest.id,
-      NOTE_RECORD_TYPES.IMAGING_REQUEST,
-      NOTE_TYPES.AREA_TO_BE_IMAGED,
-      'test-area-note',
-      app.user.id,
-    );
-
-    await models.NotePage.createForRecord(
-      createdImagingRequest.id,
-      NOTE_RECORD_TYPES.IMAGING_REQUEST,
-      NOTE_TYPES.OTHER,
-      'test-note',
-      app.user.id,
-    );
-
-    const result = await app.get(`/v1/imagingRequest/${createdImagingRequest.id}`);
-
-    expect(result).toHaveSucceeded();
-
-    const { body } = result;
-    expect(body).toHaveProperty('note', 'test-note');
-    expect(body).toHaveProperty('areaNote', 'test-area-note');
-  });
-
-  it('should get relevant notes for an imagingRequest under an encounter', async () => {
-    // Arrange
-    const createdImagingRequest = await models.ImagingRequest.create({
-      encounterId: encounter.id,
-      imagingType: IMAGING_TYPES.CT_SCAN,
-      requestedById: app.user.id,
+    it('should return note content when providing note or areaNote', async () => {
+      const result = await app.post('/v1/imagingRequest').send({
+        encounterId: encounter.id,
+        imagingType: IMAGING_TYPES.CT_SCAN,
+        requestedById: app.user.id,
+        note: 'test-note',
+        areaNote: 'test-area-note',
+      });
+      expect(result).toHaveSucceeded();
+      expect(result.body.note).toEqual('test-note');
+      expect(result.body.areaNote).toEqual('test-area-note');
     });
-    const n1 = await models.NotePage.createForRecord(
-      createdImagingRequest.id,
-      NOTE_RECORD_TYPES.IMAGING_REQUEST,
-      NOTE_TYPES.AREA_TO_BE_IMAGED,
-      'test-area-note',
-      app.user.id,
-    );
-    const n2 = await models.NotePage.createForRecord(
-      createdImagingRequest.id,
-      NOTE_RECORD_TYPES.IMAGING_REQUEST,
-      NOTE_TYPES.OTHER,
-      'test-note',
-      app.user.id,
-    );
-
-    // Act
-    const result = await app.get(
-      `/v1/encounter/${encounter.id}/imagingRequests?includeNotePages=true`,
-    );
-
-    // Assert
-    expect(result).toHaveSucceeded();
-    const { body } = result;
-    expect(body.count).toBeGreaterThan(0);
-    const retrievedImgReq = body.data.find(ir => ir.id === createdImagingRequest.id);
-    expect(retrievedImgReq).toMatchObject({
-      note: 'test-note',
-      areaNote: 'test-area-note',
-    });
-    expect(
-      retrievedImgReq.notePages
-        .map(np => np.id)
-        .sort()
-        .join(','),
-    ).toBe([n1.id, n2.id].sort().join(','));
-  });
-
-  it('should get imaging request reference info when listing imaging requests', async () => {
-    await models.ImagingRequest.create({
-      encounterId: encounter.id,
-      requestedById: app.user.id,
-      imagingType: IMAGING_TYPES.CT_SCAN,
-    });
-    const result = await app.get(`/v1/encounter/${encounter.id}/imagingRequests`);
-    expect(result).toHaveSucceeded();
-    const { body } = result;
-    expect(body.count).toBeGreaterThan(0);
-
-    const record = body.data[0];
-    expect(record).toHaveProperty('requestedBy.displayName');
   });
 
   describe('Area listing', () => {
@@ -398,8 +403,8 @@ describe('Imaging requests', () => {
     });
   });
 
-  describe('Filtering by allFacilities', () => {
-    const otherFacilityId = 'kerang';
+  describe.only('Listing requests', () => {
+    
     const makeRequestAtFacility = async (facilityId, status) => {
       const testLocation = await models.Location.create({
         ...fake(models.Location),
@@ -410,55 +415,190 @@ describe('Imaging requests', () => {
         locationId: testLocation.id,
         patientId: patient.id,
       });
-      await models.ImagingRequest.create({
+      const imagingRequest = await models.ImagingRequest.create({
         encounterId: testEncounter.id,
         imagingType: IMAGING_TYPES.CT_SCAN,
         status,
         requestedById: app.user.id,
       });
+
+      if (status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED) {
+        // add a result
+        if (Math.random() < 0.5) {
+          await models.ImagingResult.create(fake(models.ImagingResult, {
+            imagingRequestId: imagingRequest.id,
+          }));
+        }
+      }
+
+      return imagingRequest;
     };
 
-    beforeAll(async () => {
-      await models.ImagingRequest.truncate({ cascade: true });
-      await makeRequestAtFacility(config.serverFacilityId);
-      await makeRequestAtFacility(config.serverFacilityId);
-      await makeRequestAtFacility(config.serverFacilityId, IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
-      await makeRequestAtFacility(otherFacilityId);
-      await makeRequestAtFacility(otherFacilityId);
-      await makeRequestAtFacility(otherFacilityId, IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
-    });
-
-    it('should omit external requests when allFacilities is false', async () => {
-      const result = await app.get(`/v1/imagingRequest?allFacilities=false`);
-      expect(result).toHaveSucceeded();
-      result.body.data.forEach(ir => {
-        expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
+    describe('Filtering by allFacilities', () => {
+      const otherFacilityId = 'kerang';
+  
+      beforeAll(async () => {
+        await models.ImagingRequest.truncate({ cascade: true });
+        await makeRequestAtFacility(config.serverFacilityId);
+        await makeRequestAtFacility(config.serverFacilityId);
+        await makeRequestAtFacility(config.serverFacilityId, IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        await makeRequestAtFacility(otherFacilityId);
+        await makeRequestAtFacility(otherFacilityId);
+        await makeRequestAtFacility(otherFacilityId, IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+      });
+  
+      it('should omit external requests when allFacilities is false', async () => {
+        const result = await app.get(`/v1/imagingRequest?allFacilities=false`);
+        expect(result).toHaveSucceeded();
+        result.body.data.forEach(ir => {
+          expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
+        });
+      });
+  
+      it('should include all requests when allFacilities is true', async () => {
+        const result = await app.get(`/v1/imagingRequest?allFacilities=true`);
+        expect(result).toHaveSucceeded();
+  
+        const hasConfigFacility = result.body.data.some(
+          ir => ir.encounter.location.facilityId === config.serverFacilityId,
+        );
+        expect(hasConfigFacility).toBe(true);
+  
+        const hasOtherFacility = result.body.data.some(
+          ir => ir.encounter.location.facilityId === otherFacilityId,
+        );
+        expect(hasOtherFacility).toBe(true);
+      });
+  
+      it('Completed tab should only show completed imaging requests', async () => {
+        const result = await app.get(
+          `/v1/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}`,
+        );
+        expect(result).toHaveSucceeded();
+        result.body.data.forEach(ir => {
+          expect(ir.status).toBe(IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        });
       });
     });
 
-    it('should include all requests when allFacilities is true', async () => {
-      const result = await app.get(`/v1/imagingRequest?allFacilities=true`);
-      expect(result).toHaveSucceeded();
+    describe.only('Sorting by completed results', () => {
 
-      const hasConfigFacility = result.body.data.some(
-        ir => ir.encounter.location.facilityId === config.serverFacilityId,
-      );
-      expect(hasConfigFacility).toBe(true);
+      // create a bunch of tests, use a number that isn't divisible by 10 to 
+      // stress the pagination a bit harder
+      const completedCount = 17;
+      const incompleteCount = 9;
+      const totalCount = completedCount + incompleteCount;
 
-      const hasOtherFacility = result.body.data.some(
-        ir => ir.encounter.location.facilityId === otherFacilityId,
-      );
-      expect(hasOtherFacility).toBe(true);
-    });
+      beforeAll(async () => {
+        await models.ImagingRequest.truncate({ cascade: true });
 
-    it('Completed tab should only show completed imaging requests', async () => {
-      const result = await app.get(
-        `/v1/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}`,
-      );
-      expect(result).toHaveSucceeded();
-      result.body.data.forEach(ir => {
-        expect(ir.status).toBe(IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        for (let i = 0; i < completedCount; ++i) {
+          await makeRequestAtFacility(config.serverFacilityId, IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        }
+        for (let i = 0; i < incompleteCount; ++i) {
+          await makeRequestAtFacility(config.serverFacilityId);
+        }
+      });
+
+      it('Should paginate correctly', async () => {
+        const getPage = async page => {
+          const result = await app.get(`/v1/imagingRequest?page=${page}`);
+          expect(result).toHaveSucceeded();
+          return result;
+        };
+
+        const result = await getPage(0); 
+        expect(result.body.count).toBe(totalCount); // total requests
+        expect(result.body.data).toHaveLength(10); // page
+
+        const result2 = await getPage(1); 
+        expect(result2.body.count).toBe(totalCount); // total requests
+        expect(result2.body.data).toHaveLength(10); // page
+
+        const ids = new Set([
+          ...result.body.data.map(x => x.id),
+          ...result2.body.data.map(x => x.id),
+        ]);
+        expect(ids.size).toBe(20);  // ie no duplicates in the two result sets
+      });
+
+      it('Should paginate correctly when sorting by completedAt', async () => {
+        const getPage = async page => {
+          const result = await app.get(`/v1/imagingRequest?orderBy=results.completedAt&page=${page}&order=DESC`);
+          expect(result).toHaveSucceeded();
+          return result;
+        };
+
+        const result = await getPage(0); 
+        expect(result.body.count).toBe(totalCount); // total requests
+        expect(result.body.data).toHaveLength(10); // page
+
+        const result2 = await getPage(1); 
+        expect(result2.body.count).toBe(totalCount); // total requests
+        expect(result2.body.data).toHaveLength(10); // page
+
+        const result3 = await getPage(2); 
+        expect(result3.body.count).toBe(totalCount); // total requests
+        expect(result3.body.data).toHaveLength(totalCount % 10); // page
+
+        const allResults = [
+          ...result.body.data, 
+          ...result2.body.data, 
+          ...result3.body.data
+        ];
+
+        const completed = allResults.filter(x => x.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        expect(completed).toHaveLength(completedCount);
+      
+        const notCompleted = allResults.filter(x => x.status !== IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        expect(notCompleted).toHaveLength(incompleteCount);
+
+        const ids = new Set(allResults.map(x => x.id));
+        expect(ids.size).toBe(totalCount);  // ie no duplicates in the two result sets
+      });
+
+      it.only('Should paginate correctly when sorting by completedAt and filtering by status', async () => {
+        const getPage = async page => {
+          const result = await app.get(`/v1/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}&orderBy=results.completedAt&page=${page}&order=ASC`);
+          expect(result).toHaveSucceeded();
+          return result;
+        };
+
+        const result = await getPage(0); 
+        expect(result.body.count).toBe(completedCount); // total requests
+        expect(result.body.data).toHaveLength(10); // page
+
+        const result2 = await getPage(1); 
+        expect(result2.body.count).toBe(completedCount); // total requests
+        expect(result2.body.data).toHaveLength(completedCount % 10); // page
+
+        const result3 = await getPage(2); 
+        expect(result3.body.count).toBe(completedCount); // total requests
+        expect(result3.body.data).toHaveLength(0); // page
+
+        const allResults = [
+          ...result.body.data, 
+          ...result2.body.data, 
+          ...result3.body.data
+        ];
+
+        console.log(allResults.map(x => ({
+          id: x.id,
+          status: x.status,
+          completedAt: x.results[0]?.completedAt,
+          resultCount: x.results.length,
+        })))
+
+        const completed = allResults.filter(x => x.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        expect(completed).toHaveLength(completedCount);
+      
+        const notCompleted = allResults.filter(x => x.status !== IMAGING_REQUEST_STATUS_TYPES.COMPLETED);
+        expect(notCompleted).toHaveLength(0);
+
+        const ids = new Set(allResults.map(x => x.id));
+        expect(ids.size).toBe(completedCount);  // ie no duplicates in the two result sets
       });
     });
+
   });
 });

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -2,7 +2,7 @@ import express from 'express';
 import config from 'config';
 import asyncHandler from 'express-async-handler';
 import { startOfDay, endOfDay } from 'date-fns';
-import Sequelize, { Op, literal, where } from 'sequelize';
+import Sequelize, { Op, literal } from 'sequelize';
 import {
   NOTE_TYPES,
   AREA_TYPE_TO_IMAGING_TYPE,
@@ -380,7 +380,7 @@ globalImagingRequests.get(
 
     // Sequelize does not support FROM sub query, only sub query as field
     // and alias cannot be used in where clause. So to filter by MAX(imaging_results.completed_at),
-    // the sub query has to be duplicated in the where clause as well as in the select part.
+    // the sub query has to be duplicated in the where clause as well in the select part.
     if (filterParams.completedAt) {
       resultFilters.id = {
         [Op.in]: Sequelize.literal(

--- a/packages/lan/app/routes/apiv1/imaging.js
+++ b/packages/lan/app/routes/apiv1/imaging.js
@@ -305,8 +305,7 @@ globalImagingRequests.get(
 
     const orderDirection = order.toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
     const nullPosition =
-      orderBy === 'completedAt' &&
-      (orderDirection === 'ASC' ? 'NULLS FIRST' : 'NULLS LAST');
+      orderBy === 'completedAt' && (orderDirection === 'ASC' ? 'NULLS FIRST' : 'NULLS LAST');
 
     const patientFilters = mapQueryFilters(filterParams, [
       { key: 'firstName', mapFn: caseInsensitiveStartsWithFilter },
@@ -316,13 +315,6 @@ globalImagingRequests.get(
 
     const encounterFilters = mapQueryFilters(filterParams, [
       { key: 'departmentId', operator: Op.eq },
-    ]);
-    const resultFilters = mapQueryFilters(filterParams, [
-      {
-        key: 'completedAt',
-        operator: Op.startsWith,
-        mapFn: dateFilter,
-      },
     ]);
     const imagingRequestFilters = mapQueryFilters(filterParams, [
       {
@@ -407,14 +399,17 @@ globalImagingRequests.get(
       include: [requestedBy, encounter],
       attributes: {
         include: [
-          // Aggregate results into a new field using a literal subquery. This avoids Sequelize 
+          // Aggregate results into a new field using a literal subquery. This avoids Sequelize
           // including an entry for each ImagingRequest per result & messing up the pagination
-          [literal(`(
+          [
+            literal(`(
             SELECT MAX(completed_at)
             FROM imaging_results
             WHERE imaging_results.imaging_request_id = "ImagingRequest".id
-          )`), 'completedAt'],
-        ]
+          )`),
+            'completedAt',
+          ],
+        ],
       },
       limit: rowsPerPage,
       offset: page * rowsPerPage,


### PR DESCRIPTION
### Changes

NOTE: This PR also includes a little bit of a rearrange of the existing tests to make it a bit cleaner to write the new ones. I haven't touched the internal logic of the other tests, the only new ones are in the `pagination` at the bottom.


The query for ImagingRequests was joining the ImagingResults relation in a strange way - the result would include a row for each ImagingResult and still obey the LIMIT 10, and then Sequelize would filter out the duplicates (reformatting them as an associated array on the final ImagingRequest object), resulting in fewer results per page than we'd expect.

The fix was to replace the included relation in the querybuilder with an included _attribute_ using a raw SQL subquery.


### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
