### PR TITLE
EPI-651: Increase timeout for working container in cd-client

### DIFF
--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -115,7 +115,7 @@ jobs:
             docker run -dit --rm --name working \
               -v $PWD/release:/app/packages/desktop/release \
               working
-            sleep 2
+            sleep 10
             docker exec working echo "Container started"
           }
 

--- a/.github/workflows/cd-client.yml
+++ b/.github/workflows/cd-client.yml
@@ -115,7 +115,7 @@ jobs:
             docker run -dit --rm --name working \
               -v $PWD/release:/app/packages/desktop/release \
               working
-            sleep 1
+            sleep 2
             docker exec working echo "Container started"
           }
 


### PR DESCRIPTION
### Changes

Desktop builds on main are failing with
```
Unable to find image 'working:latest' locally
docker: Error response from daemon: pull access denied for working, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
Error response from daemon: No such container: working
```

This PR increases the sleep to 2 to give the container more time to start.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
