### PR TITLE
No issue: Fix incorrect labs endpoint unit test

### DIFF
--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -32,6 +32,9 @@ describe('Labs', () => {
     app = await baseApp.asRole('practitioner');
   });
   afterAll(() => ctx.close());
+  beforeEach(async () => {
+    await models.LabRequest.truncate({ cascade: true, force: true });
+  });
 
   it('should record a lab request', async () => {
     const labRequest = await randomLabRequest(models, {
@@ -286,7 +289,7 @@ describe('Labs', () => {
       });
     };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       // Because of the high number of lab requests
       // the endpoint pagination doesn't return the expected results.
       await models.LabRequest.truncate({ cascade: true, force: true });


### PR DESCRIPTION
### Changes

I don't know what is up with the test, the logic is pretty convoluted but it's obviously wrong, it was just giving a false positive because of the previous test. It was already failing intermittently anyway, here is proof https://github.com/beyondessential/tamanu/actions/runs/5460856602/jobs/9938231225

Test doesn't always break, try locally a couple of times and it should!