### PR TITLE
TAV-660: Build desktop apps in container

### DIFF
--- a/.github/workflows/branch-info.yml
+++ b/.github/workflows/branch-info.yml
@@ -1,0 +1,31 @@
+name: Branch info
+
+on:
+  workflow_call:
+    outputs:
+      branch:
+        value: ${{ jobs.run.outputs.branch }}
+      actual_ref:
+        value: ${{ github.event.pull_request.head.ref || github.ref }}
+
+jobs:
+  run:
+    name: Branch name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Normalise branch/ref name
+        uses: actions/github-script@v6
+        id: ref
+        env:
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
+        with:
+          result-encoding: string
+          script: |
+            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
+              .toLowerCase()
+              .replace(/[^a-z0-9-]/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, ''));
+    outputs:
+      branch: ${{ steps.ref.outputs.result }}

--- a/.github/workflows/branch-info.yml
+++ b/.github/workflows/branch-info.yml
@@ -7,6 +7,8 @@ on:
         value: ${{ jobs.run.outputs.branch }}
       actual_ref:
         value: ${{ github.event.pull_request.head.ref || github.ref }}
+      version:
+        value: ${{ jobs.version.outputs.version }}
 
 jobs:
   run:
@@ -29,3 +31,19 @@ jobs:
               .replace(/^-|-$/g, ''));
     outputs:
       branch: ${{ steps.ref.outputs.result }}
+
+  version:
+    name: Version
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+      - uses: actions/github-script@v6
+        id: version
+        with:
+          result-encoding: string
+          script: return require('./package.json').version;
+    outputs:
+      version: ${{ steps.version.outputs.result }}

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -31,6 +31,8 @@ jobs:
         id: comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
+        env:
+          JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}?pr=${{ github.event.pull_request.number }}
         with:
           result-encoding: string
           script: |
@@ -60,7 +62,7 @@ jobs:
                 comment_id: existing.fullDatabaseId,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: existing.body.replace(REGEX, '$1 (⏳ rebuilding)\n'),
+                body: existing.body.replace(REGEX, '$1 (⏳ [rebuilding](${process.env.JOB_URL}))\n'),
               });
             }
 

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -64,16 +64,21 @@ jobs:
 
       - name: Install build tooling
         run: |
-          docker exec working sh -c "\
+          docker exec working bash -c "\
             wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
             wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk; \
-            apk add tar glibc-2.35-r1.apk wine wine_gecko wine-mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
+            apk add tar glibc-2.35-r1.apk libc6-compat 7zip squashfs-tools wine wine_gecko wine-mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
+            ln -s /usr/bin/7z{,a}; \
           "
 
-      - name: Package for Linux, MacOS, Windows (NSIS)
+      - name: Package for Linux, Windows (NSIS)
         run: |
-          docker exec -w /app/packages/desktop working \
-            yarn run package-all
+          docker exec \
+            -w /app/packages/desktop \
+            -e USE_SYSTEM_7ZA=true \
+            -e USE_SYSTEM_MKSQUASHFS=true \
+            working \
+              yarn run package-only --x64 --linux --win
 
       - name: Enable AppData install
         run: |
@@ -85,8 +90,11 @@ jobs:
 
       - name: Package for Windows (AppData)
         run: |
-          docker exec -w /app/packages/desktop working \
-            yarn run package-win
+          docker exec \
+            -w /app/packages/desktop \
+            -e USE_SYSTEM_7ZA=true \
+            working \
+              yarn run package-only --win --x64
 
       - name: Stop container
         run: docker kill working

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -32,7 +32,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         env:
-          JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}?pr=${{ github.event.pull_request.number }}
+          JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }}
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -62,7 +62,7 @@ jobs:
                 comment_id: existing.fullDatabaseId,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: existing.body.replace(REGEX, '$1 (⏳ [rebuilding](${process.env.JOB_URL}))\n'),
+                body: existing.body.replace(REGEX, `$1 (⏳ [rebuilding](${process.env.JOB_URL}))\n`),
               });
             }
 

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -136,15 +136,13 @@ jobs:
           rm -rf release
 
       - name: Use release bucket
-        if: true
-        # startsWith(github.ref, 'refs/heads/release/')
+        if: startsWith(github.ref, 'refs/heads/release/')
         run: |
           echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
       - name: Use dev bucket
-        if: false
-        # "!startsWith(github.ref, 'refs/heads/release/')"
+        if: "!startsWith(github.ref, 'refs/heads/release/')"
         run: |
           echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -97,18 +97,18 @@ jobs:
       - name: Use release bucket
         if: startsWith(github.ref, 'refs/heads/release/')
         run: |
-          echo S3_BUCKET=bes-tamanu-release-clients | tee -a $GITHUB_ENV
-          echo S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
+          echo S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }} | tee -a $GITHUB_ENV
+          echo S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }} | tee -a $GITHUB_ENV
 
       - name: Use dev bucket
         if: ! startsWith(github.ref, 'refs/heads/release/')
         run: |
-          echo S3_BUCKET=bes-tamanu-dev-desktop-clients | tee -a $GITHUB_ENV
+          echo S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
           echo S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
 
       - name: Push to S3
         working-directory: ops
-        run: aws s3 sync . s3://${{ env.S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress
+        run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build desktop client
     steps:
       - name: Edit PR comment to show build status
-        id: comment
+        id: existing-comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         env:
@@ -153,14 +153,13 @@ jobs:
         working-directory: ops
         run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
 
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
+      - name: Prepare comment
+        id: comment
         uses: actions/github-script@v6
-        env:
-          EXISTING_COMMENT_ID: ${{ steps.comment.outputs.result }}
         with:
+          result-encoding: string
           script: |
-            const body = [
+            return [
               '### :package: Desktop clients',
               '',
               `- :window: **[Windows (System)](${process.env.S3_URL}/windows-system/)**`,
@@ -171,6 +170,15 @@ jobs:
               `- :penguin: [Linux](${process.env.S3_URL}/linux/)`,
             ].join('\n');
 
+      # TODO: for releases, post comment elsewhere? on draft/release? slack?
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        env:
+          EXISTING_COMMENT_ID: ${{ steps.existing-comment.outputs.result }}
+          COMMENT_BODY: ${{ steps.comment.outputs.result }}
+        with:
+          script: |
             if (process.env.EXISTING_COMMENT_ID) {
               console.log('Updating existing comment', process.env.EXISTING_COMMENT_ID);
               github.rest.issues.updateComment({

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -27,6 +27,43 @@ jobs:
     runs-on: ubuntu-latest
     name: Build desktop client
     steps:
+      - name: Edit PR comment to show build status
+        id: comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const {repository:{pullRequest:{comments}}} = await github.graphql(`query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo){
+                pullRequest(number:$pr) {
+                  comments(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    nodes {
+                      id
+                      body
+                    }
+                  }
+                }
+              }
+            }`, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: context.issue?.number ?? context.pull_request?.number,
+            });
+            const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients'));
+
+            if (existing) {
+              console.log('Updating existing comment', existing.id);
+              github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: existing.body.replace(/(### :package: Desktop clients.*)\n/, `$1 (⏳ rebuilding)\n`)
+              });
+            }
+
+            return existing?.id;
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -113,41 +150,25 @@ jobs:
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
+        env:
+          EXISTING_COMMENT_ID: ${{ steps.comment.outputs.result }}
         with:
           script: |
             const body = [
               '### :package: Desktop clients',
               '',
-              `- :penguin: [Linux](${process.env.S3_URL}/linux/)`,
-              `- :apple: [macOS](${process.env.S3_URL}/mac/)`,
               `- :window: **[Windows (System)](${process.env.S3_URL}/windows-system/)**`,
               `- :window: [Windows (AppData)](${process.env.S3_URL}/windows-appdata/)`,
               `- :window: [Windows (Unelevated)](${process.env.S3_URL}/windows-unelevated/)`,
               `- :window: [Windows (MSI)](${process.env.S3_URL}/windows-msi/)`,
+              `- :apple: [macOS](${process.env.S3_URL}/mac/)`,
+              `- :penguin: [Linux](${process.env.S3_URL}/linux/)`,
             ].join('\n');
 
-            const {repository:{pullRequest:{comments}}} = await github.graphql(`query($owner:String!, $repo:String!, $pr:Int!) {
-              repository(owner:$owner, name:$repo){
-                pullRequest(number:$pr) {
-                  comments(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
-                    nodes {
-                      id
-                      body
-                    }
-                  }
-                }
-              }
-            }`, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pr: context.issue?.number ?? context.pull_request?.number,
-            });
-            const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients'));
-
-            if (existing) {
-              console.log('Updating existing comment', existing.id);
+            if (process.env.EXISTING_COMMENT_ID) {
+              console.log('Updating existing comment', process.env.EXISTING_COMMENT_ID);
               github.rest.issues.updateComment({
-                comment_id: existing.id,
+                comment_id: process.env.EXISTING_COMMENT_ID,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -94,13 +94,59 @@ jobs:
           mv release/unelevated/latest.yml release/unelevated/*.exe* ops/windows-unelevated/
           rm -rf release
 
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: tamanu-desktop
-          path: ops/*
-          retention-days: 14
-
       - name: Push to S3
         working-directory: ops
         run: aws s3 sync . s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const base = 'https://s3.console.aws.amazon.com/s3/buckets/${{ vars.DESKTOP_S3_BUCKET }}?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}';
+            const body = [
+              '### :package: Desktop clients uploaded to S3.',
+              '',
+              `- :linux: [Linux](${base}/linux/)`,
+              `- :apple: [macOS](${base}/mac/)`,
+              `- :windows: **[Windows (System)](${base}/windows-system/)**`,
+              `- :windows: [Windows (AppData)](${base}/windows-appdata/)`,
+              `- :windows: [Windows (Unelevated)](${base}/windows-unelevated/)`,
+              `- :windows: [Windows (MSI)](${base}/windows-msi/)`,
+            ].join('\n');
+
+            const {data:{repository:{pullRequest:{comments}}}} = await github.graphql(`query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo){
+                pullRequest(number:$pr) {
+                  comments(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    nodes {
+                      id
+                      body
+                    }
+                  }
+                }
+              }
+            }`, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: context.issue?.number ?? context.pull_request?.number,
+            });
+            const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients uploaded to S3.'));
+
+            if (existing) {
+              console.log('Updating existing comment', existing.id);
+              github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            } else {
+              console.log('Creating new comment');
+              github.rest.issues.createComment({
+                issue_number: context.issue?.number ?? context.pull_request?.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -97,14 +97,14 @@ jobs:
       - name: Use release bucket
         if: startsWith(github.ref, 'refs/heads/release/')
         run: |
-          echo S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }} | tee -a $GITHUB_ENV
-          echo S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }} | tee -a $GITHUB_ENV
+          echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
+          echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
       - name: Use dev bucket
         if: "!startsWith(github.ref, 'refs/heads/release/')"
         run: |
-          echo S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
-          echo S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
+          echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
+          echo "S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
 
       - name: Push to S3
         working-directory: ops
@@ -116,7 +116,7 @@ jobs:
         with:
           script: |
             const body = [
-              '### :package: Desktop clients uploaded to S3.',
+              '### :package: Desktop clients',
               '',
               `- :penguin: [Linux](${process.env.S3_URL}/linux/)`,
               `- :apple: [macOS](${process.env.S3_URL}/mac/)`,
@@ -142,7 +142,7 @@ jobs:
               repo: context.repo.repo,
               pr: context.issue?.number ?? context.pull_request?.number,
             });
-            const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients uploaded to S3.'));
+            const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients'));
 
             if (existing) {
               console.log('Updating existing comment', existing.id);

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -136,13 +136,15 @@ jobs:
           rm -rf release
 
       - name: Use release bucket
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: true
+        # startsWith(github.ref, 'refs/heads/release/')
         run: |
           echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
       - name: Use dev bucket
-        if: "!startsWith(github.ref, 'refs/heads/release/')"
+        if: false
+        # "!startsWith(github.ref, 'refs/heads/release/')"
         run: |
           echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -185,7 +185,7 @@ jobs:
                 comment_id: process.env.EXISTING_COMMENT_ID,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body
+                body: process.env.COMMENT_BODY,
               });
             } else {
               console.log('Creating new comment');
@@ -193,6 +193,6 @@ jobs:
                 issue_number: context.issue?.number ?? context.pull_request?.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body
+                body: process.env.COMMENT_BODY,
               });
             }

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -50,6 +50,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
           target: build-desktop
           push: false
+          load: true
           tags: working
 
       - name: Make output folders

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -101,7 +101,7 @@ jobs:
           echo S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }} | tee -a $GITHUB_ENV
 
       - name: Use dev bucket
-        if: ! startsWith(github.ref, 'refs/heads/release/')
+        if: "!startsWith(github.ref, 'refs/heads/release/')"
         run: |
           echo S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
           echo S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -66,7 +66,7 @@ jobs:
               });
             }
 
-            return existing?.fullDatabaseId;
+            return existing?.fullDatabaseId ?? '';
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -48,76 +48,40 @@ jobs:
           context: .
           cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
           cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
-          build-args: PACKAGE_PATH=desktop
-          target: build-server
+          target: build-desktop
           push: false
           tags: working
 
       - name: Make output folders
-        run: mkdir -p ops/win-{appdata,msi}
+        run: mkdir -p release/appdata
 
       - name: Start container
         run: |
           docker run -dit --rm --name working \
-            -v $PWD/ops:/app/packages/desktop/release \
+            -v $PWD/release:/project/packages/desktop/release \
             working
 
-      - name: Install build tooling
-        run: |
-          docker exec working bash -c "\
-            wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
-            wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk; \
-            apk add tar glibc-2.35-r1.apk libc6-compat gnu-libiconv \
-              7zip mingw-w64-{crt,gcc} scons squashfs-tools \
-              wine wine_gecko wine-mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
-            ln -s /usr/bin/7z{,a}; \
-            git clone https://github.com/kichik/nsis /tmp/nsis --depth 1; \
-            cd /tmp/nsis; \
-            scons STRIP=0 SKIPSTUBS=all SKIPPLUGINS=all SKIPUTILS=all SKIPMISC=all NSIS_CONFIG_CONST_DATA_PATH=no NSIS_CONFIG_LOG=yes NSIS_MAX_STRLEN=8192 makensis
-            git clone https://github.com/electron-userland/electron-builder-binaries /tmp/electron-builder-binaries --depth 1; \
-            cd /tmp/electron-builder-binaries/nsis; \
-            rm -r linux; \
-            mv /tmp/nsis/build/urelease/makensis linux; \
-          "
-
       - name: Package for Linux, Windows
-        run: |
-          docker exec \
-            -w /app/packages/desktop \
-            -e USE_SYSTEM_7ZA=true \
-            -e USE_SYSTEM_MKSQUASHFS=true \
-            -e ELECTRON_BUILDER_NSIS_DIR=/tmp/electron-builder-binaries/nsis \
-            -e LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
-            working \
-              yarn run package-only --x64 --linux --win
+        run: docker exec working yarn run package-only --x64 --linux --win
 
-      - name: Enable AppData install
-        run: |
-          docker exec -w /app/packages/desktop working \
-            cp packages/desktop/app/package.json{,.orig}
-          docker exec -w /app/packages/desktop working \
-            sh -c 'jq \'build.win.targets = ["nsis"] | build.nsis.perMachine = true | build.directories.output = "release/win-appdata"\' \
-              packages/desktop/app/package.json.orig > packages/desktop/app/package.json'
+      - name: Switch to AppData NSIS-only build
+        run: docker exec working mv /package-appdata.json package.json
 
       - name: Package for Windows (AppData NSIS)
-        run: |
-          docker exec \
-            -w /app/packages/desktop \
-            -e USE_SYSTEM_7ZA=true \
-            -e ELECTRON_BUILDER_NSIS_DIR=/tmp/electron-builder-binaries/nsis \
-            -e LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
-            working \
-              yarn run package-only --win --x64
+        run: docker exec working yarn run package-only --win --x64
 
       - name: Stop container
         run: docker kill working
 
-      - name: Remove unpacked outputs
+      - name: Prepare final outputs
         run: |
-          sudo chown -R $USER:$USER ops
-          mv ops/{win-appdata/,AppData-}Tamanu*.exe
-          mv ops/{win-appdata/,AppData-}latest*.yml
-          rm -rf ops/win-appdata ops/*-unpacked
+          sudo chown -R $USER:$USER release
+          mkdir -p ops/{windown-{appdata,msi,system},linux}
+          mv release/latest-linux.yml release/*.{AppImage,deb} ops/linux/
+          mv release/*.msi ops/windows-msi/
+          mv release/latest.yml release/*.exe* ops/windows-system/
+          mv release/appdata/latest.yml release/appdata/*.exe* ops/windows-appdata/
+          rm -rf release
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v3
@@ -127,5 +91,5 @@ jobs:
           retention-days: 14
 
       - name: Push to S3
-        working-directory: packages/desktop
-        run: aws s3 cp tamanu-*.zip s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress
+        working-directory: ops
+        run: aws s3 sync . s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -1,0 +1,108 @@
+name: CD Client
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+
+concurrency:
+  # only one build or destroy at a time, per PR/branch, but don't cancel existing runs
+  group: cd-${{ github.pull_request.id || github.ref }}
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write # OIDC token for AWS
+
+jobs:
+  info:
+    name: Branch info
+    uses: ./.github/workflows/branch-info.yml
+
+  build:
+    needs: info
+    runs-on: ubuntu-latest
+    name: Build desktop client
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::143295493206:role/gha-desktop-s3
+          role-session-name: GithubActionsTamanuS3
+
+      - uses: actions/checkout@v3
+        with:
+          # in PRs, use the actual PR branch, not the merge branch
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Setup buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
+          cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
+          build-args: PACKAGE_PATH=desktop
+          target: build-server
+          push: false
+          tags: working
+
+      - name: Make output folders
+        run: mkdir -p ops/win-{appdata,msi}
+
+      - name: Start container
+        run: |
+          docker run -dit --rm --name working \
+            -v $PWD/ops:/app/packages/desktop/release \
+            working
+
+      - name: Install build tooling
+        run: |
+          docker exec working sh -c "\
+            wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
+            wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk; \
+            apk add tar glibc-2.35-r1.apk wine wine_gecko wine-mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
+          "
+
+      - name: Package for Linux, MacOS, Windows (NSIS)
+        run: |
+          docker exec -w /app/packages/desktop working \
+            yarn run package-all
+
+      - name: Enable AppData install
+        run: |
+          docker exec -w /app/packages/desktop working \
+            cp packages/desktop/app/package.json{,.orig}
+          docker exec -w /app/packages/desktop working \
+            sh -c 'jq \'build.nsis.perMachine = true | build.directories.output = "release/win-appdata"\' \
+              packages/desktop/app/package.json.orig > packages/desktop/app/package.json'
+
+      - name: Package for Windows (AppData)
+        run: |
+          docker exec -w /app/packages/desktop working \
+            yarn run package-win
+
+      - name: Stop container
+        run: docker kill working
+
+      - name: Remove unpacked outputs
+        run: |
+          sudo chown -R $USER:$USER ops
+          rm -rf ops/**/*-unpacked
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tamanu-desktop
+          path: ops/*
+          retention-days: 14
+
+      - name: Push to S3
+        working-directory: packages/desktop
+        run: aws s3 cp tamanu-*.zip s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -118,12 +118,12 @@ jobs:
             const body = [
               '### :package: Desktop clients uploaded to S3.',
               '',
-              `- :linux: [Linux](${process.env.S3_URL}/linux/)`,
+              `- :penguin: [Linux](${process.env.S3_URL}/linux/)`,
               `- :apple: [macOS](${process.env.S3_URL}/mac/)`,
-              `- :windows: **[Windows (System)](${process.env.S3_URL}/windows-system/)**`,
-              `- :windows: [Windows (AppData)](${process.env.S3_URL}/windows-appdata/)`,
-              `- :windows: [Windows (Unelevated)](${process.env.S3_URL}/windows-unelevated/)`,
-              `- :windows: [Windows (MSI)](${process.env.S3_URL}/windows-msi/)`,
+              `- :window: **[Windows (System)](${process.env.S3_URL}/windows-system/)**`,
+              `- :window: [Windows (AppData)](${process.env.S3_URL}/windows-appdata/)`,
+              `- :window: [Windows (Unelevated)](${process.env.S3_URL}/windows-unelevated/)`,
+              `- :window: [Windows (MSI)](${process.env.S3_URL}/windows-msi/)`,
             ].join('\n');
 
             const {repository:{pullRequest:{comments}}} = await github.graphql(`query($owner:String!, $repo:String!, $pr:Int!) {

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -50,7 +50,9 @@ jobs:
               repo: context.repo.repo,
               pr: context.issue?.number ?? context.pull_request?.number,
             });
-            const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients'));
+
+            const REGEX = /(#.* Desktop clients.*)\n/;
+            const existing = comments.nodes.find(({body}) => REGEX.test(body));
 
             if (existing) {
               console.log('Updating existing comment', existing.fullDatabaseId);
@@ -58,7 +60,7 @@ jobs:
                 comment_id: existing.fullDatabaseId,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: existing.body.replace(/(### :package: Desktop clients.*)\n/, `$1 (⏳ rebuilding)\n`)
+                body: existing.body.replace(REGEX, '$1 (⏳ rebuilding)\n'),
               });
             }
 

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -67,16 +67,27 @@ jobs:
           docker exec working bash -c "\
             wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
             wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk; \
-            apk add tar glibc-2.35-r1.apk libc6-compat 7zip squashfs-tools wine wine_gecko wine-mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
+            apk add tar glibc-2.35-r1.apk libc6-compat gnu-libiconv \
+              7zip mingw-w64-{crt,gcc} scons squashfs-tools \
+              wine wine_gecko wine-mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
             ln -s /usr/bin/7z{,a}; \
+            git clone https://github.com/kichik/nsis /tmp/nsis --depth 1; \
+            cd /tmp/nsis; \
+            scons STRIP=0 SKIPSTUBS=all SKIPPLUGINS=all SKIPUTILS=all SKIPMISC=all NSIS_CONFIG_CONST_DATA_PATH=no NSIS_CONFIG_LOG=yes NSIS_MAX_STRLEN=8192 makensis
+            git clone https://github.com/electron-userland/electron-builder-binaries /tmp/electron-builder-binaries --depth 1; \
+            cd /tmp/electron-builder-binaries/nsis; \
+            rm -r linux; \
+            mv /tmp/nsis/build/urelease/makensis linux; \
           "
 
-      - name: Package for Linux, Windows (NSIS)
+      - name: Package for Linux, Windows
         run: |
           docker exec \
             -w /app/packages/desktop \
             -e USE_SYSTEM_7ZA=true \
             -e USE_SYSTEM_MKSQUASHFS=true \
+            -e ELECTRON_BUILDER_NSIS_DIR=/tmp/electron-builder-binaries/nsis \
+            -e LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
             working \
               yarn run package-only --x64 --linux --win
 
@@ -85,14 +96,16 @@ jobs:
           docker exec -w /app/packages/desktop working \
             cp packages/desktop/app/package.json{,.orig}
           docker exec -w /app/packages/desktop working \
-            sh -c 'jq \'build.nsis.perMachine = true | build.directories.output = "release/win-appdata"\' \
+            sh -c 'jq \'build.win.targets = ["nsis"] | build.nsis.perMachine = true | build.directories.output = "release/win-appdata"\' \
               packages/desktop/app/package.json.orig > packages/desktop/app/package.json'
 
-      - name: Package for Windows (AppData)
+      - name: Package for Windows (AppData NSIS)
         run: |
           docker exec \
             -w /app/packages/desktop \
             -e USE_SYSTEM_7ZA=true \
+            -e ELECTRON_BUILDER_NSIS_DIR=/tmp/electron-builder-binaries/nsis \
+            -e LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
             working \
               yarn run package-only --win --x64
 
@@ -102,7 +115,9 @@ jobs:
       - name: Remove unpacked outputs
         run: |
           sudo chown -R $USER:$USER ops
-          rm -rf ops/**/*-unpacked
+          mv ops/{win-appdata/,AppData-}Tamanu*.exe
+          mv ops/{win-appdata/,AppData-}latest*.yml
+          rm -rf ops/win-appdata ops/*-unpacked
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -53,7 +53,7 @@ jobs:
               pr: context.issue?.number ?? context.pull_request?.number,
             });
 
-            const REGEX = /(#.* Desktop clients.*)\n/;
+            const REGEX = /(^#+ .* Desktop clients.*)\n/;
             const existing = comments.nodes.find(({body}) => REGEX.test(body));
 
             if (existing) {

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -147,7 +147,7 @@ jobs:
         # "!startsWith(github.ref, 'refs/heads/release/')"
         run: |
           echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
-          echo "S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
+          echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
 
       - name: Push to S3
         working-directory: ops
@@ -156,18 +156,22 @@ jobs:
       - name: Prepare comment
         id: comment
         uses: actions/github-script@v6
+        env:
+          VERSION: ${{ needs.info.outputs.version }}
         with:
           result-encoding: string
           script: |
+            const {S3_URL, VERSION} = process.env;
             return [
               '### :package: Desktop clients',
               '',
-              `- :window: **[Windows (System)](${process.env.S3_URL}/windows-system/)**`,
-              `- :window: [Windows (AppData)](${process.env.S3_URL}/windows-appdata/)`,
-              `- :window: [Windows (Unelevated)](${process.env.S3_URL}/windows-unelevated/)`,
-              `- :window: [Windows (MSI)](${process.env.S3_URL}/windows-msi/)`,
-              `- :apple: [macOS](${process.env.S3_URL}/mac/)`,
-              `- :penguin: [Linux](${process.env.S3_URL}/linux/)`,
+              `- :window: **[Windows (System)](${S3_URL}/windows-system/Tamanu+Setup+${VERSION}.exe)**`,
+              `- :window:   [Windows (AppData)](${S3_URL}/windows-appdata/Tamanu+Setup+${VERSION}.exe)`,
+              `- :window:   [Windows (Unelevated)](${S3_URL}/windows-unelevated/Tamanu+Setup+${VERSION}.exe)`,
+              `- :window:   [Windows (MSI)](${S3_URL}/windows-msi/Tamanu+${VERSION}.msi)`,
+              `- :apple:    [macOS (Tar)](${S3_URL}/mac/Tamanu-${VERSION}-mac.tar.xz)`,
+              `- :penguin:  [Linux (AppImage)](${S3_URL}/linux/Tamanu-${VERSION}.AppImage)`,
+              `- :penguin:  [Linux (Deb)](${S3_URL}/linux/Tamanu_${VERSION}_amd64.deb)`,
             ].join('\n');
 
       # TODO: for releases, post comment elsewhere? on draft/release? slack?

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -39,7 +39,7 @@ jobs:
                 pullRequest(number:$pr) {
                   comments(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
                     nodes {
-                      id
+                      fullDatabaseId
                       body
                     }
                   }
@@ -53,16 +53,16 @@ jobs:
             const existing = comments.nodes.find(({body}) => body.includes('### :package: Desktop clients'));
 
             if (existing) {
-              console.log('Updating existing comment', existing.id);
+              console.log('Updating existing comment', existing.fullDatabaseId);
               github.rest.issues.updateComment({
-                comment_id: existing.id,
+                comment_id: existing.fullDatabaseId,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: existing.body.replace(/(### :package: Desktop clients.*)\n/, `$1 (⏳ rebuilding)\n`)
               });
             }
 
-            return existing?.id;
+            return existing?.fullDatabaseId;
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -94,28 +94,39 @@ jobs:
           mv release/unelevated/latest.yml release/unelevated/*.exe* ops/windows-unelevated/
           rm -rf release
 
+      - name: Use release bucket
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          echo S3_BUCKET=bes-tamanu-release-clients | tee -a $GITHUB_ENV
+          echo S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
+
+      - name: Use dev bucket
+        if: ! startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          echo S3_BUCKET=bes-tamanu-dev-desktop-clients | tee -a $GITHUB_ENV
+          echo S3_URL=https://s3.console.aws.amazon.com/s3/buckets/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }} | tee -a $GITHUB_ENV
+
       - name: Push to S3
         working-directory: ops
-        run: aws s3 sync . s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress
+        run: aws s3 sync . s3://${{ env.S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           script: |
-            const base = 'https://s3.console.aws.amazon.com/s3/buckets/${{ vars.DESKTOP_S3_BUCKET }}?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}';
             const body = [
               '### :package: Desktop clients uploaded to S3.',
               '',
-              `- :linux: [Linux](${base}/linux/)`,
-              `- :apple: [macOS](${base}/mac/)`,
-              `- :windows: **[Windows (System)](${base}/windows-system/)**`,
-              `- :windows: [Windows (AppData)](${base}/windows-appdata/)`,
-              `- :windows: [Windows (Unelevated)](${base}/windows-unelevated/)`,
-              `- :windows: [Windows (MSI)](${base}/windows-msi/)`,
+              `- :linux: [Linux](${process.env.S3_URL}/linux/)`,
+              `- :apple: [macOS](${process.env.S3_URL}/mac/)`,
+              `- :windows: **[Windows (System)](${process.env.S3_URL}/windows-system/)**`,
+              `- :windows: [Windows (AppData)](${process.env.S3_URL}/windows-appdata/)`,
+              `- :windows: [Windows (Unelevated)](${process.env.S3_URL}/windows-unelevated/)`,
+              `- :windows: [Windows (MSI)](${process.env.S3_URL}/windows-msi/)`,
             ].join('\n');
 
-            const {data:{repository:{pullRequest:{comments}}}} = await github.graphql(`query($owner:String!, $repo:String!, $pr:Int!) {
+            const {repository:{pullRequest:{comments}}} = await github.graphql(`query($owner:String!, $repo:String!, $pr:Int!) {
               repository(owner:$owner, name:$repo){
                 pullRequest(number:$pr) {
                   comments(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -54,7 +54,7 @@ jobs:
           tags: working
 
       - name: Make output folders
-        run: mkdir -p release/appdata
+        run: mkdir -p release/{appdata,unelevated}
 
       - name: Start container
         run: |
@@ -62,13 +62,21 @@ jobs:
             -v $PWD/release:/project/packages/desktop/release \
             working
 
-      - name: Package for Linux, Windows
-        run: docker exec working yarn run package-only --x64 --linux --win
+      - name: Package for Linux, Mac, Windows
+        run: |
+          docker exec working mv /package-mac.json package.json
+          docker exec working yarn run package-only --x64 --linux --mac --win
 
       - name: Switch to AppData NSIS-only build
         run: docker exec working mv /package-appdata.json package.json
 
       - name: Package for Windows (AppData NSIS)
+        run: docker exec working yarn run package-only --win --x64
+
+      - name: Switch to Unelevated NSIS-only build
+        run: docker exec working mv /package-unelevated.json package.json
+
+      - name: Package for Windows (Unelevated NSIS)
         run: docker exec working yarn run package-only --win --x64
 
       - name: Stop container
@@ -77,11 +85,13 @@ jobs:
       - name: Prepare final outputs
         run: |
           sudo chown -R $USER:$USER release
-          mkdir -p ops/{windown-{appdata,msi,system},linux}
+          mkdir -p ops/{linux,mac,windows-{appdata,msi,system,unelevated}}
           mv release/latest-linux.yml release/*.{AppImage,deb} ops/linux/
+          mv release/*-mac* ops/mac/
           mv release/*.msi ops/windows-msi/
           mv release/latest.yml release/*.exe* ops/windows-system/
           mv release/appdata/latest.yml release/appdata/*.exe* ops/windows-appdata/
+          mv release/unelevated/latest.yml release/unelevated/*.exe* ops/windows-unelevated/
           rm -rf release
 
       - name: Upload as artifact

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -16,25 +16,16 @@ permissions:
   id-token: write # OIDC token for AWS
 
 jobs:
+  info:
+    name: Branch info
+    uses: ./.github/workflows/branch-info.yml
+
   down:
+    needs: info
     name: Bring down environment
     runs-on: ubuntu-latest
 
     steps:
-      - name: Normalise branch/ref name
-        uses: actions/github-script@v6
-        id: ref
-        env:
-          GH_HEAD_REF: ${{ github.head_ref }}
-          GH_REF_NAME: ${{ github.ref_name }}
-        with:
-          result-encoding: string
-          script: |
-            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
-              .replace(/[^a-z0-9-]/g, '-')
-              .replace(/-+/g, '-')
-              .replace(/^-|-$/g, ''));
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -76,7 +67,7 @@ jobs:
           work-dir: ops/pulumi/tamanu-internal
           command: destroy
           remove: true
-          stack-name: bes/${{ steps.ref.outputs.result }}
+          stack-name: bes/${{ needs.info.outputs.branch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
         env:

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -1,4 +1,4 @@
-name: CD
+name: CD Up
 
 on:
   workflow_dispatch:
@@ -27,24 +27,7 @@ jobs:
   info:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'auto-deploy'))
     name: Branch info
-    runs-on: ubuntu-latest
-    steps:
-      - name: Normalise branch/ref name
-        uses: actions/github-script@v6
-        id: ref
-        env:
-          GH_HEAD_REF: ${{ github.head_ref }}
-          GH_REF_NAME: ${{ github.ref_name }}
-        with:
-          result-encoding: string
-          script: |
-            return ((process.env.GH_HEAD_REF || process.env.GH_REF_NAME)
-              .toLowerCase()
-              .replace(/[^a-z0-9-]/g, '-')
-              .replace(/-+/g, '-')
-              .replace(/^-|-$/g, ''));
-    outputs:
-      branch: ${{ steps.ref.outputs.result }}
+    uses: ./.github/workflows/branch-info.yml
 
   build:
     needs: info
@@ -83,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           # in PRs, use the actual PR branch, not the merge branch
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ needs.info.outputs.actual_ref }}
 
       - name: Install QEMU
         if: matrix.platform.arch == 'linux/arm64'
@@ -192,49 +175,3 @@ jobs:
           }"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-
-  client:
-    needs: info
-    runs-on: ubuntu-latest
-    name: Build desktop client
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: ap-southeast-2
-          role-to-assume: arn:aws:iam::143295493206:role/gha-desktop-s3
-          role-session-name: GithubActionsTamanuS3
-
-      - uses: actions/checkout@v3
-        with:
-          # in PRs, use the actual PR branch, not the merge branch
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-
-      - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build container
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          platforms: ${{ matrix.platform.arch }}
-          cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
-          cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
-          build-args: PACKAGE_PATH=desktop
-          target: build-server
-          push: false
-        tags: working
-
-      - name: Package for Linux
-        uses: # TODO
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: tamanu-desktop
-          path: packages/desktop/tamanu-*.zip
-          retention-days: 14
-
-      - name: Push to S3
-        working-directory: packages/desktop
-        run: aws s3 cp tamanu-*.zip s3://${{ vars.DESKTOP_S3_BUCKET }}/${{ needs.info.outputs.branch }} --no-progress

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -82,6 +82,7 @@ jobs:
           cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-${{ matrix.package.name }}
           cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-${{ matrix.package.name }}
           build-args: PACKAGE_PATH=${{ matrix.package.path }}
+          target: server
           push: true
           labels: |
             org.opencontainers.image.vendor=BES

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -195,15 +195,9 @@ jobs:
 
   client:
     needs: info
-    # because wine doesn't install on ubuntu
-    # and yarn doesn't work on windows (io latency)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     name: Build desktop client
     steps:
-      - name: Install wine
-        # see https://github.com/actions/runner-images/issues/743
-        run: brew install wine-stable
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -212,30 +206,27 @@ jobs:
           role-session-name: GithubActionsTamanuS3
 
       - uses: actions/checkout@v3
-
-      - name: Install Node.js
-        uses: actions/setup-node@v3
         with:
-          node-version: 16
-          cache: yarn
+          # in PRs, use the actual PR branch, not the merge branch
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
-      - name: Install Python 3.10 (for node-gyp)
-        uses: actions/setup-python@v4
+      - name: Setup buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build container
+        uses: docker/build-push-action@v4
         with:
-          python-version: '3.10'
+          context: .
+          platforms: ${{ matrix.platform.arch }}
+          cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
+          cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
+          build-args: PACKAGE_PATH=desktop
+          target: build-server
+          push: false
+        tags: working
 
-      - name: Prepare yarn
-        run: yarn && yarn build-shared
-        env:
-          PYTHON: /opt/homebrew/bin/python3.10
-
-      - name: Build desktop client
-        working-directory: packages/desktop
-        run: yarn package-win
-
-      - name: Pack desktop client
-        working-directory: packages/desktop/release
-        run: zip -q -r ../tamanu-$(jq .version ../package.json -r)-${{ github.sha }}.zip .
+      - name: Package for Linux
+        uses: # TODO
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,18 @@ COPY package.json license ./
 FROM base AS build-base
 RUN apk add --no-cache \
     --virtual .build-deps \
-    make \
-    gcc \
-    git \
-    g++ \
-    python3 \
     bash \
-    jq
+    g++ \
+    gcc \
+    gcompat \
+    git \
+    jq \
+    make \
+    python3
 COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh ./
 
 FROM base AS run-base
-RUN apk add --no-cache bash curl jq
+RUN apk add --no-cache bash curl gcompat jq
 # set the runtime options
 COPY scripts/docker-entrypoint.sh /entrypoint
 ENTRYPOINT ["/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,10 @@ ENV NODE_ENV=production
 WORKDIR /project/packages/desktop
 RUN jq '.build.win.target = ["nsis"] | .build.nsis.perMachine = false | .build.directories.output = "release/appdata"' \
     package.json > /package-appdata.json
+RUN jq '.build.win.target = ["nsis"] | .build.nsis.allowElevation = false | .build.directories.output = "release/unelevated"' \
+    package.json > /package-unelevated.json
+RUN jq '.build.mac.target = "tar.xz"' \
+    package.json > /package-mac.json
 
 
 ## Normal final target for servers

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add --no-cache \
     bash \
     g++ \
     gcc \
-    gcompat \
     git \
     jq \
     make \
@@ -23,7 +22,7 @@ RUN apk add --no-cache \
 COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh ./
 
 FROM base AS run-base
-RUN apk add --no-cache bash curl gcompat jq
+RUN apk add --no-cache bash curl jq
 # set the runtime options
 COPY scripts/docker-entrypoint.sh /entrypoint
 ENTRYPOINT ["/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV NODE_ENV=production
 WORKDIR /project/packages/desktop
 RUN jq '.build.win.target = ["nsis"] | .build.nsis.perMachine = false | .build.directories.output = "release/appdata"' \
     package.json > /package-appdata.json
-RUN jq '.build.win.target = ["nsis"] | .build.nsis.allowElevation = false | .build.directories.output = "release/unelevated"' \
+RUN jq '.build.win.target = ["nsis"] | .build.nsis.oneClick = false | .build.nsis.allowElevation = false | .build.directories.output = "release/unelevated"' \
     package.json > /package-unelevated.json
 RUN jq '.build.mac.target = "tar.xz"' \
     package.json > /package-mac.json

--- a/packages/desktop/app/package.json
+++ b/packages/desktop/app/package.json
@@ -8,6 +8,6 @@
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
-  "author": "Beyond Essential Systems Pty. Ltd.",
+  "author": "Beyond Essential Systems Pty. Ltd. <tamanu@bes.au>",
   "license": "SEE LICENSE IN license"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -16,6 +16,7 @@
     "electron-rebuild": "electron-rebuild --parallel --force --types prod,dev,optional --module-dir app",
     "lint": "eslint app",
     "package": "npm run build && electron-builder --publish never",
+    "package-only": "electron-builder --publish never",
     "package-all": "npm run build && electron-builder -mwl --publish never",
     "package-linux": "npm run build && electron-builder --linux --publish never",
     "package-win": "npm run build && electron-builder --win --x64 --publish never",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -82,7 +82,8 @@
       ]
     },
     "nsis": {
-      "perMachine": true
+      "perMachine": true,
+      "runAfterFinish": false
     },
     "msi": {
       "perMachine": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -84,6 +84,10 @@
     "nsis": {
       "perMachine": true
     },
+    "msi": {
+      "perMachine": true,
+      "runAfterFinish": false
+    },
     "linux": {
       "target": [
         "deb",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
-  "author": "Beyond Essential Systems Pty. Ltd.",
+  "author": "Beyond Essential Systems Pty. Ltd. <tamanu@bes.au>",
   "license": "SEE LICENSE IN license",
   "scripts": {
     "build": "concurrently \"npm run build-main\" \"npm run build-renderer\"",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -76,7 +76,8 @@
     },
     "win": {
       "target": [
-        "nsis"
+        "nsis",
+        "msi"
       ]
     },
     "nsis": {

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -24,6 +24,13 @@ yarn config set cache-folder /app/packages/.yarn-cache
 # install dependencies
 yarn install --non-interactive --frozen-lockfile
 
+# this is only used to build desktop packages, not for production server images
+if [[ "$package" == "desktop" ]]; then
+  # install the desktop dependencies
+  NODE_ENV=development yarn workspace desktop install --non-interactive --frozen-lockfile
+  exit
+fi
+
 # if we're building a server package, the shared stage will bring in the builds,
 # so we don't need to build shared here, and in the shared stage we don't build
 # the server packages, hence this neat branching logic here

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -24,13 +24,6 @@ yarn config set cache-folder /app/packages/.yarn-cache
 # install dependencies
 yarn install --non-interactive --frozen-lockfile
 
-# this is only used to build desktop packages, not for production server images
-if [[ "$package" == "desktop" ]]; then
-  # install the desktop dependencies
-  NODE_ENV=development yarn workspace desktop install --non-interactive --frozen-lockfile
-  exit
-fi
-
 # if we're building a server package, the shared stage will bring in the builds,
 # so we don't need to build shared here, and in the shared stage we don't build
 # the server packages, hence this neat branching logic here


### PR DESCRIPTION
### Changes

- Package all variants at once:
  - Linux (AppImage and DEB)
  - Mac (tar only, can't make dmg on Linux)
  - Windows:
    - `system`: normal NSIS-based .exe that installs to Program Files
    - `appdata`: NSIS-based .exe that installs to AppData
    - `msi`: MSI installer (without auto-update)
    - `unelevated`: NSIS-based .exe that installs to Program Files without UAC prompt
- Do all that in a container, so it's easy to run/reproduce in GHA and locally
- GHA Desktop build is now on Linux, so we avoid the macOS tax (10x price!)
- Split the CD workflows, which also lets us build the desktop client all the time, not just for auto-deploys
- Doesn't upload artifacts to Github anymore, as they were getting too large, and leaves them in S3 but fixes the folder structure.
  - Posts a comment on the PR with links when done, and even indicates when there's a build ongoing 
![image](https://github.com/beyondessential/tamanu/assets/155787/44c5db84-aaf1-43cb-bb1c-14f72592d6f4)


Idea for production/release builds is that we'll package everything on release, and then have a separate workflow/script responsible for putting the right files in the right place for a particular deployment. That lets us control precisely when the desktop update is made available during a deployment upgrade, or provide the files before the upgrade even starts in the case of MSI distributions.

That part will be done in another PR because this one is already Quite A Thing.

Also yes Hopefully™ we Soon™ won't even _have_ desktop builds anymore but Until Then We Might As Well Be Comfortable.

### Checklist

- [x] Code is finished
