### PR TITLE
EPI-602 Add requester to ServiceRequest's  _include query

### DIFF
--- a/packages/shared/src/models/fhir/ServiceRequest/searchParameters.js
+++ b/packages/shared/src/models/fhir/ServiceRequest/searchParameters.js
@@ -37,4 +37,9 @@ export const searchParameters = {
     path: [['encounter']],
     referenceTypes: ['Encounter'],
   },
+  requester: {
+    type: FHIR_SEARCH_PARAMETERS.REFERENCE,
+    path: [['requester']],
+    referenceTypes: ['Practitioner'],
+  },
 };

--- a/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -831,13 +831,27 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       const response = await app.get(
         `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Encounter:encounter`,
       );
-
       expect(response.body.total).toBe(2);
       expect(response.body.entry.length).toBe(3);
       expect(response.body.entry.filter(({ search: { mode } }) => mode === 'match').length).toBe(2);
       expect(
         response.body.entry.find(({ search: { mode } }) => mode === 'include')?.resource.id,
       ).toBe(fhirResources.fhirEncounter.id);
+    });
+
+    it('includes requester practitioner', async () => {
+      const response = await app.get(
+        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Practitioner:requester`,
+      );
+      const practitionerRef = response.body.entry.find(
+        ({ search: { mode } }) => mode === 'include',
+      );
+      expect(practitionerRef).toBeDefined();
+      expect(practitionerRef.resource.id).toBe(fhirResources.fhirPractitioner.id);
+      expect(practitionerRef.resource.name.length).toBe(1);
+      expect(practitionerRef.resource.name[0].text).toBe(
+        fhirResources.fhirPractitioner.name[0].text,
+      );
       expect(response).toHaveSucceeded();
     });
   });


### PR DESCRIPTION
### Changes
Add requester to ServiceRequest's  `_include` query

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
