### PR TITLE
NASS-825: Shared suggester endpoints constant

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -18,6 +18,7 @@ export * from './patientFields';
 export * from './reports';
 export * from './servers';
 export * from './statuses';
+export * from './suggesters';
 export * from './surveys';
 export * from './sync';
 export * from './templates';

--- a/packages/constants/src/suggesters.ts
+++ b/packages/constants/src/suggesters.ts
@@ -1,0 +1,19 @@
+import { REFERENCE_TYPE_VALUES } from './importable';
+
+export const SUGGESTER_ENDPOINTS = [
+  ...REFERENCE_TYPE_VALUES,
+  'department',
+  'facility',
+  'facilityLocationGroup',
+  'invoiceLineTypes',
+  'labTestPanel',
+  'labTestType',
+  'location',
+  'locationGroup',
+  'patient',
+  'patientLabTestCategories',
+  'patientLabTestPanelTypes',
+  'patientLetterTemplate',
+  'practitioner',
+  'survey',
+];

--- a/packages/desktop/app/views/administration/reports/schema.js
+++ b/packages/desktop/app/views/administration/reports/schema.js
@@ -1,5 +1,5 @@
 import {
-  REFERENCE_TYPE_VALUES,
+  SUGGESTER_ENDPOINTS,
   REPORT_STATUSES_VALUES,
   REPORT_DEFAULT_DATE_RANGES_VALUES,
   REPORT_DATA_SOURCE_VALUES,
@@ -97,19 +97,9 @@ export const schema = {
           title: 'Suggester Endpoint',
           description:
             'This is the form field that is displayed to the user in the Tamanu desktop app that is used to capture the user input',
-          enum: [
-            'department',
-            'facility',
-            'facilityLocationGroup',
-            'invoiceLineTypes',
-            'practitioner',
-            'patients',
-            'labTestType',
-            'location',
-            'locationGroup',
-            'survey',
-            ...REFERENCE_TYPE_VALUES,
-          ],
+          enum: SUGGESTER_ENDPOINTS.sort((a, b) => {
+            return a.localeCompare(b);
+          }),
         },
         suggesterOptions: {
           type: 'object',

--- a/packages/lan/app/routes/apiv1/suggestions.js
+++ b/packages/lan/app/routes/apiv1/suggestions.js
@@ -10,6 +10,7 @@ import {
   REFERENCE_TYPES,
   INVOICE_LINE_TYPES,
   VISIBILITY_STATUSES,
+  SUGGESTER_ENDPOINTS,
 } from '@tamanu/constants';
 
 export const suggestions = express.Router();
@@ -325,3 +326,22 @@ createAllRecordsSuggesterRoute('labTestPanel', 'LabTestPanel', VISIBILITY_CRITER
 createNameSuggester('labTestPanel', 'LabTestPanel');
 
 createNameSuggester('patientLetterTemplate', 'PatientLetterTemplate');
+
+const routerEndpoints = suggestions.stack.map(layer => {
+  const path = layer.route.path.replace('/', '').replaceAll('$', '');
+  const root = path.split('/')[0];
+  return root;
+});
+const rootElements = [...new Set(routerEndpoints)];
+SUGGESTER_ENDPOINTS.forEach(endpoint => {
+  if (!rootElements.includes(endpoint)) {
+    throw new Error(
+      `Suggester endpoint exists in shared constant but not included in router: ${endpoint}`,
+    );
+  }
+});
+rootElements.forEach(endpoint => {
+  if (!SUGGESTER_ENDPOINTS.includes(endpoint)) {
+    throw new Error(`Suggester endpoint not added to shared constant: ${endpoint}`);
+  }
+});


### PR DESCRIPTION
### Changes
- Requirement: As we are now listing the suggesters endpoints on "Desktop Admin", we need to have a way to keep it in sync with all the suggester endpoints we have on facility server.
- Created a shared constant for Suggester endpoints
- Add a validation into the lan server that every endpoint added to /suggestions exists in there, and vice versa


Task:
https://linear.app/bes/issue/NASS-825/suggester-suggester

### Media
<img width="1484" alt="image" src="https://github.com/beyondessential/tamanu/assets/17033058/bee258b3-581b-4939-a581-50c6138afc21">

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
