### PR TITLE
SAV-358: Remove honeycomb legacy names

### DIFF
--- a/packages/shared/src/services/logging/context.js
+++ b/packages/shared/src/services/logging/context.js
@@ -7,7 +7,7 @@ export const ENV = process.env.NODE_ENV ?? 'development';
 export const PROCESS_ID = shortid.generate();
 export const HOSTNAME = os.hostname();
 
-export const SemanticAttributes = {
+const SemanticAttributes = {
   ...OpenTelSemantics,
   DEPLOYMENT_NAME: 'deployment.name',
   DEPLOYMENT_ENVIRONMENT: 'deployment.environment',

--- a/packages/shared/src/services/logging/honeycomb.js
+++ b/packages/shared/src/services/logging/honeycomb.js
@@ -1,17 +1,9 @@
 import Transport from 'winston-transport';
 import Libhoney from 'libhoney';
 import config from 'config';
-import { SemanticAttributes, serviceContext, serviceName } from './context';
+import { serviceContext, serviceName } from './context';
 
 const context = serviceContext();
-const legacyNames = {
-  deployment: context[SemanticAttributes.DEPLOYMENT_NAME],
-  nodeEnv: context[SemanticAttributes.DEPLOYMENT_ENVIRONMENT],
-  processId: context[SemanticAttributes.PROCESS_ID],
-  hostname: context[SemanticAttributes.NET_HOST_NAME],
-  version: context[SemanticAttributes.SERVICE_VERSION],
-  serverType: context[SemanticAttributes.SERVICE_TYPE],
-};
 
 const { apiKey, enabled, level = 'info' } = config?.honeycomb || {};
 
@@ -25,9 +17,8 @@ const honeyApi = new Libhoney({
 class HoneycombTransport extends Transport {
   log(info, callback) {
     const event = honeyApi.newEvent();
-    event.add(info);
     event.add(context);
-    event.add(legacyNames);
+    event.add(info);
     event.send();
     callback();
   }


### PR DESCRIPTION
### Changes

I think these aren't being used in any active honeycomb integrations, and all of the data is already being sent to honeycomb under different names. Better to drop them now rather than leaving them to hang around.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
