### PR TITLE
TAV-756: Add intercalate commits on release branches

### DIFF
--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - if: "!startsWith(github.ref, 'refs/heads/release/')"
+    - if: (!startsWith(github.ref, 'refs/heads/release/'))
       run: |
         echo "This workflow can only be run on a release branch"
         exit 1

--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -35,9 +35,10 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
         version=$(jq -r .version package.json)
+        git commit -am "Release v$version"
         echo "current_version=$version" >> $GITHUB_OUTPUT
         git tag -a "v$version" -m "Release $version"
-        git push --tags
+        git push --follow-tags
 
     - name: Bump version on branch
       run: node scripts/version.mjs '${{ github.event.inputs.version }}'

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -29,6 +29,29 @@ export async function createReleaseBranch({ readFileSync }, github, context, cwd
   console.log("It doesn't, creating branch...");
   await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha });
 
+  console.log('Creating release cutoff commit...');
+  await github.graphql(
+    `
+    mutation ($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit { url }
+      }
+    }
+    `,
+    {
+      input: {
+        branch: {
+          repositoryNameWithOwner: `${owner}/${repo}`,
+          branchName: branch,
+        },
+        message: {
+          headline: `Cut-off for release branch ${major}.${minor}`,
+        },
+        expectedHeadOid: sha,
+      },
+    },
+  );
+
   let nextVersion;
   switch (nextVersionSpec) {
     case 'patch':


### PR DESCRIPTION
### Changes

- Add cutoff commit on new release branches
- Add release commit just before tagging

#### Before:

```plain
           Bump to 1.31.0      FEAT-345: something new
main-------+-------------------+----------------
       \                                     \
        + FEAT-123: whatever (tag: v1.30.0)   release/1.31 (no commits here yet)
         \  ^-- this is the release commit
          \
           + Bump to 1.30.1
            \
             release/1.30
```

#### After:

```plain
           Bump to 1.31.0      FEAT-345: something new
main-------+-------------------+----------------
       \                                     \
        + Cut-off for release branch 1.30     + Cut-off for release branch 1.31
         \                                     \
          + FEAT-123: whatever                  release/1.31
           \
            + Release v1.30.0 (tag: v1.30.0)
             \  ^-- this is the release commit
              \
               + Bump to 1.30.1
                \
                 release/1.30
```

### Checklist

- [x] Code is finished