### PR TITLE
Don't try to run tsc --fix on some packages

### DIFF
--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -17,7 +17,8 @@
     "build:src": "swc --delete-dir-on-start --out-dir dist --copy-files --source-maps true src",
     "build:types": "tsc --declaration --emitDeclarationOnly --noEmit false && move-dts src dist",
     "build-watch": "yarn run build && yarn run build:src --watch",
-    "lint": "tsc"
+    "lint": "tsc",
+    "lint:fix": "echo tsc --fix not yet supported"
   },
   "devDependencies": {
     "@tamanu/build-tooling": "*",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "swc --delete-dir-on-start --out-dir build --copy-files --source-maps true src",
     "cli": "yarn build && node build",
-    "lint": "tsc"
+    "lint": "tsc",
+    "lint:fix": "echo tsc --fix not yet supported"
   },
   "devDependencies": {
     "@tamanu/build-tooling": "*",


### PR DESCRIPTION
### Changes

The !lint-fix macro and `yarn run lint-fix` command were failing because tsc doesn't support a `--fix` option. This adds a `lint:fix` override to those packages so that it doesn't attempt that.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
