### PR TITLE
Add safeguard for invalid inputs for publish workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "release/",
+  "version": "1.28.1",
   "description": "This repo contains all the packages for Tamanu",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/build-tooling",
-  "version": "release/",
+  "version": "1.28.1",
   "description": "Build tooling for Tamanu packages",
   "main": "index.mjs",
   "type": "module",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csca",
-  "version": "release/",
+  "version": "1.28.1",
   "private": true,
   "description": "CSCA tooling for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/app/package.json
+++ b/packages/desktop/app/package.json
@@ -3,7 +3,7 @@
   "main": "./dist/main.prod.js",
   "name": "Tamanu",
   "productName": "Tamanu",
-  "version": "release/",
+  "version": "1.28.1",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Tamanu",
-  "version": "release/",
+  "version": "1.28.1",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lan",
-  "version": "release/",
+  "version": "1.28.1",
   "private": true,
   "description": "Facility server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-server",
-  "version": "release/",
+  "version": "1.28.1",
   "private": true,
   "description": "Meta server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "release/",
+  "version": "1.28.1",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/qr-tester/package.json
+++ b/packages/qr-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-tester",
-  "version": "release/",
+  "version": "1.28.1",
   "private": true,
   "description": "BES QR Code Tester App / Website",
   "author": "",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "release/",
+  "version": "1.28.1",
   "main": "index.js",
   "license": "SEE LICENSE IN license",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/shared",
-  "version": "release/",
+  "version": "1.28.1",
   "description": "Common code across Tamanu packages",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-server",
-  "version": "release/",
+  "version": "1.28.1",
   "private": true,
   "description": "Sync server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -28,6 +28,8 @@ if (['major', 'minor', 'patch'].includes(version)) {
     default:
       throw new Error('unreachable');
   }
+} else if (!/^\d+[.]\d+[.]\d+$/.test(version)) {
+  throw new Error('Version must be major, minor, patch, or x.y.z');
 }
 
 async function bumpPackageJson(packagePath, newVersion) {


### PR DESCRIPTION
### Changes

I don't see any way that there's anything _wrong_ with the scripts, and I don't see any way for it to exhibit [the behaviour observed](https://github.com/beyondessential/tamanu/actions/runs/5551360025) under normal usage, so it must have accidentally been called with a `version` input of `release/`, probably as the caller was trying to search for the correct `release/` branch.

This patch doesn't change any behaviour as there's none to, but it adds a check that the version input is either one of the special values `major`, `minor`, `patch`, or an explicit x.y.z version.

It also manually bumps the version to what it should have been (1.28.1).

### Checklist

- [x] Code is finished