### PR TITLE
NASS-787: Fix lab test column sorting

### DIFF
--- a/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
+++ b/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
@@ -60,7 +60,7 @@ const makeRangeStringAccessor = sex => ({ labTestType }) => {
 };
 
 const columns = sex => [
-  { title: 'Test type', key: 'type', accessor: row => row.labTestType.name },
+  { title: 'Test type', key: 'labTestType.name', accessor: row => row.labTestType.name },
   {
     title: 'Result',
     key: 'result',

--- a/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
+++ b/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
@@ -66,7 +66,12 @@ const columns = sex => [
     key: 'result',
     accessor: ({ result }) => (result ? capitaliseFirstLetter(result) : ''),
   },
-  { title: 'Clinical range', key: 'reference', accessor: makeRangeStringAccessor(sex) },
+  {
+    title: 'Clinical range',
+    key: 'reference',
+    accessor: makeRangeStringAccessor(sex),
+    sortable: false,
+  },
   { title: 'Method', key: 'labTestMethod', accessor: getMethod, sortable: false },
   { title: 'Lab officer', key: 'laboratoryOfficer' },
   { title: 'Verification', key: 'verification' },


### PR DESCRIPTION
### Changes

We had a couple of columns on the Lab test table that gave sql errors when attempting to sort by it.
- Test type (updated column to proper sql col name)
- Clinical range (removed as no need to sort)

![image](https://github.com/beyondessential/tamanu/assets/58054247/a9694ccd-7a37-4705-9027-63943be35896)



### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
