### PR TITLE
no-issue: deprecate sync read only setting

### DIFF
--- a/packages/lan/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/lan/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -8,8 +8,6 @@ import { sleepAsync } from 'shared/utils/sleepAsync';
 import { createTestContext } from '../utilities';
 import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
 
-const readOnlyConfig = readOnly => ({ sync: { readOnly } });
-
 describe('snapshotOutgoingChanges', () => {
   let ctx;
   let models;
@@ -22,23 +20,6 @@ describe('snapshotOutgoingChanges', () => {
   });
 
   afterAll(() => ctx.close());
-
-  it(
-    'if in readOnly mode returns empty array',
-    withErrorShown(async () => {
-      const { LocalSystemFact } = models;
-      const tick = await LocalSystemFact.increment('currentSyncTick');
-
-      const result = await snapshotOutgoingChanges.overrideConfig(
-        ctx.sequelize,
-        models,
-        tick - 1,
-        readOnlyConfig(true),
-      );
-
-      expect(result).toEqual([]);
-    }),
-  );
 
   it(
     'if nothing changed returns empty array',

--- a/packages/lan/app/sync/snapshotOutgoingChanges.js
+++ b/packages/lan/app/sync/snapshotOutgoingChanges.js
@@ -32,11 +32,7 @@ const snapshotChangesForModel = async (model, since, transaction) => {
   }));
 };
 
-export const snapshotOutgoingChanges = withConfig(async (sequelize, models, since, config) => {
-  if (config.sync.readOnly) {
-    return [];
-  }
-
+export const snapshotOutgoingChanges = withConfig(async (sequelize, models, since) => {
   const invalidModelNames = Object.values(models)
     .filter(
       m =>

--- a/packages/lan/config/default.json
+++ b/packages/lan/config/default.json
@@ -26,7 +26,6 @@
     "email": "",
     "password": "",
     "timeout": 10000,
-    "readOnly": false,
     "persistedCacheBatchSize": 10000,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,
     "pauseBetweenCacheBatchInMilliseconds": 50,

--- a/packages/sync-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/sync-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -16,8 +16,6 @@ import { fakeUUID } from 'shared/utils/generateId';
 import { createTestContext } from '../utilities';
 import { snapshotOutgoingChanges } from '../../app/sync/snapshotOutgoingChanges';
 
-const syncConfig = readOnly => ({ sync: { readOnly, maxRecordsPerPullSnapshotChunk: 1000 } });
-
 describe('snapshotOutgoingChanges', () => {
   let ctx;
   let models;
@@ -35,33 +33,6 @@ describe('snapshotOutgoingChanges', () => {
   });
 
   afterAll(() => ctx.close());
-
-  it(
-    'if in readOnly mode returns 0',
-    withErrorShown(async () => {
-      const { SyncSession, LocalSystemFact, ReferenceData } = models;
-      const startTime = new Date();
-      const syncSession = await SyncSession.create({
-        startTime,
-        lastConnectionTime: startTime,
-      });
-      await createSnapshotTable(ctx.store.sequelize, syncSession.id);
-      await ReferenceData.create(fakeReferenceData());
-      const tock = await LocalSystemFact.increment('currentSyncTick', 2);
-
-      const result = await snapshotOutgoingChanges.overrideConfig(
-        outgoingModels,
-        tock - 1,
-        [],
-        syncSession.id,
-        '',
-        simplestSessionConfig,
-        syncConfig(true),
-      );
-
-      expect(result).toEqual(0);
-    }),
-  );
 
   it(
     'if nothing changed returns 0',

--- a/packages/sync-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/sync-server/app/sync/snapshotOutgoingChanges.js
@@ -129,10 +129,6 @@ const snapshotChangesForModel = async (
 
 export const snapshotOutgoingChanges = withConfig(
   async (outgoingModels, since, patientIds, sessionId, facilityId, sessionConfig, config) => {
-    if (config.sync.readOnly) {
-      return 0;
-    }
-
     const invalidModelNames = Object.values(outgoingModels)
       .filter(
         m =>

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -33,7 +33,6 @@
     "level": "info"
   },
   "sync": {
-    "readOnly": false,
     "persistedCacheBatchSize": 20000,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,
     "adjustDataBatchSize": 20000,
@@ -625,7 +624,7 @@
         },
         "userDisplayId": {
           "shortLabel": "Registration number",
-          "longLabel": "Registration number",
+          "longLabel": "Registration number"
         }
       },
       "features": {


### PR DESCRIPTION
### Changes
Deprecating `config.sync.readOnly` as it has undesirable consequences if turned on in production environment
Ill update the incoming settings pr too ✅ 

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
