### PR TITLE
NASS-666: Fix all mismatched corner exit button modal props

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -51,7 +51,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
       width="md"
       printable
       keepMounted
-      disableHeaderCloseIcon
+      cornerExitButton={false}
       onPrint={() => printPDF('vaccine-certificate')}
       additionalActions={<EmailButton onEmail={createVaccineCertificateNotification} />}
     >

--- a/packages/desktop/app/views/patients/LabTestResultModal.js
+++ b/packages/desktop/app/views/patients/LabTestResultModal.js
@@ -57,7 +57,7 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
       }
       open={open}
       onClose={onClose}
-      disableHeaderCloseIcon
+      cornerExitButton={false}
     >
       <ModalBody>
         <div>

--- a/packages/desktop/app/views/patients/components/LabRequestSampleDetailsModal.js
+++ b/packages/desktop/app/views/patients/components/LabRequestSampleDetailsModal.js
@@ -5,7 +5,7 @@ import { LabRequestSampleDetailsCard } from './LabRequestSampleDetailsCard';
 
 export const LabRequestSampleDetailsModal = ({ open, onClose, labRequest }) => {
   return (
-    <Modal open={open} onClose={onClose} title="Sample details" disableHeaderCloseIcon>
+    <Modal open={open} onClose={onClose} title="Sample details" cornerExitButton={false}>
       <LabRequestSampleDetailsCard labRequest={labRequest} />
       <Box display="flex" justifyContent="flex-end" pt={3}>
         <Button onClick={onClose}>Close</Button>

--- a/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
+++ b/packages/desktop/app/views/patients/components/PatientImmunisationsModal.js
@@ -7,7 +7,7 @@ export const PatientImmunisationsModal = React.memo(({ open, patient, onClose, .
     title={`${patient.firstName} ${patient.lastName} | Immunisation history`}
     open={open}
     onClose={onClose}
-    disableHeaderCloseIcon
+    cornerExitButton={false}
     {...props}
   >
     <ImmunisationsTable patient={patient} viewOnly disablePagination />


### PR DESCRIPTION
### Changes
This prop name changed leading to a few subtle merge related regressions.

### Checklist
- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
