### PR TITLE
Use per-facility setting for letterhead

### DIFF
--- a/packages/desktop/app/forms/PatientLetterForm.js
+++ b/packages/desktop/app/forms/PatientLetterForm.js
@@ -109,7 +109,7 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
 };
 
 export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, patient }) => {
-  const { currentUser } = useAuth();
+  const { currentUser, facility } = useAuth();
   const api = useApi();
 
   const handleSubmit = useCallback(
@@ -121,11 +121,12 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
         },
         name: data.title,
         clinicianId: data.clinicianId,
+        facilityId: facility.id,
       });
       const documentToOpen = printRequested ? document : null;
       onSubmit(documentToOpen);
     },
-    [api, endpoint, onSubmit, patient],
+    [api, endpoint, onSubmit, patient, facility.id],
   );
 
   const renderForm = props =>

--- a/packages/lan/app/routeHandlers/createPatientLetter.js
+++ b/packages/lan/app/routeHandlers/createPatientLetter.js
@@ -9,7 +9,7 @@ export const createPatientLetter = (modelName, idField) =>
   asyncHandler(async (req, res) => {
     req.checkPermission('create', 'DocumentMetadata');
     const { models, params } = req;
-    const { patientLetterData, clinicianId, name } = req.body;
+    const { patientLetterData, clinicianId, name, facilityId } = req.body;
 
     const documentCreatedAt = getCurrentDateTimeString();
 
@@ -32,6 +32,7 @@ export const createPatientLetter = (modelName, idField) =>
       title: patientLetterData.title,
       body: patientLetterData.body,
       patient: patientLetterData.patient,
+      facilityId,
     });
 
     const { size } = fs.statSync(filePath);

--- a/packages/lan/app/utils/makePatientLetter.js
+++ b/packages/lan/app/utils/makePatientLetter.js
@@ -5,8 +5,11 @@ import { get } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import { tmpdir, PatientLetter } from '@tamanu/shared/utils';
 
-export const makePatientLetter = async (req, { id, ...data }) => {
+export const makePatientLetter = async (req, { id, facilityId, ...data }) => {
   const { getLocalisation, models } = req;
+
+  const templates = await models.Setting.get('templates.letterhead', facilityId);
+
   const localisation = await getLocalisation();
   const getLocalisationData = key => get(localisation, key);
 
@@ -22,7 +25,12 @@ export const makePatientLetter = async (req, { id, ...data }) => {
   const filePath = path.join(folder, fileName);
 
   await ReactPDF.render(
-    <PatientLetter getLocalisation={getLocalisationData} data={data} logoSrc={logo?.data} />,
+    <PatientLetter
+      getLocalisation={getLocalisationData}
+      data={data}
+      logoSrc={logo?.data}
+      letterheadConfig={templates?.data}
+    />,
     filePath,
   );
 

--- a/packages/shared/src/utils/patientCertificates/LetterheadSection.js
+++ b/packages/shared/src/utils/patientCertificates/LetterheadSection.js
@@ -2,9 +2,14 @@ import React from 'react';
 import { CertificateLogo } from './Layout';
 import { CertificateAddress, CertificateTitle } from './Typography';
 
-export const LetterheadSection = ({ getLocalisation, logoSrc, certificateTitle }) => {
-  const title = getLocalisation('templates.letterhead.title');
-  const subTitle = getLocalisation('templates.letterhead.subTitle');
+export const LetterheadSection = ({
+  getLocalisation,
+  logoSrc,
+  certificateTitle,
+  overrideLetterhead,
+}) => {
+  const title = overrideLetterhead?.title ?? getLocalisation('templates.letterhead.title');
+  const subTitle = overrideLetterhead?.subTitle ?? getLocalisation('templates.letterhead.subTitle');
   return (
     <>
       {logoSrc && <CertificateLogo logoSrc={logoSrc} />}

--- a/packages/shared/src/utils/patientLetters/PatientLetter.js
+++ b/packages/shared/src/utils/patientLetters/PatientLetter.js
@@ -57,7 +57,7 @@ const DetailsSection = ({ getLocalisation, data }) => {
   );
 };
 
-export const PatientLetter = ({ getLocalisation, data, logoSrc }) => {
+export const PatientLetter = ({ getLocalisation, data, logoSrc, letterheadConfig }) => {
   const { title: certificateTitle, body, patient = {}, clinician, documentCreatedAt } = data;
 
   return (
@@ -68,6 +68,7 @@ export const PatientLetter = ({ getLocalisation, data, logoSrc }) => {
             getLocalisation={getLocalisation}
             logoSrc={logoSrc}
             certificateTitle={certificateTitle ?? ''}
+            overrideLetterhead={letterheadConfig}
           />
           <DetailsSection
             data={{ ...patient, clinicianName: clinician.displayName, documentCreatedAt }}


### PR DESCRIPTION
### Changes

Card: https://linear.app/bes/issue/TAN-2279/update-the-patient-letter-template-letterhead-to-filter-by-facility

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
