### PR TITLE
SAV-209: Hide all encounter actions for vaccination and survey response encounters

### DIFF
--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -149,9 +149,13 @@ export const EncounterView = () => {
         subTitle={encounter.location?.facility?.name}
         encounter={encounter}
       >
-        {(facility.id === encounter.location.facilityId || encounter.endDate) && (
-          <EncounterActions encounter={encounter} />
-        )}
+        {(facility.id === encounter.location.facilityId || encounter.endDate) &&
+          // Hide all actions if encounter type is Vaccination or Survey Response,
+          // as they should only contain 1 survey response or vaccination and discharged automatically,
+          // no need to show any summaries or actions
+          ![ENCOUNTER_TYPES.VACCINATION, ENCOUNTER_TYPES.SURVEY_RESPONSE].includes(
+            encounter.encounterType,
+          ) && <EncounterActions encounter={encounter} />}
       </EncounterTopBar>
       <ContentPane>
         <EncounterInfoPane

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -69,12 +69,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
   const onViewSummary = () => navigateToSummary();
   const onViewEncounterRecord = () => setOpenModal(ENCOUNTER_MODALS.ENCOUNTER_RECORD);
 
-  if (
-    encounter.endDate &&
-    ![ENCOUNTER_TYPES.VACCINATION, ENCOUNTER_TYPES.SURVEY_RESPONSE].includes(
-      encounter.encounterType,
-    )
-  ) {
+  if (encounter.endDate) {
     return (
       <div>
         <Button variant="outlined" color="primary" onClick={onViewSummary}>


### PR DESCRIPTION
### Changes
- Hide all encounter actions for vaccination and survey response encounters

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
