### PR TITLE
TAV-784: Replace cls-hooked with built-in AsyncLocalStorage

### DIFF
--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -46,7 +46,6 @@
     "case": "^1.6.3",
     "chalk": "^5.0.1",
     "chance": "^1.1.8",
-    "cls-hooked": "^4.2.2",
     "commander": "^9.0.0",
     "compression": "^1.7.2",
     "config": "^3.0.1",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -35,7 +35,6 @@
     "@tamanu/shared": "*",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",
-    "cls-hooked": "^4.2.2",
     "compression": "^1.7.2",
     "config": "^3.3.6",
     "connect-flash": "^0.1.1",

--- a/packages/shared/src/services/database.js
+++ b/packages/shared/src/services/database.js
@@ -1,5 +1,5 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import { Sequelize } from 'sequelize';
-import { createNamespace } from 'cls-hooked';
 import pg from 'pg';
 import util from 'util';
 
@@ -16,10 +16,22 @@ createDateTypes();
 
 // this allows us to use transaction callbacks without manually managing a transaction handle
 // https://sequelize.org/master/manual/transactions.html#automatically-pass-transactions-to-all-queries
-// done once for all sequelize objects
-const namespace = createNamespace('sequelize-transaction-namespace');
+// done once for all sequelize objects. Instead of cls-hooked we use the built-in AsyncLocalStorage.
+const asyncLocalStorage = new AsyncLocalStorage();
 // eslint-disable-next-line react-hooks/rules-of-hooks
-Sequelize.useCLS(namespace);
+Sequelize.useCLS({
+  bind() {}, // compatibility with cls-hooked, not used by sequelize
+  get(id) {
+    return asyncLocalStorage.getStore()?.get(id);
+  },
+  set(id, value) {
+    // eslint-disable-next-line no-unused-expressions
+    asyncLocalStorage.getStore()?.set(id, value);
+  },
+  run(callback) {
+    asyncLocalStorage.run(new Map(), callback);
+  },
+});
 
 // this is dangerous and should only be used in test mode
 const unsafeRecreatePgDb = async ({ name, username, password, host, port }) => {
@@ -173,8 +185,8 @@ export async function initDatabase(dbOptions) {
     }
   });
 
-  // add isInsideTransaction helper to avoid exposing the namespace
-  sequelize.isInsideTransaction = () => !!namespace.get('transaction');
+  // add isInsideTransaction helper to avoid exposing the asynclocalstorage
+  sequelize.isInsideTransaction = () => !!asyncLocalStorage.getStore();
 
   return { sequelize, models };
 }

--- a/packages/shared/src/services/database.js
+++ b/packages/shared/src/services/database.js
@@ -20,17 +20,10 @@ createDateTypes();
 const asyncLocalStorage = new AsyncLocalStorage();
 // eslint-disable-next-line react-hooks/rules-of-hooks
 Sequelize.useCLS({
-  bind() {}, // compatibility with cls-hooked, not used by sequelize
-  get(id) {
-    return asyncLocalStorage.getStore()?.get(id);
-  },
-  set(id, value) {
-    // eslint-disable-next-line no-unused-expressions
-    asyncLocalStorage.getStore()?.set(id, value);
-  },
-  run(callback) {
-    asyncLocalStorage.run(new Map(), callback);
-  },
+  bind: () => {}, // compatibility with cls-hooked, not used by sequelize
+  get: (id) => asyncLocalStorage.getStore()?.get(id),
+  set: (id, value) => asyncLocalStorage.getStore()?.set(id, value),
+  run: (callback) => asyncLocalStorage.run(new Map(), callback),
 });
 
 // this is dangerous and should only be used in test mode

--- a/packages/shared/src/services/database.js
+++ b/packages/shared/src/services/database.js
@@ -21,9 +21,9 @@ const asyncLocalStorage = new AsyncLocalStorage();
 // eslint-disable-next-line react-hooks/rules-of-hooks
 Sequelize.useCLS({
   bind: () => {}, // compatibility with cls-hooked, not used by sequelize
-  get: (id) => asyncLocalStorage.getStore()?.get(id),
+  get: id => asyncLocalStorage.getStore()?.get(id),
   set: (id, value) => asyncLocalStorage.getStore()?.set(id, value),
-  run: (callback) => asyncLocalStorage.run(new Map(), callback),
+  run: callback => asyncLocalStorage.run(new Map(), callback),
 });
 
 // this is dangerous and should only be used in test mode

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -63,7 +63,6 @@
     "chance": "^1.1.8",
     "check-disk-space": "^3.1.0",
     "cli-table3": "^0.6.2",
-    "cls-hooked": "^4.2.2",
     "commander": "^9.0.0",
     "compression": "^1.7.2",
     "config": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6146,49 +6146,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.14.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^2.14.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -7284,13 +7241,6 @@ async-exit-hook@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
   integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
-
-async-hook-jl@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
-  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
-  dependencies:
-    stack-chain "^1.3.7"
 
 async-limiter@~1.0.0:
   version "1.0.1"
@@ -9319,15 +9269,6 @@ cloudant-follow@~0.17.0:
     debug "^3.0.0"
     request "^2.83.0"
 
-cls-hooked@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
-  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
-  dependencies:
-    async-hook-jl "^1.7.6"
-    emitter-listener "^1.0.1"
-    semver "^5.4.1"
-
 clsx@^1.0.4, clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
@@ -11259,7 +11200,7 @@ elliptic@^6.4.0, elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-emitter-listener@^1.0.1, emitter-listener@^1.1.1:
+emitter-listener@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
   integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
@@ -22243,11 +22184,6 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
-
-stack-chain@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
-  integrity sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==
 
 stack-trace@0.0.x:
   version "0.0.10"


### PR DESCRIPTION
### Changes

`cls-hooked` hasn't been updated since 2017 and has known performance issues. [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html) is built on the same async-hooks API underneath but is an optimised and memory-safe implementation maintained directly by the Node.js team.

This is a tiny shim which implements only the parts that sequelize uses.

### Checklist

- [x] Code is finished
- [x] Tests pass