### PR TITLE
[NASS-723] Disable buttons when no lab request selected

### DIFF
--- a/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
+++ b/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import styled from 'styled-components';
 import { Box } from '@material-ui/core';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
@@ -100,7 +100,7 @@ export const LabRequestSummaryPane = React.memo(
     const { selectedRows, selectableColumn } = useSelectableColumn(labRequests, {
       columnKey: 'selected',
     });
-
+    const noRowSelected = useMemo(() => !selectedRows?.length, [selectedRows]);
     // All the lab requests were made in a batch and have the same details
     const { id, requestedDate, requestedBy, department, priority } = labRequests[0];
 
@@ -133,7 +133,11 @@ export const LabRequestSummaryPane = React.memo(
           />
         </Card>
         <Actions>
-          <OutlinedButton size="small" onClick={() => setIsOpen(MODALS.LABEL_PRINT)}>
+          <OutlinedButton
+            size="small"
+            onClick={() => setIsOpen(MODALS.LABEL_PRINT)}
+            disabled={noRowSelected}
+          >
             Print label
           </OutlinedButton>
           <LabRequestPrintLabelModal
@@ -142,7 +146,7 @@ export const LabRequestSummaryPane = React.memo(
             onClose={() => setIsOpen(false)}
           />
           <OutlinedButton
-            disabled={areNotesLoading}
+            disabled={areNotesLoading || noRowSelected}
             size="small"
             onClick={() => setIsOpen(MODALS.PRINT)}
           >


### PR DESCRIPTION
### Changes

- Disabled "Print Request" and "Print Label" buttons when no row is selected

Fix for this issue:
https://linear.app/bes/issue/NASS-723#comment-5984f113

### Media

https://github.com/beyondessential/tamanu/assets/17033058/c6ab5815-9647-4c9d-8953-d6167986bcce



### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
