### PR TITLE
SAV-279: Make field required

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
@@ -60,7 +60,7 @@ const COLUMNS = [
     title: 'Repeats',
     sortable: false,
     accessor: ({ repeats, onChange }) => (
-      <SelectInput options={REPEAT_OPTIONS} value={repeats} onChange={onChange} />
+      <SelectInput options={REPEAT_OPTIONS} value={repeats} onChange={onChange} required />
     ),
   },
 ];


### PR DESCRIPTION
### Changes

We found another spot where the `required` prop was missing which causes weird behaviour with the new "x" clear field. This is essentially an extension of this [previous PR](https://github.com/beyondessential/tamanu/pull/4188/files) going through and adding required to fields as needed. 

