### PR TITLE
[hotfix] disable export reference data (1.28)

### DIFF
--- a/packages/desktop/app/views/administration/PermissionsAdminView.js
+++ b/packages/desktop/app/views/administration/PermissionsAdminView.js
@@ -6,6 +6,7 @@ export const PermissionsAdminView = () => (
   <ImportExportView
     title="Permissions"
     endpoint="referenceData"
+    disableExport
     dataTypes={PERMISSION_IMPORTABLE_DATA_TYPES}
   />
 );

--- a/packages/desktop/app/views/administration/ReferenceDataAdminView.js
+++ b/packages/desktop/app/views/administration/ReferenceDataAdminView.js
@@ -7,6 +7,7 @@ export const ReferenceDataAdminView = () => (
     title="Reference data"
     endpoint="referenceData"
     dataTypes={GENERAL_IMPORTABLE_DATA_TYPES}
+    disableExport
     dataTypesSelectable
   />
 );


### PR DESCRIPTION
### Changes

- Disabled export reference data 
- Disabled export Permissions


<img width="1233" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/024ea53a-38f2-4350-9548-ca1e34e9bfd7">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
