### PR TITLE
No issue: fix intermittent sync test

### DIFF
--- a/packages/shared-src/src/models/fhir/Job.js
+++ b/packages/shared-src/src/models/fhir/Job.js
@@ -105,9 +105,7 @@ export class FhirJob extends Model {
           },
         );
       } catch (err) {
-        // 40001 is the Postgres error code for serialization failure
-        if (err?.parent?.code !== 40001 || err?.parent?.code !== '40001') throw err;
-        log.debug(`Received a different type of error`, err);
+        log.debug(`Failed to grab job`, err);
 
         // retry, with a bit of jitter to avoid thundering herd
         const delay = Math.floor(Math.random() * 500);


### PR DESCRIPTION
### Changes

Ok so this tests doesn't fail as much in CI but almost consistently fails on my local. I figured the change was caused because although it was grabbing the job, it errored along the way - so instead of throwing an error, if we retry that same job it will succeed.

Given it has 10 attempts and with 1 it was already working most of the time I think this is as close as we'll get to a fix. There's also an argument for removing that throw, and it's because a retry might actually be successful!