### PR TITLE
EPI-596: Add updatedAtByField for Patient model

### DIFF
--- a/packages/mobile/App/migrations/1691026414000-addFieldUpdateTicksToPatient.ts
+++ b/packages/mobile/App/migrations/1691026414000-addFieldUpdateTicksToPatient.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { snakeCase } from 'lodash';
+import { getTable } from './utils/queryRunner';
+
+const METADATA_FIELDS = [
+  'createdAt',
+  'updatedAt',
+  'deletedAt',
+  'updatedAtSyncTick',
+  'updatedAtByField',
+];
+
+const CURRENT_SYNC_TICK_KEY = 'currentSyncTick';
+
+export class addFieldUpdateTicksToPatient1691026414000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const tableObject = await getTable(queryRunner, 'patient');
+    await queryRunner.addColumn(
+      tableObject,
+      new TableColumn({
+        name: 'updatedAtByField',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+
+    const [localSystemFactValue] = await queryRunner.query(`
+      SELECT value FROM local_system_fact WHERE key = '${CURRENT_SYNC_TICK_KEY}'
+    `);
+
+    const syncTick =
+      localSystemFactValue !== undefined ? parseInt(localSystemFactValue.value, 10) : 1;
+
+    if (typeof syncTick !== 'number') {
+      throw new Error('Sync tick is not numeric');
+    }
+
+    const columns = await queryRunner.query("PRAGMA table_info('patient');");
+    // A little hack to make sure 'id' is the first (since id will never be null)
+    // column so that we get the commas in JSON string concatenation right
+    const includedColumnNames = [
+      'id',
+      ...columns.map(c => c.name).filter(c => !METADATA_FIELDS.includes(c) && c !== 'id'),
+    ];
+    const updateColumnConcat = includedColumnNames
+      .map(
+        (c, index) =>
+          `CASE WHEN ${c} IS NULL THEN '' ELSE '${index === 0 ? '' : ', '}"${snakeCase(
+            c,
+          )}": ${syncTick}' END\n`,
+      )
+      .join(' || ');
+
+    await queryRunner.query(`
+      UPDATE patient
+      SET updatedAtByField = (SELECT '{' || ${updateColumnConcat} || '}'
+          FROM patient AS sub_pad WHERE sub_pad.id = patient.id)
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('patient', 'updatedAtByField');
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -25,6 +25,7 @@ import { changeDateColumnToNullableForAdministeredVaccine1683598923000 } from '.
 import { addDisplayIdToUsers1688428478000 } from './1688428478000-addDisplayIdToUsers';
 import { addSpecimenTypeAndCollectedByToLabRequest1686083400000 } from './1686083400000-addSpecimenTypeAndCollectedByToLabRequest';
 import { addVitalLogs1690236942000 } from './1690236942000-addVitalLogs';
+import { addFieldUpdateTicksToPatient1691026414000 } from './1691026414000-addFieldUpdateTicksToPatient';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -53,4 +54,5 @@ export const migrationList = [
   addDisplayIdToUsers1688428478000,
   addSpecimenTypeAndCollectedByToLabRequest1686083400000,
   addVitalLogs1690236942000,
+  addFieldUpdateTicksToPatient1691026414000,
 ];

--- a/packages/shared/src/migrations/1691025254812-addFieldUpdateTicksToPatient.js
+++ b/packages/shared/src/migrations/1691025254812-addFieldUpdateTicksToPatient.js
@@ -1,0 +1,52 @@
+import Sequelize from 'sequelize';
+
+const CURRENT_SYNC_TICK_KEY = 'currentSyncTick';
+
+const METADATA_FIELDS = [
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  'updated_at_sync_tick',
+  'updated_at_by_field',
+];
+
+export async function up(query) {
+  await query.addColumn('patients', 'updated_at_by_field', {
+    type: Sequelize.JSON,
+  });
+  await query.sequelize.query(`
+    CREATE TRIGGER set_patients_updated_at_by_field
+    BEFORE INSERT OR UPDATE ON patients
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at_by_field();
+  `);
+  await query.sequelize.query(`
+    -- an initial empty object
+    UPDATE
+      patients
+    SET
+      updated_at_by_field = '{}'::json;
+
+    -- set sync tick for all fields that aren't null
+    UPDATE
+      patients
+    SET
+      updated_at_by_field = (
+        SELECT JSON_OBJECT_AGG(row_as_json.key, (SELECT value::bigint FROM local_system_facts WHERE key = '${CURRENT_SYNC_TICK_KEY}'))::jsonb
+        FROM
+          jsonb_each(row_to_json(patients)::jsonb) AS row_as_json
+        WHERE
+          row_as_json.value <> 'null'::jsonb
+        AND
+          row_as_json.key NOT IN (${METADATA_FIELDS.map(m => `'${m}'`).join(',')})
+      );
+  `);
+}
+
+export async function down(query) {
+  await query.removeColumn('patients', 'updated_at_by_field');
+  await query.sequelize.query(`
+    DROP TRIGGER IF EXISTS set_patients_updated_at_by_field
+    ON patients;
+  `);
+}

--- a/packages/shared/src/models/Patient.js
+++ b/packages/shared/src/models/Patient.js
@@ -29,6 +29,7 @@ export class Patient extends Model {
         },
         email: Sequelize.STRING,
         visibilityStatus: Sequelize.STRING,
+        updatedAtByField: Sequelize.JSON,
       },
       {
         ...options,

--- a/packages/sync-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/sync-server/__tests__/sync/CentralSyncManager.test.js
@@ -1209,7 +1209,7 @@ describe('CentralSyncManager', () => {
       const incomingChanges = changes.map(c => ({
         ...c,
         direction: SYNC_SESSION_DIRECTION.INCOMING,
-        updatedAtByFieldSum: null,
+        updatedAtByFieldSum: expect.any(Number),
       }));
 
       expect(insertSnapshotRecords).toBeCalledTimes(1);


### PR DESCRIPTION
### Changes

Creating a PR just for a clearer diff. 

This is something I was working on that unfortunately was not what we wanted. The reason we didn't want this change is because this would be a different behavior. But also, modifying the Patient model comes with a heavy cost on memory.

However I believe this might serve us as a "template" or "reference guide" if we ever choose to add `updatedAtByField` to another model in the future. It was not that easy to find all of the pieces for this (and even this might not be complete, but it could be a good start on where to look). DO NOT just copy this, migration files should be recreated from scratch to have a more recent timestamp.

Note: the central server test failed because it's missing a refactor that it's in another PR.

Steps:
Central/facility:
- Create migration file
- Add field to model

Mobile:
- Create migration file
- Add field to model
- Add `setUpdatedAtByField` hook to model (run with BeforeInsert and BeforeUpdate decorators).
  - The helper function used here depends on the `updatedAtByField` refactor to work. If that didn't get into main, then you will have to copy it over from another model. Or better yet, make the refactor yourself.
- Include static methods to convert data to/from JSON.

