### PR TITLE
No Issue: Fix a bug disallowing relative paths in provisions

### DIFF
--- a/packages/sync-server/app/subCommands/provision.js
+++ b/packages/sync-server/app/subCommands/provision.js
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
 import { Command } from 'commander';
 
 import {
@@ -49,7 +49,7 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
       throw new Error(`Unknown reference data import with keys ${Object.keys(rest).join(', ')}`);
     }
 
-    const realpath = resolve(provisioningFile, referenceDataFile);
+    const realpath = resolve(provisioningFile, dirname(referenceDataFile));
     log.info('Importing reference data file', { file: realpath });
     await referenceDataImporter({
       errors,
@@ -157,7 +157,7 @@ export async function provision({ file: provisioningFile, skipIfNotNeeded }) {
       throw new Error(`Unknown program import with keys ${Object.keys(rest).join(', ')}`);
     }
 
-    const realpath = resolve(provisioningFile, programFile);
+    const realpath = resolve(provisioningFile, dirname(programFile));
     log.info('Importing program from file', { file: realpath });
     await programImporter({
       errors,


### PR DESCRIPTION
### Changes

There was a assumed bug in `provision` subcommand of the central server. When listing a reference database as a relative path, it made a path that doesn't work.
That's due to `provision.js` using a a path to a file instead of a directory as a base of `resolve`.

### Checklist

- [x] Code is finished
- [ ] Tests are written
  - I couldn't find a test for the `provision` subcommand. Is there any?

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
