### PR TITLE
SAV-321: Sync all panels if syncAllLabRequests is on

### DIFF
--- a/packages/shared/src/models/LabTestPanelRequest.js
+++ b/packages/shared/src/models/LabTestPanelRequest.js
@@ -26,7 +26,10 @@ export class LabTestPanelRequest extends Model {
     });
   }
 
-  static buildSyncFilter(patientIds) {
+  static buildSyncFilter(patientIds, sessionConfig) {
+    if (sessionConfig.syncAllLabRequests) {
+      return ''; // include all lab panel requests
+    }
     if (patientIds.length === 0) {
       return null;
     }


### PR DESCRIPTION
### Changes

Missed from the buildSyncFilter, causing bugs in v1.27

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
