### PR TITLE
TAN-2240: Make table name singular ('user' not 'users')

### DIFF
--- a/packages/mobile/App/migrations/1688428478000-addDisplayIdToUsers.ts
+++ b/packages/mobile/App/migrations/1688428478000-addDisplayIdToUsers.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 import { getTable } from './utils/queryRunner';
 
-const tableName = 'users';
+const tableName = 'user';
 const columnName = 'displayId';
 
 export class addDisplayIdToUsers1688428478000 implements MigrationInterface {


### PR DESCRIPTION
### Changes

In #4384 the mobile migration specified `users` instead of `user` for the table name, so now mobile on `main` can't start.

We should probably have a test that runs our migrations to catch things like this, but I'm prioritising fixing `main`.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
