### PR TITLE
TAV-644: Bring down environment on PR close

### DIFF
--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
+indent_size = 4

--- a/.github/actions/tailscale/action.yml
+++ b/.github/actions/tailscale/action.yml
@@ -1,0 +1,90 @@
+# Copied from https://github.com/tailscale/github-action until a PR lands.
+# Specifically: #71 (oauth keys)
+# Original copyright Tailscale, under BSD license.
+name: 'Connect Tailscale'
+description: 'Connect your GitHub Action workflow to Tailscale'
+branding:
+  icon: 'arrow-right-circle'
+  color: 'gray-dark'
+inputs:
+  authkey:
+    description: 'Your Tailscale authentication key, from the admin panel.'
+    required: false
+    deprecationMessage: 'An OAuth API client https://tailscale.com/s/oauth-clients is recommended instead of an authkey'
+  oauth-client-id:
+    description: 'Your Tailscale OAuth Client ID.'
+    required: false
+  oauth-secret:
+    description: 'Your Tailscale OAuth Client Secret.'
+    required: false
+  tags:
+    description: 'Comma separated list of Tags to be applied to nodes. The OAuth client must have permission to apply these tags.'
+    required: false
+  version:
+    description: 'Tailscale version to use.'
+    required: true
+    default: '1.42.0'
+  args:
+    description: 'Optional additional arguments to `tailscale up`'
+    required: false
+    default: ''
+  hostname:
+    description: 'Fixed hostname to use.'
+    required: false
+    default: ''
+runs:
+    using: 'composite'
+    steps:
+      - name: Check Runner OS
+        if: ${{ runner.os != 'Linux' }}
+        shell: bash
+        run: |
+          echo "::error title=⛔ error hint::Support Linux Only"
+          exit 1
+      - name: Check Auth Info Empty
+        if: ${{ inputs.authkey == '' && (inputs['oauth-secret'] == '' || inputs.tags == '') }}
+        shell: bash
+        run: |
+          echo "::error title=⛔ error hint::OAuth identity empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets and https://tailscale.com/s/oauth-clients"
+          exit 1
+      - name: Download Tailscale
+        shell: bash
+        id: download
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          MINOR=$(echo "$VERSION" | awk -F '.' {'print $2'})
+          if [ $((MINOR % 2)) -eq 0 ]; then
+            URL="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz"
+          else
+            URL="https://pkgs.tailscale.com/unstable/tailscale_${VERSION}_amd64.tgz"
+          fi
+          curl "$URL" -o tailscale.tgz
+          tar -C /tmp -xzf tailscale.tgz
+          rm tailscale.tgz
+          TSPATH=/tmp/tailscale_${VERSION}_amd64
+          sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
+      - name: Start Tailscale Daemon
+        shell: bash
+        run: |
+          sudo -E tailscaled --state=mem: 2>~/tailscaled.log &
+          # And check that tailscaled came up. The CLI will block for a bit waiting
+          # for it. And --json will make it exit with status 0 even if we're logged
+          # out (as we will be). Without --json it returns an error if we're not up.
+          sudo -E tailscale status --json >/dev/null
+      - name: Connect to Tailscale
+        shell: bash
+        env:
+          TAILSCALE_AUTHKEY: ${{ inputs.authkey }}
+          ADDITIONAL_ARGS: ${{ inputs.args }}
+          HOSTNAME: ${{ inputs.hostname }}
+          TS_EXPERIMENT_OAUTH_AUTHKEY: 'true'
+        run: |
+          if [ -z "${HOSTNAME}" ]; then
+            HOSTNAME="github-$(cat /etc/hostname)"
+          fi
+          if [ -n "${{ inputs['oauth-secret'] }}" ]; then
+            TAILSCALE_AUTHKEY="${{ inputs['oauth-secret'] }}?preauthorized=true&ephemeral=true"
+            TAGS_ARG="--advertise-tags=${{ inputs.tags }}"
+          fi
+          sudo -E tailscale up ${TAGS_ARG} --authkey=${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS}

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           work-dir: ops/pulumi/tamanu-internal
           command: destroy
+          remove: true
           stack-name: bes/${{ steps.ref.outputs.result }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -51,6 +51,8 @@ jobs:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           path: ops
+      - name: Remove ops/.git so pulumi doesn't get confused
+        run: rm -rf ops/.git
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -57,6 +57,12 @@ jobs:
         run: npm ci
         working-directory: pulumi
 
+      - name: Connect to Tailscale
+        uses: ./.github/actions/tailscale
+        with:
+          oauth-secret: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
+          tags: tag:infra-gha-deploy
+
       - name: Down!
         uses: pulumi/actions@v3
         with:

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/tailscale
         with:
           oauth-secret: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
-          tags: tag:infra-gha-deploy
+          tags: tag:infra,tag:infra-gha-deploy
 
       - name: Down!
         uses: pulumi/actions@v3

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -1,0 +1,69 @@
+name: CD Down
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+
+concurrency:
+  # only one build or destroy at a time, per PR/branch, but don't cancel existing runs
+  group: cd-${{ github.pull_request.id || github.ref }}
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write # OIDC token for AWS
+
+jobs:
+  down:
+    name: Bring down environment
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Normalise branch/ref name
+        uses: actions/github-script@v6
+        id: ref
+        env:
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
+        with:
+          result-encoding: string
+          script: |
+            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
+              .replace(/[^a-z0-9-]/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, ''));
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::143295493206:role/gha-deploy
+          role-session-name: GithubActionsTamanuDestroy
+
+      - uses: actions/checkout@v3
+        with:
+          repository: beyondessential/ops
+          ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Prepare pulumi
+        run: npm ci
+        working-directory: pulumi
+
+      - name: Down!
+        uses: pulumi/actions@v3
+        with:
+          work-dir: pulumi/tamanu-internal
+          command: destroy
+          stack-name: bes/${{ steps.ref.outputs.result }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-pr: ${{ github.event_name == 'pull_request' }}
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -42,10 +42,15 @@ jobs:
           role-to-assume: arn:aws:iam::143295493206:role/gha-deploy
           role-session-name: GithubActionsTamanuDestroy
 
-      - uses: actions/checkout@v3
+      - name: Checkout this PR
+        uses: actions/checkout@v3
+
+      - name: Checkout ops
+        uses: actions/checkout@v3
         with:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
+          path: ops
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -55,7 +60,7 @@ jobs:
 
       - name: Prepare pulumi
         run: npm ci
-        working-directory: pulumi
+        working-directory: ops/pulumi
 
       - name: Connect to Tailscale
         uses: ./.github/actions/tailscale
@@ -66,7 +71,7 @@ jobs:
       - name: Down!
         uses: pulumi/actions@v3
         with:
-          work-dir: pulumi/tamanu-internal
+          work-dir: ops/pulumi/tamanu-internal
           command: destroy
           stack-name: bes/${{ steps.ref.outputs.result }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -136,6 +136,8 @@ jobs:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           path: ops
+      - name: Remove ops/.git so pulumi doesn't get confused
+        run: rm -rf ops/.git
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -178,9 +178,10 @@ jobs:
           config-map: "{
             tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
             tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true},
-            tamanu-internal:dbHost: {value: '${{ vars.INTERNAL_DB_HOST }}', secret: false},
-            tamanu-internal:dbUser: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: false},
-            tamanu-internal:dbPassword: {value: '${{ env.INTERNAL_DB_PASSWORD }}', secret: true},
+            postgresql:host: {value: '${{ vars.INTERNAL_DB_HOST }}', secret: false},
+            postgresql:username: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: false},
+            postgresql:password: {value: '${{ env.INTERNAL_DB_PASSWORD }}', secret: true},
+            postgresql:superuser: {value: false, secret: false}, # required for RDS
           }"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -142,6 +142,12 @@ jobs:
         run: npm ci
         working-directory: pulumi
 
+      - name: Prepare database connection
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          parse-json-secrets: true
+          secret-ids: "INTERNAL_DB, ${{ vars.INTERNAL_DB_SECRET_ARN }}"
+
       # a constant secret + a variable plain text, hashed, = a new secret!
       # importantly this needs to remain constant for the lifetime of the stack
       - name: Prepare salt
@@ -165,7 +171,10 @@ jobs:
           upsert: true
           config-map: "{
             tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
-            tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true}
+            tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true},
+            tamanu-internal:dbHost: {value: 'tamanu-internal-jumpbox', secret: false},
+            tamanu-internal:dbUser: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: true},
+            tamanu-internal:dbPassword: {value: '${{ env.INTERNAL_DB_PASSWORD }}', secret: true},
           }"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -186,7 +186,7 @@ jobs:
             postgresql:host: {value: '${{ vars.INTERNAL_DB_HOST }}', secret: false},
             postgresql:username: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: false},
             postgresql:password: {value: '${{ env.INTERNAL_DB_PASSWORD }}', secret: true},
-            postgresql:superuser: {value: false, secret: false}, # required for RDS
+            postgresql:superuser: {value: false, secret: false}
           }"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -142,11 +142,17 @@ jobs:
         run: npm ci
         working-directory: pulumi
 
-      - name: Prepare database connection
+      - name: Prepare database credentials
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
           parse-json-secrets: true
           secret-ids: "INTERNAL_DB, ${{ vars.INTERNAL_DB_SECRET_ARN }}"
+
+      - name: Connect to Tailscale
+        uses: ./.github/actions/tailscale
+        with:
+          oauth-secret: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
+          tags: tag:infra-gha-deploy
 
       # a constant secret + a variable plain text, hashed, = a new secret!
       # importantly this needs to remain constant for the lifetime of the stack
@@ -172,7 +178,7 @@ jobs:
           config-map: "{
             tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
             tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true},
-            tamanu-internal:dbHost: {value: 'tamanu-internal-jumpbox', secret: false},
+            tamanu-internal:dbHost: {value: '${{ vars.INTERNAL_DB_HOST }}', secret: false},
             tamanu-internal:dbUser: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: true},
             tamanu-internal:dbPassword: {value: '${{ env.INTERNAL_DB_PASSWORD }}', secret: true},
           }"

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -15,8 +15,8 @@ on:
       - release/*
 
 concurrency:
-  # only one build at a time, per PR/branch, but don't cancel existing builds
-  group: ${{ github.workflow }}-${{ github.pull_request.id || github.ref }}
+  # only one build or destroy at a time, per PR/branch, but don't cancel existing runs
+  group: cd-${{ github.pull_request.id || github.ref }}
 
 permissions:
   contents: read

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -179,7 +179,7 @@ jobs:
             tamanu-internal:imageTag: {value: '${{ needs.build.outputs.tag }}', secret: false},
             tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true},
             tamanu-internal:dbHost: {value: '${{ vars.INTERNAL_DB_HOST }}', secret: false},
-            tamanu-internal:dbUser: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: true},
+            tamanu-internal:dbUser: {value: '${{ env.INTERNAL_DB_USERNAME }}', secret: false},
             tamanu-internal:dbPassword: {value: '${{ env.INTERNAL_DB_PASSWORD }}', secret: true},
           }"
         env:

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -127,10 +127,15 @@ jobs:
           role-to-assume: arn:aws:iam::143295493206:role/gha-deploy
           role-session-name: GithubActionsTamanuDeploy
 
-      - uses: actions/checkout@v3
+      - name: Checkout this PR
+        uses: actions/checkout@v3
+
+      - name: Checkout ops
+        uses: actions/checkout@v3
         with:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
+          path: ops
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -140,7 +145,7 @@ jobs:
 
       - name: Prepare pulumi
         run: npm ci
-        working-directory: pulumi
+        working-directory: ops/pulumi
 
       - name: Prepare database credentials
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
@@ -169,7 +174,7 @@ jobs:
       - name: Up!
         uses: pulumi/actions@v3
         with:
-          work-dir: pulumi/tamanu-internal
+          work-dir: ops/pulumi/tamanu-internal
           command: up
           stack-name: bes/${{ needs.info.outputs.branch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -157,7 +157,7 @@ jobs:
         uses: ./.github/actions/tailscale
         with:
           oauth-secret: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
-          tags: tag:infra-gha-deploy
+          tags: tag:infra,tag:infra-gha-deploy
 
       # a constant secret + a variable plain text, hashed, = a new secret!
       # importantly this needs to remain constant for the lifetime of the stack

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ lints.md
 # Output
 /packages/sync-server/tamanu-reports/
 
+# cd-up and cd-down workflows
+/ops
+
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml


### PR DESCRIPTION
### Changes

Adds a workflow that destroys an ECS env when a PR is closed (or merged).

### Checklist

- [x] Code is finished
  - [x] Can still deploy
  - [x] Can destroy the deploy
  - [ ] ~~Can delete the desktop clients~~ Will do in another PR