### PR TITLE
Containerisation fixes

### DIFF
--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -28,9 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - linux/amd64
-          # - linux/arm64
-          # it works, but it's just too slow
+          - arch: linux/amd64
+            runs-on: ubuntu-latest
+          # - arch: linux/arm64
+          #   runs-on: ubuntu-arm64 # when available
         package:
           - name: central
             path: sync-server
@@ -41,7 +42,7 @@ jobs:
           # not yet used
 
     name: Build ${{ matrix.package.name }} container for ${{ matrix.platform.arch }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runs-on }}
 
     steps:
       - name: Configure AWS Credentials
@@ -84,7 +85,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platform.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: PACKAGE_PATH=${{ matrix.package.path }}

--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -86,8 +86,8 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ steps.ref.outputs.result }}-${{ matrix.package.name }}
+          cache-to: type=gha,mode=max,scope=${{ steps.ref.outputs.result }}-${{ matrix.package.name }}
           build-args: PACKAGE_PATH=${{ matrix.package.path }}
           push: true
           labels: |

--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -28,10 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - arch: linux/amd64
-            prefix: ''
-          # - arch: linux/arm64
-          #   prefix: linarm-
+          - linux/amd64
+          # - linux/arm64
           # it works, but it's just too slow
         package:
           - name: central
@@ -68,19 +66,6 @@ jobs:
       - name: Setup buildkit
         uses: docker/setup-buildx-action@v2
 
-      - name: Prepare image name
-        uses: actions/github-script@v6
-        id: image
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPO_NAME: ${{ matrix.package.name }}
-        with:
-          result-encoding: string
-          script: |
-            const registry = process.env.REGISTRY;
-            const repo_name = process.env.REPO_NAME;
-            const image = `${registry}/tamanu/${repo_name}`;
-            return image;
       - name: Normalise branch/ref name
         uses: actions/github-script@v6
         id: ref
@@ -90,24 +75,20 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const head_ref = process.env.GH_HEAD_REF;
-            const ref_name = process.env.GH_REF_NAME;
-            const ref = head_ref ?? ref_name;
-            const cleaned = ref
+            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
               .replace(/[^a-z0-9-]/g, '-')
               .replace(/-+/g, '-')
-              .replace(/^-|-$/g, '');
-            return cleaned;
+              .replace(/^-|-$/g, ''));
 
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: ${{ matrix.platform.arch }}
+          platforms: ${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: PACKAGE_PATH=${{ matrix.package.path }}
           push: true
           tags: |
-            ${{ steps.image.outputs.result }}:${{ matrix.platform.prefix }}${{ github.sha }}
-            ${{ steps.image.outputs.result }}:${{ matrix.platform.prefix }}${{ steps.ref.outputs.result }}
+            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ steps.ref.outputs.result }}

--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -90,6 +90,13 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: PACKAGE_PATH=${{ matrix.package.path }}
           push: true
+          labels: |
+            org.opencontainers.image.vendor=BES
+            org.opencontainers.image.title=Tamanu ${{ matrix.package.name }}
+            org.opencontainers.image.url=https://www.bes.au/products/tamanu/
+            org.opencontainers.image.source=https://github.com/beyondessential/tamanu/
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.pull_request.merged_at || github.event.head_commit.timestamp }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ steps.ref.outputs.result }}

--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -98,5 +98,5 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ github.event.pull_request.merged_at || github.event.head_commit.timestamp }}
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:sha-${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ steps.ref.outputs.result }}

--- a/packages/sync-server/app/subCommands/provision.js
+++ b/packages/sync-server/app/subCommands/provision.js
@@ -87,7 +87,7 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
   }
 
   for (const [id, { settings }] of Object.entries(facilities ?? {})) {
-    for (const [key, value] of Object.entries(settings)) {
+    for (const [key, value] of Object.entries(settings ?? {})) {
       log.info('Installing facility setting', { key, facility: id });
       await store.models.Setting.set(key, value, id);
     }
@@ -98,7 +98,9 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
 
   const allUsers = [
     ...Object.entries(users ?? {}),
-    ...Object.values(facilities ?? {}).map(({ user, password }) => [user, { password }]),
+    ...Object.values(facilities ?? {})
+      .map(({ user, password }) => user && password && [user, { password }])
+      .filter(Boolean),
   ];
 
   for (const [id, { role = 'admin', password }] of allUsers) {

--- a/packages/sync-server/app/subCommands/provision.js
+++ b/packages/sync-server/app/subCommands/provision.js
@@ -10,7 +10,7 @@ import { loadSettingFile } from '../utils/loadSettingFile';
 import { referenceDataImporter } from '../admin/referenceDataImporter';
 import { getRandomBase64String } from '../auth/utils';
 
-export async function provision({ file, skipIfNotNeeded }) {
+export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
   const store = await initDatabase({ testMode: false });
   const userCount = await store.models.User.count();
   if (userCount > 0) {
@@ -27,7 +27,7 @@ export async function provision({ file, skipIfNotNeeded }) {
   checkIntegrationsConfig();
 
   const { users, facilities, referenceData, settings: globalSettings } = await loadSettingFile(
-    file,
+    provisioningFile,
   );
 
   /// //////////////
@@ -35,12 +35,12 @@ export async function provision({ file, skipIfNotNeeded }) {
 
   const errors = [];
   const stats = {};
-  for (const { file, ...rest } of referenceData ?? []) {
-    if (!file) {
+  for (const { file: referenceDataFile, ...rest } of referenceData ?? []) {
+    if (!referenceDataFile) {
       throw new Error(`Unknown reference data import with keys ${Object.keys(rest).join(', ')}`);
     }
 
-    const realpath = relative(file, path);
+    const realpath = relative(provisioningFile, referenceDataFile);
     log.info('Importing reference data file', { file: realpath });
     await referenceDataImporter({
       errors,

--- a/packages/sync-server/app/subCommands/provision.js
+++ b/packages/sync-server/app/subCommands/provision.js
@@ -114,7 +114,7 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
       console.log(`NEW PASSWORD for ${email}: ${realPassword}`);
     }
 
-    const user = await store.models.User.findOne({ email });
+    const user = await store.models.User.findOne({ where: { email } });
     if (user) {
       log.info('Updating user', { email });
       user.set({ role, ...fields });
@@ -134,6 +134,7 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
   log.info('Creating system user');
   await store.models.User.create({
     id: SYSTEM_USER_UUID,
+    email: 'system@tamanu.io',
     role: 'system',
     displayName: 'System',
   });

--- a/packages/sync-server/app/subCommands/provision.js
+++ b/packages/sync-server/app/subCommands/provision.js
@@ -69,6 +69,8 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
       await facility.update(fields);
     } else {
       log.info('Creating facility', { id });
+      fields.name ||= id;
+      fields.code ||= id;
       await store.models.Facility.create({
         id,
         ...fields,

--- a/packages/sync-server/app/subCommands/provision.js
+++ b/packages/sync-server/app/subCommands/provision.js
@@ -1,8 +1,8 @@
-import { relative } from 'path';
+import { resolve } from 'path';
 import { Command } from 'commander';
 
-import { SYSTEM_USER_UUID } from 'shared/constants';
-import { log } from 'shared/services/logging';
+import { SYSTEM_USER_UUID } from '@tamanu/shared/constants';
+import { log } from '@tamanu/shared/services/logging';
 
 import { initDatabase } from '../database';
 import { checkIntegrationsConfig } from '../integrations';
@@ -40,7 +40,7 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
       throw new Error(`Unknown reference data import with keys ${Object.keys(rest).join(', ')}`);
     }
 
-    const realpath = relative(provisioningFile, referenceDataFile);
+    const realpath = resolve(provisioningFile, referenceDataFile);
     log.info('Importing reference data file', { file: realpath });
     await referenceDataImporter({
       errors,


### PR DESCRIPTION
### Changes

Various fixes from finishing up the containers epic:

- Fix workflow when running on a branch (instead of on a PR)
  - Also simplify the normalisation/tag generation logic
  - Add a bunch of OCI-spec labels to the image (doesn't fix anything, it's just nice)
  - Fix docker caching to not conflict between central and facility
- Provisioning didn't tolerate missing sections
- Default facility name/code when not provided
- Allow arbitrary fields in user provision (used to set displayNames)
- Allow absolute pathing for reference data files
