### PR TITLE
Fix/SAV-268 Duplicate patients appearing in recent patients list

### DIFF
--- a/packages/lan/app/utils/patientFilters.js
+++ b/packages/lan/app/utils/patientFilters.js
@@ -65,7 +65,7 @@ export const createPatientFilters = filterParams => {
     makeFilter(filterParams.sex, `patients.sex = :sex`),
     makeFilter(
       filterParams.currentPatient,
-      `recent_encounter_by_patient IS NOT NULL AND encounters.encounter_type NOT IN (:currentPatientExcludeEncounterTypes)`,
+      `encounters.encounter_type NOT IN (:currentPatientExcludeEncounterTypes)`,
       () => ({
         currentPatientExcludeEncounterTypes: [
           ENCOUNTER_TYPES.IMAGING,


### PR DESCRIPTION
[Issue found in release 1.29](https://beyondessential.slack.com/archives/C03KJSEPV9A/p1690258737414279)

### Changes
1. Get rid of recent_encounter_by_patient on filter
2. Update query for activeCovid19PatientsHandler for fetching recent patient, Same as what I did here: https://github.com/beyondessential/tamanu/pull/4173 (Can we just ask for a double check on activeCovid19PatientsHandler during v1.29 regression test?)


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
