### PR TITLE
TAN-2226: Don't show historical locations in bed management

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/lan/__tests__/apiv1/PatientLocations.test.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { createDummyPatient, createDummyEncounter } from 'shared/demoData/patients';
-import { LOCATION_AVAILABILITY_STATUS } from 'shared/constants';
+import { LOCATION_AVAILABILITY_STATUS, VISIBILITY_STATUSES } from 'shared/constants';
 import { fake } from 'shared/test-helpers/fake';
 import { createTestContext } from '../utilities';
 
@@ -285,6 +285,29 @@ describe('PatientLocations', () => {
       patientFirstName: patient2.firstName,
       patientLastName: patient2.lastName,
       status: LOCATION_AVAILABILITY_STATUS.RESERVED,
+    });
+  });
+
+  it('should hide historical and merged locations', async () => {
+    // Arrange
+    const { Location } = models;
+    const createdLocations = await Location.bulkCreate(
+      Object.values(VISIBILITY_STATUSES).map(visibilityStatus =>
+        fake(Location, { visibilityStatus, facilityId: config.serverFacilityId }),
+      ),
+    );
+    const locationIds = createdLocations.map(l => l.id);
+
+    // Act
+    const response = await app.get('/v1/patient/locations/bedManagement');
+
+    // Assert
+    expect(response).toHaveSucceeded();
+    expect(response.body?.data).toBeInstanceOf(Array);
+    const ourLocations = response.body.data.filter(datum => locationIds.includes(datum.locationId));
+    expect(ourLocations).toHaveLength(1);
+    expect(ourLocations[0]).toMatchObject({
+      locationId: createdLocations.find(l => l.visibilityStatus === VISIBILITY_STATUSES.CURRENT).id,
     });
   });
 });

--- a/packages/lan/app/routes/apiv1/patient/patientLocations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientLocations.js
@@ -3,7 +3,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { QueryTypes } from 'sequelize';
 import { objectToCamelCase } from 'shared/utils';
-import { LOCATION_AVAILABILITY_STATUS } from 'shared/constants';
+import { LOCATION_AVAILABILITY_STATUS, VISIBILITY_STATUSES } from 'shared/constants';
 
 const patientsLocationSelect = (planned, encountersWhereAndClauses) => `
   SELECT
@@ -227,7 +227,7 @@ patientLocations.get(
         FROM locations
         LEFT JOIN location_groups ON locations.location_group_id = location_groups.id
         LEFT JOIN open_encounters ON locations.id = open_encounters.location_id
-        WHERE locations.facility_id = $facilityId
+        WHERE locations.facility_id = $facilityId AND locations.visibility_status = $visibilityStatusCurrent
         GROUP BY locations.id, location_groups.id
       ) locations
       LEFT JOIN (
@@ -309,6 +309,14 @@ patientLocations.get(
       OFFSET $offset
     `;
 
+    const bindParams = {
+      ...(filterParams.status && { status: filterParams.status }),
+      ...(filterParams.area && { area: filterParams.area }),
+      ...(filterParams.location && { location: filterParams.location }),
+      facilityId: config.serverFacilityId,
+      visibilityStatusCurrent: VISIBILITY_STATUSES.CURRENT,
+    };
+
     const data = await req.db.query(
       `
         ${withClauses}
@@ -334,10 +342,7 @@ patientLocations.get(
       {
         type: QueryTypes.SELECT,
         bind: {
-          ...(filterParams.status && { status: filterParams.status }),
-          ...(filterParams.area && { area: filterParams.area }),
-          ...(filterParams.location && { location: filterParams.location }),
-          facilityId: config.serverFacilityId,
+          ...bindParams,
           limit,
           offset,
         },
@@ -354,12 +359,7 @@ patientLocations.get(
       `,
       {
         type: QueryTypes.SELECT,
-        bind: {
-          ...(filterParams.status && { status: filterParams.status }),
-          ...(filterParams.area && { area: filterParams.area }),
-          ...(filterParams.location && { location: filterParams.location }),
-          facilityId: config.serverFacilityId,
-        },
+        bind: bindParams,
       },
     );
 


### PR DESCRIPTION
### Changes

We don't want to show historical locations in bed management. This is going out as hotfix 1.26.2, but because branches and process are all up in the air and we're in the middle of the transition to not merging things back, I'm going to squash it onto main and then cherry-pick it to a release branch.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
