### PR TITLE
[NASS-818] Export and Import reference data in chunks

### DIFF
--- a/packages/desktop/app/views/administration/ReferenceDataAdminView.js
+++ b/packages/desktop/app/views/administration/ReferenceDataAdminView.js
@@ -8,5 +8,6 @@ export const ReferenceDataAdminView = () => (
     endpoint="referenceData"
     dataTypes={GENERAL_IMPORTABLE_DATA_TYPES}
     dataTypesSelectable
+    useChunkData
   />
 );

--- a/packages/desktop/app/views/administration/components/ImportExportView.js
+++ b/packages/desktop/app/views/administration/components/ImportExportView.js
@@ -21,7 +21,7 @@ const TabContainer = styled.div`
 `;
 
 export const ImportExportView = memo(
-  ({ title, endpoint, dataTypes, dataTypesSelectable, disableExport }) => {
+  ({ title, endpoint, dataTypes, dataTypesSelectable, disableExport, useChunkData }) => {
     const [currentTab, setCurrentTab] = useState('import');
     const [isLoading, setIsLoading] = useState(false);
 
@@ -38,6 +38,7 @@ export const ImportExportView = memo(
                 dataTypes={dataTypes}
                 dataTypesSelectable={dataTypesSelectable}
                 setIsLoading={setIsLoading}
+                useChunkData={useChunkData}
               />
             </TabContainer>
           ),
@@ -54,12 +55,13 @@ export const ImportExportView = memo(
                 dataTypes={dataTypes}
                 dataTypesSelectable={dataTypesSelectable}
                 setIsLoading={setIsLoading}
+                useChunkData={useChunkData}
               />
             </TabContainer>
           ),
         },
       ],
-      [title, endpoint, dataTypes, dataTypesSelectable, disableExport],
+      [title, endpoint, dataTypes, dataTypesSelectable, disableExport, useChunkData],
     );
 
     return (

--- a/packages/sync-server/app/admin/exporter/exporter.js
+++ b/packages/sync-server/app/admin/exporter/exporter.js
@@ -1,5 +1,3 @@
-import { promises as asyncFs } from 'fs';
-import config from 'config';
 import { writeExcelFile } from './excelUtils';
 import { createModelExporter } from './modelExporters/createModelExporter';
 
@@ -26,20 +24,6 @@ async function buildSheetDataForDataType(models, dataType) {
   };
 }
 
-async function validateFileSize(fileName, maxSizeInMb) {
-  if (!fileName) {
-    return;
-  }
-  const ONE_MEGABYTE_IN_BYTES = 1024 * 1024;
-  const { size: fileSizeInBytes } = await asyncFs.stat(fileName);
-  const maxSizeInBytes = maxSizeInMb * ONE_MEGABYTE_IN_BYTES;
-  if (fileSizeInBytes > maxSizeInBytes) {
-    throw new Error(
-      `File exported exceeds configured maximum of ${maxSizeInMb}mb. Please try again with less data types.`,
-    );
-  }
-}
-
 export async function exporter(models, includedDataTypes = {}, fileName = '') {
   const sheets = await Promise.all(
     Object.values(includedDataTypes).map(async dataType => {
@@ -50,11 +34,5 @@ export async function exporter(models, includedDataTypes = {}, fileName = '') {
       };
     }),
   );
-  const exportedFileName = writeExcelFile(sheets, fileName);
-
-  // This is a temporary fix for limiting the exported file size.
-  // TODO: Remove this validation as soon as we implement the download in chunks.
-  const { maxFileSizeInMB } = config.export;
-  await validateFileSize(exportedFileName, maxFileSizeInMB);
-  return exportedFileName;
+  return writeExcelFile(sheets, fileName);
 }

--- a/packages/sync-server/app/admin/exporter/fileUtils.js
+++ b/packages/sync-server/app/admin/exporter/fileUtils.js
@@ -1,0 +1,15 @@
+import { promises as fs } from 'fs';
+import config from 'config';
+
+const ONE_MEGABYTE_IN_BYTES = 1024 * 1024;
+
+export async function getExportedFileSize(filename) {
+  const { maxFileSizeInMB } = config.export;
+  const maxChunkSizeInBytes = maxFileSizeInMB * ONE_MEGABYTE_IN_BYTES;
+  const { size } = await fs.stat(filename);
+  return { sizeInBytes: size, maxChunkSizeInBytes };
+}
+
+export function getExportedFileName(userId) {
+  return `exported-${userId}.xlsx`;
+}

--- a/packages/sync-server/app/admin/exporter/index.js
+++ b/packages/sync-server/app/admin/exporter/index.js
@@ -1,1 +1,2 @@
 export * from './exporter';
+export * from './fileUtils';

--- a/packages/sync-server/app/admin/exporter/writeChunkData.js
+++ b/packages/sync-server/app/admin/exporter/writeChunkData.js
@@ -1,0 +1,24 @@
+import fs from 'fs';
+
+export async function writeChunkData(fileName, start, end, res) {
+  if (isNaN(start) || isNaN(end) || start >= end) {
+    res.status(400).send('Invalid start or end parameter.');
+    return;
+  }
+
+  // Get the file's size using fs.promises.stat
+  const { size } = await fs.promises.stat(fileName);
+
+  // Validate start and end range
+  if (end > size) {
+    res.status(400).send('End is greater than the file size.');
+    return;
+  }
+
+  res.set('Content-Type', 'application/octet-stream'); // Set the appropriate content type for your file
+  res.set('Content-Disposition', `attachment; filename=${fileName}`);
+  const fileStream = fs.createReadStream(fileName, { start, end });
+
+  // Pipe the file stream to the response stream
+  fileStream.pipe(res);
+}


### PR DESCRIPTION
https://linear.app/bes/issue/NASS-818/importexport-with-chunking

### Changes

- Created a new endpoint that allows the upload/download using chunks of data
- This is needed due to a validation we have on `nginx` for larger files 


### Media
## Export

https://github.com/beyondessential/tamanu/assets/17033058/1d0859f9-4706-4c52-bc0d-30f620514326


## Import

https://github.com/beyondessential/tamanu/assets/17033058/2546e145-d0c3-4c63-87b8-3e9d3f2b4ee6



### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
