### PR TITLE
TAV-735: Upload builds to release and write client download list

### DIFF
--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -161,13 +161,13 @@ jobs:
           rm -rf release
 
       - name: Use release bucket
-        if: inputs.bucket == 'release' || startsWith(github.ref, 'refs/tags/v')
+        if: inputs.bucket == 'release' || github.ref_type == 'tag'
         run: |
           echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
       - name: Use dev bucket
-        if: inputs.bucket == 'dev or rc' || !startsWith(github.ref, 'refs/tags/v')
+        if: inputs.bucket == 'dev or rc' || github.ref_type != 'tag'
         run: |
           echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
           echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
@@ -224,11 +224,11 @@ jobs:
             }
 
       - name: Push to release
-        if: github.ref_type == 'tag' || github.event_name == 'pull_request'
+        if: github.ref_type == 'tag'
         uses: actions/github-script@v6
         env:
           RELEASE_SECTION: ${{ steps.comment.outputs.result }}
-          RELEASE_VERSION: '1.31.0'
+          RELEASE_VERSION: ${{ needs.info.outputs.version }}
         with:
           script: |
             const cwd = '${{ github.workspace }}';

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -149,11 +149,13 @@ jobs:
       - name: Prepare final outputs
         run: |
           sudo chown -R $USER:$USER release
-          mkdir -p ops/{linux,mac,windows-{appdata,msi,system,aspen}}
+          mkdir -p ops/{linux,mac,windows-{appdata,msi,system,aspen}} artifacts
           mv release/latest-linux.yml release/*.AppImage ops/linux/
           mv release/*-mac* ops/mac/
+          cp release/*.msi artifacts/TamanuSetup.x64.msi
           mv release/*.msi ops/windows-msi/
           mv release/aspen/*.msi ops/windows-aspen/
+          cp release/*.exe artifacts/TamanuSetup.x64.exe
           mv release/latest.yml release/*.exe* ops/windows-system/
           mv release/appdata/latest.yml release/appdata/*.exe* ops/windows-appdata/
           rm -rf release
@@ -175,7 +177,7 @@ jobs:
         run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
 
       - name: Prepare comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.ref_type == 'tag'
         id: comment
         uses: actions/github-script@v6
         env:
@@ -220,3 +222,22 @@ jobs:
                 body: process.env.COMMENT_BODY,
               });
             }
+
+      - name: Push to release
+        if: github.ref_type == 'tag'
+        uses: actions/github-script@v6
+        env:
+          RELEASE_SECTION: ${{ steps.comment.outputs.result }}
+          RELEASE_VERSION: ${{ needs.info.outputs.version }}
+        with:
+          script: |
+            const cwd = '${{ github.workspace }}';
+            const { uploadToRelease } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
+            await uploadToRelease({
+              fs: await import('fs/promises'),
+              github,
+              context,
+              artifactsDir: `${cwd}/artifacts`,
+              version: process.env.RELEASE_VERSION,
+              section: process.env.RELEASE_SECTION,
+            });

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -91,65 +91,67 @@ jobs:
           # in PRs, use the actual PR branch, not the merge branch
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
-      - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+      # - name: Setup buildkit
+      #   uses: docker/setup-buildx-action@v2
 
-      - name: Build container
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
-          cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
-          target: build-desktop
-          push: false
-          load: true
-          tags: working
+      # - name: Build container
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
+      #     cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
+      #     target: build-desktop
+      #     push: false
+      #     load: true
+      #     tags: working
 
       - name: Make output folders
         run: mkdir -p release/{appdata,unelevated}
 
-      - name: Start container
-        run: |
-          tryonce() {
-            docker run -dit --rm --name working \
-              -v $PWD/release:/app/packages/desktop/release \
-              working
-            sleep 1
-            docker exec working echo "Container started"
-          }
+      # - name: Start container
+      #   run: |
+      #     tryonce() {
+      #       docker run -dit --rm --name working \
+      #         -v $PWD/release:/app/packages/desktop/release \
+      #         working
+      #       sleep 1
+      #       docker exec working echo "Container started"
+      #     }
 
-          tryonce || tryonce || tryonce
+      #     tryonce || tryonce || tryonce
 
-      - name: Package for Linux, Mac, Windows
-        run: |
-          docker exec working mv /package-mac.json package.json
-          docker exec working yarn run package-only --x64 --linux --mac --win
+      # - name: Package for Linux, Mac, Windows
+      #   run: |
+      #     docker exec working mv /package-mac.json package.json
+      #     docker exec working yarn run package-only --x64 --linux --mac --win
 
-      - name: Switch to AppData NSIS-only build
-        run: docker exec working mv /package-appdata.json package.json
+      # - name: Switch to AppData NSIS-only build
+      #   run: docker exec working mv /package-appdata.json package.json
 
-      - name: Package for Windows (AppData NSIS)
-        run: docker exec working yarn run package-only --win --x64
+      # - name: Package for Windows (AppData NSIS)
+      #   run: docker exec working yarn run package-only --win --x64
 
-      - name: Switch to MSI build
-        run: docker exec working mv /package-msi.json package.json
+      # - name: Switch to MSI build
+      #   run: docker exec working mv /package-msi.json package.json
 
-      - name: Package for Windows (MSI)
-        run: docker exec working yarn run package-only --win --x64
+      # - name: Package for Windows (MSI)
+      #   run: docker exec working yarn run package-only --win --x64
 
-      - name: Switch to Aspen build
-        run: docker exec working mv /package-aspen.json package.json
+      # - name: Switch to Aspen build
+      #   run: docker exec working mv /package-aspen.json package.json
 
-      - name: Package for Windows (Aspen)
-        run: docker exec working yarn run package-only --win --x64
+      # - name: Package for Windows (Aspen)
+      #   run: docker exec working yarn run package-only --win --x64
 
-      - name: Stop container
-        run: docker kill working
+      # - name: Stop container
+      #   run: docker kill working
 
       - name: Prepare final outputs
         run: |
           sudo chown -R $USER:$USER release
           mkdir -p ops/{linux,mac,windows-{appdata,msi,system,aspen}} artifacts
+          touch artifacts/TamanuSetup.x64.msi
+          exit 0
           mv release/latest-linux.yml release/*.AppImage ops/linux/
           mv release/*-mac* ops/mac/
           cp release/*.msi artifacts/TamanuSetup.x64.msi
@@ -160,21 +162,21 @@ jobs:
           mv release/appdata/latest.yml release/appdata/*.exe* ops/windows-appdata/
           rm -rf release
 
-      - name: Use release bucket
-        if: inputs.bucket == 'release' || startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
-          echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
+      # - name: Use release bucket
+      #   if: inputs.bucket == 'release' || startsWith(github.ref, 'refs/tags/v')
+      #   run: |
+      #     echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
+      #     echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
-      - name: Use dev bucket
-        if: inputs.bucket == 'dev or rc' || !startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
-          echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
+      # - name: Use dev bucket
+      #   if: inputs.bucket == 'dev or rc' || !startsWith(github.ref, 'refs/tags/v')
+      #   run: |
+      #     echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
+      #     echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
 
-      - name: Push to S3
-        working-directory: ops
-        run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
+      # - name: Push to S3
+      #   working-directory: ops
+      #   run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
 
       - name: Prepare comment
         if: github.event_name == 'pull_request' || github.ref_type == 'tag'

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -91,67 +91,65 @@ jobs:
           # in PRs, use the actual PR branch, not the merge branch
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
-      # - name: Setup buildkit
-      #   uses: docker/setup-buildx-action@v2
+      - name: Setup buildkit
+        uses: docker/setup-buildx-action@v2
 
-      # - name: Build container
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
-      #     cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
-      #     target: build-desktop
-      #     push: false
-      #     load: true
-      #     tags: working
+      - name: Build container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          cache-from: type=gha,scope=${{ needs.info.outputs.branch }}-desktop
+          cache-to: type=gha,mode=max,scope=${{ needs.info.outputs.branch }}-desktop
+          target: build-desktop
+          push: false
+          load: true
+          tags: working
 
       - name: Make output folders
         run: mkdir -p release/{appdata,unelevated}
 
-      # - name: Start container
-      #   run: |
-      #     tryonce() {
-      #       docker run -dit --rm --name working \
-      #         -v $PWD/release:/app/packages/desktop/release \
-      #         working
-      #       sleep 1
-      #       docker exec working echo "Container started"
-      #     }
+      - name: Start container
+        run: |
+          tryonce() {
+            docker run -dit --rm --name working \
+              -v $PWD/release:/app/packages/desktop/release \
+              working
+            sleep 1
+            docker exec working echo "Container started"
+          }
 
-      #     tryonce || tryonce || tryonce
+          tryonce || tryonce || tryonce
 
-      # - name: Package for Linux, Mac, Windows
-      #   run: |
-      #     docker exec working mv /package-mac.json package.json
-      #     docker exec working yarn run package-only --x64 --linux --mac --win
+      - name: Package for Linux, Mac, Windows
+        run: |
+          docker exec working mv /package-mac.json package.json
+          docker exec working yarn run package-only --x64 --linux --mac --win
 
-      # - name: Switch to AppData NSIS-only build
-      #   run: docker exec working mv /package-appdata.json package.json
+      - name: Switch to AppData NSIS-only build
+        run: docker exec working mv /package-appdata.json package.json
 
-      # - name: Package for Windows (AppData NSIS)
-      #   run: docker exec working yarn run package-only --win --x64
+      - name: Package for Windows (AppData NSIS)
+        run: docker exec working yarn run package-only --win --x64
 
-      # - name: Switch to MSI build
-      #   run: docker exec working mv /package-msi.json package.json
+      - name: Switch to MSI build
+        run: docker exec working mv /package-msi.json package.json
 
-      # - name: Package for Windows (MSI)
-      #   run: docker exec working yarn run package-only --win --x64
+      - name: Package for Windows (MSI)
+        run: docker exec working yarn run package-only --win --x64
 
-      # - name: Switch to Aspen build
-      #   run: docker exec working mv /package-aspen.json package.json
+      - name: Switch to Aspen build
+        run: docker exec working mv /package-aspen.json package.json
 
-      # - name: Package for Windows (Aspen)
-      #   run: docker exec working yarn run package-only --win --x64
+      - name: Package for Windows (Aspen)
+        run: docker exec working yarn run package-only --win --x64
 
-      # - name: Stop container
-      #   run: docker kill working
+      - name: Stop container
+        run: docker kill working
 
       - name: Prepare final outputs
         run: |
           sudo chown -R $USER:$USER release
           mkdir -p ops/{linux,mac,windows-{appdata,msi,system,aspen}} artifacts
-          touch artifacts/TamanuSetup.x64.msi
-          exit 0
           mv release/latest-linux.yml release/*.AppImage ops/linux/
           mv release/*-mac* ops/mac/
           cp release/*.msi artifacts/TamanuSetup.x64.msi
@@ -162,21 +160,21 @@ jobs:
           mv release/appdata/latest.yml release/appdata/*.exe* ops/windows-appdata/
           rm -rf release
 
-      # - name: Use release bucket
-      #   if: inputs.bucket == 'release' || startsWith(github.ref, 'refs/tags/v')
-      #   run: |
-      #     echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
-      #     echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
+      - name: Use release bucket
+        if: inputs.bucket == 'release' || startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "S3_BUCKET=bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
+          echo "S3_URL=https://s3-ap-southeast-2.amazonaws.com/bes-tamanu-release-clients/${{ needs.info.outputs.version }}" >> $GITHUB_ENV
 
-      # - name: Use dev bucket
-      #   if: inputs.bucket == 'dev or rc' || !startsWith(github.ref, 'refs/tags/v')
-      #   run: |
-      #     echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
-      #     echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
+      - name: Use dev bucket
+        if: inputs.bucket == 'dev or rc' || !startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "S3_BUCKET=bes-tamanu-dev-desktop-clients/${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
+          echo "S3_URL=https://s3.console.aws.amazon.com/s3/object/bes-tamanu-dev-desktop-clients?region=ap-southeast-2&prefix=${{ needs.info.outputs.branch }}" >> $GITHUB_ENV
 
-      # - name: Push to S3
-      #   working-directory: ops
-      #   run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
+      - name: Push to S3
+        working-directory: ops
+        run: aws s3 sync . s3://${{ env.S3_BUCKET }} --no-progress
 
       - name: Prepare comment
         if: github.event_name == 'pull_request' || github.ref_type == 'tag'
@@ -189,7 +187,7 @@ jobs:
           script: |
             const {S3_URL, VERSION} = process.env;
             return [
-              '### :package: Desktop clients',
+              '## :package: Desktop clients',
               '',
               `- :window: **[Windows (System)](${S3_URL}/windows-system/Tamanu+Setup+${VERSION}.exe)**`,
               `- :window:   [Windows (AppData)](${S3_URL}/windows-appdata/Tamanu+Setup+${VERSION}.exe)`,

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -24,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write # for uploading to release
+  pull-requests: write # for writing comment
   id-token: write # OIDC token for AWS
 
 jobs:

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -224,11 +224,11 @@ jobs:
             }
 
       - name: Push to release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || github.event_name == 'pull_request'
         uses: actions/github-script@v6
         env:
           RELEASE_SECTION: ${{ steps.comment.outputs.result }}
-          RELEASE_VERSION: ${{ needs.info.outputs.version }}
+          RELEASE_VERSION: '1.31.0'
         with:
           script: |
             const cwd = '${{ github.workspace }}';

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -93,13 +93,12 @@ export async function createDraftRelease({ readFileSync }, github, context, cwd,
 }
 
 async function getDraftReleases(github, context) {
-  const releases = await github.rest.repos.listReleases({
+  const response = await github.rest.repos.listReleases({
     owner: context.repo.owner,
     repo: context.repo.repo,
   });
-  console.log(JSON.stringify(releases));
 
-  return releases.filter(release => release.draft);
+  return response.data.filter(release => release.draft);
 }
 
 async function getPublishedReleases(github, context, cursor = null) {

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -92,21 +92,31 @@ export async function createDraftRelease({ readFileSync }, github, context, cwd,
   });
 }
 
-async function getReleases(github, context, cursor = null) {
+async function getDraftReleases(github, context) {
+  const releases = await github.rest.listReleases({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+  });
+
+  return releases.filter(release => release.draft);
+}
+
+async function getPublishedReleases(github, context, cursor = null) {
+  // GraphQL is more efficient than API but doesn't contain draft releases
   const { repository: { releases } } = await github.graphql(
     `
-    query($owner: String!, $name: String!, $cursor: String, $batchSize: Int) {
-      repository(owner: $owner, name: $name) {
+    query($owner: String!, $repo: String!, $cursor: String, $batchSize: Int) {
+      repository(owner: $owner, repo: $repo) {
         releases(last: $batchSize, before: $cursor, orderBy: { field: CREATED_AT, direction: DESC }) {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
           nodes {
             databaseId
             name
             tagName
-            isDraft
             description
-          }
-          edges {
-            cursor
           }
         }
       }
@@ -115,31 +125,45 @@ async function getReleases(github, context, cursor = null) {
     {
       batchSize: MAX_GITHUB_RELEASES_BATCH_SIZE,
       owner: context.repo.owner,
-      name: context.repo.repo,
+      repo: context.repo.repo,
       cursor,
     },
   );
 
   return releases.nodes.length
     ? {
-        cursor: releases.edges[releases.edges.length - 1].cursor,
+        cursor: releases.pageInfo.hasNextPage && releases.pageInfo.endCursor,
         releases: releases.nodes,
       }
     : null;
 }
 
-async function findRelease(github, context, testForMatch) {
+async function findDraftRelease(github, context, testForMatch) {
+  const releases = await getDraftReleases(github, context);
+
+  for (const release of releases) {
+    console.log(`::debug:: Draft release ${JSON.stringify(release)}`);
+    if (testForMatch(release.tagName, release) || testForMatch(release.name, release)) {
+      return release;
+    }
+  }
+
+  return null;
+}
+
+async function findPublishedRelease(github, context, testForMatch) {
   let nextCursor = null;
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const data = await getReleases(github, context, nextCursor);
+    const data = await getPublishedReleases(github, context, nextCursor);
     if (!data) break;
 
     const { cursor, releases } = data;
+    if (!cursor) break;
     nextCursor = cursor;
 
     for (const release of releases) {
-      console.log(`::debug::Release ${JSON.stringify(release)}`);
+      console.log(`::debug:: Published release ${JSON.stringify(release)}`);
       if (testForMatch(release.tagName, release) || testForMatch(release.name, release)) {
         return release;
       }
@@ -151,45 +175,28 @@ async function findRelease(github, context, testForMatch) {
 
 export async function publishRelease(github, context, version) {
   console.log(`Find draft release matching ${version}...`);
-  const releaseId = await findRelease(
+  const release = await findDraftRelease(
     github,
     context,
-    (name, { isDraft }) => isDraft && (name === `v${version}` || name === version),
-  )?.databaseId;
+    name => name === `v${version}` || name === version,
+  );
 
-  if (!releaseId) {
+  if (!release) {
     console.log(`::error title=Draft not found::Draft release ${version} not found!`);
     throw new Error(`Draft release ${version} not found!`);
   }
 
-  console.log(`Get release #${releaseId}...`);
-  const release = (
-    await github.rest.repos.getRelease({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      releaseId,
-    })
-  )?.data;
-
-  if (!release?.draft) {
-    console.log(`Release ${version} is not a draft, skipping`);
-    console.log(
-      `::warning title=Not a draft::Release ${version} is not a draft, skipped publishing`,
-    );
-    return;
-  }
-
   console.log('Fetching latest published release...');
   let markLatest = true;
-  const latestPublished = await findRelease(github, context, (_, { isDraft }) => !isDraft);
+  const latestPublished = await findPublishedRelease(github, context, () => true);
   if (!latestPublished) {
     console.log('No published releases found');
   } else {
     console.log(
-      `Latest published release is ${latestPublished.name} (tag: ${latestPublished.tagName})`,
+      `Latest published release is tag=${latestPublished.tagName} name=${latestPublished.name}`,
     );
     const [thisMajor, thisMinor] = version.split('.', 3);
-    const [, latestMajor, latestMinor] = (latestPublished.name ?? latestPublished.tagName).match(
+    const [, latestMajor, latestMinor] = latestPublished.tagName.match(
       /^v?(\d+)[.](\d+)/,
     );
 
@@ -215,32 +222,47 @@ export async function publishRelease(github, context, version) {
 }
 
 export async function uploadToRelease({ fs, github, context, artifactsDir, version, section }) {
-  console.log(`Find release matching ${version}...`);
-  const release = await findRelease(
+  // Presumption is that there's less drafts so this should be one just-in-case
+  // call if this workflow happens to run before the release is published.
+  console.log(`Find draft release matching ${version}...`);
+  let release = await findDraftRelease(
     github,
     context,
     name => name === `v${version}` || name === version,
   );
 
   if (!release) {
+    console.log(`Find published release matching ${version}...`);
+    release = await findPublishedRelease(
+      github,
+      context,
+      name => name === `v${version}` || name === version,
+    );
+  }
+
+  if (!release) {
     throw new Error('Cannot find a matching release!');
   }
+
+  // GraphQL and API have different names for the same fields
+  const releaseId = release.databaseId ?? release.id;
+  const body = release.description ?? release.body;
 
   console.log('Updating release description');
   await github.rest.repos.updateRelease({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    release_id: release.id,
-    body: `${release.description}\n\n${section}`,
+    release_id: releaseId,
+    body: `${body}\n\n${section}`,
   });
 
   const fileList = await fs.readdir(artifactsDir);
   for (const file of fileList) {
-    console.log('Uploading', file, 'to release', release.databaseId);
+    console.log('Uploading', file, 'to release', releaseId);
     await github.rest.repos.uploadReleaseAsset({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      release_id: release.databaseId,
+      release_id: releaseId,
       name: file,
       data: await fs.readFile(`${artifactsDir}/${file}`),
     });

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -106,7 +106,7 @@ async function getPublishedReleases(github, context, cursor = null) {
   const { repository: { releases } } = await github.graphql(
     `
     query($owner: String!, $repo: String!, $cursor: String, $batchSize: Int) {
-      repository(owner: $owner, repo: $repo) {
+      repository(owner: $owner, name: $repo) {
         releases(last: $batchSize, before: $cursor, orderBy: { field: CREATED_AT, direction: DESC }) {
           pageInfo {
             endCursor

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -117,6 +117,7 @@ async function getPublishedReleases(github, context, cursor = null) {
             name
             tagName
             description
+            isDraft
           }
         }
       }
@@ -130,10 +131,11 @@ async function getPublishedReleases(github, context, cursor = null) {
     },
   );
 
+  // isDraft filtering there just in case they start adding them to GraphQL
   return releases.nodes.length
     ? {
         cursor: releases.pageInfo.hasNextPage && releases.pageInfo.endCursor,
-        releases: releases.nodes,
+        releases: releases.nodes.filter(release => !release.isDraft),
       }
     : null;
 }

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -93,20 +93,16 @@ export async function createDraftRelease({ readFileSync }, github, context, cwd,
 }
 
 async function getReleases(github, context, cursor = null) {
-  const {
-    data: {
-      repository: { releases },
-    },
-  } = await github.graphql(
+  const { errors, data } = await github.graphql(
     `
     query($owner: String!, $name: String!, $cursor: String, $batchSize: Int) {
       repository(owner: $owner, name: $name) {
         releases(last: $batchSize, before: $cursor, orderBy: { field: CREATED_AT, direction: DESC }) {
           nodes {
-            databaseId,
-            name,
-            tagName,
-            isDraft,
+            databaseId
+            name
+            tagName
+            isDraft
             description
           }
           edges {
@@ -124,6 +120,11 @@ async function getReleases(github, context, cursor = null) {
     },
   );
 
+  if (errors) {
+    throw new Error(`Graphql errors ${errors.map(e => e.message).join(', ')}`);
+  }
+
+  const { releases } = data.repository;
   return releases.nodes.length
     ? {
         cursor: releases.edges[releases.edges.length - 1].cursor,

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -103,10 +103,10 @@ async function getReleases(github, context, cursor = null) {
       repository(owner: $owner, name: $name) {
         releases(last: $batchSize, before: $cursor, orderBy: { field: CREATED_AT, direction: DESC }) {
           nodes {
-            databaseId
-            name
-            tagName
-            isDraft
+            databaseId,
+            name,
+            tagName,
+            isDraft,
             description
           }
           edges {

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -97,6 +97,7 @@ async function getDraftReleases(github, context) {
     owner: context.repo.owner,
     repo: context.repo.repo,
   });
+  console.log(JSON.stringify(releases));
 
   return releases.filter(release => release.draft);
 }

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -93,7 +93,7 @@ export async function createDraftRelease({ readFileSync }, github, context, cwd,
 }
 
 async function getDraftReleases(github, context) {
-  const releases = await github.rest.listReleases({
+  const releases = await github.rest.repos.listReleases({
     owner: context.repo.owner,
     repo: context.repo.repo,
   });

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -234,7 +234,7 @@ export async function uploadToRelease({ fs, github, context, artifactsDir, versi
     owner: context.repo.owner,
     repo: context.repo.repo,
     release_id: release.id,
-    description: `${release.description}\n\n${section}`,
+    body: `${release.description}\n\n${section}`,
   });
 
   const fileList = await fs.readdir(artifactsDir);

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -93,7 +93,7 @@ export async function createDraftRelease({ readFileSync }, github, context, cwd,
 }
 
 async function getReleases(github, context, cursor = null) {
-  const { errors, data } = await github.graphql(
+  const { repository: { releases } } = await github.graphql(
     `
     query($owner: String!, $name: String!, $cursor: String, $batchSize: Int) {
       repository(owner: $owner, name: $name) {
@@ -120,11 +120,6 @@ async function getReleases(github, context, cursor = null) {
     },
   );
 
-  if (errors) {
-    throw new Error(`Graphql errors ${errors.map(e => e.message).join(', ')}`);
-  }
-
-  const { releases } = data.repository;
   return releases.nodes.length
     ? {
         cursor: releases.edges[releases.edges.length - 1].cursor,

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -139,6 +139,7 @@ async function findRelease(github, context, testForMatch) {
     nextCursor = cursor;
 
     for (const release of releases) {
+      console.log(`::debug::Release ${JSON.stringify(release)}`);
       if (testForMatch(release.tagName, release) || testForMatch(release.name, release)) {
         return release;
       }


### PR DESCRIPTION
### Changes

When a tag is created, we build desktop clients. Currently, those are silently uploaded to S3. With this PR:
- Two variants (Windows exe and msi) are also uploaded to the github release
- The full list of public S3 URLs that you get on PRs is copied to the release description

The files uploaded to the github release are renamed to a permanent name like `TamanuSetup.x64.exe`; that means that we have a permalink to the latest release on github:

<https://github.com/beyondessential/tamanu/releases/latest/download/TamanuSetup.x64.exe>

### Checklist

- [x] Code is finished
- [x] Has been tested