### PR TITLE
EPI-584: Fully remove queries on logout, don't just invalidate them

### DIFF
--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -22,7 +22,7 @@ export const useAuth = () => {
     })),
     onLogout: () => {
       dispatch(logout());
-      queries.invalidateQueries();
+      queries.resetQueries();
     },
     onTimeout: () => dispatch(idleTimeout()),
     refreshToken: () => api.refreshToken(),

--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -22,7 +22,9 @@ export const useAuth = () => {
     })),
     onLogout: () => {
       dispatch(logout());
+      // setTimeout prevents resetQueries from triggering a page rerender and blocking logout
       setTimeout(() => {
+        // resets queries instead of invalidating them (clears from cache as well as refetching)
         queries.resetQueries();
       }, 1);
     },

--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -22,7 +22,9 @@ export const useAuth = () => {
     })),
     onLogout: () => {
       dispatch(logout());
-      queries.resetQueries();
+      setTimeout(() => {
+        queries.resetQueries();
+      }, 1);
     },
     onTimeout: () => dispatch(idleTimeout()),
     refreshToken: () => api.refreshToken(),

--- a/packages/desktop/app/contexts/Auth.js
+++ b/packages/desktop/app/contexts/Auth.js
@@ -22,11 +22,9 @@ export const useAuth = () => {
     })),
     onLogout: () => {
       dispatch(logout());
-      // setTimeout prevents resetQueries from triggering a page rerender and blocking logout
-      setTimeout(() => {
-        // resets queries instead of invalidating them (clears from cache as well as refetching)
-        queries.resetQueries();
-      }, 1);
+      // removes items from cache but doesn't trigger a re-render
+      // because the login screen doesn't have any queries on it, this should be fine
+      queries.removeQueries();
     },
     onTimeout: () => dispatch(idleTimeout()),
     refreshToken: () => api.refreshToken(),


### PR DESCRIPTION
### Changes

Resets queries rather than invalidating them on logout, meaning that the underlying cache results are fully cleared and not just marked stale.

In EPI-584 there are two things going on: SAV-280, which we don't care about; and discharges being shown to users who shouldn't be able to see them, which we _do_ care about quite a lot. I believe this is happening because we invalidate queries on logout, which _leaves them in the cache_ while they refetch...but if they fail to refetch, probably just shows them.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
