### PR TITLE
SAV-389: Fix triage closing

### DIFF
--- a/packages/lan/__tests__/apiv1/Triage.test.js
+++ b/packages/lan/__tests__/apiv1/Triage.test.js
@@ -159,6 +159,40 @@ describe('Triage', () => {
     expect(updatedTriage.closedTime).toBeTruthy();
   });
 
+  it('should not update the closed time of an already-closed triage', async () => {
+    const encounterPatient = await models.Patient.create(await createDummyPatient(models));
+    const createdTriage = await models.Triage.create(
+      await createDummyTriage(models, {
+        patientId: encounterPatient.id,
+        departmentId: await randomRecordId(models, 'Department'),
+      }),
+    );
+    const createdEncounter = await models.Encounter.findByPk(createdTriage.encounterId);
+    expect(createdEncounter).toBeTruthy();
+
+    const DATE_1 = '2023-01-01 10:00:00';
+    const DATE_2 = '2023-01-01 10:30:00';
+
+    // progress encounter once (which should update the triage)
+    const progressResponse = await app.put(`/v1/encounter/${createdEncounter.id}`).send({
+      encounterType: ENCOUNTER_TYPES.EMERGENCY,
+      submittedTime: DATE_1,
+    });
+    expect(progressResponse).toHaveSucceeded();
+    const updatedTriage = await models.Triage.findByPk(createdTriage.id);
+    expect(updatedTriage.closedTime).toEqual(DATE_1);
+
+    // and again (which should NOT update the triage)
+    const progressResponse2 = await app.put(`/v1/encounter/${createdEncounter.id}`).send({
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      submittedTime: DATE_2,
+    });
+    expect(progressResponse2).toHaveSucceeded();
+    const updatedTriage2 = await models.Triage.findByPk(createdTriage.id);
+    expect(updatedTriage2.closedTime).toEqual(DATE_1);
+    
+  });
+
   it('should set the encounter reason to the text of the chief complaints', async () => {
     const encounterPatient = await models.Patient.create(await createDummyPatient(models));
     const createdTriage = await models.Triage.create(

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -399,8 +399,8 @@ export class Encounter extends Model {
   async closeTriage(endDate) {
     const triage = await this.getLinkedTriage();
     if (!triage) return;
-    if (triage.closedTime) return;  // already closed
-    
+    if (triage.closedTime) return; // already closed
+
     await triage.update({
       closedTime: endDate,
     });

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -398,11 +398,12 @@ export class Encounter extends Model {
 
   async closeTriage(endDate) {
     const triage = await this.getLinkedTriage();
-    if (triage) {
-      await triage.update({
-        closedTime: endDate,
-      });
-    }
+    if (!triage) return;
+    if (triage.closedTime) return;  // already closed
+    
+    await triage.update({
+      closedTime: endDate,
+    });
   }
 
   async updateClinician(newClinicianId, submittedTime, user) {


### PR DESCRIPTION
### Changes

Adds a check to only set closedTime on a triage if closedTime is null.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
