### PR TITLE
Fix: mobile builds needing vitals survey

### DIFF
--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -133,7 +133,7 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
       try {
         vitalsSurvey = await Survey.getVitalsSurvey();
       } catch (e) {
-        console.error('No vital survey could be found');
+        console.error(`Errored while trying to get vitals survey: ${e}`);
       }
 
       // use optional chaining because vitals survey might not exist

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -129,7 +129,13 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
         questionConfig.writeToPatient?.isAdditionalDataField;
 
       // figure out if its a vital survey response
-      const vitalsSurvey = await Survey.getVitalsSurvey();
+      let vitalsSurvey;
+      try {
+        vitalsSurvey = await Survey.getVitalsSurvey();
+      } catch (e) {
+        console.error('No vital survey could be found');
+      }
+
       // use optional chaining because vitals survey might not exist
       const isVitalSurvey = surveyId === vitalsSurvey?.id;
 


### PR DESCRIPTION
### Changes

Discovered this one testing another thing. This was the only place that didn't fail gracefully, causing it to error when accessing `vitalsSurvey.id`. With this fix, we no longer require a vitals survey for submitting other survey types.