### PR TITLE
NASS-583: Remove patient results value rounding and fix required field on status change

### DIFF
--- a/packages/desktop/app/components/FormattedTableCell.js
+++ b/packages/desktop/app/components/FormattedTableCell.js
@@ -33,7 +33,7 @@ function round(float, { rounding } = {}) {
 }
 
 function getTooltip(float, config = {}, visibilityCriteria = {}) {
-  const { unit } = config;
+  const { unit = '' } = config;
   const { normalRange } = visibilityCriteria;
   if (normalRange && float < normalRange.min) {
     return {

--- a/packages/desktop/app/components/FormattedTableCell.js
+++ b/packages/desktop/app/components/FormattedTableCell.js
@@ -83,7 +83,7 @@ export const RangeTooltipCell = React.memo(({ value, config, validationCriteria 
 
 export const RangeValidatedCell = React.memo(({ value, config, validationCriteria, ...props }) => {
   const float = round(parseFloat(value), config);
-  const formattedValue = isNaN(float) ? capitalize(value) : float;
+  const formattedValue = isNaN(float) ? capitalize(value) || '-' : float;
   const { tooltip, severity } = useMemo(() => getTooltip(float, config, validationCriteria), [
     float,
     config,

--- a/packages/desktop/app/components/FormattedTableCell.js
+++ b/packages/desktop/app/components/FormattedTableCell.js
@@ -53,10 +53,12 @@ export const RangeValidatedCell = React.memo(({ value, config, validationCriteri
   let severity = 'info';
   const { rounding = 0, unit = '' } = config || {};
   const { normalRange } = validationCriteria || {};
+  const shouldRound = rounding !== null;
+
   const float = parseFloat(value);
   const formattedValue = isNaN(float)
     ? capitalize(value) || '-'
-    : `${float.toFixed(rounding)}${unit && unit.length <= 2 ? unit : ''}`;
+    : `${shouldRound ? float.toFixed(rounding) : float}${unit && unit.length <= 2 ? unit : ''}`;
 
   if (normalRange) {
     const baseTooltip = `Outside normal range\n`;
@@ -71,7 +73,7 @@ export const RangeValidatedCell = React.memo(({ value, config, validationCriteri
 
   if (!tooltip && unit && unit.length > 2 && !isNaN(float)) {
     // Show full unit in tooltip as its not displayed on table
-    tooltip = `${float.toFixed(rounding)}${unit}`;
+    tooltip = `${shouldRound ? float.toFixed(rounding) : float}${unit}`;
   }
   return tooltip ? (
     <TableTooltip title={tooltip}>

--- a/packages/desktop/app/views/patients/PatientLabTestsTable.js
+++ b/packages/desktop/app/views/patients/PatientLabTestsTable.js
@@ -178,7 +178,7 @@ export const PatientLabTestsTable = React.memo(
                 <StyledButton onClick={() => openModal(cellData.id)}>
                   <RangeValidatedCell
                     value={cellData.result}
-                    config={{ unit: row.unit }}
+                    config={{ unit: row.unit, rounding: null }}
                     validationCriteria={{ normalRange: normalRange?.min ? normalRange : null }}
                   />
                 </StyledButton>

--- a/packages/desktop/app/views/patients/PatientLabTestsTable.js
+++ b/packages/desktop/app/views/patients/PatientLabTestsTable.js
@@ -19,15 +19,16 @@ const StyledTable = styled(Table)`
     position: relative;
     width: initial;
 
-    thead tr th:nth-child(1),
-    tbody tr td:nth-child(1),
-    thead tr th:nth-child(2),
-    tbody tr td:nth-child(2),
-    thead tr th:nth-child(3),
-    tbody tr td:nth-child(3) {
+    thead tr th:nth-child(-n + ${props => props.$stickyColumns}),
+    tbody tr td:nth-child(-n + ${props => props.$stickyColumns}) {
       position: sticky;
       z-index: 1;
       border-right: 1px solid ${Colors.outline};
+    }
+
+    thead tr th:nth-child(${props => props.$stickyColumns}),
+    tbody tr td:nth-child(${props => props.$stickyColumns}) {
+      border-right: 2px solid ${Colors.outline};
     }
 
     thead tr th:nth-child(1),
@@ -46,14 +47,17 @@ const StyledTable = styled(Table)`
       left: ${COLUMNS[1]}px;
     }
 
+    ${props =>
+      props.$stickyColumns === 3 &&
+      `
     thead tr th:nth-child(3),
     tbody tr td:nth-child(3) {
       width: ${COLUMNS[3]}px;
       min-width: ${COLUMNS[3]}px;
       max-width: ${COLUMNS[3]}px;
       left: ${COLUMNS[1] + COLUMNS[2]}px;
-      border-right: 2px solid ${Colors.outline};
     }
+    `}
 
     tfoot {
       inset-inline-end: 0;
@@ -205,6 +209,7 @@ export const PatientLabTestsTable = React.memo(
           count={count}
           allowExport
           exportName="PatientResults"
+          $stickyColumns={searchParameters.categoryId ? 2 : 3}
         />
         <LabTestResultModal
           open={modalOpen}

--- a/packages/desktop/app/views/patients/components/LabRequestChangeStatusModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestChangeStatusModal.js
@@ -22,7 +22,7 @@ const validationSchema = yup.object().shape({
     .required(),
   sampleTime: yup.string().when('status', {
     is: LAB_REQUEST_STATUSES.PUBLISHED,
-    then: yup.string().required(),
+    then: yup.string().required('Sample date & time is required'),
     otherwise: yup.string().nullable(),
   }),
   labSampleSiteId: yup.string(),

--- a/packages/desktop/app/views/patients/components/LabRequestChangeStatusModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestChangeStatusModal.js
@@ -21,7 +21,7 @@ const validationSchema = yup.object().shape({
     .oneOf(Object.values(LAB_REQUEST_STATUSES))
     .required(),
   sampleTime: yup.string().when('status', {
-    is: LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,
+    is: LAB_REQUEST_STATUSES.PUBLISHED,
     then: yup.string().required(),
     otherwise: yup.string().nullable(),
   }),


### PR DESCRIPTION
### Changes
- Due to sharing RangeValidatedCell with vitals table lab result table was rounding the values to default `toFixed(0)`
- The incorrect status was used to determine weither sampleTime was a required field on lab request status update to published. (this caused a related issue of not being able to submit a status change to `Sample not collected`

Result lab test values now showing full result
![Screenshot 2023-07-04 at 4 04 36 PM](https://github.com/beyondessential/tamanu/assets/38335330/287b7be6-7eef-4826-8357-9853d5860942)

Form required field working when changing status to published
![Screenshot 2023-07-04 at 4 10 46 PM](https://github.com/beyondessential/tamanu/assets/38335330/3a5fa6c0-2cf0-438e-9a30-69b0c695b1b4)

Also included in this pr a style regression fix for this issue (see how the sticky columns on left now include the first lab result entry)
![Screenshot 2023-07-04 at 4 05 37 PM](https://github.com/beyondessential/tamanu/assets/38335330/c6452a88-32ad-49bb-941a-d85d46869b64)


### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
