### PR TITLE
NASS-906: Setup translation context with debug mode

### DIFF
--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -3,16 +3,33 @@ import React, { ReactElement, useEffect, useState } from 'react';
 type TranslatedTextProps = {
   stringId: string;
   fallback: string;
+  replacements?: object;
 };
 
-export const TranslatedText = ({ stringId, fallback }: TranslatedTextProps): ReactElement => {
+// Duplicated from TranslatedText.js on desktop
+const replaceStringVariables = (templateString, replacements) => {
+    const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
+      // Even indexes are the unchanged parts of the string
+      if (index % 2 === 0) return part;
+      return replacements[part.slice(1)] || part;
+    });
+  
+    return jsxElements;
+  };
+
+export const TranslatedText = ({ stringId, fallback, replacements }: TranslatedTextProps): ReactElement => {
   const [displayElements, setDisplayElements] = useState(fallback);
   // Placeholder for fetching translation from context
-  const translation = null;
+  const translation = 'My name is :name';
+
+  const stringToDisplay = translation || fallback;
 
   useEffect(() => {
-    if (!translation) return;
-    setDisplayElements(translation);
+    if (!replacements) {
+        setDisplayElements(stringToDisplay);
+        return;
+    }
+    setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
   }, [translation]);
 
   return <>{displayElements}</>;

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 type TranslatedTextProps = {
   stringId: string;
   fallback: string;
-  replacements?: object;
+  replacements?: {[key: string]: ReactNode};
 };
 
 // Duplicated from TranslatedText.js on desktop

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+
+type TranslatedTextProps = {
+  stringId: string;
+  fallback: string;
+};
+
+export const TranslatedText = ({ stringId, fallback }: TranslatedTextProps): ReactElement => {
+  const [displayElements, setDisplayElements] = useState(fallback);
+  // Placeholder for fetching translation from context
+  const translation = null;
+
+  useEffect(() => {
+    if (!translation) return;
+    setDisplayElements(translation);
+  }, [translation]);
+
+  return <>{displayElements}</>;
+};

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -3,16 +3,22 @@ import styled from 'styled-components';
 import { StyledText } from '~/ui/styled/common';
 import { useTranslation } from '~/ui/contexts/TranslationContext';
 
-type Replacements = {[key: string]: ReactNode};
+type Replacements = { [key: string]: ReactNode };
 interface TranslatedTextProps {
   stringId: string;
   fallback: string;
   replacements?: Replacements;
-};
+}
 
-const DebugHighlighted = styled(StyledText)`
-  background-color: red;
-  color: white;
+const TextWrapper = styled(StyledText)<{
+  $isDebugMode: boolean;
+}>`
+  ${props =>
+    props.$isDebugMode &&
+    `
+    background-color: red;
+    color: white;
+  `};
 `;
 
 // Duplicated from TranslatedText.js on desktop
@@ -31,7 +37,7 @@ export const TranslatedText = ({
   fallback,
   replacements,
 }: TranslatedTextProps): ReactElement => {
-  const { getDebugMode } = useTranslation();
+  const { debugMode } = useTranslation();
   // Placeholder for fetching translation from context
   const translation = null;
 
@@ -44,8 +50,7 @@ export const TranslatedText = ({
     return replaceStringVariables(stringToDisplay, replacements);
   }, [translation, replacements]);
 
-  const isDebugMode = __DEV__ && getDebugMode();
-  const TextWrapper = isDebugMode ? DebugHighlighted : React.Fragment;
+  const isDebugMode = __DEV__ && debugMode;
 
-  return <TextWrapper>{displayElements}</TextWrapper>;
+  return <TextWrapper $isDebugMode={isDebugMode}>{displayElements}</TextWrapper>;
 };

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
 type TranslatedTextProps = {
   stringId: string;
@@ -22,7 +22,7 @@ export const TranslatedText = ({
   fallback,
   replacements,
 }: TranslatedTextProps): ReactElement => {
-  const [displayElements, setDisplayElements] = useState(fallback);
+  const [displayElements, setDisplayElements] = useState<ReactNode>(fallback);
   // Placeholder for fetching translation from context
   const translation = null;
 

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
-type TranslatedTextProps = {
+interface TranslatedTextProps {
   stringId: string;
   fallback: string;
   replacements?: {[key: string]: ReactNode};

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -7,27 +7,31 @@ type TranslatedTextProps = {
 };
 
 // Duplicated from TranslatedText.js on desktop
-const replaceStringVariables = (templateString, replacements) => {
-    const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
-      // Even indexes are the unchanged parts of the string
-      if (index % 2 === 0) return part;
-      return replacements[part.slice(1)] || part;
-    });
-  
-    return jsxElements;
-  };
+const replaceStringVariables = (templateString: string, replacements: object) => {
+  const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
+    // Even indexes are the unchanged parts of the string
+    if (index % 2 === 0) return part;
+    return replacements[part.slice(1)] || part;
+  });
 
-export const TranslatedText = ({ stringId, fallback, replacements }: TranslatedTextProps): ReactElement => {
+  return jsxElements;
+};
+
+export const TranslatedText = ({
+  stringId,
+  fallback,
+  replacements,
+}: TranslatedTextProps): ReactElement => {
   const [displayElements, setDisplayElements] = useState(fallback);
   // Placeholder for fetching translation from context
-  const translation = 'My name is :name';
+  const translation = null;
 
   const stringToDisplay = translation || fallback;
 
   useEffect(() => {
     if (!replacements) {
-        setDisplayElements(stringToDisplay);
-        return;
+      setDisplayElements(stringToDisplay);
+      return;
     }
     setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
   }, [translation]);

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,13 +1,14 @@
 import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
+type Replacements = {[key: string]: ReactNode};
 interface TranslatedTextProps {
   stringId: string;
   fallback: string;
-  replacements?: {[key: string]: ReactNode};
+  replacements?: Replacements;
 };
 
 // Duplicated from TranslatedText.js on desktop
-const replaceStringVariables = (templateString: string, replacements: object) => {
+const replaceStringVariables = (templateString: string, replacements: Replacements) => {
   const jsxElements = templateString.split(/(:[a-zA-Z]+)/g).map((part, index) => {
     // Even indexes are the unchanged parts of the string
     if (index % 2 === 0) return part;

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, useMemo } from 'react';
 
 type Replacements = {[key: string]: ReactNode};
 interface TranslatedTextProps {
@@ -23,19 +23,17 @@ export const TranslatedText = ({
   fallback,
   replacements,
 }: TranslatedTextProps): ReactElement => {
-  const [displayElements, setDisplayElements] = useState<ReactNode>(fallback);
   // Placeholder for fetching translation from context
   const translation = null;
 
   const stringToDisplay = translation || fallback;
 
-  useEffect(() => {
+  const displayElements = useMemo(() => {
     if (!replacements) {
-      setDisplayElements(stringToDisplay);
-      return;
+      return stringToDisplay;
     }
-    setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
-  }, [translation]);
+    return replaceStringVariables(stringToDisplay, replacements);
+  }, [translation, replacements]);
 
   return <>{displayElements}</>;
 };

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,10 +1,18 @@
 import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { StyledText } from '~/ui/styled/common';
+import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 type TranslatedTextProps = {
   stringId: string;
   fallback: string;
   replacements?: object;
 };
+
+const DebugHighlighted = styled(StyledText)`
+  background-color: red;
+  color: white;
+`;
 
 // Duplicated from TranslatedText.js on desktop
 const replaceStringVariables = (templateString: string, replacements: object) => {
@@ -22,6 +30,7 @@ export const TranslatedText = ({
   fallback,
   replacements,
 }: TranslatedTextProps): ReactElement => {
+  const { getDebugMode } = useTranslation();
   const [displayElements, setDisplayElements] = useState<ReactNode>(fallback);
   // Placeholder for fetching translation from context
   const translation = null;
@@ -36,5 +45,8 @@ export const TranslatedText = ({
     setDisplayElements(replaceStringVariables(stringToDisplay, replacements));
   }, [translation]);
 
-  return <>{displayElements}</>;
+  const isDebugMode = __DEV__ && getDebugMode();
+  const TextWrapper = isDebugMode ? DebugHighlighted : React.Fragment;
+
+  return <TextWrapper>{displayElements}</TextWrapper>;
 };

--- a/packages/mobile/App/ui/contexts/TranslationContext.tsx
+++ b/packages/mobile/App/ui/contexts/TranslationContext.tsx
@@ -1,0 +1,30 @@
+import React, {
+    createContext,
+    useContext,
+    useState,
+    PropsWithChildren,
+    ReactElement,
+  } from 'react';
+    
+  interface TranslationContextData {
+    getDebugMode: () => boolean;
+    toggleDebugMode: () => void;
+  }
+  
+  const TranslationContext = createContext<TranslationContextData>({} as TranslationContextData);
+  
+  
+  export const TranslationProvider = ({ children }: PropsWithChildren<object>): ReactElement => {
+    const [isDebugMode, setIsDebugMode] = useState(false);
+
+    const toggleDebugMode = () => setIsDebugMode(!isDebugMode);
+  
+  
+    return <TranslationContext.Provider value={{
+        getDebugMode: () => isDebugMode,
+        toggleDebugMode
+      }}>{children}</TranslationContext.Provider>;
+  };
+  
+  export const useTranslation = (): TranslationContextData => useContext(TranslationContext);
+  

--- a/packages/mobile/App/ui/contexts/TranslationContext.tsx
+++ b/packages/mobile/App/ui/contexts/TranslationContext.tsx
@@ -3,7 +3,6 @@ import { DevSettings } from 'react-native';
 
 interface TranslationContextData {
   getDebugMode: () => boolean;
-  toggleDebugMode: () => void;
 }
 
 const TranslationContext = createContext<TranslationContextData>({} as TranslationContextData);
@@ -11,20 +10,14 @@ const TranslationContext = createContext<TranslationContextData>({} as Translati
 export const TranslationProvider = ({ children }: PropsWithChildren<object>): ReactElement => {
   const [isDebugMode, setIsDebugMode] = useState(false);
 
-  const toggleDebugMode = () => setIsDebugMode(!isDebugMode);
-
   if (__DEV__) {
-    DevSettings.addMenuItem('Toggle translation highlighting', async () => {
-      setIsDebugMode(!isDebugMode);
-      console.log(isDebugMode)
-    });
+    DevSettings.addMenuItem('Toggle translation highlighting', async () => setIsDebugMode(!isDebugMode));
   }
 
   return (
     <TranslationContext.Provider
       value={{
         getDebugMode: () => isDebugMode,
-        toggleDebugMode,
       }}
     >
       {children}

--- a/packages/mobile/App/ui/contexts/TranslationContext.tsx
+++ b/packages/mobile/App/ui/contexts/TranslationContext.tsx
@@ -1,30 +1,35 @@
-import React, {
-    createContext,
-    useContext,
-    useState,
-    PropsWithChildren,
-    ReactElement,
-  } from 'react';
-    
-  interface TranslationContextData {
-    getDebugMode: () => boolean;
-    toggleDebugMode: () => void;
-  }
-  
-  const TranslationContext = createContext<TranslationContextData>({} as TranslationContextData);
-  
-  
-  export const TranslationProvider = ({ children }: PropsWithChildren<object>): ReactElement => {
-    const [isDebugMode, setIsDebugMode] = useState(false);
+import React, { createContext, useContext, useState, PropsWithChildren, ReactElement } from 'react';
+import { DevSettings } from 'react-native';
 
-    const toggleDebugMode = () => setIsDebugMode(!isDebugMode);
-  
-  
-    return <TranslationContext.Provider value={{
+interface TranslationContextData {
+  getDebugMode: () => boolean;
+  toggleDebugMode: () => void;
+}
+
+const TranslationContext = createContext<TranslationContextData>({} as TranslationContextData);
+
+export const TranslationProvider = ({ children }: PropsWithChildren<object>): ReactElement => {
+  const [isDebugMode, setIsDebugMode] = useState(false);
+
+  const toggleDebugMode = () => setIsDebugMode(!isDebugMode);
+
+  if (__DEV__) {
+    DevSettings.addMenuItem('Toggle translation highlighting', async () => {
+      setIsDebugMode(!isDebugMode);
+      console.log(isDebugMode)
+    });
+  }
+
+  return (
+    <TranslationContext.Provider
+      value={{
         getDebugMode: () => isDebugMode,
-        toggleDebugMode
-      }}>{children}</TranslationContext.Provider>;
-  };
-  
-  export const useTranslation = (): TranslationContextData => useContext(TranslationContext);
-  
+        toggleDebugMode,
+      }}
+    >
+      {children}
+    </TranslationContext.Provider>
+  );
+};
+
+export const useTranslation = (): TranslationContextData => useContext(TranslationContext);

--- a/packages/mobile/App/ui/contexts/TranslationContext.tsx
+++ b/packages/mobile/App/ui/contexts/TranslationContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState, PropsWithChildren, ReactEle
 import { DevSettings } from 'react-native';
 
 interface TranslationContextData {
-  getDebugMode: () => boolean;
+  debugMode: boolean;
 }
 
 const TranslationContext = createContext<TranslationContextData>({} as TranslationContextData);
@@ -11,13 +11,13 @@ export const TranslationProvider = ({ children }: PropsWithChildren<object>): Re
   const [isDebugMode, setIsDebugMode] = useState(false);
 
   if (__DEV__) {
-    DevSettings.addMenuItem('Toggle translation highlighting', async () => setIsDebugMode(!isDebugMode));
+    DevSettings.addMenuItem('Toggle translation highlighting', () => setIsDebugMode(!isDebugMode));
   }
 
   return (
     <TranslationContext.Provider
       value={{
-        getDebugMode: () => isDebugMode,
+        debugMode: isDebugMode,
       }}
     >
       {children}

--- a/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
@@ -19,6 +19,8 @@ import { ModalInfo } from '/components/ModalInfo';
 import { authSelector } from '/helpers/selectors';
 import { OutdatedVersionError } from '~/services/error';
 import { useFacility } from '~/ui/contexts/FacilityContext';
+import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
+import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 interface ModalContent {
   message: string;
@@ -28,6 +30,7 @@ interface ModalContent {
 
 export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
   const authState = useSelector(authSelector);
+  const { toggleDebugMode, getDebugMode } = useTranslation();
 
   const [modalVisible, setModalVisible] = useState(false);
   const [modalContent, setModalContent] = useState<ModalContent>({ message: '' });
@@ -54,6 +57,7 @@ export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
 
   return (
     <FullView background={theme.colors.PRIMARY_MAIN}>
+      {__DEV__ && <StyledTouchableOpacity onPress={() => toggleDebugMode()}><StyledText color="white" >Translation Debug: {getDebugMode() ? 'ON' : 'OFF'}</StyledText></StyledTouchableOpacity>}
       <StatusBar barStyle="light-content" />
       <ModalInfo
         onVisibilityChange={onChangeModalVisibility}
@@ -96,7 +100,7 @@ export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
           </StyledView>
           <StyledView marginLeft={screenPercentageToDP(2.43, Orientation.Width)}>
             <StyledText fontSize={30} fontWeight="bold" marginBottom={5} color={theme.colors.WHITE}>
-              Log In
+              <TranslatedText fallback="mate" />
             </StyledText>
             <StyledText fontSize={14} color={theme.colors.WHITE}>
               Enter your details below to log in

--- a/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
@@ -97,7 +97,7 @@ export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
           </StyledView>
           <StyledView marginLeft={screenPercentageToDP(2.43, Orientation.Width)}>
             <StyledText fontSize={30} fontWeight="bold" marginBottom={5} color={theme.colors.WHITE}>
-              Log in
+              Log In
             </StyledText>
             <StyledText fontSize={14} color={theme.colors.WHITE}>
               Enter your details below to log in

--- a/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
@@ -20,7 +20,6 @@ import { authSelector } from '/helpers/selectors';
 import { OutdatedVersionError } from '~/services/error';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
-import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 interface ModalContent {
   message: string;
@@ -30,7 +29,6 @@ interface ModalContent {
 
 export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
   const authState = useSelector(authSelector);
-  const { toggleDebugMode, getDebugMode } = useTranslation();
 
   const [modalVisible, setModalVisible] = useState(false);
   const [modalContent, setModalContent] = useState<ModalContent>({ message: '' });
@@ -57,7 +55,6 @@ export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
 
   return (
     <FullView background={theme.colors.PRIMARY_MAIN}>
-      {__DEV__ && <StyledTouchableOpacity onPress={() => toggleDebugMode()}><StyledText color="white" >Translation Debug: {getDebugMode() ? 'ON' : 'OFF'}</StyledText></StyledTouchableOpacity>}
       <StatusBar barStyle="light-content" />
       <ModalInfo
         onVisibilityChange={onChangeModalVisibility}
@@ -100,7 +97,7 @@ export const SignIn: FunctionComponent<any> = ({ navigation }: SignInProps) => {
           </StyledView>
           <StyledView marginLeft={screenPercentageToDP(2.43, Orientation.Width)}>
             <StyledText fontSize={30} fontWeight="bold" marginBottom={5} color={theme.colors.WHITE}>
-              <TranslatedText fallback="mate" />
+              Log in
             </StyledText>
             <StyledText fontSize={14} color={theme.colors.WHITE}>
               Enter your details below to log in

--- a/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
@@ -19,7 +19,6 @@ import { ModalInfo } from '/components/ModalInfo';
 import { authSelector } from '/helpers/selectors';
 import { OutdatedVersionError } from '~/services/error';
 import { useFacility } from '~/ui/contexts/FacilityContext';
-import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
 
 interface ModalContent {
   message: string;

--- a/packages/mobile/App/ui/navigation/stacks/Root.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Root.tsx
@@ -8,6 +8,7 @@ import { store, persistor } from '../../store/index';
 import { AuthProvider } from '../../contexts/AuthContext';
 import { FacilityProvider } from '../../contexts/FacilityContext';
 import { LocalisationProvider } from '../../contexts/LocalisationContext';
+import { TranslationProvider } from '../../contexts/TranslationContext';
 import { Core } from './Core';
 import { DetectIdleLayer } from './DetectIdleLayer';
 
@@ -20,13 +21,15 @@ export const RootStack = (): ReactElement => {
           <PersistGate loading={null} persistor={persistor}>
             <NavigationContainer ref={navigationRef}>
               <LocalisationProvider>
-                <AuthProvider navRef={navigationRef}>
-                  <FacilityProvider>
-                    <DetectIdleLayer>
-                      <Core />
-                    </DetectIdleLayer>
-                  </FacilityProvider>
-                </AuthProvider>
+                <TranslationProvider>
+                  <AuthProvider navRef={navigationRef}>
+                    <FacilityProvider>
+                      <DetectIdleLayer>
+                        <Core />
+                      </DetectIdleLayer>
+                    </FacilityProvider>
+                  </AuthProvider>
+                </TranslationProvider>
               </LocalisationProvider>
             </NavigationContainer>
           </PersistGate>


### PR DESCRIPTION
### Changes

This card covers adding the debug mode for TranslatedText components on mobile. As part of this card I have created a basic context for reading the debug mode that will be used in a later card for storing and fetching the translations.

This debug tool is only available in `dev` mode and will highlight the translated text in red to make it stand out. It can be activated using the react native dev menu. This is accessed by shaking the physical phone or by pressing `Cmd ⌘` + `M` on android studio emulator on mac

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
