### PR TITLE
[NASS-637] Fix modal label and default lab request type

### DIFF
--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -68,6 +68,8 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
       setNewLabRequestIds([]);
       await loadEncounter(encounter.id);
     }
+
+    setRequestFormType(null);
     onClose();
   };
 
@@ -80,7 +82,7 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
       isSubmitting={isLoading}
       onSubmit={handleSubmit}
       onChangeStep={handleChangeStep}
-      onCancel={onClose}
+      onCancel={handleClose}
       encounter={encounter}
       practitionerSuggester={practitionerSuggester}
       departmentSuggester={departmentSuggester}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -33,7 +33,7 @@ export const LabRequestMultiStepForm = ({
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}
       initialValues={{
-        requestFormType: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
+        requestFormType: LAB_REQUEST_FORM_TYPES.PANEL,
         requestedById: currentUser.id,
         departmentId: encounter.departmentId,
         requestedDate: getCurrentDateTimeString(),


### PR DESCRIPTION
### Changes

- Fixed default request type when creating lab request
- Fixed modal's header when closing by using cancel button

In regards to those issues:
https://linear.app/bes/issue/NASS-637#comment-61d53ebf (Default request type)
https://linear.app/bes/issue/NASS-637#comment-cc752008 (Modal Header)


### Media

https://github.com/beyondessential/tamanu/assets/17033058/bb15b174-064b-466e-bf1b-40e082e29367



### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
