### PR TITLE
Fix: Line chart as default

### DIFF
--- a/packages/desktop/app/views/charts/getVitalChartComponent.js
+++ b/packages/desktop/app/views/charts/getVitalChartComponent.js
@@ -9,6 +9,10 @@ const VITAL_CHARTS_MAPPING = {
 
 export const getVitalChartComponent = chartKey => {
   const chartType = VITAL_CHARTS[chartKey];
+  if (!chartType) {
+    return VitalLineChart;
+  }
+
   const VitalChartComponent = VITAL_CHARTS_MAPPING[chartType];
   return VitalChartComponent;
 };


### PR DESCRIPTION
### Changes
`PatientVitalsSPO2onOxygen` is not a hard coded vital code, the chart mapping return undefined and it break things.


</body>

</html>

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
