### PR TITLE
TAMOC-24: importReport QOL improvements

### DIFF
--- a/packages/sync-server/app/subCommands/importReport/actions.js
+++ b/packages/sync-server/app/subCommands/importReport/actions.js
@@ -61,11 +61,14 @@ export async function createVersion(versionData, definition, versions, store, ve
     version.status === REPORT_STATUSES.PUBLISHED &&
     (created || getLatestVersion(versions).versionNumber === version.versionNumber);
 
-  log.info(
-    `${created ? 'Created new' : 'Updated'} ${isActive ? `${ACTIVE_TEXT} ` : ''}version ${
-      version.versionNumber
-    } for definition ${definition.name}`,
-  );
+  log.info('Imported new report version', {
+    action: created ? 'createdNew' : 'updated',
+    active: isActive,
+    userId,
+    versionNumber: version.versionNumber,
+    definitionName: definition.name,
+    definitionId: definition.id,
+  });
 }
 
 export async function listVersions(definition, versions) {

--- a/packages/sync-server/app/subCommands/importReport/index.js
+++ b/packages/sync-server/app/subCommands/importReport/index.js
@@ -32,6 +32,7 @@ async function listReport(options) {
   const definition = await store.models.ReportDefinition.findOne({
     where: { name },
   });
+  if (!definition) throw new Error('No definition found by that name');
   const versions = await definition.getVersions();
   await importActions.listVersions(definition, versions, store);
   process.exit(0);

--- a/packages/sync-server/app/subCommands/importReport/index.js
+++ b/packages/sync-server/app/subCommands/importReport/index.js
@@ -32,7 +32,7 @@ async function listReport(options) {
   const definition = await store.models.ReportDefinition.findOne({
     where: { name },
   });
-  if (!definition) throw new Error('No definition found by that name');
+  if (!definition) throw new Error(`No definition found with name=${name}`);
   const versions = await definition.getVersions();
   await importActions.listVersions(definition, versions, store);
   process.exit(0);

--- a/packages/sync-server/app/subCommands/importReport/index.js
+++ b/packages/sync-server/app/subCommands/importReport/index.js
@@ -9,7 +9,7 @@ export async function importReport(options) {
   const name = options.name || versionData.name;
 
   if (!name) {
-    throw new Error("Name must be provided in the JSON file or via the -n parameter");
+    throw new Error('Name must be provided in the JSON file or via the -n parameter');
   }
 
   const store = await initDatabase({ testMode: false });


### PR DESCRIPTION
### Changes

- updates the `importReport` subcommand to allow the `name` parameter to be read from the JSON rather than having to provide it in the command line every time
- splits out the `-l` flag from `importReport` to a separate `listReport` subcommand
- includes the ID of the report in the console output so that it doesn't need to be queried separately

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
