### PR TITLE
NASS-919: Report creator permission fixes

### DIFF
--- a/packages/desktop/app/views/administration/reports/ReportEditor.js
+++ b/packages/desktop/app/views/administration/reports/ReportEditor.js
@@ -121,12 +121,14 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit }) =>
   const onParamsDelete = paramId => setParams(params.filter(p => p.id !== paramId));
 
   const canWriteRawReportUser = Boolean(ability?.can('write', 'ReportDbSchema'));
-  // Show data source field if user is writing a raw report OR if reporting schema is disabled.
-  const showDataSourceField = values.dbSchema === REPORT_DB_SCHEMAS.RAW || values.dbSchema === null;
 
-  const { data: schemaOptions } = useQuery(['dbSchemaOptions'], () =>
+  const { data: schemaOptions = [] } = useQuery(['dbSchemaOptions'], () =>
     api.get(`admin/reports/dbSchemaOptions`),
   );
+
+  // Show data source field if user is writing a raw report OR if reporting schema is disabled.
+  const showDataSourceField =
+    values.dbSchema === REPORT_DB_SCHEMAS.RAW || schemaOptions.length === 0;
 
   return (
     <>

--- a/packages/desktop/app/views/administration/reports/ReportEditor.js
+++ b/packages/desktop/app/views/administration/reports/ReportEditor.js
@@ -121,6 +121,7 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit }) =>
   const onParamsDelete = paramId => setParams(params.filter(p => p.id !== paramId));
 
   const canWriteRawReportUser = Boolean(ability?.can('write', 'ReportDbSchema'));
+  // Show data source field if user is writing a raw report OR if reporting is disabled.
   const showDataSourceField = values.dbSchema === REPORT_DB_SCHEMAS.RAW || values.dbSchema === null;
 
   const { data: schemaOptions } = useQuery(['dbSchemaOptions'], () =>

--- a/packages/desktop/app/views/administration/reports/ReportEditor.js
+++ b/packages/desktop/app/views/administration/reports/ReportEditor.js
@@ -121,7 +121,7 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit }) =>
   const onParamsDelete = paramId => setParams(params.filter(p => p.id !== paramId));
 
   const canWriteRawReportUser = Boolean(ability?.can('write', 'ReportDbSchema'));
-  const showDataSourceField = values.dbSchema === REPORT_DB_SCHEMAS.RAW;
+  const showDataSourceField = values.dbSchema === REPORT_DB_SCHEMAS.RAW || values.dbSchema === null;
 
   const { data: schemaOptions } = useQuery(['dbSchemaOptions'], () =>
     api.get(`admin/reports/dbSchemaOptions`),

--- a/packages/desktop/app/views/administration/reports/ReportEditor.js
+++ b/packages/desktop/app/views/administration/reports/ReportEditor.js
@@ -121,7 +121,7 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit }) =>
   const onParamsDelete = paramId => setParams(params.filter(p => p.id !== paramId));
 
   const canWriteRawReportUser = Boolean(ability?.can('write', 'ReportDbSchema'));
-  // Show data source field if user is writing a raw report OR if reporting is disabled.
+  // Show data source field if user is writing a raw report OR if reporting schema is disabled.
   const showDataSourceField = values.dbSchema === REPORT_DB_SCHEMAS.RAW || values.dbSchema === null;
 
   const { data: schemaOptions } = useQuery(['dbSchemaOptions'], () =>

--- a/packages/desktop/app/views/administration/reports/SelectReportView.js
+++ b/packages/desktop/app/views/administration/reports/SelectReportView.js
@@ -1,12 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { REPORT_DB_SCHEMAS } from '@tamanu/constants/reports';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { push } from 'connected-react-router';
 import { useDispatch } from 'react-redux';
 import { useApi } from '../../../api';
 import { ReportTable, VersionTable } from './ReportTables';
-import { useAuth } from '../../../contexts/Auth';
 
 const FlexContainer = styled.div`
   padding: 20px;
@@ -21,7 +19,6 @@ const VersionsTableContainer = styled.div`
 export const SelectReportView = () => {
   const api = useApi();
   const dispatch = useDispatch();
-  const { ability } = useAuth();
 
   const [report, setReport] = useState(null);
 

--- a/packages/desktop/app/views/administration/reports/SelectReportView.js
+++ b/packages/desktop/app/views/administration/reports/SelectReportView.js
@@ -43,15 +43,10 @@ export const SelectReportView = () => {
     },
   );
 
-  const canEditRawReports = ability?.can('write', 'ReportDbSchema');
-  const filteredReportList = canEditRawReports
-    ? reportList
-    : reportList.filter(reportData => reportData.dbSchema !== REPORT_DB_SCHEMAS.RAW);
-
   return (
     <FlexContainer>
       <ReportTable
-        data={filteredReportList}
+        data={reportList}
         selected={report?.id}
         onRowClick={setReport}
         loading={isReportLoading}

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -17,6 +17,7 @@
       // "evict": 1000
     },
     "reportSchemas": {
+      "enabled": true,
       "connections": {
         "raw": {
           "pool": {


### PR DESCRIPTION
### Changes

Klaus found a couple of small bugs with the permissions that were introduced after we introduced the different default reporting schemas based on whether reporting is `enabled: true` or `false`. These two bugs appeared when reports were set to `enabled: false` and without permission to edit dbSchema field

1. List of reports is only showing "reporting" type reports whereas they should see all reports (as per current behaviour) if reporting isn't enabled - **Have added filtering on the endpoint based on config and permission**
2. "Can be run on/dbSchema" dropdown doesn't appear ever as it is dependent on default value which is set to `null` when reports is disabled and no permission - **Now also show when reporting schema is disabled and set to `null`**

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
