### PR TITLE
SAV-291: Created Imaging Request did not show up in Encounter's Imaging request tab, but appear again later

### DIFF
--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -94,13 +94,15 @@ export const ImagingRequestsTable = React.memo(({ encounterId, status = '' }) =>
     [loadEncounter, dispatch, params.patientId, params.category, encounterId],
   );
 
+  const globalImagingRequestsFetchOptions = { ...searchParameters, ...statusFilter };
+
   return (
     <SearchTable
       endpoint={encounterId ? `encounter/${encounterId}/imagingRequests` : 'imagingRequest'}
       columns={encounterId ? encounterColumns : globalColumns}
       noDataMessage="No imaging requests found"
       onRowClick={selectImagingRequest}
-      fetchOptions={{ ...searchParameters, ...statusFilter }}
+      fetchOptions={encounterId ? undefined : globalImagingRequestsFetchOptions}
       elevated={false}
       initialSort={{
         order: 'desc',


### PR DESCRIPTION
### Changes
- Only apply search values from context when the IR table is not for Encounter

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
