### PR TITLE
EPI-474: Failing tests cleanup

### DIFF
--- a/packages/sync-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
@@ -290,9 +290,6 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       expect(response.body).toEqual({
         resourceType: 'Bundle',
         id: expect.any(String),
-        meta: {
-          lastUpdated: expect.any(String),
-        },
         type: 'searchset',
         timestamp: expect.any(String),
         total: 1,

--- a/packages/sync-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
@@ -155,14 +155,14 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
-      expect(response.headers['last-modified']).toBe(formatRFC7231(new Date(labTest.updatedAt)));
+      expect(response.headers['last-modified']).toBe(formatRFC7231(new Date(mat.lastUpdated)));
       expect(response.body).toMatchObject({
         resourceType: 'DiagnosticReport',
         id: expect.any(String),
         meta: {
           // TODO: uncomment when we support versioning
           // versionId: expect.any(String),
-          lastUpdated: formatFhirDate(labTest.updatedAt),
+          lastUpdated: formatFhirDate(mat.lastUpdated),
         },
         effectiveDateTime: convertISO9075toRFC3339(labRequest.sampleTime),
         issued: convertISO9075toRFC3339(labRequest.requestedDate),
@@ -291,7 +291,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
         resourceType: 'Bundle',
         id: expect.any(String),
         meta: {
-          lastUpdated: formatFhirDate(labTest.updatedAt),
+          lastUpdated: expect.any(String),
         },
         type: 'searchset',
         timestamp: expect.any(String),
@@ -314,7 +314,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
               meta: {
                 // TODO: uncomment when we support versioning
                 // versionId: expect.any(String),
-                lastUpdated: formatFhirDate(labTest.updatedAt),
+                lastUpdated: formatFhirDate(mat.lastUpdated),
               },
               code: {
                 coding: [

--- a/packages/sync-server/__tests__/hl7fhir/materialised/Immunization.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/Immunization.test.js
@@ -123,13 +123,11 @@ describe(`Materialised FHIR - Immunization`, () => {
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
-      expect(response.headers['last-modified']).toBe(
-        formatRFC7231(new Date(administeredVaccine.updatedAt)),
-      );
+      expect(response.headers['last-modified']).toBe(formatRFC7231(new Date(mat.lastUpdated)));
       expect(response.body).toMatchObject({
         resourceType: 'Immunization',
         meta: {
-          lastUpdated: formatFhirDate(administeredVaccine.updatedAt),
+          lastUpdated: formatFhirDate(mat.lastUpdated),
         },
         status: 'completed',
         vaccineCode: {
@@ -181,13 +179,11 @@ describe(`Materialised FHIR - Immunization`, () => {
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
-      expect(response.headers['last-modified']).toBe(
-        formatRFC7231(new Date(administeredVaccine.updatedAt)),
-      );
+      expect(response.headers['last-modified']).toBe(formatRFC7231(new Date(mat.lastUpdated)));
       expect(response.body).toMatchObject({
         resourceType: 'Immunization',
         meta: {
-          lastUpdated: formatFhirDate(administeredVaccine.updatedAt),
+          lastUpdated: formatFhirDate(mat.lastUpdated),
         },
         status: 'completed',
         performer: [],

--- a/packages/sync-server/__tests__/hl7fhir/materialised/Patient.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/Patient.test.js
@@ -131,9 +131,6 @@ describe(`Materialised FHIR - Patient`, () => {
         resourceType: 'Bundle',
         id: expect.any(String),
         timestamp: expect.any(String),
-        meta: {
-          lastUpdated: expect.any(String),
-        },
         type: 'searchset',
         total: 1,
         link: [

--- a/packages/sync-server/__tests__/hl7fhir/materialised/Patient.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/Patient.test.js
@@ -51,7 +51,7 @@ describe(`Materialised FHIR - Patient`, () => {
         meta: {
           // TODO: uncomment when we support versioning
           // versionId: expect.any(String),
-          lastUpdated: formatFhirDate(additionalData.updatedAt),
+          lastUpdated: formatFhirDate(mat.lastUpdated),
         },
         active: true,
         address: [
@@ -105,9 +105,7 @@ describe(`Materialised FHIR - Patient`, () => {
           },
         ],
       });
-      expect(response.headers['last-modified']).toBe(
-        formatRFC7231(new Date(additionalData.updatedAt)),
-      );
+      expect(response.headers['last-modified']).toBe(formatRFC7231(new Date(mat.lastUpdated)));
       expect(response).toHaveSucceeded();
     });
 
@@ -120,7 +118,7 @@ describe(`Materialised FHIR - Patient`, () => {
         patientId: patient.id,
       });
       await patient.reload(); // saving PatientAdditionalData updates the patient too
-      await FhirPatient.materialiseFromUpstream(patient.id);
+      const mat = await FhirPatient.materialiseFromUpstream(patient.id);
 
       const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
       const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-issued&_page=0&_count=2&status=final&identifier=${id}`;
@@ -134,7 +132,7 @@ describe(`Materialised FHIR - Patient`, () => {
         id: expect.any(String),
         timestamp: expect.any(String),
         meta: {
-          lastUpdated: formatFhirDate(additionalData.updatedAt),
+          lastUpdated: expect.any(String),
         },
         type: 'searchset',
         total: 1,
@@ -152,7 +150,7 @@ describe(`Materialised FHIR - Patient`, () => {
               meta: {
                 // TODO: uncomment when we support versioning
                 // versionId: expect.any(String),
-                lastUpdated: formatFhirDate(additionalData.updatedAt),
+                lastUpdated: formatFhirDate(mat.lastUpdated),
               },
               active: true,
               address: [

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -317,9 +317,6 @@ Patient may need mobility assistance`,
         resourceType: 'Bundle',
         id: expect.any(String),
         timestamp: expect.any(String),
-        meta: {
-          lastUpdated: expect.any(String),
-        },
         type: 'searchset',
         total: 1,
         link: [
@@ -437,9 +434,6 @@ Patient may need mobility assistance`,
         resourceType: 'Bundle',
         id: expect.any(String),
         timestamp: expect.any(String),
-        meta: {
-          lastUpdated: expect.any(String),
-        },
         type: 'searchset',
         total: 1,
         link: [
@@ -557,9 +551,6 @@ Patient may need mobility assistance`,
         resourceType: 'Bundle',
         id: expect.any(String),
         timestamp: expect.any(String),
-        meta: {
-          lastUpdated: expect.any(String),
-        },
         type: 'searchset',
         total: 1,
         link: [

--- a/packages/sync-server/app/hl7fhir/materialised/bundle.js
+++ b/packages/sync-server/app/hl7fhir/materialised/bundle.js
@@ -41,12 +41,11 @@ export class Bundle {
   }
 
   asFhir() {
-    const currentFhirDate = formatFhirDate(new Date());
     const fields = {
       resourceType: 'Bundle',
       id: uuidv4(),
       type: this.type,
-      timestamp: currentFhirDate,
+      timestamp: formatFhirDate(new Date()),
     };
 
     if (typeof this.options.total === 'number') {

--- a/packages/sync-server/app/hl7fhir/materialised/bundle.js
+++ b/packages/sync-server/app/hl7fhir/materialised/bundle.js
@@ -47,9 +47,6 @@ export class Bundle {
       id: uuidv4(),
       type: this.type,
       timestamp: currentFhirDate,
-      meta: {
-        lastUpdated: currentFhirDate,
-      },
     };
 
     if (typeof this.options.total === 'number') {


### PR DESCRIPTION
### Changes

Because of the change needed to the core work of the card, we don't have a way of knowing the exact timestamp of the bundles. The timestamps from the resources can be determined by reading their field, which is not great, but what's most important is the format.

I only realized this was happening now because sometimes the tests run so fast that the `lastUpdated` field is exactly the same as the previous `updatedAt` 😆 