### PR TITLE
No-issue: fix flaky apiKeys.test.js test

### DIFF
--- a/packages/sync-server/__tests__/subCommands/apiKeys.test.js
+++ b/packages/sync-server/__tests__/subCommands/apiKeys.test.js
@@ -15,8 +15,11 @@ describe('apiKeys issue', () => {
     const { User } = ctx.store.models;
     const user = await User.create(fake(User));
     const token = await genToken('default', user.email, { expiresIn: '1 day' });
-    expect(await verifyToken(token, DEFAULT_JWT_SECRET)).toMatchObject({
-      exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
-    });
+    const result = await verifyToken(token, DEFAULT_JWT_SECRET);
+
+    // handle off-by-one error when the second ticks over
+    const expectedExp = Math.floor(Date.now() / 1000) + 24 * 60 * 60;
+    expect(result.exp).toBeLessThanOrEqual(expectedExp);
+    expect(result.exp).toBeGreaterThanOrEqual(expectedExp - 1);
   });
 });


### PR DESCRIPTION
### Changes

I'm sorry for inflicting this flaky test on everyone for the past few months 😂

The problem is that `genToken` takes a bit over a hundred ms to sign, and then `verifyToken` takes the same. That's enough time for the second to tick over and intermittently break our tests. The change checks that `exp` is within `[currentTime-1,currentTime]` instead, which is close enough to the expiry time that it's not a problem: nobody cares if one of our tokens expires one second early.

### Checklist

- [x] Tests are written