### PR TITLE
TAN-2279: Use letterhead config from settings in patient letter

### DIFF
--- a/packages/lan/app/routeHandlers/createPatientLetter.js
+++ b/packages/lan/app/routeHandlers/createPatientLetter.js
@@ -1,5 +1,6 @@
 import asyncHandler from 'express-async-handler';
 import fs, { promises as asyncFs } from 'fs';
+import config from 'config';
 import { NotFoundError } from 'shared/errors';
 import { DOCUMENT_SOURCES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from 'shared/utils/dateTime';
@@ -32,6 +33,7 @@ export const createPatientLetter = (modelName, idField) =>
       title: patientLetterData.title,
       body: patientLetterData.body,
       patient: patientLetterData.patient,
+      facilityId: config.serverFacilityId,
     });
 
     const { size } = fs.statSync(filePath);

--- a/packages/lan/app/utils/makePatientLetter.js
+++ b/packages/lan/app/utils/makePatientLetter.js
@@ -5,10 +5,11 @@ import { get } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import { tmpdir, PatientLetter } from '@tamanu/shared/utils';
 
-export const makePatientLetter = async (req, { id, ...data }) => {
+export const makePatientLetter = async (req, { id, facilityId, ...data }) => {
   const { getLocalisation, models } = req;
   const localisation = await getLocalisation();
   const getLocalisationData = key => get(localisation, key);
+  const letterheadConfig = await models.Setting.get('templates.letterhead', facilityId);
 
   const logo = await models.Asset.findOne({
     raw: true,
@@ -22,7 +23,12 @@ export const makePatientLetter = async (req, { id, ...data }) => {
   const filePath = path.join(folder, fileName);
 
   await ReactPDF.render(
-    <PatientLetter getLocalisation={getLocalisationData} data={data} logoSrc={logo?.data} />,
+    <PatientLetter
+      getLocalisation={getLocalisationData}
+      data={data}
+      logoSrc={logo?.data}
+      letterheadConfig={letterheadConfig}
+    />,
     filePath,
   );
 

--- a/packages/shared/src/utils/patientCertificates/LetterheadSection.js
+++ b/packages/shared/src/utils/patientCertificates/LetterheadSection.js
@@ -2,9 +2,15 @@ import React from 'react';
 import { CertificateLogo } from './Layout';
 import { CertificateAddress, CertificateTitle } from './Typography';
 
-export const LetterheadSection = ({ getLocalisation, logoSrc, certificateTitle }) => {
-  const title = getLocalisation('templates.letterhead.title');
-  const subTitle = getLocalisation('templates.letterhead.subTitle');
+export const LetterheadSection = ({
+  getLocalisation,
+  logoSrc,
+  certificateTitle,
+  letterheadConfig,
+}) => {
+  // Give priority to letterheadConfig which is extracted from settings
+  const title = letterheadConfig?.title ?? getLocalisation('templates.letterhead.title');
+  const subTitle = letterheadConfig?.subTitle ?? getLocalisation('templates.letterhead.subTitle');
   return (
     <>
       {logoSrc && <CertificateLogo logoSrc={logoSrc} />}

--- a/packages/shared/src/utils/patientLetters/PatientLetter.js
+++ b/packages/shared/src/utils/patientLetters/PatientLetter.js
@@ -57,7 +57,7 @@ const DetailsSection = ({ getLocalisation, data }) => {
   );
 };
 
-export const PatientLetter = ({ getLocalisation, data, logoSrc }) => {
+export const PatientLetter = ({ getLocalisation, data, logoSrc, letterheadConfig }) => {
   const { title: certificateTitle, body, patient = {}, clinician, documentCreatedAt } = data;
 
   return (
@@ -68,6 +68,7 @@ export const PatientLetter = ({ getLocalisation, data, logoSrc }) => {
             getLocalisation={getLocalisation}
             logoSrc={logoSrc}
             certificateTitle={certificateTitle ?? ''}
+            letterheadConfig={letterheadConfig}
           />
           <DetailsSection
             data={{ ...patient, clinicianName: clinician.displayName, documentCreatedAt }}


### PR DESCRIPTION
### Changes

Revamping Alistair's great work to avoid touching the desktop client.

A bit of info why this has to happen through prop pierce: we are using shared components (from the shared folder) which do not have context unfortunately. Also this change is supposed to be contained so that's the reason for the fallback to read from localisation in the letterhead component