### PR TITLE
Add corepack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ $ pyenv global 2.7.18
 Put eval "$(pyenv init --path)" in ~/.zprofile (or ~/.bash_profile or ~/.zshrc)
 ```
 
+Enable corepack (once):
+
+```bash
+$ corepack enable
+```
+
 Install dependencies with yarn:
 
 ```bash
@@ -48,16 +54,21 @@ $ cd tamanu
 $ yarn
 ```
 
-Install docker, then use it to build and run the system:
+Build all packages:
 
 ```bash
-$ yarn build && docker compose up
+$ yarn build
 ```
+
+Run the Tamanu components (in different terminals):
+
 ```bash
+$ yarn sync-start-dev
+$ yarn lan-start-dev
 $ yarn desktop-start-dev
 ```
 
-You can also run `yarn sync-start-dev`, `yarn lan-start-dev`, and `yarn meta-start-dev` to run individual processes without docker. You'll need to install postgres and configure databases for lan and sync.
+You'll need to install postgres and configure databases for lan and sync.
 
 ## Configure
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "engines": {
     "node": "^16.16.0"
   },
+  "packageManager": "yarn@1.22.19",
   "private": true,
   "workspaces": {
     "packages": [


### PR DESCRIPTION
### Changes

- Add the [`packageManager`](https://nodejs.org/docs/latest-v16.x/api/packages.html#packagemanager) field to package.json
- Add instructions to the readme

Essentially with [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) there's no need to `npm i -g yarn` and also no need to keep yarn updated globally, and corepack is distributed with nodejs, so there's really nothing to do except:

```bash
$ corepack enable
```

once.

### Checklist

- [x] Code is finished
- [x] On merge: amend onboarding