### PR TITLE
[NASS-751] Removed sample details option when sample not collected

### DIFF
--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -134,18 +134,13 @@ export const LabRequestView = () => {
   const displayStatus = areLabRequestsReadOnly ? LAB_REQUEST_STATUSES.CANCELLED : labRequest.status;
 
   const ActiveModal = MODALS[modalId] || null;
-  const actions = {
-    [labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
-      ? 'Record sample'
-      : 'Edit']: () => {
-      handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
-    },
-  };
+  const actions = {};
 
-  if (labRequest.status !== LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED) {
-    actions['View details'] = () => {
-      handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS);
-    };
+  if (labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED) {
+      actions['Record sample'] = () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
+    } else {
+     actions['Edit'] = () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
+     actions['View details'] = () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS);
   }
   return (
     <Container>

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -134,7 +134,19 @@ export const LabRequestView = () => {
   const displayStatus = areLabRequestsReadOnly ? LAB_REQUEST_STATUSES.CANCELLED : labRequest.status;
 
   const ActiveModal = MODALS[modalId] || null;
+  const actions = {
+    [labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
+      ? 'Record sample'
+      : 'Edit']: () => {
+      handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
+    },
+  };
 
+  if (labRequest.status !== LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED) {
+    actions['View details'] = () => {
+      handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS);
+    };
+  }
   return (
     <Container>
       <Heading2 gutterBottom>Labs</Heading2>
@@ -190,16 +202,7 @@ export const LabRequestView = () => {
               <DateDisplay date={labRequest.sampleTime} showTime />
             </>
           }
-          actions={{
-            'View details': () => {
-              handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS);
-            },
-            [labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
-              ? 'Record sample'
-              : 'Edit']: () => {
-              handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
-            },
-          }}
+          actions={actions}
         />
         <Tile
           Icon={Business}

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -134,14 +134,14 @@ export const LabRequestView = () => {
   const displayStatus = areLabRequestsReadOnly ? LAB_REQUEST_STATUSES.CANCELLED : labRequest.status;
 
   const ActiveModal = MODALS[modalId] || null;
-  const actions = {};
+  const actions =
+    labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
+      ? { 'Record sample': () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE) }
+      : {
+          Edit: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+          'View Details': () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS),
+        };
 
-  if (labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED) {
-      actions['Record sample'] = () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
-    } else {
-     actions['Edit'] = () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE);
-     actions['View details'] = () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS);
-  }
   return (
     <Container>
       <Heading2 gutterBottom>Labs</Heading2>


### PR DESCRIPTION
### Changes
- Removed view details option when sample not collected

Related to the issue reported https://linear.app/bes/issue/NASS-751#comment-4d92997b
### Media
<img width="890" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/7dab3687-56b8-4285-8596-89f0b36197d5">

<img width="1203" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/3f3a2ffa-b2bb-4109-8f3a-cf39142e7f8c">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
