### PR TITLE
NASS-642: Fix 2 desktop lab request notes date issues

### DIFF
--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
+import { getCurrentDateString, getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import styled from 'styled-components';
 import { useApi, useSuggester } from '../api';
 import { combineQueries } from '../api/combineQueries';
@@ -46,9 +47,17 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
   });
 
   const handleSubmit = async data => {
-    const response = await api.post(`labRequest`, {
-      ...data,
+    const { notes, ...rest } = data;
+    const response = await api.post('labRequest', {
+      ...rest,
       encounterId: encounter.id,
+      labTest: {
+        date: getCurrentDateString(),
+      },
+      note: {
+        date: getCurrentDateTimeString(),
+        content: notes,
+      },
     });
     setNewLabRequestIds(response.map(request => request.id));
   };

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -86,7 +86,7 @@ export const LabRequestFormScreen2 = props => {
         />
       </div>
       <div style={{ gridColumn: '1 / -1' }}>
-        <Field name="note" label="Notes" component={TextField} multiline rows={3} />
+        <Field name="notes" label="Notes" component={TextField} multiline rows={3} />
       </div>
     </>
   );

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as yup from 'yup';
-import { getCurrentDateString, getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
+import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { LAB_REQUEST_STATUSES, LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
 import { useAuth } from '../../contexts/Auth';
 
@@ -41,8 +41,6 @@ export const LabRequestMultiStepForm = ({
         status: LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
         labTestTypeIds: [],
         notes: '',
-        // LabTest date
-        date: getCurrentDateString(),
         ...editedObject,
       }}
       validationSchema={combinedValidationSchema}

--- a/packages/desktop/app/views/patients/components/LabRequestCancelModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestCancelModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { LAB_REQUEST_STATUSES, NOTE_TYPES } from '@tamanu/shared/constants';
+import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { useApi } from '../../../api';
 import { useLocalisation } from '../../../contexts/Localisation';
 import { CancelModal } from '../../../components/CancelModal';
@@ -30,6 +31,7 @@ export const LabRequestCancelModal = React.memo(({ open, onClose, updateLabReq, 
       content: note,
       authorId: auth.currentUser.id,
       noteType: NOTE_TYPES.OTHER,
+      date: getCurrentDateTimeString(),
     });
 
     await updateLabReq({

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -94,7 +94,7 @@ labRequest.post(
         };
 
         const newLabRequest = await models.LabRequest.createWithTests(labRequestData);
-        if (note.content) {
+        if (note?.content) {
           const notePage = await newLabRequest.createNotePage({
             noteType: NOTE_TYPES.OTHER,
             date: note.date,

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -94,11 +94,12 @@ labRequest.post(
         };
 
         const newLabRequest = await models.LabRequest.createWithTests(labRequestData);
-        if (note) {
+        if (note.content) {
           const notePage = await newLabRequest.createNotePage({
             noteType: NOTE_TYPES.OTHER,
+            date: note.date,
           });
-          await notePage.createNoteItem({ content: note, authorId: user.id });
+          await notePage.createNoteItem({ ...note, authorId: user.id });
         }
         return newLabRequest;
       }),

--- a/packages/shared/src/models/LabRequest.js
+++ b/packages/shared/src/models/LabRequest.js
@@ -77,14 +77,13 @@ export class LabRequest extends Model {
         newLabRequest = await this.create(requestData);
       }
 
-      const { date } = labTest;
       // then create tests
       await Promise.all(
         labTestTypeIds.map(t =>
           LabTest.create({
             labTestTypeId: t,
             labRequestId: newLabRequest.id,
-            date,
+            date: labTest?.date,
           }),
         ),
       );

--- a/packages/shared/src/models/LabRequest.js
+++ b/packages/shared/src/models/LabRequest.js
@@ -64,7 +64,7 @@ export class LabRequest extends Model {
         throw new InvalidOperationError('A request must have at least one test');
       }
       const { LabTest, LabTestPanelRequest } = this.sequelize.models;
-      const { date, labTestPanelId, ...requestData } = data;
+      const { labTest, labTestPanelId, ...requestData } = data;
       let newLabRequest;
 
       if (labTestPanelId) {
@@ -77,6 +77,7 @@ export class LabRequest extends Model {
         newLabRequest = await this.create(requestData);
       }
 
+      const { date } = labTest;
       // then create tests
       await Promise.all(
         labTestTypeIds.map(t =>


### PR DESCRIPTION
### Changes
Fix two areas where lab request dates can be created with incorrect timezone offset

- Note during multistep lab request form
- Note created on cancelling lab request

I changed the way the data is sent from front end to be a bit cleaner and more descriptive
- Change note/notes inconsistency in form
- Don't use form values to silently add the lab test date
- Change the endpoint expected data to be more closely shaped in relation to joined data types

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
