### PR TITLE
NASS-637: Lab request form type don't set default option when fetching 

### DIFF
--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -56,21 +56,18 @@ const useLabRequestFormTypeOptions = () => {
   const { getLocalisation } = useLocalisation();
   const { onlyAllowLabPanels } = getLocalisation('features') || {};
 
-  const { data, isSuccess, isLoading } = useQuery(
+  const { data, isSuccess, isLoading, isFetching } = useQuery(
     ['suggestions/labTestPanel/all'],
     () => api.get(`suggestions/labTestPanel/all`),
-    {
-      // We want up to date information re lab test panels to determine default
-      cacheTime: 0,
-    },
   );
-  const options = isSuccess
-    ? POSSIBLE_OPTIONS_LIST.filter(option => {
-        if (option.value === LAB_REQUEST_FORM_TYPES.PANEL) return data?.length > 0;
-        if (option.value === LAB_REQUEST_FORM_TYPES.INDIVIDUAL) return !onlyAllowLabPanels;
-        return true;
-      })
-    : [];
+  const options =
+    isSuccess && !isFetching
+      ? POSSIBLE_OPTIONS_LIST.filter(option => {
+          if (option.value === LAB_REQUEST_FORM_TYPES.PANEL) return data?.length > 0;
+          if (option.value === LAB_REQUEST_FORM_TYPES.INDIVIDUAL) return !onlyAllowLabPanels;
+          return true;
+        })
+      : [];
   const defaultOption = options?.[0]?.value;
 
   return { options, isLoading, defaultOption };

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -56,8 +56,13 @@ const useLabRequestFormTypeOptions = () => {
   const { getLocalisation } = useLocalisation();
   const { onlyAllowLabPanels } = getLocalisation('features') || {};
 
-  const { data, isSuccess, isLoading } = useQuery(['suggestions/labTestPanel/all'], () =>
-    api.get(`suggestions/labTestPanel/all`),
+  const { data, isSuccess, isLoading } = useQuery(
+    ['suggestions/labTestPanel/all'],
+    () => api.get(`suggestions/labTestPanel/all`),
+    {
+      // We want up to date information re lab test panels to determine default
+      cacheTime: 0,
+    },
   );
   const options = isSuccess
     ? POSSIBLE_OPTIONS_LIST.filter(option => {


### PR DESCRIPTION
### Changes
*Update* The issue was actually caused by the hook running when query is in a state of `isFetching`.
So the default would be set from the previous value 
If: Query is stale at time of reopening form.
Its one of those situations where its always one step behind or out of sync.

̶-̶ ̶T̶h̶i̶s̶ ̶a̶d̶d̶r̶e̶s̶s̶e̶s̶ ̶(̶r̶a̶r̶e̶?̶)̶ ̶s̶i̶t̶u̶a̶t̶i̶o̶n̶ ̶w̶h̶e̶r̶e̶ ̶t̶h̶e̶ ̶e̶x̶i̶s̶t̶e̶n̶c̶e̶ ̶o̶f̶ ̶p̶a̶n̶e̶l̶s̶ ̶i̶n̶ ̶a̶ ̶s̶y̶s̶t̶e̶m̶ ̶c̶h̶a̶n̶g̶e̶s̶ ̶a̶t̶ ̶r̶u̶n̶t̶i̶m̶e̶ ̶d̶u̶r̶i̶n̶g̶ ̶u̶s̶e̶r̶ ̶s̶e̶s̶s̶i̶o̶n̶ ̶c̶a̶u̶s̶i̶n̶g̶ ̶a̶n̶ ̶i̶n̶c̶o̶r̶r̶e̶c̶t̶ ̶d̶e̶f̶a̶u̶l̶t̶ ̶
-̶ ̶s̶t̶u̶c̶k̶ ̶w̶i̶t̶h̶ ̶u̶s̶e̶Q̶u̶e̶r̶y̶ ̶b̶u̶t̶ ̶w̶i̶t̶h̶o̶u̶t̶ ̶t̶h̶e̶ ̶c̶a̶c̶h̶e̶T̶i̶m̶e̶

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
