### PR TITLE
TAN-2358: Add new suggesters

### DIFF
--- a/packages/constants/src/suggesters.ts
+++ b/packages/constants/src/suggesters.ts
@@ -19,5 +19,7 @@ export const SUGGESTER_ENDPOINTS = [
   'patientLabTestPanelTypes',
   'patientLetterTemplate',
   'practitioner',
+  'programRegistry',
+  'programRegistryClinicalStatus',
   'survey',
 ];

--- a/packages/desktop/app/views/programRegistry/ProgramRegistryForm.js
+++ b/packages/desktop/app/views/programRegistry/ProgramRegistryForm.js
@@ -22,7 +22,7 @@ export const ProgramRegistryForm = ({ onCancel, onSubmit, editedObject, patient 
   const { currentUser, facility } = useAuth();
   const [program, setProgram] = useState();
   const [conditions, setConditions] = useState(undefined);
-  const programRegistrySuggester = useSuggester('programRegistries', {
+  const programRegistrySuggester = useSuggester('programRegistry', {
     baseQueryParameters: { patientId: patient.id },
   });
   const programRegistryStatusSuggester = useSuggester('clinicalStatus', {

--- a/packages/lan/app/routes/apiv1/suggestions.js
+++ b/packages/lan/app/routes/apiv1/suggestions.js
@@ -11,6 +11,7 @@ import {
   INVOICE_LINE_TYPES,
   VISIBILITY_STATUSES,
   SUGGESTER_ENDPOINTS,
+  REGISTRATION_STATUSES,
 } from '@tamanu/constants';
 
 export const suggestions = express.Router();
@@ -211,17 +212,13 @@ createNameSuggester('facilityLocationGroup', 'LocationGroup', (search, query) =>
   filterByFacilityWhereBuilder(search, { ...query, filterByFacility: true }),
 );
 
-createSuggester(
-  'survey',
-  'Survey',
-  search => ({
-    name: { [Op.iLike]: search },
-    surveyType: {
-      [Op.notIn]: [SURVEY_TYPES.OBSOLETE, SURVEY_TYPES.VITALS],
-    },
-  }),
-  ({ id, name }) => ({ id, name }),
-);
+createNameSuggester('survey', 'Survey', (search, { programId }) => ({
+  ...DEFAULT_WHERE_BUILDER(search),
+  ...(programId ? { programId } : programId),
+  surveyType: {
+    [Op.notIn]: [SURVEY_TYPES.OBSOLETE, SURVEY_TYPES.VITALS],
+  },
+}));
 
 createSuggester(
   'invoiceLineTypes',
@@ -315,6 +312,40 @@ createSuggester('patientLabTestPanelTypes', 'LabTestPanel', (search, query) => {
             encounters ON encounters.id = lab_requests.encounter_id
           WHERE lab_requests.status = '${status}'
             AND encounters.patient_id = '${query.patientId}'
+        )`,
+      ),
+    },
+  };
+});
+
+createNameSuggester(
+  'programRegistryClinicalStatus',
+  'ProgramRegistryClinicalStatus',
+  (search, { programRegistryId }) => ({
+    ...DEFAULT_WHERE_BUILDER(search),
+    ...(programRegistryId ? { programRegistryId } : {}),
+  }),
+);
+
+createNameSuggester('programRegistry', 'ProgramRegistry', (search, query) => {
+  const baseWhere = DEFAULT_WHERE_BUILDER(search);
+
+  if (!query.parentId) {
+    return baseWhere;
+  }
+
+  return {
+    ...baseWhere,
+    // Only suggest program registries this patient isn't already part of
+    id: {
+      [Op.notIn]: Sequelize.literal(
+        `(
+          SELECT DISTINCT(id)
+          FROM program_registries pr
+          WHERE
+            pr.patient_id = '${query.patientId}'
+          AND
+            pr.registrationStatus != '${REGISTRATION_STATUSES.RECORDED_IN_ERROR}'
         )`,
       ),
     },


### PR DESCRIPTION
### Changes

https://linear.app/bes/issue/TAN-2358/program-registry-apis-suggesters

Not including the conditions suggester as that will come later
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
