### PR TITLE
fix/EPI-489 Make scroll bar to be visible at all time

### DIFF
--- a/packages/desktop/app/components/Appointments/DailySchedule.js
+++ b/packages/desktop/app/components/Appointments/DailySchedule.js
@@ -10,15 +10,15 @@ const Column = ({ header, appointments, onAppointmentUpdated }) => {
   // If header's length is larger than 14 characters, split it into two lines. Width expands if needed.
   const hasSpace = header.includes(' ');
   let width = '100%';
-  let midWidth = null;
+  let minWidth = null;
   if (header.length > 14 && hasSpace) {
     width = `${(header.length * 15) / 2}px`; // shrink width to make text becomes two lines
-    midWidth = '100%'; // expand width if it is smaller than the appointment content below it
+    minWidth = '100%'; // expand width if it is smaller than the appointment content below it
   }
 
   return (
     <>
-      <ColumnHeader className="location" $width={width} $midWidth={midWidth}>
+      <ColumnHeader className="location" $width={width} $minWidth={minWidth}>
         {header}
       </ColumnHeader>
       <ColumnBody className="appointments">
@@ -98,7 +98,7 @@ const ColumnHeader = styled.div`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   width: ${({ $width }) => $width};
-  min-width: ${({ $midWidth }) => $midWidth};
+  min-width: ${({ $minWidth }) => $minWidth};
   border: 1px solid ${Colors.outline};
   border-right: none;
   font-weight: bold;

--- a/packages/desktop/app/components/Appointments/DailySchedule.js
+++ b/packages/desktop/app/components/Appointments/DailySchedule.js
@@ -9,11 +9,16 @@ const Column = ({ header, appointments, onAppointmentUpdated }) => {
   const appointmentsByStartTime = [...appointments].sort((a, b) => a.startTime - b.startTime);
   // If header's length is larger than 14 characters, split it into two lines. Width expands if needed.
   const hasSpace = header.includes(' ');
-  const width = header.length > 14 && hasSpace ? `${(header.length * 15) / 2}px` : '100%';
+  let width = '100%';
+  let midWidth = null;
+  if (header.length > 14 && hasSpace) {
+    width = `${(header.length * 15) / 2}px`; // shrink width to make text becomes two lines
+    midWidth = '100%'; // expand width if it is smaller than the appointment content below it
+  }
 
   return (
     <>
-      <ColumnHeader className="location" $width={width}>
+      <ColumnHeader className="location" $width={width} $midWidth={midWidth}>
         {header}
       </ColumnHeader>
       <ColumnBody className="appointments">
@@ -92,7 +97,8 @@ const ColumnHeader = styled.div`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  width: ${({ $width }) => $width}};
+  width: ${({ $width }) => $width};
+  min-width: ${({ $midWidth }) => $midWidth};
   border: 1px solid ${Colors.outline};
   border-right: none;
   font-weight: bold;


### PR DESCRIPTION
### Changes
Issue: https://linear.app/bes/issue/EPI-489#comment-15eef649
Fix: expand width if it is smaller than the appointment content below it. 
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
