### PR TITLE
No issue: Fix intermittent LAN test

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/lan/__tests__/apiv1/PatientLocations.test.js
@@ -27,7 +27,6 @@ describe('PatientLocations', () => {
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
     patient = await models.Patient.create(await createDummyPatient(models));
-    const locationTest = await models.Location.count({ where: { maxOccupancy: 1 } });
     locations = await models.Location.bulkCreate([
       generateFakeLocation(models.Location),
       generateFakeLocation(models.Location),
@@ -35,8 +34,6 @@ describe('PatientLocations', () => {
       generateFakeLocation(models.Location, { maxOccupancy: null }),
     ]);
     maxOneOccupancyLocations = locations.filter(location => location.maxOccupancy === 1);
-    console.log('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@');
-    console.log(locationTest, maxOneOccupancyLocations.length);
   });
   beforeEach(async () => {
     await models.Encounter.truncate({

--- a/packages/lan/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/lan/__tests__/apiv1/PatientLocations.test.js
@@ -27,6 +27,7 @@ describe('PatientLocations', () => {
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
     patient = await models.Patient.create(await createDummyPatient(models));
+    const locationTest = await models.Location.count({ where: { maxOccupancy: 1 } });
     locations = await models.Location.bulkCreate([
       generateFakeLocation(models.Location),
       generateFakeLocation(models.Location),
@@ -34,6 +35,8 @@ describe('PatientLocations', () => {
       generateFakeLocation(models.Location, { maxOccupancy: null }),
     ]);
     maxOneOccupancyLocations = locations.filter(location => location.maxOccupancy === 1);
+    console.log('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@');
+    console.log(locationTest, maxOneOccupancyLocations.length);
   });
   beforeEach(async () => {
     await models.Encounter.truncate({

--- a/packages/lan/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/lan/__tests__/apiv1/PatientLocations.test.js
@@ -26,6 +26,9 @@ describe('PatientLocations', () => {
     baseApp = ctx.baseApp;
     models = ctx.models;
     app = await baseApp.asRole('practitioner');
+    await models.Location.truncate({
+      cascade: true,
+    });
     patient = await models.Patient.create(await createDummyPatient(models));
     locations = await models.Location.bulkCreate([
       generateFakeLocation(models.Location),

--- a/packages/lan/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/lan/__tests__/apiv1/PatientLocations.test.js
@@ -109,7 +109,8 @@ describe('PatientLocations', () => {
     );
 
     const patient2 = await models.Patient.create(await createDummyPatient(models));
-    const outpatientEncounter = await models.Encounter.create({
+    // Outpatient encounter
+    await models.Encounter.create({
       ...(await createDummyEncounter(models)),
       patientId: patient2.id,
       encounterType: 'clinic',
@@ -139,7 +140,8 @@ describe('PatientLocations', () => {
     await encounter.update({
       endDate: new Date(),
     });
-    const outpatientEncounter = await models.Encounter.create({
+    // Outpatient encounter
+    await models.Encounter.create({
       ...(await createDummyEncounter(models)),
       patientId: patient.id,
       encounterType: 'admission',
@@ -160,7 +162,8 @@ describe('PatientLocations', () => {
     twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
 
     const patient2 = await models.Patient.create(await createDummyPatient(models));
-    const twoDayEncounter = await models.Encounter.create({
+    // Two day encounter
+    await models.Encounter.create({
       ...(await createDummyEncounter(models)),
       patientId: patient2.id,
       locationId: maxOneOccupancyLocations[1].id,
@@ -177,7 +180,8 @@ describe('PatientLocations', () => {
     fourDaysAgo.setDate(fourDaysAgo.getDate() - 4);
 
     const patient3 = await models.Patient.create(await createDummyPatient(models));
-    const fourDayEncounter = await models.Encounter.create({
+    // Four day encounter
+    await models.Encounter.create({
       ...(await createDummyEncounter(models)),
       patientId: patient3.id,
       locationId: maxOneOccupancyLocations[2].id,
@@ -192,8 +196,6 @@ describe('PatientLocations', () => {
   });
 
   it('should return correct bed management table values', async () => {
-    let data, count;
-
     const oneEncounterBedManagementResponse = await app.get('/v1/patient/locations/bedManagement');
     expect(oneEncounterBedManagementResponse).toHaveSucceeded();
     expect(oneEncounterBedManagementResponse.body.count).toEqual(locations.length);
@@ -218,7 +220,8 @@ describe('PatientLocations', () => {
 
     const threeDaysAgo = new Date();
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-    const olderEncounter = await models.Encounter.create({
+    // Older encounter
+    await models.Encounter.create({
       ...(await createDummyEncounter(models)),
       patientId: patient.id,
       encounterType: 'admission',
@@ -246,7 +249,8 @@ describe('PatientLocations', () => {
     });
 
     const patient2 = await models.Patient.create(await createDummyPatient(models));
-    const sameLocationOpenEncounter = await models.Encounter.create({
+    // Same location open encounter
+    await models.Encounter.create({
       ...(await createDummyEncounter(models)),
       patientId: patient2.id,
       encounterType: 'admission',


### PR DESCRIPTION
### Changes

~~It seems this test doesn't fail locally (what?).~~ Doesn't fail as much! So I'll be pushing some debug logs here for CI.

Finally got it to error locally somehow, this was the log:
```
$ NODE_ENV=test jest patientlocations
  console.log
    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

      at Object.log (__tests__/apiv1/PatientLocations.test.js:38:13)
          at runMicrotasks (<anonymous>)

  console.log
    8 3

      at Object.log (__tests__/apiv1/PatientLocations.test.js:39:13)
          at runMicrotasks (<anonymous>)
```

As I suspected, there are more locations than we expect, so that just means we didn't clean properly.

I assume the reason it happens is that we probably create some locations randomly on the test setup, if these end up with a `maxOccupancy` of 1 by chance, then these tests get screwed up!

Scratch that, we always seed locations with that max occupancy, the thing is that they might grab the config facility ID, so that's the issue