### PR TITLE
SAV-486: Add 'Support centre' link to Tamanu desktop

### DIFF
--- a/packages/desktop/app/components/Sidebar/Sidebar.js
+++ b/packages/desktop/app/components/Sidebar/Sidebar.js
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
 import { List, Divider, Box, Typography, Button, IconButton } from '@material-ui/core';
-import { NavigateBefore, NavigateNext } from '@material-ui/icons';
+import { NavigateBefore, NavigateNext, Launch } from '@material-ui/icons';
+
 import { TamanuLogoWhite, TamanuLogoWhiteNoText } from '../TamanuLogo';
 import { Colors } from '../../constants';
 import { Translated } from '../Translated';
@@ -15,6 +16,7 @@ import { getCurrentRoute } from '../../store/router';
 import { checkAbility } from '../../utils/ability';
 import { useAuth } from '../../contexts/Auth';
 import { useApi } from '../../api';
+import { useLocalisation } from '../../contexts/Localisation';
 
 const Container = styled.div`
   display: flex;
@@ -67,30 +69,34 @@ const RetractedLogo = styled(TamanuLogoWhiteNoText)``;
 
 const Footer = styled.div`
   margin-top: auto;
-  padding-bottom: 20px;
-  padding-right: ${props => (props.$retracted ? '0' : '18px')};
+  padding-bottom: 3px;
+  padding-right: ${props => (props.$retracted ? '0' : '10px')};
 `;
 
-const FooterContent = styled.div`
+const UserInfo = styled.div`
   display: flex;
   color: white;
   min-height: 65px;
   align-items: center;
   justify-content: ${props => (props.$retracted ? 'center' : 'default')};
   transition: ${props => props.theme.transitions.create('justify-content')};
+  margin-top: 5px;
+  margin-bottom: 5px;
+`;
+
+const StyledUserInfoContent = styled(Box)`
+  margin-top: 8px;
 `;
 
 const StyledDivider = styled(Divider)`
   background-color: ${props => (props.$invisible ? 'transparent' : 'rgba(255, 255, 255, 0.2)')};
   transition: ${props => props.theme.transitions.create('background-color')};
-  margin-bottom: 14px;
-  margin-left: 16px;
+  margin-left: 5px;
 `;
 
 const UserName = styled(Typography)`
   font-weight: 500;
   font-size: 14px;
-  margin-bottom: 5px;
   line-height: 18px;
 `;
 
@@ -120,6 +126,25 @@ const LogoutButton = styled(Button)`
   text-transform: none;
   text-decoration: underline;
   color: ${Colors.white};
+  margin-top: 8px;
+  margin-left: 10px;
+  min-height: 0;
+  min-width: 0;
+  padding-left: 0;
+  padding-right: 0;
+`;
+
+const SupportDeskButton = styled(Button)`
+  font-weight: 400;
+  font-size: 11px;
+  line-height: 15px;
+  text-transform: none;
+  text-decoration: underline;
+  color: ${Colors.white};
+  min-height: 0;
+  min-width: 0;
+  padding-left: 0;
+  padding-right: 0;
 `;
 
 const getInitials = string =>
@@ -153,6 +178,7 @@ export const Sidebar = React.memo(({ items }) => {
   const { facility, centralHost, currentUser, onLogout, currentRole } = useAuth();
   const currentPath = useSelector(getCurrentRoute);
   const dispatch = useDispatch();
+  const { getLocalisation } = useLocalisation();
 
   const extendSidebar = () => setIsRetracted(false);
 
@@ -175,6 +201,7 @@ export const Sidebar = React.memo(({ items }) => {
 
   const initials = getInitials(currentUser.displayName);
   const roleName = currentRole?.name ?? currentUser?.role;
+  const supportUrl = getLocalisation('supportDeskUrl');
 
   return (
     <Container $retracted={isRetracted}>
@@ -243,7 +270,7 @@ export const Sidebar = React.memo(({ items }) => {
       </List>
       <Footer $retracted={isRetracted}>
         <StyledDivider $invisible={isRetracted} />
-        <FooterContent $retracted={isRetracted}>
+        <UserInfo $retracted={isRetracted}>
           <StyledHiddenSyncAvatar
             $retracted={isRetracted}
             onClick={isRetracted ? extendSidebar : undefined}
@@ -251,13 +278,12 @@ export const Sidebar = React.memo(({ items }) => {
             {initials}
           </StyledHiddenSyncAvatar>
           {!isRetracted && (
-            <Box flex={1}>
+            <StyledUserInfoContent flex={1}>
               <UserName>{currentUser?.displayName}</UserName>
-              <ConnectedTo>
-                {roleName} | {facility?.name ? facility.name : centralHost}
-              </ConnectedTo>
               <Box display="flex" justifyContent="space-between">
-                <Version>Version {appVersion}</Version>
+                <ConnectedTo>
+                  {roleName} <br /> {facility?.name ? facility.name : centralHost}
+                </ConnectedTo>
                 <LogoutButton
                   type="button"
                   onClick={onLogout}
@@ -267,9 +293,22 @@ export const Sidebar = React.memo(({ items }) => {
                   <Translated id="logout" />
                 </LogoutButton>
               </Box>
-            </Box>
+            </StyledUserInfoContent>
           )}
-        </FooterContent>
+        </UserInfo>
+        {!isRetracted && (
+          <>
+            <StyledDivider $invisible={isRetracted} />
+            <Box display="flex" justifyContent="space-between">
+              <a href={supportUrl} target="_blank" rel="noreferrer">
+                <SupportDeskButton type="button" id="logout" data-test-id="siderbar-logout-item">
+                  Support centre <Launch style={{ marginLeft: '5px', fontSize: '12px' }} />
+                </SupportDeskButton>
+              </a>
+              <Version>Version {appVersion}</Version>
+            </Box>
+          </>
+        )}
       </Footer>
     </Container>
   );

--- a/packages/desktop/app/components/Sidebar/Sidebar.js
+++ b/packages/desktop/app/components/Sidebar/Sidebar.js
@@ -134,17 +134,20 @@ const LogoutButton = styled(Button)`
   padding-right: 0;
 `;
 
-const SupportDeskButton = styled(Button)`
+const SupportDesktopLink = styled.a`
+  margin-top: 4px;
   font-weight: 400;
   font-size: 11px;
   line-height: 15px;
-  text-transform: none;
   text-decoration: underline;
   color: ${Colors.white};
-  min-height: 0;
-  min-width: 0;
-  padding-left: 0;
-  padding-right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StyledMetadataBox = styled(Box)`
+  margin-bottom: 5px;
 `;
 
 const getInitials = string =>
@@ -299,14 +302,13 @@ export const Sidebar = React.memo(({ items }) => {
         {!isRetracted && (
           <>
             <StyledDivider $invisible={isRetracted} />
-            <Box display="flex" justifyContent="space-between">
-              <a href={supportUrl} target="_blank" rel="noreferrer">
-                <SupportDeskButton type="button" id="logout" data-test-id="siderbar-logout-item">
-                  Support centre <Launch style={{ marginLeft: '5px', fontSize: '12px' }} />
-                </SupportDeskButton>
-              </a>
+            <StyledMetadataBox display="flex" justifyContent="space-between">
+              <SupportDesktopLink href={supportUrl} target="_blank" rel="noreferrer">
+                Support centre
+                <Launch style={{ marginLeft: '5px', fontSize: '12px' }} />
+              </SupportDesktopLink>
               <Version>Version {appVersion}</Version>
-            </Box>
+            </StyledMetadataBox>
           </>
         )}
       </Footer>

--- a/packages/desktop/app/components/Sidebar/Sidebar.js
+++ b/packages/desktop/app/components/Sidebar/Sidebar.js
@@ -144,6 +144,10 @@ const SupportDesktopLink = styled.a`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  :hover {
+    font-weight: bold;
+  }
 `;
 
 const StyledMetadataBox = styled(Box)`

--- a/packages/desktop/app/main.dev.js
+++ b/packages/desktop/app/main.dev.js
@@ -115,6 +115,12 @@ app.on('ready', async () => {
     }
   });
 
+  // To open redirect link in default browser
+  mainWindow.webContents.on('new-window', function(e, url) {
+    e.preventDefault();
+    require('electron').shell.openExternal(url);
+  });
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/packages/desktop/app/menu.js
+++ b/packages/desktop/app/menu.js
@@ -122,7 +122,7 @@ export default class MenuBuilder {
       ],
     };
     const subMenuHelp = {
-      label: 'Help',
+      label: 'About us',
       submenu: [
         {
           label: 'Learn More',
@@ -194,7 +194,7 @@ export default class MenuBuilder {
               ],
       },
       {
-        label: 'Help',
+        label: 'About us',
         submenu: [
           {
             label: 'Learn More',

--- a/packages/sync-server/app/localisation.js
+++ b/packages/sync-server/app/localisation.js
@@ -474,6 +474,7 @@ const rootLocalisationSchema = yup
       .noUnknown(),
     printMeasures: printMeasuresSchema,
     disabledReports: yup.array(yup.string().required()).defined(),
+    supportDeskUrl: yup.string().required(),
     ageDisplayFormat: yup
       .array(
         yup.object({

--- a/packages/sync-server/config/default.json
+++ b/packages/sync-server/config/default.json
@@ -932,7 +932,8 @@
             "min": { "duration": { "years": 2 } }
           }
         }
-      ]
+      ],
+      "supportDeskUrl": "https://bes-support.zendesk.com/hc/en-us"
     }
   },
   "reportProcess": {


### PR DESCRIPTION
### Changes
- Add 'Support centre' link to Tamanu desktop

<img width="253" alt="Screen Shot 2023-11-02 at 6 44 07 pm" src="https://github.com/beyondessential/tamanu/assets/63621318/cf1eba4f-e3b7-40d6-80c5-aee79e98cd4f">

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
