### PR TITLE
TAMOC-65: Make facility server independent

### DIFF
--- a/packages/lan/app/subCommands/serve.js
+++ b/packages/lan/app/subCommands/serve.js
@@ -35,7 +35,6 @@ async function serve({ skipMigrationCheck }) {
   await performDatabaseIntegrityChecks(context);
 
   context.centralServer = new CentralServerConnection(context);
-  context.centralServer.connect(); // preemptively connect central server to speed up sync
   context.syncManager = new FacilitySyncManager(context);
 
   await performTimeZoneChecks({

--- a/packages/lan/app/subCommands/serve.js
+++ b/packages/lan/app/subCommands/serve.js
@@ -40,7 +40,6 @@ async function serve({ skipMigrationCheck }) {
   await performTimeZoneChecks({
     remote: context.centralServer,
     sequelize: context.sequelize,
-    models: context.models,
     config,
   });
 

--- a/packages/lan/app/subCommands/serve.js
+++ b/packages/lan/app/subCommands/serve.js
@@ -40,6 +40,7 @@ async function serve({ skipMigrationCheck }) {
   await performTimeZoneChecks({
     remote: context.centralServer,
     sequelize: context.sequelize,
+    models: context.models,
     config,
   });
 

--- a/packages/lan/app/sync/CentralServerConnection.js
+++ b/packages/lan/app/sync/CentralServerConnection.js
@@ -168,7 +168,7 @@ export class CentralServerConnection {
     throw new Error(`Did not get a truthy response after ${maxAttempts} attempts for ${endpoint}`);
   }
 
-  async connect(backoff, timeout) {
+  async connect(backoff, timeout = this.timeout) {
     // if there's an ongoing connect attempt, reuse it
     if (this.connectionPromise) {
       return this.connectionPromise;

--- a/packages/lan/app/sync/CentralServerConnection.js
+++ b/packages/lan/app/sync/CentralServerConnection.js
@@ -69,7 +69,7 @@ export class CentralServerConnection {
       try {
         if (!this.token) {
           // Deliberately use same backoff policy to avoid retrying in some places
-          await this.connect(backoff);
+          await this.connect(backoff, otherParams.timeout);
         } else {
           await this.connectionPromise;
         }
@@ -168,7 +168,7 @@ export class CentralServerConnection {
     throw new Error(`Did not get a truthy response after ${maxAttempts} attempts for ${endpoint}`);
   }
 
-  async connect(backoff) {
+  async connect(backoff, timeout) {
     // if there's an ongoing connect attempt, reuse it
     if (this.connectionPromise) {
       return this.connectionPromise;
@@ -191,6 +191,7 @@ export class CentralServerConnection {
         awaitConnection: false,
         retryAuth: false,
         backoff,
+        timeout,
       });
 
       if (!body.token || !body.user) {

--- a/packages/lan/app/sync/CentralServerConnection.js
+++ b/packages/lan/app/sync/CentralServerConnection.js
@@ -68,7 +68,8 @@ export class CentralServerConnection {
     if (awaitConnection) {
       try {
         if (!this.token) {
-          await this.connect();
+          // Deliberately use same backoff policy to avoid retrying in some places
+          await this.connect(backoff);
         } else {
           await this.connectionPromise;
         }
@@ -167,7 +168,7 @@ export class CentralServerConnection {
     throw new Error(`Did not get a truthy response after ${maxAttempts} attempts for ${endpoint}`);
   }
 
-  async connect() {
+  async connect(backoff) {
     // if there's an ongoing connect attempt, reuse it
     if (this.connectionPromise) {
       return this.connectionPromise;
@@ -189,6 +190,7 @@ export class CentralServerConnection {
         },
         awaitConnection: false,
         retryAuth: false,
+        backoff,
       });
 
       if (!body.token || !body.user) {

--- a/packages/shared/src/utils/timeZoneCheck.js
+++ b/packages/shared/src/utils/timeZoneCheck.js
@@ -24,7 +24,7 @@ async function getDatabaseTimeZone(sequelize) {
 async function getRemoteTimeZone(remote, models) {
   const { LocalSystemFact } = models;
   try {
-    const health = await remote.fetch('health', { backoff: { maxAttempts: 1 } });
+    const health = await remote.fetch('health', { timeout: 2000, backoff: { maxAttempts: 1 } });
     const { countryTimeZone } = health.config;
     await LocalSystemFact.set('lastCentralServerCountryTimeZone', countryTimeZone);
     return countryTimeZone;

--- a/packages/shared/src/utils/timeZoneCheck.js
+++ b/packages/shared/src/utils/timeZoneCheck.js
@@ -29,7 +29,7 @@ async function getRemoteTimeZone(remote, models) {
     await LocalSystemFact.set('lastCentralServerCountryTimeZone', countryTimeZone);
     return countryTimeZone;
   } catch (error) {
-    log.info('Unable to grab countryTimeZone from central server.');
+    log.warn('Unable to grab countryTimeZone from central server.');
   }
 
   const lastCentralServerCountryTimeZone = await LocalSystemFact.get(

--- a/packages/shared/src/utils/timeZoneCheck.js
+++ b/packages/shared/src/utils/timeZoneCheck.js
@@ -24,7 +24,7 @@ async function getDatabaseTimeZone(sequelize) {
 async function getRemoteTimeZone(remote, models) {
   const { LocalSystemFact } = models;
   try {
-    const health = await remote.fetch('health');
+    const health = await remote.fetch('health', { backoff: { maxAttempts: 1 } });
     const { countryTimeZone } = health.config;
     await LocalSystemFact.set('lastCentralServerCountryTimeZone', countryTimeZone);
     return countryTimeZone;


### PR DESCRIPTION
### Changes

A whole bunch of info on the card. Issue is that facility server cannot start if it fails to connect to the central server. This is obviously bad as it should stand on its own.

~This approach will let it connect through but will have to wait out around 10 seconds where we timeout our request (could be less depending on config, but at the same time, could be more!). Still, this is an improvement in that theoretically we will know how long will a server be offline or not.~ No longer true - fixating this to 2 seconds wait, so total of 4 because we will make two requests.

~We could pierce the `timeout` argument and make it smaller only whenever no token has been set.~ I'm actually applying this, I don't think we should let to config how long is a facility server unavailable, given this step makes Tamanu unusable.

Note that this update will only affect on start, where `this.token` is `null`, whenever we get an invalid token we will try to connect again with another call to `connect()`, so those parameters won't be used anywhere. Hopefully.