### PR TITLE
Don't bring CD Down on permanent branches

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -17,6 +17,8 @@ permissions:
 
 jobs:
   info:
+    # only run for manual dispatch or for non-permanent branches
+    if: github.event_name == 'workflow_dispatch' || (!startsWith(github.ref, 'refs/heads/release') && github.ref != 'refs/heads/main')
     name: Branch info
     uses: ./.github/workflows/branch-info.yml
 


### PR DESCRIPTION
### Changes

Exclude release/* and main from CD Down. Otherwise it's possible to bring a permanent environment down by making and closing/merging a PR from main or a release branch.

### Checklist

- [x] Code is finished
- [ ] Reviewer please check my conditional logic I haven't had :tea: yet