### PR TITLE
NASS-646: use ModalActionRow in lab request edit laboratory and priority

### DIFF
--- a/packages/desktop/app/views/patients/components/LabRequestChangeLabModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestChangeLabModal.js
@@ -6,9 +6,9 @@ import {
   Form,
   Field,
   AutocompleteField,
-  ConfirmCancelRow,
   FormGrid,
   Modal,
+  ModalActionRow,
 } from '../../../components';
 
 const validationSchema = yup.object().shape({
@@ -43,7 +43,7 @@ export const LabRequestChangeLabModal = React.memo(
                 suggester={laboratorySuggester}
                 required
               />
-              <ConfirmCancelRow onConfirm={submitForm} confirmText="Save" onCancel={onClose} />
+              <ModalActionRow confirmText="Confirm" onConfirm={submitForm} onCancel={onClose} />
             </FormGrid>
           )}
         />

--- a/packages/desktop/app/views/patients/components/LabRequestChangePriorityModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestChangePriorityModal.js
@@ -1,13 +1,6 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { useSuggester } from '../../../api';
-import { AutocompleteInput, ConfirmCancelRow, FormGrid, Modal } from '../../../components';
-import { Colors } from '../../../constants';
-
-const StyledConfirmCancelRow = styled(ConfirmCancelRow)`
-  border-top: 1px solid ${Colors.outline};
-  padding-top: 26px;
-`;
+import { AutocompleteInput, FormGrid, Modal, ModalActionRow } from '../../../components';
 
 export const LabRequestChangePriorityModal = React.memo(
   ({ labRequest, updateLabReq, open, onClose }) => {
@@ -33,7 +26,7 @@ export const LabRequestChangePriorityModal = React.memo(
               setPriorityId(value);
             }}
           />
-          <StyledConfirmCancelRow onConfirm={updateLab} confirmText="Confirm" onCancel={onClose} />
+          <ModalActionRow confirmText="Confirm" onConfirm={updateLab} onCancel={onClose} />
         </FormGrid>
       </Modal>
     );


### PR DESCRIPTION
### Changes
ModalActionRow has that divider line requested for these two modals.
Also fix submit button reverting to "Save"

<img width="974" alt="Screenshot 2023-07-04 at 11 24 30 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/44f45547-a9ee-412b-8138-e34093e49d59">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
