### PR TITLE
NASS-869: Print dialog keeps reopening when saving patient details

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/PatientIDCardPage.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PatientIDCardPage.js
@@ -151,7 +151,7 @@ export const PatientIDCardPage = ({ patient, imageData }) => {
         width: cardDimensions.height * 1000,
       },
     });
-  });
+  }, [printPage]);
 
   return (
     <PrintPortal>

--- a/packages/desktop/app/components/PatientPrinting/modals/PatientStickerLabelPage.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PatientStickerLabelPage.js
@@ -65,7 +65,7 @@ export const PatientStickerLabelPage = ({ patient }) => {
   const measures = getLocalisation('printMeasures.stickerLabelPage');
   useEffect(() => {
     printPage();
-  });
+  }, [printPage]);
 
   return (
     <PrintPortal>


### PR DESCRIPTION
### Changes
I think this issue has likely been around a long time.
No dependency array on useEffect meant that this could be re-triggered if the component was to ever re-render.

Issue was after printing id or sticker label - and then saving a patient it would retrigger the print inside use effect.

### Checklist
- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
