### PR TITLE
🔥 hotfix 1.36: default reportingSchema.enabled as false on central config

### DIFF
--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -17,7 +17,7 @@
       // "evict": 1000
     },
     "reportSchemas": {
-      "enabled": true,
+      "enabled": false,
       "connections": {
         "raw": {
           "pool": {


### PR DESCRIPTION
### Changes
It seems that this was mistakenly updated to true 🙏 but needs to be false before the credentials are provided

### Checklist
- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
