### PR TITLE
TAV-813: Tie Aspen's MSI to the version

### DIFF
--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -193,7 +193,6 @@ jobs:
               `- :window: **[Windows (System)](${S3_URL}/windows-system/Tamanu+Setup+${VERSION}.exe)**`,
               `- :window:   [Windows (AppData)](${S3_URL}/windows-appdata/Tamanu+Setup+${VERSION}.exe)`,
               `- :window:   [Windows (MSI)](${S3_URL}/windows-msi/Tamanu+${VERSION}.msi)`,
-              `- :window:   [Windows (Aspen)](${S3_URL}/windows-aspen/Tamanu+${VERSION}.msi)`,
               `- :apple:    [macOS (Tar)](${S3_URL}/mac/Tamanu-${VERSION}-mac.tar.xz)`,
               `- :penguin:  [Linux (AppImage)](${S3_URL}/linux/Tamanu-${VERSION}.AppImage)`,
             ].join('\n');

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -91,7 +91,7 @@ build_desktop() {
     package.json > /package-appdata.json
   jq '.build.win.target = ["msi"] | .build.msi.shortcutName = "Tamanu \(.version)"' \
     package.json > /package-msi.json
-  jq '.build.productName = "Tamanu Fiji" | .build.appId = "org.beyondessential.TamanuFiji" | .build.directories.output = "release/aspen"' \
+  jq '.build.productName = "Tamanu \(.version | split(".") | "\(.[0]).\(.[1])")" | .build.appId = "org.beyondessential.TamanuFiji\(.version | split(".") | "\(.[0])\(.[1])")" | .build.directories.output = "release/aspen"' \
     /package-msi.json > /package-aspen.json
   jq '.build.mac.target = "tar.xz"' \
     package.json > /package-mac.json


### PR DESCRIPTION
### Changes

Aspen have requested that their next update MSI install to another folder named `Tamanu 1.35`. This PR simply makes their install always depend on the version number, so that e.g. their next _next_ upgrade will be installed to `Tamanu 1.38` (or whatever) without needing further changes from us here.

### Checklist

- [x] Code is finished