### PR TITLE
Refuse merge if the merge-paused label is on

### DIFF
--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -3,6 +3,8 @@ name: Check label
 on:
   pull_request:
     types:
+      - opened
+      - reopened
       - labelled
       - unlabelled
 

--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -5,8 +5,8 @@ on:
     types:
       - opened
       - reopened
-      - labelled
-      - unlabelled
+      - labeled
+      - unlabeled
 
 jobs:
   merge-paused:

--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -1,0 +1,18 @@
+name: Check label
+
+on:
+  pull_request:
+    types:
+      - labelled
+      - unlabelled
+
+jobs:
+  merge-paused:
+    name: Merge paused
+    runs-on: ubuntu-latest
+    steps:
+    # fail if the merge paused label is present
+    - if: "contains(github.event.pull_request.labels.*.name, 'merge paused')"
+      run: exit 1
+    # else
+    - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,6 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labelled
-      - unlabelled
   push:
     branches:
       - dev
@@ -188,7 +182,4 @@ jobs:
     steps:
     # fail if ANY dependency has failed or been skipped or cancelled
     - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')"
-      run: exit 1
-    # fail if the merge paused label is present
-    - if: "contains(github.event.pull_request.labels.*.name, 'merge paused')"
       run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labelled
+      - unlabelled
   push:
     branches:
       - dev
@@ -182,4 +188,7 @@ jobs:
     steps:
     # fail if ANY dependency has failed or been skipped or cancelled
     - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')"
+      run: exit 1
+    # fail if the merge paused label is present
+    - if: "contains(github.event.pull_request.labels.*.name, 'merge paused')"
       run: exit 1


### PR DESCRIPTION
### Changes

This adds a status check that fails if the label is on.

If we add this to the required checks it would actively stop those PRs from being merged.
(Incidentally it would make it possible to enable auto merge on merge-paused PRs.)

### Checklist

- [x] Code is finished