### PR TITLE
[NASS-750] Added panel to request finalised modal

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -134,7 +134,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
         labRequest.tests.forEach(test => {
           updatedLabRequests.push({
             testType: test.labTestType.name,
-            testCategory: labRequest.category.name,
+            testCategory: labRequest.category?.name,
             requestedByName: labRequest.requestedBy?.displayName,
             requestDate: labRequest.requestedDate,
             completedDate: test.completedDate,

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -415,6 +415,12 @@ async function createPanelLabRequests(models, body, note, user) {
   const response = await Promise.all(
     panels.map(async panel => {
       const panelId = panel.id;
+      const testPanelRequest = await models.LabTestPanelRequest.create({
+        labTestPanelId: panelId,
+        encounterId: labRequestBody.encounterId,
+      });
+      labRequestBody.labTestPanelRequestId = testPanelRequest.id;
+
       const requestSampleDetails = sampleDetails[panelId] || {};
       const labTestTypeIds = panel.labTestTypes?.map(testType => testType.id) || [];
       const labTestCategoryId = panel.categoryId;


### PR DESCRIPTION
### Changes
- Fix to display panel on finalised modal

Issue: https://linear.app/bes/issue/NASS-750#comment-9b2599ce

### Media
<img width="1187" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/54e2f8a5-9cac-4d6d-afcf-441a368f225f">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
