### PR TITLE
TAV-703: Some release/repo workflow improvements

### DIFF
--- a/.github/workflows/branch-info.yml
+++ b/.github/workflows/branch-info.yml
@@ -36,6 +36,7 @@ jobs:
     name: Version
     needs: run
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'dev'
     steps:
-    - name: Warn if branch name is not prefixed with feature/ or fix/
+    - name: Warn if branch name doesn't start with conventional prefixes
       env:
         BRANCH_NAME: ${{ github.head_ref }}
       shell: bash
       run: |
-        if ! grep -qP '^(feature|fix|epic)/' <<< "$BRANCH_NAME"; then
-          echo "::warning::Branch name should be prefixed with feature/ or fix/ or epic/"
+        if ! grep -qP '^(feature|fix|epic|merge)/' <<< "$BRANCH_NAME"; then
+          echo "::warning::Branch name should be prefixed with feature/ or fix/ or epic/ or merge/"
           exit 1
         fi
 

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -31,7 +31,7 @@ jobs:
         script: |
           const cwd = '${{ github.workspace }}';
           const { createReleaseBranch } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
-          await createReleaseBranch(await import('fs'), github, context, cwd);
+          await createReleaseBranch(await import('fs'), github, context, cwd, '${{ github.event.inputs.version }}');
 
     - name: Bump version on main
       run: node scripts/version.mjs '${{ github.event.inputs.version }}'

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-export async function createReleaseBranch({ readFileSync }, github, context, cwd) {
+export async function createReleaseBranch({ readFileSync }, github, context, cwd, nextVersionSpec) {
   console.log('Reading current version...');
   const { version } = JSON.parse(readFileSync(`${cwd}/package.json`, 'utf-8'));
 
@@ -28,8 +28,23 @@ export async function createReleaseBranch({ readFileSync }, github, context, cwd
 
   console.log("It doesn't, creating branch...");
   await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha });
-  console.log('Creating draft release...');
-  await createDraftRelease({ readFileSync }, github, context, cwd, version);
+
+  let nextVersion;
+  switch (nextVersionSpec) {
+    case 'patch':
+      throw new Error('Patch version bump is not supported');
+    case 'minor':
+      nextVersion = `${major}.${Number(minor) + 1}.0`;
+      break;
+    case 'major':
+      nextVersion = `${Number(major) + 1}.0.0`;
+      break;
+    default:
+      nextVersion = nextVersionSpec;
+  }
+  console.log(`Creating draft release for next major (${nextVersion})...`);
+  await createDraftRelease({ readFileSync }, github, context, cwd, nextVersion);
+
   console.log('Done.');
 }
 

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -42,7 +42,7 @@ export async function createReleaseBranch({ readFileSync }, github, context, cwd
     default:
       nextVersion = nextVersionSpec;
   }
-  console.log(`Creating draft release for next major (${nextVersion})...`);
+  console.log(`Creating draft release for next ${nextVersionSpec} (${nextVersion})...`);
   await createDraftRelease({ readFileSync }, github, context, cwd, nextVersion);
 
   console.log('Done.');


### PR DESCRIPTION
### Changes

- On cutoff, create the draft release for the _next_ version branch rather than for the _newly branched off_ release. That aligns better with how we actually work (notably means there shouldn't ever be a need for anyone to manually create draft releases).
- Add the `merge/` conventional prefix, to delineate branches that are only for managing merge conflicts.

### Checklist

- [x] Code is finished