### PR TITLE
Feature/tan-2293 program registry dashboard

### DIFF
--- a/packages/desktop/app/api/queries/usePatientProgramRegistry.js
+++ b/packages/desktop/app/api/queries/usePatientProgramRegistry.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { useApi } from '../useApi';
+
+export const usePatientProgramRegistry = (patientId, programRegistryId, fetchOptions) => {
+  const api = useApi();
+  return useQuery(['PatientProgramRegistry', { patientId, programRegistryId }], () =>
+    api.get(
+      `patient/${encodeURIComponent(patientId)}/programRegistration/${encodeURIComponent(
+        programRegistryId,
+      )}`,
+      fetchOptions,
+    ),
+  );
+};

--- a/packages/desktop/app/components/PatientInfoPane/InfoPaneList.js
+++ b/packages/desktop/app/components/PatientInfoPane/InfoPaneList.js
@@ -130,6 +130,14 @@ export const InfoPaneList = memo(
     );
 
     const EditForm = CustomEditForm || InfoPaneAddEditForm;
+    const _items = [
+      {
+        id: '1',
+        name: 'Seasonal fever',
+        status: 'Removed',
+        clinicalStatus: 'Needs review',
+      },
+    ];
     return (
       <>
         {isIssuesPane && <PatientAlert alerts={warnings} />}
@@ -147,58 +155,27 @@ export const InfoPaneList = memo(
         </TitleContainer>
         <DataList>
           {error && error.message}
-          {!error &&
-            items.map(item => {
-              const { id } = item;
-              const name = getName(item);
-              if (behavior === 'collapse') {
-                return (
-                  <React.Fragment key={id}>
-                    <Collapse in={editKey !== id}>
-                      {ListItemComponent ? (
-                        <ListItemComponent
-                          item={item}
-                          handleRowClick={handleRowClick}
-                          ListItem={ListItem}
-                          getName={getName}
-                        />
-                      ) : (
-                        <ListItem onClick={() => handleRowClick(id)}>{name}</ListItem>
-                      )}
-                    </Collapse>
-                    <Collapse in={editKey === id}>
-                      <EditForm
-                        patient={patient}
-                        Form={Form}
-                        endpoint={endpoint}
-                        item={item}
-                        onClose={handleCloseForm}
-                        title={title}
-                        items={items}
-                      />
-                    </Collapse>
-                  </React.Fragment>
-                );
-              }
-
+          {/* {!error && */}
+          {(ListItemComponent ? _items : items).map(item => {
+            // items.map(item => {
+            const { id } = item;
+            const name = getName(item);
+            if (behavior === 'collapse') {
               return (
                 <React.Fragment key={id}>
-                  {ListItemComponent ? (
-                    <ListItemComponent
-                      item={item}
-                      handleRowClick={handleRowClick}
-                      ListItem={ListItem}
-                      getName={getName}
-                    />
-                  ) : (
-                    <ListItem onClick={() => handleRowClick(id)}>{name}</ListItem>
-                  )}
-                  <Modal
-                    width="md"
-                    title={getEditFormName(item)}
-                    open={editKey === id}
-                    onClose={handleCloseForm}
-                  >
+                  <Collapse in={editKey !== id}>
+                    {ListItemComponent ? (
+                      <ListItemComponent
+                        item={item}
+                        handleRowClick={handleRowClick}
+                        ListItem={ListItem}
+                        getName={getName}
+                      />
+                    ) : (
+                      <ListItem onClick={() => handleRowClick(id)}>{name}</ListItem>
+                    )}
+                  </Collapse>
+                  <Collapse in={editKey === id}>
                     <EditForm
                       patient={patient}
                       Form={Form}
@@ -208,10 +185,42 @@ export const InfoPaneList = memo(
                       title={title}
                       items={items}
                     />
-                  </Modal>
+                  </Collapse>
                 </React.Fragment>
               );
-            })}
+            }
+
+            return (
+              <React.Fragment key={id}>
+                {ListItemComponent ? (
+                  <ListItemComponent
+                    item={item}
+                    handleRowClick={handleRowClick}
+                    ListItem={ListItem}
+                    getName={getName}
+                  />
+                ) : (
+                  <ListItem onClick={() => handleRowClick(id)}>{name}</ListItem>
+                )}
+                <Modal
+                  width="md"
+                  title={getEditFormName(item)}
+                  open={editKey === id}
+                  onClose={handleCloseForm}
+                >
+                  <EditForm
+                    patient={patient}
+                    Form={Form}
+                    endpoint={endpoint}
+                    item={item}
+                    onClose={handleCloseForm}
+                    title={title}
+                    items={items}
+                  />
+                </Modal>
+              </React.Fragment>
+            );
+          })}
           {addForm}
         </DataList>
       </>

--- a/packages/desktop/app/components/Table/Paginator.js
+++ b/packages/desktop/app/components/Table/Paginator.js
@@ -132,8 +132,8 @@ export const Paginator = React.memo(
             IconComponent={ChevronIcon}
             MenuProps={{ classes: { paper: classes.selectMenu } }}
           >
-            {rowsPerPageOptions.map((option, index) => (
-              <StyledMenuItem key={`key-${index}`} value={option}>
+            {rowsPerPageOptions.map(option => (
+              <StyledMenuItem key={option} value={option}>
                 {option}
               </StyledMenuItem>
             ))}

--- a/packages/desktop/app/components/Table/Paginator.js
+++ b/packages/desktop/app/components/Table/Paginator.js
@@ -133,7 +133,7 @@ export const Paginator = React.memo(
             MenuProps={{ classes: { paper: classes.selectMenu } }}
           >
             {rowsPerPageOptions.map((option, index) => (
-              <StyledMenuItem key={index} value={option}>
+              <StyledMenuItem key={`key-${index}`} value={option}>
                 {option}
               </StyledMenuItem>
             ))}

--- a/packages/desktop/app/components/Table/Table.js
+++ b/packages/desktop/app/components/Table/Table.js
@@ -211,10 +211,7 @@ const StatusTableCell = styled(StyledTableCell)`
 const Row = React.memo(
   ({ rowIndex, columns, data, onClick, cellOnChange, lazyLoading, rowStyle, refreshTable }) => {
     const cells = columns.map(
-      (
-        { key, accessor, CellComponent, numeric, maxWidth, cellColor, dontCallRowInput },
-        cIndex,
-      ) => {
+      ({ key, accessor, CellComponent, numeric, maxWidth, cellColor, dontCallRowInput }) => {
         const onChange = cellOnChange ? event => cellOnChange(event, key, rowIndex, data) : null;
         const value = accessor
           ? React.createElement(accessor, { refreshTable, onChange, ...data, rowIndex })
@@ -223,7 +220,7 @@ const Row = React.memo(
         const backgroundColor = typeof cellColor === 'function' ? cellColor(data) : cellColor;
         return (
           <StyledTableCell
-            key={key ? key : `key-${cIndex}`}
+            key={key}
             onClick={dontCallRowInput ? preventInputCallback : undefined}
             background={backgroundColor}
             align={numeric ? 'right' : 'left'}

--- a/packages/desktop/app/components/Table/Table.js
+++ b/packages/desktop/app/components/Table/Table.js
@@ -223,7 +223,7 @@ const Row = React.memo(
         const backgroundColor = typeof cellColor === 'function' ? cellColor(data) : cellColor;
         return (
           <StyledTableCell
-            key={!!key ? key : cIndex}
+            key={key ? key : `key-${cIndex}`}
             onClick={dontCallRowInput ? preventInputCallback : undefined}
             background={backgroundColor}
             align={numeric ? 'right' : 'left'}

--- a/packages/desktop/app/constants/patientPaths.js
+++ b/packages/desktop/app/constants/patientPaths.js
@@ -18,6 +18,7 @@ const ENCOUNTER_PATH = `${PATIENT_PATH}/encounter/:encounterId`;
 const SUMMARY_PATH = `${ENCOUNTER_PATH}/summary`;
 const LAB_REQUEST_PATH = `${ENCOUNTER_PATH}/lab-request/:labRequestId`;
 const IMAGING_REQUEST_PATH = `${ENCOUNTER_PATH}/imaging-request/:imagingRequestId`;
+const PROGRAM_REGISTRY_PATH = `${PATIENT_PATH}/program-registry/:programRegistryId`;
 
 export const PATIENT_PATHS = {
   CATEGORY: CATEGORY_PATH,
@@ -26,6 +27,7 @@ export const PATIENT_PATHS = {
   SUMMARY: SUMMARY_PATH,
   LAB_REQUEST: LAB_REQUEST_PATH,
   IMAGING_REQUEST: IMAGING_REQUEST_PATH,
+  PROGRAM_REGISTRY: PROGRAM_REGISTRY_PATH,
 };
 
 export const PATIENT_TABS = {

--- a/packages/desktop/app/hooks/index.js
+++ b/packages/desktop/app/hooks/index.js
@@ -1,1 +1,2 @@
 export { useSexValues, useSexOptions } from './useSexValues';
+export { useUrlQueryParams } from './useUrlQuery';

--- a/packages/desktop/app/hooks/useUrlQuery.js
+++ b/packages/desktop/app/hooks/useUrlQuery.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export function useUrlQueryParams() {
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
+}

--- a/packages/desktop/app/routes/PatientRoutes.js
+++ b/packages/desktop/app/routes/PatientRoutes.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
 import styled from 'styled-components';
+import { useUrlQueryParams } from '../hooks';
 import { PatientInfoPane } from '../components/PatientInfoPane';
 import { getPatientNameAsString } from '../components/PatientNameDisplay';
 import { PatientNavigation } from '../components/PatientNavigation';
@@ -19,11 +20,17 @@ import {
 import { getEncounterType } from '../views/patients/panes/EncounterInfoPane';
 import { ProgramsView } from '../views/programs/ProgramsView';
 import { ReferralsView } from '../views/referrals/ReferralsView';
+import { ProgramRegistryView } from '../views/programRegistry/ProgramRegistryView';
 
 export const usePatientRoutes = () => {
-  const { navigateToEncounter, navigateToPatient } = usePatientNavigation();
+  const {
+    navigateToEncounter,
+    navigateToPatient,
+    navigateToProgramRegistry,
+  } = usePatientNavigation();
   const patient = useSelector(state => state.patient);
   const { encounter } = useEncounter();
+  const queryParams = useUrlQueryParams();
   return [
     {
       path: PATIENT_PATHS.PATIENT,
@@ -68,6 +75,12 @@ export const usePatientRoutes = () => {
               title: 'Imaging Request',
             },
           ],
+        },
+        {
+          path: `${PATIENT_PATHS.PROGRAM_REGISTRY}`,
+          component: ProgramRegistryView,
+          navigateTo: programRegistry => navigateToProgramRegistry(programRegistry.id),
+          title: queryParams.get('title'),
         },
       ],
     },

--- a/packages/desktop/app/utils/usePatientNavigation.js
+++ b/packages/desktop/app/utils/usePatientNavigation.js
@@ -73,11 +73,10 @@ export const usePatientNavigation = () => {
   };
 
   const navigateToProgramRegistry = (programRegistryId, title) => {
-    const programRegistryRoute =
-      generatePath(PATIENT_PATHS.PROGRAM_REGISTRY, {
-        ...params,
-        programRegistryId,
-      }) + `?title=${title}`;
+    const programRegistryRoute = `${generatePath(PATIENT_PATHS.PROGRAM_REGISTRY, {
+      ...params,
+      programRegistryId,
+    })}?title=${title}`;
     navigate(programRegistryRoute);
   };
   return {

--- a/packages/desktop/app/utils/usePatientNavigation.js
+++ b/packages/desktop/app/utils/usePatientNavigation.js
@@ -72,6 +72,14 @@ export const usePatientNavigation = () => {
     );
   };
 
+  const navigateToProgramRegistry = (programRegistryId, title) => {
+    const programRegistryRoute =
+      generatePath(PATIENT_PATHS.PROGRAM_REGISTRY, {
+        ...params,
+        programRegistryId,
+      }) + `?title=${title}`;
+    navigate(programRegistryRoute);
+  };
   return {
     navigateToPatient,
     navigateToEncounter,
@@ -79,5 +87,6 @@ export const usePatientNavigation = () => {
     navigateToImagingRequest,
     navigateToCategory,
     navigateToSummary,
+    navigateToProgramRegistry,
   };
 };

--- a/packages/desktop/app/views/programRegistry/ActivateProgramRegistryFormModal.js
+++ b/packages/desktop/app/views/programRegistry/ActivateProgramRegistryFormModal.js
@@ -88,15 +88,15 @@ export const ActivateProgramRegistryFormModal = React.memo(
   },
 );
 
-ActivateProgramRegistryFormModal.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  editedObject: PropTypes.shape({}),
-  patient: PropTypes.shape({}).isRequired,
-  program: PropTypes.shape({ id: PropTypes.string }).isRequired,
-  open: PropTypes.bool.isRequired,
-};
+// ActivateProgramRegistryFormModal.propTypes = {
+//   onSubmit: PropTypes.func.isRequired,
+//   onCancel: PropTypes.func.isRequired,
+//   editedObject: PropTypes.shape({}),
+//   patient: PropTypes.shape({}).isRequired,
+//   program: PropTypes.shape({ id: PropTypes.string }).isRequired,
+//   open: PropTypes.bool.isRequired,
+// };
 
-ActivateProgramRegistryFormModal.defaultProps = {
-  editedObject: null,
-};
+// ActivateProgramRegistryFormModal.defaultProps = {
+//   editedObject: null,
+// };

--- a/packages/desktop/app/views/programRegistry/ActivateProgramRegistryFormModal.js
+++ b/packages/desktop/app/views/programRegistry/ActivateProgramRegistryFormModal.js
@@ -88,15 +88,15 @@ export const ActivateProgramRegistryFormModal = React.memo(
   },
 );
 
-// ActivateProgramRegistryFormModal.propTypes = {
-//   onSubmit: PropTypes.func.isRequired,
-//   onCancel: PropTypes.func.isRequired,
-//   editedObject: PropTypes.shape({}),
-//   patient: PropTypes.shape({}).isRequired,
-//   program: PropTypes.shape({ id: PropTypes.string }).isRequired,
-//   open: PropTypes.bool.isRequired,
-// };
+ActivateProgramRegistryFormModal.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  editedObject: PropTypes.shape({}),
+  patient: PropTypes.shape({}).isRequired,
+  program: PropTypes.shape({ id: PropTypes.string }).isRequired,
+  open: PropTypes.bool.isRequired,
+};
 
-// ActivateProgramRegistryFormModal.defaultProps = {
-//   editedObject: null,
-// };
+ActivateProgramRegistryFormModal.defaultProps = {
+  editedObject: null,
+};

--- a/packages/desktop/app/views/programRegistry/DisplayPatientRegDetails.js
+++ b/packages/desktop/app/views/programRegistry/DisplayPatientRegDetails.js
@@ -65,7 +65,7 @@ const MenuContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   .menu {
     border-radius: 100px;
     background-color: ${Colors.hoverGrey};

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryForm.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryForm.js
@@ -20,7 +20,7 @@ export const ProgramRegistryForm = React.memo(({ onCancel, onSubmit, editedObjec
   const api = useApi();
   const { currentUser, facility } = useAuth();
   const [program, setProgram] = useState();
-  const programRegistrySuggester = useSuggester('program', {
+  const programRegistrySuggester = useSuggester('programRegistries', {
     baseQueryParameters: { patientId: patient.id },
   });
   const programRegistryStatusSuggester = useSuggester('programRegistryClinicalStatus', {
@@ -31,7 +31,7 @@ export const ProgramRegistryForm = React.memo(({ onCancel, onSubmit, editedObjec
 
   const onProgramSelect = async id => {
     try {
-      const { data } = await api.get(`program/${id}`);
+      const { data } = await api.get(`programRegistry/${id}`);
       setProgram(data);
     } catch (error) {
       setProgram(undefined);
@@ -127,12 +127,12 @@ export const ProgramRegistryForm = React.memo(({ onCancel, onSubmit, editedObjec
   );
 });
 
-ProgramRegistryForm.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  editedObject: PropTypes.shape({}),
-};
+// ProgramRegistryForm.propTypes = {
+//   onSubmit: PropTypes.func.isRequired,
+//   onCancel: PropTypes.func.isRequired,
+//   editedObject: PropTypes.shape({}),
+// };
 
-ProgramRegistryForm.defaultProps = {
-  editedObject: null,
-};
+// ProgramRegistryForm.defaultProps = {
+//   editedObject: null,
+// };

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryForm.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryForm.js
@@ -127,12 +127,12 @@ export const ProgramRegistryForm = React.memo(({ onCancel, onSubmit, editedObjec
   );
 });
 
-// ProgramRegistryForm.propTypes = {
-//   onSubmit: PropTypes.func.isRequired,
-//   onCancel: PropTypes.func.isRequired,
-//   editedObject: PropTypes.shape({}),
-// };
+ProgramRegistryForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  editedObject: PropTypes.shape({}),
+};
 
-// ProgramRegistryForm.defaultProps = {
-//   editedObject: null,
-// };
+ProgramRegistryForm.defaultProps = {
+  editedObject: null,
+};

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryFormHistory.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryFormHistory.js
@@ -58,7 +58,7 @@ export const ProgramRegistryFormHistory = ({ programRegistry, patient }) => {
   );
 };
 
-ProgramRegistryFormHistory.prototype = {
+ProgramRegistryFormHistory.propTypes = {
   patient: PropTypes.shape({
     id: PropTypes.string,
   }),

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryFormHistory.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryFormHistory.js
@@ -66,3 +66,8 @@ ProgramRegistryFormHistory.propTypes = {
     id: PropTypes.string,
   }),
 };
+
+ProgramRegistryFormHistory.defaultProps = {
+  patient: null,
+  programRegistry: null,
+};

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryListItem.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryListItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Tooltip } from '@material-ui/core';
+import { usePatientNavigation } from '../../utils/usePatientNavigation';
 
 const Spacer = styled.div`
   display: flex;
@@ -30,10 +31,11 @@ const StatusInactiveDot = styled.div`
   margin: 0px 5px;
 `;
 
-export const ProgramRegistryListItem = ({ item, handleRowClick, ListItem }) => {
+export const ProgramRegistryListItem = ({ item, ListItem }) => {
   const { id, name, status, clinicalStatus } = item;
+  const { navigateToProgramRegistry } = usePatientNavigation();
   return (
-    <ListItem onClick={() => handleRowClick(id)}>
+    <ListItem onClick={() => navigateToProgramRegistry(id, name)}>
       <Spacer>
         <RowContents>
           <Tooltip title={status} arrow placement="top-end">

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ProgramRegistryView = () => {
+  return <div>ProgramRegistryView</div>;
+};

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { CircularProgress } from '@material-ui/core';
 import { Colors } from '../../constants';
 import { useUrlQueryParams } from '../../hooks';
 import { DisplayPatientRegDetails } from './DisplayPatientRegDetails';
 import { ProgramRegistryStatusHistory } from './ProgramRegistryStatusHistory';
+import { usePatientProgramRegistry } from '../../api/queries/usePatientProgramRegistry';
 
 const ViewHeader = styled.div`
   background-color: ${Colors.white};
@@ -52,45 +55,54 @@ const StatusInactiveDot = styled.div`
 `;
 export const ProgramRegistryView = () => {
   const queryParams = useUrlQueryParams();
-  return (
-    <>
-      <ViewHeader>
-        <h1>{queryParams.get('title')}</h1>
-        <StatusDiv>
-          <StatusActiveDot />
-          <span>Active</span>
-        </StatusDiv>
-      </ViewHeader>
-      <Container>
-        <Row>
-          <DisplayPatientRegDetails
-            patientProgramRegistration={{
-              date: '2023-08-28T02:40:16.237Z',
-              programRegistryClinicalStatusId: '123123',
-              programRegistryClinicalStatus: {
-                id: '123123',
-                code: 'low_risk',
-                name: 'Low risk',
-                color: 'green',
-              },
-              clinicianId: '213123',
-              clinician: {
-                id: '213123',
-                displayName: 'Alaister',
-              },
-              removedById: '213123',
-              removedBy: {
-                id: '213123',
-                displayName: 'Alaister',
-              },
-              registrationStatus: 'removed',
-            }}
-          />
-        </Row>
-        <Row>
-          <ProgramRegistryStatusHistory />
-        </Row>
-      </Container>
-    </>
-  );
+  const params = useParams();
+  const title = queryParams.get('title');
+  const programRegistryId = params.id;
+
+  const { data, isLoading, isError } = usePatientProgramRegistry(programRegistryId);
+
+  if (isLoading) return <CircularProgress size="5rem" />;
+  else if (isError) return <p>Program registry '{title}' not found.</p>;
+  else
+    return (
+      <>
+        <ViewHeader>
+          <h1></h1>
+          <StatusDiv>
+            <StatusActiveDot />
+            <span>Active</span>
+          </StatusDiv>
+        </ViewHeader>
+        <Container>
+          <Row>
+            <DisplayPatientRegDetails
+              patientProgramRegistration={{
+                date: '2023-08-28T02:40:16.237Z',
+                programRegistryClinicalStatusId: '123123',
+                programRegistryClinicalStatus: {
+                  id: '123123',
+                  code: 'low_risk',
+                  name: 'Low risk',
+                  color: 'green',
+                },
+                clinicianId: '213123',
+                clinician: {
+                  id: '213123',
+                  displayName: 'Alaister',
+                },
+                removedById: '213123',
+                removedBy: {
+                  id: '213123',
+                  displayName: 'Alaister',
+                },
+                registrationStatus: 'removed',
+              }}
+            />
+          </Row>
+          <Row>
+            <ProgramRegistryStatusHistory />
+          </Row>
+        </Container>
+      </>
+    );
 };

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
@@ -1,5 +1,96 @@
 import React from 'react';
+import styled from 'styled-components';
+import { Colors } from '../../constants';
+import { useUrlQueryParams } from '../../hooks';
+import { DisplayPatientRegDetails } from './DisplayPatientRegDetails';
+import { ProgramRegistryStatusHistory } from './ProgramRegistryStatusHistory';
 
+const ViewHeader = styled.div`
+  background-color: ${Colors.white};
+  border-bottom: 1px solid ${Colors.softOutline};
+  padding: 20px 30px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  h1 {
+    margin: 0px;
+    font-weight: 500;
+    font-size: 16px;
+  }
+`;
+
+const Container = styled.div`
+  margin: 20px 20px;
+  // display: flex;
+  // flex-direction: column;
+  // justify-content: space-between;
+  // align-items: center;
+`;
+const Row = styled.div`
+  margin: 20px 0px;
+`;
+const StatusDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+`;
+const StatusActiveDot = styled.div`
+  background-color: green;
+  height: 10px;
+  width: 10px;
+  border-radius: 10px;
+  margin: 0px 5px;
+`;
+const StatusInactiveDot = styled.div`
+  background-color: lightGray;
+  height: 10px;
+  width: 10px;
+  border-radius: 10px;
+  margin: 0px 5px;
+`;
 export const ProgramRegistryView = () => {
-  return <div>ProgramRegistryView</div>;
+  const queryParams = useUrlQueryParams();
+  return (
+    <>
+      <ViewHeader>
+        <h1>{queryParams.get('title')}</h1>
+        <StatusDiv>
+          <StatusActiveDot />
+          <span>Active</span>
+        </StatusDiv>
+      </ViewHeader>
+      <Container>
+        <Row>
+          <DisplayPatientRegDetails
+            patientProgramRegistration={{
+              date: '2023-08-28T02:40:16.237Z',
+              programRegistryClinicalStatusId: '123123',
+              programRegistryClinicalStatus: {
+                id: '123123',
+                code: 'low_risk',
+                name: 'Low risk',
+                color: 'green',
+              },
+              clinicianId: '213123',
+              clinician: {
+                id: '213123',
+                displayName: 'Alaister',
+              },
+              removedById: '213123',
+              removedBy: {
+                id: '213123',
+                displayName: 'Alaister',
+              },
+              registrationStatus: 'removed',
+            }}
+          />
+        </Row>
+        <Row>
+          <ProgramRegistryStatusHistory />
+        </Row>
+      </Container>
+    </>
+  );
 };

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryView.js
@@ -67,28 +67,28 @@ export const ProgramRegistryView = () => {
   const { data, isLoading, isError } = usePatientProgramRegistry(patientId, programRegistryId);
 
   if (isLoading) return <CircularProgress size="5rem" />;
-  else if (isError) return <p>Program registry '{title || 'Unknown'}' not found.</p>;
-  else
-    return (
-      <>
-        <ViewHeader>
-          <h1>{title || data.name}</h1>
-          <StatusDiv>
-            <StatusActiveDot />
-            <b>{getFirstCharUpperCase(data.registrationStatus)}</b>
-          </StatusDiv>
-        </ViewHeader>
-        <Container>
-          <Row>
-            <DisplayPatientRegDetails patientProgramRegistration={data} />
-          </Row>
-          <Row>
-            <ProgramRegistryStatusHistory programRegistry={data} />
-          </Row>
-          <Row>
-            <ProgramRegistryFormHistory programRegistry={data} patient={{ id: patientId }} />
-          </Row>
-        </Container>
-      </>
-    );
+  if (isError) return <p>Program registry &apos;{title || 'Unknown'}&apos; not found.</p>;
+
+  return (
+    <>
+      <ViewHeader>
+        <h1>{title || data.name}</h1>
+        <StatusDiv>
+          {data.registrationStatus === 'active' ? <StatusActiveDot /> : <StatusInactiveDot />}
+          <b>{getFirstCharUpperCase(data.registrationStatus)}</b>
+        </StatusDiv>
+      </ViewHeader>
+      <Container>
+        <Row>
+          <DisplayPatientRegDetails patientProgramRegistration={data} />
+        </Row>
+        <Row>
+          <ProgramRegistryStatusHistory programRegistry={data} />
+        </Row>
+        <Row>
+          <ProgramRegistryFormHistory programRegistry={data} patient={{ id: patientId }} />
+        </Row>
+      </Container>
+    </>
+  );
 };

--- a/packages/desktop/stories/programRegistry.stories.js
+++ b/packages/desktop/stories/programRegistry.stories.js
@@ -15,6 +15,7 @@ import { DisplayPatientRegDetails } from '../app/views/programRegistry/DisplayPa
 import { ProgramRegistryStatusHistory } from '../app/views/programRegistry/ProgramRegistryStatusHistory';
 import { DeleteProgramRegistry } from '../app/views/programRegistry/DeleteProgramRegistry';
 import { ActivateProgramRegistryFormModal } from '../app/views/programRegistry/ActivateProgramRegistryFormModal';
+import { ProgramRegistryView } from '../app/views/programRegistry/ProgramRegistryView';
 
 function sleep(milliseconds) {
   return new Promise(resolve => {
@@ -80,7 +81,7 @@ const programRegistriesForInfoPaneList = [
   },
 ];
 
-const patient = { id: '323r2r234r' };
+const patient = { id: 'patient_id' };
 const programRegistry1 = {
   data: {
     id: '1',
@@ -349,7 +350,7 @@ const dummyApi = {
     switch (endpoint) {
       case 'programRegistration/program_registry_id/clinicalStatuses':
         return getSortedData(programRegistryStatusHistories, options);
-      case '/patient/23242234234/programRegistration/23242234234/surveyResponses':
+      case '/patient/patient_id/programRegistration/1/surveyResponses':
         return getSortedData(programRegistryFormHistory, options);
       case 'suggestions/facility':
         return facilities;
@@ -365,7 +366,7 @@ const dummyApi = {
         return programRegistry2;
       case 'programRegistry/3':
         return programRegistry3;
-      case 'patient/323r2r234r/program-registry':
+      case 'patient/patient_id/program-registry':
         return { data: programRegistriesForInfoPaneList };
     }
   },
@@ -424,7 +425,21 @@ storiesOf('Program Registry', module).add('DisplayPatientRegDetails Low risk', (
 storiesOf('Program Registry', module).add('DisplayPatientRegDetails Critical', () => (
   <div style={{ width: '797px' }}>
     <DisplayPatientRegDetails
-      patientProgramRegistration={{ ...patientProgramRegistration, registrationStatus: 'removed' }}
+      patientProgramRegistration={{
+        ...patientProgramRegistration,
+        removedById: '213123',
+        removedBy: {
+          id: '213123',
+          displayName: 'Alaister',
+        },
+        programRegistryClinicalStatus: {
+          id: '123123',
+          code: 'critical',
+          name: 'Critical',
+          color: 'red',
+        },
+        registrationStatus: 'removed',
+      }}
     />
   </div>
 ));
@@ -434,6 +449,11 @@ storiesOf('Program Registry', module).add('DisplayPatientRegDetails Needs review
     <DisplayPatientRegDetails
       patientProgramRegistration={{
         ...patientProgramRegistration,
+        removedById: '213123',
+        removedBy: {
+          id: '213123',
+          displayName: 'Alaister',
+        },
         programRegistryClinicalStatus: {
           id: '123123',
           code: 'needs_review',
@@ -475,14 +495,7 @@ storiesOf('Program Registry', module).add('ProgramRegistryStatusHistory removed 
 
 storiesOf('Program Registry', module).add('ProgramRegistryFormHistory', () => (
   <ApiContext.Provider value={dummyApi}>
-    <ProgramRegistryFormHistory
-      programRegistry={{
-        id: '23242234234',
-      }}
-      patient={{
-        id: '23242234234',
-      }}
-    />
+    <ProgramRegistryFormHistory programRegistry={programRegistry1.data} patient={patient} />
   </ApiContext.Provider>
 ));
 //#endregion ProgramRegistryFormHistory
@@ -531,6 +544,10 @@ storiesOf('Program Registry', module).add('ActivateProgramRegistryFormModal', ()
 ));
 //#endregion
 
-//#region
-// storiesOf('Program Registry', module).add('ProgramRegistryView', () => <ProgramRegistryView />);
-//#endregion
+//#region ProgramRegistryView
+storiesOf('Program Registry', module).add('ProgramRegistryView', () => (
+  <ApiContext.Provider value={dummyApi}>
+    <ProgramRegistryView />
+  </ApiContext.Provider>
+));
+//#endregion ProgramRegistryView

--- a/packages/desktop/stories/programRegistry.stories.js
+++ b/packages/desktop/stories/programRegistry.stories.js
@@ -1,9 +1,10 @@
+// @ts-check
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { ChangeStatusFormModal } from '../app/views/programRegistry/ChangeStatusFormModal';
 import { ApiContext } from '../app/api';
-import { MockedApi } from './utils/mockedApi';
 import { Modal } from '../app/components/Modal';
 import { PROGRAM_REGISTRY } from '../app/components/PatientInfoPane/paneTitles';
 import { InfoPaneList } from '../app/components/PatientInfoPane/InfoPaneList';
@@ -15,8 +16,32 @@ import { ProgramRegistryStatusHistory } from '../app/views/programRegistry/Progr
 import { DeleteProgramRegistry } from '../app/views/programRegistry/DeleteProgramRegistry';
 import { ActivateProgramRegistryFormModal } from '../app/views/programRegistry/ActivateProgramRegistryFormModal';
 
-//#region InfoPaneList
-const dummyProgramRegistriesForInfoPaneList = [
+function sleep(milliseconds) {
+  return new Promise(resolve => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+const getSortedData = (
+  list = [],
+  options = { page: 0, orderBy: '', order: 'asc', rowsPerPage: 10 },
+) => {
+  const sortedData =
+    options.order && options.orderBy
+      ? list.sort(({ [options.orderBy]: a }, { [options.orderBy]: b }) => {
+          if (typeof a === 'string') {
+            return options.order === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
+          }
+          return options.order === 'asc' ? a - b : b - a;
+        })
+      : list;
+  const startIndex = options.page * options.rowsPerPage || 0;
+  const endIndex = startIndex + options.rowsPerPage ? options.rowsPerPage : sortedData.length;
+  return {
+    data: sortedData.slice(startIndex, endIndex),
+    count: list.length,
+  };
+};
+const programRegistriesForInfoPaneList = [
   {
     id: '1',
     name: 'Seasonal fever',
@@ -54,173 +79,48 @@ const dummyProgramRegistriesForInfoPaneList = [
     clinicalStatus: 'Low risk',
   },
 ];
-const dummyApiForInfoPaneList = {
-  get: async endpoint => {
-    await sleep(1000);
-    return {
-      data: dummyProgramRegistriesForInfoPaneList,
-    };
+
+const patient = { id: '323r2r234r' };
+const programRegistry1 = {
+  data: {
+    id: '1',
+    name: 'Hepatitis B',
+    currentlyAtType: 'facility',
   },
 };
-storiesOf('Program Registry', module).add('ProgramRegistry Info Panlist', () => {
-  const patient = { id: '323r2r234r' };
-  return (
-    <MockedApi endpoints={mockProgramRegistrytFormEndpoints}>
-      <ApiContext.Provider value={dummyApiForInfoPaneList}>
-        <div style={{ width: '250px', backgroundColor: 'white', padding: '10px' }}>
-          <InfoPaneList
-            patient={patient}
-            readonly={false}
-            title={PROGRAM_REGISTRY}
-            endpoint="programRegistry"
-            getEndpoint={`patient/${patient.id}/program-registry`}
-            Form={ProgramRegistryForm}
-            ListItemComponent={ProgramRegistryListItem}
-            getName={programRegistry => programRegistry.name}
-            behavior="modal"
-            itemTitle="Add program registry"
-            getEditFormName={programRegistry => `Program registry: ${programRegistry.name}`}
-          />
-        </div>
-      </ApiContext.Provider>
-    </MockedApi>
-  );
-});
-//#endregion InfoPaneList
-
-//#region ProgramRegistryForm
-const mockProgramRegistrytFormEndpoints = {
-  'program/1': () => ({
-    data: {
-      id: '1',
-      currentlyAtType: 'facility',
-    },
-  }),
-  'program/2': () => ({
-    data: {
-      id: '2',
-      currentlyAtType: 'facility',
-    },
-  }),
-  'program/3': () => ({
-    data: {
-      id: '3',
-      currentlyAtType: 'village',
-    },
-  }),
-  'suggestions/program': () => [
-    { id: '1', name: 'Arm' },
-    { id: '2', name: 'Leg' },
-    { id: '3', name: 'Shoulder' },
-  ],
-  'suggestions/facility': () => [
-    { id: '1', name: 'Hospital 1' },
-    { id: '2', name: 'Hospital 2' },
-  ],
-  'suggestions/practitioner': () => [
-    { id: 'test-user-id', name: 'Test user id' },
-    { id: '2', name: 'Test user id 2' },
-  ],
+const programRegistry2 = {
+  data: {
+    id: '2',
+    name: 'Pneomonia',
+    currentlyAtType: 'facility',
+  },
+};
+const programRegistry3 = {
+  data: {
+    id: '3',
+    name: 'Diabetis',
+    currentlyAtType: 'village',
+  },
+};
+const programRegistries = [programRegistry1.data, programRegistry2.data, programRegistry3.data];
+const patientProgramRegistration = {
+  date: '2023-08-28T02:40:16.237Z',
+  programRegistryClinicalStatusId: '123123',
+  programRegistryClinicalStatus: {
+    id: '123123',
+    code: 'low_risk',
+    name: 'Low risk',
+    color: 'green',
+  },
+  clinicianId: '213123',
+  clinician: {
+    id: '213123',
+    displayName: 'Alaister',
+  },
+  registrationStatus: 'active',
 };
 
-storiesOf('Program Registry', module).add('ProgramRegistryFrom', () => (
-  <MockedApi endpoints={mockProgramRegistrytFormEndpoints}>
-    <Modal width="md" title="Add program registry" open>
-      <ProgramRegistryForm
-        onSubmit={action('submit')}
-        onCancel={action('cancel')}
-        patient={{ id: '323r2r234r' }}
-      />
-    </Modal>
-  </MockedApi>
-));
-
-//#endregion ProgramRegistryForm
-
-//#region DisplayPatientRegDetails
-storiesOf('Program Registry', module).add('DisplayPatientRegDetails Low risk', () => (
-  <div style={{ width: '797px' }}>
-    <DisplayPatientRegDetails
-      patientProgramRegistration={{
-        date: '2023-08-28T02:40:16.237Z',
-        programRegistryClinicalStatusId: '123123',
-        programRegistryClinicalStatus: {
-          id: '123123',
-          code: 'low_risk',
-          name: 'Low risk',
-          color: 'green',
-        },
-        clinicianId: '213123',
-        clinician: {
-          id: '213123',
-          displayName: 'Alaister',
-        },
-        registrationStatus: 'active',
-      }}
-    />
-  </div>
-));
-
-storiesOf('Program Registry', module).add('DisplayPatientRegDetails Critical', () => (
-  <div style={{ width: '797px' }}>
-    <DisplayPatientRegDetails
-      patientProgramRegistration={{
-        date: '2023-08-28T02:40:16.237Z',
-        programRegistryClinicalStatusId: '123123',
-        programRegistryClinicalStatus: {
-          id: '123123',
-          code: 'critical',
-          name: 'Critical',
-          color: 'red',
-        },
-        clinicianId: '213123',
-        clinician: {
-          id: '213123',
-          displayName: 'Alaister',
-        },
-        removedById: '213123',
-        removedBy: {
-          id: '213123',
-          displayName: 'Alaister',
-        },
-        registrationStatus: 'removed',
-      }}
-    />
-  </div>
-));
-
-storiesOf('Program Registry', module).add('DisplayPatientRegDetails Needs review', () => (
-  <div style={{ width: '797px' }}>
-    <DisplayPatientRegDetails
-      patientProgramRegistration={{
-        date: '2023-08-28T02:40:16.237Z',
-        programRegistryClinicalStatusId: '123123',
-        programRegistryClinicalStatus: {
-          id: '123123',
-          code: 'needs_review',
-          name: 'Needs review',
-          color: 'yellow',
-        },
-        clinicianId: '213123',
-        clinician: {
-          id: '213123',
-          displayName: 'Alaister',
-        },
-        removedById: '213123',
-        removedBy: {
-          id: '213123',
-          displayName: 'Alaister',
-        },
-        registrationStatus: 'removed',
-      }}
-    />
-  </div>
-));
-//#endregion DisplayPatientRegDetails
-
-//#region ProgramRegistryStatusHistory
-
-const dummyDataForProgramRegistryStatusHistory = [
+const programRegistryStatusHistories = [
   {
     id: '1',
     registrationStatus: 'active',
@@ -325,53 +225,7 @@ const dummyDataForProgramRegistryStatusHistory = [
   },
 ];
 
-const dummyApiForProgramRegistryStatusHistory = {
-  get: async (endpoint, options) => {
-    await sleep(5000);
-    const sortedData =
-      options.order && options.orderBy
-        ? dummyDataForProgramRegistryStatusHistory.sort(
-            ({ [options.orderBy]: a }, { [options.orderBy]: b }) => {
-              if (typeof a === 'string') {
-                return options.order === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
-              }
-              return options.order === 'asc' ? a - b : b - a;
-            },
-          )
-        : sortedData;
-    const startIndex = options.page * options.rowsPerPage || 0;
-    const endIndex = startIndex + options.rowsPerPage ? options.rowsPerPage : sortedData.length;
-    return {
-      data: sortedData.slice(startIndex, endIndex),
-      count: dummyDataForProgramRegistryStatusHistory.length,
-    };
-  },
-};
-storiesOf('Program Registry', module).add('ProgramRegistryStatusHistory removed never', () => (
-  <ApiContext.Provider value={dummyApiForProgramRegistryStatusHistory}>
-    <ProgramRegistryStatusHistory
-      programRegistry={{
-        id: '23242234234',
-      }}
-    />
-  </ApiContext.Provider>
-));
-
-storiesOf('Program Registry', module).add('ProgramRegistryStatusHistory removed once', () => (
-  <ApiContext.Provider value={dummyApiForProgramRegistryStatusHistory}>
-    <ProgramRegistryStatusHistory
-      programRegistry={{
-        id: '23242234234',
-      }}
-    />
-  </ApiContext.Provider>
-));
-
-//#endregion ProgramRegistryStatusHistory
-
-//#region ProgramRegistryFormHistory
-
-const dummyDataForProgramRegistryFormHistory = [
+const programRegistryFormHistory = [
   {
     id: 1,
     endTime: '2023-09-07 15:54:00',
@@ -471,35 +325,156 @@ const dummyDataForProgramRegistryFormHistory = [
     resultText: '4687',
   },
 ];
-function sleep(milliseconds) {
-  return new Promise(resolve => {
-    setTimeout(resolve, milliseconds);
-  });
-}
 
-const dummyApiForProgramRegistryFormHistory = {
-  get: async (endpoint, { order, orderBy, page, rowsPerPage }) => {
+const facilities = [
+  { id: '1', name: 'Hospital 1' },
+  { id: '2', name: 'Hospital 2' },
+];
+
+const practitioners = [
+  { id: 'test-user-id', name: 'Test user id' },
+  { id: '2', name: 'Test user id 2' },
+];
+
+const programRegistryClinicalStatusList = [
+  { id: '1', name: 'Low risk', color: 'green' },
+  { id: '2', name: 'Needs review', color: 'yellow' },
+  { id: '3', name: 'Critical', color: 'red' },
+];
+
+const dummyApi = {
+  get: async (endpoint, options) => {
     console.log(endpoint);
-    await sleep(1000);
-    const sortedData = dummyDataForProgramRegistryFormHistory.sort(
-      ({ [orderBy]: a }, { [orderBy]: b }) => {
-        if (typeof a === 'string') {
-          return order === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
-        }
-        return order === 'asc' ? a - b : b - a;
-      },
-    );
-    const startIndex = page * rowsPerPage;
-    const endIndex = startIndex + rowsPerPage;
-
-    return {
-      data: sortedData.slice(startIndex, endIndex),
-      count: dummyDataForProgramRegistryFormHistory.length,
-    };
+    await sleep(500);
+    switch (endpoint) {
+      case 'programRegistration/program_registry_id/clinicalStatuses':
+        return getSortedData(programRegistryStatusHistories, options);
+      case '/patient/23242234234/programRegistration/23242234234/surveyResponses':
+        return getSortedData(programRegistryFormHistory, options);
+      case 'suggestions/facility':
+        return facilities;
+      case 'suggestions/practitioner':
+        return practitioners;
+      case 'suggestions/programRegistryClinicalStatus':
+        return programRegistryClinicalStatusList;
+      case 'suggestions/programRegistries':
+        return programRegistries;
+      case 'programRegistry/1':
+        return programRegistry1;
+      case 'programRegistry/2':
+        return programRegistry2;
+      case 'programRegistry/3':
+        return programRegistry3;
+      case 'patient/323r2r234r/program-registry':
+        return { data: programRegistriesForInfoPaneList };
+    }
   },
 };
+
+//#region InfoPaneList
+
+storiesOf('Program Registry', module).add('ProgramRegistry Info Panlist', () => {
+  return (
+    <ApiContext.Provider value={dummyApi}>
+      <div style={{ width: '250px', backgroundColor: 'white', padding: '10px' }}>
+        <InfoPaneList
+          patient={patient}
+          readonly={false}
+          title={PROGRAM_REGISTRY}
+          endpoint="programRegistry"
+          getEndpoint={`patient/${patient.id}/program-registry`}
+          Form={ProgramRegistryForm}
+          ListItemComponent={ProgramRegistryListItem}
+          getName={programRegistry => programRegistry.name}
+          behavior="modal"
+          itemTitle="Add program registry"
+          getEditFormName={programRegistry => `Program registry: ${programRegistry.name}`}
+        />
+      </div>
+    </ApiContext.Provider>
+  );
+});
+//#endregion InfoPaneList
+
+//#region ProgramRegistryForm
+
+storiesOf('Program Registry', module).add('ProgramRegistryFrom', () => (
+  // <MockedApi endpoints={mockProgramRegistrytFormEndpoints}>
+  //     </MockedApi>
+  <ApiContext.Provider value={dummyApi}>
+    <Modal width="md" title="Add program registry" open>
+      <ProgramRegistryForm
+        onSubmit={action('submit')}
+        onCancel={action('cancel')}
+        patient={patient}
+      />
+    </Modal>
+  </ApiContext.Provider>
+));
+
+//#endregion ProgramRegistryForm
+
+//#region DisplayPatientRegDetails
+storiesOf('Program Registry', module).add('DisplayPatientRegDetails Low risk', () => (
+  <div style={{ width: '797px' }}>
+    <DisplayPatientRegDetails patientProgramRegistration={patientProgramRegistration} />
+  </div>
+));
+
+storiesOf('Program Registry', module).add('DisplayPatientRegDetails Critical', () => (
+  <div style={{ width: '797px' }}>
+    <DisplayPatientRegDetails
+      patientProgramRegistration={{ ...patientProgramRegistration, registrationStatus: 'removed' }}
+    />
+  </div>
+));
+
+storiesOf('Program Registry', module).add('DisplayPatientRegDetails Needs review', () => (
+  <div style={{ width: '797px' }}>
+    <DisplayPatientRegDetails
+      patientProgramRegistration={{
+        ...patientProgramRegistration,
+        programRegistryClinicalStatus: {
+          id: '123123',
+          code: 'needs_review',
+          name: 'Needs review',
+          color: 'yellow',
+        },
+        registrationStatus: 'removed',
+      }}
+    />
+  </div>
+));
+//#endregion DisplayPatientRegDetails
+
+//#region ProgramRegistryStatusHistory
+
+storiesOf('Program Registry', module).add('ProgramRegistryStatusHistory removed never', () => (
+  <ApiContext.Provider value={dummyApi}>
+    <ProgramRegistryStatusHistory
+      programRegistry={{
+        id: 'program_registry_id',
+      }}
+    />
+  </ApiContext.Provider>
+));
+
+storiesOf('Program Registry', module).add('ProgramRegistryStatusHistory removed once', () => (
+  <ApiContext.Provider value={dummyApi}>
+    <ProgramRegistryStatusHistory
+      programRegistry={{
+        id: 'program_registry_id',
+      }}
+    />
+  </ApiContext.Provider>
+));
+
+//#endregion ProgramRegistryStatusHistory
+
+//#region ProgramRegistryFormHistory
+
 storiesOf('Program Registry', module).add('ProgramRegistryFormHistory', () => (
-  <ApiContext.Provider value={dummyApiForProgramRegistryFormHistory}>
+  <ApiContext.Provider value={dummyApi}>
     <ProgramRegistryFormHistory
       programRegistry={{
         id: '23242234234',
@@ -513,24 +488,17 @@ storiesOf('Program Registry', module).add('ProgramRegistryFormHistory', () => (
 //#endregion ProgramRegistryFormHistory
 
 //#region ChangeStatusFormModal
-const mockProgramRegistrytFormEndpointsForChangeStatusFormModal = {
-  'suggestions/programRegistryClinicalStatus': () => [
-    { id: '1', name: 'current' },
-    { id: '2', name: 'historical' },
-    { id: '3', name: 'merged' },
-  ],
-};
 
-storiesOf('Program Registry', module).add('ProgramRegistry Status Cahnge', () => {
+storiesOf('Program Registry', module).add('ProgramRegistry Status Change', () => {
   return (
-    <MockedApi endpoints={mockProgramRegistrytFormEndpointsForChangeStatusFormModal}>
+    <ApiContext.Provider value={dummyApi}>
       <ChangeStatusFormModal
         onSubmit={action('submit')}
         onCancel={action('cancel')}
         program={{ id: '3e2r23r23r', programRegistryClinicalStatusId: '1' }}
         patient={{ id: '3e2r23r23r' }}
       />
-    </MockedApi>
+    </ApiContext.Provider>
   );
 });
 
@@ -549,31 +517,20 @@ storiesOf('Program Registry', module).add('ProgramRegistry Delete Modal', () => 
 //#endregion DeleteProgramRegistry
 
 //#region
-const mockProgramRegistrytFormEndpointsForActivateProgramRegistryFormModal = {
-  'suggestions/facility': () => [
-    { id: '1', name: 'Hospital 1' },
-    { id: '2', name: 'Hospital 2' },
-  ],
-  'suggestions/practitioner': () => [
-    { id: 'test-user-id', name: 'Test user id' },
-    { id: '2', name: 'Test user id 2' },
-  ],
-  'suggestions/programRegistryClinicalStatus': () => [
-    { id: '1', name: 'current' },
-    { id: '2', name: 'historical' },
-    { id: '3', name: 'merged' },
-  ],
-};
 
 storiesOf('Program Registry', module).add('ActivateProgramRegistryFormModal', () => (
-  <MockedApi endpoints={mockProgramRegistrytFormEndpointsForActivateProgramRegistryFormModal}>
+  <ApiContext.Provider value={dummyApi}>
     <ActivateProgramRegistryFormModal
       onSubmit={action('submit')}
       onCancel={action('cancel')}
-      patient={{ id: '323r2r234r' }}
+      patient={patient}
       program={{ id: 'asdasdasdasd', programRegistryClinicalStatusId: '2', name: 'Hepatitis B' }}
       open
     />
-  </MockedApi>
+  </ApiContext.Provider>
 ));
+//#endregion
+
+//#region
+// storiesOf('Program Registry', module).add('ProgramRegistryView', () => <ProgramRegistryView />);
 //#endregion

--- a/packages/desktop/stories/programRegistry.stories.js
+++ b/packages/desktop/stories/programRegistry.stories.js
@@ -577,3 +577,7 @@ storiesOf('Program Registry', module).add('ActivateProgramRegistryFormModal', ()
   </MockedApi>
 ));
 //#endregion
+
+//#region
+storiesOf('Program Registry', module).add('ProgramRegistryView', () => <ProgramRegistryView />);
+//#endregion


### PR DESCRIPTION
### Changes
![Screenshot 2023-09-14 at 10 30 01 AM](https://github.com/beyondessential/tamanu/assets/4245521/23fc6fba-a9d3-45d8-ac8f-1cd97b7c8776)

- Create new patient program registry screen 

- Hook up screen to navigation of app 

- End results - can navigate to and from registry dashboard but won't have any content

- The left side of the header will display the program registry name

- The right side of the banner will display the registration status for the patient. I.e. Active (with green icon displayed) or Removed (with grey icon displayed).


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
