### PR TITLE
TAMOC-42: Add a min width to the programs pane

### DIFF
--- a/packages/desktop/app/views/programs/ProgramsPane.js
+++ b/packages/desktop/app/views/programs/ProgramsPane.js
@@ -7,6 +7,7 @@ export const ProgramsPane = styled(Paper)`
   background: white;
   padding: 30px;
   max-width: 700px;
+  min-width: 500px;
   margin: 50px auto;
   border-radius: 3px;
 `;


### PR DESCRIPTION
### Changes

I couldn't figure out why the modal was showing up as a normal width previously - I wonder if it used to have some additional content that was removed? But we probably never want it to show up narrower than about 500px either way, so I'm just including that as a new min-width to try and keep a light touch.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
