### PR TITLE
EPI-658: Read only field should be disabled

### DIFF
--- a/packages/desktop/app/components/Field/TextField.js
+++ b/packages/desktop/app/components/Field/TextField.js
@@ -111,11 +111,11 @@ export const TallMultilineTextField = props => (
 
 export const ReadOnlyTextField = ({ field, ...props }) => (
   <TextInput
-    disabled
     name={field.name}
     value={field.value || ''}
     onChange={field.onChange}
     {...props}
+    disabled
   />
 );
 


### PR DESCRIPTION
### Changes

Pretty self explanatory. This field is used by question types: calculated question, user data and patient data. All of these should be disabled except patient data when there is a specific config for it (and that's already working). This also resolves EPI-656!