### PR TITLE
[NASS-649] Fix lab test panel get method to retrieve only panels which has visibility status = current

### DIFF
--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -346,7 +346,7 @@ describe('Labs', () => {
     });
   });
 
-  it('should not retrieve panel if the visibility status is "current"', async () => {
+  it('should only retrieve panels with a visibilityStatus status of current', async () => {
     await models.LabTestPanel.create({
       name: 'Historical test panel',
       code: 'historical-test-panel',

--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -346,6 +346,20 @@ describe('Labs', () => {
     });
   });
 
+  it('should not retrieve panel if the visibility status is "current"', async () => {
+    await models.LabTestPanel.create({
+      name: 'Historical test panel',
+      code: 'historical-test-panel',
+      visibilityStatus: 'historical',
+    });
+    const result = await app.get('/v1/labTestPanel');
+    expect(result).toHaveSucceeded();
+    const { body } = result;
+    body.forEach(labTestPanel => {
+      expect(labTestPanel.visibilityStatus).toBe('current');
+    });
+  });
+
   describe('Filtering by allFacilities', () => {
     // These are the only statuses returned by the listing endpoint
     // when no specific argument is included.

--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -355,9 +355,8 @@ describe('Labs', () => {
     const result = await app.get('/v1/labTestPanel');
     expect(result).toHaveSucceeded();
     const { body } = result;
-    body.forEach(labTestPanel => {
-      expect(labTestPanel.visibilityStatus).toBe('current');
-    });
+
+    expect(body.every(panel => panel.visibilityStatus === 'current')).toBeTruthy();
   });
 
   describe('Filtering by allFacilities', () => {

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -367,6 +367,9 @@ labTestPanel.get('/', async (req, res) => {
         as: 'category',
       },
     ],
+    where: {
+      visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+    },
   });
   res.send(response);
 });

--- a/packages/shared/src/roles.js
+++ b/packages/shared/src/roles.js
@@ -38,6 +38,9 @@ export const practitioner = [
   { verb: 'list', noun: 'LabTestType' },
   { verb: 'read', noun: 'LabTestType' },
 
+  { verb: 'list', noun: 'LabTestPanel' },
+  { verb: 'read', noun: 'LabTestPanel' },
+
   { verb: 'read', noun: 'Encounter' },
   { verb: 'list', noun: 'Encounter' },
   { verb: 'create', noun: 'Encounter' },


### PR DESCRIPTION
### Changes

 - Removed panels which has the visibility status different than "current"

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
