### PR TITLE
NASS-782: Mobile form fields being cut-off and style tweaks

### DIFF
--- a/packages/mobile/App/ui/components/Forms/DeceasedForm/CauseOfDeathSection.tsx
+++ b/packages/mobile/App/ui/components/Forms/DeceasedForm/CauseOfDeathSection.tsx
@@ -11,51 +11,50 @@ import { CurrentUserField } from '../../CurrentUserField/CurrentUserField';
 export const CauseOfDeathSection = ({
   scrollToField,
 }: FormSectionProps): JSX.Element => (
-    <>
-      <StyledView
-        marginBottom={screenPercentageToDP(0.605, Orientation.Height)}
-      >
-        <SectionHeader h3>CAUSE OF DEATH</SectionHeader>
-      </StyledView>
-      <StyledView
-        height={screenPercentageToDP(45.87, Orientation.Height)}
-        justifyContent="space-between"
-      >
-        <CurrentUserField
-          name="staffMember"
-          label="Staff Member"
-        />
-        <Field
-          component={TextField}
-          name="deathCertificateNumber"
-          label="Death Certificate Number"
-          onFocus={scrollToField('deathCertificateNumber')}
-        />
-        <Field
-          component={DateField}
-          name="date"
-          label="Date"
-          onFocus={scrollToField('date')}
-        />
-        <Field
-          component={DateField}
-          mode="time"
-          name="time"
-          label="Time"
-          onFocus={scrollToField('time')}
-        />
-        <Field
-          component={TextField}
-          name="causeOfDeath"
-          label="Cause of Death"
-          onFocus={scrollToField('causeOfDeath')}
-        />
-        <Field
-          component={TextField}
-          name="placeOfDeath"
-          label="Place Of Death"
-          onFocus={scrollToField('placeOfDeath')}
-        />
-      </StyledView>
-    </>
-  );
+  <>
+    <StyledView
+      marginBottom={screenPercentageToDP(0.605, Orientation.Height)}
+    >
+      <SectionHeader h3>CAUSE OF DEATH</SectionHeader>
+    </StyledView>
+    <StyledView
+      justifyContent="space-between"
+    >
+      <CurrentUserField
+        name="staffMember"
+        label="Staff Member"
+      />
+      <Field
+        component={TextField}
+        name="deathCertificateNumber"
+        label="Death Certificate Number"
+        onFocus={scrollToField('deathCertificateNumber')}
+      />
+      <Field
+        component={DateField}
+        name="date"
+        label="Date"
+        onFocus={scrollToField('date')}
+      />
+      <Field
+        component={DateField}
+        mode="time"
+        name="time"
+        label="Time"
+        onFocus={scrollToField('time')}
+      />
+      <Field
+        component={TextField}
+        name="causeOfDeath"
+        label="Cause of Death"
+        onFocus={scrollToField('causeOfDeath')}
+      />
+      <Field
+        component={TextField}
+        name="placeOfDeath"
+        label="Place Of Death"
+        onFocus={scrollToField('placeOfDeath')}
+      />
+    </StyledView>
+  </>
+);

--- a/packages/mobile/App/ui/components/TextField/TextField.tsx
+++ b/packages/mobile/App/ui/components/TextField/TextField.tsx
@@ -74,13 +74,6 @@ export const TextField = React.memo(
     const [focused, setFocus] = useState(false);
     const defaultRef: RefObject<any> = useRef(null);
     const ref = inputRef || defaultRef;
-    const onFocusLabel = useCallback((): void => {
-      if (!focused && ref.current) {
-        ref.current.focus();
-      } else if (focused && ref.current) {
-        ref.current.blur();
-      }
-    }, [focused, inputRef]);
     const onFocusInput = useCallback((): void => {
       if (onFocus) onFocus();
       setFocus(true);
@@ -114,10 +107,6 @@ export const TextField = React.memo(
         <InputContainer>
           {!!label && (
             <TextFieldLabel
-              error={error}
-              focus={focused}
-              onFocus={onFocusLabel}
-              isValueEmpty={value !== ''}
               labelColor={labelColor}
               labelFontSize={labelFontSize}
             >

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/AddIllnessDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/AddIllnessDetails.tsx
@@ -119,6 +119,7 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
                 <StyledView justifyContent="space-between">
                   <Field
                     component={AutocompleteModalField}
+                    label="Select"
                     placeholder="Diagnosis"
                     navigation={navigation}
                     suggester={icd10Suggester}
@@ -139,6 +140,7 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
                   <CurrentUserField name="examiner" label="Recorded By" />
                   <Button
                     marginTop={screenPercentageToDP(1.22, Orientation.Height)}
+                    marginBottom={screenPercentageToDP(1.22, Orientation.Height)}
                     backgroundColor={theme.colors.PRIMARY_MAIN}
                     onPress={handleSubmit}
                     buttonText="Submit"

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
@@ -94,7 +94,6 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                 />
                 <StyledView
                   marginTop={screenPercentageToDP(2.105, Orientation.Height)}
-                  height={screenPercentageToDP(21.87, Orientation.Height)}
                   justifyContent="space-between"
                 >
                   <SectionHeader h3 marginBottom={screenPercentageToDP(2.105, Orientation.Height)}>
@@ -110,7 +109,6 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                   />
                 </StyledView>
                 <StyledView
-                  marginTop={screenPercentageToDP(16.42, Orientation.Height)}
                   marginBottom={screenPercentageToDP(0.605, Orientation.Height)}
                 >
                   <SectionHeader h3>Prescription notes</SectionHeader>
@@ -118,6 +116,7 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                 <Field component={TextField} name="note" multiline />
                 <Button
                   marginTop={screenPercentageToDP(1.22, Orientation.Height)}
+                  marginBottom={screenPercentageToDP(1.22, Orientation.Height)}
                   backgroundColor={theme.colors.PRIMARY_MAIN}
                   onPress={handleSubmit}
                   buttonText="Submit"


### PR DESCRIPTION
### Changes
Issues in mobiles from text field changes: 

Im thinking mabye the static height where accounting for incorrect height elements? but let me know if there is programatic reason for them

Prescribe medication form cutoff
![image (37)](https://github.com/beyondessential/tamanu/assets/38335330/49c95fae-2baa-42d9-a4f3-2d699d2e4974)

Select label fallback making surveys look a bit weird
<img width="383" alt="Screenshot 2023-06-06 at 2 45 44 PM" src="https://github.com/beyondessential/tamanu/assets/38335330/c672cf8a-cdfe-47e9-906f-68a138edd584">

Form cuttoff (death form not used it submits to nowhere)
<img width="466" alt="Screenshot 2023-06-06 at 2 55 50 PM" src="https://github.com/beyondessential/tamanu/assets/38335330/d25aade1-605e-447f-be12-58c62fad80a6">

### Checklist
- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
