### PR TITLE
SAV-389: Fix arrival time tooltip

### DIFF
--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -59,7 +59,7 @@ export const TriageWaitTimeCell = React.memo(
       case ENCOUNTER_TYPES.OBSERVATION:
       case ENCOUNTER_TYPES.EMERGENCY:
         return (
-          <TriageCell arrivalTime={arrivalTime}>
+          <TriageCell arrivalTime={assumedArrivalTime}>
             {`Seen at ${format(new Date(closedTime), 'h:mma')}`}
           </TriageCell>
         );


### PR DESCRIPTION
### Changes

The Observation and Emergency type tooltips were reading the wrong variable, resulting in an empty tooltip.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
