### PR TITLE
Feature/epi 494 Add arrows on custom date selector

### DIFF
--- a/packages/desktop/app/components/Button.js
+++ b/packages/desktop/app/components/Button.js
@@ -181,6 +181,13 @@ export const RefreshIconButton = ({ ...props }) => (
   </IconButton>
 );
 
+export const DefaultIconButton = styled(({ children, ...props }) => (
+  <IconButton {...props}>{children}</IconButton>
+))`
+  border-radius: 20%;
+  padding: 0px;
+`;
+
 const getLocationProps = ({ to }) => {
   if (to) {
     return { component: Link, to };

--- a/packages/desktop/app/components/Charts/components/DateTimeSelector.js
+++ b/packages/desktop/app/components/Charts/components/DateTimeSelector.js
@@ -27,18 +27,18 @@ const options = [
   {
     value: 'Last 24 hours',
     label: 'Last 24 hours',
-    getStartDate: () => addDays(new Date(), -1),
+    getDefaultStartDate: () => addDays(new Date(), -1),
   },
   {
     value: 'Last 48 hours',
     label: 'Last 48 hours',
-    getStartDate: () => addDays(new Date(), -2),
+    getDefaultStartDate: () => addDays(new Date(), -2),
   },
   {
     value: CUSTOM_DATE,
     label: 'Custom Date',
-    getStartDate: () => startOfDay(new Date()),
-    getEndDate: () => startOfDay(addDays(new Date(), 1)),
+    getDefaultStartDate: () => startOfDay(new Date()),
+    getDefaultEndDate: () => startOfDay(addDays(new Date(), 1)),
   },
 ];
 
@@ -60,9 +60,11 @@ export const DateTimeSelector = props => {
   );
 
   useEffect(() => {
-    const { getStartDate, getEndDate } = options.find(option => option.value === value);
-    const newStartDate = getStartDate ? getStartDate() : new Date();
-    const newEndDate = getEndDate ? getEndDate() : new Date();
+    const { getDefaultStartDate, getDefaultEndDate } = options.find(
+      option => option.value === value,
+    );
+    const newStartDate = getDefaultStartDate ? getDefaultStartDate() : new Date();
+    const newEndDate = getDefaultEndDate ? getDefaultEndDate() : new Date();
 
     formatAndSetStartDate(newStartDate);
     formatAndSetEndDate(newEndDate);

--- a/packages/desktop/app/components/Charts/components/DateTimeSelector.js
+++ b/packages/desktop/app/components/Charts/components/DateTimeSelector.js
@@ -27,21 +27,23 @@ const options = [
   {
     value: 'Last 24 hours',
     label: 'Last 24 hours',
-    startDateOffset: -1,
+    getStartDate: () => addDays(new Date(), -1),
   },
   {
     value: 'Last 48 hours',
     label: 'Last 48 hours',
-    startDateOffset: -2,
+    getStartDate: () => addDays(new Date(), -2),
   },
   {
     value: CUSTOM_DATE,
     label: 'Custom Date',
+    getStartDate: () => startOfDay(new Date()),
+    getEndDate: () => startOfDay(addDays(new Date(), 1)),
   },
 ];
 
 export const DateTimeSelector = props => {
-  const { setStartDate, setEndDate } = props;
+  const { startDate: startDateString, setStartDate, setEndDate } = props;
   const [value, setValue] = useState(options[0].value);
 
   const formatAndSetStartDate = useCallback(
@@ -58,11 +60,12 @@ export const DateTimeSelector = props => {
   );
 
   useEffect(() => {
-    const { startDateOffset } = options.find(option => option.value === value);
-    if (startDateOffset) {
-      formatAndSetStartDate(addDays(new Date(), startDateOffset));
-      formatAndSetEndDate(new Date());
-    }
+    const { getStartDate, getEndDate } = options.find(option => option.value === value);
+    const newStartDate = getStartDate ? getStartDate() : new Date();
+    const newEndDate = getEndDate ? getEndDate() : new Date();
+
+    formatAndSetStartDate(newStartDate);
+    formatAndSetEndDate(newEndDate);
   }, [value, formatAndSetStartDate, formatAndSetEndDate]);
 
   return (
@@ -80,6 +83,7 @@ export const DateTimeSelector = props => {
         <DateInput
           size="small"
           saveDateAsString
+          value={format(new Date(startDateString), 'yyyy-MM-dd')} // display date in yyyy-MM-dd format on text input
           onChange={newValue => {
             const { value: dateString } = newValue.target;
             if (dateString) {
@@ -87,6 +91,7 @@ export const DateTimeSelector = props => {
               formatAndSetEndDate(startOfDay(addDays(new Date(dateString), 1)));
             }
           }}
+          arrows
         />
       )}
     </Wrapper>

--- a/packages/desktop/app/components/Charts/components/InwardArrowVectorDot.js
+++ b/packages/desktop/app/components/Charts/components/InwardArrowVectorDot.js
@@ -32,8 +32,8 @@ export const InwardArrowVectorDot = props => {
       x={x}
       y={y}
       width="12"
-      height={startAndEndPointOfBottomInwardArrow + 2}
-      viewBox={`0 0 12 ${startAndEndPointOfBottomInwardArrow + 2}`}
+      height={startAndEndPointOfBottomInwardArrow.y + 2}
+      viewBox={`0 0 12 ${startAndEndPointOfBottomInwardArrow.y + 2}`}
       fill="none"
     >
       <path

--- a/packages/desktop/app/components/Field/DateField.js
+++ b/packages/desktop/app/components/Field/DateField.js
@@ -1,6 +1,9 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
-import { isAfter, isBefore, parse } from 'date-fns';
+import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+import { Box } from '@material-ui/core';
+import { addDays, isAfter, isBefore, parse } from 'date-fns';
 import {
   toDateString,
   toDateTimeString,
@@ -9,6 +12,7 @@ import {
 import PropTypes from 'prop-types';
 import { TextInput } from './TextField';
 import { Colors } from '../../constants';
+import { DefaultIconButton } from '../Button';
 
 // This component is pretty tricky! It has to keep track of two layers of state:
 //
@@ -56,6 +60,7 @@ export const DateInput = ({
   max = '9999-12-31',
   min,
   saveDateAsString = false,
+  arrows = false,
   ...props
 }) => {
   const [currentText, setCurrentText] = useState(fromRFC3339(value, format));
@@ -101,6 +106,13 @@ export const DateInput = ({
     [onChange, format, name, min, max, saveDateAsString, type],
   );
 
+  const onArrowChange = addDaysAmount => {
+    const date = parse(currentText, format, new Date());
+    const newDate = formatDate(addDays(date, addDaysAmount), format);
+
+    onValueChange({ target: { value: newDate } });
+  };
+
   useEffect(() => {
     const formattedValue = fromRFC3339(value, format);
     if (value && formattedValue) {
@@ -113,7 +125,7 @@ export const DateInput = ({
     };
   }, [value, format]);
 
-  return (
+  const defaultDateField = (
     <CustomIconTextInput
       type={type}
       value={currentText}
@@ -126,6 +138,20 @@ export const DateInput = ({
       {...props}
     />
   );
+
+  const ContainerWithArrows = ({ children }) => (
+    <Box display="flex" alignContent="center">
+      <DefaultIconButton onClick={() => onArrowChange(-1)}>
+        <KeyboardArrowLeftIcon />
+      </DefaultIconButton>
+      {children}
+      <DefaultIconButton onClick={() => onArrowChange(1)}>
+        <KeyboardArrowRightIcon />
+      </DefaultIconButton>
+    </Box>
+  );
+
+  return arrows ? <ContainerWithArrows>{defaultDateField}</ContainerWithArrows> : defaultDateField;
 };
 
 export const TimeInput = props => <DateInput type="time" format="HH:mm" {...props} />;

--- a/packages/desktop/app/components/VitalChartsModal.js
+++ b/packages/desktop/app/components/VitalChartsModal.js
@@ -12,6 +12,7 @@ export const VitalChartsModal = React.memo(() => {
     vitalChartModalOpen,
     setVitalChartModalOpen,
     modalTitle,
+    startDate,
     setStartDate,
     setEndDate,
     isInMultiChartsView,
@@ -29,7 +30,7 @@ export const VitalChartsModal = React.memo(() => {
         setVitalChartModalOpen(false);
       }}
     >
-      <DateTimeSelector setStartDate={setStartDate} setEndDate={setEndDate} />
+      <DateTimeSelector startDate={startDate} setStartDate={setStartDate} setEndDate={setEndDate} />
       <ViewComponent />
     </Modal>
   );

--- a/packages/desktop/app/views/charts/MultiVitalChartsView.js
+++ b/packages/desktop/app/views/charts/MultiVitalChartsView.js
@@ -30,7 +30,7 @@ export const MultiVitalChartsView = () => {
         const visualisationConfig = visualisationConfigs.find(config => config.key === chartKey);
 
         return (
-          <>
+          <div key={chartKey}>
             <Divider />
             <TitleContainer>
               <span>{visualisationConfigs.find(config => config.key === chartKey)?.name}</span>
@@ -42,7 +42,7 @@ export const MultiVitalChartsView = () => {
               visualisationConfig={visualisationConfig}
               isInMultiChartsView
             />
-          </>
+          </div>
         );
       })}
     </>

--- a/packages/desktop/stories/forms/fields.stories.js
+++ b/packages/desktop/stories/forms/fields.stories.js
@@ -183,6 +183,12 @@ addStories('DateInput', props => (
   />
 ));
 
+addStories('DateInput', props => (
+  <StoryControlWrapper Component={DateInput} label="Date of birth" {...props} />
+)).add('With arrows', props => (
+  <StoryControlWrapper Component={DateInput} value="2019-10-04T08:30:56.200Z" arrows {...props} />
+));
+
 addStories('DateTimeInput', props => (
   <StoryControlWrapper Component={DateTimeInput} label="Sample taken" {...props} />
 )).add('With prefilled date', props => (


### PR DESCRIPTION
### Changes
I hope this description helps to understand the code, so default behaviour of date time selector in chart view:
Last 24 hours: 
- startDate: current date time - 24 hours
- endDate: current date time

Last 48 hours: 
- startDate: current date time - 48 hours
- endDate: current date time


Custom date: 
- default startDate: start time of current date  
- default endDate:  end time of current date  
- selected endDate: 
- - startDate: start time of selected date  
- - endDate:  end time of selected date

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
