### PR TITLE
Fix the CD Down workflow

### DIFF
--- a/.github/workflows/branch-info.yml
+++ b/.github/workflows/branch-info.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref || 'main' }}
       - uses: actions/github-script@v6
         id: version
         with:

--- a/.github/workflows/branch-info.yml
+++ b/.github/workflows/branch-info.yml
@@ -39,7 +39,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref || 'main' }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      # if the checkout fails, we're most likely on a workflow from a deleted
+      # branch from a merged PR, so checkout main instead. This could yield
+      # wrong version information but the only workflow where this can happen
+      # at writing is "CD Down", which doesn't use version info.
+      - if: failure()
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
       - uses: actions/github-script@v6
         id: version
         with:

--- a/.github/workflows/branch-info.yml
+++ b/.github/workflows/branch-info.yml
@@ -41,19 +41,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
-      # if the checkout fails, we're most likely on a workflow from a deleted
-      # branch from a merged PR, so checkout main instead. This could yield
-      # wrong version information but the only workflow where this can happen
-      # at writing is "CD Down", which doesn't use version info.
-      - if: failure()
-        uses: actions/checkout@v2
-        with:
-          ref: main
-
       - uses: actions/github-script@v6
         id: version
         with:
           result-encoding: string
           script: return require('./package.json').version;
+
+      # if the workflow fails, we're most likely on a workflow from a deleted
+      # branch from a merged PR, so version info is meaningless.
+      - if: failure()
+        id: fallback
+        run: echo "result=" >> $GITHUB_OUTPUT
     outputs:
-      version: ${{ steps.version.outputs.result }}
+      version: ${{ steps.version.outputs.result || steps.fallback.outputs.result }}

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -9,8 +9,8 @@ on:
       - release/*
 
 concurrency:
-  # only one build or destroy at a time, per PR/branch, but don't cancel existing runs
-  group: cd-${{ github.pull_request.id || github.ref }}
+  group: ${{ github.workflow }}-${{ github.pull_request.id || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
### Changes

In a recent PR I made a `branch-info` shared workflow which provides some branch information, such as a normalised name for the CD auto deploys, and version information for the CD client builder.

The normalised branch name is obtained directly from the github information, and the version information is obtained by checking out the branch and reading the package.json.

However, what I failed to notice is that when a PR is merged or closed, its branch gets deleted, and the version part of the workflow fails because it can't check out the branch anymore. Thus, the CD Down workflow fails and auto deploys are no longer deleted when a PR is closed or merged.

~~This PR defaults the version workflow to checkout the `main` branch if it can't checkout the actual branch. This is a bit weird and may result in wrong version info, but only for workflows running on a deleted branch, which at the moment is only CD Down, and CD Down doesn't use the version info.~~

This PR defaults the version to the empty string if it can't checkout the branch.

---

Also brings in a drive-by fix for overzealous concurrency control for building the desktop client. That build should not interfere with the CD Up/Down operations, nor vice versa.

### Checklist

- [x] Code is finished