### PR TITLE
TAMOC-44: Fix loading indicator obscuring modal

### DIFF
--- a/packages/desktop/app/components/DropdownButton.js
+++ b/packages/desktop/app/components/DropdownButton.js
@@ -95,7 +95,7 @@ const MenuButton = styled(Button)`
 
 const Popper = styled(MuiPopper)`
   margin-top: 2px;
-  z-index: 1500; // This needs to be higher than the modal z-index (1400) to be visible in modals
+  z-index: 1500; // This needs to be higher than the modal z-index (1300) to be visible in modals
   min-width: ${props => (props.anchorEl ? `${props.anchorEl.offsetWidth}px` : `${0}`)};
 `;
 

--- a/packages/desktop/app/components/LoadingIndicator.js
+++ b/packages/desktop/app/components/LoadingIndicator.js
@@ -9,7 +9,7 @@ const LoadingIconContainer = styled.div`
   background: ${props => props.backgroundColor || '#cecece'};
   opacity: 0.5;
   overflow: hidden;
-  z-index: 9999;
+  z-index: 1300; // high but below modal z-index
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(3, 1fr);
 

--- a/packages/desktop/app/components/LoadingIndicator.js
+++ b/packages/desktop/app/components/LoadingIndicator.js
@@ -9,7 +9,7 @@ const LoadingIconContainer = styled.div`
   background: ${props => props.backgroundColor || '#cecece'};
   opacity: 0.5;
   overflow: hidden;
-  z-index: 1300; // high but below modal z-index
+  z-index: 1200; // high but below a modal's z-index of 1300
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(3, 1fr);
 


### PR DESCRIPTION
### Changes

The loading indicator z-index was set too high and was rendering over the top of the modal. I can't tell why it was set at all? But I'm going in with a light touch and have just brought it down a little bit.

### Checklist

- [x] Code is finished

