### PR TITLE
Fix: Add validation to report imports using the raw schema

### DIFF
--- a/packages/sync-server/app/admin/reports/reportRoutes.js
+++ b/packages/sync-server/app/admin/reports/reportRoutes.js
@@ -186,7 +186,9 @@ reportsRouter.post(
       throw new InvalidOperationError('Cannot import a report with a version number');
 
     if (reportSchemas.enabled && !canEditSchema && versionData.dbSchema === REPORT_DB_SCHEMAS.RAW) {
-      throw new InvalidOperationError('You do not have permission to create raw reports');
+      throw new InvalidOperationError(
+        'You do not have permission to import reports using the raw schema',
+      );
     }
 
     const existingDefinition = await ReportDefinition.findOne({ where: { name } });

--- a/packages/sync-server/app/admin/reports/reportRoutes.js
+++ b/packages/sync-server/app/admin/reports/reportRoutes.js
@@ -174,6 +174,9 @@ reportsRouter.post(
       models: { ReportDefinition, ReportDefinitionVersion },
       sequelize,
     } = store;
+    const { reportSchemas } = config.db;
+
+    const canEditSchema = req.ability.can('write', 'ReportDbSchema');
 
     const { name, file, dryRun, deleteFileAfterImport = true } = await getUploadedData(req);
 
@@ -181,6 +184,10 @@ reportsRouter.post(
 
     if (versionData.versionNumber)
       throw new InvalidOperationError('Cannot import a report with a version number');
+
+    if (reportSchemas.enabled && !canEditSchema && versionData.dbSchema === REPORT_DB_SCHEMAS.RAW) {
+      throw new InvalidOperationError('You do not have permission to create raw reports');
+    }
 
     const existingDefinition = await ReportDefinition.findOne({ where: { name } });
     if (existingDefinition && existingDefinition.dbSchema !== versionData.dbSchema) {
@@ -205,9 +212,7 @@ reportsRouter.post(
           const [definition, createdDefinition] = await ReportDefinition.findOrCreate({
             where: {
               name,
-              dbSchema: config.db.reportSchemas.enabled
-                ? versionData.dbSchema
-                : REPORT_DB_SCHEMAS.RAW,
+              dbSchema: reportSchemas.enabled ? versionData.dbSchema : REPORT_DB_SCHEMAS.RAW,
             },
             include: [
               {


### PR DESCRIPTION
### Changes

Currently we have dbSchema validation on the report creator but not on the import endpoint. This adds a permission check to the import endpoint which will check if the user has permission to create a raw report if they attempt to import a JSON with a dbSchema of 'raw'. If the user doesn't have permission, it will throw an error letting them know.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
