### PR TITLE
NASS-637: Default lab request form type determined before field available

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
 import * as yup from 'yup';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
 import { Heading3, BodyText } from '../../components/Typography';
@@ -8,12 +7,10 @@ import {
   DateTimeField,
   Field,
   FormSeparatorLine,
-  RadioField,
   SuggesterSelectField,
 } from '../../components';
 import { foreignKey } from '../../utils/validation';
-import { useApi } from '../../api';
-import { useLocalisation } from '../../contexts/Localisation';
+import { LabRequestFormTypeRadioField } from './LabRequestFormTypeRadioField';
 
 export const screen1ValidationSchema = yup.object().shape({
   requestedById: foreignKey('Requesting clinician is required'),
@@ -21,94 +18,49 @@ export const screen1ValidationSchema = yup.object().shape({
   requestFormType: yup
     .string()
     .oneOf(Object.values(LAB_REQUEST_FORM_TYPES))
-    .required('Select type must be selected'),
+    .required('Request type must be selected'),
 });
 
-const OPTIONS = {
-  INDIVIDUAL: {
-    label: 'Individual',
-    description: 'Select an individual or multiple individual tests',
-    value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
-  },
-  PANEL: {
-    label: 'Panel',
-    description: 'Select from a list of test panels',
-    value: LAB_REQUEST_FORM_TYPES.PANEL,
-  },
-  SUPERSET: {
-    label: 'Superset',
-    description: 'Select from a list of supersets',
-    value: LAB_REQUEST_FORM_TYPES.SUPERSET,
-  },
-};
-
-const useLabRequestFormTypeOptions = () => {
-  const api = useApi();
-  const { getLocalisation } = useLocalisation();
-  const { onlyAllowLabPanels } = getLocalisation('features') || {};
-
-  const { data, isSuccess } = useQuery(['suggestions/labTestPanel/all'], () =>
-    api.get(`suggestions/labTestPanel/all`),
-  );
-  const arePanels = isSuccess && data?.length > 0;
-  const options = [];
-  if (arePanels) {
-    options.push(OPTIONS.PANEL);
-  }
-  if (!onlyAllowLabPanels) {
-    options.push(OPTIONS.INDIVIDUAL);
-  }
-
-  return { options };
-};
-
-export const LabRequestFormScreen1 = ({ practitionerSuggester, departmentSuggester }) => {
-  const { options } = useLabRequestFormTypeOptions();
-
-  return (
-    <>
-      <div style={{ gridColumn: '1 / -1' }}>
-        <Heading3 mb="12px">Creating a new lab request</Heading3>
-        <BodyText mb="28px" color="textTertiary">
-          Please complete the details below and select the lab request type
-        </BodyText>
-      </div>
-      <Field
-        name="requestedById"
-        label="Requesting clinician"
-        required
-        component={AutocompleteField}
-        suggester={practitionerSuggester}
-      />
-      <Field
-        name="requestedDate"
-        label="Request date & time"
-        required
-        component={DateTimeField}
-        saveDateAsString
-      />
-      <Field
-        name="departmentId"
-        label="Department"
-        component={AutocompleteField}
-        suggester={departmentSuggester}
-      />
-      <Field
-        name="labTestPriorityId"
-        label="Priority"
-        component={SuggesterSelectField}
-        endpoint="labTestPriority"
-      />
-      <FormSeparatorLine />
-      <div style={{ gridColumn: '1 / -1' }}>
-        <Field
-          required
-          name="requestFormType"
-          label="Select your request type"
-          component={RadioField}
-          options={options}
-        />
-      </div>
-    </>
-  );
-};
+export const LabRequestFormScreen1 = ({
+  setFieldValue,
+  values,
+  practitionerSuggester,
+  departmentSuggester,
+}) => (
+  <>
+    <div style={{ gridColumn: '1 / -1' }}>
+      <Heading3 mb="12px">Creating a new lab request</Heading3>
+      <BodyText mb="28px" color="textTertiary">
+        Please complete the details below and select the lab request type
+      </BodyText>
+    </div>
+    <Field
+      name="requestedById"
+      label="Requesting clinician"
+      required
+      component={AutocompleteField}
+      suggester={practitionerSuggester}
+    />
+    <Field
+      name="requestedDate"
+      label="Request date & time"
+      required
+      component={DateTimeField}
+      saveDateAsString
+    />
+    <Field
+      name="departmentId"
+      label="Department"
+      component={AutocompleteField}
+      suggester={departmentSuggester}
+    />
+    <Field
+      name="labTestPriorityId"
+      label="Priority"
+      component={SuggesterSelectField}
+      endpoint="labTestPriority"
+    />
+    <FormSeparatorLine />
+    <LabRequestFormTypeRadioField setFieldValue={setFieldValue} value={values.requestFormType} />
+  </>
+);

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -86,13 +86,7 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
         {isLoading ? (
           <RadioItemSkeleton itemsLength={POSSIBLE_OPTIONS_LIST.length} />
         ) : (
-          <Field
-            required
-            name="requestFormType"
-            isLoading={isLoading}
-            component={RadioField}
-            options={options}
-          />
+          <Field required name="requestFormType" component={RadioField} options={options} />
         )}
       </OuterLabelFieldWrapper>
     </div>

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -26,6 +26,8 @@ const OPTIONS = {
   },
 };
 
+const POSSIBLE_OPTIONS_LIST = [OPTIONS.PANEL, OPTIONS.INDIVIDUAL];
+
 const ItemSkeleton = styled(Skeleton)`
   padding: 16px 14px;
   margin-right: 14px;
@@ -57,21 +59,20 @@ const useLabRequestFormTypeOptions = () => {
   const { data, isSuccess, isLoading } = useQuery(['suggestions/labTestPanel/all'], () =>
     api.get(`suggestions/labTestPanel/all`),
   );
-  const possibleOptions = [OPTIONS.PANEL, OPTIONS.INDIVIDUAL];
   const options =
     isSuccess &&
-    possibleOptions.filter(option => {
+    POSSIBLE_OPTIONS_LIST.filter(option => {
       if (option.value === LAB_REQUEST_FORM_TYPES.PANEL) return data?.length > 0;
       if (option.value === LAB_REQUEST_FORM_TYPES.INDIVIDUAL) return !onlyAllowLabPanels;
       return true;
     });
   const defaultOption = options?.[0]?.value;
 
-  return { options, possibleOptions, isLoading, defaultOption };
+  return { options, isLoading, defaultOption };
 };
 
 export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
-  const { options, defaultOption, possibleOptions, isLoading } = useLabRequestFormTypeOptions();
+  const { options, defaultOption, isLoading } = useLabRequestFormTypeOptions();
 
   useEffect(() => {
     if (!defaultOption || value) return;
@@ -83,7 +84,7 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
     <div style={{ gridColumn: '1 / -1' }}>
       <OuterLabelFieldWrapper label="Select your request type" required>
         {isLoading ? (
-          <RadioItemSkeleton itemsLength={possibleOptions.length} />
+          <RadioItemSkeleton itemsLength={POSSIBLE_OPTIONS_LIST.length} />
         ) : (
           <Field
             required

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -1,0 +1,90 @@
+import React, { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Skeleton } from '@material-ui/lab';
+import { Box } from '@material-ui/core';
+import styled from 'styled-components';
+import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
+import { Field, OuterLabelFieldWrapper, RadioField } from '../../components';
+import { useApi } from '../../api';
+import { useLocalisation } from '../../contexts/Localisation';
+import { Colors } from '../../constants';
+
+const OPTIONS = {
+  INDIVIDUAL: {
+    label: 'Individual',
+    description: 'Select an individual or multiple individual tests',
+    value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
+  },
+  PANEL: {
+    label: 'Panel',
+    description: 'Select from a list of test panels',
+    value: LAB_REQUEST_FORM_TYPES.PANEL,
+  },
+  SUPERSET: {
+    label: 'Superset',
+    description: 'Select from a list of supersets',
+    value: LAB_REQUEST_FORM_TYPES.SUPERSET,
+  },
+};
+
+const RadioItemSkeleton = styled(Skeleton)`
+  padding: 16px 14px;
+  margin-right: 14px;
+  border-radius: 4px;
+  border: 1px solid ${Colors.outline};
+  width: 247px;
+  height: 88px;
+`;
+
+const useLabRequestFormTypeOptions = () => {
+  const api = useApi();
+  const { getLocalisation } = useLocalisation();
+  const { onlyAllowLabPanels } = getLocalisation('features') || {};
+
+  const { data, isSuccess, isLoading } = useQuery(['suggestions/labTestPanel/all'], () =>
+    api.get(`suggestions/labTestPanel/all`),
+  );
+  const arePanels = isSuccess && data?.length > 0;
+  const options = [];
+  if (arePanels) {
+    options.push(OPTIONS.PANEL);
+  }
+  if (!onlyAllowLabPanels) {
+    options.push(OPTIONS.INDIVIDUAL);
+  }
+
+  const defaultOption = isSuccess && options.length > 0 ? options[0].value : undefined;
+  return { options, defaultOption, isLoading };
+};
+
+export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
+  const { options, defaultOption, isLoading } = useLabRequestFormTypeOptions();
+
+  useEffect(() => {
+    if (!defaultOption || value) return;
+    // Initialize the form type to the first available option
+    setFieldValue('requestFormType', defaultOption);
+  }, [defaultOption, setFieldValue, value]);
+
+  return (
+    <div style={{ gridColumn: '1 / -1' }}>
+      {isLoading ? (
+        <OuterLabelFieldWrapper label="Select your request type" required>
+          <Box display="flex" alignItems="center" marginTop='3px'>
+            <RadioItemSkeleton variant="rect" />
+            <RadioItemSkeleton variant="rect" />
+          </Box>
+        </OuterLabelFieldWrapper>
+      ) : (
+        <Field
+          required
+          name="requestFormType"
+          isLoading={isLoading}
+          label="Select your request type"
+          component={RadioField}
+          options={options}
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -59,13 +59,13 @@ const useLabRequestFormTypeOptions = () => {
   const { data, isSuccess, isLoading } = useQuery(['suggestions/labTestPanel/all'], () =>
     api.get(`suggestions/labTestPanel/all`),
   );
-  const options =
-    isSuccess &&
-    POSSIBLE_OPTIONS_LIST.filter(option => {
-      if (option.value === LAB_REQUEST_FORM_TYPES.PANEL) return data?.length > 0;
-      if (option.value === LAB_REQUEST_FORM_TYPES.INDIVIDUAL) return !onlyAllowLabPanels;
-      return true;
-    });
+  const options = isSuccess
+    ? POSSIBLE_OPTIONS_LIST.filter(option => {
+        if (option.value === LAB_REQUEST_FORM_TYPES.PANEL) return data?.length > 0;
+        if (option.value === LAB_REQUEST_FORM_TYPES.INDIVIDUAL) return !onlyAllowLabPanels;
+        return true;
+      })
+    : [];
   const defaultOption = options?.[0]?.value;
 
   return { options, isLoading, defaultOption };

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
-import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
 import { useAuth } from '../../contexts/Auth';
 
 import { MultiStepForm, FormStep } from '../MultiStepForm';
@@ -33,7 +32,6 @@ export const LabRequestMultiStepForm = ({
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}
       initialValues={{
-        requestFormType: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
         requestedById: currentUser.id,
         departmentId: encounter.departmentId,
         requestedDate: getCurrentDateTimeString(),


### PR DESCRIPTION
### Changes

This gets around an issue where its not always safe to default form select type to panels, or individual (and in future superset) as the selection is dynamic based on a few factors
- Move the lab request form type logic to own file 
- skeletonized loading state see video (note load times exaggerated in local-dev)
- As the value is required field you won't be able to click through until it has loaded and populated default option.
- I began building this into Radio logic - but currently we determine the design of the radio by weither its options have description which aren't available at this point. A full solution for loading state skeletons for radio is out of scope for this 1.27 ticket in my opinion

Skeleton loading state for this radio set
https://github.com/beyondessential/tamanu/assets/38335330/73e7fa35-d064-43c7-b18c-d73812dac8f1

### Checklist
- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
