### PR TITLE
NASS-784: Remove marked_for_sync column from lab_request_logs

### DIFF
--- a/packages/shared-src/src/migrations/1686527887112-removeMarkedForSyncFromLabRequestLog.js
+++ b/packages/shared-src/src/migrations/1686527887112-removeMarkedForSyncFromLabRequestLog.js
@@ -1,0 +1,13 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.removeColumn('lab_request_logs', 'marked_for_sync');
+}
+
+export async function down(query) {
+  await query.addColumn('lab_request_logs', 'marked_for_sync', {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  });
+}


### PR DESCRIPTION
### Changes

This card is just about cleaning up the `marked_for_sync` column on the `lab_request_logs` table which is no longer in use after the upgrade to the new sync engine

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (look for the draft release [here](https://github.com/beyondessential/tamanu/releases, or create a new one if it doesn't exist following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-draft-release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
