### PR TITLE
SAV-432: Merge patient birth data into 1 when merging patients

### DIFF
--- a/packages/sync-server/__tests__/admin/patientMerge.test.js
+++ b/packages/sync-server/__tests__/admin/patientMerge.test.js
@@ -434,7 +434,7 @@ describe('Patient merge', () => {
       );
     });
 
-    it('merges patient birth data even if the keep patient birth data is null', async () => {
+    it('merges Patient Birth Data even if the keep Patient Birth Data is null', async () => {
       const { PatientBirthData } = models;
       const [keep, merge] = await makeTwoPatients();
 
@@ -458,7 +458,7 @@ describe('Patient merge', () => {
       expect(newKeepPatientBirthData).toHaveProperty('patientId', keep.id);
     });
 
-    it('keeps birth data from the keep patient and fill unknown values from merge patient', async () => {
+    it('keeps Patient Birth Data from the keep patient and fill unknown values from merge patient', async () => {
       const { PatientBirthData } = models;
       const [keep, merge] = await makeTwoPatients();
 

--- a/packages/sync-server/__tests__/admin/patientMerge.test.js
+++ b/packages/sync-server/__tests__/admin/patientMerge.test.js
@@ -354,7 +354,7 @@ describe('Patient merge', () => {
       const systemFact = await LocalSystemFact.findOne({ where: { key: 'currentSyncTick' } });
       await systemFact.update({ value: 2 });
 
-     // Create merge PAD second, so it would be preferred under sync logic (but NOT under merge logic)
+      // Create merge PAD second, so it would be preferred under sync logic (but NOT under merge logic)
       await PatientAdditionalData.create({
         patientId: merge.id,
         passport: 'merge-passport',
@@ -366,6 +366,128 @@ describe('Patient merge', () => {
         paranoid: false,
       });
       expect(newKeepPatientPad).toHaveProperty('passport', 'keep-passport');
+    });
+  });
+
+  describe('PatientBirthData', () => {
+    it('deletes both PatientBirthData records and generate a new one', async () => {
+      const { PatientBirthData } = models;
+      const [keep, merge] = await makeTwoPatients();
+      const oldKeepPatientBirthData = await PatientBirthData.create({
+        patientId: keep.id,
+        birthWeight: 5,
+      });
+      await PatientBirthData.create({
+        patientId: merge.id,
+        birthWeight: 7,
+      });
+      const oldKeepPatientBirthDataCreatedAt = oldKeepPatientBirthData.createdAt;
+
+      const { updates } = await mergePatient(models, keep.id, merge.id);
+      expect(updates).toEqual({
+        Patient: 2,
+        PatientBirthData: 1,
+      });
+
+      const newKeepPatientBirthData = await PatientBirthData.findOne({
+        where: { patientId: keep.id },
+        paranoid: false,
+      });
+      const newMergePatientPa = await PatientBirthData.findOne({
+        where: { patientId: merge.id },
+        paranoid: false,
+      });
+
+      expect(newMergePatientPa).toEqual(null);
+      expect(newKeepPatientBirthData.createdAt).not.toBe(oldKeepPatientBirthDataCreatedAt);
+      expect(newKeepPatientBirthData).toHaveProperty('deletedAt', null);
+    });
+
+    it('merges Patient Birth Data cleanly', async () => {
+      const { PatientBirthData } = models;
+      const [keep, merge] = await makeTwoPatients();
+
+      const keepPatientBirthData = await PatientBirthData.create({
+        patientId: keep.id,
+        birthWeight: 5,
+      });
+
+      const mergePatientBirthData = await PatientBirthData.create({
+        patientId: merge.id,
+        birthLength: 6,
+      });
+
+      await mergePatient(models, keep.id, merge.id);
+
+      const newKeepPatientBirthData = await PatientBirthData.findOne({
+        where: { patientId: keep.id },
+        paranoid: false,
+      });
+
+      expect(newKeepPatientBirthData).toHaveProperty(
+        'birthWeight',
+        keepPatientBirthData.birthWeight,
+      );
+      expect(newKeepPatientBirthData).toHaveProperty(
+        'birthLength',
+        mergePatientBirthData.birthLength,
+      );
+    });
+
+    it('merges patient birth data even if the keep patient birth data is null', async () => {
+      const { PatientBirthData } = models;
+      const [keep, merge] = await makeTwoPatients();
+
+      await PatientBirthData.create({
+        patientId: keep.id,
+      });
+
+      const mergePatientBirthData = await PatientBirthData.create({
+        patientId: merge.id,
+        birthWeight: 5,
+      });
+
+      await mergePatient(models, keep.id, merge.id);
+
+      const newKeepPatientPad = await PatientBirthData.findOne({
+        where: { patientId: keep.id },
+        paranoid: false,
+      });
+
+      expect(newKeepPatientPad).toHaveProperty('birthWeight', mergePatientBirthData.birthWeight);
+      expect(newKeepPatientPad).toHaveProperty('patientId', keep.id);
+    });
+
+    it('keeps birth data from the keep patient and fill unknown values from merge patient', async () => {
+      const { PatientBirthData } = models;
+      const [keep, merge] = await makeTwoPatients();
+
+      const keepPatientBirthData = await PatientBirthData.create({
+        patientId: keep.id,
+        birthWeight: 3,
+        birthLength: 20,
+        gestationalAgeEstimate: 6,
+      });
+
+      const mergePatientBirthData = await PatientBirthData.create({
+        patientId: merge.id,
+        birthWeight: 4,
+        apgarScoreOneMinute: 3,
+        apgarScoreFiveMinutes: 4,
+        apgarScoreTenMinutes: 5,
+      });
+
+      await mergePatient(models, keep.id, merge.id);
+
+      const newKeepPatientBirthData = await PatientBirthData.findOne({
+        where: { patientId: keep.id },
+        paranoid: false,
+      });
+
+      expect(newKeepPatientBirthData).toHaveProperty('birthWeight', keepPatientBirthData.birthWeight);
+      expect(newKeepPatientBirthData).toHaveProperty('apgarScoreOneMinute', mergePatientBirthData.apgarScoreOneMinute);
+      expect(newKeepPatientBirthData).toHaveProperty('apgarScoreFiveMinutes', mergePatientBirthData.apgarScoreFiveMinutes);
+      expect(newKeepPatientBirthData).toHaveProperty('apgarScoreTenMinutes', mergePatientBirthData.apgarScoreTenMinutes);
     });
   });
 

--- a/packages/sync-server/__tests__/admin/patientMerge.test.js
+++ b/packages/sync-server/__tests__/admin/patientMerge.test.js
@@ -449,13 +449,13 @@ describe('Patient merge', () => {
 
       await mergePatient(models, keep.id, merge.id);
 
-      const newKeepPatientPad = await PatientBirthData.findOne({
+      const newKeepPatientBirthData = await PatientBirthData.findOne({
         where: { patientId: keep.id },
         paranoid: false,
       });
 
-      expect(newKeepPatientPad).toHaveProperty('birthWeight', mergePatientBirthData.birthWeight);
-      expect(newKeepPatientPad).toHaveProperty('patientId', keep.id);
+      expect(newKeepPatientBirthData).toHaveProperty('birthWeight', mergePatientBirthData.birthWeight);
+      expect(newKeepPatientBirthData).toHaveProperty('patientId', keep.id);
     });
 
     it('keeps birth data from the keep patient and fill unknown values from merge patient', async () => {

--- a/packages/sync-server/__tests__/admin/patientMerge.test.js
+++ b/packages/sync-server/__tests__/admin/patientMerge.test.js
@@ -484,10 +484,22 @@ describe('Patient merge', () => {
         paranoid: false,
       });
 
-      expect(newKeepPatientBirthData).toHaveProperty('birthWeight', keepPatientBirthData.birthWeight);
-      expect(newKeepPatientBirthData).toHaveProperty('apgarScoreOneMinute', mergePatientBirthData.apgarScoreOneMinute);
-      expect(newKeepPatientBirthData).toHaveProperty('apgarScoreFiveMinutes', mergePatientBirthData.apgarScoreFiveMinutes);
-      expect(newKeepPatientBirthData).toHaveProperty('apgarScoreTenMinutes', mergePatientBirthData.apgarScoreTenMinutes);
+      expect(newKeepPatientBirthData).toHaveProperty(
+        'birthWeight',
+        keepPatientBirthData.birthWeight,
+      );
+      expect(newKeepPatientBirthData).toHaveProperty(
+        'apgarScoreOneMinute',
+        mergePatientBirthData.apgarScoreOneMinute,
+      );
+      expect(newKeepPatientBirthData).toHaveProperty(
+        'apgarScoreFiveMinutes',
+        mergePatientBirthData.apgarScoreFiveMinutes,
+      );
+      expect(newKeepPatientBirthData).toHaveProperty(
+        'apgarScoreTenMinutes',
+        mergePatientBirthData.apgarScoreTenMinutes,
+      );
     });
   });
 

--- a/packages/sync-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/sync-server/app/admin/patientMerge/mergePatient.js
@@ -161,6 +161,8 @@ export async function mergePatientBirthData(models, keepPatientId, unwantedPatie
     ...getMergedFieldsForUpdate(existingKeepPatientBirthData, existingUnwantedPatientBirthData),
     patientId: keepPatientId,
   };
+
+  // hard delete the old patient birth data, we're going to create a new one
   await models.PatientBirthData.destroy({
     where: { patientId: { [Op.in]: [keepPatientId, unwantedPatientId] } },
     force: true,

--- a/packages/sync-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/sync-server/app/admin/patientMerge/mergePatient.js
@@ -157,7 +157,7 @@ export async function mergePatientBirthData(models, keepPatientId, unwantedPatie
     where: { patientId: keepPatientId },
     raw: true,
   });
-  const mergedPAD = {
+  const mergedPatientBirthData = {
     ...getMergedFieldsForUpdate(existingKeepPatientBirthData, existingUnwantedPatientBirthData),
     patientId: keepPatientId,
   };
@@ -165,7 +165,7 @@ export async function mergePatientBirthData(models, keepPatientId, unwantedPatie
     where: { patientId: { [Op.in]: [keepPatientId, unwantedPatientId] } },
     force: true,
   });
-  return models.PatientBirthData.create(mergedPAD);
+  return models.PatientBirthData.create(mergedPatientBirthData);
 }
 
 export async function mergePatientFieldValues(models, keepPatientId, unwantedPatientId) {

--- a/packages/sync-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/sync-server/app/admin/patientMerge/mergePatient.js
@@ -314,7 +314,11 @@ export async function mergePatient(models, keepPatientId, unwantedPatientId) {
     }
 
     // Only keep 1 PatientBirthData
-    const updatedPatientBirthData = await mergePatientBirthData(models, keepPatientId, unwantedPatientId);
+    const updatedPatientBirthData = await mergePatientBirthData(
+      models,
+      keepPatientId,
+      unwantedPatientId,
+    );
     if (updatedPatientBirthData) {
       updates.PatientBirthData = 1;
     }

--- a/packages/sync-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/sync-server/app/admin/patientMerge/mergePatient.js
@@ -22,7 +22,6 @@ export const simpleUpdateModels = [
   'PatientCarePlan',
   'PatientCommunication',
   'PatientDeathData',
-  'PatientBirthData',
   'Appointment',
   'DocumentMetadata',
   'CertificateNotification',
@@ -36,6 +35,7 @@ export const simpleUpdateModels = [
 export const specificUpdateModels = [
   'Patient',
   'PatientAdditionalData',
+  'PatientBirthData',
   'Note',
   'PatientFacility',
   'PatientFieldValue',
@@ -145,6 +145,27 @@ export async function mergePatientAdditionalData(models, keepPatientId, unwanted
     force: true,
   });
   return models.PatientAdditionalData.create(mergedPAD);
+}
+
+export async function mergePatientBirthData(models, keepPatientId, unwantedPatientId) {
+  const existingUnwantedPatientBirthData = await models.PatientBirthData.findOne({
+    where: { patientId: unwantedPatientId },
+    raw: true,
+  });
+  if (!existingUnwantedPatientBirthData) return null;
+  const existingKeepPatientBirthData = await models.PatientBirthData.findOne({
+    where: { patientId: keepPatientId },
+    raw: true,
+  });
+  const mergedPAD = {
+    ...getMergedFieldsForUpdate(existingKeepPatientBirthData, existingUnwantedPatientBirthData),
+    patientId: keepPatientId,
+  };
+  await models.PatientBirthData.destroy({
+    where: { patientId: { [Op.in]: [keepPatientId, unwantedPatientId] } },
+    force: true,
+  });
+  return models.PatientBirthData.create(mergedPAD);
 }
 
 export async function mergePatientFieldValues(models, keepPatientId, unwantedPatientId) {
@@ -287,9 +308,15 @@ export async function mergePatient(models, keepPatientId, unwantedPatientId) {
 
     // Now reconcile patient additional data.
     // This is a special case as we want to just keep one, merged PAD record
-    const updated = await mergePatientAdditionalData(models, keepPatientId, unwantedPatientId);
-    if (updated) {
+    const updatedPAD = await mergePatientAdditionalData(models, keepPatientId, unwantedPatientId);
+    if (updatedPAD) {
       updates.PatientAdditionalData = 1;
+    }
+
+    // Only keep 1 PatientBirthData
+    const updatedPatientBirthData = await mergePatientBirthData(models, keepPatientId, unwantedPatientId);
+    if (updatedPatientBirthData) {
+      updates.PatientBirthData = 1;
     }
 
     const fieldValueUpdates = await mergePatientFieldValues(

--- a/packages/sync-server/app/tasks/PatientMergeMaintainer.js
+++ b/packages/sync-server/app/tasks/PatientMergeMaintainer.js
@@ -9,6 +9,7 @@ import { NOTE_RECORD_TYPES } from '@tamanu/constants/notes';
 import { QueryTypes } from 'sequelize';
 import {
   mergePatientAdditionalData,
+  mergePatientBirthData,
   mergePatientFieldValues,
   reconcilePatientFacilities,
   simpleUpdateModels,
@@ -129,6 +130,24 @@ export class PatientMergeMaintainer extends ScheduledTask {
       );
       if (mergedPad) {
         records.push(mergedPad);
+      }
+    }
+    return records;
+  }
+
+  async specificUpdate_PatientBirthData() {
+    const { PatientBirthData } = this.models;
+    const patientBirthDataMerges = await this.findPendingMergePatients(PatientBirthData);
+
+    const records = [];
+    for (const { keepPatientId, mergedPatientId } of patientBirthDataMerges) {
+      const mergedPatientBirthData = await mergePatientBirthData(
+        this.models,
+        keepPatientId,
+        mergedPatientId,
+      );
+      if (mergedPatientBirthData) {
+        records.push(mergedPatientBirthData);
       }
     }
     return records;


### PR DESCRIPTION
### Changes
- Merge patient birth data into 1 when merging patients

**MERGE PAUSED** until after #4686 is merged.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
