### PR TITLE
TAV-735: more release fixes

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -22,26 +22,62 @@ jobs:
         ref: main
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
 
+    - name: Set up committer info
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+
     - uses: actions/setup-node@v3
       with:
         node-version: 16
 
+    - name: Compute new release branch name
+      uses: actions/github-script@v6
+      id: branchname
+      with:
+        github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
+        result-encoding: string
+        script: |
+          const cwd = '${{ github.workspace }}';
+          const { currentVersion } = await import(`/tmp/gha-release-ops.mjs`);
+          return currentVersion(import('fs'), cwd).branch;
+
+    - name: Check new release branch doesn't already exist
+      uses: actions/github-script@v6
+      env:
+        NEW_BRANCH_NAME: ${{ steps.branchname.outputs.result }}
+      with:
+        github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
+        script: |
+          const cwd = '${{ github.workspace }}';
+          const { checkNewReleaseBranchDoesNotExist } = await import(`/tmp/gha-release-ops.mjs`);
+          await checkNewReleaseBranchDoesNotExist(github, context, process.env.NEW_BRANCH_NAME);
+
     - name: Create new release branch
+      env:
+        NEW_BRANCH_NAME: ${{ steps.branchname.outputs.result }}
+      run: |
+        set -ex
+        git switch --create "$NEW_BRANCH_NAME"
+        git commit --allow-empty -m "Cut-off for $NEW_BRANCH_NAME"
+        git push
+        git switch main
+
+    - name: Create next release draft
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
         script: |
           const cwd = '${{ github.workspace }}';
-          const { createReleaseBranch } = await import(`/tmp/gha-release-ops.mjs`);
-          await createReleaseBranch(await import('fs'), github, context, cwd, '${{ github.event.inputs.version }}');
+          const { createNextDraft } = await import(`/tmp/gha-release-ops.mjs`);
+          await createNextDraft(await import('fs'), github, context, cwd, '${{ github.event.inputs.version }}');
 
     - name: Bump version on main
       run: node scripts/version.mjs '${{ github.event.inputs.version }}'
 
     - name: Commit and push
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        set -ex
         version=$(jq -r .version package.json)
         git commit -am "Bump version to $version"
         git push

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -16,8 +16,6 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v3
-    - run: cp scripts/gha-release-ops.mjs /tmp/
-    - uses: actions/checkout@v3
       with:
         ref: main
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
@@ -39,7 +37,7 @@ jobs:
         result-encoding: string
         script: |
           const cwd = '${{ github.workspace }}';
-          const { currentVersion } = await import(`/tmp/gha-release-ops.mjs`);
+          const { currentVersion } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
           return currentVersion(await import('fs'), cwd).branch;
 
     - name: Check new release branch doesn't already exist
@@ -50,7 +48,7 @@ jobs:
         github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
         script: |
           const cwd = '${{ github.workspace }}';
-          const { checkBranchDoesNotExist } = await import(`/tmp/gha-release-ops.mjs`);
+          const { checkBranchDoesNotExist } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
           await checkBranchDoesNotExist(github, context, process.env.NEW_BRANCH_NAME);
 
     - name: Create new release branch
@@ -69,7 +67,7 @@ jobs:
         github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
         script: |
           const cwd = '${{ github.workspace }}';
-          const { createNextDraft } = await import(`/tmp/gha-release-ops.mjs`);
+          const { createNextDraft } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
           await createNextDraft(await import('fs'), github, context, cwd, '${{ github.event.inputs.version }}');
 
     - name: Bump version on main

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -50,8 +50,8 @@ jobs:
         github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
         script: |
           const cwd = '${{ github.workspace }}';
-          const { checkNewReleaseBranchDoesNotExist } = await import(`/tmp/gha-release-ops.mjs`);
-          await checkNewReleaseBranchDoesNotExist(github, context, process.env.NEW_BRANCH_NAME);
+          const { checkBranchDoesNotExist } = await import(`/tmp/gha-release-ops.mjs`);
+          await checkBranchDoesNotExist(github, context, process.env.NEW_BRANCH_NAME);
 
     - name: Create new release branch
       env:

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -40,7 +40,7 @@ jobs:
         script: |
           const cwd = '${{ github.workspace }}';
           const { currentVersion } = await import(`/tmp/gha-release-ops.mjs`);
-          return currentVersion(import('fs'), cwd).branch;
+          return currentVersion(await import('fs'), cwd).branch;
 
     - name: Check new release branch doesn't already exist
       uses: actions/github-script@v6

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v3
+    - run: cp scripts/gha-release-ops.mjs /tmp/
+    - uses: actions/checkout@v3
       with:
         ref: main
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
@@ -30,7 +32,7 @@ jobs:
         github-token: ${{ secrets.TAMANU_RELEASE_PAT }}
         script: |
           const cwd = '${{ github.workspace }}';
-          const { createReleaseBranch } = await import(`${cwd}/scripts/gha-release-ops.mjs`);
+          const { createReleaseBranch } = await import(`/tmp/gha-release-ops.mjs`);
           await createReleaseBranch(await import('fs'), github, context, cwd, '${{ github.event.inputs.version }}');
 
     - name: Bump version on main

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -60,7 +60,7 @@ jobs:
         set -ex
         git switch --create "$NEW_BRANCH_NAME"
         git commit --allow-empty -m "Cut-off for $NEW_BRANCH_NAME"
-        git push
+        git push origin "$NEW_BRANCH_NAME"
         git switch main
 
     - name: Create next release draft

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -30,11 +30,16 @@ export async function createReleaseBranch({ readFileSync }, github, context, cwd
   }
 
   console.log('It does not, creating release cutoff commit...');
+  const currentTree = await github.rest.git.getCommit({
+    owner,
+    repo,
+    commit_sha: sha,
+  });
   const tree = await github.rest.git.createTree({
     owner,
     repo,
     tree: [], // empty commit
-    base_tree: sha,
+    base_tree: currentTree.data.tree.sha,
   });
   const tip = await github.rest.git.createCommit({
     owner,

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -91,7 +91,7 @@ export async function createDraftRelease({ readFileSync }, github, context, cwd,
     name: `v${version}`,
     draft: true,
     prerelease: false,
-    make_latest: false,
+    make_latest: "false", // yes this has to be a string https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
     body: template.replace(/%VERSION%/g, version),
   });
 }
@@ -191,7 +191,7 @@ export async function publishRelease(github, context, version) {
   }
 
   console.log('Fetching latest published release...');
-  let markLatest = true;
+  let markLatest = "true"; // string, see https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release
   const latestPublished = await findPublishedRelease(github, context, () => true);
   if (!latestPublished) {
     console.log('No published releases found');
@@ -208,7 +208,7 @@ export async function publishRelease(github, context, version) {
     ) {
       console.log('Not marking release as latest as there is a higher published version');
       console.log(`::notice title=Hotfix::Release ${version} not marked latest`);
-      markLatest = false;
+      markLatest = "false";
     }
   }
 

--- a/scripts/gha-release-ops.mjs
+++ b/scripts/gha-release-ops.mjs
@@ -33,29 +33,6 @@ export async function checkBranchDoesNotExist(github, context, branch) {
   }
 }
 
-  // console.log('It does not, creating release cutoff commit...');
-  // const currentTree = await github.rest.git.getCommit({
-  //   owner,
-  //   repo,
-  //   commit_sha: sha,
-  // });
-  // const tree = await github.rest.git.createTree({
-  //   owner,
-  //   repo,
-  //   tree: [], // empty commit
-  //   base_tree: currentTree.data.tree.sha,
-  // });
-  // const tip = await github.rest.git.createCommit({
-  //   owner,
-  //   repo,
-  //   message: `Cut-off for release branch ${major}.${minor}`,
-  //   tree: tree.data.sha,
-  //   parents: [sha],
-  // });
-
-  // console.log('Creating branch...');
-  // await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha: tip.data.sha });
-
 export async function createNextDraft({ readFileSync }, github, context, cwd, nextVersionSpec) {
   const { major, minor } = currentVersion({ readFileSync }, cwd);
 


### PR DESCRIPTION
### Changes

- Replace GraphQL create commit API with good old git CLI commands
- That splits a single function in three but ah well
- `make_latest` in the API is a boolean [AS A STRING WTAF](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)
- address minor comments from previous PR

**1.31 cut release workflow has been run with this code, no need to re-run**

### Checklist

- [x] Code is finished