### PR TITLE
EPI-531: Fix http:// instead of https:// in meta-server host

### DIFF
--- a/packages/meta-server/__tests__/index.test.js
+++ b/packages/meta-server/__tests__/index.test.js
@@ -25,4 +25,11 @@ describe('Meta server', () => {
       expect(response.body).toHaveProperty('version');
     });
   });
+
+  it('should always have https:// in the server URLs', async () => {
+    const response = await testApp.get('/servers');
+    response.body.forEach(({ host }) => {
+      expect(host).toMatch(/^https:\/\/.*/);
+    });
+  });
 });

--- a/packages/meta-server/app/servers.js
+++ b/packages/meta-server/app/servers.js
@@ -41,7 +41,7 @@ const servers = [
 
   // test servers
   { name: 'Test (Aspen)', type: 'demo', host: 'https://central-aspen-clone.tamanu.io' },
-  { name: 'Test (Fiji)', type: 'demo', host: 'http://central-clone.tamanu-fiji.org' },
+  { name: 'Test (Fiji)', type: 'demo', host: 'https://central-clone.tamanu-fiji.org' },
   { name: 'Test (Kiribati)', type: 'demo', host: 'https://central-clone.tamanu-kiribati.org' },
   { name: 'Test (Nauru)', type: 'demo', host: 'https://central-clone.tamanu-nauru.org' },
   { name: 'Test (Palau)', type: 'demo', host: 'https://central-clone.tamanu-palau.org' },


### PR DESCRIPTION
### Changes

If you put `http://` instead of `https://` then mobile freaks out about the redirect and won't log in.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
