### PR TITLE
SAV-362 Use the right key for sorting

### DIFF
--- a/packages/desktop/app/components/ProcedureTable.js
+++ b/packages/desktop/app/components/ProcedureTable.js
@@ -8,7 +8,7 @@ const getCodeLabel = ({ procedureType }) => procedureType.code;
 
 const COLUMNS = [
   { key: 'date', title: 'Date', accessor: ({ date }) => <DateDisplay date={date} /> },
-  { key: 'code', title: 'Code', accessor: getCodeLabel },
+  { key: 'ProcedureType.code', title: 'Code', accessor: getCodeLabel },
   { key: 'type', title: 'Procedure', accessor: getProcedureLabel },
 ];
 


### PR DESCRIPTION
### Changes
#### Frontend change only: 
Use the right key `ProcedureType.code` for sorting, it will be put to `orderBy` query in request as 
```
GET {{lanserver}}/v1/encounter/{{encounterId}}/procedures?page=0&rowsPerPage=10&order=desc&orderBy=ProcedureType.code
```  

Our endpoint is powerful enough to allow `association.column` as a sort query. 

TBH I love to have a sorting key to avoid confusion but key like `ProcedureType.code` also give a better info of what that is.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
