### PR TITLE
SAV-358: Include facility id in start session logs

### DIFF
--- a/packages/lan/app/sync/CentralServerConnection.js
+++ b/packages/lan/app/sync/CentralServerConnection.js
@@ -211,7 +211,10 @@ export class CentralServerConnection {
   }
 
   async startSyncSession() {
-    const { sessionId } = await this.fetch('sync', { method: 'POST' });
+    const { sessionId } = await this.fetch('sync', {
+      method: 'POST',
+      body: { facilityId: config.serverFacilityId },
+    });
 
     // then, poll the sync/:sessionId/ready endpoint until we get a valid response
     // this is because POST /sync (especially the tickTockGlobalClock action) might get blocked

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -142,7 +142,8 @@ export class CentralServerConnection {
   }
 
   async startSyncSession() {
-    const { sessionId } = await this.post('sync', {}, {});
+    const facilityId = await readConfig('facilityId', '');
+    const { sessionId } = await this.post('sync', {}, { facilityId });
 
     // then, poll the sync/:sessionId/ready endpoint until we get a valid response
     // this is because POST /sync (especially the tickTockGlobalClock action) might get blocked

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -67,7 +67,7 @@ export class CentralSyncManager {
     return { tick: tock - 1, tock };
   }
 
-  async startSession(userId, deviceId, facilityId) {
+  async startSession(debugInfo = {}) {
     // as a side effect of starting a new session, cause a tick on the global sync clock
     // this is a convenient way to tick the clock, as it means that no two sync sessions will
     // happen at the same global sync time, meaning there's no ambiguity when resolving conflicts
@@ -76,7 +76,7 @@ export class CentralSyncManager {
     const syncSession = await this.store.models.SyncSession.create({
       startTime,
       lastConnectionTime: startTime,
-      debugInfo: { userId, deviceId, facilityId },
+      debugInfo,
     });
 
     // no await as prepare session (especially the tickTockGlobalClock action) might get blocked
@@ -86,8 +86,7 @@ export class CentralSyncManager {
 
     log.info('CentralSyncManager.startSession', {
       sessionId: syncSession.id,
-      deviceId,
-      facilityId,
+      ...debugInfo,
     });
 
     return { sessionId: syncSession.id };

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -67,7 +67,7 @@ export class CentralSyncManager {
     return { tick: tock - 1, tock };
   }
 
-  async startSession(userId, deviceId) {
+  async startSession(userId, deviceId, facilityId) {
     // as a side effect of starting a new session, cause a tick on the global sync clock
     // this is a convenient way to tick the clock, as it means that no two sync sessions will
     // happen at the same global sync time, meaning there's no ambiguity when resolving conflicts
@@ -76,7 +76,7 @@ export class CentralSyncManager {
     const syncSession = await this.store.models.SyncSession.create({
       startTime,
       lastConnectionTime: startTime,
-      debugInfo: { userId, deviceId },
+      debugInfo: { userId, deviceId, facilityId },
     });
 
     // no await as prepare session (especially the tickTockGlobalClock action) might get blocked
@@ -84,7 +84,11 @@ export class CentralSyncManager {
     // Client should poll for the result later.
     this.prepareSession(syncSession);
 
-    log.info('CentralSyncManager.startSession', { sessionId: syncSession.id, deviceId });
+    log.info('CentralSyncManager.startSession', {
+      sessionId: syncSession.id,
+      deviceId,
+      facilityId,
+    });
 
     return { sessionId: syncSession.id };
   }
@@ -136,7 +140,7 @@ export class CentralSyncManager {
     const durationMs = Date.now() - session.startTime;
     log.debug('CentralSyncManager.completingSession', { sessionId, durationMs });
     await completeSyncSession(this.store, sessionId);
-    log.info('CentralSyncManager.completedSession', { 
+    log.info('CentralSyncManager.completedSession', {
       sessionId,
       durationMs,
       facilityId: session.debugInfo.facilityId,
@@ -227,7 +231,6 @@ export class CentralSyncManager {
       );
 
       await models.SyncSession.addDebugInfo(sessionId, {
-        facilityId,
         isMobile,
         tablesForFullResync,
       });

--- a/packages/sync-server/app/sync/buildSyncRoutes.js
+++ b/packages/sync-server/app/sync/buildSyncRoutes.js
@@ -14,7 +14,11 @@ export const buildSyncRoutes = ctx => {
     '/',
     asyncHandler(async (req, res) => {
       const { user, deviceId, facilityId } = req;
-      const { sessionId, tick } = await syncManager.startSession(user.id, deviceId, facilityId);
+      const { sessionId, tick } = await syncManager.startSession({
+        userId: user.id,
+        deviceId,
+        facilityId,
+      });
       res.json({ sessionId, tick });
     }),
   );

--- a/packages/sync-server/app/sync/buildSyncRoutes.js
+++ b/packages/sync-server/app/sync/buildSyncRoutes.js
@@ -13,8 +13,8 @@ export const buildSyncRoutes = ctx => {
   syncRoutes.post(
     '/',
     asyncHandler(async (req, res) => {
-      const { user, deviceId } = req;
-      const { sessionId, tick } = await syncManager.startSession(user.id, deviceId);
+      const { user, deviceId, facilityId } = req;
+      const { sessionId, tick } = await syncManager.startSession(user.id, deviceId, facilityId);
       res.json({ sessionId, tick });
     }),
   );


### PR DESCRIPTION
### Changes

When connecting to central server to debug sync issues, it's a common frustration that the facility that is connecting is only available once it gets into the pull phase. This PR sends through the `facilityId` when it first starts a sync session, for logging in both the `debug_info` column and the honeycomb logs

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
