### PR TITLE
EPI-491: Editable vitals reason for change field

### DIFF
--- a/packages/desktop/app/components/EditVitalCellModal.js
+++ b/packages/desktop/app/components/EditVitalCellModal.js
@@ -38,7 +38,7 @@ export const EditVitalCellModal = ({ cell, onConfirm, onClose }) => {
     onClose();
   }, [onClose]);
   const { getLocalisation } = useLocalisation();
-  const reasonForChangeToVitals = getLocalisation('reasonForChangeToVitals') || [];
+  const vitalEditReasons = getLocalisation('vitalEditReasons') || [];
   const vitalLabel = cell?.vitalLabel;
   const date = formatShortest(cell?.recordedDate);
   const time = formatTime(cell?.recordedDate);
@@ -71,7 +71,7 @@ export const EditVitalCellModal = ({ cell, onConfirm, onClose }) => {
               component={SelectField}
               label="Reason for change to record"
               name="reasonForChange"
-              options={reasonForChangeToVitals}
+              options={vitalEditReasons}
               style={{ gridColumn: '1 / 4' }}
             />
             <FormSeparatorLine />

--- a/packages/desktop/app/components/EditVitalCellModal.js
+++ b/packages/desktop/app/components/EditVitalCellModal.js
@@ -39,6 +39,7 @@ export const EditVitalCellModal = ({ cell, onConfirm, onClose }) => {
   }, [onClose]);
   const { getLocalisation } = useLocalisation();
   const vitalEditReasons = getLocalisation('vitalEditReasons') || [];
+  const mandatoryVitalEditReason = getLocalisation('mandatoryVitalEditReason');
   const vitalLabel = cell?.vitalLabel;
   const date = formatShortest(cell?.recordedDate);
   const time = formatTime(cell?.recordedDate);
@@ -67,7 +68,7 @@ export const EditVitalCellModal = ({ cell, onConfirm, onClose }) => {
               />
             )}
             <Field
-              required
+              required={mandatoryVitalEditReason}
               component={SelectField}
               label="Reason for change to record"
               name="reasonForChange"

--- a/packages/desktop/app/components/EditVitalCellModal.js
+++ b/packages/desktop/app/components/EditVitalCellModal.js
@@ -6,6 +6,7 @@ import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { Modal } from './Modal';
 import { ConfirmCancelRow } from './ButtonRow';
 import { SelectField, Form, Field, TextField } from './Field';
+import { useLocalisation } from '../contexts/Localisation';
 import { FormGrid } from './FormGrid';
 import { FormSeparatorLine } from './FormSeparatorLine';
 import { formatShortest, formatTime } from './DateDisplay';
@@ -36,6 +37,8 @@ export const EditVitalCellModal = ({ cell, onConfirm, onClose }) => {
     setIsDeleted(false);
     onClose();
   }, [onClose]);
+  const { getLocalisation } = useLocalisation();
+  const reasonForChangeToVitals = getLocalisation('reasonForChangeToVitals') || [];
   const vitalLabel = cell?.vitalLabel;
   const date = formatShortest(cell?.recordedDate);
   const time = formatTime(cell?.recordedDate);
@@ -68,7 +71,7 @@ export const EditVitalCellModal = ({ cell, onConfirm, onClose }) => {
               component={SelectField}
               label="Reason for change to record"
               name="reasonForChange"
-              // options={options}
+              options={reasonForChangeToVitals}
               style={{ gridColumn: '1 / 4' }}
             />
             <FormSeparatorLine />

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -443,6 +443,7 @@ const rootLocalisationSchema = yup
         onlyAllowLabPanels: yup.boolean().required(),
         displayProcedureCodesInDischargeSummary: yup.boolean().required(),
         displayIcd10CodesInDischargeSummary: yup.boolean().required(),
+        mandatoryVitalEditReason: yup.boolean().required(),
       })
       .required()
       .noUnknown(),

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -448,6 +448,12 @@ const rootLocalisationSchema = yup
       .noUnknown(),
     printMeasures: printMeasuresSchema,
     disabledReports: yup.array(yup.string().required()).defined(),
+    vitalEditReasons: yup.array(
+      yup.object({
+        value: yup.string().required(),
+        label: yup.string().required(),
+      }),
+    ),
   })
   .required()
   .noUnknown();

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -637,7 +637,8 @@
         "fhirNewZealandEthnicity": false,
         "onlyAllowLabPanels": false,
         "displayProcedureCodesInDischargeSummary": true,
-        "displayIcd10CodesInDischargeSummary": true
+        "displayIcd10CodesInDischargeSummary": true,
+        "mandatoryVitalEditReason": false
       },
       "templates": {
         "letterhead": {

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -789,7 +789,25 @@
       // generated in the sync server. Can be `tamanu` or `icao` or `eudcc`.
       // `tamanu` implies that the signing integrations are not enabled.
       "previewUvciFormat": "tamanu",
-      "disabledReports": []
+      "disabledReports": [],
+      "vitalEditReasons": [
+        {
+          "value": "incorrect-patient",
+          "label": "Incorrent patient"
+        },
+        {
+          "value": "incorrect-value",
+          "label": "Incorrect value recorded"
+        },
+        {
+          "value": "recorded-in-error",
+          "label": "Recorded in error"
+        },
+        {
+          "value": "other",
+          "label": "Other"
+        }
+      ]
     }
   },
   "reportProcess": {


### PR DESCRIPTION
### Changes

This field was already partially drafted, I'm just trying to make diffs smaller/easier to review. I don't think the field needs its own component because it is very small plus very specific.

- Field options are configurable (but have a default).
- Field required is false by default, but should have feature flag to make it required.

Config changes:
- New localisation entry `vitalEditReasons` that should be a list of options (with a default).
- New feature flag entry `mandatoryVitalEditReason` that specifies whether the field is required or not.