### PR TITLE
NASS-817: Differentiate between suggester endpoints and those support /all in report params

### DIFF
--- a/packages/constants/src/suggesters.ts
+++ b/packages/constants/src/suggesters.ts
@@ -1,15 +1,19 @@
 import { REFERENCE_TYPE_VALUES } from './importable';
 
-export const SUGGESTER_ENDPOINTS = [
+export const SUGGESTER_ENDPOINTS_SUPPORTING_ALL = [
   ...REFERENCE_TYPE_VALUES,
+  'labTestPanel',
+  'labTestType',
+  'locationGroup',
+];
+
+export const SUGGESTER_ENDPOINTS = [
+  ...SUGGESTER_ENDPOINTS_SUPPORTING_ALL,
   'department',
   'facility',
   'facilityLocationGroup',
   'invoiceLineTypes',
-  'labTestPanel',
-  'labTestType',
   'location',
-  'locationGroup',
   'patient',
   'patientLabTestCategories',
   'patientLabTestPanelTypes',

--- a/packages/desktop/app/views/administration/reports/components/editing/ParameterItem.js
+++ b/packages/desktop/app/views/administration/reports/components/editing/ParameterItem.js
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import { Divider as BaseDivider } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import BaseDeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
-import { SUGGESTER_ENDPOINTS } from '@tamanu/constants';
 import {
   TextField,
   DefaultIconButton,
@@ -19,6 +18,7 @@ import {
   PARAMETER_FIELD_COMPONENTS,
   FIELD_TYPES_WITH_SUGGESTERS,
   FIELD_TYPES_WITH_PREDEFINED_OPTIONS,
+  FIELD_TYPES_TO_SUGGESTER_OPTIONS,
 } from '../../../../reports/ParameterField';
 
 const Divider = styled(BaseDivider)`
@@ -127,10 +127,12 @@ export const ParameterItem = props => {
             }}
             placeholder="Text"
             label="Suggester endpoint"
-            options={SUGGESTER_ENDPOINTS.sort((a, b) => a.localeCompare(b)).map(key => ({
-              label: key,
-              value: key,
-            }))}
+            options={FIELD_TYPES_TO_SUGGESTER_OPTIONS[parameterField]
+              .sort((a, b) => a.localeCompare(b))
+              .map(key => ({
+                label: key,
+                value: key,
+              }))}
           />
         </Grid>
       )}

--- a/packages/desktop/app/views/administration/reports/components/editing/ParameterItem.js
+++ b/packages/desktop/app/views/administration/reports/components/editing/ParameterItem.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { Divider as BaseDivider } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import BaseDeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
-import { SUGGESTER_ENDPOINTS } from '@tamanu/constants';
+import { SUGGESTER_ENDPOINTS_SUPPORTING_ALL } from '@tamanu/constants';
 import {
   TextField,
   DefaultIconButton,
@@ -127,10 +127,12 @@ export const ParameterItem = props => {
             }}
             placeholder="Text"
             label="Suggester endpoint"
-            options={SUGGESTER_ENDPOINTS.sort((a, b) => a.localeCompare(b)).map(key => ({
-              label: key,
-              value: key,
-            }))}
+            options={SUGGESTER_ENDPOINTS_SUPPORTING_ALL.sort((a, b) => a.localeCompare(b)).map(
+              key => ({
+                label: key,
+                value: key,
+              }),
+            )}
           />
         </Grid>
       )}

--- a/packages/desktop/app/views/reports/ParameterField.js
+++ b/packages/desktop/app/views/reports/ParameterField.js
@@ -18,10 +18,12 @@ import { ImagingTypeField } from './ImagingTypeField';
 import { VaccineField } from './VaccineField';
 import { useSuggester } from '../../api';
 
-export const FIELD_TYPES_WITH_SUGGESTERS = [
-  'ParameterSuggesterSelectField',
-  'ParameterAutocompleteField',
-];
+export const FIELD_TYPES_TO_SUGGESTER_OPTIONS = {
+  ParameterSuggesterSelectField: 'suggesterOptions',
+  ParameterAutocompleteField: 'suggesterOptions',
+};
+
+export const FIELD_TYPES_WITH_SUGGESTERS = Object.keys(FIELD_TYPES_TO_SUGGESTER_OPTIONS);
 
 export const FIELD_TYPES_WITH_PREDEFINED_OPTIONS = [
   'ParameterSelectField',

--- a/packages/desktop/app/views/reports/ReportGeneratorForm.js
+++ b/packages/desktop/app/views/reports/ReportGeneratorForm.js
@@ -245,7 +245,6 @@ export const ReportGeneratorForm = () => {
                         label={label}
                         parameterValues={values}
                         parameterField={parameterField}
-                        options={typeof options === 'string' ? JSON.parse(options) : options}
                         {...restOfProps}
                       />
                     );


### PR DESCRIPTION
### Changes

- SuggesterSelect fields use `/all` suggester endpoint and therefore don't work for every suggester causing an error from mismatch from the suggester select in report form parameters and report generation form.

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
