### PR TITLE
NASS-846: Lab results completed date timezone offset fix

### DIFF
--- a/packages/desktop/app/views/patients/components/LabTestResultsModal.js
+++ b/packages/desktop/app/views/patients/components/LabTestResultsModal.js
@@ -131,6 +131,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
           component={DateTimeField}
           name={LAB_TEST_PROPERTIES.COMPLETED_DATE}
           tabIndex={tabIndex(3, i)}
+          saveDateAsString
         />
       ),
     },


### PR DESCRIPTION
### Changes
- Just needed this prop
- I feel high priority to remove this prop - or reverse default behaviour for date fields, I believe this is covered in maintenance. 

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
