### PR TITLE
[NASS-749] Bugfix: clear fields when clicking back

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen3.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen3.js
@@ -1,8 +1,11 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { Field } from '../../components';
 import { Heading3, BodyText } from '../../components/Typography';
-import { SampleDetailsField } from '../../views/labRequest/SampleDetailsField';
+import {
+  SampleDetailsField,
+  SAMPLE_DETAILS_FIELD_PREFIX,
+} from '../../views/labRequest/SampleDetailsField';
 
 const StyledBodyText = styled(BodyText)`
   margin-bottom: 28px;
@@ -11,6 +14,7 @@ const StyledBodyText = styled(BodyText)`
 
 export const LabRequestFormScreen3 = props => {
   const {
+    values,
     values: { requestFormType, labTestPanelId },
     setFieldValue,
     initialSamples,
@@ -18,17 +22,23 @@ export const LabRequestFormScreen3 = props => {
     specimenTypeSuggester,
     labSampleSiteSuggester,
   } = props;
-
-  const handleClearPanel = () => {
-    setFieldValue('labTestPanelId', undefined);
-  };
-
   const setSamples = useCallback(
     sampleDetails => {
       setFieldValue('sampleDetails', sampleDetails);
     },
     [setFieldValue],
   );
+
+  // Reset sample details field when loading step
+  useEffect(() => {
+    for (const key of Object.keys(values)) {
+      if (key.startsWith(SAMPLE_DETAILS_FIELD_PREFIX)) {
+        setFieldValue(key, null);
+      }
+    }
+    // Don't want to have it executing every time value is changed, just when the screen is loaded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div style={{ gridColumn: '1 / -1' }}>
@@ -39,7 +49,6 @@ export const LabRequestFormScreen3 = props => {
       </StyledBodyText>
       <Field
         name="sampleDetails"
-        onClearPanel={handleClearPanel}
         component={SampleDetailsField}
         onSampleChange={setSamples}
         requestFormType={requestFormType}

--- a/packages/desktop/app/views/labRequest/SampleDetailsField.js
+++ b/packages/desktop/app/views/labRequest/SampleDetailsField.js
@@ -53,6 +53,7 @@ const StyledField = styled(Field)`
 
 const HEADERS = ['Category', 'Date & time collected', 'Collected by', 'Specimen type', 'Site'];
 const WITH_PANELS_HEADERS = ['Panel', ...HEADERS];
+export const SAMPLE_DETAILS_FIELD_PREFIX = 'sample-details-field-';
 
 export const SampleDetailsField = ({
   initialSamples,
@@ -121,7 +122,7 @@ export const SampleDetailsField = ({
           </Cell>
           <Cell>
             <StyledField
-              name={`sampleTime-${identifier}`}
+              name={`${SAMPLE_DETAILS_FIELD_PREFIX}sampleTime-${identifier}`}
               component={DateTimeField}
               max={getCurrentDateTimeString()}
               onChange={({ target: { value } }) => {
@@ -135,7 +136,7 @@ export const SampleDetailsField = ({
           </Cell>
           <Cell>
             <StyledField
-              name={`collectedBy-${identifier}`}
+              name={`${SAMPLE_DETAILS_FIELD_PREFIX}collectedBy-${identifier}`}
               disabled={!isSampleCollected}
               component={AutocompleteField}
               suggester={practitionerSuggester}
@@ -147,7 +148,7 @@ export const SampleDetailsField = ({
           </Cell>
           <Cell>
             <StyledField
-              name={`specimenType-${identifier}`}
+              name={`${SAMPLE_DETAILS_FIELD_PREFIX}specimenType-${identifier}`}
               disabled={!isSampleCollected}
               component={AutocompleteField}
               suggester={specimenTypeSuggester}
@@ -159,7 +160,7 @@ export const SampleDetailsField = ({
           </Cell>
           <Cell>
             <StyledField
-              name={`labSampleSiteSuggester-${identifier}`}
+              name={`${SAMPLE_DETAILS_FIELD_PREFIX}labSampleSiteSuggester-${identifier}`}
               disabled={!isSampleCollected}
               component={AutocompleteField}
               suggester={labSampleSiteSuggester}


### PR DESCRIPTION
### Changes

- Clear Sample detail field values when opening the sample details modal.
It's related to the following issues:
https://linear.app/bes/issue/NASS-749#comment-3c8a6a74
and
https://linear.app/bes/issue/NASS-731#comment-a11953fc

### Media
https://github.com/beyondessential/tamanu/assets/17033058/96faeefc-0dc1-4b82-80b9-f144f996dfbb


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
