### PR TITLE
no-issue: Add missing afterAll ctx.close() to sync-server test

### DIFF
--- a/packages/sync-server/__tests__/tasks/FhirRefreshHandler.test.js
+++ b/packages/sync-server/__tests__/tasks/FhirRefreshHandler.test.js
@@ -34,6 +34,8 @@ describe('FHIR refresh handler', () => {
     await imagingRequest.setAreas([resources.area1.id, resources.area2.id]);
   });
 
+  afterAll(() => ctx.close());
+
   it('allFromUpstream', async () => {
     await allFromUpstream(
       {


### PR DESCRIPTION
### Changes

Noticed this in db config epic, that this connection did not get closed 🙏 

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
