### PR TITLE
fix/NASS-752: Update naming of sidebar imaging labels

### DIFF
--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -50,7 +50,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, memoryKey, status
       title: 'Type',
       accessor: getImagingRequestType(imagingTypes),
     },
-    { key: 'requestedDate', title: 'Date & time', accessor: getDate },
+    { key: 'requestedDate', title: 'Requested at time', accessor: getDate },
     { key: 'requestedBy.displayName', title: 'Requested by', accessor: getDisplayName },
     ...(isCompletedTable
       ? [

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -27,11 +27,7 @@ const Spacer = styled.div`
   width: 100%;
 `;
 
-const BASE_ADVANCED_FIELDS = ['allFacilities', 'locationGroupId', 'departmentId'];
-const ACTIVE_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'requestedById'];
-const COMPLETED_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'completedAt'];
-
-export const ImagingRequestsSearchBar = ({ memoryKey, statuses = [] }) => {
+export const ImagingRequestsSearchBar = ({ memoryKey, statuses = [], advancedFields }) => {
   const { getLocalisation } = useLocalisation();
   const imagingTypes = getLocalisation('imagingTypes') || {};
   const imagingPriorities = getLocalisation('imagingPriorities') || [];
@@ -43,7 +39,7 @@ export const ImagingRequestsSearchBar = ({ memoryKey, statuses = [] }) => {
   const { searchParameters, setSearchParameters } = useImagingRequests(memoryKey);
 
   const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
-    isCompletedTable ? COMPLETED_ADVANCED_FIELDS : ACTIVE_ADVANCED_FIELDS,
+    advancedFields,
     searchParameters,
   );
   const statusFilter = statuses ? { status: statuses } : {};

--- a/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/ImagingRequestsSearchBar.js
@@ -27,14 +27,9 @@ const Spacer = styled.div`
   width: 100%;
 `;
 
-const BASE_ADVANCED_FIELDS = ['allFacilities'];
-const COMPLETED_ADVANCED_FIELDS = [
-  ...BASE_ADVANCED_FIELDS,
-  'locationGroupId',
-  'departmentId',
-  'completedAt',
-];
-const ALL_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS];
+const BASE_ADVANCED_FIELDS = ['allFacilities', 'locationGroupId', 'departmentId'];
+const ACTIVE_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'requestedById'];
+const COMPLETED_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'completedAt'];
 
 export const ImagingRequestsSearchBar = ({ memoryKey, statuses = [] }) => {
   const { getLocalisation } = useLocalisation();
@@ -48,7 +43,7 @@ export const ImagingRequestsSearchBar = ({ memoryKey, statuses = [] }) => {
   const { searchParameters, setSearchParameters } = useImagingRequests(memoryKey);
 
   const { showAdvancedFields, setShowAdvancedFields } = useAdvancedFields(
-    isCompletedTable ? COMPLETED_ADVANCED_FIELDS : ALL_ADVANCED_FIELDS,
+    isCompletedTable ? COMPLETED_ADVANCED_FIELDS : ACTIVE_ADVANCED_FIELDS,
     searchParameters,
   );
   const statusFilter = statuses ? { status: statuses } : {};

--- a/packages/desktop/app/routes/ImagingRoutes.js
+++ b/packages/desktop/app/routes/ImagingRoutes.js
@@ -8,9 +8,9 @@ import {
 export const ImagingRoutes = React.memo(({ match }) => (
   <div>
     <Switch>
-      <Route path={`${match.path}/all`} component={ImagingRequestListingView} />
+      <Route path={`${match.path}/active`} component={ImagingRequestListingView} />
       <Route path={`${match.path}/completed`} component={CompletedImagingRequestListingView} />
-      <Redirect to={`${match.path}/all`} />
+      <Redirect to={`${match.path}/active`} />
     </Switch>
   </div>
 ));

--- a/packages/desktop/app/views/ImagingRequestListingView.js
+++ b/packages/desktop/app/views/ImagingRequestListingView.js
@@ -9,14 +9,22 @@ import {
 } from '../components';
 import { ImagingRequestsTable } from '../components/ImagingRequestsTable';
 
-const ImagingRequestListing = ({ tableVersion }) => {
+const BASE_ADVANCED_FIELDS = ['allFacilities', 'locationGroupId', 'departmentId'];
+const ACTIVE_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'requestedById'];
+const COMPLETED_ADVANCED_FIELDS = [...BASE_ADVANCED_FIELDS, 'completedAt'];
+
+const ImagingRequestListing = ({ tableVersion, advancedFields }) => {
   // Since we need to track the state of the search bar and table for each version of the Imaging request table,
   // We assign a memoryKey to each version of the based on the grouping of statuses it is displaying.
   const { memoryKey, statuses } = tableVersion;
   return (
     <ContentPane>
       <SearchTableTitle>Imaging request search</SearchTableTitle>
-      <ImagingRequestsSearchBar memoryKey={memoryKey} statuses={statuses} />
+      <ImagingRequestsSearchBar
+        memoryKey={memoryKey}
+        statuses={statuses}
+        advancedFields={advancedFields}
+      />
       <ImagingRequestsTable memoryKey={memoryKey} statuses={statuses} />
     </ContentPane>
   );
@@ -27,7 +35,10 @@ export const ImagingRequestListingView = () => (
     <TopBar title="Active imaging requests" />
     {/* Here we give the listing an object containing the code for tracking the search state and also an array
     of statuses to be filtered by for each table */}
-    <ImagingRequestListing tableVersion={IMAGING_TABLE_VERSIONS.ACTIVE} />
+    <ImagingRequestListing
+      tableVersion={IMAGING_TABLE_VERSIONS.ACTIVE}
+      advancedFields={ACTIVE_ADVANCED_FIELDS}
+    />
   </PageContainer>
 );
 
@@ -36,6 +47,9 @@ export const CompletedImagingRequestListingView = () => (
     <TopBar title="Completed imaging requests" />
     {/* This is the same situation as above. We decided to seperate out the active and completed components as we were
     running into state problems when switching between contexts for the same component */}
-    <ImagingRequestListing tableVersion={IMAGING_TABLE_VERSIONS.COMPLETED} />
+    <ImagingRequestListing
+      tableVersion={IMAGING_TABLE_VERSIONS.COMPLETED}
+      advancedFields={COMPLETED_ADVANCED_FIELDS}
+    />
   </PageContainer>
 );

--- a/packages/desktop/app/views/ImagingRequestListingView.js
+++ b/packages/desktop/app/views/ImagingRequestListingView.js
@@ -24,7 +24,7 @@ const ImagingRequestListing = ({ tableVersion }) => {
 
 export const ImagingRequestListingView = () => (
   <PageContainer>
-    <TopBar title="Imaging requests" />
+    <TopBar title="Active imaging requests" />
     {/* Here we give the listing an object containing the code for tracking the search state and also an array
     of statuses to be filtered by for each table */}
     <ImagingRequestListing tableVersion={IMAGING_TABLE_VERSIONS.ACTIVE} />


### PR DESCRIPTION
### Changes

A round of small bugfixes from regression testing (mostly just changing the names of some labels and updating some code that was missed initially)
- [x] Change title of active tab to "Active imaging requests"
- [x] Sidebar highlighting
- [x] Remember whether advanced is open or closed
- [x] Date and time wrong name
