### PR TITLE
NASS-716 Use report definition id in db-defined reports admin panel details

### DIFF
--- a/packages/desktop/app/views/administration/reports/VersionEditor.js
+++ b/packages/desktop/app/views/administration/reports/VersionEditor.js
@@ -87,12 +87,12 @@ const SaveIcon = styled(SaveAsIcon)`
   margin-right: 10px;
 `;
 
-const VersionInfo = ({ name, id, version }) => (
+const VersionInfo = ({ name, reportDefinitionId, version }) => (
   <VersionInfoCard>
     <CardHeader>
       <CardItem label="Name" value={name} />
       <CardItem label="Version" value={version.versionNumber} />
-      <CardItem label="Report id" value={id} />
+      <CardItem label="Report id" value={reportDefinitionId} />
     </CardHeader>
     <CardDivider />
     <CardItem
@@ -152,7 +152,7 @@ export const VersionEditor = ({ report, version, onBack, onSave }) => {
     versionNumber,
     ...editableData
   } = version;
-  const { name } = report;
+  const { name, id: reportDefinitionId } = report;
   const { currentUser } = useAuth();
   const [showSqlEditor, setShowSqlEditor] = useState(false);
   const [isValid, setIsValid] = useState(true);
@@ -233,7 +233,7 @@ export const VersionEditor = ({ report, version, onBack, onSave }) => {
           </StyledButton>
         </ButtonContainer>
         <DetailList>
-          <VersionInfo id={id} name={name} version={version} />
+          <VersionInfo reportDefinitionId={reportDefinitionId} name={name} version={version} />
           {value && (
             <ErrorBoundary errorKey={version.id} ErrorComponent={LoadError}>
               <JsonEditor


### PR DESCRIPTION
### Changes
Silly mistake
I was surface wrong ID here, it needs to refer to reportDefinitionId and not versionId

### Checklist
- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
