### PR TITLE
NASS-814: Add initial sort to medications table

### DIFF
--- a/packages/desktop/app/components/MedicationTable.js
+++ b/packages/desktop/app/components/MedicationTable.js
@@ -116,6 +116,7 @@ export const DataFetchingMedicationTable = () => {
       endpoint="medication"
       columns={FULL_LISTING_COLUMNS}
       noDataMessage="No medication requests found"
+      initialSort={{ order: 'desc', orderBy: 'date' }}
       onRowClick={onMedicationSelect}
     />
   );


### PR DESCRIPTION
### Changes

We have had a request to default the sort for the sidebar medications table to be reverse chronological (newest to oldest). This is done simply by adding the prop with the default sort state. 

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
