### PR TITLE
Shard tests across parallel workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,48 +20,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          # - macos
-          - ubuntu
-          # - windows
-        node:
-          - '16.x'
-        postgres:
-          # - '12'
-          - '14'
-        package:
-          - lan
-          - meta-server
-          - "@tamanu/shared"
-          - sync-server
+        include:
+          - { package: lan,         shard: 1/3, postgres: 14 }
+          - { package: lan,         shard: 2/3, postgres: 14 }
+          - { package: lan,         shard: 3/3, postgres: 14 }
+          - { package: sync-server, shard: 1/3, postgres: 14 }
+          - { package: sync-server, shard: 2/3, postgres: 14 }
+          - { package: sync-server, shard: 3/3, postgres: 14 }
+          - { package: meta-server }
+          - { package: "@tamanu/shared" }
 
-    name: Test ${{ matrix.package }} os=${{ matrix.os }} node=${{ matrix.node }}
-      pg=${{ matrix.postgres }}
-    runs-on: ${{ matrix.os }}-latest
+    name: Test ${{ matrix.package }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
           cache: yarn
       - run: yarn
       - run: yarn build-shared
 
-      - name: Install and start postgres ${{ matrix.postgres }} if needed
-        if: matrix.package == 'sync-server' || matrix.package == 'lan'
-        run: .github/scripts/install-postgres-${{ matrix.os }}.sh ${{ matrix.postgres }}
-          ${{ matrix.package }}
+      - name: Install and start postgres if needed
+        if: matrix.postgres
+        run: .github/scripts/install-postgres-ubuntu.sh ${{ matrix.postgres }} ${{ matrix.package }}
 
-      - if: matrix.package == 'sync-server' || matrix.package == 'lan'
-        run: yarn workspace ${{ matrix.package }} run test --shard 1/3
-      - if: matrix.package == 'sync-server' || matrix.package == 'lan'
-        run: yarn workspace ${{ matrix.package }} run test --shard 2/3
-      - if: matrix.package == 'sync-server' || matrix.package == 'lan'
-        run: yarn workspace ${{ matrix.package }} run test --shard 3/3
-
-      - if: matrix.package != 'sync-server' && matrix.package != 'lan'
-        run: yarn workspace ${{ matrix.package }} run test
+      - name: Run tests
+        env:
+          package: ${{ matrix.package }}
+          shard: ${{ matrix.shard }}
+        run: |
+          [[ ! -z "$shared" ]] && shard="--shard $shard"
+          yarn workspace "$package" run test "$shard"
 
   build-all:
     name: Build all packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 16
           cache: yarn
       - run: yarn
-      - run: tar -caf node_modules.tar.zst node_modules packages/*/node_modules
+      - run: tar -c node_modules packages/*/node_modules | zstd -10 -T0 -o node_modules.tar.zst
       - uses: actions/upload-artifact@v3
         with:
           name: node_modules
@@ -58,7 +58,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: node_modules
-          path: node_modules.tar.zst
       - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
@@ -88,7 +87,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: node_modules
-          path: node_modules.tar.zst
       - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build
@@ -107,7 +105,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: node_modules
-          path: node_modules.tar.zst
       - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
@@ -141,7 +138,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: node_modules
-          path: node_modules.tar.zst
       - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
@@ -171,7 +167,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: node_modules
-          path: node_modules.tar.zst
       - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,7 @@ env:
   NODE_ENV: test
 
 jobs:
-  dependencies:
-    name: Install dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-      - run: yarn
-      - run: tar -c node_modules packages/*/node_modules | zstd -10 -T0 -o node_modules.tar.zst
-      - uses: actions/upload-artifact@v3
-        with:
-          name: node_modules
-          path: node_modules.tar.zst
-
   test:
-    needs: dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -55,10 +38,6 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      - uses: actions/download-artifact@v3
-        with:
-          name: node_modules
-      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
 
@@ -75,7 +54,6 @@ jobs:
           yarn workspace "$package" run test "$shard"
 
   build-all:
-    needs: dependencies
     name: Build all packages
     runs-on: ubuntu-latest
     steps:
@@ -84,15 +62,10 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      - uses: actions/download-artifact@v3
-        with:
-          name: node_modules
-      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build
 
   lint:
-    needs: dependencies
     name: Lint packages
     runs-on: ubuntu-latest
     steps:
@@ -102,10 +75,6 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      - uses: actions/download-artifact@v3
-        with:
-          name: node_modules
-      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
 
@@ -114,7 +83,6 @@ jobs:
           CONTINUE_ON_ERROR: true
 
   storybook:
-    needs: dependencies
     # Workaround for define plugin conflict warning
     env:
       NODE_ENV: development
@@ -135,16 +103,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
-      - uses: actions/download-artifact@v3
-        with:
-          name: node_modules
-      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
       - run: yarn workspace desktop run verify-storybook
 
   migrations:
-    needs: dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -164,10 +127,6 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      - uses: actions/download-artifact@v3
-        with:
-          name: node_modules
-      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           shard: ${{ matrix.shard }}
         run: |
           [[ -z "$shard" ]] || shard="--shard $shard"
-          yarn workspace "$package" run test "$shard"
+          yarn workspace "$package" run test $shard
 
   build-all:
     name: Build all packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,24 @@ env:
   NODE_ENV: test
 
 jobs:
+  dependencies:
+    name: Install dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
+      - run: yarn
+      - run: tar -caf node_modules.tar.zst node_modules packages/*/node_modules
+      - uses: actions/upload-artifact@v3
+        with:
+          name: node_modules
+          path: node_modules.tar.zst
+
   test:
+    needs: dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +47,7 @@ jobs:
           - { package: meta-server }
           - { package: "@tamanu/shared" }
 
-    name: Test ${{ matrix.package }}
+    name: Test ${{ matrix.package }} ${{ matrix.shard }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +55,11 @@ jobs:
         with:
           node-version: 16
           cache: yarn
+      - uses: actions/download-artifact@v3
+        with:
+          name: node_modules
+          path: node_modules.tar.zst
+      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
 
@@ -54,27 +76,39 @@ jobs:
           yarn workspace "$package" run test "$shard"
 
   build-all:
+    needs: dependencies
     name: Build all packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
+      - uses: actions/download-artifact@v3
+        with:
+          name: node_modules
+          path: node_modules.tar.zst
+      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build
 
   lint:
+    needs: dependencies
     name: Lint packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
+      - uses: actions/download-artifact@v3
+        with:
+          name: node_modules
+          path: node_modules.tar.zst
+      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
 
@@ -83,6 +117,7 @@ jobs:
           CONTINUE_ON_ERROR: true
 
   storybook:
+    needs: dependencies
     # Workaround for define plugin conflict warning
     env:
       NODE_ENV: development
@@ -97,17 +132,23 @@ jobs:
     name: Test storybook node=${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
+      - uses: actions/download-artifact@v3
+        with:
+          name: node_modules
+          path: node_modules.tar.zst
+      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
       - run: yarn workspace desktop run verify-storybook
 
   migrations:
+    needs: dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -122,11 +163,16 @@ jobs:
     name: Test migrations server=${{ matrix.server }} pg=${{ matrix.postgres }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
+      - uses: actions/download-artifact@v3
+        with:
+          name: node_modules
+          path: node_modules.tar.zst
+      - run: tar -xf node_modules.tar.zst
       - run: yarn
       - run: yarn build-shared
 
@@ -146,7 +192,7 @@ jobs:
     name: Test mobile node=${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           package: ${{ matrix.package }}
           shard: ${{ matrix.shard }}
         run: |
-          [[ ! -z "$shared" ]] && shard="--shard $shard"
+          [[ -z "$shard" ]] || shard="--shard $shard"
           yarn workspace "$package" run test "$shard"
 
   build-all:

--- a/scripts/create-package.mjs
+++ b/scripts/create-package.mjs
@@ -26,12 +26,6 @@ async function createPackage(name) {
   pkg.workspaces.packages.push(`packages/${name}`);
   await writeFile(PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
 
-  console.log('Adding to CI...');
-  const ciPath = './.github/workflows/ci.yml';
-  const ci = parseDocument(await readFile(ciPath, 'utf-8'));
-  ci.contents.addIn(['jobs', 'test', 'strategy', 'matrix', 'package'], `@tamanu/${name}`);
-  await writeFile(ciPath, ci.toString());
-
   console.log("All done! Don't forget to run yarn and yarn build-shared, and add to Dockerfile if needed");
   process.exit(0);
 }


### PR DESCRIPTION
### Changes

Distribute the sharded tests across parallel distinct workers rather than in serial within the one run. That adds a little to the cumulative run time, but drops the wall clock time from ~15-20 minutes to ~8-10 minutes.

Also sideswipe disable the create-package script adding to the CI, as most packages we create don't/won't have tests; when tests are added the packages should in turn be added to CI but that can be a "just in time" step rather than adding useless runs upfront.