### PR TITLE
EPI-617: Show N/A when there is no handover notes

### DIFF
--- a/packages/shared/src/utils/handoverNotes/HandoverPatient.js
+++ b/packages/shared/src/utils/handoverNotes/HandoverPatient.js
@@ -71,7 +71,7 @@ export const HandoverPatient = ({
           {diagnosis && <ValueDisplay width="100%" title="Diagnosis" value={diagnosis} />}
           <Row>
             <ValueDisplay width="100%" title="Notes" value={notes || 'N/A'} />
-            {createdAt && ( // createdAt only exists if notes exists
+            {!!notes && !!createdAt && (
               <Col style={{ width: '100%' }}>
                 <P style={{ fontSize: 8 }}>
                   {`${getDisplayDate(createdAt, 'dd/MM/yyyy hh:mm a')}${

--- a/packages/shared/src/utils/handoverNotes/HandoverPatient.js
+++ b/packages/shared/src/utils/handoverNotes/HandoverPatient.js
@@ -69,20 +69,18 @@ export const HandoverPatient = ({
             />
           </Row>
           {diagnosis && <ValueDisplay width="100%" title="Diagnosis" value={diagnosis} />}
-          {notes && (
-            <Row>
-              <ValueDisplay width="100%" title="Notes" value={notes} />
-              {createdAt && (
-                <Col style={{ width: '100%' }}>
-                  <P style={{ fontSize: 8 }}>
-                    {`${getDisplayDate(createdAt, 'dd/MM/yyyy hh:mm a')}${
-                      isEdited ? ' (edited)' : ''
-                    }`}
-                  </P>
-                </Col>
-              )}
-            </Row>
-          )}
+          <Row>
+            <ValueDisplay width="100%" title="Notes" value={notes || 'N/A'} />
+            {createdAt && ( // createdAt only exists if notes exists
+              <Col style={{ width: '100%' }}>
+                <P style={{ fontSize: 8 }}>
+                  {`${getDisplayDate(createdAt, 'dd/MM/yyyy hh:mm a')}${
+                    isEdited ? ' (edited)' : ''
+                  }`}
+                </P>
+              </Col>
+            )}
+          </Row>
         </Col>
       </Row>
       <Divider />


### PR DESCRIPTION
### Changes
- Show N/A when there is no handover notes

<img width="755" alt="Screen Shot 2023-08-29 at 2 53 40 pm" src="https://github.com/beyondessential/tamanu/assets/63621318/16e98734-233a-4733-b40b-266c48ca82a6">

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
