### PR TITLE
SAV-350: Populate note content when edit

### DIFF
--- a/packages/desktop/app/forms/NoteForm.js
+++ b/packages/desktop/app/forms/NoteForm.js
@@ -84,7 +84,14 @@ export const NoteForm = ({
           .required('Note type is required'),
         date: yup.date().required('Date is required'),
         content: yup.string().required('Content is required'),
-        writtenById: foreignKey('Written by (or on behalf of) is required'),
+        writtenById: foreignKey(
+          `${
+            noteFormMode === NOTE_FORM_MODES.EDIT_NOTE &&
+            note.noteType === NOTE_TYPES.TREATMENT_PLAN
+              ? 'Updated'
+              : 'Created'
+          } by (or on behalf of) is required`,
+        ),
       })}
     />
   );

--- a/packages/desktop/app/forms/NoteForm.js
+++ b/packages/desktop/app/forms/NoteForm.js
@@ -75,6 +75,7 @@ export const NoteForm = ({
         date: getCurrentDateTimeString(),
         noteType: note?.noteType,
         writtenById: currentUser.id,
+        content: note?.content,
       }}
       validationSchema={yup.object().shape({
         noteType: yup

--- a/packages/desktop/app/forms/NoteForm.js
+++ b/packages/desktop/app/forms/NoteForm.js
@@ -87,7 +87,7 @@ export const NoteForm = ({
         writtenById: foreignKey(
           `${
             noteFormMode === NOTE_FORM_MODES.EDIT_NOTE &&
-            note.noteType === NOTE_TYPES.TREATMENT_PLAN
+            note?.noteType === NOTE_TYPES.TREATMENT_PLAN
               ? 'Updated'
               : 'Created'
           } by (or on behalf of) is required`,


### PR DESCRIPTION
### Changes
- Should populate note content when edit

<img width="1319" alt="Screen Shot 2023-08-17 at 4 48 00 pm" src="https://github.com/beyondessential/tamanu/assets/63621318/01872f17-6e0b-4813-bb62-ed45543dd9e2">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
