### PR TITLE
No issue: Use one entry for time range in useVitalQuery

### DIFF
--- a/packages/desktop/app/api/queries/useVitalQuery.js
+++ b/packages/desktop/app/api/queries/useVitalQuery.js
@@ -13,8 +13,9 @@ const transformVitalDataToChartData = vitalQuery => {
   return chartData;
 };
 
-export const useVitalQuery = (encounterId, vitalDataElementId, startDate, endDate) => {
+export const useVitalQuery = (encounterId, vitalDataElementId, dateRange) => {
   const api = useApi();
+  const [startDate, endDate] = dateRange;
 
   const vitalQuery = useQuery(
     ['encounterVital', encounterId, vitalDataElementId, startDate, endDate],

--- a/packages/desktop/app/components/Charts/components/DateTimeSelector.js
+++ b/packages/desktop/app/components/Charts/components/DateTimeSelector.js
@@ -45,20 +45,17 @@ const options = [
 ];
 
 export const DateTimeSelector = props => {
-  const { startDate: startDateString, setStartDate, setEndDate } = props;
+  const { dateRange, setDateRange } = props;
+  const [startDateString] = dateRange;
   const [value, setValue] = useState(options[0].value);
 
-  const formatAndSetStartDate = useCallback(
-    newStartDate => {
-      setStartDate(format(newStartDate, DATE_TIME_FORMAT));
+  const formatAndSetDateRange = useCallback(
+    (newStartDate, newEndDate) => {
+      const newStartDateString = format(newStartDate, DATE_TIME_FORMAT);
+      const newEndDateString = format(newEndDate, DATE_TIME_FORMAT);
+      setDateRange([newStartDateString, newEndDateString]);
     },
-    [setStartDate],
-  );
-  const formatAndSetEndDate = useCallback(
-    newEndDate => {
-      setEndDate(format(newEndDate, DATE_TIME_FORMAT));
-    },
-    [setEndDate],
+    [setDateRange],
   );
 
   useEffect(() => {
@@ -68,9 +65,8 @@ export const DateTimeSelector = props => {
     const newStartDate = getDefaultStartDate ? getDefaultStartDate() : new Date();
     const newEndDate = getDefaultEndDate ? getDefaultEndDate() : new Date();
 
-    formatAndSetStartDate(newStartDate);
-    formatAndSetEndDate(newEndDate);
-  }, [value, formatAndSetStartDate, formatAndSetEndDate]);
+    formatAndSetDateRange(newStartDate, newEndDate);
+  }, [value, formatAndSetDateRange]);
 
   return (
     <Wrapper>
@@ -96,8 +92,7 @@ export const DateTimeSelector = props => {
               const startOfDayDate = startOfDay(selectedDayDate);
               const endOfDayDate = startOfDay(addDays(selectedDayDate, 1));
 
-              formatAndSetStartDate(startOfDayDate);
-              formatAndSetEndDate(endOfDayDate);
+              formatAndSetDateRange(startOfDayDate, endOfDayDate);
             }
           }, 200)}
           arrows

--- a/packages/desktop/app/components/Charts/helpers/axisTicks.js
+++ b/packages/desktop/app/components/Charts/helpers/axisTicks.js
@@ -1,7 +1,8 @@
 import { getTime } from 'date-fns';
 
-export const getXAxisTicks = (startDate, endDate) => {
+export const getXAxisTicks = dateRange => {
   const ticks = [];
+  const [startDate, endDate] = dateRange;
 
   // Get ticks for every 4 hours
   let nextTickTimestamp = getTime(new Date(startDate));

--- a/packages/desktop/app/components/Charts/helpers/getVitalChartProps.js
+++ b/packages/desktop/app/components/Charts/helpers/getVitalChartProps.js
@@ -4,15 +4,10 @@ import { getXAxisTicks, getYAxisTicks } from './axisTicks';
 
 export const defaultTableHeight = 500;
 
-export const getVitalChartProps = ({
-  visualisationConfig,
-  startDate,
-  endDate,
-  isInMultiChartsView,
-}) => {
+export const getVitalChartProps = ({ visualisationConfig, dateRange, isInMultiChartsView }) => {
   const { yAxis: yAxisConfigs } = visualisationConfig;
   const margin = CHART_MARGIN;
-  const xAxisTicks = getXAxisTicks(startDate, endDate);
+  const xAxisTicks = getXAxisTicks(dateRange);
   const yAxisTicks = getYAxisTicks(yAxisConfigs);
   const tableHeight = isInMultiChartsView
     ? (yAxisTicks.length - 1) * MULTI_CHARTS_VIEW_INTERVAL_HEIGHT

--- a/packages/desktop/app/components/VitalChartsModal.js
+++ b/packages/desktop/app/components/VitalChartsModal.js
@@ -12,9 +12,8 @@ export const VitalChartsModal = React.memo(() => {
     vitalChartModalOpen,
     setVitalChartModalOpen,
     modalTitle,
-    startDate,
-    setStartDate,
-    setEndDate,
+    dateRange,
+    setDateRange,
     isInMultiChartsView,
   } = useVitalChartData();
 
@@ -30,7 +29,7 @@ export const VitalChartsModal = React.memo(() => {
         setVitalChartModalOpen(false);
       }}
     >
-      <DateTimeSelector startDate={startDate} setStartDate={setStartDate} setEndDate={setEndDate} />
+      <DateTimeSelector dateRange={dateRange} setDateRange={setDateRange} />
       <ViewComponent />
     </Modal>
   );

--- a/packages/desktop/app/contexts/VitalChartData.js
+++ b/packages/desktop/app/contexts/VitalChartData.js
@@ -12,10 +12,8 @@ export const VitalChartDataContext = React.createContext({
   chartKeys: ['vital-chart'],
   modalTitle: 'Vital Chart',
   setModalTitle: () => {},
-  setStartDate: () => {},
-  setEndDate: () => {},
-  startDate: '',
-  endDate: '',
+  setDateRange: () => {},
+  dateRange: ['', ''],
   isInMultiChartsView: false,
 });
 
@@ -24,8 +22,10 @@ export const useVitalChartData = () => useContext(VitalChartDataContext);
 export const VitalChartDataProvider = ({ children }) => {
   const [chartKeys, setChartKeys] = useState([]);
   const [modalTitle, setModalTitle] = useState(null);
-  const [startDate, setStartDate] = useState(format(addDays(new Date(), -1), DATE_TIME_FORMAT));
-  const [endDate, setEndDate] = useState(format(new Date(), DATE_TIME_FORMAT));
+  const [dateRange, setDateRange] = useState([
+    format(addDays(new Date(), -1), DATE_TIME_FORMAT),
+    format(new Date(), DATE_TIME_FORMAT),
+  ]);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
 
   const { visualisationConfigs } = useVitalsSurvey();
@@ -40,10 +40,8 @@ export const VitalChartDataProvider = ({ children }) => {
         setChartKeys,
         modalTitle,
         setModalTitle,
-        setStartDate,
-        setEndDate,
-        startDate,
-        endDate,
+        dateRange,
+        setDateRange,
         isInMultiChartsView: chartKeys.length > 1,
       }}
     >

--- a/packages/desktop/app/views/charts/MultiVitalChartsView.js
+++ b/packages/desktop/app/views/charts/MultiVitalChartsView.js
@@ -21,7 +21,7 @@ const TitleContainer = styled.div`
 
 // Fetching and preparing data for vital chart
 export const MultiVitalChartsView = () => {
-  const { visualisationConfigs, chartKeys, startDate, endDate } = useVitalChartData();
+  const { visualisationConfigs, chartKeys, dateRange } = useVitalChartData();
 
   return (
     <>
@@ -37,8 +37,7 @@ export const MultiVitalChartsView = () => {
             </TitleContainer>
             <VitalChartComponent
               chartKey={chartKey}
-              startDate={startDate}
-              endDate={endDate}
+              dateRange={dateRange}
               visualisationConfig={visualisationConfig}
               isInMultiChartsView
             />

--- a/packages/desktop/app/views/charts/SingleVitalChartView.js
+++ b/packages/desktop/app/views/charts/SingleVitalChartView.js
@@ -4,13 +4,7 @@ import { useVitalChartData } from '../../contexts/VitalChartData';
 import { getVitalChartComponent } from './getVitalChartComponent';
 
 export const SingleVitalChartView = () => {
-  const {
-    chartKeys,
-    visualisationConfigs,
-    startDate,
-    endDate,
-    isInMultiChartsView,
-  } = useVitalChartData();
+  const { chartKeys, visualisationConfigs, dateRange, isInMultiChartsView } = useVitalChartData();
   const chartKey = chartKeys[0];
   const VitalChartComponent = getVitalChartComponent(chartKey);
   const visualisationConfig = visualisationConfigs.find(config => config.key === chartKey);
@@ -19,8 +13,7 @@ export const SingleVitalChartView = () => {
     <VitalChartComponent
       chartKey={chartKey}
       visualisationConfig={visualisationConfig}
-      startDate={startDate}
-      endDate={endDate}
+      dateRange={dateRange}
       isInMultiChartsView={isInMultiChartsView}
     />
   );

--- a/packages/desktop/app/views/charts/VitalBloodPressureChart.js
+++ b/packages/desktop/app/views/charts/VitalBloodPressureChart.js
@@ -7,21 +7,19 @@ import { getVitalChartProps } from '../../components/Charts/helpers/getVitalChar
 
 // Fetching and preparing blood pressure data for vital chart
 export const VitalBloodPressureChart = props => {
-  const { visualisationConfig, startDate, endDate, isInMultiChartsView } = props;
+  const { visualisationConfig, dateRange, isInMultiChartsView } = props;
   const { encounter } = useEncounter();
 
   const { data: sbpChartData, isLoading: isSbpLoading } = useVitalQuery(
     encounter.id,
     VITALS_DATA_ELEMENT_IDS.sbp,
-    startDate,
-    endDate,
+    dateRange,
   );
 
   const { data: dbpChartData, isLoading: isDbpLoading } = useVitalQuery(
     encounter.id,
     VITALS_DATA_ELEMENT_IDS.dbp,
-    startDate,
-    endDate,
+    dateRange,
   );
 
   const chartData = sbpChartData.map(sbpData => {
@@ -38,8 +36,7 @@ export const VitalBloodPressureChart = props => {
 
   const chartProps = getVitalChartProps({
     visualisationConfig,
-    startDate,
-    endDate,
+    dateRange,
     isInMultiChartsView,
   });
 

--- a/packages/desktop/app/views/charts/VitalLineChart.js
+++ b/packages/desktop/app/views/charts/VitalLineChart.js
@@ -6,13 +6,12 @@ import { useVitalQuery } from '../../api/queries/useVitalQuery';
 
 // Fetching and preparing data for vital chart
 export const VitalLineChart = props => {
-  const { chartKey, visualisationConfig, startDate, endDate, isInMultiChartsView } = props;
+  const { chartKey, visualisationConfig, dateRange, isInMultiChartsView } = props;
   const { encounter } = useEncounter();
-  const { data: chartData, isLoading } = useVitalQuery(encounter.id, chartKey, startDate, endDate);
+  const { data: chartData, isLoading } = useVitalQuery(encounter.id, chartKey, dateRange);
   const chartProps = getVitalChartProps({
     visualisationConfig,
-    startDate,
-    endDate,
+    dateRange,
     isInMultiChartsView,
   });
 

--- a/packages/desktop/stories/vitalsChart.stories.js
+++ b/packages/desktop/stories/vitalsChart.stories.js
@@ -53,7 +53,7 @@ const inwardArrowData = data.map(item => ({
   ...item,
   inwardArrowVector: {
     top: item.value,
-    bottom: item.value - (Math.random() * 2).toFixed(2),
+    bottom: item.value - 2,
   },
   config: { unit: 'mmHg' },
 }));
@@ -66,10 +66,13 @@ const visualisationConfig = {
   },
 };
 
+const dateRange = [
+  format(addDays(new Date(), -1), 'yyyy-MM-dd HH:mm:ss'),
+  format(new Date(), 'yyyy-MM-dd HH:mm:ss'),
+];
 const chartProps = getVitalChartProps({
   visualisationConfig,
-  startDate: format(addDays(new Date(), -1), 'yyyy-MM-dd HH:mm:ss'),
-  endDate: format(new Date(), 'yyyy-MM-dd HH:mm:ss'),
+  dateRange,
 });
 
 storiesOf('Vitals', module)


### PR DESCRIPTION
### Changes
This is simple but has 11 changed files. Basically setStartDate and setEndDate will always be called together, but in fact it is called one after another, which triggers fetching data twice by each setState. This PR will combine them as one state. 

I will do a smoke test once it gets into the epic.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
