### PR TITLE
NASS-723: Fix style for disabled outline button

### DIFF
--- a/packages/desktop/app/components/Button.js
+++ b/packages/desktop/app/components/Button.js
@@ -83,6 +83,9 @@ Button.defaultProps = {
 
 const StyledOutlinedButton = styled(StyledButton)`
   border-color: ${props => props.theme.palette.primary.main};
+  :disabled {
+    border-color: ${Colors.softText};
+  }
 `;
 
 export const OutlinedButton = props => (


### PR DESCRIPTION
### Changes

Changed border color for outline button when disabled
Issue:
https://linear.app/bes/issue/NASS-723#comment-c7efa747


### Media:
Disabled:
<img width="1176" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/be39404b-0269-47b8-b842-bf40e71892a8">

Enabled:
<img width="1174" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/af66ca34-2e86-429a-99cb-46452101828e">


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
