### PR TITLE
EPI-536 Add age to patient summary screen on desktop

### DIFF
--- a/packages/shared/__tests__/utils/date.test.js
+++ b/packages/shared/__tests__/utils/date.test.js
@@ -1,8 +1,9 @@
+import { format } from 'date-fns';
 import { getDisplayAge } from '../../src/utils/date';
 
 describe('date', () => {
   describe('getDisplayAge', () => {
-    const now = new Date('2023-07-11');
+    const now = new Date('2023-07-11 22:55:36');
 
     beforeAll(() => {
       jest.resetModules();
@@ -100,7 +101,9 @@ describe('date', () => {
     ];
 
     testCases.forEach(testCase => {
-      it(`should display age '${testCase.expectedDisplayAge}' from date of birth '${testCase.dateOfBirth}'`, () => {
+      it(`should display age '${testCase.expectedDisplayAge}' from date of birth '${
+        testCase.dateOfBirth
+      }' at '${format(now, 'yyyy-MM-dd')}'`, () => {
         const displayAge = getDisplayAge(testCase.dateOfBirth, ageDisplayFormat);
         expect(displayAge).toEqual(testCase.expectedDisplayAge);
       });

--- a/packages/shared/src/utils/date.js
+++ b/packages/shared/src/utils/date.js
@@ -28,7 +28,7 @@ const getDifferenceFnByUnit = {
 };
 
 export function getAgeDurationFromDate(date) {
-  return intervalToDuration({ start: new Date(date), end: new Date() });
+  return intervalToDuration({ start: parseDate(date), end: new Date() });
 }
 
 const comparators = {

--- a/packages/shared/src/utils/date.js
+++ b/packages/shared/src/utils/date.js
@@ -52,11 +52,12 @@ function ageIsWithinRange(birthDate, range) {
   const { min = {}, max = {} } = range;
   const { duration: minDuration, exclusive: minExclusive } = min;
   const { duration: maxDuration, exclusive: maxExclusive } = max;
-  const minDate = addDuration(birthDate, minDuration);
-  const maxDate = addDuration(birthDate, maxDuration);
+  const minDate = minDuration ? addDuration(birthDate, minDuration) : -Infinity;
+  const maxDate = maxDuration ? addDuration(birthDate, maxDuration) : Infinity;
   const now = startOfDay(new Date());
   return (
-    compareDate(minDate, '<', now, minExclusive) && compareDate(now, '<', maxDate, maxExclusive)
+    (!minDate || compareDate(minDate, '<', now, minExclusive)) &&
+    (!maxDate || compareDate(now, '<', maxDate, maxExclusive))
   );
 }
 


### PR DESCRIPTION
### Issues:
1. [Issue here](https://linear.app/bes/issue/EPI-536#comment-8864f9a1) are Timezone related, which is that in GMT-0600, if birth date is '2023/07/06' as a date string, it will parse into Date and become '2023/07/05 18:00 GMT -6:00'.
2. Set system timezone to GMT-6, unit tests will capture these issues, however cannot dynamically set timezone in an easy way in Jest, because node always looks at system environments. Can run with 'yarn TZ=GMT-6 NODE_ENV=test jest' but it will set TZ globally. Will chat about it on dev chat.

### Changes:
1. Use parseDate() instead of new Date()


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
