### PR TITLE
TAV-738: Release logic improvements

### DIFF
--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -53,15 +53,6 @@ jobs:
 
     # do release management after the critical bits above as we care less if those fail
 
-    - name: Publish the draft release if one exists
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const cwd = '${{ github.workspace }}';
-          const { publishRelease } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
-          await publishRelease(github, context, '${{ steps.tagged.outputs.current_version }}');
-
     - name: Create draft for next release
       uses: actions/github-script@v6
       with:
@@ -70,3 +61,12 @@ jobs:
           const cwd = '${{ github.workspace }}';
           const { createDraftRelease } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
           await createDraftRelease(await import('fs'), github, context, cwd, '${{ steps.nextv.outputs.next_version }}');
+
+    - name: Publish the draft release if one exists
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const cwd = '${{ github.workspace }}';
+          const { publishRelease } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
+          await publishRelease(github, context, '${{ steps.tagged.outputs.current_version }}');

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -76,9 +76,9 @@ async function getReleases(github, context, cursor = null) {
     },
   } = await github.graphql(
     `
-    query($owner: String!, $name: String!, $cursor: String, $batchSize: Integer!) {) {
-      repository(owner: $owner, name: $name, before: $cursor) {
-        releases(last: $batchSize, orderBy: { field: CREATED_AT, direction: DESC }) {
+    query($owner: String!, $name: String!, $cursor: String, $batchSize: Int) {
+      repository(owner: $owner, name: $name) {
+        releases(last: $batchSize, before: $cursor, orderBy: { field: CREATED_AT, direction: DESC }) {
           nodes {
             databaseId,
             name,

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -172,7 +172,7 @@ export async function publishRelease(github, context, version) {
       parseInt(thisMajor) < parseInt(latestMajor) ||
       parseInt(thisMinor) < parseInt(latestMinor)
     ) {
-      console.log('Not marking release as latest');
+      console.log('Not marking release as latest as there is a higher published version');
       console.log(`::notice title=Hotfix::Release ${version} not marked latest`);
       markLatest = false;
     }


### PR DESCRIPTION
### Changes

- TAN-2265: Find release by name and tag, rather than by exact tag only, and check both `1.2.3` and `v1.2.3` variations, so we don't miss publishing an existing release draft.
- Swap the "make next draft" (which never fails) and the "publish release" (which might) steps so we don't skip the former if the latter fails.
- TAV-738: If we're publishing a hotfix on a branch that is not the latest published branch, we shouldn't mark it as latest.

### Checklist

- [x] Code is finished