### PR TITLE
TAMOC-43: fix header moving offscreen on details route

### DIFF
--- a/packages/desktop/app/routes/PatientRoutes.js
+++ b/packages/desktop/app/routes/PatientRoutes.js
@@ -86,8 +86,6 @@ const RouteWithSubRoutes = ({ path, component, routes }) => (
 );
 
 const PatientPane = styled.div`
-  // contain size needs to be set for the tabs to work correctly
-  contain: size;
   overflow: auto;
 `;
 
@@ -96,9 +94,6 @@ const PatientPaneInner = styled.div`
   // We don't support mobile devices.
   // Set a minimum width to stop layouts breaking on small screens
   min-width: ${PATIENT_PANE_WIDTH};
-  display: flex;
-  flex-direction: column;
-  height: 100%;
 `;
 
 export const PatientRoutes = React.memo(() => {


### PR DESCRIPTION
### Changes
I changed some styles in the results pr and it turns out we don't need any of these styles anymore for the use cases it was implemented for.

- Tabs work correctly without size: contains now
- pages like lab view which want to full page with no scroll - but inner scroll work
- Details page doesn't have disappearing navigation

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
