### PR TITLE
NASS-810: Vitals table export missing button and spreadsheet cell fix

### DIFF
--- a/packages/desktop/app/components/FormattedTableCell.js
+++ b/packages/desktop/app/components/FormattedTableCell.js
@@ -1,4 +1,4 @@
-import { capitalize, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { Colors } from '../constants';
@@ -12,6 +12,7 @@ const CellWrapper = styled.div`
   padding: 8px 14px;
   margin: -8px ${({ severity }) => (severity === 'alert' ? '0px' : '-14px')};
   width: fit-content;
+  text-transform: capitalize;
 `;
 
 const HeadCellWrapper = styled.div`
@@ -30,6 +31,10 @@ function round(float, { rounding } = {}) {
     return float;
   }
   return float.toFixed(rounding);
+}
+
+function getDisplayValue(float, value, fallback) {
+  return isNaN(float) ? value || fallback : float;
 }
 
 function getTooltip(float, config = {}, visibilityCriteria = {}) {
@@ -81,21 +86,28 @@ export const RangeTooltipCell = React.memo(({ value, config, validationCriteria 
   );
 });
 
+export const ExportableRangeValidatedCell = React.memo(({ value, config }) => {
+  const float = round(parseFloat(value), config);
+  return <CellWrapper>{getDisplayValue(float, value)}</CellWrapper>;
+});
+
 export const RangeValidatedCell = React.memo(({ value, config, validationCriteria, ...props }) => {
   const float = round(parseFloat(value), config);
-  const formattedValue = isNaN(float) ? capitalize(value) || '-' : float;
+  const displayValue = getDisplayValue(float, value, '-');
+
   const { tooltip, severity } = useMemo(() => getTooltip(float, config, validationCriteria), [
     float,
     config,
     validationCriteria,
   ]);
+
   return tooltip ? (
     <TableTooltip title={tooltip}>
       <CellWrapper severity={severity} {...props}>
-        {formattedValue}
+        {displayValue}
       </CellWrapper>
     </TableTooltip>
   ) : (
-    <CellWrapper {...props}>{formattedValue}</CellWrapper>
+    <CellWrapper {...props}>{displayValue}</CellWrapper>
   );
 });

--- a/packages/desktop/app/components/Table/Table.js
+++ b/packages/desktop/app/components/Table/Table.js
@@ -414,7 +414,7 @@ TableComponent.propTypes = {
 TableComponent.defaultProps = {
   errorMessage: '',
   noDataMessage: 'No data found',
-  count: 0,
+  count: null,
   isLoading: false,
   onChangePage: null,
   onChangeRowsPerPage: null,
@@ -444,7 +444,7 @@ export const Table = ({ columns: allColumns, data, exportName, ...props }) => {
     <TableComponent
       columns={columns}
       data={data}
-      exportname={exportName}
+      exportName={exportName}
       getLocalisation={getLocalisation}
       {...props}
     />

--- a/packages/desktop/app/components/VitalsTable.js
+++ b/packages/desktop/app/components/VitalsTable.js
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 import { Table } from './Table';
 import { useEncounter } from '../contexts/Encounter';
 import { Colors } from '../constants';
-import { RangeValidatedCell, DateHeadCell, RangeTooltipCell } from './FormattedTableCell';
+import {
+  RangeValidatedCell,
+  DateHeadCell,
+  RangeTooltipCell,
+  ExportableRangeValidatedCell,
+} from './FormattedTableCell';
 import { useVitals } from '../api/queries/useVitals';
 import { formatShortest, formatTimeWithSeconds } from './DateDisplay';
 
@@ -65,6 +70,10 @@ export const VitalsTable = React.memo(() => {
         },
         exportOverrides: {
           title: `${formatShortest(date)} ${formatTimeWithSeconds(date)}`,
+          accessor: cells => {
+            const { value, config } = cells[date];
+            return <ExportableRangeValidatedCell value={value} config={config} />;
+          },
         },
       })),
   ];
@@ -73,9 +82,11 @@ export const VitalsTable = React.memo(() => {
     <StyledTable
       columns={columns}
       data={data}
+      exportName="Vitals"
       elevated={false}
       isLoading={isLoading}
       errorMessage={error?.message}
+      allowExport
     />
   );
 });


### PR DESCRIPTION
### Changes
Vitals table export button disapeared due to logic determining the hiding of footer when no results.
- Remove default of 0 from count as not always appropriate to table without pagination
  - Another option here would be to just pass in data.length i guess 🤔 but kinda weird 
- Capatilize result cells with css and not lodash
- Fix prop name on exportName (it was not being passed through)
- Make a version of cell that is designed for export and doesn't render tooltips and do range validation logic
  - This was done also because the output export had loads of `-` in empty cells which could cause trouble i feel.
  
 Its back :)
<img width="600" alt="Screenshot 2023-07-10 at 11 28 09 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/1dd6ed0c-18e3-4bc8-bf6f-5fe14f3bcff4">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
