### PR TITLE
Abort if linter is about to run tsc --fix

### DIFF
--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -17,8 +17,7 @@
     "build:src": "swc --delete-dir-on-start --out-dir dist --copy-files --source-maps true src",
     "build:types": "tsc --declaration --emitDeclarationOnly --noEmit false && move-dts src dist",
     "build-watch": "yarn run build && yarn run build:src --watch",
-    "lint": "tsc",
-    "lint:fix": "echo tsc --fix not yet supported"
+    "lint": "tsc"
   },
   "devDependencies": {
     "@tamanu/build-tooling": "*",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "build": "swc --delete-dir-on-start --out-dir build --copy-files --source-maps true src",
     "cli": "yarn build && node build",
-    "lint": "tsc",
-    "lint:fix": "echo tsc --fix not yet supported"
+    "lint": "tsc"
   },
   "devDependencies": {
     "@tamanu/build-tooling": "*",

--- a/scripts/lint-all.mjs
+++ b/scripts/lint-all.mjs
@@ -8,17 +8,22 @@ doWithAllPackages((name, pkg) => {
     return;
   }
 
-  console.log(`Linting ${name}...`);
-
   const args = ['workspace', pkg.name, 'run'];
-  if (process.argv.includes('--fix') && pkg?.scripts?.['lint:fix']) {
+  const fixing = process.argv.includes('--fix');
+
+  if (fixing && pkg.scripts['lint:fix']) {
     // Some packages require special handling for lint --fix
     args.push('lint:fix');
     args.push(...process.argv.slice(2).filter(arg => arg !== '--fix'));
+  } else if (fixing && pkg.scripts.lint === 'tsc') {
+    console.log(`Skipping ${name} as tsc doesn't support --fix...`);
+    return;
   } else {
     args.push('lint');
     args.push(...process.argv.slice(2));
   }
+
+  console.log(`Linting ${name}...`);
 
   try {
     execFileSync('yarn', args, {


### PR DESCRIPTION
### Changes

Linter broke again - the previous fix was to override "lint:fix" for the typescript packages, but a new typescript package (api-client) was merged to main without it, which broke it again.

I considered just adding a "lint:fix" override to the new package, but it's clearly not very ergonomic to have to remember to add a manual lint:fix override for every new tsc package. Instead I've updated the lint-all.mjs script to notice if it's about to run `tsc --fix` and skip the file in those cases.

### Checklist

- [x] Code is finished
