### PR TITLE
Allow release/ prefix in branch names

### DIFF
--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -16,8 +16,8 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref }}
       shell: bash
       run: |
-        if ! grep -qP '^(feature|fix|epic|merge)/' <<< "$BRANCH_NAME"; then
-          echo "::warning::Branch name should be prefixed with feature/ or fix/ or epic/ or merge/"
+        if ! grep -qP '^(feature|fix|epic|merge|release)/' <<< "$BRANCH_NAME"; then
+          echo "::warning::Branch name should be prefixed with one of: feature/ fix/ epic/ merge/ release/"
           exit 1
         fi
 


### PR DESCRIPTION
### Changes

The branch name checker action was failing when merging a `release/` branch back into `main`, this fixes that.

### Checklist

- [x] Code is finished
