### PR TITLE
TAMOC-67: fix sorting of imaging request with relation column requestedBy.displayName

### DIFF
--- a/packages/lan/__tests__/apiv1/Encounter.test.js
+++ b/packages/lan/__tests__/apiv1/Encounter.test.js
@@ -1369,7 +1369,7 @@ describe('Encounter', () => {
         ]);
       });
 
-      it.only('should get a list of imaging requests ordered by joined column', async () => {
+      it('should get a list of imaging requests ordered by joined column', async () => {
         // arrange
 
         const practictionerB = await models.User.create({ ...fakeUser(), displayName: 'B' });

--- a/packages/lan/__tests__/apiv1/Encounter.test.js
+++ b/packages/lan/__tests__/apiv1/Encounter.test.js
@@ -248,53 +248,6 @@ describe('Encounter', () => {
   test.todo('should get a list of procedures');
   test.todo('should get a list of prescriptions');
 
-  it('should get a list of imaging requests', async () => {
-    // arrange
-    const encounter = await models.Encounter.create({
-      ...(await createDummyEncounter(models)),
-      patientId: patient.id,
-    });
-
-    const imagingRequest = await models.ImagingRequest.create(
-      fake(models.ImagingRequest, {
-        patientId: patient.id,
-        encounterId: encounter.id,
-        requestedById: app.user.id,
-        status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
-      }),
-    );
-
-    const areaRefData = await models.ReferenceData.create(
-      fake(models.ReferenceData, { type: 'xRayImagingArea' }),
-    );
-
-    const area = await models.ImagingRequestArea.create(
-      fake(models.ImagingRequestArea, {
-        areaId: areaRefData.id,
-        imagingRequestId: imagingRequest.id,
-      }),
-    );
-
-    // act
-    const result = await app.get(
-      `/v1/encounter/${encodeURIComponent(encounter.id)}/imagingRequests`,
-    );
-
-    // assert
-    expect(result).toHaveSucceeded();
-    expect(result.body).toMatchObject({
-      count: 1,
-      data: expect.any(Array),
-    });
-    const resultLabReq = result.body.data[0];
-    expect(resultLabReq.areas).toEqual([
-      expect.objectContaining({
-        id: areaRefData.id,
-        ImagingRequestArea: expect.objectContaining({ id: area.id }),
-      }),
-    ]);
-  });
-
   describe('GET encounter lab requests', () => {
     it('should get a list of lab requests', async () => {
       const encounter = await models.Encounter.create({
@@ -1365,6 +1318,101 @@ describe('Encounter', () => {
         const metadata = await models.DocumentMetadata.findByPk(result.body.id);
         expect(metadata).toBeDefined();
         expect(uploadAttachment.mock.calls.length).toBe(1);
+      });
+    });
+
+    describe('imaging request', () => {
+      it('should get a list of imaging requests', async () => {
+        // arrange
+        const encounter = await models.Encounter.create({
+          ...(await createDummyEncounter(models)),
+          patientId: patient.id,
+        });
+
+        const imagingRequest = await models.ImagingRequest.create(
+          fake(models.ImagingRequest, {
+            patientId: patient.id,
+            encounterId: encounter.id,
+            requestedById: app.user.id,
+            status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+          }),
+        );
+
+        const areaRefData = await models.ReferenceData.create(
+          fake(models.ReferenceData, { type: 'xRayImagingArea' }),
+        );
+
+        const area = await models.ImagingRequestArea.create(
+          fake(models.ImagingRequestArea, {
+            areaId: areaRefData.id,
+            imagingRequestId: imagingRequest.id,
+          }),
+        );
+
+        // act
+        const result = await app.get(
+          `/v1/encounter/${encodeURIComponent(encounter.id)}/imagingRequests`,
+        );
+
+        // assert
+        expect(result).toHaveSucceeded();
+        expect(result.body).toMatchObject({
+          count: 1,
+          data: expect.any(Array),
+        });
+        const resultLabReq = result.body.data[0];
+        expect(resultLabReq.areas).toEqual([
+          expect.objectContaining({
+            id: areaRefData.id,
+            ImagingRequestArea: expect.objectContaining({ id: area.id }),
+          }),
+        ]);
+      });
+
+      it.only('should get a list of imaging requests ordered by joined column', async () => {
+        // arrange
+
+        const practictionerB = await models.User.create({ ...fakeUser(), displayName: 'B' });
+        const practictionerA = await models.User.create({ ...fakeUser(), displayName: 'A' });
+        const encounter = await models.Encounter.create({
+          ...(await createDummyEncounter(models)),
+          patientId: patient.id,
+        });
+
+        const imagingRequestB = await models.ImagingRequest.create(
+          fake(models.ImagingRequest, {
+            patientId: patient.id,
+            encounterId: encounter.id,
+            requestedById: practictionerB.id,
+            status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+          }),
+        );
+
+        const imagingRequestA = await models.ImagingRequest.create(
+          fake(models.ImagingRequest, {
+            patientId: patient.id,
+            encounterId: encounter.id,
+            requestedById: practictionerA.id,
+            status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+          }),
+        );
+
+        // act
+        const result = await app.get(
+          `/v1/encounter/${encodeURIComponent(
+            encounter.id,
+          )}/imagingRequests?orderBy=requestedBy.displayName&order=asc`,
+        );
+
+        // assert
+        expect(result).toHaveSucceeded();
+        expect(result.body).toMatchObject({
+          count: 2,
+          data: [
+            expect.objectContaining({ id: imagingRequestA.id }),
+            expect.objectContaining({ id: imagingRequestB.id }),
+          ],
+        });
       });
     });
 

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -183,13 +183,13 @@ encounterRelations.get(
       where: {
         encounterId,
         status: status || {
-          [Op.and]: [
-            { [Op.ne]: IMAGING_REQUEST_STATUS_TYPES.DELETED },
-            { [Op.ne]: IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR },
+          [Op.notIn]: [
+            IMAGING_REQUEST_STATUS_TYPES.DELETED,
+            IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
           ],
         },
       },
-      order: orderBy ? [[orderBy, order.toUpperCase()]] : undefined,
+      order: orderBy ? [[...orderBy.split('.'), order.toUpperCase()]] : undefined,
       include: associations,
     };
 


### PR DESCRIPTION
### Changes
Example of error before change:
![image (45)](https://github.com/beyondessential/tamanu/assets/38335330/7056c1d2-c7f2-4403-9282-2c9c59db1a19)
- Fixes error when attempting to order by `requestedBy.displayName` in imaging request encounter table by passing array of column names separated by `.` as per other tables with this requirement

- majority of test dif is moving inside a labeled describe
- other small thing is change the two `and not equal to` to a single `not in`

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
