### PR TITLE
Hotfix: Add a default schema to import endpoint when reportingSchema config disabled

### DIFF
--- a/packages/sync-server/app/admin/reports/reportRoutes.js
+++ b/packages/sync-server/app/admin/reports/reportRoutes.js
@@ -205,7 +205,9 @@ reportsRouter.post(
           const [definition, createdDefinition] = await ReportDefinition.findOrCreate({
             where: {
               name,
-              dbSchema: versionData.dbSchema,
+              dbSchema: config.db.reportSchemas.enabled
+                ? versionData.dbSchema
+                : REPORT_DB_SCHEMAS.RAW,
             },
             include: [
               {


### PR DESCRIPTION
### Changes

Small case that wasn't handled when creating the new reporting schemas where it will throw a validation error when a json report is imported without a `dbSchema` key **EVEN** if the reportingSchemas flag is off. This just checks the config to see if reporting schemas are enabled. If they are, use the schema from the JSON file, otherwise default to 'raw'

### Checklist

- [x] Code is finished
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
