### PR TITLE
TAMOC-35: Clarify and fix version compatibilty checks

### DIFF
--- a/packages/lan/__tests__/versionCompatibility.test.js
+++ b/packages/lan/__tests__/versionCompatibility.test.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import { MAX_CLIENT_VERSION } from '../app/middleware/versionCompatibility';
+import { gte as semverGte, lte as semverLte } from 'semver';
+import { MIN_CLIENT_VERSION, MAX_CLIENT_VERSION } from '../app/middleware/versionCompatibility';
 
 describe('Other packages', () => {
   let versions;
@@ -18,6 +19,7 @@ describe('Other packages', () => {
 
   it('Should support the current version of desktop', async () => {
     const desktopVersions = versions.map(([, v]) => v);
-    desktopVersions.forEach(v => expect(MAX_CLIENT_VERSION).toEqual(v));
+    desktopVersions.forEach(v => expect(semverLte(MIN_CLIENT_VERSION, v)).toBe(true));
+    desktopVersions.forEach(v => expect(semverLte(v, MAX_CLIENT_VERSION)).toBe(true));
   });
 });

--- a/packages/lan/app/middleware/versionCompatibility.js
+++ b/packages/lan/app/middleware/versionCompatibility.js
@@ -1,10 +1,24 @@
-import { buildVersionCompatibilityCheck } from 'shared/utils';
+import { parse } from 'semver';
+import { buildVersionCompatibilityCheck } from '@tamanu/shared/utils';
 
 // only works via webpack, not direct nodejs
 import pkgjson from '../../package.json';
 
-export const MIN_CLIENT_VERSION = pkgjson.version;
-export const MAX_CLIENT_VERSION = pkgjson.version; // note that higher patch versions will be allowed to connect
+const { major, minor } = parse(pkgjson.version);
+
+// In general, all versions in the current minor version should be compatible with each other.
+// However, if there is an incompatibility between the desktop client version and a facility server
+// version, this can be used to override the forbid clients below a certain version from connecting.
+//
+// To do so, set this to a string like '1.30.2'.
+//
+// THIS SHOULD BE RARE and only used in exceptional circumstances.
+// When merging to main or other branches, this MUST be reset to null.
+const MIN_CLIENT_OVERRIDE = null;
+
+export const MIN_CLIENT_VERSION = MIN_CLIENT_OVERRIDE ?? `${major}.${minor}.0`;
+export const MAX_CLIENT_VERSION = `${major}.${minor}.999`;
+// Note that .999 is only for clarity; higher patch versions will always be allowed
 
 export const versionCompatibility = (req, res, next) =>
   buildVersionCompatibilityCheck(MIN_CLIENT_VERSION, MAX_CLIENT_VERSION)(req, res, next);

--- a/packages/lan/app/middleware/versionCompatibility.js
+++ b/packages/lan/app/middleware/versionCompatibility.js
@@ -12,7 +12,7 @@ const { major, minor } = parse(pkgjson.version);
 //
 // To do so, set this to a string like '1.30.2'.
 //
-// THIS SHOULD BE RARE and only used in exceptional circumstances.
+// THIS SHOULD BE RARE and only used in exceptional circumstances.
 // When merging to main or other branches, this MUST be reset to null.
 const MIN_CLIENT_OVERRIDE = null;
 

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@beyondessential/eslint-config-js": "^1.1.0",
-    "@tamanu/build-tooling": "*",
     "@swc/jest": "0.2.26",
+    "@tamanu/build-tooling": "*",
     "chai": "^4.1.2",
     "eslint": "^5.15.2",
     "eslint-import-resolver-webpack": "^0.11.0",
@@ -71,6 +71,7 @@
     "react": "16.8.5",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
+    "semver": "^7.5.4",
     "sequelize": "^6.21.3",
     "shortid": "^2.2.13",
     "umzug": "^2.3.0",

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -14,7 +14,7 @@ const { major, minor } = parse(pkgjson.version);
 //
 // To do so, set this to a string like '1.30.2'.
 //
-// THIS SHOULD BE RARE and only used in exceptional circumstances.
+// THIS SHOULD BE RARE and only used in exceptional circumstances.
 // When merging to main or other branches, this MUST be reset to null.
 const MIN_CLIENT_OVERRIDE = null;
 

--- a/packages/sync-server/app/middleware/versionCompatibility.js
+++ b/packages/sync-server/app/middleware/versionCompatibility.js
@@ -1,21 +1,39 @@
+import { parse } from 'semver';
 import { buildVersionCompatibilityCheck } from 'shared/utils';
 import { InvalidClientHeadersError } from 'shared/errors';
 
 // only works via webpack, not direct nodejs
 import pkgjson from '../../package.json';
 
+const { major, minor } = parse(pkgjson.version);
+
+// In general, all versions in the current minor version should be compatible with each other.
+// However, if there is an incompatibility between any (desktop, facility) client version and a
+// central server version, this can be used to override the forbid clients below a certain version
+// from connecting.
+//
+// To do so, set this to a string like '1.30.2'.
+//
+// THIS SHOULD BE RARE and only used in exceptional circumstances.
+// When merging to main or other branches, this MUST be reset to null.
+const MIN_CLIENT_OVERRIDE = null;
+
+export const MIN_CLIENT_VERSION = MIN_CLIENT_OVERRIDE ?? `${major}.${minor}.0`;
+export const MAX_CLIENT_VERSION = `${major}.${minor}.999`;
+// Note that .999 is only for clarity; higher patch versions will always be allowed
+
 export const SUPPORTED_CLIENT_VERSIONS = {
   'Tamanu LAN Server': {
-    min: pkgjson.version,
-    max: pkgjson.version, // note that higher patch versions will be allowed to connect
+    min: MIN_CLIENT_VERSION,
+    max: MAX_CLIENT_VERSION,
   },
   'Tamanu Desktop': {
-    min: pkgjson.version,
-    max: pkgjson.version, // note that higher patch versions will be allowed to connect
+    min: MIN_CLIENT_VERSION,
+    max: MAX_CLIENT_VERSION,
   },
   'Tamanu Mobile': {
-    min: pkgjson.version,
-    max: pkgjson.version, // note that higher patch versions will be allowed to connect
+    min: MIN_CLIENT_VERSION,
+    max: MAX_CLIENT_VERSION,
   },
   'fiji-vps': {
     min: null,

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -101,6 +101,7 @@
     "read": "^1.0.7",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
+    "semver": "^7.5.4",
     "sequelize": "^6.21.3",
     "tiny-async-pool": "^1.2.0",
     "transliteration": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21720,6 +21720,13 @@ semver@^7.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"


### PR DESCRIPTION
### Changes

- Parse the version and reformat it so that, in general:
  - MIN_CLIENT_VERSION is always x.y.0
  - MAX_CLIENT_VERSION is always x.y.999
    - the patch version of MAX_CLIENT_VERSION doesn't matter, as we always allow higher patch versions to connect. nevertheless, i think having it as .999 makes the intent clearer.
- Setup a simple way to add an override if one is ever needed.
- Improve the comments to make all this clear.

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue