### PR TITLE
SAV-345: Additional columns in encounter history

### DIFF
--- a/packages/constants/src/encounterHistory.ts
+++ b/packages/constants/src/encounterHistory.ts
@@ -1,0 +1,6 @@
+export enum EncounterChangeType {
+  EncounterType = 'encounter_type',
+  Location = 'location',
+  Department = 'department',
+  Examiner = 'examiner',
+}

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -24,3 +24,4 @@ export * from './sync';
 export * from './templates';
 export * from './vaccines';
 export * from './settings';
+export * from './encounterHistory';

--- a/packages/lan/__tests__/apiv1/Encounter.test.js
+++ b/packages/lan/__tests__/apiv1/Encounter.test.js
@@ -1371,10 +1371,13 @@ describe('Encounter', () => {
     describe('encounter history', () => {
       describe('single change', () => {
         it('should record an encounter history when an encounter is created', async () => {
-          const encounter = await models.Encounter.create({
+          const result = await app.post('/v1/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
           });
+
+          expect(result).toHaveSucceeded();
+          const encounter = await models.Encounter.findByPk(result.body.id);
 
           const encounterHistoryRecords = await models.EncounterHistory.findAll({
             where: {
@@ -1389,6 +1392,7 @@ describe('Encounter', () => {
             locationId: encounter.locationId,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
+            actorId: user.id,
           });
         });
 
@@ -1402,7 +1406,6 @@ describe('Encounter', () => {
           });
 
           expect(result).toHaveSucceeded();
-          expect(result.body.id).toBeTruthy();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
@@ -1448,7 +1451,6 @@ describe('Encounter', () => {
           });
 
           expect(result).toHaveSucceeded();
-          expect(result.body.id).toBeTruthy();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
@@ -1494,7 +1496,6 @@ describe('Encounter', () => {
           });
 
           expect(result).toHaveSucceeded();
-          expect(result.body.id).toBeTruthy();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
@@ -1541,7 +1542,6 @@ describe('Encounter', () => {
           });
 
           expect(result).toHaveSucceeded();
-          expect(result.body.id).toBeTruthy();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
@@ -1593,7 +1593,6 @@ describe('Encounter', () => {
           });
 
           expect(result).toHaveSucceeded();
-          expect(result.body.id).toBeTruthy();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
           const locationChangeSubmittedTime = getCurrentDateTimeString();

--- a/packages/lan/__tests__/apiv1/Encounter.test.js
+++ b/packages/lan/__tests__/apiv1/Encounter.test.js
@@ -1395,14 +1395,15 @@ describe('Encounter', () => {
         it('should record an encounter history for a location change', async () => {
           const [oldLocation, newLocation] = await models.Location.findAll({ limit: 2 });
           const submittedTime = getCurrentDateTimeString();
-          const encounter = await models.Encounter.create(
-            {
-              ...(await createDummyEncounter(models)),
-              patientId: patient.id,
-              locationId: oldLocation.id,
-            },
-            user,
-          );
+          const result = await app.post('/v1/encounter').send({
+            ...(await createDummyEncounter(models)),
+            patientId: patient.id,
+            locationId: oldLocation.id,
+          });
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.id).toBeTruthy();
+          const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
             locationId: newLocation.id,
@@ -1422,7 +1423,7 @@ describe('Encounter', () => {
             locationId: oldLocation.id,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
 
           expect(encounterHistoryRecords[1]).toMatchObject({
@@ -1433,21 +1434,22 @@ describe('Encounter', () => {
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
             changeType: EncounterChangeType.Location,
-            modifierId: user.id,
+            actorId: user.id,
           });
         });
 
         it('should record an encounter history for a department change', async () => {
           const [oldDepartment, newDepartment] = await models.Department.findAll({ limit: 2 });
           const submittedTime = getCurrentDateTimeString();
-          const encounter = await models.Encounter.create(
-            {
-              ...(await createDummyEncounter(models)),
-              patientId: patient.id,
-              departmentId: oldDepartment.id,
-            },
-            user,
-          );
+          const result = await app.post('/v1/encounter').send({
+            ...(await createDummyEncounter(models)),
+            patientId: patient.id,
+            departmentId: oldDepartment.id,
+          });
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.id).toBeTruthy();
+          const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
             departmentId: newDepartment.id,
@@ -1467,7 +1469,7 @@ describe('Encounter', () => {
             locationId: encounter.locationId,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
           expect(encounterHistoryRecords[1]).toMatchObject({
             date: submittedTime,
@@ -1477,21 +1479,23 @@ describe('Encounter', () => {
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
             changeType: EncounterChangeType.Department,
-            modifierId: user.id,
+            actorId: user.id,
           });
         });
 
         it('should record an encounter history for a clinician change', async () => {
           const [oldClinician, newClinician] = await models.User.findAll({ limit: 2 });
           const submittedTime = getCurrentDateTimeString();
-          const encounter = await models.Encounter.create(
-            {
-              ...(await createDummyEncounter(models)),
-              patientId: patient.id,
-              examinerId: oldClinician.id,
-            },
-            user,
-          );
+
+          const result = await app.post('/v1/encounter').send({
+            ...(await createDummyEncounter(models)),
+            patientId: patient.id,
+            examinerId: oldClinician.id,
+          });
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.id).toBeTruthy();
+          const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
             examinerId: newClinician.id,
@@ -1511,7 +1515,7 @@ describe('Encounter', () => {
             locationId: encounter.locationId,
             examinerId: oldClinician.id,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
           expect(encounterHistoryRecords[1]).toMatchObject({
             date: submittedTime,
@@ -1521,7 +1525,7 @@ describe('Encounter', () => {
             examinerId: newClinician.id,
             encounterType: encounter.encounterType,
             changeType: EncounterChangeType.Examiner,
-            modifierId: user.id,
+            actorId: user.id,
           });
         });
 
@@ -1529,14 +1533,16 @@ describe('Encounter', () => {
           const oldEncounterType = 'admission';
           const newEncounterType = 'clinic';
           const submittedTime = getCurrentDateTimeString();
-          const encounter = await models.Encounter.create(
-            {
-              ...(await createDummyEncounter(models)),
-              patientId: patient.id,
-              encounterType: oldEncounterType,
-            },
-            user,
-          );
+
+          const result = await app.post('/v1/encounter').send({
+            ...(await createDummyEncounter(models)),
+            patientId: patient.id,
+            encounterType: oldEncounterType,
+          });
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.id).toBeTruthy();
+          const encounter = await models.Encounter.findByPk(result.body.id);
 
           await app.put(`/v1/encounter/${encounter.id}`).send({
             encounterType: newEncounterType,
@@ -1557,7 +1563,7 @@ describe('Encounter', () => {
             locationId: encounter.locationId,
             examinerId: encounter.examinerId,
             encounterType: oldEncounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
           expect(encounterHistoryRecords[1]).toMatchObject({
             date: submittedTime,
@@ -1567,7 +1573,7 @@ describe('Encounter', () => {
             examinerId: encounter.examinerId,
             encounterType: newEncounterType,
             changeType: EncounterChangeType.EncounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
         });
       });
@@ -1578,16 +1584,17 @@ describe('Encounter', () => {
           const [oldDepartment, newDepartment] = await models.Department.findAll({ limit: 2 });
           const [oldClinician, newClinician] = await models.User.findAll({ limit: 2 });
 
-          const encounter = await models.Encounter.create(
-            {
-              ...(await createDummyEncounter(models)),
-              patientId: patient.id,
-              examinerId: oldClinician.id,
-              locationId: oldLocation.id,
-              departmentId: oldDepartment.id,
-            },
-            user,
-          );
+          const result = await app.post('/v1/encounter').send({
+            ...(await createDummyEncounter(models)),
+            patientId: patient.id,
+            examinerId: oldClinician.id,
+            locationId: oldLocation.id,
+            departmentId: oldDepartment.id,
+          });
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.id).toBeTruthy();
+          const encounter = await models.Encounter.findByPk(result.body.id);
 
           const locationChangeSubmittedTime = getCurrentDateTimeString();
           await app.put(`/v1/encounter/${encounter.id}`).send({
@@ -1639,7 +1646,7 @@ describe('Encounter', () => {
             locationId: encounter.locationId,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
           expect(encounterHistoryRecords[1]).toMatchObject({
             date: locationChangeSubmittedTime,
@@ -1648,7 +1655,7 @@ describe('Encounter', () => {
             locationId: newLocation.id,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
             changeType: EncounterChangeType.Location,
           });
           expect(encounterHistoryRecords[2]).toMatchObject({
@@ -1658,7 +1665,7 @@ describe('Encounter', () => {
             locationId: newLocation.id,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
             changeType: EncounterChangeType.Department,
           });
 
@@ -1682,7 +1689,7 @@ describe('Encounter', () => {
             locationId: encounter.locationId,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
           });
           expect(encounterHistoryRecords[1]).toMatchObject({
             date: locationChangeSubmittedTime,
@@ -1691,7 +1698,7 @@ describe('Encounter', () => {
             locationId: newLocation.id,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
             changeType: EncounterChangeType.Location,
           });
           expect(encounterHistoryRecords[2]).toMatchObject({
@@ -1701,7 +1708,7 @@ describe('Encounter', () => {
             locationId: newLocation.id,
             examinerId: encounter.examinerId,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
             changeType: EncounterChangeType.Department,
           });
           expect(encounterHistoryRecords[3]).toMatchObject({
@@ -1711,7 +1718,7 @@ describe('Encounter', () => {
             locationId: newLocation.id,
             examinerId: newClinician.id,
             encounterType: encounter.encounterType,
-            modifierId: user.id,
+            actorId: user.id,
             changeType: EncounterChangeType.Examiner,
           });
         });

--- a/packages/lan/__tests__/apiv1/reports/Admissions.test.js
+++ b/packages/lan/__tests__/apiv1/reports/Admissions.test.js
@@ -173,6 +173,9 @@ describe('Admissions report', () => {
 
       await expectedEncounter.update({
         departmentId: expectedDepartment2.id,
+      });
+
+      await expectedEncounter.update({
         locationId: newLocation.id,
       });
 

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -35,7 +35,7 @@ encounter.post(
   asyncHandler(async (req, res) => {
     const { models, body, user } = req;
     req.checkPermission('create', 'Encounter');
-    const object = await models.Encounter.create(body, user);
+    const object = await models.Encounter.create({ ...body, actorId: user.id });
     res.send(object);
   }),
 );

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -31,7 +31,15 @@ import { getLabRequestList } from '../../routeHandlers/labs';
 export const encounter = express.Router();
 
 encounter.get('/:id', simpleGet('Encounter'));
-encounter.post('/$', simplePost('Encounter'));
+encounter.post(
+  '/$',
+  asyncHandler(async (req, res) => {
+    const { models, body, user } = req;
+    req.checkPermission('create', 'Encounter');
+    const object = await models.Encounter.create(body, user);
+    res.send(object);
+  }),
+);
 
 encounter.put(
   '/:id',

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -16,7 +16,6 @@ import {
 import {
   simpleGet,
   simpleGetHasOne,
-  simplePost,
   simpleGetList,
   permissionCheckingRouter,
   runPaginatedQuery,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -212,8 +212,8 @@ patientVaccineRoutes.post(
             locationId,
             departmentId,
             reasonForEncounter: await getVaccinationDescription(req.models, vaccineData),
+            actorId: user.id,
           },
-          user,
         );
         await newEncounter.update({
           endDate: vaccineData.date || currentDate,

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -151,7 +151,7 @@ async function getVaccinationDescription(models, vaccineData) {
 patientVaccineRoutes.post(
   '/:id/administeredVaccine',
   asyncHandler(async (req, res) => {
-    const { db } = req;
+    const { db, user } = req;
     req.checkPermission('create', 'PatientVaccine');
 
     // Require scheduledVaccineId if vaccine category is not OTHER
@@ -203,15 +203,18 @@ patientVaccineRoutes.post(
       if (existingEncounter) {
         encounterId = existingEncounter.get('id');
       } else {
-        const newEncounter = await req.models.Encounter.create({
-          encounterType: ENCOUNTER_TYPES.VACCINATION,
-          startDate: vaccineData.date || currentDate,
-          patientId,
-          examinerId: vaccineData.recorderId,
-          locationId,
-          departmentId,
-          reasonForEncounter: await getVaccinationDescription(req.models, vaccineData),
-        });
+        const newEncounter = await req.models.Encounter.create(
+          {
+            encounterType: ENCOUNTER_TYPES.VACCINATION,
+            startDate: vaccineData.date || currentDate,
+            patientId,
+            examinerId: vaccineData.recorderId,
+            locationId,
+            departmentId,
+            reasonForEncounter: await getVaccinationDescription(req.models, vaccineData),
+          },
+          user,
+        );
         await newEncounter.update({
           endDate: vaccineData.date || currentDate,
           systemNote: 'Automatically discharged',

--- a/packages/lan/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/lan/app/routes/apiv1/patient/patientVaccine.js
@@ -203,18 +203,16 @@ patientVaccineRoutes.post(
       if (existingEncounter) {
         encounterId = existingEncounter.get('id');
       } else {
-        const newEncounter = await req.models.Encounter.create(
-          {
-            encounterType: ENCOUNTER_TYPES.VACCINATION,
-            startDate: vaccineData.date || currentDate,
-            patientId,
-            examinerId: vaccineData.recorderId,
-            locationId,
-            departmentId,
-            reasonForEncounter: await getVaccinationDescription(req.models, vaccineData),
-            actorId: user.id,
-          },
-        );
+        const newEncounter = await req.models.Encounter.create({
+          encounterType: ENCOUNTER_TYPES.VACCINATION,
+          startDate: vaccineData.date || currentDate,
+          patientId,
+          examinerId: vaccineData.recorderId,
+          locationId,
+          departmentId,
+          reasonForEncounter: await getVaccinationDescription(req.models, vaccineData),
+          actorId: user.id,
+        });
         await newEncounter.update({
           endDate: vaccineData.date || currentDate,
           systemNote: 'Automatically discharged',

--- a/packages/lan/app/routes/apiv1/triage.js
+++ b/packages/lan/app/routes/apiv1/triage.js
@@ -18,7 +18,7 @@ triage.put('/:id', simplePut('Triage'));
 triage.post(
   '/$',
   asyncHandler(async (req, res) => {
-    const { models, db } = req;
+    const { models, db, user } = req;
     const { vitals, notes } = req.body;
 
     req.checkPermission('create', 'Triage');
@@ -26,7 +26,7 @@ triage.post(
       req.checkPermission('create', 'Vitals');
     }
 
-    const triageRecord = await models.Triage.create(req.body);
+    const triageRecord = await models.Triage.create({ ...req.body, actorId: user.id });
 
     if (vitals) {
       const getDefaultId = async type => models.SurveyResponseAnswer.getDefaultId(type);

--- a/packages/mobile/App/migrations/1693484817000-addEncounterHistoryTable.ts
+++ b/packages/mobile/App/migrations/1693484817000-addEncounterHistoryTable.ts
@@ -1,0 +1,115 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey } from 'typeorm';
+
+const TABLE_NAME = 'encounter_history';
+const ISO9075_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+const ISO9075_FORMAT_LENGTH = ISO9075_FORMAT.length;
+
+const BaseColumns = [
+  new TableColumn({
+    name: 'id',
+    type: 'varchar',
+    isPrimary: true,
+  }),
+  new TableColumn({
+    name: 'createdAt',
+    type: 'datetime',
+    default: "datetime('now')",
+  }),
+  new TableColumn({
+    name: 'updatedAt',
+    type: 'datetime',
+    default: "datetime('now')",
+  }),
+  new TableColumn({
+    name: 'updatedAtSyncTick',
+    type: 'bigint',
+    isNullable: false,
+    default: -999,
+  }),
+];
+
+const EncounterHistory = new Table({
+  name: TABLE_NAME,
+  columns: [
+    ...BaseColumns,
+    new TableColumn({
+      name: 'date',
+      type: 'varchar',
+      length: `${ISO9075_FORMAT_LENGTH}`,
+      isNullable: false,
+      default: "date('now')",
+    }),
+    new TableColumn({
+      name: 'encounterId',
+      type: 'varchar',
+      isNullable: false,
+    }),
+    new TableColumn({
+      name: 'examinerId',
+      type: 'varchar',
+      isNullable: false,
+    }),
+    new TableColumn({
+      name: 'departmentId',
+      type: 'varchar',
+      isNullable: false,
+    }),
+    new TableColumn({
+      name: 'actorId',
+      type: 'varchar',
+      isNullable: true,
+    }),
+    new TableColumn({
+      name: 'locationId',
+      type: 'varchar',
+      isNullable: false,
+    }),
+    new TableColumn({
+      name: 'encounterType',
+      type: 'varchar',
+      isNullable: false,
+    }),
+    new TableColumn({
+      name: 'changeType',
+      type: 'varchar',
+      isNullable: true,
+    }),
+  ],
+  foreignKeys: [
+    new TableForeignKey({
+      columnNames: ['encounterId'],
+      referencedTableName: 'encounter',
+      referencedColumnNames: ['id'],
+    }),
+    new TableForeignKey({
+      columnNames: ['actorId'],
+      referencedTableName: 'user',
+      referencedColumnNames: ['id'],
+    }),
+    new TableForeignKey({
+      columnNames: ['examinerId'],
+      referencedTableName: 'user',
+      referencedColumnNames: ['id'],
+    }),
+    new TableForeignKey({
+      columnNames: ['departmentId'],
+      referencedTableName: 'department',
+      referencedColumnNames: ['id'],
+    }),
+    new TableForeignKey({
+      columnNames: ['locationId'],
+      referencedTableName: 'location',
+      referencedColumnNames: ['id'],
+    }),
+  ],
+});
+
+export class addEncounterHistoryTable1693484817000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(EncounterHistory, true);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable(TABLE_NAME, true);
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -26,6 +26,7 @@ import { addDisplayIdToUsers1688428478000 } from './1688428478000-addDisplayIdTo
 import { addSpecimenTypeAndCollectedByToLabRequest1686083400000 } from './1686083400000-addSpecimenTypeAndCollectedByToLabRequest';
 import { addVitalLogs1690236942000 } from './1690236942000-addVitalLogs';
 import { migrateNotePagesToNotes1688950151000 } from './1688950151000-migrateNotePagesToNotes';
+import { addEncounterHistoryTable1693484817000 } from './1693484817000-addEncounterHistoryTable';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -55,4 +56,5 @@ export const migrationList = [
   addSpecimenTypeAndCollectedByToLabRequest1686083400000,
   addVitalLogs1690236942000,
   migrateNotePagesToNotes1688950151000,
+  addEncounterHistoryTable1693484817000,
 ];

--- a/packages/mobile/App/models/EncounterHistory.ts
+++ b/packages/mobile/App/models/EncounterHistory.ts
@@ -1,0 +1,79 @@
+import { Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
+import { BaseModel } from './BaseModel';
+import { EncounterType } from '~/types';
+import { Encounter } from './Encounter';
+import { User } from './User';
+import { Department } from './Department';
+import { Location } from './Location';
+import { SYNC_DIRECTIONS } from './types';
+import { DateTimeStringColumn } from './DateColumns';
+import { getCurrentDateTimeString } from '~/ui/helpers/date';
+
+export enum EncounterChangeType {
+  EncounterType = 'encounter_type',
+  Location = 'location',
+  Department = 'department',
+  Examiner = 'examiner',
+}
+
+@Entity('encounter_history')
+export class EncounterHistory extends BaseModel {
+  static syncDirection = SYNC_DIRECTIONS.BIDIRECTIONAL;
+
+  @DateTimeStringColumn({ nullable: false })
+  date?: string;
+
+  @ManyToOne(
+    () => Encounter,
+    encounter => encounter.encounterHistory,
+  )
+  encounter: Encounter;
+  @RelationId(({ encounter }) => encounter)
+  encounterId: string;
+
+  @ManyToOne(() => Location)
+  location: Location;
+
+  @RelationId(({ location }) => location)
+  locationId: string;
+
+  @ManyToOne(() => Department)
+  department: Department;
+
+  @RelationId(({ department }) => department)
+  departmentId: string;
+
+  @ManyToOne(() => User)
+  examiner: User;
+
+  @RelationId(({ examiner }) => examiner)
+  examinerId: string;
+
+  @ManyToOne(() => User)
+  actor: User;
+
+  @RelationId(({ actor }) => actor)
+  actorId: string;
+
+  @Column({ type: 'varchar', nullable: false })
+  encounterType: EncounterType;
+
+  @Column({ type: 'varchar' })
+  changeType: EncounterChangeType;
+
+  static async createSnapshot(encounter) {
+    return EncounterHistory.createAndSaveOne({
+      encounter: encounter.id,
+      encounterType: encounter.encounterType,
+      location: encounter.location,
+      department: encounter.department,
+      examiner: encounter.examiner,
+      actor: encounter.examiner,
+      date: getCurrentDateTimeString(),
+    });
+  }
+
+  static getTableNameForSync(): string {
+    return 'encounter_history';
+  }
+}

--- a/packages/mobile/App/models/modelsMap.ts
+++ b/packages/mobile/App/models/modelsMap.ts
@@ -5,6 +5,7 @@ import { PatientIssue } from './PatientIssue';
 import { PatientSecondaryId } from './PatientSecondaryId';
 import { User } from './User';
 import { Encounter } from './Encounter';
+import { EncounterHistory } from './EncounterHistory';
 import { Program } from './Program';
 import { ProgramDataElement } from './ProgramDataElement';
 import { Survey } from './Survey';
@@ -44,6 +45,7 @@ export const MODELS_MAP = {
   PatientSecondaryId,
   User,
   Encounter,
+  EncounterHistory,
   Program,
   ProgramDataElement,
   Survey,

--- a/packages/shared/src/migrations/1693040825684-addExtraEncounterHistoryColumns.js
+++ b/packages/shared/src/migrations/1693040825684-addExtraEncounterHistoryColumns.js
@@ -1,0 +1,22 @@
+import Sequelize from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('encounter_history', 'modifier_id', {
+    type: Sequelize.STRING,
+    references: {
+      model: 'users',
+      key: 'id',
+    },
+    allowNull: true,
+  });
+
+  await query.addColumn('encounter_history', 'change_type', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.dropColumn('encounter_history', 'modifier_id');
+  await query.dropColumn('encounter_history', 'change_type');
+}

--- a/packages/shared/src/migrations/1693040825684-addExtraEncounterHistoryColumns.js
+++ b/packages/shared/src/migrations/1693040825684-addExtraEncounterHistoryColumns.js
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 
 export async function up(query) {
-  await query.addColumn('encounter_history', 'modifier_id', {
+  await query.addColumn('encounter_history', 'actor_id', {
     type: Sequelize.STRING,
     references: {
       model: 'users',
@@ -17,6 +17,6 @@ export async function up(query) {
 }
 
 export async function down(query) {
-  await query.removeColumn('encounter_history', 'modifier_id');
+  await query.removeColumn('encounter_history', 'actor_id');
   await query.removeColumn('encounter_history', 'change_type');
 }

--- a/packages/shared/src/migrations/1693040825684-addExtraEncounterHistoryColumns.js
+++ b/packages/shared/src/migrations/1693040825684-addExtraEncounterHistoryColumns.js
@@ -17,6 +17,6 @@ export async function up(query) {
 }
 
 export async function down(query) {
-  await query.dropColumn('encounter_history', 'modifier_id');
-  await query.dropColumn('encounter_history', 'change_type');
+  await query.removeColumn('encounter_history', 'modifier_id');
+  await query.removeColumn('encounter_history', 'change_type');
 }

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -314,11 +314,13 @@ export class Encounter extends Model {
     await dischargeOutpatientEncounters(this.sequelize.models, recordIds);
   }
 
-  static async create(encounterData, user) {
+  static async create(data, ...args) {
+    const { actorId, ...encounterData } = data;
+    const encounter = await super.create(encounterData, ...args);
+
     const { EncounterHistory } = this.sequelize.models;
-    const encounter = await super.create(encounterData);
     await EncounterHistory.createSnapshot(encounter, {
-      modifierId: user?.id,
+      actorId,
       submittedTime: getCurrentDateTimeString(),
     });
 
@@ -515,7 +517,7 @@ export class Encounter extends Model {
         isClinicianChanged
       ) {
         await EncounterHistory.createSnapshot(updatedEncounter, {
-          modifierId: user?.id,
+          actorId: user?.id,
           changeType,
           submittedTime: data.submittedTime,
         });

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -320,7 +320,7 @@ export class Encounter extends Model {
 
     const { EncounterHistory } = this.sequelize.models;
     await EncounterHistory.createSnapshot(encounter, {
-      actorId,
+      actorId: actorId || encounter.examinerId,
       submittedTime: getCurrentDateTimeString(),
     });
 
@@ -510,6 +510,7 @@ export class Encounter extends Model {
       const { submittedTime, ...encounterData } = data;
       const updatedEncounter = await super.update({ ...encounterData, ...additionalChanges }, user);
 
+      // multiple changes in 1 update transaction is not supported at the moment
       if (
         isEncounterTypeChanged ||
         isDepartmentChanged ||

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -510,13 +510,22 @@ export class Encounter extends Model {
       const { submittedTime, ...encounterData } = data;
       const updatedEncounter = await super.update({ ...encounterData, ...additionalChanges }, user);
 
+      const snapshotTableChanges = [
+        isEncounterTypeChanged,
+        isDepartmentChanged,
+        isLocationChanged,
+        isClinicianChanged,
+      ].filter(Boolean);
+
+      if (snapshotTableChanges.length > 1) {
+        // Will revert all the changes above if error is thrown as this is in a transaction
+        throw new InvalidOperationError(
+          'Encounter type, department, location and clinician must be changed in separate operations',
+        );
+      }
+
       // multiple changes in 1 update transaction is not supported at the moment
-      if (
-        isEncounterTypeChanged ||
-        isDepartmentChanged ||
-        isLocationChanged ||
-        isClinicianChanged
-      ) {
+      if (snapshotTableChanges.length === 1) {
         await EncounterHistory.createSnapshot(updatedEncounter, {
           actorId: user?.id,
           changeType,

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -510,14 +510,14 @@ export class Encounter extends Model {
       const { submittedTime, ...encounterData } = data;
       const updatedEncounter = await super.update({ ...encounterData, ...additionalChanges }, user);
 
-      const snapshotTableChanges = [
+      const snapshotChanges = [
         isEncounterTypeChanged,
         isDepartmentChanged,
         isLocationChanged,
         isClinicianChanged,
       ].filter(Boolean);
 
-      if (snapshotTableChanges.length > 1) {
+      if (snapshotChanges.length > 1) {
         // Will revert all the changes above if error is thrown as this is in a transaction
         throw new InvalidOperationError(
           'Encounter type, department, location and clinician must be changed in separate operations',
@@ -525,7 +525,7 @@ export class Encounter extends Model {
       }
 
       // multiple changes in 1 update transaction is not supported at the moment
-      if (snapshotTableChanges.length === 1) {
+      if (snapshotChanges.length === 1) {
         await EncounterHistory.createSnapshot(updatedEncounter, {
           actorId: user?.id,
           changeType,

--- a/packages/shared/src/models/EncounterHistory.js
+++ b/packages/shared/src/models/EncounterHistory.js
@@ -15,6 +15,9 @@ export class EncounterHistory extends Model {
           type: Sequelize.STRING,
           allowNull: false,
         },
+        changeType: {
+          type: Sequelize.STRING,
+        },
         date: dateTimeType('date', {
           allowNull: false,
           defaultValue: getCurrentDateTimeString,
@@ -48,15 +51,22 @@ export class EncounterHistory extends Model {
       foreignKey: 'departmentId',
       as: 'department',
     });
+
+    this.belongsTo(models.User, {
+      foreignKey: 'modifierId',
+      as: 'modifier',
+    });
   }
 
-  static async createSnapshot(encounter, submittedTime) {
+  static async createSnapshot(encounter, { modifierId, changeType, submittedTime }) {
     return EncounterHistory.create({
       encounterId: encounter.id,
       encounterType: encounter.encounterType,
       locationId: encounter.locationId,
       departmentId: encounter.departmentId,
       examinerId: encounter.examinerId,
+      modifierId,
+      changeType,
       date: submittedTime || getCurrentDateTimeString(),
     });
   }

--- a/packages/shared/src/models/EncounterHistory.js
+++ b/packages/shared/src/models/EncounterHistory.js
@@ -53,19 +53,19 @@ export class EncounterHistory extends Model {
     });
 
     this.belongsTo(models.User, {
-      foreignKey: 'modifierId',
-      as: 'modifier',
+      foreignKey: 'actorId',
+      as: 'actor',
     });
   }
 
-  static async createSnapshot(encounter, { modifierId, changeType, submittedTime }) {
+  static async createSnapshot(encounter, { actorId, changeType, submittedTime }) {
     return EncounterHistory.create({
       encounterId: encounter.id,
       encounterType: encounter.encounterType,
       locationId: encounter.locationId,
       departmentId: encounter.departmentId,
       examinerId: encounter.examinerId,
-      modifierId,
+      actorId,
       changeType,
       date: submittedTime || getCurrentDateTimeString(),
     });

--- a/packages/shared/src/models/SurveyResponse.js
+++ b/packages/shared/src/models/SurveyResponse.js
@@ -166,6 +166,7 @@ export class SurveyResponse extends Model {
       // Survey responses will usually have a startTime and endTime and we prefer to use that
       // for the encounter to ensure the times are set in the browser timezone
       startDate: responseData.startTime ? responseData.startTime : getCurrentDateTimeString(),
+      actorId: userId,
     });
 
     return newEncounter.update({

--- a/packages/shared/src/models/Triage.js
+++ b/packages/shared/src/models/Triage.js
@@ -111,6 +111,7 @@ export class Triage extends Model {
         departmentId,
         locationId: data.locationId,
         examinerId: data.practitionerId,
+        actorId: data.actorId,
       });
 
       return super.create({

--- a/packages/sync-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
+++ b/packages/sync-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
@@ -276,7 +276,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -286,7 +286,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -328,7 +328,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -338,7 +338,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -380,7 +380,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: oldClinician.id,
         encounterType: 'admission',
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -390,7 +390,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: newClinician.id,
         encounterType: 'admission',
         changeType: EncounterChangeType.Examiner,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -431,7 +431,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -441,7 +441,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'clinic',
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -484,7 +484,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -494,7 +494,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'clinic',
         changeType: EncounterChangeType.EncounterType,
-        modifierId: modifier.id,
+        actorId: modifier.id,
       });
     });
   });
@@ -583,7 +583,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // Location change history
@@ -594,7 +594,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Department change history
@@ -605,7 +605,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Clinician change history
@@ -616,7 +616,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: newUser.id,
         encounterType: oldEncounterType,
         changeType: EncounterChangeType.Examiner,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Encounter type change history
@@ -627,7 +627,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: newUser.id,
         encounterType: newEncounterType,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -699,7 +699,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // Location change history 1
@@ -710,7 +710,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Location change history 2
@@ -721,7 +721,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Location change history 3
@@ -732,7 +732,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -803,7 +803,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // Department change history 1
@@ -814,7 +814,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Department change history 2
@@ -825,7 +825,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Department change history 3
@@ -836,7 +836,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -907,7 +907,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // Clinician change history 1
@@ -918,7 +918,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician2.id,
         encounterType,
         changeType: EncounterChangeType.Examiner,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Clinician change history 2
@@ -929,7 +929,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician3.id,
         encounterType,
         changeType: EncounterChangeType.Examiner,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Clinician change history 3
@@ -940,7 +940,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician4.id,
         encounterType,
         changeType: EncounterChangeType.Examiner,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -1011,7 +1011,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType1,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // Encounter type change history 1
@@ -1022,7 +1022,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType2,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Encounter type change history 2
@@ -1033,7 +1033,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       // Encounter type change history 3
@@ -1044,7 +1044,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType4,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -1170,7 +1170,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType1,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -1180,7 +1180,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType1,
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[2]).toMatchObject({
@@ -1190,7 +1190,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType2,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[3]).toMatchObject({
@@ -1200,7 +1200,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[4]).toMatchObject({
@@ -1210,7 +1210,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.Location,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[5]).toMatchObject({
@@ -1220,7 +1220,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[6]).toMatchObject({
@@ -1230,7 +1230,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.Department,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[7]).toMatchObject({
@@ -1240,7 +1240,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician2.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.Examiner,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[8]).toMatchObject({
@@ -1250,7 +1250,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician2.id,
         encounterType: encounterType4,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: defaultUser.id,
+        actorId: defaultUser.id,
       });
     });
 
@@ -1327,7 +1327,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType1,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // Encounter type change history 1
@@ -1338,7 +1338,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType2,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: modifier1.id,
+        actorId: modifier1.id,
       });
 
       // Encounter type change history 2
@@ -1349,7 +1349,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType3,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: modifier2.id,
+        actorId: modifier2.id,
       });
 
       // Encounter type change history 3
@@ -1360,7 +1360,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: encounterType4,
         changeType: EncounterChangeType.EncounterType,
-        modifierId: modifier1.id,
+        actorId: modifier1.id,
       });
     });
   });
@@ -1438,7 +1438,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated location from 1 to 2
@@ -1449,7 +1449,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated location from 2 to 4
@@ -1460,7 +1460,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -1553,7 +1553,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated location from 1 to 3
@@ -1565,7 +1565,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated location from 3 to 5
@@ -1577,7 +1577,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated location from 5 to 6
@@ -1588,7 +1588,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -1659,7 +1659,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated location from 1 to 2
@@ -1670,7 +1670,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated location from 2 to 4
@@ -1681,7 +1681,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -1752,7 +1752,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated location from 1 to 3
@@ -1763,7 +1763,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated location from 3 to 4
@@ -1774,7 +1774,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -1847,7 +1847,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated location from 1 to 3
@@ -1858,7 +1858,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated location from 3 to 4
@@ -1869,7 +1869,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -1941,7 +1941,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Should skip location2 as location name has been changed
@@ -1952,7 +1952,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2016,7 +2016,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         expect(encounterHistoryRecords[1]).toMatchObject({
@@ -2026,7 +2026,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         expect(encounterHistoryRecords[2]).toMatchObject({
@@ -2036,7 +2036,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
     });
@@ -2110,7 +2110,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated department 1 to department 2
@@ -2121,7 +2121,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated department 2 to department 4
@@ -2132,7 +2132,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2205,7 +2205,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated department 1 to department 2
@@ -2216,7 +2216,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated department 1 to department 4
@@ -2227,7 +2227,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2300,7 +2300,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated deparment 1 to department 3
@@ -2311,7 +2311,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated deparment 3 to department 4
@@ -2322,7 +2322,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2397,7 +2397,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Updated deparment 1 to department 3
@@ -2408,7 +2408,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Updated deparment 3 to department 4
@@ -2419,7 +2419,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2492,7 +2492,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Department 2 should be skipped as department name has been changed
@@ -2503,7 +2503,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Department,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2573,7 +2573,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         expect(encounterHistoryRecords[1]).toMatchObject({
@@ -2583,7 +2583,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         expect(encounterHistoryRecords[2]).toMatchObject({
@@ -2593,7 +2593,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
     });
@@ -2659,7 +2659,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician1.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // 2nd encounter
@@ -2670,7 +2670,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician3.id,
           encounterType,
           changeType: EncounterChangeType.Examiner,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         // Latest encounter
@@ -2681,7 +2681,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician4.id,
           encounterType,
           changeType: EncounterChangeType.Examiner,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2747,7 +2747,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician1.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         // Should skip clinician 2 as the name has been updated
@@ -2758,7 +2758,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician3.id,
           encounterType,
           changeType: EncounterChangeType.Examiner,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
 
@@ -2826,7 +2826,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician1.id,
           encounterType,
           changeType: null,
-          modifierId: null,
+          actorId: null,
         });
 
         expect(encounterHistoryRecords[1]).toMatchObject({
@@ -2836,7 +2836,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician1.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
 
         expect(encounterHistoryRecords[2]).toMatchObject({
@@ -2846,7 +2846,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           examinerId: clinician1.id,
           encounterType,
           changeType: EncounterChangeType.Location,
-          modifierId: defaultUser.id,
+          actorId: defaultUser.id,
         });
       });
     });
@@ -2893,7 +2893,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
     });
 
@@ -2956,7 +2956,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // 2nd encounter
@@ -2967,7 +2967,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician2.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // 3rd encounter
@@ -2978,7 +2978,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician3.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
     });
 
@@ -3044,7 +3044,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // 2nd encounter
@@ -3055,7 +3055,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician2.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
 
       // 3rd encounter
@@ -3066,7 +3066,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician3.id,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
     });
 
@@ -3117,7 +3117,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         date: encounter.startDate,
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
     });
 
@@ -3168,7 +3168,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         date: getDateSubtractedFromToday(5), // changelog date is 4 days ago, so 5 should be expected
         encounterType,
         changeType: null,
-        modifierId: null,
+        actorId: null,
       });
     });
   });

--- a/packages/sync-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
+++ b/packages/sync-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
@@ -2046,10 +2046,10 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationGroupId: locationGroup1.id,
         });
         const location2 = await createLocation('location same name', {
-          locationGroupId: null,
+          locationGroupId: null, // no location group so generated changelog will not contain it
         });
         const location3 = await createLocation('location same name', {
-          locationGroupId: null,
+          locationGroupId: null, // no location group so generated changelog will not contain it
         });
         const location4 = await createLocation('location 4', {
           locationGroupId: locationGroup2.id,
@@ -2116,18 +2116,18 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           actorId: null,
         });
 
-        // Updated location from 1 to 2
+        // Updated location from 1 to 3
         expect(encounterHistoryRecords[1]).toMatchObject({
           encounterId: encounter.id,
           departmentId: department.id,
-          locationId: location3.id,
+          locationId: location3.id, // location 3 is picked as it was updated later
           examinerId: clinician.id,
           encounterType,
           changeType: EncounterChangeType.Location,
           actorId: defaultUser.id,
         });
 
-        // Updated location from 2 to 4
+        // Updated location from 3 to 4
         expect(encounterHistoryRecords[2]).toMatchObject({
           encounterId: encounter.id,
           departmentId: department.id,

--- a/packages/sync-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
+++ b/packages/sync-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
@@ -1,15 +1,23 @@
 import { sub, startOfDay } from 'date-fns';
+import { Op } from 'sequelize';
 
 import { toDateTimeString, getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { createDummyEncounter, createDummyPatient } from '@tamanu/shared/demoData/patients';
 import { fake } from '@tamanu/shared/test-helpers/fake';
-import { NOTE_RECORD_TYPES, NOTE_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
+import {
+  NOTE_RECORD_TYPES,
+  NOTE_TYPES,
+  VISIBILITY_STATUSES,
+  EncounterChangeType,
+} from '@tamanu/constants';
 import { sleepAsync } from '@tamanu/shared/utils';
 
 import { createTestContext } from '../utilities';
 import { migrateChangelogNotesToEncounterHistory } from '../../app/subCommands';
 
-const addSystemNote = async (models, recordId, content, date) => {
+const DEFAULT_USER_ID = 'DEFAULT_USER_ID';
+
+const addSystemNote = async (models, recordId, content, date, user) => {
   const notePage = await models.LegacyNotePage.create({
     recordId,
     recordType: NOTE_RECORD_TYPES.ENCOUNTER,
@@ -21,6 +29,7 @@ const addSystemNote = async (models, recordId, content, date) => {
     notePageId: notePage.id,
     date,
     content,
+    authorId: user?.id || DEFAULT_USER_ID,
   });
 };
 
@@ -30,6 +39,7 @@ const addLocationChangeNote = async (
   oldLocationId,
   newLocationId,
   submittedTime,
+  user,
 ) => {
   const { Location } = models;
   const oldLocation = await Location.findOne({
@@ -48,6 +58,7 @@ const addLocationChangeNote = async (
       oldLocation,
     )} to ${Location.formatFullLocationName(newLocation)}`,
     submittedTime,
+    user,
   );
 };
 
@@ -57,6 +68,7 @@ const addDepartmentChangeNote = async (
   fromDepartmentId,
   toDepartmentId,
   submittedTime,
+  user,
 ) => {
   const { Department } = models;
   const oldDepartment = await Department.findOne({ where: { id: fromDepartmentId } });
@@ -66,10 +78,18 @@ const addDepartmentChangeNote = async (
     recordId,
     `Changed department from ${oldDepartment.name} to ${newDepartment.name}`,
     submittedTime,
+    user,
   );
 };
 
-const updateClinician = async (models, recordId, oldClinicianId, newClinicianId, submittedTime) => {
+const updateClinician = async (
+  models,
+  recordId,
+  oldClinicianId,
+  newClinicianId,
+  submittedTime,
+  user,
+) => {
   const { User } = models;
   const oldClinician = await User.findOne({ where: { id: oldClinicianId } });
   const newClinician = await User.findOne({ where: { id: newClinicianId } });
@@ -78,6 +98,7 @@ const updateClinician = async (models, recordId, oldClinicianId, newClinicianId,
     recordId,
     `Changed supervising clinician from ${oldClinician.displayName} to ${newClinician.displayName}`,
     submittedTime,
+    user,
   );
 };
 
@@ -106,6 +127,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
   let facility2;
   let locationGroup1;
   let locationGroup2;
+  let defaultUser;
 
   const SUB_COMMAND_OPTIONS = {
     batchSize: 1,
@@ -170,15 +192,21 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
     });
     await models.LegacyNoteItem.truncate({ cascade: true, force: true });
     await models.LegacyNotePage.truncate({ cascade: true, force: true });
-    await models.User.truncate({
+    await models.User.destroy({
       cascade: true,
       force: true,
+      where: {
+        id: {
+          [Op.not]: DEFAULT_USER_ID,
+        },
+      },
     });
   };
 
   beforeAll(async () => {
     ctx = await createTestContext();
     models = ctx.store.models;
+    defaultUser = await createUser('default user', { id: DEFAULT_USER_ID });
 
     patient = await models.Patient.create(await createDummyPatient(models));
     facility1 = await models.Facility.create({
@@ -247,6 +275,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: oldLocation.id,
         examinerId: clinician.id,
         encounterType: 'admission',
+        changeType: null,
+        modifierId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -255,6 +285,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: newLocation.id,
         examinerId: clinician.id,
         encounterType: 'admission',
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -295,6 +327,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: 'admission',
+        changeType: null,
+        modifierId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -303,6 +337,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: 'admission',
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -343,6 +379,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: oldClinician.id,
         encounterType: 'admission',
+        changeType: null,
+        modifierId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -351,6 +389,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: newClinician.id,
         encounterType: 'admission',
+        changeType: EncounterChangeType.Examiner,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -390,6 +430,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: 'admission',
+        changeType: null,
+        modifierId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -398,6 +440,61 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: 'clinic',
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
+      });
+    });
+
+    it('migrates changelog with modifier change', async () => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+      const location = await createLocation('location');
+      const department = await createDepartment('department');
+      const clinician = await createUser('testUser');
+      const modifier = await createUser('modifier');
+      const encounter = await createEncounter(patient, {
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: 'admission',
+        startDate: getDateSubtractedFromNow(6),
+      });
+      await onEncounterProgression(
+        models,
+        encounter.id,
+        'admission',
+        'clinic',
+        getCurrentDateTimeString(),
+        modifier,
+      );
+      encounter.encounterType = 'clinic';
+      await encounter.save();
+
+      await migrateChangelogNotesToEncounterHistory(SUB_COMMAND_OPTIONS);
+
+      expect(exitSpy).toBeCalledWith(0);
+
+      const encounterHistoryRecords = await models.EncounterHistory.findAll({
+        order: [['date', 'ASC']],
+      });
+
+      expect(encounterHistoryRecords[0]).toMatchObject({
+        encounterId: encounter.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: 'admission',
+        changeType: null,
+        modifierId: null,
+      });
+
+      expect(encounterHistoryRecords[1]).toMatchObject({
+        encounterId: encounter.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: 'clinic',
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: modifier.id,
       });
     });
   });
@@ -485,6 +582,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: oldLocation.id,
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // Location change history
@@ -494,6 +593,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: newLocation.id,
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
 
       // Department change history
@@ -503,6 +604,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: newLocation.id,
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
 
       // Clinician change history
@@ -512,6 +615,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: newLocation.id,
         examinerId: newUser.id,
         encounterType: oldEncounterType,
+        changeType: EncounterChangeType.Examiner,
+        modifierId: defaultUser.id,
       });
 
       // Encounter type change history
@@ -521,6 +626,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: newLocation.id,
         examinerId: newUser.id,
         encounterType: newEncounterType,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -591,6 +698,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location1.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // Location change history 1
@@ -600,6 +709,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location2.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
 
       // Location change history 2
@@ -609,6 +720,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
 
       // Location change history 3
@@ -618,6 +731,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location4.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -687,6 +802,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // Department change history 1
@@ -696,6 +813,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
 
       // Department change history 2
@@ -705,6 +824,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
 
       // Department change history 3
@@ -714,6 +835,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -783,6 +906,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician1.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // Clinician change history 1
@@ -792,6 +917,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician2.id,
         encounterType,
+        changeType: EncounterChangeType.Examiner,
+        modifierId: defaultUser.id,
       });
 
       // Clinician change history 2
@@ -801,6 +928,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician3.id,
         encounterType,
+        changeType: EncounterChangeType.Examiner,
+        modifierId: defaultUser.id,
       });
 
       // Clinician change history 3
@@ -810,6 +939,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician4.id,
         encounterType,
+        changeType: EncounterChangeType.Examiner,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -879,6 +1010,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: encounterType1,
+        changeType: null,
+        modifierId: null,
       });
 
       // Encounter type change history 1
@@ -888,6 +1021,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: encounterType2,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
       });
 
       // Encounter type change history 2
@@ -897,6 +1032,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: encounterType3,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
       });
 
       // Encounter type change history 3
@@ -906,6 +1043,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType: encounterType4,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
       });
     });
 
@@ -1030,6 +1169,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location1.id,
         examinerId: clinician1.id,
         encounterType: encounterType1,
+        changeType: null,
+        modifierId: null,
       });
 
       expect(encounterHistoryRecords[1]).toMatchObject({
@@ -1038,6 +1179,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location2.id,
         examinerId: clinician1.id,
         encounterType: encounterType1,
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[2]).toMatchObject({
@@ -1046,6 +1189,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location2.id,
         examinerId: clinician1.id,
         encounterType: encounterType2,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[3]).toMatchObject({
@@ -1054,6 +1199,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location2.id,
         examinerId: clinician1.id,
         encounterType: encounterType3,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[4]).toMatchObject({
@@ -1062,6 +1209,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician1.id,
         encounterType: encounterType3,
+        changeType: EncounterChangeType.Location,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[5]).toMatchObject({
@@ -1070,6 +1219,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician1.id,
         encounterType: encounterType3,
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[6]).toMatchObject({
@@ -1078,6 +1229,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician1.id,
         encounterType: encounterType3,
+        changeType: EncounterChangeType.Department,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[7]).toMatchObject({
@@ -1086,6 +1239,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician2.id,
         encounterType: encounterType3,
+        changeType: EncounterChangeType.Examiner,
+        modifierId: defaultUser.id,
       });
 
       expect(encounterHistoryRecords[8]).toMatchObject({
@@ -1094,6 +1249,118 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician2.id,
         encounterType: encounterType4,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: defaultUser.id,
+      });
+    });
+
+    it('migrates changelog with multiple modifiers', async () => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+      const location = await createLocation('location');
+      const department = await createDepartment('department');
+      const clinician = await createUser('testUser');
+      const modifier1 = await createUser('modifier1');
+      const modifier2 = await createUser('modifier2');
+
+      const encounterType1 = 'triage';
+      const encounterType2 = 'observation';
+      const encounterType3 = 'admission';
+      const encounterType4 = 'clinic';
+
+      const encounter = await createEncounter(patient, {
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: encounterType1,
+        startDate: getDateSubtractedFromNow(8),
+      });
+
+      // Change encounter type 1
+      await onEncounterProgression(
+        models,
+        encounter.id,
+        encounterType1,
+        encounterType2,
+        getDateSubtractedFromNow(6),
+        modifier1,
+      );
+      encounter.encounterType = encounterType2;
+      await encounter.save();
+
+      // Change encounter type 2
+      await onEncounterProgression(
+        models,
+        encounter.id,
+        encounterType2,
+        encounterType3,
+        getDateSubtractedFromNow(5),
+        modifier2,
+      );
+      encounter.encounterType = encounterType3;
+      await encounter.save();
+
+      // Change encounter type 3
+      await onEncounterProgression(
+        models,
+        encounter.id,
+        encounterType3,
+        encounterType4,
+        getDateSubtractedFromNow(4),
+        modifier1,
+      );
+      encounter.encounterType = encounterType4;
+      await encounter.save();
+
+      await migrateChangelogNotesToEncounterHistory(SUB_COMMAND_OPTIONS);
+
+      expect(exitSpy).toBeCalledWith(0);
+
+      const encounterHistoryRecords = await models.EncounterHistory.findAll({
+        order: [['date', 'ASC']],
+      });
+
+      // Original encounter
+      expect(encounterHistoryRecords[0]).toMatchObject({
+        encounterId: encounter.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: encounterType1,
+        changeType: null,
+        modifierId: null,
+      });
+
+      // Encounter type change history 1
+      expect(encounterHistoryRecords[1]).toMatchObject({
+        encounterId: encounter.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: encounterType2,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: modifier1.id,
+      });
+
+      // Encounter type change history 2
+      expect(encounterHistoryRecords[2]).toMatchObject({
+        encounterId: encounter.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: encounterType3,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: modifier2.id,
+      });
+
+      // Encounter type change history 3
+      expect(encounterHistoryRecords[3]).toMatchObject({
+        encounterId: encounter.id,
+        departmentId: department.id,
+        locationId: location.id,
+        examinerId: clinician.id,
+        encounterType: encounterType4,
+        changeType: EncounterChangeType.EncounterType,
+        modifierId: modifier1.id,
       });
     });
   });
@@ -1170,6 +1437,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated location from 1 to 2
@@ -1179,6 +1448,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location2.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         // Updated location from 2 to 4
@@ -1188,6 +1459,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location4.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1279,6 +1552,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated location from 1 to 3
@@ -1289,6 +1564,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location3.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         // Updated location from 3 to 5
@@ -1299,6 +1576,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location5.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         // Updated location from 5 to 6
@@ -1308,6 +1587,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location6.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1377,6 +1658,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated location from 1 to 2
@@ -1386,6 +1669,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location2.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         // Updated location from 2 to 4
@@ -1395,6 +1680,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location4.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1464,6 +1751,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated location from 1 to 3
@@ -1473,6 +1762,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location3.id, // location 3 has same name as location 2 but created later
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         // Updated location from 3 to 4
@@ -1482,6 +1773,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location4.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1553,6 +1846,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated location from 1 to 3
@@ -1562,6 +1857,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location3.id, // location 3 has same name as location 2 but created later
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         // Updated location from 3 to 4
@@ -1571,6 +1868,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location4.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1641,6 +1940,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Should skip location2 as location name has been changed
@@ -1650,6 +1951,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location3.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1712,6 +2015,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         expect(encounterHistoryRecords[1]).toMatchObject({
@@ -1720,6 +2025,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
 
         expect(encounterHistoryRecords[2]).toMatchObject({
@@ -1728,6 +2035,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
       });
     });
@@ -1800,6 +2109,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated department 1 to department 2
@@ -1809,6 +2120,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
 
         // Updated department 2 to department 4
@@ -1818,6 +2131,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1889,6 +2204,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated department 1 to department 2
@@ -1898,6 +2215,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
 
         // Updated department 1 to department 4
@@ -1907,6 +2226,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -1978,6 +2299,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated deparment 1 to department 3
@@ -1987,6 +2310,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
 
         // Updated deparment 3 to department 4
@@ -1996,6 +2321,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -2069,6 +2396,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Updated deparment 1 to department 3
@@ -2078,6 +2407,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
 
         // Updated deparment 3 to department 4
@@ -2087,6 +2418,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -2158,6 +2491,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Department 2 should be skipped as department name has been changed
@@ -2167,6 +2502,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Department,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -2235,6 +2572,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         expect(encounterHistoryRecords[1]).toMatchObject({
@@ -2243,6 +2582,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location2.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         expect(encounterHistoryRecords[2]).toMatchObject({
@@ -2251,6 +2592,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location3.id,
           examinerId: clinician.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
     });
@@ -2315,6 +2658,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician1.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // 2nd encounter
@@ -2324,6 +2669,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician3.id,
           encounterType,
+          changeType: EncounterChangeType.Examiner,
+          modifierId: defaultUser.id,
         });
 
         // Latest encounter
@@ -2333,6 +2680,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician4.id,
           encounterType,
+          changeType: EncounterChangeType.Examiner,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -2397,6 +2746,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician1.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         // Should skip clinician 2 as the name has been updated
@@ -2406,6 +2757,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location.id,
           examinerId: clinician3.id,
           encounterType,
+          changeType: EncounterChangeType.Examiner,
+          modifierId: defaultUser.id,
         });
       });
 
@@ -2472,6 +2825,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location1.id,
           examinerId: clinician1.id,
           encounterType,
+          changeType: null,
+          modifierId: null,
         });
 
         expect(encounterHistoryRecords[1]).toMatchObject({
@@ -2480,6 +2835,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location2.id,
           examinerId: clinician1.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
 
         expect(encounterHistoryRecords[2]).toMatchObject({
@@ -2488,6 +2845,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
           locationId: location3.id,
           examinerId: clinician1.id,
           encounterType,
+          changeType: EncounterChangeType.Location,
+          modifierId: defaultUser.id,
         });
       });
     });
@@ -2533,6 +2892,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location.id,
         examinerId: clinician.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
     });
 
@@ -2594,6 +2955,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location1.id,
         examinerId: clinician1.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // 2nd encounter
@@ -2603,6 +2966,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location2.id,
         examinerId: clinician2.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // 3rd encounter
@@ -2612,6 +2977,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician3.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
     });
 
@@ -2676,6 +3043,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location1.id,
         examinerId: clinician1.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // 2nd encounter
@@ -2685,6 +3054,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location2.id,
         examinerId: clinician2.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
 
       // 3rd encounter
@@ -2694,6 +3065,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         locationId: location3.id,
         examinerId: clinician3.id,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
     });
 
@@ -2743,6 +3116,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         date: encounter.startDate,
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
     });
 
@@ -2792,6 +3167,8 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician1.id,
         date: getDateSubtractedFromToday(5), // changelog date is 4 days ago, so 5 should be expected
         encounterType,
+        changeType: null,
+        modifierId: null,
       });
     });
   });


### PR DESCRIPTION
### Changes
- Added 2 new columns to encounter_history table: modifier_id and change_type
- Modified the migration to migrate the 2 new columns from historical data

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
