### PR TITLE
TAN-2220: syncAllLabRequests shouldn't resync encounters that are already synced

### DIFF
--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -225,6 +225,7 @@ export class Encounter extends Model {
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
           WHERE e.updated_at_sync_tick > :since
           OR lr.updated_at_sync_tick > :since
+          AND encounters.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway
           GROUP BY e.id
         ) AS encounters_with_labs ON encounters_with_labs.id = encounters.id
       `);
@@ -257,6 +258,7 @@ export class Encounter extends Model {
             OR
               av.updated_at_sync_tick > :since
             )
+          AND encounters.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway
           GROUP BY e.id
         ) AS encounters_with_scheduled_vaccines
         ON encounters_with_scheduled_vaccines.id = encounters.id

--- a/packages/shared-src/src/models/Encounter.js
+++ b/packages/shared-src/src/models/Encounter.js
@@ -225,7 +225,11 @@ export class Encounter extends Model {
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
           WHERE e.updated_at_sync_tick > :since
           OR lr.updated_at_sync_tick > :since
-          AND encounters.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway
+          ${
+            patientIds.length > 0
+              ? 'AND e.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway'
+              : ''
+          }
           GROUP BY e.id
         ) AS encounters_with_labs ON encounters_with_labs.id = encounters.id
       `);
@@ -258,7 +262,11 @@ export class Encounter extends Model {
             OR
               av.updated_at_sync_tick > :since
             )
-          AND encounters.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway
+          ${
+            patientIds.length > 0
+              ? 'AND e.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway'
+              : ''
+          }
           GROUP BY e.id
         ) AS encounters_with_scheduled_vaccines
         ON encounters_with_scheduled_vaccines.id = encounters.id

--- a/packages/sync-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/sync-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -352,14 +352,22 @@ describe('snapshotOutgoingChanges', () => {
       } = models;
       const firstTock = await LocalSystemFact.increment('currentSyncTick', 2);
       const user = await User.create(fake(User));
-      const patient = await Patient.create(fake(Patient));
+      const patient1 = await Patient.create(fake(Patient));
+      const patient2 = await Patient.create(fake(Patient));
       const facility = await Facility.create(fake(Facility));
       const location = await Location.create({ ...fake(Location), facilityId: facility.id });
       const department = await Department.create({ ...fake(Department), facilityId: facility.id });
-      const encounter = await Encounter.create({
+      const encounter1 = await Encounter.create({
         ...fake(Encounter),
         examinerId: user.id,
-        patientId: patient.id,
+        patientId: patient1.id,
+        locationId: location.id,
+        departmentId: department.id,
+      });
+      const encounter2 = await Encounter.create({
+        ...fake(Encounter),
+        examinerId: user.id,
+        patientId: patient2.id,
         locationId: location.id,
         departmentId: department.id,
       });
@@ -369,20 +377,31 @@ describe('snapshotOutgoingChanges', () => {
         ...fake(ReferenceData),
         type: 'labTestCategory',
       });
-      const labRequest = await LabRequest.create({
+      const labRequest1 = await LabRequest.create({
         ...fake(LabRequest),
         requestedById: user.id,
-        encounterId: encounter.id,
+        encounterId: encounter1.id,
+        labTestCategoryId: labTestCategory.id,
+      });
+      const labRequest2 = await LabRequest.create({
+        ...fake(LabRequest),
+        requestedById: user.id,
+        encounterId: encounter2.id,
         labTestCategoryId: labTestCategory.id,
       });
       const labTestType = await LabTestType.create({
         ...fake(LabTestType),
         labTestCategoryId: labTestCategory.id,
       });
-      const labTest = await LabTest.create({
+      const labTest1 = await LabTest.create({
         ...fake(LabTest),
         labTestTypeId: labTestType.id,
-        labRequestId: labRequest.id,
+        labRequestId: labRequest1.id,
+      });
+      const labTest2 = await LabTest.create({
+        ...fake(LabTest),
+        labTestTypeId: labTestType.id,
+        labRequestId: labRequest2.id,
       });
 
       const startTime = new Date();
@@ -392,17 +411,39 @@ describe('snapshotOutgoingChanges', () => {
       });
       await createSnapshotTable(ctx.store.sequelize, syncSession.id);
 
-      return { encounter, labTest, labRequest, firstTock, secondTock, syncSession };
+      return {
+        encounter1,
+        encounter2,
+        labTest1,
+        labTest2,
+        labRequest1,
+        labRequest2,
+        patient1,
+        patient2,
+        firstTock,
+        secondTock,
+        syncSession,
+      };
     };
 
     it('includes a lab request for a patient not marked for sync, with its associated test and encounter, if turned on', async () => {
       const { Encounter, LabRequest, LabTest } = models;
-      const { encounter, labTest, labRequest, firstTock, syncSession } = await setupTestData();
+      const {
+        encounter1,
+        encounter2,
+        labTest1,
+        labTest2,
+        labRequest1,
+        labRequest2,
+        patient2,
+        firstTock,
+        syncSession,
+      } = await setupTestData();
 
       await snapshotOutgoingChanges(
         { Encounter, LabRequest, LabTest },
         firstTock - 1,
-        [],
+        [patient2.id],
         syncSession.id,
         fakeUUID(),
         { ...simplestSessionConfig, syncAllLabRequests: true },
@@ -414,18 +455,34 @@ describe('snapshotOutgoingChanges', () => {
         SYNC_SESSION_DIRECTION.OUTGOING,
       );
       expect(outgoingSnapshotRecords.map(r => r.recordId).sort()).toEqual(
-        [labTest.id, labRequest.id, encounter.id].sort(),
+        [
+          labTest1.id,
+          labTest2.id,
+          labRequest1.id,
+          labRequest2.id,
+          encounter1.id,
+          encounter2.id,
+        ].sort(),
       );
     });
 
-    it('includes encounters for new lab requests even if the encounter is older than the sync "since" time', async () => {
+    it('includes encounters for patients not marked for sync even if the encounter is older than the sync "since" time', async () => {
       const { Encounter, LabRequest, LabTest } = models;
-      const { encounter, labTest, labRequest, secondTock, syncSession } = await setupTestData();
+      const {
+        encounter1,
+        labTest1,
+        labTest2,
+        labRequest1,
+        labRequest2,
+        patient2,
+        secondTock,
+        syncSession,
+      } = await setupTestData();
 
       await snapshotOutgoingChanges(
         { Encounter, LabRequest, LabTest },
         secondTock - 1,
-        [],
+        [patient2.id],
         syncSession.id,
         fakeUUID(),
         { ...simplestSessionConfig, syncAllLabRequests: true },
@@ -437,7 +494,15 @@ describe('snapshotOutgoingChanges', () => {
         SYNC_SESSION_DIRECTION.OUTGOING,
       );
       expect(outgoingSnapshotRecords.map(r => r.recordId).sort()).toEqual(
-        [labTest.id, labRequest.id, encounter.id].sort(),
+        [
+          labTest1.id,
+          labTest2.id,
+          labRequest1.id,
+          labRequest2.id,
+          // n.b. only expect encounter1 here, as encounter2 is for a marked-for-sync patient,
+          // and older than the sync tick so is not synced here
+          encounter1.id,
+        ].sort(),
       );
     });
 


### PR DESCRIPTION
### Changes

Currently, the `buildSyncFilter` for `Encounter` will sync an encounter attached to a lab request every time the lab request changes, even if that encounter is already in sync locally. 

This is causing a really bad bug in Aspen's environment, when the following happens:
- Create a lab request on encounter x to record some result back from the lab
- Sync kicks in, snapshotting that lab request to be pushed to the central server
- Discharge encounter x, recording it locally just after the push has started so it's not pushed yet to the central server
- Push finishes
- Pull starts, and detects there's a new lab request for encounter x on the central server, so pulls down the central server copy of encounter x _with no end_date_
- The encounter no longer appears as discharged on the facility server

While this PR does not account for every case where the encounter might already be in sync on the facility server (e.g. when it has already synced with an earlier lab request), it does fix the issue at hand in Ba Hospital where the encounters being reverted are all for patients that are marked for sync.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
