### PR TITLE
Fix constants package in codeship builds

### DIFF
--- a/Dockerfile.codeship
+++ b/Dockerfile.codeship
@@ -41,7 +41,7 @@ RUN yarn install --non-interactive --frozen-lockfile \
     && rm -rf node_modules packages/*/node_modules
 
 # Tool configs
-COPY .eslintignore .eslintrc .prettierignore .prettierrc *.config.* ./
+COPY .eslintignore .eslintrc .prettierignore .prettierrc *.config.* common.tsconfig.json ./
 
 # Rest of the source
 COPY scripts/ scripts/

--- a/common.tsconfig.json
+++ b/common.tsconfig.json
@@ -8,6 +8,7 @@
     "importsNotUsedAsValues": "preserve",
     "isolatedModules": true,
     "module": "ES2020",
+    "lib": "es2020",
     "moduleResolution": "Node16",
     "noEmit": true,
     "noUnusedLocals": true,

--- a/common.tsconfig.json
+++ b/common.tsconfig.json
@@ -8,7 +8,7 @@
     "importsNotUsedAsValues": "preserve",
     "isolatedModules": true,
     "module": "ES2020",
-    "lib": "es2020",
+    "lib": ["es2020"],
     "moduleResolution": "Node16",
     "noEmit": true,
     "noUnusedLocals": true,

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -4,6 +4,6 @@
     "src/**/*.ts"
   ],
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": "./src"
   }
 }

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "swc --delete-dir-on-start --out-dir build --copy-files --source-maps true src",
     "cli": "yarn build && node build",
-    "lint": "tsc"
+    "lint:types": "tsc"
   },
   "devDependencies": {
     "@tamanu/build-tooling": "*",

--- a/packages/sync-server/app/tasks/FhirMissingResources.js
+++ b/packages/sync-server/app/tasks/FhirMissingResources.js
@@ -1,8 +1,8 @@
 import config from 'config';
-import { ScheduledTask } from 'shared/tasks';
 import { FHIR_INTERACTIONS, JOB_TOPICS } from '@tamanu/constants';
-import { log } from 'shared/services/logging';
-import { resourcesThatCanDo } from 'shared/utils/fhir/resources';
+import { ScheduledTask } from '@tamanu/shared/tasks';
+import { log } from '@tamanu/shared/services/logging';
+import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 
 export class FhirMissingResources extends ScheduledTask {
   constructor(context) {

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -16,8 +16,7 @@ buildplace=$(mktemp -d)
 # copy workspace root and shared into buildplace
 cp package.json   "$buildplace/package.json.orig"
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json > "$buildplace/package.json"
-ls -la
-cp -R yarn.lock common.tsconfig.json *.config.*   "$buildplace/"
+cp -R yarn.lock *.config.*   "$buildplace/"
 mkdir -p "$buildplace/packages"
 cp -R packages/build-tooling packages/shared packages/constants   "$buildplace/packages/"
 
@@ -36,8 +35,6 @@ rm -rf packages/*/config/{development,test,local}.json || true
 
 # do the build
 yarn install --non-interactive --production --frozen-lockfile
-yarn workspace @tamanu/constants build
-yarn workspace @tamanu/shared build
 yarn workspace $pkg_name build
 
 # clear out the build-tooling

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -16,7 +16,7 @@ buildplace=$(mktemp -d)
 # copy workspace root and shared into buildplace
 cp package.json   "$buildplace/package.json.orig"
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json > "$buildplace/package.json"
-cp -R yarn.lock *.config.*   "$buildplace/"
+cp -R yarn.lock common.tsconfig.json *.config.*   "$buildplace/"
 mkdir -p "$buildplace/packages"
 cp -R packages/build-tooling packages/shared packages/constants   "$buildplace/packages/"
 
@@ -43,6 +43,7 @@ yarn workspace $pkg_name build
 rm -rf node_modules/@tamanu/build-tooling
 rm -rf packages/build-tooling
 rm -rf packages/**/node_modules/@tamanu/build-tooling
+rm common.tsconfig.json
 
 # clear out the build configs
 rm -rf packages/*/*.config.* || true

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -11,14 +11,14 @@ shopt -s extglob
 pkg_name="${1?must specify a package}"
 RELEASE_DIR="${RELEASE_DIR:-release-nodejs}"
 target="$(pwd)/packages/$pkg_name/$RELEASE_DIR"
-buildplace=$(mktemp --directory)
+buildplace=$(mktemp -d)
 
 # copy workspace root and shared into buildplace
 cp package.json   "$buildplace/package.json.orig"
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json > "$buildplace/package.json"
 cp -R yarn.lock *.config.*   "$buildplace/"
 mkdir -p "$buildplace/packages"
-cp -R packages/build-tooling packages/shared   "$buildplace/packages/"
+cp -R packages/build-tooling packages/shared packages/constants   "$buildplace/packages/"
 
 # copy desired package
 cp -R "packages/$pkg_name"   "$buildplace/packages/"
@@ -53,6 +53,8 @@ mv -v package.json{.orig,}
 # this is quite hacky but we'll change how this works altogether very soon (SAV-263)
 cp -R packages/shared/node_modules/*   node_modules/
 rm -rf packages/$pkg_name/node_modules/@tamanu/shared || true
+cp -R packages/constants/node_modules/*   node_modules/ || true # doesn't exist yet
+rm -rf packages/$pkg_name/node_modules/@tamanu/constants || true
 cp -R packages/$pkg_name/node_modules/*   node_modules/
 rm -rf packages/$pkg_name/node_modules || true
 mv -v node_modules   packages/$pkg_name/node_modules
@@ -61,6 +63,8 @@ mv -v node_modules   packages/$pkg_name/node_modules
 mkdir -p packages/$pkg_name/node_modules/@tamanu
 rm -rf packages/$pkg_name/node_modules/@tamanu/shared
 mv -v packages/shared   packages/$pkg_name/node_modules/@tamanu/shared
+rm -rf packages/$pkg_name/node_modules/@tamanu/constants
+mv -v packages/constants   packages/$pkg_name/node_modules/@tamanu/constants
 
 # out of build
 popd

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -35,6 +35,7 @@ rm -rf packages/*/config/{development,test,local}.json || true
 
 # do the build
 yarn install --non-interactive --production --frozen-lockfile
+yarn workspace @tamanu/constants build
 yarn workspace @tamanu/shared build
 yarn workspace $pkg_name build
 

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -16,7 +16,8 @@ buildplace=$(mktemp -d)
 # copy workspace root and shared into buildplace
 cp package.json   "$buildplace/package.json.orig"
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json > "$buildplace/package.json"
-cp -R yarn.lock *.config.*   "$buildplace/"
+ls -la
+cp -R yarn.lock common.tsconfig.json *.config.*   "$buildplace/"
 mkdir -p "$buildplace/packages"
 cp -R packages/build-tooling packages/shared packages/constants   "$buildplace/packages/"
 
@@ -35,6 +36,8 @@ rm -rf packages/*/config/{development,test,local}.json || true
 
 # do the build
 yarn install --non-interactive --production --frozen-lockfile
+yarn workspace @tamanu/constants build
+yarn workspace @tamanu/shared build
 yarn workspace $pkg_name build
 
 # clear out the build-tooling

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -16,6 +16,7 @@ buildplace=$(mktemp -d)
 # copy workspace root and shared into buildplace
 cp package.json   "$buildplace/package.json.orig"
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json > "$buildplace/package.json"
+ls -la
 cp -R yarn.lock common.tsconfig.json *.config.*   "$buildplace/"
 mkdir -p "$buildplace/packages"
 cp -R packages/build-tooling packages/shared packages/constants   "$buildplace/packages/"

--- a/scripts/build_package_release.sh
+++ b/scripts/build_package_release.sh
@@ -16,7 +16,6 @@ buildplace=$(mktemp -d)
 # copy workspace root and shared into buildplace
 cp package.json   "$buildplace/package.json.orig"
 jq '.dependencies["@tamanu/build-tooling"] = "*"' package.json > "$buildplace/package.json"
-ls -la
 cp -R yarn.lock common.tsconfig.json *.config.*   "$buildplace/"
 mkdir -p "$buildplace/packages"
 cp -R packages/build-tooling packages/shared packages/constants   "$buildplace/packages/"

--- a/scripts/build_shared.sh
+++ b/scripts/build_shared.sh
@@ -3,6 +3,4 @@ set -euxo pipefail
 
 yarn install --non-interactive --frozen-lockfile
 yarn workspace @tamanu/shared run build
-pwd
-ls -la
 yarn workspace @tamanu/constants run build

--- a/scripts/build_shared.sh
+++ b/scripts/build_shared.sh
@@ -3,4 +3,6 @@ set -euxo pipefail
 
 yarn install --non-interactive --frozen-lockfile
 yarn workspace @tamanu/shared run build
+pwd
+ls -la
 yarn workspace @tamanu/constants run build

--- a/scripts/build_shared.sh
+++ b/scripts/build_shared.sh
@@ -3,3 +3,4 @@ set -euxo pipefail
 
 yarn install --non-interactive --frozen-lockfile
 yarn workspace @tamanu/shared run build
+yarn workspace @tamanu/constants run build

--- a/scripts/build_shared.sh
+++ b/scripts/build_shared.sh
@@ -3,4 +3,3 @@ set -euxo pipefail
 
 yarn install --non-interactive --frozen-lockfile
 yarn workspace @tamanu/shared run build
-yarn workspace @tamanu/constants run build

--- a/yarn.lock
+++ b/yarn.lock
@@ -6655,7 +6655,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.12.3, ajv
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.10.0, ajv@^8.6.3, ajv@^8.8.0:
+ajv@^8.0.0, ajv@^8.10.0, ajv@^8.6.3, ajv@^8.8.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==


### PR DESCRIPTION
### Changes

Splitting out the constants package in https://github.com/beyondessential/tamanu/pull/4537 broke the codeship build for meta-server and for server zips. This hopefully fixes it, so we can unblock the creation of server zips for Taveuni and the deploying of meta from the latest main

Test build at https://app.codeship.com/projects/9355b080-d34d-0136-45ef-2e8db6e7ba42/builds/4ccb7e62-8eab-485d-ad46-7b71b35cc95a?component=step_tamanu_deployment_push_and_deploy_the_meta_server_onto_dev

### Checklist

- [x] Code is finished
