### PR TITLE
[no-issue] Fix intermittent test fail when having the same category for both tests

### DIFF
--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -96,6 +96,37 @@ describe('Labs', () => {
     }
   });
 
+  it('it should create one record only when the category is the same', async () => {
+    const categories = await models.ReferenceData.findAll({
+      where: {
+        type: 'labTestCategory',
+      },
+    });
+    const category1 = categories[0].id;
+    const labRequest = await randomLabRequest(models, {
+      patientId,
+      categoryId: category1,
+    });
+    const labRequest2 = await randomLabRequest(models, {
+      patientId,
+      categoryId: category1,
+    });
+    const labTestTypeIds = [...labRequest.labTestTypeIds, ...labRequest2.labTestTypeIds];
+    const response = await app.post('/v1/labRequest').send({
+      ...labRequest,
+      labTestTypeIds,
+    });
+    expect(response).toHaveSucceeded();
+    expect(response.body.length).toEqual(1);
+    const createdRequest = await models.LabRequest.findByPk(response.body[0].id);
+    expect(createdRequest).toBeTruthy();
+    expect(createdRequest.status).toEqual(LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED);
+    const createdTests = await models.LabTest.findAll({
+      where: { labRequestId: createdRequest.id },
+    });
+    expect(createdTests).toHaveLength(labTestTypeIds.length);
+  });
+
   it('should record a lab request with a note', async () => {
     const data = await randomLabRequest(models, {
       patientId,

--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -60,11 +60,20 @@ describe('Labs', () => {
   });
 
   it('should record two lab requests with one test type each', async () => {
+    const categories = await models.ReferenceData.findAll({
+      where: {
+        type: 'labTestCategory',
+      },
+    });
+    const category1 = categories[0].id;
+    const category2 = categories[1].id;
     const labRequest = await randomLabRequest(models, {
       patientId,
+      categoryId: category1,
     });
     const labRequest2 = await randomLabRequest(models, {
       patientId,
+      categoryId: category2,
     });
 
     const response = await app.post('/v1/labRequest').send({
@@ -98,12 +107,12 @@ describe('Labs', () => {
       note: {
         date: chance.date(),
         content,
-      }
+      },
     });
     expect(response).toHaveSucceeded();
 
     const labRequest = await models.LabRequest.findByPk(response.body[0].id, {
-      include: 'notePages'
+      include: 'notePages',
     });
     expect(labRequest).toBeTruthy();
 

--- a/packages/shared/src/demoData/labRequests.js
+++ b/packages/shared/src/demoData/labRequests.js
@@ -2,7 +2,7 @@ import { randomReferenceId } from './patients';
 import { fake } from '../test-helpers/fake';
 
 export const randomLabRequest = async (models, overrides) => {
-  const categoryId = await randomReferenceId(models, 'labTestCategory');
+  const categoryId = overrides?.categoryId || (await randomReferenceId(models, 'labTestCategory'));
   const labTestTypes = await createLabTestTypes(models, categoryId);
 
   return {


### PR DESCRIPTION

### Changes

- Fixed intermittent fail when having both tests attached to the same categoryId
- Now we are sending a fixed categoryId in order to avoid this issue 

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
