### PR TITLE
TAMOC-54: Fix broken builds due to @tamanu/api-client not building

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -26,7 +26,11 @@ common() {
 
 build_shared() {
   yarn clean
-  yarn build-shared
+  # as `yarn build-shared` removes anything that's not a dependency of another
+  #   package, and when the Dockerfile builds `shared` it removes non-shared
+  #   packages, we want to run `yarn build` to ensure every remaining package
+  #   is build regardless of whether it appears to be dependent
+  yarn build
 }
 
 remove_irrelevant_packages() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6655,7 +6655,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.12.3, ajv
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.10.0, ajv@^8.6.3, ajv@^8.8.0:
+ajv@^8.0.0, ajv@^8.10.0, ajv@^8.6.3, ajv@^8.8.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==


### PR DESCRIPTION
### Changes

1. Github Actions runs the root Dockerfile as part of the CD Client/Build desktop client job
2. The Dockerfile builds shared by removing everything except shared
3. The _do-with-all-packages.mjs script determines whether a package is shared by whether it's depended on by other workspaces packages
4. Because 2. removed everything except shared, @tamanu/api-client is not dependent on by anything, and is not built
5. For some reason this doesn't break the build and instead the client is built with a missing package

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
