### PR TITLE
SAV-402: Remove Notes self FK for revised_by_id column

### DIFF
--- a/packages/shared/src/migrations/1694130891220-removeRevisedByIdFKInNotes.js
+++ b/packages/shared/src/migrations/1694130891220-removeRevisedByIdFKInNotes.js
@@ -1,0 +1,15 @@
+export async function up(query) {
+  await query.removeConstraint('notes', 'notes_revised_by_id_fkey');
+}
+
+export async function down(query) {
+  await query.addConstraint('notes', {
+    type: 'foreign key',
+    name: 'notes_revised_by_id_fkey',
+    fields: ['revised_by_id'],
+    references: {
+      table: 'notes',
+      field: 'id',
+    },
+  });
+}

--- a/packages/shared/src/models/Note.js
+++ b/packages/shared/src/models/Note.js
@@ -36,10 +36,6 @@ export class Note extends Model {
           allowNull: false,
           defaultValue: '',
         },
-        revisedById: {
-          type: DataTypes.UUID,
-          allowNull: true,
-        },
         visibilityStatus: {
           type: DataTypes.TEXT,
           defaultValue: VISIBILITY_STATUSES.CURRENT,
@@ -86,6 +82,7 @@ export class Note extends Model {
     this.belongsTo(models.Note, {
       foreignKey: 'revisedById',
       as: 'revisedBy',
+      constraints: false,
     });
   }
 


### PR DESCRIPTION
### Changes
- Remove Notes self FK for revised_by_id column

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
