### PR TITLE
Iterate packages in dependency order for build-shared

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache \
     jq \
     make \
     python3
-COPY yarn.lock .yarnrc common.* babel.config.js scripts ./
+COPY yarn.lock .yarnrc common.* babel.config.js ./
+COPY scripts/ scripts/
 
 FROM base AS run-base
 RUN apk add --no-cache bash curl jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache \
     jq \
     make \
     python3
-COPY yarn.lock .yarnrc common.* babel.config.js scripts/docker-build-server.sh ./
+COPY yarn.lock .yarnrc common.* babel.config.js scripts ./
 
 FROM base AS run-base
 RUN apk add --no-cache bash curl jq
@@ -45,7 +45,7 @@ RUN git log -1 --pretty=%cI         | tee /meta/SOURCE_DATE_ISO
 FROM build-base as shared
 COPY packages/build-tooling/ packages/build-tooling/
 COPY packages/shared/ packages/shared/
-RUN ./docker-build-server.sh
+RUN scripts/docker-build-server.sh
 
 
 ## Build the target server
@@ -59,7 +59,7 @@ COPY --from=shared /app/packages/ packages/
 COPY packages/${PACKAGE_PATH}/ packages/${PACKAGE_PATH}/
 
 # do the build
-RUN ./docker-build-server.sh ${PACKAGE_PATH}
+RUN scripts/docker-build-server.sh ${PACKAGE_PATH}
 
 
 ## Special target for packaging the desktop app

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "license": "SEE LICENSE IN license",
   "scripts": {
     "create-package": "node scripts/create-package.mjs",
-    "build-shared": "node scripts/build-shared.mjs",
-    "build": "yarn build-shared && concurrently \"yarn workspace sync-server run build\" \"yarn workspace lan run build\" \"yarn workspace desktop run build\" \"yarn workspace meta-server run build\" \"yarn workspace csca run build\"",
+    "build": "node scripts/build-all.mjs",
+    "build-shared": "yarn run build --shared-only",
     "test": "yarn run build-shared && node scripts/test-all.mjs",
     "test-coverage": "yarn run test --coverage",
     "lint-all": "node scripts/lint-all.mjs",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "Beyond Essential Systems Pty. Ltd.",
   "license": "SEE LICENSE IN license",
   "scripts": {
+    "clean": "rimraf packages/*/dist packages/*/*.tsbuildinfo",
     "create-package": "node scripts/create-package.mjs",
     "build": "node scripts/build-all.mjs",
     "build-shared": "yarn run build --shared-only",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -7,6 +7,7 @@
   "bin": {
     "pkg": "./node_modules/.bin/pkg",
     "swc": "./node_modules/.bin/swc",
+    "tsc": "./node_modules/.bin/tsc",
     "webpack": "./node_modules/.bin/webpack"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "pkg": "^4.4.8",
     "swc-loader": "^0.2.3",
     "terser-webpack-plugin": "^5.3.6",
+    "typescript": "^5.1.6",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-node-externals": "^3.0.0"

--- a/scripts/_do-with-all-packages.mjs
+++ b/scripts/_do-with-all-packages.mjs
@@ -1,18 +1,31 @@
 import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 
 export function doWithAllPackages(fn) {
-  const topPkg = JSON.parse(readFileSync('./package.json'));
+  const workspaceTree = JSON.parse(
+    execFileSync('yarn', ['-s', 'workspaces', 'info'], { encoding: 'utf8' }),
+  );
+  const workspaces = new Set(Object.keys(workspaceTree));
+  const processed = new Set();
 
-  for (const name of topPkg.workspaces.packages) {
-    const pkgPath = `./${name}/package.json`;
-    let pkg;
-    try {
-      pkg = JSON.parse(readFileSync(pkgPath));
-    } catch (err) {
-      console.log(`Skipping ${name} as we can't read its package.json...`);
-      continue;
+  while (processed.size < workspaces.size) {
+    for (const workspace of workspaces) {
+      if (processed.has(workspace)) continue;
+      const { location, workspaceDependencies } = workspaceTree[workspace];
+      if (workspaceDependencies.every(dep => processed.has(dep))) {
+        processed.add(workspace);
+
+        const pkgPath = `./${location}/package.json`;
+        let pkg;
+        try {
+          pkg = JSON.parse(readFileSync(pkgPath));
+        } catch (err) {
+          console.log(`Skipping ${workspace} as we can't read its package.json...`);
+          continue;
+        }
+
+        fn(workspace, pkg, pkgPath);
+      }
     }
-
-    fn(name, pkg, pkgPath);
   }
 }

--- a/scripts/_do-with-all-packages.mjs
+++ b/scripts/_do-with-all-packages.mjs
@@ -8,6 +8,8 @@ export function doWithAllPackages(fn) {
   const workspaces = new Set(Object.keys(workspaceTree));
   const processed = new Set();
 
+  const packagesThatAreDependedOn = new Set(Object.values(workspaceTree).flatMap(({ workspaceDependencies }) => workspaceDependencies));
+
   while (processed.size < workspaces.size) {
     for (const workspace of workspaces) {
       if (processed.has(workspace)) continue;
@@ -24,7 +26,7 @@ export function doWithAllPackages(fn) {
           continue;
         }
 
-        fn(workspace, pkg, pkgPath);
+        fn(workspace, pkg, pkgPath, packagesThatAreDependedOn.has(workspace));
       }
     }
   }

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -1,9 +1,12 @@
 import { execFileSync } from 'child_process';
 import { doWithAllPackages } from './_do-with-all-packages.mjs';
 
-doWithAllPackages((name, pkg) => {
+doWithAllPackages((name, pkg, _pkgPath, isShared) => {
   console.log(`Checking ${name}...`);
-  if (!pkg.name.startsWith('@tamanu/')) return;
+  if (process.argv.includes('--shared-only') && !isShared) {
+    console.log(`Skipping ${name} as it's not a shared package...`);
+    return;
+  }
 
   if (!pkg.scripts?.build) {
     console.log(`Skipping ${name} as it doesn't have a build script...`);

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -28,7 +28,8 @@ yarn install --non-interactive --frozen-lockfile
 # so we don't need to build shared here, and in the shared stage we don't build
 # the server packages, hence this neat branching logic here
 if is_building_shared; then
-  yarn workspace @tamanu/shared build
+  yarn clean
+  yarn build-shared
 else
   # clear out the tests and files not useful for production
   rm -rf packages/*/__tests__ || true


### PR DESCRIPTION
### Changes

- Iterate packages in dependency order for build-shared
- Define sharedness of a package programmatically instead of statically (ie "has something that depends on it")
- And therefore make a top-level `build` script that also resolves the dependency order to avoid issues (it's the same script)
- Run build-shared in container build instead of just the shared package's build, so it (will) works properly with multiple "shared" packages.

### Checklist

- [x] Code is finished