### PR TITLE
TAN-2276: Remove scrollbar on document printing

### DIFF
--- a/packages/desktop/app/components/DocumentPreview/DocumentPreviewModal.js
+++ b/packages/desktop/app/components/DocumentPreview/DocumentPreviewModal.js
@@ -35,7 +35,7 @@ const Preview = ({ documentType, attachmentId, ...props }) => {
   return `Preview is not supported for document type ${documentType}`;
 };
 
-export const DocumentPreviewModal = ({ open, onClose, onDownload, document }) => {
+export const DocumentPreviewModal = ({ open, onClose, onDownload, document, onPrintPDF }) => {
   const [scrollPage, setScrollPage] = useState(1);
   const [pageCount, setPageCount] = useState();
   const { type: documentType, attachmentId } = document;
@@ -54,8 +54,8 @@ export const DocumentPreviewModal = ({ open, onClose, onDownload, document }) =>
         </div>
       }
       printable={document.source === DOCUMENT_SOURCES.PATIENT_LETTER}
+      onPrint={() => onPrintPDF(attachmentId)}
       additionalActions={[<DownloadButton onClick={onDownload} key="Download" />]}
-      onPrint={() => window.print()}
       width="md"
       overrideContentPadding
       onClose={() => {

--- a/packages/desktop/app/components/DocumentPreview/DocumentPreviewModal.js
+++ b/packages/desktop/app/components/DocumentPreview/DocumentPreviewModal.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import { Typography } from '@material-ui/core';
 import { DOCUMENT_SOURCES } from '@tamanu/shared/constants';
-
 import { Modal } from '../Modal';
 import PDFPreview from './PDFPreview';
 import PhotoPreview from './PhotoPreview';
@@ -56,6 +55,7 @@ export const DocumentPreviewModal = ({ open, onClose, onDownload, document }) =>
       }
       printable={document.source === DOCUMENT_SOURCES.PATIENT_LETTER}
       additionalActions={[<DownloadButton onClick={onDownload} key="Download" />]}
+      onPrint={() => window.print()}
       width="md"
       overrideContentPadding
       onClose={() => {

--- a/packages/desktop/app/views/patients/panes/DocumentsPane.js
+++ b/packages/desktop/app/views/patients/panes/DocumentsPane.js
@@ -83,7 +83,7 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
           iframe.contentWindow.print();
         };
       } catch (error) {
-        console.error('Printing PDF error:', error.message);
+        notifyError(error.message);
       }
     },
     [api],

--- a/packages/desktop/app/views/patients/panes/DocumentsPane.js
+++ b/packages/desktop/app/views/patients/panes/DocumentsPane.js
@@ -65,6 +65,30 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
     [api, openPath, showSaveDialog, writeFile],
   );
 
+  const onPrintPDF = useCallback(
+    async attachmentId => {
+      try {
+        const { data } = await api.get(`attachment/${attachmentId}`, {
+          base64: true,
+        });
+        const dataUri = `data:application/pdf;base64,${data}`;
+        const iframe = document.createElement('iframe');
+        iframe.style.display = 'none';
+        iframe.src = dataUri;
+
+        document.body.appendChild(iframe);
+
+        iframe.onload = () => {
+          // Print the PDF after it's loaded in the iframe
+          iframe.contentWindow.print();
+        };
+      } catch (error) {
+        console.error('Printing PDF error:', error.message);
+      }
+    },
+    [api],
+  );
+
   const refreshTable = useCallback(() => setRefreshCount(count => count + 1), [setRefreshCount]);
   const closeModal = useCallback(() => setModalStatus(MODAL_STATES.CLOSED), [setModalStatus]);
   const downloadCurrent = useCallback(() => onDownload(selectedDocument), [
@@ -117,6 +141,7 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
         onClose={closeModal}
         document={selectedDocument ?? {}}
         onDownload={downloadCurrent}
+        onPrintPDF={onPrintPDF}
       />
     </>
   );


### PR DESCRIPTION
### Changes

Currently on windows when printing the new patient letters a scrollbar will appear in the actual PDF. On further investigation we discovered that this is because the printable prop was added to the document preview modal but the document preview logic isn't setup for printing so we into problems.

To fix this I added a custom print handler which puts the PDF data into an iframe which is then printed. 

Because this was a windows specific error I actually let Klaus test and pass this on autodeploy before code review as we weren't sure if we were even going down the right path and I couldn't test on my Mac. 
