### PR TITLE
SAV-257: active color text fix & SAV-259: read more position test fix

### DIFF
--- a/packages/desktop/app/components/Field/TextField.js
+++ b/packages/desktop/app/components/Field/TextField.js
@@ -57,7 +57,8 @@ export const StyledTextField = styled(MuiTextField)`
   }
 
   // Focused state
-  .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+  .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline,
+  .MuiOutlinedInput-root.Mui-focused:hover .MuiOutlinedInput-notchedOutline {
     border: 1px solid ${props => props.theme.palette.primary.main};
   }
 

--- a/packages/desktop/app/components/NoteTable.js
+++ b/packages/desktop/app/components/NoteTable.js
@@ -5,7 +5,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import { NOTE_TYPES } from '@tamanu/shared/constants';
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
-import { noteTypes, Colors } from '../constants';
+import { Colors, NOTE_TYPE_LABELS } from '../constants';
 import { useAuth } from '../contexts/Auth';
 import { NOTE_FORM_MODES, NoteModal } from './NoteModal';
 import { withPermissionCheck } from './withPermissionCheck';
@@ -114,9 +114,7 @@ const NoteContent = ({
     <NoteRowContainer>
       {isNotFilteredByNoteType && (
         <NoteHeaderContainer>
-          <NoteHeaderText>
-            {noteTypes.find(type => type.value === note.noteType).label}
-          </NoteHeaderText>
+          <NoteHeaderText>{NOTE_TYPE_LABELS[note.noteType]}</NoteHeaderText>
         </NoteHeaderContainer>
       )}
       <NoteBodyContainer>

--- a/packages/desktop/app/components/NoteTable.js
+++ b/packages/desktop/app/components/NoteTable.js
@@ -263,6 +263,7 @@ const NoteTable = ({ encounterId, hasPermission, noteModalOnSaved, noteType }) =
         endpoint={`encounter/${encounterId}/notes`}
         fetchOptions={{ noteType }}
         elevated={false}
+        noDataBackgroundColor={Colors.background}
         noDataMessage={`This patient has no notes ${
           noteType ? 'of this type ' : ''
         }to display. Click ‘New note’ to add a note.`}

--- a/packages/desktop/app/forms/NoteForm.js
+++ b/packages/desktop/app/forms/NoteForm.js
@@ -171,7 +171,7 @@ export const NoteForm = ({
       initialValues={{
         date: getCurrentDateTimeString(),
         noteType: note?.noteType,
-        writtenById: currentUser.id,
+        writtenById: note?.onBehalfOfId || note?.authorId || currentUser.id,
       }}
       validationSchema={yup.object().shape({
         noteType: yup


### PR DESCRIPTION
### Changes

Test fixes:
- SAV-257: Make text field active state blue outline even when hovered
- SAV-259: Fix position of "read more" button in notes table that was buggy after adding line-break support

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
