### PR TITLE
Allow configuring deviceId in config

### DIFF
--- a/packages/facility-server/app/sync/initDeviceId.js
+++ b/packages/facility-server/app/sync/initDeviceId.js
@@ -1,11 +1,16 @@
+import config from 'config';
 import shortid from 'shortid';
 
 export async function initDeviceId(context) {
   const { LocalSystemFact } = context.models;
   let deviceId = await LocalSystemFact.get('deviceId');
   if (!deviceId) {
-    deviceId = `facility-${shortid()}`;
+    deviceId = config.deviceId ?? `facility-${shortid()}`;
     await LocalSystemFact.set('deviceId', deviceId);
+  } else if (config.deviceId && deviceId !== config.deviceId) {
+    throw new Error(
+      `Device ID mismatch: ${deviceId} (from database) vs ${config.deviceId} (from config)`,
+    );
   }
   // eslint-disable-next-line require-atomic-updates
   context.deviceId = deviceId;


### PR DESCRIPTION

### Changes

Make it possible to specify a deviceId in the facility server config. This is used by the auto-deploys.

### Checklist

- [x] Code is finished

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) as needed
