### PR TITLE
NASS-940: Patient search listing translated components

### DIFF
--- a/packages/desktop/app/components/RecentlyViewedPatientsList.js
+++ b/packages/desktop/app/components/RecentlyViewedPatientsList.js
@@ -10,6 +10,7 @@ import { useApi } from '../api';
 import { Colors } from '../constants';
 import { DateDisplay } from './DateDisplay';
 import { ThemedTooltip } from './Tooltip';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const colorFromEncounterType = {
   admission: Colors.green,
@@ -144,7 +145,8 @@ const Card = ({ patient, handleClick }) => {
         <CardText>{patient.displayId}</CardText>
         <CapitalizedCardText>{patient.sex}</CapitalizedCardText>
         <CardText>
-          DOB: <DateDisplay date={patient.dateOfBirth} shortYear />
+          <TranslatedText stringId="recentlyViewedPatients.dateOfBirthLabel" fallback="DOB" />:{' '}
+          <DateDisplay date={patient.dateOfBirth} shortYear />
         </CardText>
       </CardComponentContent>
     </CardComponent>
@@ -182,7 +184,9 @@ export const RecentlyViewedPatientsList = ({ encounterType }) => {
   return (
     <Container>
       <ContainerTitle onClick={() => setIsExpanded(!isExpanded)}>
-        <SectionLabel>Recently Viewed</SectionLabel>
+        <SectionLabel>
+          <TranslatedText stringId="recentlyViewedPatients.title" fallback="Recently Viewed" />
+        </SectionLabel>
         {isExpanded ? <ExpandLess /> : <ExpandMore />}
       </ContainerTitle>
       <Collapse in={isExpanded} timeout="auto" unmountOnExit>

--- a/packages/desktop/app/components/RecentlyViewedPatientsList.js
+++ b/packages/desktop/app/components/RecentlyViewedPatientsList.js
@@ -188,7 +188,7 @@ export const RecentlyViewedPatientsList = ({ encounterType }) => {
     <Container>
       <ContainerTitle onClick={() => setIsExpanded(!isExpanded)}>
         <SectionLabel>
-          <TranslatedText stringId="patient.recentlyViewed.title" fallback="Recently Viewed" />
+          <TranslatedText stringId="patientList.recentlyViewed.title" fallback="Recently Viewed" />
         </SectionLabel>
         {isExpanded ? <ExpandLess /> : <ExpandMore />}
       </ContainerTitle>

--- a/packages/desktop/app/components/RecentlyViewedPatientsList.js
+++ b/packages/desktop/app/components/RecentlyViewedPatientsList.js
@@ -148,8 +148,8 @@ const Card = ({ patient, handleClick }) => {
           <SexDisplay sex={patient.sex} />
         </CapitalizedCardText>
         <CardText>
-          <TranslatedText stringId="recentlyViewedPatients.dateOfBirthLabel" fallback="DOB" />:{' '}
-          <DateDisplay date={patient.dateOfBirth} shortYear />
+          <TranslatedText stringId="general.form.dateOfBirth.label" fallback="DOB" />
+          : <DateDisplay date={patient.dateOfBirth} shortYear />
         </CardText>
       </CardComponentContent>
     </CardComponent>
@@ -188,7 +188,7 @@ export const RecentlyViewedPatientsList = ({ encounterType }) => {
     <Container>
       <ContainerTitle onClick={() => setIsExpanded(!isExpanded)}>
         <SectionLabel>
-          <TranslatedText stringId="recentlyViewedPatients.title" fallback="Recently Viewed" />
+          <TranslatedText stringId="patient.recentlyViewed.title" fallback="Recently Viewed" />
         </SectionLabel>
         {isExpanded ? <ExpandLess /> : <ExpandMore />}
       </ContainerTitle>

--- a/packages/desktop/app/components/RecentlyViewedPatientsList.js
+++ b/packages/desktop/app/components/RecentlyViewedPatientsList.js
@@ -11,6 +11,7 @@ import { Colors } from '../constants';
 import { DateDisplay } from './DateDisplay';
 import { ThemedTooltip } from './Tooltip';
 import { TranslatedText } from './Translation/TranslatedText';
+import { SexDisplay } from './Translation/SexDisplay';
 
 const colorFromEncounterType = {
   admission: Colors.green,
@@ -143,7 +144,9 @@ const Card = ({ patient, handleClick }) => {
           </CardTitle>
         </ThemedTooltip>
         <CardText>{patient.displayId}</CardText>
-        <CapitalizedCardText>{patient.sex}</CapitalizedCardText>
+        <CapitalizedCardText>
+          <SexDisplay sex={patient.sex} />
+        </CapitalizedCardText>
         <CardText>
           <TranslatedText stringId="recentlyViewedPatients.dateOfBirthLabel" fallback="DOB" />:{' '}
           <DateDisplay date={patient.dateOfBirth} shortYear />

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -15,6 +15,7 @@ import { useSuggester } from '../../api';
 import { DateField } from '../Field/DateField';
 import { useSexOptions } from '../../hooks';
 import { SearchBarCheckField } from './SearchBarCheckField';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const TwoColumnsField = styled(Box)`
   grid-column: span 2;
@@ -61,7 +62,15 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             suggester={villageSuggester}
             size="small"
           />
-          <SearchBarCheckField name="deceased" label="Include deceased patients" />
+          <SearchBarCheckField
+            name="deceased"
+            label={
+              <TranslatedText
+                stringId="patientListing.includeDeceasedLabel"
+                fallback="Include deceased patients"
+              />
+            }
+          />
         </>
       }
     >
@@ -72,7 +81,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
         name="dateOfBirthExact"
         component={DateField}
         saveDateAsString
-        label="DOB"
+        label={<TranslatedText stringId="patientListing.dateOfBirthLabel" fallback="DOB" />}
         max={getCurrentDateString()}
       />
     </CustomisableSearchBar>

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -66,7 +66,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             name="deceased"
             label={
               <TranslatedText
-                stringId="patient.table.includeDeceasedCheckbox.label"
+                stringId="patientList.table.includeDeceasedCheckbox.label"
                 fallback="Include deceased patients"
               />
             }

--- a/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/AllPatientsSearchBar.js
@@ -66,7 +66,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             name="deceased"
             label={
               <TranslatedText
-                stringId="patientListing.includeDeceasedLabel"
+                stringId="patient.table.includeDeceasedCheckbox.label"
                 fallback="Include deceased patients"
               />
             }
@@ -81,7 +81,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
         name="dateOfBirthExact"
         component={DateField}
         saveDateAsString
-        label={<TranslatedText stringId="patientListing.dateOfBirthLabel" fallback="DOB" />}
+        label={<TranslatedText stringId="general.form.dateOfBirth.label" fallback="DOB" />}
         max={getCurrentDateString()}
       />
     </CustomisableSearchBar>

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -7,6 +7,7 @@ import doubleUp from '../../assets/images/double_up.svg';
 import { Button, TextButton } from '../Button';
 import { Form } from '../Field';
 import { Colors, FORM_TYPES } from '../../constants';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const Container = styled.div`
   border: 1px solid ${Colors.outline};
@@ -104,7 +105,9 @@ export const CustomisableSearchBar = ({
                   />
                 </IconButton>
               )}
-              <SearchButton type="submit">Search</SearchButton>
+              <SearchButton type="submit">
+                <TranslatedText stringId="patientListing.searchButton" fallback="Search" />
+              </SearchButton>
               <ClearButton
                 onClick={() => {
                   // Cant check for dirty as form is reinitialized with persisted values
@@ -115,7 +118,7 @@ export const CustomisableSearchBar = ({
                   setTimeout(() => clearForm(), 0);
                 }}
               >
-                Clear
+                <TranslatedText stringId="patientListing.clearButton" fallback="Clear" />
               </ClearButton>
             </ActionsContainer>
           </CustomisableSearchBarGrid>

--- a/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/CustomisableSearchBar.js
@@ -106,7 +106,7 @@ export const CustomisableSearchBar = ({
                 </IconButton>
               )}
               <SearchButton type="submit">
-                <TranslatedText stringId="patientListing.searchButton" fallback="Search" />
+                <TranslatedText stringId="general.action.search" fallback="Search" />
               </SearchButton>
               <ClearButton
                 onClick={() => {
@@ -118,7 +118,7 @@ export const CustomisableSearchBar = ({
                   setTimeout(() => clearForm(), 0);
                 }}
               >
-                <TranslatedText stringId="patientListing.clearButton" fallback="Clear" />
+                <TranslatedText stringId="general.action.clear" fallback="Clear" />
               </ClearButton>
             </ActionsContainer>
           </CustomisableSearchBarGrid>

--- a/packages/desktop/app/components/Table/DownloadDataButton.js
+++ b/packages/desktop/app/components/Table/DownloadDataButton.js
@@ -6,6 +6,7 @@ import XLSX from 'xlsx';
 
 import { GreyOutlinedButton } from '../Button';
 import { useElectron } from '../../contexts/Electron';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 function getHeaderValue(column) {
   if (!column.title) {
@@ -91,7 +92,7 @@ export function DownloadDataButton({ exportName, columns, data }) {
       data-test-class="download-data-button"
       startIcon={<GetAppIcon />}
     >
-      Export
+      <TranslatedText stringId="table.exportButton" fallback="Export" />
     </GreyOutlinedButton>
   );
 }

--- a/packages/desktop/app/components/Translation/SexDisplay.js
+++ b/packages/desktop/app/components/Translation/SexDisplay.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { SEX_VALUE_INDEX } from '../../constants';
+import { TranslatedText } from './TranslatedText';
+
+export const SexDisplay = ({ sex }) => {
+  switch (sex) {
+    case SEX_VALUE_INDEX.male.value:
+      return <TranslatedText stringId="patient.property.sex.male" fallback="Male" />;
+    case SEX_VALUE_INDEX.female.value:
+      return <TranslatedText stringId="patient.property.sex.female" fallback="Female" />;
+    case SEX_VALUE_INDEX.other.value:
+      return <TranslatedText stringId="patient.property.sex.other" fallback="Other" />;
+    default:
+      return <TranslatedText stringId="patient.property.sex.unknown" fallback="Unknown" />;
+  }
+};

--- a/packages/desktop/app/utils/getPatientStatus.js
+++ b/packages/desktop/app/utils/getPatientStatus.js
@@ -12,7 +12,7 @@ const ENCOUNTER_TYPE_TO_STATUS = {
   [ENCOUNTER_TYPES.TRIAGE]: PATIENT_STATUS.EMERGENCY,
 };
 
-const STATUS_TO_TRANSLATION = {
+const STATUS_TO_LABEL = {
   [PATIENT_STATUS.INPATIENT]: (
     <TranslatedText stringId="patient.table.status.inpatient" fallback="Inpatient" />
   ),
@@ -28,5 +28,5 @@ export const getPatientStatus = encounterType => {
   if (!encounterType) {
     return '';
   }
-  return STATUS_TO_TRANSLATION[ENCOUNTER_TYPE_TO_STATUS[encounterType]];
+  return STATUS_TO_LABEL[ENCOUNTER_TYPE_TO_STATUS[encounterType]];
 };

--- a/packages/desktop/app/utils/getPatientStatus.js
+++ b/packages/desktop/app/utils/getPatientStatus.js
@@ -1,5 +1,7 @@
+import React from 'react';
 import { ENCOUNTER_TYPES } from '@tamanu/constants';
 import { PATIENT_STATUS } from '../constants';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const ENCOUNTER_TYPE_TO_STATUS = {
   [ENCOUNTER_TYPES.ADMISSION]: PATIENT_STATUS.INPATIENT,
@@ -10,9 +12,21 @@ const ENCOUNTER_TYPE_TO_STATUS = {
   [ENCOUNTER_TYPES.TRIAGE]: PATIENT_STATUS.EMERGENCY,
 };
 
+const STATUS_TO_TRANSLATION = {
+  [PATIENT_STATUS.INPATIENT]: (
+    <TranslatedText stringId="patient.table.status.inpatient" fallback="Inpatient" />
+  ),
+  [PATIENT_STATUS.OUTPATIENT]: (
+    <TranslatedText stringId="patient.table.status.outpatient" fallback="Outpatient" />
+  ),
+  [PATIENT_STATUS.EMERGENCY]: (
+    <TranslatedText stringId="patient.table.status.emergency" fallback="Emergency" />
+  ),
+};
+
 export const getPatientStatus = encounterType => {
   if (!encounterType) {
     return '';
   }
-  return ENCOUNTER_TYPE_TO_STATUS[encounterType];
+  return STATUS_TO_TRANSLATION[ENCOUNTER_TYPE_TO_STATUS[encounterType]];
 };

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -119,7 +119,7 @@ const NewPatientButton = ({ onCreateNewPatient }) => {
         noun="Patient"
         onClick={showNewPatient}
       >
-        <TranslatedText stringId="patient.action.add" fallback="+ Add new patient" />
+        + <TranslatedText stringId="patient.action.add" fallback="Add new patient" />
       </ButtonWithPermissionCheck>
       <NewPatientModal
         title="New patient"
@@ -144,7 +144,7 @@ export const PatientListingView = ({ onViewPatient }) => {
       <RecentlyViewedPatientsList />
       <ContentPane>
         <SearchTableTitle>
-          <TranslatedText stringId="patientList.table.title" fallback="Patient search" />
+          <TranslatedText stringId="patientList.table.search.title" fallback="Patient search" />
         </SearchTableTitle>
         <AllPatientsSearchBar onSearch={setSearchParameters} />
         <PatientTable
@@ -177,7 +177,7 @@ export const AdmittedPatientsView = () => {
       <RecentlyViewedPatientsList encounterType="admission" />
       <ContentPane>
         <SearchTableTitle>
-          <TranslatedText stringId="patientList.table.title" fallback="Patient search" />
+          <TranslatedText stringId="patientList.table.search.title" fallback="Patient search" />
         </SearchTableTitle>
         <PatientSearchBar onSearch={setSearchParameters} searchParameters={searchParameters} />
         <PatientTable
@@ -206,7 +206,7 @@ export const OutpatientsView = () => {
       <RecentlyViewedPatientsList encounterType="clinic" />
       <ContentPane>
         <SearchTableTitle>
-          <TranslatedText stringId="patientList.table.title" fallback="Patient search" />
+          <TranslatedText stringId="patientList.table.search.title" fallback="Patient search" />
         </SearchTableTitle>
         <PatientSearchBar onSearch={setSearchParameters} searchParameters={searchParameters} />
         <PatientTable

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -119,7 +119,7 @@ const NewPatientButton = ({ onCreateNewPatient }) => {
         noun="Patient"
         onClick={showNewPatient}
       >
-        + Add new patient
+        <TranslatedText stringId="patientListing.newPatientButton" fallback="+ Add new patient" />
       </ButtonWithPermissionCheck>
       <NewPatientModal
         title="New patient"

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -30,6 +30,7 @@ import {
 } from './columns';
 import { useAuth } from '../../contexts/Auth';
 import { usePatientSearch, PatientSearchKeys } from '../../contexts/PatientSearch';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const PATIENT_SEARCH_ENDPOINT = 'patient';
 
@@ -135,12 +136,14 @@ export const PatientListingView = ({ onViewPatient }) => {
 
   return (
     <PageContainer>
-      <TopBar title="Patient listing">
+      <TopBar title={<TranslatedText stringId="patientListing.title" fallback="Patient listing" />}>
         <NewPatientButton onCreateNewPatient={onViewPatient} />
       </TopBar>
       <RecentlyViewedPatientsList />
       <ContentPane>
-        <SearchTableTitle>Patient search</SearchTableTitle>
+        <SearchTableTitle>
+          <TranslatedText stringId="patientListing.tableTitle" fallback="Patient search" />
+        </SearchTableTitle>
         <AllPatientsSearchBar onSearch={setSearchParameters} />
         <PatientTable
           onViewPatient={onViewPatient}
@@ -161,10 +164,19 @@ export const AdmittedPatientsView = () => {
 
   return (
     <PageContainer>
-      <TopBar title="Admitted patient listing" />
+      <TopBar
+        title={
+          <TranslatedText
+            stringId="patientListing.outpatientTitle"
+            fallback="Admitted patient listing"
+          />
+        }
+      />
       <RecentlyViewedPatientsList encounterType="admission" />
       <ContentPane>
-        <SearchTableTitle>Patient search</SearchTableTitle>
+        <SearchTableTitle>
+          <TranslatedText stringId="patientListing.tableTitle" fallback="Patient search" />
+        </SearchTableTitle>
         <PatientSearchBar onSearch={setSearchParameters} searchParameters={searchParameters} />
         <PatientTable
           fetchOptions={{ inpatient: 1 }}
@@ -184,10 +196,16 @@ export const OutpatientsView = () => {
 
   return (
     <PageContainer>
-      <TopBar title="Outpatient listing" />
+      <TopBar
+        title={
+          <TranslatedText stringId="patientListing.outpatientTitle" fallback="Outpatient listing" />
+        }
+      />
       <RecentlyViewedPatientsList encounterType="clinic" />
       <ContentPane>
-        <SearchTableTitle>Patient search</SearchTableTitle>
+        <SearchTableTitle>
+          <TranslatedText stringId="patientListing.tableTitle" fallback="Patient search" />
+        </SearchTableTitle>
         <PatientSearchBar onSearch={setSearchParameters} searchParameters={searchParameters} />
         <PatientTable
           fetchOptions={{ outpatient: 1 }}

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -119,7 +119,7 @@ const NewPatientButton = ({ onCreateNewPatient }) => {
         noun="Patient"
         onClick={showNewPatient}
       >
-        <TranslatedText stringId="patientListing.newPatientButton" fallback="+ Add new patient" />
+        <TranslatedText stringId="patient.action.add" fallback="+ Add new patient" />
       </ButtonWithPermissionCheck>
       <NewPatientModal
         title="New patient"
@@ -136,13 +136,15 @@ export const PatientListingView = ({ onViewPatient }) => {
 
   return (
     <PageContainer>
-      <TopBar title={<TranslatedText stringId="patientListing.title" fallback="Patient listing" />}>
+      <TopBar
+        title={<TranslatedText stringId="patientList.default.title" fallback="Patient listing" />}
+      >
         <NewPatientButton onCreateNewPatient={onViewPatient} />
       </TopBar>
       <RecentlyViewedPatientsList />
       <ContentPane>
         <SearchTableTitle>
-          <TranslatedText stringId="patientListing.tableTitle" fallback="Patient search" />
+          <TranslatedText stringId="patientList.table.title" fallback="Patient search" />
         </SearchTableTitle>
         <AllPatientsSearchBar onSearch={setSearchParameters} />
         <PatientTable
@@ -167,7 +169,7 @@ export const AdmittedPatientsView = () => {
       <TopBar
         title={
           <TranslatedText
-            stringId="patientListing.outpatientTitle"
+            stringId="patientList.inpatient.title"
             fallback="Admitted patient listing"
           />
         }
@@ -175,7 +177,7 @@ export const AdmittedPatientsView = () => {
       <RecentlyViewedPatientsList encounterType="admission" />
       <ContentPane>
         <SearchTableTitle>
-          <TranslatedText stringId="patientListing.tableTitle" fallback="Patient search" />
+          <TranslatedText stringId="patientList.table.title" fallback="Patient search" />
         </SearchTableTitle>
         <PatientSearchBar onSearch={setSearchParameters} searchParameters={searchParameters} />
         <PatientTable
@@ -198,13 +200,13 @@ export const OutpatientsView = () => {
     <PageContainer>
       <TopBar
         title={
-          <TranslatedText stringId="patientListing.outpatientTitle" fallback="Outpatient listing" />
+          <TranslatedText stringId="patientList.outpatient.title" fallback="Outpatient listing" />
         }
       />
       <RecentlyViewedPatientsList encounterType="clinic" />
       <ContentPane>
         <SearchTableTitle>
-          <TranslatedText stringId="patientListing.tableTitle" fallback="Patient search" />
+          <TranslatedText stringId="patientList.table.title" fallback="Patient search" />
         </SearchTableTitle>
         <PatientSearchBar onSearch={setSearchParameters} searchParameters={searchParameters} />
         <PatientTable

--- a/packages/desktop/app/views/patients/columns.js
+++ b/packages/desktop/app/views/patients/columns.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { CloudDownload, CloudOff } from '@material-ui/icons';
 import { DateDisplay } from '../../components';
-import { capitaliseFirstLetter } from '../../utils/capitalise';
 import { getPatientStatus } from '../../utils/getPatientStatus';
+import { SexDisplay } from '../../components/Translation/SexDisplay';
 
 const DateCell = React.memo(({ value }) => <DateDisplay date={value} />);
-const SexCell = React.memo(({ value = '' }) => <span>{capitaliseFirstLetter(value)}</span>);
+const SexCell = React.memo(({ value }) => <SexDisplay sex={value} />);
 const SyncedCell = React.memo(({ value }) => (value === true ? <CloudDownload /> : <CloudOff />));
 
 export const markedForSync = {


### PR DESCRIPTION
### Changes

This card replaces the hardcoded strings with translated components for the patient listing view. This doesn't include the localised ones however (addressed in upcoming card) which actually make up most of the search fields/column names.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
