### PR TITLE
NASS-886: Update new row colour for auto-refresh tables

### DIFF
--- a/packages/desktop/app/components/Table/DataFetchingTable.js
+++ b/packages/desktop/app/components/Table/DataFetchingTable.js
@@ -302,7 +302,7 @@ export const DataFetchingTable = memo(
           orderBy={orderBy}
           rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
           refreshTable={refreshTable}
-          rowStyle={row => (row.highlighted ? 'background-color: #F8FFF8;' : '')}
+          rowStyle={row => (row.highlighted ? 'background-color: #F0FFF0;' : '')}
           lazyLoading={lazyLoading}
           ref={tableRef}
           {...props}


### PR DESCRIPTION
### Changes

Previously we used a light green to indicate new rows since last refresh. This was a little hard to see so we tweaked it to a more vivid green.

### Checklist

- [x] Code is finished
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
