### PR TITLE
SAV-326: Add 'useConfig' and 'useFeatureFlag' hooks to desktop

### DIFF
--- a/packages/desktop/app/components/Field/DisplayIdField.js
+++ b/packages/desktop/app/components/Field/DisplayIdField.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 
-import { useLocalisation } from '../../contexts/Localisation';
+import { useConfig } from '../../contexts/Localisation';
 import { TextField } from './TextField';
 import { LocalisedField } from './LocalisedField';
 
 export const DisplayIdField = ({ name = 'displayId', required }) => {
   const { initialValues } = useFormikContext();
-  const { getLocalisation } = useLocalisation();
-  const longLabel = getLocalisation('fields.displayId.longLabel');
-  const pattern = getLocalisation('fields.displayId.pattern') || null;
+  const [longLabel, pattern = null] = useConfig([
+    'fields.displayId.longLabel',
+    'fields.displayId.pattern',
+  ]);
   const regex = pattern ? new RegExp(pattern) : null;
 
   const validateFn = value => {

--- a/packages/desktop/app/components/Field/ImagingPriorityField.js
+++ b/packages/desktop/app/components/Field/ImagingPriorityField.js
@@ -2,11 +2,10 @@ import React from 'react';
 
 import { Field } from './Field';
 import { SelectField } from './SelectField';
-import { useLocalisation } from '../../contexts/Localisation';
+import { useConfig } from '../../contexts/Localisation';
 
 export const ImagingPriorityField = ({ name = 'priority', required }) => {
-  const { getLocalisation } = useLocalisation();
-  const imagingPriorities = getLocalisation('imagingPriorities') || [];
+  const imagingPriorities = useConfig('imagingPriorities') || [];
 
   return (
     <Field

--- a/packages/desktop/app/components/Field/LocalisedField.js
+++ b/packages/desktop/app/components/Field/LocalisedField.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as yup from 'yup';
 import { Field } from './Field';
-import { useLocalisation } from '../../contexts/Localisation';
+import { useConfig, useLocalisation } from '../../contexts/Localisation';
 
 export const LocalisedField = ({
   name,
@@ -11,15 +11,11 @@ export const LocalisedField = ({
   defaultLabel,
   ...props
 }) => {
-  const { getLocalisation } = useLocalisation();
-  const hidden = getLocalisation(`${path}.hidden`);
-  const label =
-    (useShortLabel
-      ? getLocalisation(`${path}.shortLabel`)
-      : getLocalisation(`${path}.longLabel`)) ||
-    defaultLabel ||
-    path;
-  const required = getLocalisation(`${path}.required`) || false;
+  const [hidden, label = defaultLabel || path, required = false] = useConfig([
+    `${path}.hidden`,
+    useShortLabel ? `${path}.shortLabel` : `${path}.longLabel`,
+    `${path}.required`,
+  ]);
   if (hidden) {
     return null;
   }

--- a/packages/desktop/app/components/Field/LocationField.js
+++ b/packages/desktop/app/components/Field/LocationField.js
@@ -9,7 +9,7 @@ import {
 import { AutocompleteInput } from './AutocompleteField';
 import { useApi, useSuggester } from '../../api';
 import { Suggester } from '../../utils/suggester';
-import { useLocalisation } from '../../contexts/Localisation';
+import { useConfig } from '../../contexts/Localisation';
 import { BodyText } from '../Typography';
 import { useAuth } from '../../contexts/Auth';
 
@@ -156,14 +156,12 @@ export const LocationField = React.memo(({ field, error, ...props }) => (
 
 export const LocalisedLocationField = React.memo(
   ({ defaultGroupLabel = 'Area', defaultLabel = 'Location', ...props }) => {
-    const { getLocalisation } = useLocalisation();
-
     const locationGroupIdPath = 'fields.locationGroupId';
-    const locationGroupLabel =
-      getLocalisation(`${locationGroupIdPath}.longLabel`) || defaultGroupLabel;
-
     const locationIdPath = 'fields.locationId';
-    const locationLabel = getLocalisation(`${locationIdPath}.longLabel`) || defaultLabel;
+    const [locationGroupLabel = defaultGroupLabel, locationLabel = defaultLabel] = useConfig([
+      `${locationGroupIdPath}.longLabel`,
+      `${locationIdPath}.longLabel`,
+    ]);
 
     return (
       <LocationField label={locationLabel} locationGroupLabel={locationGroupLabel} {...props} />

--- a/packages/desktop/app/components/ImagingRequestsTable.js
+++ b/packages/desktop/app/components/ImagingRequestsTable.js
@@ -9,7 +9,7 @@ import { PatientNameDisplay } from './PatientNameDisplay';
 import { reloadPatient } from '../store/patient';
 import { useEncounter } from '../contexts/Encounter';
 import { reloadImagingRequest } from '../store';
-import { useLocalisation } from '../contexts/Localisation';
+import { useConfig } from '../contexts/Localisation';
 import { getImagingRequestType } from '../utils/getImagingRequestType';
 import { TableCellTag } from './Tag';
 import { useImagingRequests } from '../contexts/ImagingRequests';
@@ -36,8 +36,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, memoryKey, status
   const dispatch = useDispatch();
   const params = useParams();
   const { loadEncounter } = useEncounter();
-  const { getLocalisation } = useLocalisation();
-  const imagingTypes = getLocalisation('imagingTypes') || {};
+  const imagingTypes = useConfig('imagingTypes') || {};
   const { searchParameters } = useImagingRequests(memoryKey);
   const isCompletedTable = memoryKey === IMAGING_TABLE_VERSIONS.COMPLETED.memoryKey;
 

--- a/packages/desktop/app/components/LocalisedText.js
+++ b/packages/desktop/app/components/LocalisedText.js
@@ -1,11 +1,10 @@
-import { useLocalisation } from '../contexts/Localisation';
+import { useConfig } from '../contexts/Localisation';
 
 export const LocalisedText = ({ path }) => {
-  const { getLocalisation } = useLocalisation();
+  const value = useConfig(path);
   if (!path) {
     return '<no path specified>';
   }
-  const value = getLocalisation(path);
   if (typeof value !== 'string') {
     return `<path not set to text: ${path}>`;
   }

--- a/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
+++ b/packages/desktop/app/components/PatientInfoPane/PatientInfoPane.js
@@ -16,7 +16,7 @@ import {
 import { DeathModal } from '../DeathModal';
 import { Colors } from '../../constants';
 import { PatientCarePlanDetails } from './PatientCarePlanNotes';
-import { useLocalisation } from '../../contexts/Localisation';
+import { useFeatureFlag } from '../../contexts/Localisation';
 import {
   CONDITIONS_TITLE,
   ALLERGIES_TITLE,
@@ -144,15 +144,14 @@ export const PatientInfoPane = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const openModal = useCallback(() => setModalOpen(true), [setModalOpen]);
   const closeModal = useCallback(() => setModalOpen(false), [setModalOpen]);
-  const { getLocalisation } = useLocalisation();
   const patient = useSelector(state => state.patient);
   const api = useApi();
   const { data: deathData, isLoading } = useQuery(['patientDeathSummary', patient.id], () =>
     api.get(`patient/${patient.id}/death`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
   );
 
+  const patientDeathsEnabled = useFeatureFlag('enablePatientDeaths');
   const readonly = !!patient.death;
-  const patientDeathsEnabled = getLocalisation('features.enablePatientDeaths');
   const showRecordDeathActions = !isLoading && patientDeathsEnabled && !deathData?.isFinal;
   const showCauseOfDeathButton = showRecordDeathActions && Boolean(deathData);
 

--- a/packages/desktop/app/components/PatientPrinting/modals/PatientIDCardPage.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PatientIDCardPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
-import { useLocalisation } from '../../../contexts/Localisation';
+import { useConfig } from '../../../contexts/Localisation';
 import { useElectron } from '../../../contexts/Electron';
 import { SEX_VALUE_INDEX } from '../../../constants';
 import { DateDisplay } from '../../DateDisplay';
@@ -80,8 +80,7 @@ const InfoRow = styled.div`
 `;
 
 const DetailsRow = ({ name, value }) => {
-  const { getLocalisation } = useLocalisation();
-  const label = getLocalisation(`fields.${name}.shortLabel`);
+  const label = useConfig(`fields.${name}.shortLabel`);
   return (
     <InfoRow>
       <DetailsKey>{`${label}: `}</DetailsKey>
@@ -98,8 +97,7 @@ const TopRow = styled.div`
 `;
 
 const DisplayIdRow = ({ name, value }) => {
-  const { getLocalisation } = useLocalisation();
-  const label = getLocalisation(`fields.${name}.shortLabel`);
+  const label = useConfig(`fields.${name}.shortLabel`);
   return (
     <TopRow>
       <DetailsKey>{`${label}: `}</DetailsKey>

--- a/packages/desktop/app/components/UserActivityMonitor.js
+++ b/packages/desktop/app/components/UserActivityMonitor.js
@@ -9,7 +9,7 @@ import { useIdleTimer } from 'react-idle-timer';
 import Typography from '@material-ui/core/Typography';
 import styled from 'styled-components';
 
-import { useLocalisation } from '../contexts/Localisation';
+import { useFeatureFlag } from '../contexts/Localisation';
 import { useAuth } from '../contexts/Auth';
 import { checkIsLoggedIn } from '../store/auth';
 
@@ -57,11 +57,10 @@ export const UserActivityMonitor = () => {
   const isUserLoggedIn = useSelector(checkIsLoggedIn);
   const [showWarning, setShowWarning] = useState(false);
   const { onTimeout, refreshToken } = useAuth();
-  const { getLocalisation } = useLocalisation();
 
   // Can't fetch localisation prior to login so add defaults
   const { enabled = false, timeoutDuration = 0, warningPromptDuration = 0, refreshInterval = 0 } =
-    getLocalisation('features.idleTimeout') || {};
+    useFeatureFlag('idleTimeout') || {};
 
   const onIdle = () => {
     // TODO: WAITM-598 Replace this full logout with a login modal

--- a/packages/desktop/app/components/VitalsTable.js
+++ b/packages/desktop/app/components/VitalsTable.js
@@ -13,7 +13,7 @@ import { formatShortest, formatTimeWithSeconds } from './DateDisplay';
 import { EditVitalCellModal } from './EditVitalCellModal';
 import { VitalVectorIcon } from './Icons/VitalVectorIcon';
 import { useVitalChartData } from '../contexts/VitalChartData';
-import { useLocalisation } from '../contexts/Localisation';
+import { useFeatureFlag } from '../contexts/Localisation';
 import { getNormalRangeByAge } from '../utils';
 
 const StyledTable = styled(Table)`
@@ -130,8 +130,7 @@ export const VitalsTable = React.memo(() => {
   const { data, recordedDates, error, isLoading } = useVitals(encounter.id);
   const [openEditModal, setOpenEditModal] = useState(false);
   const [selectedCell, setSelectedCell] = useState(null);
-  const { getLocalisation } = useLocalisation();
-  const isVitalEditEnabled = getLocalisation('features.enableVitalEdit');
+  const isVitalEditEnabled = useFeatureFlag('enableVitalEdit');
   const showFooterLegend = data.some(entry =>
     recordedDates.some(date => entry[date].historyLogs.length > 1),
   );

--- a/packages/desktop/app/contexts/Localisation.js
+++ b/packages/desktop/app/contexts/Localisation.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState, useCallback, useContext, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
 
@@ -14,17 +14,38 @@ export const LocalisationProvider = ({ children }) => {
   const [localisation, setLocalisation] = useState({});
   const reduxLocalisation = useSelector(state => state.auth.localisation);
 
+  const getLocalisation = useCallback(
+    path => {
+      if (Array.isArray(path)) return path.map(p => get(localisation, p));
+      return get(localisation, path);
+    },
+    [localisation],
+  );
+
   useEffect(() => {
     setLocalisation({ ...reduxLocalisation, ...overrides });
   }, [reduxLocalisation]);
 
   return (
-    <LocalisationContext.Provider
-      value={{
-        getLocalisation: path => get(localisation, path),
-      }}
-    >
+    <LocalisationContext.Provider value={{ getLocalisation }}>
       {children}
     </LocalisationContext.Provider>
   );
+};
+
+export const useConfig = path => {
+  const { getLocalisation } = useLocalisation();
+  return path ? getLocalisation(path) : undefined;
+};
+
+const featuresPath = 'features';
+
+export const useFeatureFlag = path => {
+  const { getLocalisation } = useLocalisation();
+  const toFeaturePath = useCallback(p => `${featuresPath}.${p}`, []);
+
+  // If !path, return entire features object
+  if (!path) return getLocalisation(featuresPath);
+  if (Array.isArray(path)) getLocalisation(path.map(toFeaturePath));
+  return getLocalisation(toFeaturePath(path));
 };

--- a/packages/desktop/app/forms/EditVitalCellForm.js
+++ b/packages/desktop/app/forms/EditVitalCellForm.js
@@ -7,7 +7,7 @@ import { PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/shared/constants';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { ConfirmCancelRow } from '../components/ButtonRow';
 import { SelectField, Form, Field, OuterLabelFieldWrapper } from '../components/Field';
-import { useLocalisation } from '../contexts/Localisation';
+import { useConfig } from '../contexts/Localisation';
 import { FormGrid } from '../components/FormGrid';
 import { FormSeparatorLine } from '../components/FormSeparatorLine';
 import { SurveyQuestion } from '../components/Surveys';
@@ -84,9 +84,10 @@ export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose }) => {
   const api = useApi();
   const queryClient = useQueryClient();
   const { encounter } = useEncounter();
-  const { getLocalisation } = useLocalisation();
-  const vitalEditReasons = getLocalisation('vitalEditReasons') || [];
-  const mandatoryVitalEditReason = getLocalisation('features.mandatoryVitalEditReason');
+  const [vitalEditReasons = [], mandatoryVitalEditReason] = useConfig([
+    'vitalEditReasons',
+    'features.mandatoryVitalEditReason',
+  ]);
   const initialValue = dataPoint.value;
   const showDeleteEntryButton = ['', undefined].includes(initialValue) === false;
   const valueName = dataPoint.component.dataElement.id;

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/shared/constants/labs';
 import { Field, OuterLabelFieldWrapper, RadioField } from '../../components';
 import { useApi } from '../../api';
-import { useLocalisation } from '../../contexts/Localisation';
+import { useFeatureFlag } from '../../contexts/Localisation';
 import { Colors } from '../../constants';
 
 const OPTIONS = {
@@ -53,8 +53,7 @@ const RadioItemSkeleton = ({ itemsLength }) => (
 
 const useLabRequestFormTypeOptions = () => {
   const api = useApi();
-  const { getLocalisation } = useLocalisation();
-  const { onlyAllowLabPanels } = getLocalisation('features') || {};
+  const onlyAllowLabPanels = useFeatureFlag('onlyAllowLabPanels');
 
   const { data, isSuccess, isLoading, isFetching } = useQuery(
     ['suggestions/labTestPanel/all'],

--- a/packages/desktop/app/forms/NotePageForm.js
+++ b/packages/desktop/app/forms/NotePageForm.js
@@ -7,7 +7,7 @@ import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import Divider from '@material-ui/core/Divider';
 import Tooltip from '@material-ui/core/Tooltip';
 import { NOTE_TYPES } from '@tamanu/shared/constants';
-import { useLocalisation } from '../contexts/Localisation';
+import { useFeatureFlag } from '../contexts/Localisation';
 import { useAuth } from '../contexts/Auth';
 import { foreignKey } from '../utils/validation';
 
@@ -90,7 +90,7 @@ export const NotePageForm = ({
   contentRef,
 }) => {
   const { currentUser } = useAuth();
-  const { getLocalisation } = useLocalisation();
+  const enableNoteBackdating = useFeatureFlag('enableNoteBackdating');
 
   const creatingNewNotePage = isEmpty(notePage);
 
@@ -139,7 +139,7 @@ export const NotePageForm = ({
           label="Date & time"
           component={DateTimeField}
           required
-          disabled={!getLocalisation('features.enableNoteBackdating')}
+          disabled={!enableNoteBackdating}
           saveDateAsString
         />
       </StyledFormGrid>

--- a/packages/desktop/app/forms/PatientDetailsForm.js
+++ b/packages/desktop/app/forms/PatientDetailsForm.js
@@ -21,7 +21,7 @@ import {
   socialMediaOptions,
   titleOptions,
 } from '../constants';
-import { useLocalisation } from '../contexts/Localisation';
+import { useFeatureFlag } from '../contexts/Localisation';
 import { useApi, useSuggester, usePatientSuggester } from '../api';
 import { getPatientDetailsValidation } from '../validations';
 import {
@@ -64,9 +64,10 @@ const StyledPatientDetailSecondaryDetailsGroupWrapper = styled.div`
 
 export const PrimaryDetailsGroup = () => {
   const villageSuggester = useSuggester('village');
-  const { getLocalisation } = useLocalisation();
+  const hideOtherSexFeature = useFeatureFlag('hideOtherSex');
+
   let filteredSexOptions = sexOptions;
-  if (getLocalisation('features.hideOtherSex') === true) {
+  if (hideOtherSexFeature === true) {
     filteredSexOptions = filteredSexOptions.filter(s => s.value !== 'other');
   }
 
@@ -96,8 +97,8 @@ export const PrimaryDetailsGroup = () => {
 };
 
 export const SecondaryDetailsGroup = ({ patientRegistryType, values = {}, isEdit = false }) => {
-  const { getLocalisation } = useLocalisation();
-  const canEditDisplayId = isEdit && getLocalisation('features.editDisplayId');
+  const editDisplayIdFeature = useFeatureFlag('editDisplayId');
+  const canEditDisplayId = isEdit && editDisplayIdFeature;
   const countrySuggester = useSuggester('country');
   const divisionSuggester = useSuggester('division');
   const ethnicitySuggester = useSuggester('ethnicity');

--- a/packages/desktop/app/hooks/useSexValues.js
+++ b/packages/desktop/app/hooks/useSexValues.js
@@ -1,11 +1,11 @@
-import { useLocalisation } from '../contexts/Localisation';
+import { useFeatureFlag } from '../contexts/Localisation';
 import { sexOptions } from '../constants';
 
 export const useSexValues = () => {
-  const { getLocalisation } = useLocalisation();
+  const hideOtherSexFeature = useFeatureFlag('hideOtherSex');
   const sexValues = sexOptions.map(o => o.value);
 
-  if (getLocalisation('features.hideOtherSex') === true) {
+  if (hideOtherSexFeature === true) {
     return sexValues.filter(s => s !== 'other');
   }
 
@@ -13,11 +13,9 @@ export const useSexValues = () => {
 };
 
 export const useSexOptions = (includeAll = false) => {
-  const { getLocalisation } = useLocalisation();
+  const hideOtherSexFeature = useFeatureFlag('hideOtherSex');
   const options =
-    getLocalisation('features.hideOtherSex') === true
-      ? sexOptions.filter(s => s.value !== 'other')
-      : sexOptions;
+    hideOtherSexFeature === true ? sexOptions.filter(s => s.value !== 'other') : sexOptions;
 
   return [...(includeAll ? [{ value: '', label: 'All' }] : []), ...options];
 };

--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -18,7 +18,7 @@ import { useCertificate } from '../../utils/useCertificate';
 import { getDepartmentName } from '../../utils/department';
 import { getDisplayAge } from '../../utils/dateTime';
 import { capitaliseFirstLetter } from '../../utils/capitalise';
-import { useLocalisation } from '../../contexts/Localisation';
+import { useConfig, useFeatureFlag } from '../../contexts/Localisation';
 import {
   usePatientAdditionalData,
   usePatientConditions,
@@ -114,8 +114,7 @@ const NavContainer = styled.div`
 `;
 
 const DiagnosesList = ({ diagnoses }) => {
-  const { getLocalisation } = useLocalisation();
-  const displayIcd10Codes = getLocalisation('features.displayIcd10CodesInDischargeSummary');
+  const displayIcd10Codes = useFeatureFlag('displayIcd10CodesInDischargeSummary');
 
   return diagnoses.map(item => (
     <li>
@@ -126,8 +125,7 @@ const DiagnosesList = ({ diagnoses }) => {
 };
 
 const ProceduresList = ({ procedures }) => {
-  const { getLocalisation } = useLocalisation();
-  const displayProcedureCodes = getLocalisation('features.displayProcedureCodesInDischargeSummary');
+  const displayProcedureCodes = useFeatureFlag('displayProcedureCodesInDischargeSummary');
 
   return procedures.map(procedure => (
     <li>
@@ -155,10 +153,7 @@ const MedicationsList = ({ medications, discontinued }) => {
 const SummaryPage = React.memo(({ encounter, discharge }) => {
   const { title, subTitle, logo } = useCertificate();
 
-  const { getLocalisation } = useLocalisation();
-  const dischargeDispositionVisible =
-    getLocalisation('fields.dischargeDisposition.hidden') === false;
-
+  const dischargeDispositionVisible = useConfig('fields.dischargeDisposition.hidden') === false;
   const patient = useSelector(state => state.patient);
   const { data: village } = useReferenceData(patient.villageId);
   const { data: patientAdditionalData, isLoading: isPADLoading } = usePatientAdditionalData(

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { ENCOUNTER_TYPES } from '@tamanu/shared/constants';
-import { useLocalisation } from '../../../contexts/Localisation';
+import { useFeatureFlag } from '../../../contexts/Localisation';
 import { DischargeModal } from '../../../components/DischargeModal';
 import { ChangeEncounterTypeModal } from '../../../components/ChangeEncounterTypeModal';
 import { ChangeDepartmentModal } from '../../../components/ChangeDepartmentModal';
@@ -52,7 +52,7 @@ const ENCOUNTER_MODALS = {
 
 const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType }) => {
   const { navigateToSummary } = usePatientNavigation();
-  const { getLocalisation } = useLocalisation();
+  const enablePatientMoveActions = useFeatureFlag('patientPlannedMove');
 
   const onChangeEncounterType = type => {
     setNewEncounterType(type);
@@ -88,8 +88,6 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
   };
   const isProgressionForward = (currentState, nextState) =>
     progression[nextState] > progression[currentState];
-
-  const enablePatientMoveActions = getLocalisation('features.patientPlannedMove');
 
   const actions = [
     {

--- a/packages/desktop/app/views/patients/components/RandomPatientButton.js
+++ b/packages/desktop/app/views/patients/components/RandomPatientButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Chance } from 'chance';
 import { Button } from '../../../components';
-import { useLocalisation } from '../../../contexts/Localisation';
+import { useFeatureFlag } from '../../../contexts/Localisation';
 
 const makeRandomPatient = generateId => {
   const chance = new Chance();
@@ -32,8 +32,7 @@ const RandomButtonStyled = styled(Button)`
 `;
 
 export const RandomPatientButton = ({ generateId, setValues }) => {
-  const { getLocalisation } = useLocalisation();
-  const allowGenerator = getLocalisation('features.quickPatientGenerator');
+  const allowGenerator = useFeatureFlag('quickPatientGenerator');
 
   if (!allowGenerator) {
     return null;


### PR DESCRIPTION
### Changes

- Add `useConfig('key')` hook to replace `useLocalisation().getLocalisation('key')`
- Add `useFeatureFlag('key')` hook to replace `useLocalisation().getLocalisation('features.key')`
- Replaced all instances of 2nd point with `useFeatureFlag`
- Replaced some instances of `getLocalisation` with `useConfig`
- Refactor `getLocalisation` function
- Add `const [val1, val2, val3, etc.] = getLocalisation([key1, key2, key3, etc.])` functionality, also implemented in `useFeatureFlag` and `useConfig`

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
