### PR TITLE
NASS-904 NASS-905: Mobile translated text component with replacements

### DIFF
--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -3,16 +3,33 @@ import React, { ReactElement, useEffect, useState } from 'react';
 type TranslatedTextProps = {
   stringId: string;
   fallback: string;
+  replacements?: object;
 };
 
-export const TranslatedText = ({ stringId, fallback }: TranslatedTextProps): ReactElement => {
+// Duplicated from TranslatedText.js on desktop
+const replaceStringVariables = (templateString, replacements) => {
+    const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
+      // Even indexes are the unchanged parts of the string
+      if (index % 2 === 0) return part;
+      return replacements[part.slice(1)] || part;
+    });
+  
+    return jsxElements;
+  };
+
+export const TranslatedText = ({ stringId, fallback, replacements }: TranslatedTextProps): ReactElement => {
   const [displayElements, setDisplayElements] = useState(fallback);
   // Placeholder for fetching translation from context
-  const translation = null;
+  const translation = 'My name is :name';
+
+  const stringToDisplay = translation || fallback;
 
   useEffect(() => {
-    if (!translation) return;
-    setDisplayElements(translation);
+    if (!replacements) {
+        setDisplayElements(stringToDisplay);
+        return;
+    }
+    setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
   }, [translation]);
 
   return <>{displayElements}</>;

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 type TranslatedTextProps = {
   stringId: string;
   fallback: string;
-  replacements?: object;
+  replacements?: {[key: string]: ReactNode};
 };
 
 // Duplicated from TranslatedText.js on desktop

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+
+type TranslatedTextProps = {
+  stringId: string;
+  fallback: string;
+};
+
+export const TranslatedText = ({ stringId, fallback }: TranslatedTextProps): ReactElement => {
+  const [displayElements, setDisplayElements] = useState(fallback);
+  // Placeholder for fetching translation from context
+  const translation = null;
+
+  useEffect(() => {
+    if (!translation) return;
+    setDisplayElements(translation);
+  }, [translation]);
+
+  return <>{displayElements}</>;
+};

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
 type TranslatedTextProps = {
   stringId: string;
@@ -22,7 +22,7 @@ export const TranslatedText = ({
   fallback,
   replacements,
 }: TranslatedTextProps): ReactElement => {
-  const [displayElements, setDisplayElements] = useState(fallback);
+  const [displayElements, setDisplayElements] = useState<ReactNode>(fallback);
   // Placeholder for fetching translation from context
   const translation = null;
 

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
-type TranslatedTextProps = {
+interface TranslatedTextProps {
   stringId: string;
   fallback: string;
   replacements?: {[key: string]: ReactNode};

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -7,27 +7,31 @@ type TranslatedTextProps = {
 };
 
 // Duplicated from TranslatedText.js on desktop
-const replaceStringVariables = (templateString, replacements) => {
-    const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
-      // Even indexes are the unchanged parts of the string
-      if (index % 2 === 0) return part;
-      return replacements[part.slice(1)] || part;
-    });
-  
-    return jsxElements;
-  };
+const replaceStringVariables = (templateString: string, replacements: object) => {
+  const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
+    // Even indexes are the unchanged parts of the string
+    if (index % 2 === 0) return part;
+    return replacements[part.slice(1)] || part;
+  });
 
-export const TranslatedText = ({ stringId, fallback, replacements }: TranslatedTextProps): ReactElement => {
+  return jsxElements;
+};
+
+export const TranslatedText = ({
+  stringId,
+  fallback,
+  replacements,
+}: TranslatedTextProps): ReactElement => {
   const [displayElements, setDisplayElements] = useState(fallback);
   // Placeholder for fetching translation from context
-  const translation = 'My name is :name';
+  const translation = null;
 
   const stringToDisplay = translation || fallback;
 
   useEffect(() => {
     if (!replacements) {
-        setDisplayElements(stringToDisplay);
-        return;
+      setDisplayElements(stringToDisplay);
+      return;
     }
     setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
   }, [translation]);

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,13 +1,14 @@
 import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
+type Replacements = {[key: string]: ReactNode};
 interface TranslatedTextProps {
   stringId: string;
   fallback: string;
-  replacements?: {[key: string]: ReactNode};
+  replacements?: Replacements;
 };
 
 // Duplicated from TranslatedText.js on desktop
-const replaceStringVariables = (templateString: string, replacements: object) => {
+const replaceStringVariables = (templateString: string, replacements: Replacements) => {
   const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
     // Even indexes are the unchanged parts of the string
     if (index % 2 === 0) return part;

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, useMemo } from 'react';
 
 type Replacements = {[key: string]: ReactNode};
 interface TranslatedTextProps {
@@ -23,19 +23,17 @@ export const TranslatedText = ({
   fallback,
   replacements,
 }: TranslatedTextProps): ReactElement => {
-  const [displayElements, setDisplayElements] = useState<ReactNode>(fallback);
   // Placeholder for fetching translation from context
   const translation = null;
 
   const stringToDisplay = translation || fallback;
 
-  useEffect(() => {
+  const displayElements = useMemo(() => {
     if (!replacements) {
-      setDisplayElements(stringToDisplay);
-      return;
+      return stringToDisplay;
     }
-    setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
-  }, [translation]);
+    return replaceStringVariables(stringToDisplay, replacements);
+  }, [translation, replacements]);
 
   return <>{displayElements}</>;
 };


### PR DESCRIPTION
### Changes

This is the basic setup for the TranslatedText component on mobile. This has already been done on desktop so is basically a typescript version of the desktop component generated in 881 and 883 (more details + component [here](https://github.com/beyondessential/tamanu/pull/4764)) without the debug mode which will be implemented in the next card

As this logic is almost completely duplicated from the desktop cards, I have bundled these two for the basic TranslatedText functionality into this one PR:
- NASS-904
- NASS-905

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
