### PR TITLE
TAV-541: Deploy to ECS

### DIFF
--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -44,6 +44,9 @@ jobs:
     name: Build ${{ matrix.package.name }} container for ${{ matrix.platform.arch }}
     runs-on: ${{ matrix.platform.runs-on }}
 
+    outputs:
+      tag: "sha-${{ github.sha }}"
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -196,8 +196,15 @@ jobs:
           node-version: 16
           cache: yarn
 
+      - name: Install Python 3.10 (for node-gyp)
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+
       - name: Prepare yarn
         run: yarn && yarn build-shared
+        env:
+          PYTHON: /opt/homebrew/bin/python3.10
 
       - name: Prepare env
         working-directory: packages/desktop

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,8 @@ on:
       - release/*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.pull_request.id || github.sha || github.run_id }}
-  cancel-in-progress: true
+  # only one build at a time, per PR/branch, but don't cancel existing builds
+  group: ${{ github.workflow }}-${{ github.pull_request.id || github.ref }}
 
 permissions:
   contents: read

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,13 +135,13 @@ jobs:
         working-directory: pulumi
 
       # a constant secret + a variable plain text, hashed, = a new secret!
+      # importantly this needs to remain constant for the lifetime of the stack
       - name: Prepare salt
         id: salt
         env:
           KEY: ${{ secrets.TAMANU_OPS_SSH }}
           NAME: ${{ needs.build.outputs.name }}
-        run: echo salt=ghp_$(echo "$KEY" "$NAME" | sha1sum | cut -d' ' -f1) >> $GITHUB_OUTPUT
-        # prefix the salt with ghp_ to make it look like a valid github token and get censored
+        run: echo salt=$(sha1sum <<< "$KEY$NAME" | cut -d' ' -f1) >> $GITHUB_OUTPUT
 
       - name: Up!
         uses: pulumi/actions@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -205,14 +205,6 @@ jobs:
         env:
           PYTHON: /opt/homebrew/bin/python3.10
 
-      - name: Prepare env
-        working-directory: packages/desktop
-        run: |
-          cat <<EOF > .env
-          HOST="https://facility-1.${{ needs.info.outputs.branch }}.internal.tamanu.io"
-          REALM_PATH="/realm"
-          EOF
-
       - name: Build desktop client
         working-directory: packages/desktop
         run: yarn package-win

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,12 +129,13 @@ jobs:
         with:
           node-version: 16
           cache: npm
+
       - name: Prepare pulumi
         run: npm ci
         working-directory: pulumi
 
       # a constant secret + a variable plain text, hashed, = a new secret!
-      - name: Write files for salt hash
+      - name: Prepare salt
         id: salt
         env:
           KEY: ${{ secrets.TAMANU_OPS_SSH }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install Python 3.10 (for node-gyp)
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Prepare yarn
         run: yarn && yarn build-shared

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -161,3 +161,23 @@ jobs:
           }"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+  client:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    name: Build desktop client
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::143295493206:role/gha-s3
+          role-session-name: GithubActionsTamanuS3
+
+      - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -153,7 +153,8 @@ jobs:
           upsert: true
           config-map: "{
             tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
-            tamanu-internal:salt: {value: '${{ hashFiles('salt.*') }}', secret: true}
+            tamanu-internal:salt: {value: 'ghp_${{ hashFiles('salt.*') }}', secret: true}
           }"
+          # prefix the salt with ghp_ to make it look like a valid github token and get censored
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -185,7 +185,7 @@ jobs:
           sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
           sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y msitools wine32 wine-stable wixl
+          sudo apt-get install --no-install-recommends -y msitools wine-stable wixl
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD Containers
+name: CD
 
 on:
   workflow_dispatch:
@@ -8,22 +8,24 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
   push:
     branches:
-      - dev
       - main
+      - release/*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_id }}
+  group: ${{ github.workflow }}-${{ github.pull_request.id || github.sha || github.run_id }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  id-token: write # OIDC token for ECR login
+  pull-requests: write
+  id-token: write # OIDC token for AWS
 
 jobs:
   build:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'auto-deploy'))
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +48,8 @@ jobs:
 
     outputs:
       tag: "sha-${{ github.sha }}"
+      image: "${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}"
+      name: ${{ steps.ref.outputs.result }}
 
     steps:
       - name: Configure AWS Credentials
@@ -103,3 +107,63 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:sha-${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ steps.ref.outputs.result }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::143295493206:role/gha-deploy
+          role-session-name: GithubActionsTamanuDeploy
+
+      - uses: actions/checkout@v3
+        with:
+          repository: beyondessential/ops
+          ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - name: Prepare pulumi
+        run: npm ci
+        working-directory: pulumi
+
+      - name: Refresh stack
+        uses: pulumi/actions@v3
+        with:
+          work-dir: pulumi/tamanu-internal
+          command: config refresh
+          stack-name: bes/${{ steps.build.outputs.name }}
+          upsert: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+      - name: Setup salt
+        run: ls
+        working-directory: pulumi/tamanu-internal
+
+      - name: Configure image tag
+        uses: pulumi/actions@v3
+        with:
+          work-dir: pulumi/tamanu-internal
+          command: config set tamanu-internal:imageTag ${{ needs.build.outputs.tag }}
+          stack-name: bes/${{ steps.build.outputs.name }}
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+      - name: Up!
+        uses: pulumi/actions@v3
+        with:
+          work-dir: pulumi/tamanu-internal
+          command: up
+          stack-name: bes/${{ steps.build.outputs.name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-pr: ${{ github.event_name == 'pull_request' }}
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -171,7 +171,7 @@ jobs:
 
   client:
     needs: info
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     name: Build desktop client
     steps:
       - name: Configure AWS Credentials
@@ -190,7 +190,9 @@ jobs:
           cache: yarn
 
       - name: Prepare yarn
-        run: yarn && yarn build-shared
+        run: |
+          yarn
+          yarn build-shared
 
       - name: Prepare env
         working-directory: packages/desktop
@@ -207,7 +209,8 @@ jobs:
       - name: Pack desktop client
         working-directory: packages/desktop/release
         run: zip -q -r ../tamanu-$(jq .version ../package.json -r)-${{ github.sha }}.zip .
-      
+        shell: bash
+
       - name: Upload as artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -207,6 +207,13 @@ jobs:
       - name: Pack desktop client
         working-directory: packages/desktop/release
         run: zip -q -r ../tamanu-$(jq .version ../package.json -r)-${{ github.sha }}.zip .
+      
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tamanu-desktop
+          path: packages/desktop/tamanu-*.zip
+          retention-days: 14
 
       - name: Push to S3
         working-directory: packages/desktop

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -173,14 +173,6 @@ jobs:
     needs: info
     runs-on: ubuntu-latest
     name: Build desktop client
-    env:
-      CI_BRANCH: ${{ needs.info.outputs.branch }}
-      CI_COMMIT_ID: ${{ github.sha }}
-      CONFIG_DESKTOP: HOST="https://facility-1.${{ needs.info.outputs.branch }}.internal.tamanu.io"|REALM_PATH="/realm"
-      DESKTOP_ROOT: ${{ github.workspace }}/packages/desktop
-      DESKTOP_RELEASE_DIR: ${{ github.workspace }}/packages/desktop/release
-      DEPLOY_DIR: ${{ github.workspace }}/deploy
-      S3_BUCKET: ${{ vars.DESKTOP_S3_BUCKET }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -195,13 +187,27 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: npm
+          cache: yarn
 
-      - name: Prepare dirs
-        run: mkdir -p $DESKTOP_RELEASE_DIR $DEPLOY_DIR 
+      - name: Prepare yarn
+        run: yarn && yarn build-shared
+
+      - name: Prepare env
+        working-directory: packages/desktop
+        run: |
+        cat <<EOF > .env
+        HOST="https://facility-1.${{ needs.info.outputs.branch }}.internal.tamanu.io"
+        REALM_PATH="/realm"
+        EOF
 
       - name: Build desktop client
-        run: scripts/build_desktop.sh build-only
+        working-directory: packages/desktop
+        run: yarn package-win
+
+      - name: Pack desktop client
+        working-directory: packages/desktop/release
+        run: zip -q -r ../tamanu-$(jq .version ../package.json -r)-${{ github.sha }}.zip .
 
       - name: Push to S3
-        run: scripts/push.sh
+        working-directory: packages/desktop
+        run: aws s3 cp tamanu-*.zip s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -196,7 +196,7 @@ jobs:
           cache: yarn
 
       - name: Install Python 3.10 (for node-gyp)
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Prepare yarn
         run: |
-          yarn
+          yarn --network-timeout 120000 # ms
           yarn build-shared
 
       - name: Prepare env

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -171,9 +171,20 @@ jobs:
 
   client:
     needs: info
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     name: Build desktop client
     steps:
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
+      
+      - name: Install wine
+        run: |
+          dpkg --add-architecture i386
+          apt install -y msitools wine32 wine wixl
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -183,16 +194,8 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
       - name: Prepare yarn
-        run: |
-          yarn --network-timeout 120000 # ms
-          yarn build-shared
+        run: yarn && yarn build-shared
 
       - name: Prepare env
         working-directory: packages/desktop

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,7 @@ jobs:
 
   build:
     needs: info
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -174,12 +174,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Build desktop client
     steps:
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
       - name: Install wine
         # see https://github.com/actions/runner-images/issues/7589
         run: |
@@ -201,6 +195,12 @@ jobs:
           role-session-name: GithubActionsTamanuS3
 
       - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
 
       - name: Prepare yarn
         run: yarn && yarn build-shared

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,8 +48,7 @@ jobs:
 
     outputs:
       tag: "sha-${{ github.sha }}"
-      image: "${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}"
-      name: ${{ steps.ref.outputs.result }}
+      name: "${{ steps.ref.outputs.result }}"
 
     steps:
       - name: Configure AWS Credentials
@@ -134,10 +133,11 @@ jobs:
         run: npm ci
         working-directory: pulumi
 
+      # a constant secret + a variable plain text, hashed, = a new secret!
       - name: Write files for salt hash
         env:
           KEY: ${{ secrets.TAMANU_OPS_SSH }}
-          NAME: ${{ steps.build.outputs.name }}
+          NAME: ${{ needs.build.outputs.name }}
         run: |
           echo "$KEY" > salt.key
           echo "$NAME" > salt.name
@@ -147,12 +147,12 @@ jobs:
         with:
           work-dir: pulumi/tamanu-internal
           command: up
-          stack-name: bes/${{ steps.build.outputs.name }}
+          stack-name: bes/${{ needs.build.outputs.name }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
           upsert: true
           config-map: "{
-            tamanu-internal:imageTag: {value: '${{ steps.build.outputs.tag }}', secret: false},
+            tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
             tamanu-internal:salt: {value: '${{ hashFiles('salt.*') }}', secret: true}
           }"
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,12 +172,14 @@ jobs:
 
   client:
     needs: info
-    runs-on: macos-latest # because wine doesn't install on ubuntu
+    # because wine doesn't install on ubuntu
+    # and yarn doesn't work on windows (io latency)
+    runs-on: macos-latest
     name: Build desktop client
     steps:
       - name: Install wine
         # see https://github.com/actions/runner-images/issues/743
-        run: brew cask install wine-stable
+        run: brew install wine-stable
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      
+
       - name: Install wine
         # see https://github.com/actions/runner-images/issues/7589
         run: |
@@ -220,7 +220,6 @@ jobs:
       - name: Pack desktop client
         working-directory: packages/desktop/release
         run: zip -q -r ../tamanu-$(jq .version ../package.json -r)-${{ github.sha }}.zip .
-        shell: bash
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,21 +172,12 @@ jobs:
 
   client:
     needs: info
-    runs-on: ubuntu-latest
+    runs-on: macos-latest # because wine doesn't install on ubuntu
     name: Build desktop client
     steps:
       - name: Install wine
-        # see https://github.com/actions/runner-images/issues/7589
-        run: |
-          set -e
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install ppa-purge
-          sudo ppa-purge -y ppa:ubuntu-toolchain-r/test
-          sudo mkdir -pm755 /etc/apt/keyrings
-          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y msitools wine-stable wine-stable-i386 wixl
+        # see https://github.com/actions/runner-images/issues/743
+        run: brew cask install wine-stable
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -181,9 +181,17 @@ jobs:
           cache: yarn
       
       - name: Install wine
+        # see https://github.com/actions/runner-images/issues/7589
         run: |
-          dpkg --add-architecture i386
-          apt install -y msitools wine32 wine wixl
+          set -e
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install ppa-purge
+          sudo ppa-purge -y ppa:ubuntu-toolchain-r/test
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y msitools wine32 wine-stable wixl
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,6 @@ jobs:
 
   build:
     needs: info
-    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -195,10 +195,10 @@ jobs:
       - name: Prepare env
         working-directory: packages/desktop
         run: |
-        cat <<EOF > .env
-        HOST="https://facility-1.${{ needs.info.outputs.branch }}.internal.tamanu.io"
-        REALM_PATH="/realm"
-        EOF
+          cat <<EOF > .env
+          HOST="https://facility-1.${{ needs.info.outputs.branch }}.internal.tamanu.io"
+          REALM_PATH="/realm"
+          EOF
 
       - name: Build desktop client
         working-directory: packages/desktop

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -141,7 +141,10 @@ jobs:
         env:
           KEY: ${{ secrets.TAMANU_OPS_SSH }}
           NAME: ${{ needs.build.outputs.name }}
-        run: echo salt=$(sha1sum <<< "$KEY$NAME" | cut -d' ' -f1) >> $GITHUB_OUTPUT
+        run: |
+          salt=$(sha1sum <<< "$KEY$NAME" | cut -d' ' -f1)
+          echo "::add-mask::$salt"
+          echo "salt=$salt" >> $GITHUB_OUTPUT
 
       - name: Up!
         uses: pulumi/actions@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,8 +24,29 @@ permissions:
   id-token: write # OIDC token for AWS
 
 jobs:
-  build:
+  info:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'auto-deploy'))
+    name: Branch info
+    runs-on: ubuntu-latest
+    steps:
+      - name: Normalise branch/ref name
+        uses: actions/github-script@v6
+        id: ref
+        env:
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
+        with:
+          result-encoding: string
+          script: |
+            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
+              .replace(/[^a-z0-9-]/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, ''));
+    outputs:
+      branch: ${{ steps.ref.outputs.result }}
+
+  build:
+    needs: info
     strategy:
       fail-fast: false
       matrix:
@@ -45,10 +66,6 @@ jobs:
 
     name: Build ${{ matrix.package.name }} container for ${{ matrix.platform.arch }}
     runs-on: ${{ matrix.platform.runs-on }}
-
-    outputs:
-      tag: "sha-${{ github.sha }}"
-      name: "${{ steps.ref.outputs.result }}"
 
     steps:
       - name: Configure AWS Credentials
@@ -73,27 +90,13 @@ jobs:
       - name: Setup buildkit
         uses: docker/setup-buildx-action@v2
 
-      - name: Normalise branch/ref name
-        uses: actions/github-script@v6
-        id: ref
-        env:
-          GH_HEAD_REF: ${{ github.head_ref }}
-          GH_REF_NAME: ${{ github.ref_name }}
-        with:
-          result-encoding: string
-          script: |
-            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
-              .replace(/[^a-z0-9-]/g, '-')
-              .replace(/-+/g, '-')
-              .replace(/^-|-$/g, ''));
-
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: ${{ matrix.platform.arch }}
-          cache-from: type=gha,scope=${{ steps.ref.outputs.result }}-${{ matrix.package.name }}
-          cache-to: type=gha,mode=max,scope=${{ steps.ref.outputs.result }}-${{ matrix.package.name }}
+          cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-${{ matrix.package.name }}
+          cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-${{ matrix.package.name }}
           build-args: PACKAGE_PATH=${{ matrix.package.path }}
           push: true
           labels: |
@@ -105,10 +108,14 @@ jobs:
             org.opencontainers.image.created=${{ github.event.pull_request.merged_at || github.event.head_commit.timestamp }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:sha-${{ github.sha }}
-            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ steps.ref.outputs.result }}
+            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:${{ needs.info.outputs.branch }}
+    outputs:
+      tag: "sha-${{ github.sha }}"
 
   deploy:
-    needs: build
+    needs:
+      - info
+      - build
     runs-on: ubuntu-latest
     name: Deploy
     steps:
@@ -140,7 +147,7 @@ jobs:
         id: salt
         env:
           KEY: ${{ secrets.TAMANU_OPS_SSH }}
-          NAME: ${{ needs.build.outputs.name }}
+          NAME: ${{ needs.info.outputs.branch }}
         run: |
           salt=$(sha1sum <<< "$KEY$NAME" | cut -d' ' -f1)
           echo "::add-mask::$salt"
@@ -151,7 +158,7 @@ jobs:
         with:
           work-dir: pulumi/tamanu-internal
           command: up
-          stack-name: bes/${{ needs.build.outputs.name }}
+          stack-name: bes/${{ needs.info.outputs.branch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
           upsert: true
@@ -163,9 +170,17 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
   client:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    needs: info
     runs-on: ubuntu-latest
     name: Build desktop client
+    env:
+      CI_BRANCH: ${{ needs.info.outputs.branch }}
+      CI_COMMIT_ID: ${{ github.sha }}
+      CONFIG_DESKTOP: HOST="https://facility-1.${{ needs.info.outputs.branch }}.internal.tamanu.io"|REALM_PATH="/realm"
+      DESKTOP_ROOT: ${{ github.workspace }}/packages/desktop
+      DESKTOP_RELEASE_DIR: ${{ github.workspace }}/packages/desktop/release
+      DEPLOY_DIR: ${{ github.workspace }}/deploy
+      S3_BUCKET: ${{ vars.DESKTOP_S3_BUCKET }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -181,3 +196,12 @@ jobs:
         with:
           node-version: 16
           cache: npm
+
+      - name: Prepare dirs
+        run: mkdir -p $DESKTOP_RELEASE_DIR $DEPLOY_DIR 
+
+      - name: Build desktop client
+        run: scripts/build_desktop.sh build-only
+
+      - name: Push to S3
+        run: scripts/push.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -178,7 +178,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ap-southeast-2
-          role-to-assume: arn:aws:iam::143295493206:role/gha-s3
+          role-to-assume: arn:aws:iam::143295493206:role/gha-desktop-s3
           role-session-name: GithubActionsTamanuS3
 
       - uses: actions/checkout@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,28 +134,13 @@ jobs:
         run: npm ci
         working-directory: pulumi
 
-      - name: Refresh stack
-        uses: pulumi/actions@v3
-        with:
-          work-dir: pulumi/tamanu-internal
-          command: config refresh
-          stack-name: bes/${{ steps.build.outputs.name }}
-          upsert: true
+      - name: Write files for salt hash
         env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-
-      - name: Setup salt
-        run: ls
-        working-directory: pulumi/tamanu-internal
-
-      - name: Configure image tag
-        uses: pulumi/actions@v3
-        with:
-          work-dir: pulumi/tamanu-internal
-          command: config set tamanu-internal:imageTag ${{ needs.build.outputs.tag }}
-          stack-name: bes/${{ steps.build.outputs.name }}
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          KEY: ${{ secrets.TAMANU_OPS_SSH }}
+          NAME: ${{ steps.build.outputs.name }}
+        run: |
+          echo "$KEY" > salt.key
+          echo "$NAME" > salt.name
 
       - name: Up!
         uses: pulumi/actions@v3
@@ -165,5 +150,10 @@ jobs:
           stack-name: bes/${{ steps.build.outputs.name }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
+          upsert: true
+          config-map: "{
+            tamanu-internal:imageTag: {value: '${{ steps.build.outputs.tag }}', secret: false},
+            tamanu-internal:salt: {value: '${{ hashFiles('salt.*') }}', secret: true}
+          }"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,12 +135,12 @@ jobs:
 
       # a constant secret + a variable plain text, hashed, = a new secret!
       - name: Write files for salt hash
+        id: salt
         env:
           KEY: ${{ secrets.TAMANU_OPS_SSH }}
           NAME: ${{ needs.build.outputs.name }}
-        run: |
-          echo "$KEY" > salt.key
-          echo "$NAME" > salt.name
+        run: echo salt=ghp_$(echo "$KEY" "$NAME" | sha1sum | cut -d' ' -f1) >> $GITHUB_OUTPUT
+        # prefix the salt with ghp_ to make it look like a valid github token and get censored
 
       - name: Up!
         uses: pulumi/actions@v3
@@ -153,8 +153,7 @@ jobs:
           upsert: true
           config-map: "{
             tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
-            tamanu-internal:salt: {value: 'ghp_${{ hashFiles('salt.*') }}', secret: true}
+            tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true}
           }"
-          # prefix the salt with ghp_ to make it look like a valid github token and get censored
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -186,7 +186,7 @@ jobs:
           sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
           sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y msitools wine-stable wixl
+          sudo apt-get install --no-install-recommends -y msitools wine-stable wine-stable-i386 wixl
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - main

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,7 +1,7 @@
 - name: tamanu deployment
   type: serial
   encrypted_dockercfg_path: dockercfg.encrypted
-  tag: ^(main$|release/|staging-|ci-|uat-|uatrispacs-|uatpmi-|release-desktop-|klaus-|sima-|sepi-|da-|deploy-meta$|deploy-nauru-demo$)
+  tag: ^(master$|main$|staging-|ci-|uat-|uatrispacs-|uatpmi-|release-desktop-|klaus-|sima-|sepi-|da-|(feature|epic|fix|release)/|deploy-meta$|deploy-nauru-demo$)
   steps:
     - name: copy files
       service: build
@@ -22,7 +22,7 @@
               exclude: ^deploy-meta$
               command: ./scripts/build_desktop.sh build-only
             - name: for lan
-              exclude: ^deploy-meta$
+              exclude: ^(deploy-meta$|(feature|epic|fix)/)
               type: serial
               steps:
                 - name: build linux release
@@ -31,7 +31,7 @@
                   tag: ^(master$|dev$|main$|release/|staging-|ci-)
                   command: ./scripts/build_server_zip.sh lan ./deploy package-desktop
         - name: for sync release
-          exclude: ^deploy-meta$
+          exclude: ^(deploy-meta$|(feature|epic|fix)/)
           type: serial
           steps:
             - name: build linux release
@@ -52,7 +52,7 @@
         # collide if an application is deployed in parallel
         # see https://github.com/codeship-library/aws-utilities/issues/115
         - name: the sync server
-          exclude: ^(release-desktop-|deploy-meta$)
+          exclude: ^(release-desktop-|deploy-meta$|(feature|epic|fix|release)/)
           type: serial
           service: deploy
           steps:
@@ -87,7 +87,7 @@
               tag: ^(da-)
               command: ./scripts/deploy_sync.sh da tamanu-central-server-da
         - name: the lan server
-          exclude: ^(release-desktop-|deploy-meta$)
+          exclude: ^(release-desktop-|deploy-meta$|(feature|epic|fix|release)/)
           type: serial
           service: deploy
           steps:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,7 +1,7 @@
 - name: tamanu deployment
   type: serial
   encrypted_dockercfg_path: dockercfg.encrypted
-  tag: ^(master$|main$|staging-|ci-|uat-|uatrispacs-|uatpmi-|release-desktop-|klaus-|sima-|sepi-|da-|(feature|epic|fix|release)/|deploy-meta$|deploy-nauru-demo$)
+  tag: ^(master$|main$|staging-|ci-|uat-|uatrispacs-|uatpmi-|release-desktop-|klaus-|sima-|sepi-|da-|deploy-meta$|deploy-nauru-demo$)
   steps:
     - name: copy files
       service: build
@@ -22,7 +22,7 @@
               exclude: ^deploy-meta$
               command: ./scripts/build_desktop.sh build-only
             - name: for lan
-              exclude: ^(deploy-meta$|(feature|epic|fix)/)
+              exclude: ^deploy-meta$
               type: serial
               steps:
                 - name: build linux release
@@ -31,7 +31,7 @@
                   tag: ^(master$|dev$|main$|release/|staging-|ci-)
                   command: ./scripts/build_server_zip.sh lan ./deploy package-desktop
         - name: for sync release
-          exclude: ^(deploy-meta$|(feature|epic|fix)/)
+          exclude: ^deploy-meta$
           type: serial
           steps:
             - name: build linux release
@@ -52,7 +52,7 @@
         # collide if an application is deployed in parallel
         # see https://github.com/codeship-library/aws-utilities/issues/115
         - name: the sync server
-          exclude: ^(release-desktop-|deploy-meta$|(feature|epic|fix|release)/)
+          exclude: ^(release-desktop-|deploy-meta$)
           type: serial
           service: deploy
           steps:
@@ -87,7 +87,7 @@
               tag: ^(da-)
               command: ./scripts/deploy_sync.sh da tamanu-central-server-da
         - name: the lan server
-          exclude: ^(release-desktop-|deploy-meta$|(feature|epic|fix|release)/)
+          exclude: ^(release-desktop-|deploy-meta$)
           type: serial
           service: deploy
           steps:


### PR DESCRIPTION
### Changes

- Replaces the "build container images" workflow with a full CD one.
- CD only runs when _both_:
  - the PR is not in draft, and
  - the PR has the `auto-deploy` label (which is bright pink so it's obvious).
- CD is also triggered by undrafting and labelling, so that there's no need to push a commit after undrafting and labelling to deploy.
- CD also runs on the `main` and `release/*` branches.
- What CD does:
  - Build containers
  	- Deploy to a branch-specific environment
  - Build the desktop client
  	- Push to S3

There's another ticket (and a future PR) for deleting a PR's deployment when the PR is closed. (Incidentally this makes it possible to delete or reset a PR's deployment by removing the `auto-deploy` label, then closing it and immediately re-opening it.)

#### New secrets

- [x] `TAMANU_OPS_SSH` a private key (deploy key) for the Tamanu Ops repo. Should be in bitwarden.
- [x] `PULUMI_ACCESS_TOKEN` an API key for pulumi.

### Checklist

- [x] Code is finished