### PR TITLE
NASS-829: add imaging_results imaging_request_id index for completed table subquery performance

### DIFF
--- a/packages/shared/src/migrations/1690847027746-addImagingResultImagingRequestIdIndex.js
+++ b/packages/shared/src/migrations/1690847027746-addImagingResultImagingRequestIdIndex.js
@@ -1,0 +1,9 @@
+export async function up(query) {
+  await query.addIndex('imaging_results', {
+    fields: ['imaging_request_id'],
+  });
+}
+
+export async function down(query) {
+  await query.removeIndex('imaging_results', ['imaging_request_id']);
+}


### PR DESCRIPTION
### Changes
Found this to be bottleneck in explain analyzing query
Index reduces time from `72590.088 ms` to `408.572 ms` In deployment with a massive amount of data.
This is due to the custom aggregation subquery attribute we added to get around sequelize bug with subqueries, limits and nested joins.

Just getting Megan to go through clone environment that I applied index and confirm everything.

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
