### PR TITLE
EPI-637: Update default central server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ the API url and login credentials as well (see config/default.json for how this 
 
 #### Setting up a new Elastic Beanstalk application and environment:
 
-- add a certificate for a subdomain (e.g. [central-dev.tamanu.io](https://central-dev.tamanu.io)) using AWS's ACM
+- add a certificate for a subdomain (e.g. [central-dev.tamanu.io](https://central.main.internal.tamanu.io)) using AWS's ACM
 - configure the application and environment in AWS
   1. select "web server" when prompted
   2. fill out the basic details of your environment

--- a/docs/requests/deletion.http
+++ b/docs/requests/deletion.http
@@ -1,5 +1,5 @@
 @token=fake-token
-@server=https://central-dev.tamanu.io
+@server=https://central.main.internal.tamanu.io
 
 ### Delete a survey screen component
 DELETE {{server}}/v1/sync/surveyScreenComponent/program-snap-fiji-2%2Fsurvey-snap-fiji-2%2Fcomponent-FijSNAP_18  HTTP/1.1

--- a/docs/requests/reference.http
+++ b/docs/requests/reference.http
@@ -1,6 +1,6 @@
 
 @token=fake-token
-@server=https://central-dev.tamanu.io
+@server=https://central.main.internal.tamanu.io
 
 ### Get a list of reference data
 GET {{server}}/v1/sync/reference?since=0  HTTP/1.1

--- a/packages/lan/config/default.json
+++ b/packages/lan/config/default.json
@@ -22,7 +22,7 @@
   },
   "sync": {
     "schedule": "*/1 * * * *",
-    "host": "https://central-dev.tamanu.io",
+    "host": "https://central.main.internal.tamanu.io",
     "email": "",
     "password": "",
     "timeout": 10000,

--- a/packages/mobile/request-examples.http
+++ b/packages/mobile/request-examples.http
@@ -1,4 +1,4 @@
-@server = https://central-dev.tamanu.io
+@server = https://central.main.internal.tamanu.io
 @token = {{login.response.body.token}}
 
 ### Login

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -1,6 +1,6 @@
 {
   "port": 3000,
-  // this should be set to the external address of the server, e.g. "https://central-dev.tamanu.io"
+  // this should be set to the external address of the server, e.g. "https://central.main.internal.tamanu.io"
   "canonicalHostName": "http://localhost:3000",
   "db": {
     "name": "tamanu-sync",


### PR DESCRIPTION
### Changes

Just a small cleanup, that URL is long gone now. This touches two config files but isn't really something to worry about for deployments!