### PR TITLE
NASS-666: Fix overflow on vitals table and vaccine cert close button

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -51,7 +51,6 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
       width="md"
       printable
       keepMounted
-      cornerExitButton={false}
       onPrint={() => printPDF('vaccine-certificate')}
       additionalActions={<EmailButton onEmail={createVaccineCertificateNotification} />}
     >

--- a/packages/desktop/app/components/VitalsTable.js
+++ b/packages/desktop/app/components/VitalsTable.js
@@ -8,6 +8,8 @@ import { useVitals } from '../api/queries/useVitals';
 import { formatShortest, formatTimeWithSeconds } from './DateDisplay';
 
 const StyledTable = styled(Table)`
+  overflow-x: auto;
+  overflow-y: hidden;
   table {
     position: relative;
     thead tr th:first-child,


### PR DESCRIPTION
### Changes
Altho it doesn't happen on my mac machine. The table is designed to just resize vertically when extra rows are added so `overflow-y` should never have to `auto` add a scrollbar anyway.

New design:
![Screenshot 2023-07-06 at 12 17 46 PM](https://github.com/beyondessential/tamanu/assets/38335330/65f17515-5c6a-4381-87d0-ba6012543121)

The other small issue is a classic - I corrected an incorrectly named prop but turns out we where relying on it not being correct, so that was a bit of a annoying one.

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
