### PR TITLE
NASS-583: Patient result tabled style corrections

### DIFF
--- a/packages/desktop/app/views/patients/PatientLabTestsTable.js
+++ b/packages/desktop/app/views/patients/PatientLabTestsTable.js
@@ -5,6 +5,7 @@ import { Table } from '../../components/Table';
 import { RangeValidatedCell, DateHeadCell } from '../../components/FormattedTableCell';
 import { Colors } from '../../constants';
 import { LabTestResultModal } from './LabTestResultModal';
+import { BodyText } from '../../components';
 
 const COLUMNS = {
   1: 150,
@@ -81,6 +82,7 @@ const StyledTable = styled(Table)`
     thead tr th {
       color: ${props => props.theme.palette.text.secondary};
       background: ${Colors.background};
+      white-space: break-spaces;
     }
 
     td {
@@ -140,7 +142,7 @@ export const PatientLabTestsTable = React.memo(
           <CategoryCell>
             {row.testType}
             <br />
-            {row.unit ? `(${row.unit})` : null}
+            <BodyText color="textTertiary">{row.unit ? `(${row.unit})` : null}</BodyText>
           </CategoryCell>
         ),
       },


### PR DESCRIPTION
### Changes
Noticed some style issues with nass-583 in dev

- Head cells where changed to `white-space: nowrap` but design explicitly wrap to save on space in this table
- Made unit text tertiary text

After cleanup:
<img width="883" alt="Screenshot 2023-06-08 at 3 28 00 PM" src="https://github.com/beyondessential/tamanu/assets/38335330/11b6e1c6-e6c0-4a4e-80f5-92e448030bb3">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
