### PR TITLE
SAV-440: Refactor sync functions out of centralServerConnection

### DIFF
--- a/packages/lan/app/sync/pullIncomingChanges.js
+++ b/packages/lan/app/sync/pullIncomingChanges.js
@@ -8,11 +8,11 @@ import { calculatePageLimit } from './calculatePageLimit';
 
 const { persistedCacheBatchSize, pauseBetweenCacheBatchInMilliseconds } = config.sync;
 
-export const pullIncomingChanges = async (centralServer, sequelize, sessionId, since) => {
+export const pullIncomingChanges = async (syncManager, sequelize, sessionId, since) => {
   // initiating pull also returns the sync tick (or point on the sync timeline) that the
   // central server considers this session will be up to after pulling all changes
   log.info('FacilitySyncManager.pull.waitingForCentral');
-  const { totalToPull, pullUntil } = await centralServer.initiatePull(sessionId, since);
+  const { totalToPull, pullUntil } = await syncManager.initiatePull(sessionId, since);
 
   log.info('FacilitySyncManager.pulling', { since, totalToPull });
   let fromId;
@@ -26,7 +26,7 @@ export const pullIncomingChanges = async (centralServer, sequelize, sessionId, s
       limit,
     });
     const startTime = Date.now();
-    const records = await centralServer.pull(sessionId, {
+    const records = await syncManager.pull(sessionId, {
       fromId,
       limit,
     });

--- a/packages/lan/app/sync/pushOutgoingChanges.js
+++ b/packages/lan/app/sync/pushOutgoingChanges.js
@@ -1,6 +1,6 @@
 import { calculatePageLimit } from './calculatePageLimit';
 
-export const pushOutgoingChanges = async (centralServer, sessionId, changes) => {
+export const pushOutgoingChanges = async (syncManager, sessionId, changes) => {
   let startOfPage = 0;
   let limit = calculatePageLimit();
   while (startOfPage < changes.length) {
@@ -8,11 +8,11 @@ export const pushOutgoingChanges = async (centralServer, sessionId, changes) => 
     const page = changes.slice(startOfPage, endOfPage);
 
     const startTime = Date.now();
-    await centralServer.push(sessionId, page);
+    await syncManager.push(sessionId, page);
     const endTime = Date.now();
 
     startOfPage = endOfPage;
     limit = calculatePageLimit(limit, endTime - startTime);
   }
-  await centralServer.completePush(sessionId);
+  await syncManager.completePush(sessionId);
 };


### PR DESCRIPTION
### Changes

While starting work on SAV-440 I noticed that there were a few functions in CentralServerConnection (which is meant to manage sending general http requests to the central server, managing parsing JSON, auth, headers etc) that were extremely sync-specific and which probably should live in FacilityServerManager instead (which is meant to manage sync).

This is just moving some functions, it represents 0% new or altered functionality. I figured I'd do it in a separate PR so that the actual functionality changes for SAV-440 don't get mixed up with this work.

### Checklist

- [x] Code is finished
- [x] Tests are written

_Upon merging:_

No followup merge actions, this is purely refactoring work.