### PR TITLE
NASS-804: Missing panel request buildSyncFilters

### DIFF
--- a/packages/shared/src/models/LabTestPanelRequest.js
+++ b/packages/shared/src/models/LabTestPanelRequest.js
@@ -1,5 +1,6 @@
 import { SYNC_DIRECTIONS } from '../constants';
 import { Model } from './Model';
+import { buildEncounterLinkedSyncFilter } from './buildEncounterLinkedSyncFilter';
 
 export class LabTestPanelRequest extends Model {
   static init({ primaryKey, ...options }) {
@@ -23,5 +24,12 @@ export class LabTestPanelRequest extends Model {
       foreignKey: 'labTestPanelId',
       as: 'labTestPanel',
     });
+  }
+
+  static buildSyncFilter(patientIds) {
+    if (patientIds.length === 0) {
+      return null;
+    }
+    return buildEncounterLinkedSyncFilter([this.tableName, 'encounters']);
   }
 }


### PR DESCRIPTION
### Changes
Add missing buildSyncFilters to **lab_test_panel_requests** to prevent error on sync when associated encounter is not available.

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
