### PR TITLE
EPI-574: Fine tune vitals

### DIFF
--- a/packages/desktop/app/components/Charts/LineChart.js
+++ b/packages/desktop/app/components/Charts/LineChart.js
@@ -22,11 +22,23 @@ import { InwardArrowVectorDot } from './components/InwardArrowVectorDot';
 import { CustomTooltip } from './components/CustomTooltip';
 
 export const LineChart = props => {
-  const { chartData, visualisationConfig, isLoading, useInwardArrowVector, chartProps } = props;
+  const {
+    chartData,
+    visualisationConfig,
+    isLoading,
+    useInwardArrowVector,
+    chartProps,
+    secondaryConfig,
+  } = props;
 
   const { margin, tableHeight, height, xAxisTicks, yAxisTicks } = chartProps;
   const { yAxis: yAxisConfigs } = visualisationConfig;
-  const measureData = getMeasureData(chartData, visualisationConfig, useInwardArrowVector);
+  const measureData = getMeasureData(
+    chartData,
+    visualisationConfig,
+    useInwardArrowVector,
+    secondaryConfig,
+  );
   const DotComponent = useInwardArrowVector ? InwardArrowVectorDot : CustomDot;
 
   return (

--- a/packages/desktop/app/components/Charts/components/InwardArrowVectorDot.js
+++ b/packages/desktop/app/components/Charts/components/InwardArrowVectorDot.js
@@ -20,9 +20,10 @@ export const InwardArrowVectorDot = props => {
 
   const heightPerInterval = getHeightPerYAxisInterval(yAxis, tableHeight);
   const vectorHeight = ((top - bottom) / interval) * heightPerInterval;
+  const clampedVectorHeight = Math.min(vectorHeight, tableHeight);
 
   const verticalLine = {
-    bottom: { x: 6, y: 7.5 + vectorHeight },
+    bottom: { x: 6, y: 7.5 + clampedVectorHeight },
   };
   const startAndEndPointOfBottomInwardArrow = {
     y: verticalLine.bottom.y + 6,

--- a/packages/desktop/app/components/Charts/components/NoDataStateScreen.js
+++ b/packages/desktop/app/components/Charts/components/NoDataStateScreen.js
@@ -26,8 +26,8 @@ export const NoDataStateScreen = props => {
     textAnchor: 'middle',
   };
   const lineHeight = 18;
-  const lineOne = `No recorded vitals to display. To record vitals, please click the`;
-  const lineTwo = `'Record vitals' button from the vitals table`;
+  const lineOne = `No recorded vitals to display for the selected date range. To record`;
+  const lineTwo = `vitals, please click the 'Record vitals' button from the vitals table.`;
 
   const loadingMessage = 'Vitals graph loading...';
 

--- a/packages/desktop/app/components/Charts/components/TooltipContent.js
+++ b/packages/desktop/app/components/Charts/components/TooltipContent.js
@@ -64,7 +64,14 @@ export const TooltipContent = props => {
 };
 
 export const InwardArrowVectorTooltipContent = props => {
-  const { name, description, visualisationConfig, dotColor, inwardArrowVector } = props;
+  const {
+    name,
+    description,
+    secondDescription,
+    visualisationConfig,
+    dotColor,
+    inwardArrowVector,
+  } = props;
   const { config = {} } = visualisationConfig;
   const { unit = '' } = config;
 
@@ -78,6 +85,7 @@ export const InwardArrowVectorTooltipContent = props => {
         <FlexColumn>
           <span>{`${inwardArrowVector.top}/${inwardArrowVector.bottom} ${unit}`}</span>
           <span>{description}</span>
+          <span>{secondDescription}</span>
         </FlexColumn>
       </ValueWrapper>
     </Wrapper>

--- a/packages/desktop/app/components/Charts/helpers/getMeasureData.js
+++ b/packages/desktop/app/components/Charts/helpers/getMeasureData.js
@@ -1,3 +1,4 @@
+import { VITALS_DATA_ELEMENT_IDS } from '@tamanu/shared/constants/surveys';
 import { Colors } from '../../../constants';
 
 const getDotColor = ({ isInsideNormalRange, isOutsideGraphRange, useInwardArrowVector }) => {
@@ -36,40 +37,94 @@ const getDisplayValue = ({ data, isOutsideGraphRange, yAxis }) => {
   return displayValue;
 };
 
+// Alter descriptions cause otherwise is a bit involved and it's very specific
+const getBloodPressureDescription = (description, key) => {
+  if (description.length === 0) return description;
+  const vitalSymbol = key === VITALS_DATA_ELEMENT_IDS.sbp ? 'SBP' : 'DBP';
+  return description.replaceAll('(Outside', `(${vitalSymbol} outside`);
+};
+
+const getDefaultMeasureData = (rawData, visualisationConfig) => {
+  const { yAxis } = visualisationConfig;
+  return rawData.map(d => {
+    const isInsideNormalRange =
+      d.value >= yAxis.normalRange.min && d.value <= yAxis.normalRange.max;
+    const isOutsideGraphRange = d.value < yAxis.graphRange.min || d.value > yAxis.graphRange.max;
+
+    const dotColor = getDotColor({
+      isInsideNormalRange,
+      isOutsideGraphRange,
+    });
+    const displayValue = getDisplayValue({ data: d, isOutsideGraphRange, yAxis });
+    const description = getDescription({
+      data: d,
+      isInsideNormalRange,
+      isOutsideGraphRange,
+      yAxis,
+    });
+
+    return {
+      ...d,
+      timestamp: Date.parse(d.name),
+      [DISPLAY_VALUE_KEY]: displayValue,
+      dotColor,
+      description,
+      visualisationConfig,
+    };
+  });
+};
+
+const getInwardArrowMeasureData = (rawData, visualisationConfig, secondaryConfig) => {
+  const defaultMeasureData = getDefaultMeasureData(rawData, visualisationConfig);
+  const { yAxis } = secondaryConfig;
+
+  // Adjust shape calculations for secondary value in arrow vector
+  // (currently this just applies to DBP in blood pressure).
+  return defaultMeasureData.map(baseData => {
+    const secondaryData = { value: baseData.inwardArrowVector.bottom };
+
+    const isInsideNormalRange =
+      secondaryData.value >= yAxis.normalRange.min && secondaryData.value <= yAxis.normalRange.max;
+    const isOutsideGraphRange =
+      secondaryData.value < yAxis.graphRange.min || secondaryData.value > yAxis.graphRange.max;
+
+    const secondaryValueDotColor = getDotColor({
+      isInsideNormalRange,
+      isOutsideGraphRange,
+    });
+    const secondDescription = getDescription({
+      data: secondaryData,
+      isInsideNormalRange,
+      isOutsideGraphRange,
+      yAxis,
+    });
+
+    // Preserve the first one if its an alert, otherwise the secondary
+    const finalDotColor =
+      baseData.dotColor === Colors.alert ? Colors.alert : secondaryValueDotColor;
+
+    return {
+      ...baseData,
+      dotColor: finalDotColor,
+      description: getBloodPressureDescription(baseData.description, visualisationConfig.key),
+      secondDescription: getBloodPressureDescription(secondDescription, secondaryConfig.key),
+    };
+  });
+};
+
 export const DISPLAY_VALUE_KEY = 'displayValue';
 
-export const getMeasureData = (rawData, visualisationConfig, useInwardArrowVector) => {
-  const { yAxis } = visualisationConfig;
+export const getMeasureData = (
+  rawData,
+  visualisationConfig,
+  useInwardArrowVector,
+  secondaryConfig,
+) => {
+  const measureData = useInwardArrowVector
+    ? getInwardArrowMeasureData(rawData, visualisationConfig, secondaryConfig)
+    : getDefaultMeasureData(rawData, visualisationConfig);
 
-  return rawData
-    .map(d => {
-      const isInsideNormalRange =
-        d.value >= yAxis.normalRange.min && d.value <= yAxis.normalRange.max;
-      const isOutsideGraphRange = d.value < yAxis.graphRange.min || d.value > yAxis.graphRange.max;
-
-      const dotColor = getDotColor({
-        isInsideNormalRange,
-        isOutsideGraphRange,
-        useInwardArrowVector,
-      });
-      const displayValue = getDisplayValue({ data: d, isOutsideGraphRange, yAxis });
-      const description = getDescription({
-        data: d,
-        isInsideNormalRange,
-        isOutsideGraphRange,
-        yAxis,
-      });
-
-      return {
-        ...d,
-        timestamp: Date.parse(d.name),
-        [DISPLAY_VALUE_KEY]: displayValue,
-        dotColor,
-        description,
-        visualisationConfig,
-      };
-    })
-    .sort((a, b) => {
-      return a.timestamp - b.timestamp;
-    });
+  return measureData.sort((a, b) => {
+    return a.timestamp - b.timestamp;
+  });
 };

--- a/packages/desktop/app/components/Charts/helpers/getMeasureData.js
+++ b/packages/desktop/app/components/Charts/helpers/getMeasureData.js
@@ -91,6 +91,7 @@ const getInwardArrowMeasureData = (rawData, visualisationConfig, secondaryConfig
     const secondaryValueDotColor = getDotColor({
       isInsideNormalRange,
       isOutsideGraphRange,
+      useInwardArrowVector: true,
     });
     const secondDescription = getDescription({
       data: secondaryData,

--- a/packages/desktop/app/components/VitalsTable.js
+++ b/packages/desktop/app/components/VitalsTable.js
@@ -67,9 +67,9 @@ const MeasureCell = React.memo(({ value, data }) => {
   // Currently DBP and SBP data are both shown on the same chart (VitalBloodPressureChart), it should use SBP's visualisation_config and validation_criteria to render the chart
 
   const chartKey =
-    visualisationConfig.key === VITALS_DATA_ELEMENT_IDS.dbp
+    visualisationConfig?.key === VITALS_DATA_ELEMENT_IDS.dbp
       ? VITALS_DATA_ELEMENT_IDS.sbp
-      : visualisationConfig.key;
+      : visualisationConfig?.key;
 
   return (
     <>

--- a/packages/desktop/app/components/VitalsTable.js
+++ b/packages/desktop/app/components/VitalsTable.js
@@ -203,7 +203,7 @@ export const VitalsTable = React.memo(() => {
       />
       {showFooterLegend && (
         <Box textAlign="end" marginTop="8px" fontSize="9px" color={Colors.softText}>
-          *Changed entry
+          *Changed record
         </Box>
       )}
     </>

--- a/packages/desktop/app/views/charts/VitalBloodPressureChart.js
+++ b/packages/desktop/app/views/charts/VitalBloodPressureChart.js
@@ -4,11 +4,18 @@ import { LineChart } from '../../components/Charts/LineChart';
 import { useEncounter } from '../../contexts/Encounter';
 import { useVitalQuery } from '../../api/queries/useVitalQuery';
 import { getVitalChartProps } from '../../components/Charts/helpers/getVitalChartProps';
+import { useVitalChartData } from '../../contexts/VitalChartData';
 
 // Fetching and preparing blood pressure data for vital chart
 export const VitalBloodPressureChart = props => {
   const { visualisationConfig, dateRange, isInMultiChartsView } = props;
   const { encounter } = useEncounter();
+  const { visualisationConfigs } = useVitalChartData();
+
+  // Because this is a special view it needs more information
+  const dbpVisualisationConfig = visualisationConfigs.find(
+    config => config.key === VITALS_DATA_ELEMENT_IDS.dbp,
+  );
 
   const { data: sbpChartData, isLoading: isSbpLoading } = useVitalQuery(
     encounter.id,
@@ -48,6 +55,7 @@ export const VitalBloodPressureChart = props => {
         isLoading={isSbpLoading || isDbpLoading}
         chartProps={chartProps}
         useInwardArrowVector
+        secondaryConfig={dbpVisualisationConfig}
       />
     </>
   );


### PR DESCRIPTION
### Changes

Five commits, five fixes:
- Change the copy in the table legend
- Change copy on no data graph view
- The tooltip on blood pressure only showed results for SBP, with this change it now shows both places.
- Fix intermittent vital table error. This happened because by the time the table was rendering there was no `visualisationConfigs` to match. This value will get updated accordingly once the state settles in.
- The lower boundary on arrow vectors went beyond the max lower range. This is just clamping that value to be a little bit better.