### PR TITLE
TAN-2360: Add program filter to programResponses endpoint

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patientRelations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientRelations.js
@@ -236,7 +236,13 @@ patientRelations.get(
     const { db, models, params, query } = req;
     req.checkPermission('list', 'SurveyResponse');
     const patientId = params.id;
-    const { surveyId, surveyType = 'programs', order = 'asc', orderBy = 'endTime' } = query;
+    const {
+      surveyId,
+      programId,
+      surveyType = 'programs',
+      order = 'asc',
+      orderBy = 'endTime',
+    } = query;
     const sortKey = PROGRAM_RESPONSE_SORT_KEYS[orderBy] || PROGRAM_RESPONSE_SORT_KEYS.endTime;
     const sortDirection = order.toLowerCase() === 'asc' ? 'ASC' : 'DESC';
     const { count, data } = await runPaginatedQuery(
@@ -279,9 +285,10 @@ patientRelations.get(
           encounters.patient_id = :patientId
           AND surveys.survey_type = :surveyType
           ${surveyId ? 'AND surveys.id = :surveyId' : ''}
+          ${programId ? 'AND programs.id = :programId' : ''}
         ORDER BY ${sortKey} ${sortDirection}
       `,
-      { patientId, surveyId, surveyType },
+      { patientId, surveyId, programId, surveyType },
       query,
     );
 


### PR DESCRIPTION
### Changes

https://linear.app/bes/issue/TAN-2360/program-registry-patientidprogramresponses-api-allows-a-program-filter

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
