### PR TITLE
NASS-751: Planned move patient encounter info pane incorrectly displaying

### DIFF
--- a/packages/desktop/app/components/InfoCard.js
+++ b/packages/desktop/app/components/InfoCard.js
@@ -80,9 +80,9 @@ export const InfoCardItem = ({ label, value, ...props }) => (
   </CardCell>
 );
 
-export const InfoCard = ({ HeaderComponent = null, children, elevated, inlineValues }) => (
+export const InfoCard = ({ children, elevated, inlineValues, headerContent = null, }) => (
   <Card $elevated={elevated} $inlineValues={inlineValues}>
-    {HeaderComponent}
+    {headerContent}
     <CardBody>{children}</CardBody>
   </Card>
 );

--- a/packages/desktop/app/components/InfoCard.js
+++ b/packages/desktop/app/components/InfoCard.js
@@ -80,7 +80,7 @@ export const InfoCardItem = ({ label, value, ...props }) => (
   </CardCell>
 );
 
-export const InfoCard = ({ children, elevated, inlineValues, headerContent = null, }) => (
+export const InfoCard = ({ children, elevated, inlineValues, headerContent = null }) => (
   <Card $elevated={elevated} $inlineValues={inlineValues}>
     {headerContent}
     <CardBody>{children}</CardBody>

--- a/packages/desktop/app/components/InfoCard.js
+++ b/packages/desktop/app/components/InfoCard.js
@@ -1,22 +1,15 @@
-import React, { createContext, useContext } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Colors } from '../constants';
 
 const GRID_ROW_GAP = 18;
-const inlineContext = createContext(false);
-
-const Card = styled.div`
-  background: white;
-  box-shadow: ${({ $elevated }) => ($elevated ? '2px 2px 25px rgba(0, 0, 0, 0.1)' : 'none')};
-  border-radius: 5px;
-  padding: 32px 30px;
-  border: 1px solid ${Colors.outline};
-`;
 
 const CardHeader = styled.div`
   border-bottom: 1px solid ${Colors.softOutline};
-  padding-bottom: 12px;
+  padding-bottom: 10px;
   margin-bottom: 15px;
+  color: ${props => props.theme.palette.text.tertiary};
+  font-size: 16px;
 `;
 
 const CardBody = styled.div`
@@ -43,28 +36,37 @@ const CardCell = styled.div`
   }
 `;
 
-const CardLabel = styled.span`
-  ${props => (props.$inline ? 'margin-right: 5px' : 'margin-bottom: 8px')};
-`;
+const CardLabel = styled.span``;
 
 const CardValue = styled(CardLabel)`
   font-weight: 500;
   color: ${props => props.theme.palette.text.secondary};
-  display: ${props => (props.$inline ? 'inline' : 'block')};
 `;
 
-const InfoCardEntry = ({ label, value }) => {
-  const inline = useContext(inlineContext);
-  return (
-    <>
-      <CardLabel $inline={inline}>
-        {label}
-        {inline ? ':' : ''}
-      </CardLabel>
-      <CardValue $inline={inline}>{value}</CardValue>
-    </>
-  );
-};
+const Card = styled.div`
+  background: white;
+  box-shadow: ${({ $elevated }) => ($elevated ? '2px 2px 25px rgba(0, 0, 0, 0.1)' : 'none')};
+  border-radius: 5px;
+  padding: 32px 30px;
+  border: 1px solid ${Colors.outline};
+
+  ${CardLabel} {
+    ${({ $inlineValues }) => ($inlineValues ? 'margin-right: 5px' : 'margin-bottom: 8px')};
+    &:first-child:after {
+      content: ${({ $inlineValues }) => ($inlineValues ? "':'" : '')};
+    }
+  }
+  ${CardValue} {
+    display: ${({ $inlineValues }) => ($inlineValues ? 'inline' : 'block')};
+  }
+`;
+
+const InfoCardEntry = ({ label, value }) => (
+  <>
+    <CardLabel>{label}</CardLabel>
+    <CardValue>{value}</CardValue>
+  </>
+);
 
 export const InfoCardHeader = ({ label, value, ...props }) => (
   <CardHeader {...props}>
@@ -78,10 +80,9 @@ export const InfoCardItem = ({ label, value, ...props }) => (
   </CardCell>
 );
 
-export const InfoCard = ({ children, elevated, inlineValues }) => (
-  <inlineContext.Provider value={inlineValues}>
-    <Card $elevated={elevated}>
-      <CardBody>{children}</CardBody>
-    </Card>
-  </inlineContext.Provider>
+export const InfoCard = ({ HeaderComponent = null, children, elevated, inlineValues }) => (
+  <Card $elevated={elevated} $inlineValues={inlineValues}>
+    {HeaderComponent}
+    <CardBody>{children}</CardBody>
+  </Card>
 );

--- a/packages/desktop/app/views/patients/panes/EncounterInfoPane.js
+++ b/packages/desktop/app/views/patients/panes/EncounterInfoPane.js
@@ -17,7 +17,7 @@ export const EncounterInfoPane = React.memo(
   ({ encounter, getLocalisation, patientBillingType }) => (
     <InfoCard
       inlineValues
-      HeaderComponent={
+      headerContent={
         encounter.plannedLocation && (
           <InfoCardHeader
             label="Planned move"

--- a/packages/desktop/app/views/patients/panes/EncounterInfoPane.js
+++ b/packages/desktop/app/views/patients/panes/EncounterInfoPane.js
@@ -15,15 +15,17 @@ const referralSourcePath = 'fields.referralSourceId';
 
 export const EncounterInfoPane = React.memo(
   ({ encounter, getLocalisation, patientBillingType }) => (
-    <InfoCard inlineValues>
-      {encounter.plannedLocation && (
-        <InfoCardHeader>
-          <InfoCardItem
+    <InfoCard
+      inlineValues
+      HeaderComponent={
+        encounter.plannedLocation && (
+          <InfoCardHeader
             label="Planned move"
             value={getFullLocationName(encounter.plannedLocation)}
           />
-        </InfoCardHeader>
-      )}
+        )
+      }
+    >
       <InfoCardItem label="Department" value={getDepartmentName(encounter)} />
       <InfoCardItem label="Patient type" value={patientBillingType} />
       <InfoCardItem label="Location" value={getFullLocationName(encounter?.location)} />

--- a/packages/desktop/stories/cards/infocard.stories.js
+++ b/packages/desktop/stories/cards/infocard.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Chance } from 'chance';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
-import { InfoCard, InfoCardItem } from '../../app/components/InfoCard';
+import { InfoCard, InfoCardHeader, InfoCardItem } from '../../app/components/InfoCard';
 import { EncounterInfoPane } from '../../app/views/patients/panes/EncounterInfoPane';
 import { LabRequestSampleDetailsCard } from '../../app/views/patients/components/LabRequestSampleDetailsCard';
 
@@ -35,6 +35,12 @@ InlineValues.args = {
   inlineValues: true,
 };
 
+export const HeaderContent = Template.bind({});
+HeaderContent.args = {
+  inlineValues: true,
+  headerContent: <InfoCardHeader label="User summary" value="General info" />,
+};
+
 export const EncounterInfo = EncounterInfoPaneTemplate.bind({});
 EncounterInfo.args = {
   patientBillingType: 'Private',
@@ -50,6 +56,7 @@ EncounterInfo.args = {
     department: { name: 'Cardiology' },
     location: { name: 'Clinical treatment room' },
     referralSource: { name: 'Alan Chan' },
+    plannedLocation: { name: 'Ward 2', locationGroup: { name: 'Clinical center building 1' } },
   },
 };
 


### PR DESCRIPTION
### Changes

- Bring header outside of nth-child logic of determining the divider that only applies when there are two elements in row.
- Remove context and replace with selectors from components `toString` or some magic im not sure see [styled-components: Advanced Usage](https://styled-components.com/docs/advanced#referring-to-other-components) Thank u heaps @tcaiger 

Sadly our chrome version (electrons one) doesn't quite support `nth-child(odd of .class)` yet or else I could have avoided the header prop by excluding the header component from the odd counting. Discussed with tom c that this was cleaner without the ability to use that exact syntax right now.

![Screenshot 2023-07-07 at 4 39 28 PM](https://github.com/beyondessential/tamanu/assets/38335330/2d63fc05-958d-47ab-87ac-300cfec02757)

### Checklist
- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
