### PR TITLE
EPI-513: Create new database/model for vital logs

### DIFF
--- a/packages/shared-src/src/migrations/1685405020041-addVitalLogTable.js
+++ b/packages/shared-src/src/migrations/1685405020041-addVitalLogTable.js
@@ -39,7 +39,7 @@ export async function up(query) {
       type: DataTypes.TEXT,
       allowNull: true,
     },
-    user_id: {
+    recorded_by_id: {
       type: DataTypes.STRING,
       allowNull: false,
       references: {

--- a/packages/shared-src/src/migrations/1685405020041-addVitalLogTable.js
+++ b/packages/shared-src/src/migrations/1685405020041-addVitalLogTable.js
@@ -1,0 +1,63 @@
+import { DataTypes, Sequelize } from 'sequelize';
+
+export async function up(query) {
+  await query.createTable('vital_logs', {
+    id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('uuid_generate_v4'),
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      defaultValue: Sequelize.NOW,
+      allowNull: false,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      defaultValue: Sequelize.NOW,
+      allowNull: false,
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+
+    date: {
+      type: DataTypes.DATETIMESTRING,
+      allowNull: false,
+    },
+    previous_value: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    new_value: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    reason_for_change: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    user_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id',
+      },
+    },
+    answer_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: 'survey_response_answers',
+        key: 'id',
+      },
+    },
+  });
+}
+
+export async function down(query) {
+  await query.dropTable('vital_logs');
+}

--- a/packages/shared-src/src/models/VitalLog.js
+++ b/packages/shared-src/src/models/VitalLog.js
@@ -1,0 +1,51 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from 'shared/constants';
+
+import { Model } from './Model';
+import { dateTimeType } from './dateTimeTypes';
+import { getCurrentDateTimeString } from '../utils/dateTime';
+
+export class VitalLog extends Model {
+  static init({ primaryKey, ...options }) {
+    super.init(
+      {
+        id: {
+          ...primaryKey,
+          type: DataTypes.UUID,
+        },
+        previousValue: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+        newValue: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+        reasonForChange: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+        date: dateTimeType('date', {
+          allowNull: false,
+          defaultValue: getCurrentDateTimeString,
+        }),
+      },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
+      },
+    );
+  }
+
+  static initRelations(models) {
+    this.belongsTo(models.SurveyResponseAnswer, {
+      foreignKey: 'answerId',
+      as: 'answer',
+    });
+
+    this.belongsTo(models.User, {
+      foreignKey: 'userId',
+      as: 'user',
+    });
+  }
+}

--- a/packages/shared-src/src/models/VitalLog.js
+++ b/packages/shared-src/src/models/VitalLog.js
@@ -44,8 +44,8 @@ export class VitalLog extends Model {
     });
 
     this.belongsTo(models.User, {
-      foreignKey: 'userId',
-      as: 'user',
+      foreignKey: 'recordedById',
+      as: 'recordedBy',
     });
   }
 }

--- a/packages/shared-src/src/models/index.js
+++ b/packages/shared-src/src/models/index.js
@@ -27,6 +27,7 @@ export * from './Triage';
 
 export * from './ReferenceData';
 
+export * from './VitalLog';
 export * from './Vitals';
 export * from './Procedure';
 export * from './EncounterDiagnosis';


### PR DESCRIPTION
### Changes

I think most fields and choices are straightforward, the ones that probably need a bit of clarification are:

- Storing both previous and next values
  - The solution to determine both values based on a chain of records adds quite some complexity.
  - That same solution is not sync proofed since we would have to assume what value they edited.
  - This is a closer representation of what's being registered: a log.

- These can be null
  - Easier to explain, previous value could be non-existent, new value could be trying to nullify something.