### PR TITLE
NASS-716: db defined reports surface id of report definitions

### DIFF
--- a/packages/desktop/app/views/administration/reports/ReportsImportView.js
+++ b/packages/desktop/app/views/administration/reports/ReportsImportView.js
@@ -51,7 +51,7 @@ const ImportFeedback = ({ feedback }) => (
       {feedback.createdDefinition ? 'Created new' : 'Updated existing'} definition:{' '}
       <b>{feedback.name}</b>
     </BodyText>
-    {feedback.createdDefinition && (
+    {feedback.reportDefinitionId && (
       <BodyText mb={1}>
         Report id: <b>{feedback.reportDefinitionId}</b>
       </BodyText>

--- a/packages/desktop/app/views/administration/reports/ReportsImportView.js
+++ b/packages/desktop/app/views/administration/reports/ReportsImportView.js
@@ -51,6 +51,11 @@ const ImportFeedback = ({ feedback }) => (
       {feedback.createdDefinition ? 'Created new' : 'Updated existing'} definition:{' '}
       <b>{feedback.name}</b>
     </BodyText>
+    {feedback.createdDefinition && (
+      <BodyText mb={1}>
+        Report id: <b>{feedback.reportDefinitionId}</b>
+      </BodyText>
+    )}
     <BodyText>
       created new version: <b>{feedback.versionNumber}</b>
     </BodyText>

--- a/packages/desktop/app/views/administration/reports/VersionEditor.js
+++ b/packages/desktop/app/views/administration/reports/VersionEditor.js
@@ -87,11 +87,12 @@ const SaveIcon = styled(SaveAsIcon)`
   margin-right: 10px;
 `;
 
-const VersionInfo = ({ name, version }) => (
+const VersionInfo = ({ name, id, version }) => (
   <VersionInfoCard>
     <CardHeader>
       <CardItem label="Name" value={name} />
       <CardItem label="Version" value={version.versionNumber} />
+      <CardItem label="Report id" value={id} />
     </CardHeader>
     <CardDivider />
     <CardItem
@@ -232,7 +233,7 @@ export const VersionEditor = ({ report, version, onBack, onSave }) => {
           </StyledButton>
         </ButtonContainer>
         <DetailList>
-          <VersionInfo name={name} version={version} />
+          <VersionInfo id={id} name={name} version={version} />
           {value && (
             <ErrorBoundary errorKey={version.id} ErrorComponent={LoadError}>
               <JsonEditor

--- a/packages/sync-server/__tests__/admin/reports/reportRoutes.test.js
+++ b/packages/sync-server/__tests__/admin/reports/reportRoutes.test.js
@@ -224,16 +224,17 @@ describe('reportRoutes', () => {
         deleteFileAfterImport: false,
       });
       expect(res).toHaveSucceeded();
-      expect(res.body).toEqual({
-        versionNumber: 1,
-        createdDefinition: true,
-      });
       const report = await models.ReportDefinition.findOne({
         where: { name: 'Report Import Test' },
         include: {
           model: models.ReportDefinitionVersion,
           as: 'versions',
         },
+      });
+      expect(res.body).toEqual({
+        versionNumber: 1,
+        createdDefinition: true,
+        reportDefinitionId: report.id,
       });
       expect(report).toBeTruthy();
       expect(report.versions).toHaveLength(1);
@@ -248,16 +249,17 @@ describe('reportRoutes', () => {
         deleteFileAfterImport: false,
       });
       expect(res).toHaveSucceeded();
-      expect(res.body).toEqual({
-        versionNumber: 2,
-        createdDefinition: false,
-      });
       const report = await models.ReportDefinition.findOne({
         where: { name: testReport.name },
         include: {
           model: models.ReportDefinitionVersion,
           as: 'versions',
         },
+      });
+      expect(res.body).toEqual({
+        versionNumber: 2,
+        reportDefinitionId: report.id,
+        createdDefinition: false,
       });
       expect(report).toBeTruthy();
       expect(report.versions).toHaveLength(2);

--- a/packages/sync-server/app/admin/reports/reportRoutes.js
+++ b/packages/sync-server/app/admin/reports/reportRoutes.js
@@ -212,6 +212,8 @@ reportsRouter.post(
           if (dryRun) {
             throw new DryRun();
           }
+
+          feedback.reportDefinitionId = definition.id;
         },
       );
     } catch (err) {


### PR DESCRIPTION
### Changes

into release 1.30
For permission adding.
1. Add id in success message when a report is imported 
<img width="552" alt="Screenshot 2023-08-10 at 11 17 47 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/1f1dfe81-230f-49ac-b825-ae87e4698138">

2. Available on editor details section too anytime
<img width="1033" alt="Screenshot 2023-08-10 at 11 16 30 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/1d8b93e1-8724-438c-aacd-ea4624e8a847">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
