### PR TITLE
NASS-637: 2 lab request form type persistence issues

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import * as yup from 'yup';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
@@ -42,7 +42,7 @@ const OPTIONS = {
   },
 };
 
-const useLabRequestFormTypeOptions = setFieldValue => {
+const useLabRequestFormTypeOptions = () => {
   const api = useApi();
   const { getLocalisation } = useLocalisation();
   const { onlyAllowLabPanels } = getLocalisation('features') || {};
@@ -50,7 +50,7 @@ const useLabRequestFormTypeOptions = setFieldValue => {
   const { data, isSuccess } = useQuery(['suggestions/labTestPanel/all'], () =>
     api.get(`suggestions/labTestPanel/all`),
   );
-  const arePanels = data?.length > 0;
+  const arePanels = isSuccess && data?.length > 0;
   const options = [];
   if (arePanels) {
     options.push(OPTIONS.PANEL);
@@ -59,23 +59,11 @@ const useLabRequestFormTypeOptions = setFieldValue => {
     options.push(OPTIONS.INDIVIDUAL);
   }
 
-  const defaultOption = options.length > 0 ? options[0].value : undefined;
-
-  useEffect(() => {
-    if (isSuccess) {
-      setFieldValue('requestFormType', defaultOption);
-    }
-  }, [defaultOption, setFieldValue, isSuccess]);
-
   return { options };
 };
 
-export const LabRequestFormScreen1 = ({
-  setFieldValue,
-  practitionerSuggester,
-  departmentSuggester,
-}) => {
-  const { options } = useLabRequestFormTypeOptions(setFieldValue);
+export const LabRequestFormScreen1 = ({ practitionerSuggester, departmentSuggester }) => {
+  const { options } = useLabRequestFormTypeOptions();
 
   return (
     <>

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -33,7 +33,7 @@ export const LabRequestMultiStepForm = ({
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}
       initialValues={{
-        requestFormType: LAB_REQUEST_FORM_TYPES.PANEL,
+        requestFormType: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
         requestedById: currentUser.id,
         departmentId: encounter.departmentId,
         requestedDate: getCurrentDateTimeString(),

--- a/packages/desktop/app/forms/MultiStepForm.js
+++ b/packages/desktop/app/forms/MultiStepForm.js
@@ -38,16 +38,19 @@ export const MultiStepForm = ({
 
   const next = values => {
     setSnapshot(values);
-    const nextStep = stepNumber + 1;
+    const nextStep = Math.min(stepNumber + 1, totalSteps - 1);
     if (onChangeStep) {
       onChangeStep(nextStep, values);
     }
-    setStepNumber(Math.min(nextStep, totalSteps - 1));
+    setStepNumber(nextStep);
   };
 
   const previous = values => {
-    setSnapshot(values);
-    setStepNumber(Math.max(stepNumber - 1, 0));
+    const prevStep = Math.max(stepNumber - 1, 0);
+    if (onChangeStep) {
+      onChangeStep(prevStep, values);
+    }
+    setStepNumber(prevStep);
   };
 
   const handleSubmit = async (values, bag) => {


### PR DESCRIPTION
### Changes
Fixes to issues identified in regression testing for NASS-637 see [thread](https://linear.app/bes/issue/NASS-637#comment-0d5a0051)

- Remove the setting of default lab request type as it would run every time you clicked back and reset that form selection.
  - **Just realised** This bit of code was mabye added to account for panel only setting, but not an appropriate implementation due to the multistep nature of form. It needs to be ready at time of form defaults being set I think
 **update on this update**: This is an unrelated issue - this was setting the form type when panel success was succesful
 Solution to this one I feel is to have all the information ready at time of form initialization.
- Incorporate back into onStepChange logic for multistep form to fix behaviour of showing the `| Individual` or `| Panel` on that initial screen.
 
### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
