### PR TITLE
Fix selected date issue in different timezone

### DIFF
--- a/packages/desktop/app/components/Charts/components/DateTimeSelector.js
+++ b/packages/desktop/app/components/Charts/components/DateTimeSelector.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
-import { addDays, format, startOfDay } from 'date-fns';
+import { addDays, format, parse, startOfDay } from 'date-fns';
 
 import { DateInput as DateInputComponent, SelectInput as SelectInputComponent } from '../../Field';
 import { Y_AXIS_WIDTH } from '../constants';
@@ -23,6 +23,7 @@ const DateInput = styled(DateInputComponent)`
 
 const CUSTOM_DATE = 'Custom Date';
 export const DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
+const DATE_FORMAT = 'yyyy-MM-dd';
 
 const options = [
   {
@@ -86,12 +87,16 @@ export const DateTimeSelector = props => {
         <DateInput
           size="small"
           saveDateAsString
-          value={format(new Date(startDateString), 'yyyy-MM-dd')} // display date in yyyy-MM-dd format on text input
+          value={format(new Date(startDateString), DATE_FORMAT)} // display date in yyyy-MM-dd format on text input
           onChange={debounce(newValue => {
             const { value: dateString } = newValue.target;
             if (dateString) {
-              formatAndSetStartDate(startOfDay(new Date(dateString)));
-              formatAndSetEndDate(startOfDay(addDays(new Date(dateString), 1)));
+              const selectedDayDate = parse(dateString, DATE_FORMAT, new Date());
+              const startOfDayDate = startOfDay(selectedDayDate);
+              const endOfDayDate = startOfDay(addDays(selectedDayDate, 1));
+
+              formatAndSetStartDate(startOfDayDate);
+              formatAndSetEndDate(endOfDayDate);
             }
           }, 200)}
           arrows

--- a/packages/desktop/app/components/Charts/components/DateTimeSelector.js
+++ b/packages/desktop/app/components/Charts/components/DateTimeSelector.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
-import { addDays, format, parse, startOfDay } from 'date-fns';
+import { addDays, format, parseISO, startOfDay } from 'date-fns';
 
 import { DateInput as DateInputComponent, SelectInput as SelectInputComponent } from '../../Field';
 import { Y_AXIS_WIDTH } from '../constants';
@@ -87,11 +87,12 @@ export const DateTimeSelector = props => {
         <DateInput
           size="small"
           saveDateAsString
-          value={format(new Date(startDateString), DATE_FORMAT)} // display date in yyyy-MM-dd format on text input
+          format={DATE_FORMAT} // set format so we can safely use parseISO
+          value={startDateString}
           onChange={debounce(newValue => {
             const { value: dateString } = newValue.target;
             if (dateString) {
-              const selectedDayDate = parse(dateString, DATE_FORMAT, new Date());
+              const selectedDayDate = parseISO(dateString);
               const startOfDayDate = startOfDay(selectedDayDate);
               const endOfDayDate = startOfDay(addDays(selectedDayDate, 1));
 


### PR DESCRIPTION
### Changes

[Issue 2 in this comment](https://linear.app/bes/issue/EPI-494#comment-41f4e3df), which is that in different timezone, if you select '2023/07/06' as a date string, when it is parsed into Date it could become '2023/07/05 02:00 GMT -4:00' and its 'startOfDay' is '07/05 00:00:00' but not '07/06 00:00:00'.

The fix is to use .parse() from 'date-fns' as it has options to handle it.  

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
