### PR TITLE
EPI-519: Save FHIR resource lastUpdated in local time

### DIFF
--- a/packages/shared/src/models/fhir/Resource.js
+++ b/packages/shared/src/models/fhir/Resource.js
@@ -1,6 +1,7 @@
 import { snakeCase } from 'lodash';
 import { Sequelize, Utils, DataTypes, QueryTypes } from 'sequelize';
 import * as yup from 'yup';
+import { subMinutes } from 'date-fns';
 
 import {
   SYNC_DIRECTIONS,
@@ -37,6 +38,15 @@ export class FhirResource extends Model {
           type: DataTypes.TIMESTAMP,
           allowNull: false,
           defaultValue: Sequelize.NOW,
+          set(utcDate) {
+            // Sequelize converts TIMESTAMP into UTC, so we convert it back to local time
+            if (!(utcDate instanceof Date)) {
+              return utcDate;
+            }
+            const localOffsetMinutes = new Date().getTimezoneOffset();
+            this.setDataValue('lastUpdated', subMinutes(utcDate, localOffsetMinutes));
+            return this.lastUpdated;
+          },
         },
         ...attributes,
       },


### PR DESCRIPTION
### Changes

Hotfix for the UTC last_updated issue in Aspen FHIR records.

Duplicate of https://github.com/beyondessential/tamanu/pull/4224 because it's more important to get this working than to convert it to a string field.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
