### PR TITLE
[NASS-645] Fix sample date color

### DIFF
--- a/packages/desktop/app/components/DateDisplay.js
+++ b/packages/desktop/app/components/DateDisplay.js
@@ -135,7 +135,7 @@ export const DateDisplay = React.memo(
     showExplicitDate = false,
     shortYear = false,
     timeOnlyTooltip = false,
-    className = '',
+    color = 'unset',
   }) => {
     const dateObj = parseDate(dateValue);
 
@@ -159,7 +159,7 @@ export const DateDisplay = React.memo(
 
     return (
       <DateTooltip date={dateObj} timeOnlyTooltip={timeOnlyTooltip}>
-        <span className={className}>{parts.join(' ')}</span>
+        <span style={{ color }}>{parts.join(' ')}</span>
       </DateTooltip>
     );
   },

--- a/packages/desktop/app/components/DateDisplay.js
+++ b/packages/desktop/app/components/DateDisplay.js
@@ -135,6 +135,7 @@ export const DateDisplay = React.memo(
     showExplicitDate = false,
     shortYear = false,
     timeOnlyTooltip = false,
+    className = '',
   }) => {
     const dateObj = parseDate(dateValue);
 
@@ -158,7 +159,7 @@ export const DateDisplay = React.memo(
 
     return (
       <DateTooltip date={dateObj} timeOnlyTooltip={timeOnlyTooltip}>
-        <span>{parts.join(' ')}</span>
+        <span className={className}>{parts.join(' ')}</span>
       </DateTooltip>
     );
   },

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -43,10 +43,6 @@ const Rule = styled(Divider)`
   margin: 0 0 20px 0;
 `;
 
-const SampleCollectedDate = styled(DateDisplay)`
-  color: ${props => (!props.date ? Colors.softText : 'unset')};
-`;
-
 const HIDDEN_STATUSES = [
   LAB_REQUEST_STATUSES.DELETED,
   LAB_REQUEST_STATUSES.CANCELLED,
@@ -192,7 +188,11 @@ export const LabRequestView = () => {
           isReadOnly={areLabRequestsReadOnly}
           main={
             <>
-              <SampleCollectedDate date={labRequest.sampleTime} showTime />
+              <DateDisplay
+                color={labRequest.sampleTime ? 'unset' : Colors.softText}
+                date={labRequest.sampleTime}
+                showTime
+              />
             </>
           }
           actions={{

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -33,6 +33,7 @@ import { LabRequestRecordSampleModal } from './components/LabRequestRecordSample
 import { useUrlSearchParams } from '../../utils/useUrlSearchParams';
 import { LabRequestPrintLabelModal } from '../../components/PatientPrinting/modals/LabRequestPrintLabelModal';
 import { LabRequestSampleDetailsModal } from './components/LabRequestSampleDetailsModal';
+import { Colors } from '../../constants';
 
 const Container = styled.div`
   padding: 12px 30px;
@@ -40,6 +41,10 @@ const Container = styled.div`
 
 const Rule = styled(Divider)`
   margin: 0 0 20px 0;
+`;
+
+const SampleCollectedDate = styled(DateDisplay)`
+  color: ${props => (!props.date ? Colors.softText : 'unset')};
 `;
 
 const HIDDEN_STATUSES = [
@@ -187,7 +192,7 @@ export const LabRequestView = () => {
           isReadOnly={areLabRequestsReadOnly}
           main={
             <>
-              <DateDisplay date={labRequest.sampleTime} showTime />
+              <SampleCollectedDate date={labRequest.sampleTime} showTime />
             </>
           }
           actions={{


### PR DESCRIPTION
### Changes

- Fixed color when sample date is empty

Issue: https://linear.app/bes/issue/NASS-645#comment-9301ba3a

### Media
<img width="1243" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/49db87c0-7d89-4bcf-9d00-fceb3da7522b">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
