### PR TITLE
TAMOC-37: Fix report query replacements not using from date

### DIFF
--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -25,7 +25,7 @@ export const getReportQueryReplacements = async (
   const currentFacilityId = (await LocalSystemFact.get('facilityId')) || null;
 
   const toDate = params.toDate ? new Date(params.toDate) : new Date();
-  const fromDate = getStartDate(dateRange, toDate);
+  const fromDate = params.fromDate ? new Date(params.fromDate) : getStartDate(dateRange, toDate);
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
   return {
     ...paramDefaults,


### PR DESCRIPTION
### Changes
This was a result of a refactor inside `currentFacilityId` replacement pr. 
From date would never be passed as replacement to query - and instead the default logic always supplied it as 30 days ago in the case of hospital ward summary.

Gone for low touch here but:
**Follow up**
I also noticed some possible cleanups re date handling here but will do in another pr into main once I check some things.
- avoid using new Date on string dates - we only need to convert them to Date if the subtraction of 30 days has to take place. Also if we do need to convert them to date

```
import { subDays, startOfDay, parseISO } from 'date-fns';
import { getCurrentDateString, toDateString } from '@tamanu/shared/utils/date';
import { REPORT_DEFAULT_DATE_RANGES } from '../../constants';

const CATCH_ALL_FROM_DATE = '1970-01-01';

function getStartDate(dateRange, endDate) {
  switch (dateRange) {
    case REPORT_DEFAULT_DATE_RANGES.ALL_TIME:
      return CATCH_ALL_FROM_DATE;
    case REPORT_DEFAULT_DATE_RANGES.THIRTY_DAYS:
      // If we have a toDate, but no fromDate, run 30 days prior to the toDate
      return toDateString(startOfDay(subDays(parseISO(endDate), 30)));
    default:
      throw new Error('Unknown date range for report generation');
  }
}

export const getReportQueryReplacements = async (
  context,
  paramDefinitions,
  params = {},
  dateRange = REPORT_DEFAULT_DATE_RANGES.ALL_TIME,
) => {
  const { LocalSystemFact } = context.models;
  const currentFacilityId = (await LocalSystemFact.get('facilityId')) || null;

  const toDate = params.toDate || getCurrentDateString();
  const fromDate = params.fromDate || getStartDate(dateRange, toDate);
  const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});

  return {
    ...paramDefaults,
    ...params,
    currentFacilityId,
    fromDate,
    toDate,
```

### Checklist

- [x] Code is finished
- [] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
