### PR TITLE
NASS-829: Add if not exists to imaging result index creation

### DIFF
--- a/packages/shared/src/migrations/1690847027746-addImagingResultImagingRequestIdIndex.js
+++ b/packages/shared/src/migrations/1690847027746-addImagingResultImagingRequestIdIndex.js
@@ -1,9 +1,15 @@
 export async function up(query) {
-  await query.addIndex('imaging_results', {
-    fields: ['imaging_request_id'],
-  });
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS
+      imaging_results_imaging_request_id
+    ON
+      imaging_results (imaging_request_id)
+  `);
 }
 
 export async function down(query) {
-  await query.removeIndex('imaging_results', ['imaging_request_id']);
+  await query.sequelize.query(`
+    DROP INDEX
+      imaging_results_imaging_request_id
+  `);
 }


### PR DESCRIPTION
### Changes
- My test of addIndex (and online discussion) was a mistake and we have to specify this for it to not error if we add index manually.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
