### PR TITLE
SAV-257: Implement design fixes and show note type in unfiltered note…

### DIFF
--- a/packages/desktop/app/components/NoteChangeLog.js
+++ b/packages/desktop/app/components/NoteChangeLog.js
@@ -13,10 +13,14 @@ const StyledListItemText = styled(ListItemText)`
     white-space: pre-line;
     width: 100%;
   }
+  &.MuiListItemText-root {
+    margin-bottom: 0;
+  }
 `;
 const StyledNoteChangeLogSecondaryWrapper = styled.div`
+  font-weight: 500;
   font-size: 11px;
-  line-height: 18px;
+  line-height: 15px;
   color: ${Colors.softText};
   margin-top: 5px;
 `;

--- a/packages/desktop/app/components/NoteChangeLogs.js
+++ b/packages/desktop/app/components/NoteChangeLogs.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { isEmpty } from 'lodash';
 import { useQuery } from '@tanstack/react-query';
 
+import { Colors } from '../constants';
 import { useApi } from '../api';
 import { OuterLabelFieldWrapper } from './Field/OuterLabelFieldWrapper';
 import { NoteChangeLog } from './NoteChangeLog';
@@ -11,6 +12,11 @@ import { NoteChangeLog } from './NoteChangeLog';
 const StyledBox = styled(Box)`
   .MuiListItem-root {
     padding-bottom: 0;
+  }
+  &.MuiBox-root {
+    border-radius: 3px;
+    border: 1px solid ${Colors.outline};
+    padding-bottom: 16px;
   }
 `;
 

--- a/packages/desktop/app/components/NoteTable.js
+++ b/packages/desktop/app/components/NoteTable.js
@@ -5,7 +5,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import { NOTE_TYPES } from '@tamanu/shared/constants';
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
-import { Colors } from '../constants';
+import { noteTypes, Colors } from '../constants';
 import { useAuth } from '../contexts/Auth';
 import { NOTE_FORM_MODES, NoteModal } from './NoteModal';
 import { withPermissionCheck } from './withPermissionCheck';
@@ -27,6 +27,7 @@ const NoteContentContainer = styled.div`
   position: relative;
   overflow: hidden;
   display: -webkit-box;
+  white-space: pre-line;
   ${props =>
     !props.$expanded
       ? `
@@ -54,6 +55,15 @@ const ReadMoreSpan = styled(EllipsisHideShowSpan)`
 `;
 
 const ShowLessSpan = styled(EllipsisHideShowSpan)``;
+
+const NoteHeaderContainer = styled.div`
+  margin-bottom: 5px;
+`;
+
+const NoteHeaderText = styled.span`
+  font-weight: 500;
+  color: ${Colors.midText};
+`;
 
 const NoteBodyContainer = styled.div`
   display: flex;
@@ -91,6 +101,7 @@ const NoteContent = ({
   currentUser,
   handleEditNote,
   handleViewNoteChangeLog,
+  isNotFilteredByNoteType,
 }) => {
   const [contentIsClipped, setContentIsClipped] = useState(false);
   const [textIsExpanded, setTextIsExpanded] = useState(false);
@@ -98,6 +109,13 @@ const NoteContent = ({
   const handleReadLess = useCallback(() => setTextIsExpanded(false), []);
   return (
     <NoteRowContainer>
+      {isNotFilteredByNoteType && (
+        <NoteHeaderContainer>
+          <NoteHeaderText>
+            {noteTypes.find(type => type.value === note.noteType).label}
+          </NoteHeaderText>
+        </NoteHeaderContainer>
+      )}
       <NoteBodyContainer>
         <NoteContentContainer
           $expanded={textIsExpanded}
@@ -183,12 +201,13 @@ const NoteTable = ({ encounterId, hasPermission, noteModalOnSaved, noteType }) =
             currentUser={currentUser}
             handleEditNote={handleEditNote}
             handleViewNoteChangeLog={handleViewNoteChangeLog}
+            isNotFilteredByNoteType={!noteType}
           />
         ),
         sortable: false,
       },
     ],
-    [hasPermission, currentUser, handleEditNote, handleViewNoteChangeLog],
+    [hasPermission, currentUser, noteType, handleEditNote, handleViewNoteChangeLog],
   );
 
   return (

--- a/packages/desktop/app/forms/NoteForm.js
+++ b/packages/desktop/app/forms/NoteForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
+import Divider from '@material-ui/core/Divider';
 import Tooltip from '@material-ui/core/Tooltip';
 import { NOTE_TYPES } from '@tamanu/shared/constants';
 import { useLocalisation } from '../contexts/Localisation';
@@ -46,6 +47,10 @@ const getSelectableNoteTypes = noteTypeCountByType =>
 
 const StyledFormGrid = styled(FormGrid)`
   margin-bottom: 20px;
+`;
+const StyledDivider = styled(Divider)`
+  margin-top: 30px;
+  margin-bottom: 30px;
 `;
 const StyledTooltip = styled(props => (
   <Tooltip classes={{ popper: props.className }} {...props}>
@@ -148,6 +153,7 @@ export const NoteForm = ({
           rows={6}
         />
       )}
+      <StyledDivider />
       <ConfirmCancelRow
         onConfirm={noteFormMode === NOTE_FORM_MODES.VIEW_NOTE ? onCancel : submitForm}
         confirmText={confirmText}


### PR DESCRIPTION
… table

### Changes

- Implement design fixes to match figma
- Add line breaks to note table content
- Add note type to note table content when notes are not filtered by type

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
