### PR TITLE
SAV-287: Separate vaccination default settings for given elsewhere and not given elsewhere vaccine

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -148,8 +148,12 @@ patientVaccineRoutes.post(
 
     if (!departmentId || !locationId) {
       const vaccinationDefaults =
-        (await models.Setting.get(SETTING_KEYS.VACCINATION_DEFAULTS, config.serverFacilityId)) ||
-        {};
+        (await models.Setting.get(
+          vaccineData.givenElsewhere
+            ? SETTING_KEYS.VACCINATION_GIVEN_ELSEWHERE_DEFAULTS
+            : SETTING_KEYS.VACCINATION_DEFAULTS,
+          config.serverFacilityId,
+        )) || {};
       departmentId = departmentId || vaccinationDefaults.departmentId;
       locationId = locationId || vaccinationDefaults.locationId;
     }

--- a/packages/shared-src/src/constants/settings.js
+++ b/packages/shared-src/src/constants/settings.js
@@ -1,3 +1,4 @@
 export const SETTING_KEYS = {
   VACCINATION_DEFAULTS: 'vaccinations.defaults',
+  VACCINATION_GIVEN_ELSEWHERE_DEFAULTS: 'vaccinations.givenElsewhere.defaults',
 };


### PR DESCRIPTION
### Changes
- Separate location/department populate for given elsewhere and not given elsewhere vaccines

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
