### PR TITLE
TAMOC-57:  Lab test types historical not excluded from individual test selector

### DIFF
--- a/packages/lan/__tests__/apiv1/Labs.test.js
+++ b/packages/lan/__tests__/apiv1/Labs.test.js
@@ -298,7 +298,7 @@ describe('Labs', () => {
     expect(labRequest).toHaveProperty('status', status);
   });
 
-  it('should not fetch lab test types directly from general labTestType get route when visibilityStatus set to "panelsOnly"', async () => {
+  it('should not fetch lab test types directly from general labTestType get route when visibilityStatus set to "panelsOnly" or "historical"', async () => {
     const makeLabTestType = async visibilityStatus => {
       const category = await models.ReferenceData.create({
         ...fake(models.ReferenceData),
@@ -320,13 +320,16 @@ describe('Labs', () => {
     await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.PANEL_ONLY);
     await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.PANEL_ONLY);
     await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.PANEL_ONLY);
+    await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.HISTORICAL);
+    await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.HISTORICAL);
+    await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.HISTORICAL);
 
     const result = await app.get('/v1/labTestType');
     expect(result).toHaveSucceeded();
     const { body } = result;
     expect(body.length).toBe(3);
     body.forEach(labTestType => {
-      expect(labTestType.visibilityStatus).not.toBe('panelsOnly');
+      expect(labTestType.visibilityStatus).toBe(LAB_TEST_TYPE_VISIBILITY_STATUSES.CURRENT);
     });
   });
 

--- a/packages/lan/app/routes/apiv1/labs.js
+++ b/packages/lan/app/routes/apiv1/labs.js
@@ -384,7 +384,12 @@ labTestType.get(
       ],
       // We dont include lab tests with a visibility status of panels only in this route as it is only used for the indivudual lab workflow
       where: {
-        visibilityStatus: { [Op.not]: LAB_TEST_TYPE_VISIBILITY_STATUSES.PANEL_ONLY },
+        visibilityStatus: {
+          [Op.notIn]: [
+            LAB_TEST_TYPE_VISIBILITY_STATUSES.PANEL_ONLY,
+            LAB_TEST_TYPE_VISIBILITY_STATUSES.HISTORICAL,
+          ],
+        },
       },
     });
     res.send(labTests);


### PR DESCRIPTION
### Changes
- Hotfix to 1.31 
- This could also be done by just going `{visibilityStatus:  'current'}` but let me know what yal think is appropriate here, i thought this change let that panelOnly exclusion read clearer

### Checklist
- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
