### PR TITLE
NASS-831: adding sync filter for user preference

### DIFF
--- a/packages/shared/src/models/Note.js
+++ b/packages/shared/src/models/Note.js
@@ -108,5 +108,5 @@ export class Note extends Model {
     return this[parentGetter](options);
   }
 
-  static buildSyncFilter = buildNoteLinkedSyncFilter;
+  static buildPatientSyncFilter = buildNoteLinkedSyncFilter;
 }

--- a/packages/shared/src/models/UserPreference.js
+++ b/packages/shared/src/models/UserPreference.js
@@ -35,4 +35,8 @@ export class UserPreference extends Model {
       as: 'user',
     });
   }
+  
+  static buildSyncFilter() {
+    return null; // syncs everywhere
+  }
 }

--- a/packages/shared/src/models/UserPreference.js
+++ b/packages/shared/src/models/UserPreference.js
@@ -35,7 +35,7 @@ export class UserPreference extends Model {
       as: 'user',
     });
   }
-  
+
   static buildSyncFilter() {
     return null; // syncs everywhere
   }


### PR DESCRIPTION
### Changes

- Added sync filter for user preference model.
- Changed note sync filter to use the new approach added on https://github.com/beyondessential/tamanu/pull/4509


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
