### PR TITLE
NASS-801: lab request duplicate notes on double submit and date fallback to server time

### DIFF
--- a/packages/desktop/app/forms/LabRequestNoteForm.js
+++ b/packages/desktop/app/forms/LabRequestNoteForm.js
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import NotesIcon from '@material-ui/icons/Notes';
 import { Button, Box } from '@material-ui/core';
 import { NOTE_TYPES } from '@tamanu/shared/constants';
+import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { useApi } from '../api';
 import { Form, Field, TextField, DateDisplay } from '../components';
 
@@ -74,12 +75,13 @@ export const LabRequestNoteForm = React.memo(({ labRequestId, isReadOnly }) => {
     api.get(`labRequest/${labRequestId}/notes`),
   );
 
-  const { mutate: saveNote } = useMutation(
+  const { mutate: saveNote, isLoading: isSavingNote } = useMutation(
     ({ values }) => {
       return api.post(`labRequest/${labRequestId}/notes`, {
         content: values.content?.trim(),
         authorId: api.user.id,
         noteType: NOTE_TYPES.OTHER,
+        date: getCurrentDateTimeString(),
       });
     },
     {
@@ -112,7 +114,7 @@ export const LabRequestNoteForm = React.memo(({ labRequestId, isReadOnly }) => {
               saveNote({ values, formProps });
             }}
             render={({ values }) => {
-              const formSubmitIsDisabled = !values.content?.trim();
+              const formSubmitIsDisabled = !values.content?.trim() || isSavingNote;
               return active ? (
                 <Box display="flex" alignItems="center">
                   <NotesInput label="" name="content" component={TextField} autoFocus />


### PR DESCRIPTION
### Changes
Issues identified in 1.27 regression

- Disable lab request notes save when its submitting mutation
- Generate date on server for notePage and noteItem

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
