### PR TITLE
EPI-519: Save FHIR resource lastUpdated in local time

### DIFF
--- a/packages/shared-src/src/models/fhir/Resource.js
+++ b/packages/shared-src/src/models/fhir/Resource.js
@@ -1,6 +1,7 @@
 import { snakeCase } from 'lodash';
 import { Sequelize, Utils, DataTypes, QueryTypes } from 'sequelize';
 import * as yup from 'yup';
+import { subMinutes } from 'date-fns';
 
 import {
   SYNC_DIRECTIONS,
@@ -37,6 +38,15 @@ export class FhirResource extends Model {
           type: DataTypes.TIMESTAMP,
           allowNull: false,
           defaultValue: Sequelize.NOW,
+          set(utcDate) {
+            // Sequelize converts TIMESTAMP into UTC, so we convert it back to local time
+            if (!(utcDate instanceof Date)) {
+              return utcDate;
+            }
+            const localOffsetMinutes = new Date().getTimezoneOffset();
+            this.setDataValue('lastUpdated', subMinutes(utcDate, localOffsetMinutes));
+            return this.lastUpdated;
+          },
         },
         ...attributes,
       },


### PR DESCRIPTION
### Changes

In https://github.com/beyondessential/tamanu/pull/4028 we moved the `lastUpdated` timestamp to `TIMESTAMP WITHOUT TIMEZONE`. On the way into the database, these times are converted into UTC (e.g. timezone isn't just dropped, they're moved forwards/backward according to local time). This means when they're read they come out with the wrong time unless the server is in UTC. Our CI/CD and our dev/staging/tester servers are in UTC, but not our prod servers or local dev environments.

I tried a few resolutions for this, but:
- fixing the timezone on the way _out_ of the database felt very hacky and had to be done every place it was read, which could have led to lots of bugs
- I couldn't get a `static parse()` method to work properly with the custom TIMESTAMP datatype

This way, we have to add a setter to any TIMESTAMP field, but we don't have to worry about reading it.

The two major caveats here are:
- Existing `lastUpdated` times will all be wrong and we won't fix them
- New `lastUpdated` times will be moved forwards/backwards

I think this is acceptable because all our prod environments have a timezone greater than zero, so after the fix all our records will move forwards in time and there won't be any messy situations where new records have a `lastUpdated` before old records.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/pulls?q=is%3Apr+is%3Aopen+label%3Arelease), or if the previous PR is merging into master then create a new release candidate PR for the next version following [the Slab doc](https://beyond-essential.slab.com/posts/merging-a-tamanu-ticket-okxp8s4s#h0y52-creating-a-release-candidate-pr))
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
