### PR TITLE
Don't bring CD Down on permanent branches

### DIFF
--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -7,9 +7,11 @@ on:
     branches:
       - main
       - release/*
+    tags:
+      - v*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.pull_request.id || github.ref }}
+  group: ${{ github.workflow }}-${{ github.pull_request.id || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -136,13 +138,13 @@ jobs:
           rm -rf release
 
       - name: Use release bucket
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
-          echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
+          echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-release-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
       - name: Use dev bucket
-        if: "!startsWith(github.ref, 'refs/heads/release/')"
+        if: "!startsWith(github.ref, 'refs/tags/')"
         run: |
           echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV


### PR DESCRIPTION
### Changes

Exclude release/* and main from CD Down. Otherwise it's possible to bring a permanent environment down by making and closing/merging a PR from main or a release branch.

### Checklist

- [x] Code is finished
- [ ] Reviewer please check my conditional logic I haven't had 🍵 yet