### PR TITLE
NASS-775: Add location back to inpatient/outpatient listing view columns

### DIFF
--- a/packages/desktop/app/components/LocationCell.js
+++ b/packages/desktop/app/components/LocationCell.js
@@ -3,7 +3,7 @@ import { Typography } from '@material-ui/core';
 import { Colors } from '../constants';
 
 export const LocationCell = ({ locationName, plannedLocationName, style }) => (
-  <div style={{ minWidth: 180, ...style }}>
+  <div style={{ minWidth: 100, ...style }}>
     {locationName}
     {plannedLocationName && (
       <Typography style={{ fontSize: 12, color: Colors.darkText }}>
@@ -17,6 +17,6 @@ export const LocationGroupCell = ({ locationGroupName, plannedLocationGroupName 
   <LocationCell
     locationName={locationGroupName}
     plannedLocationName={plannedLocationGroupName}
-    style={{ minWidth: 150 }}
+    style={{ minWidth: 100 }}
   />
 );

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -48,7 +48,6 @@ const LISTING_COLUMNS = [
 const location = {
   key: 'locationName',
   title: 'Location',
-  minWidth: 100,
   accessor: LocationCell,
 };
 

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { LocationGroupCell } from '../../components/LocationCell';
+import { LocationCell, LocationGroupCell } from '../../components/LocationCell';
 import { usePatientNavigation } from '../../utils/usePatientNavigation';
 import { reloadPatient } from '../../store/patient';
 import {
@@ -45,6 +45,13 @@ const LISTING_COLUMNS = [
   status,
 ];
 
+const location = {
+  key: 'locationName',
+  title: 'Location',
+  minWidth: 100,
+  accessor: LocationCell,
+};
+
 const locationGroup = {
   key: 'locationGroupName',
   title: 'Area',
@@ -52,7 +59,7 @@ const locationGroup = {
 };
 
 const INPATIENT_COLUMNS = [markedForSync, displayId, firstName, lastName, dateOfBirth, sex].concat(
-  [locationGroup, department, clinician].map(column => ({
+  [locationGroup, location, department, clinician].map(column => ({
     ...column,
     sortable: false,
   })),


### PR DESCRIPTION
### Changes

This was mistakenly removed in designs for inpatient table updates and removed in 1.26 by TAN-2164

This restores this view on inpatient
<img width="501" alt="Screenshot 2023-06-26 at 4 55 54 PM" src="https://github.com/beyondessential/tamanu/assets/38335330/1e9f7118-a2cd-4af0-8972-4d162f60fc2f">



### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
