### PR TITLE
TAN-2137: Remove template validation

### DIFF
--- a/packages/desktop/app/forms/PatientLetterForm.js
+++ b/packages/desktop/app/forms/PatientLetterForm.js
@@ -81,7 +81,13 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
           component={AutocompleteField}
           onChange={e => onChangeTemplate(e.target.value)}
         />
-        <Field name="title" label="Letter title" component={TextField} disabled={templateLoading} />
+        <Field
+          name="title"
+          label="Letter title"
+          required
+          component={TextField}
+          disabled={templateLoading}
+        />
         <Field
           name="body"
           label="Note"
@@ -142,6 +148,7 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
       }}
       validationSchema={yup.object().shape({
         clinicianId: yup.string().required('Clinician is required'),
+        title: yup.string().required('Letter title is required'),
       })}
     />
   );

--- a/packages/desktop/app/forms/PatientLetterForm.js
+++ b/packages/desktop/app/forms/PatientLetterForm.js
@@ -91,6 +91,7 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
         <Field
           name="body"
           label="Note"
+          required
           component={TallMultilineTextField}
           disabled={templateLoading}
         />
@@ -149,6 +150,7 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
       validationSchema={yup.object().shape({
         clinicianId: yup.string().required('Clinician is required'),
         title: yup.string().required('Letter title is required'),
+        body: yup.string().required('Note is required'),
       })}
     />
   );

--- a/packages/desktop/app/forms/PatientLetterForm.js
+++ b/packages/desktop/app/forms/PatientLetterForm.js
@@ -148,6 +148,7 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
         ...editedObject,
       }}
       validationSchema={yup.object().shape({
+        date: yup.date().required('Date is required'),
         clinicianId: yup.string().required('Clinician is required'),
         title: yup.string().required('Letter title is required'),
         body: yup.string().required('Note is required'),

--- a/packages/desktop/app/forms/PatientLetterForm.js
+++ b/packages/desktop/app/forms/PatientLetterForm.js
@@ -142,7 +142,6 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
       }}
       validationSchema={yup.object().shape({
         clinicianId: yup.string().required('Clinician is required'),
-        templateId: yup.string().required('Template is required'),
       })}
     />
   );


### PR DESCRIPTION
### Changes

Missed some validation tweaks on my last pr. Template needed was still being validated even without the required star and  the name didn't have a required star even though it was required for the form to submit properly. We also made the body required per comment from Megan

