### PR TITLE
SAV-315: Change note modal date value

### DIFF
--- a/packages/desktop/app/forms/NoteForm.js
+++ b/packages/desktop/app/forms/NoteForm.js
@@ -45,6 +45,13 @@ const getSelectableNoteTypes = noteTypeCountByType =>
         !!noteTypeCountByType[x.value],
     }));
 
+const getNoteDateFieldValue = (noteFormMode, note) => {
+  if (noteFormMode === NOTE_FORM_MODES.CREATE_NOTE) return new Date();
+  if (note.noteType === NOTE_TYPES.TREATMENT_PLAN && noteFormMode === NOTE_FORM_MODES.EDIT_NOTE)
+    return note.date;
+  return note.revisedBy?.date || note.date;
+};
+
 const StyledFormGrid = styled(FormGrid)`
   margin-bottom: 20px;
 `;
@@ -128,13 +135,19 @@ export const NoteForm = ({
         />
         <Field
           name="date"
-          label="Date & time"
+          label={`${
+            noteFormMode === NOTE_FORM_MODES.EDIT_NOTE &&
+            note.noteType === NOTE_TYPES.TREATMENT_PLAN
+              ? 'Last updated'
+              : 'Created at'
+          } Date & time`}
           component={DateTimeField}
           required={noteFormMode === NOTE_FORM_MODES.CREATE_NOTE}
           disabled={
             !getLocalisation('features.enableNoteBackdating') ||
             noteFormMode !== NOTE_FORM_MODES.CREATE_NOTE
           }
+          value={getNoteDateFieldValue(noteFormMode, note)}
           saveDateAsString
         />
       </StyledFormGrid>


### PR DESCRIPTION
### Changes

Change the note modal value to the created at date or last updated date for treatment plan notes

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
