### PR TITLE
SAV-448: Invalidate queries for additional data of patients when patient finished syncing

### DIFF
--- a/packages/desktop/app/utils/index.js
+++ b/packages/desktop/app/utils/index.js
@@ -4,3 +4,4 @@ export * from './survey';
 export { flattenObject } from './flattenObject';
 export * from './invoice';
 export * from './getVisibleQuestions';
+export * from './invalidatePatientDataQueries';

--- a/packages/desktop/app/utils/invalidatePatientDataQueries.js
+++ b/packages/desktop/app/utils/invalidatePatientDataQueries.js
@@ -1,0 +1,5 @@
+export const invalidatePatientDataQueries = (queryClient, patientId) => {
+  queryClient.invalidateQueries(['additionalData', patientId]);
+  queryClient.invalidateQueries(['birthData', patientId]);
+  queryClient.invalidateQueries(['patientFields', patientId]);
+};

--- a/packages/desktop/app/views/patients/PatientView.js
+++ b/packages/desktop/app/views/patients/PatientView.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { TabDisplay } from '../../components/TabDisplay';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { PatientAlert } from '../../components/PatientAlert';
@@ -94,6 +94,7 @@ const TABS = [
 ];
 
 export const PatientView = () => {
+  const queryClient = useQueryClient();
   const { getLocalisation } = useLocalisation();
   const query = useUrlSearchParams();
   const patient = useSelector(state => state.patient);
@@ -112,6 +113,17 @@ export const PatientView = () => {
   useEffect(() => {
     api.post(`user/recently-viewed-patients/${patient.id}`);
   }, [api, patient.id]);
+
+  useEffect(() => {
+    if (!patient.syncing) {
+      queryClient.invalidateQueries(['additionalData', patient.id]);
+      queryClient.invalidateQueries(['birthData', patient.id]);
+      queryClient.invalidateQueries(['patientFields', patient.id]);
+    }
+
+    // invalidate queries
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [patient.syncing]);
 
   if (patient.loading || isLoadingAdditionalData || isLoadingBirthData) {
     return <LoadingIndicator />;

--- a/packages/desktop/app/views/patients/PatientView.js
+++ b/packages/desktop/app/views/patients/PatientView.js
@@ -121,7 +121,7 @@ export const PatientView = () => {
       queryClient.invalidateQueries(['patientFields', patient.id]);
     }
 
-    // invalidate queries
+    // invalidate queries only when syncing is done (changed from true to false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [patient.syncing]);
 

--- a/packages/desktop/app/views/patients/PatientView.js
+++ b/packages/desktop/app/views/patients/PatientView.js
@@ -23,6 +23,7 @@ import { PATIENT_TABS } from '../../constants/patientPaths';
 import { NAVIGATION_CONTAINER_HEIGHT } from '../../components/PatientNavigation';
 import { useUrlSearchParams } from '../../utils/useUrlSearchParams';
 import { PatientSearchParametersProvider } from '../../contexts/PatientViewSearchParameters';
+import { invalidatePatientDataQueries } from '../../utils';
 
 const StyledDisplayTabs = styled(TabDisplay)`
   overflow: initial;
@@ -116,9 +117,8 @@ export const PatientView = () => {
 
   useEffect(() => {
     if (!patient.syncing) {
-      queryClient.invalidateQueries(['additionalData', patient.id]);
-      queryClient.invalidateQueries(['birthData', patient.id]);
-      queryClient.invalidateQueries(['patientFields', patient.id]);
+      // invalidate the cache of patient data queries to reload the patient data
+      invalidatePatientDataQueries(queryClient, patient.id);
     }
 
     // invalidate queries only when syncing is done (changed from true to false)

--- a/packages/desktop/app/views/patients/panes/DetailsPane.js
+++ b/packages/desktop/app/views/patients/panes/DetailsPane.js
@@ -7,7 +7,7 @@ import { useAuth } from '../../../contexts/Auth';
 import { ContentPane } from '../../../components';
 import { PatientDetailsForm } from '../../../forms/PatientDetailsForm';
 import { reloadPatient } from '../../../store/patient';
-import { notifyError } from '../../../utils';
+import { notifyError, invalidatePatientDataQueries } from '../../../utils';
 
 // Momentary component to just display a message, will need design and
 // refactor later.
@@ -35,9 +35,8 @@ export const PatientDetailsPane = React.memo(
         return;
       }
 
-      queryClient.invalidateQueries(['additionalData', patient.id]);
-      queryClient.invalidateQueries(['birthData', patient.id]);
-      queryClient.invalidateQueries(['patientFields', patient.id]);
+      // invalidate the cache of patient data queries to reload the patient data
+      invalidatePatientDataQueries(queryClient, patient.id);
       dispatch(reloadPatient(patient.id));
     };
 


### PR DESCRIPTION
### Changes
- Invalidate additional data of patients when patient finished syncing

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
