### PR TITLE
NASS-943: patient registration and register birth translated components

### DIFF
--- a/packages/desktop/app/components/Field/IdField.js
+++ b/packages/desktop/app/components/Field/IdField.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Autorenew } from '@material-ui/icons';
 import { Colors } from '../../constants';
 import { InvertedDisplayIdLabel } from '../DisplayIdLabel';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const IdControl = styled.div`
   display: flex;
@@ -43,7 +44,9 @@ export const IdInput = ({ value, name, onChange, regenerateId }) => (
     <Id data-test-class="id-field-div">{value || ''}</Id>
     <RegenerateId onClick={() => onChange({ target: { value: regenerateId(), name } })}>
       <Autorenew />
-      <Text>Regenerate</Text>
+      <Text>
+        <TranslatedText stringId="patient.form.id.regenerate" fallback="Regenerate" />
+      </Text>
     </RegenerateId>
   </IdControl>
 );

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -604,8 +604,14 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
 ];
 
 export const BIRTH_TYPE_OPTIONS = [
-  { value: BIRTH_TYPES.SINGLE, label: 'Single' },
-  { value: BIRTH_TYPES.PLURAL, label: 'Plural' },
+  {
+    value: BIRTH_TYPES.SINGLE,
+    label: <TranslatedText stringId="birth.form.birthType.options.single" fallback="Single" />,
+  },
+  {
+    value: BIRTH_TYPES.PLURAL,
+    label: <TranslatedText stringId="birth.form.birthType.options.plural" fallback="Plural" />,
+  },
 ];
 
 export const PLACE_OF_BIRTH_OPTIONS = [

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -262,11 +262,11 @@ export const bloodOptions = [
   },
   {
     value: 'O+',
-    label: <TranslatedText stringId="patient.form.bloodType.option.o+" faloback="O+" />,
+    label: <TranslatedText stringId="patient.form.bloodType.option.o+" fallback="O+" />,
   },
   {
     value: 'O-',
-    label: <TranslatedText stringId="patient.form.bloodType.option.o-" faloback="O-" />,
+    label: <TranslatedText stringId="patient.form.bloodType.option.o-" fallback="O-" />,
   },
 ];
 

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -381,13 +381,69 @@ export const maritalStatusOptions = [
 ];
 
 export const educationalAttainmentOptions = [
-  { value: 'No formal schooling', label: 'No formal schooling' },
-  { value: 'Less than primary school', label: 'Less than primary school' },
-  { value: 'Primary school completed', label: 'Primary school completed' },
-  { value: 'Sec school completed', label: 'Sec school completed' },
-  { value: 'High school completed', label: 'High school completed' },
-  { value: 'University completed', label: 'University completed' },
-  { value: 'Post grad completed', label: 'Post grad completed' },
+  {
+    value: 'No formal schooling',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.noFormalSchooling"
+        fallback="No formal schooling"
+      />
+    ),
+  },
+  {
+    value: 'Less than primary school',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.lessThanPrimary"
+        fallback="Less than primary"
+      />
+    ),
+  },
+  {
+    value: 'Primary school completed',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.primaryCompleted"
+        fallback="Primary school completed"
+      />
+    ),
+  },
+  {
+    value: 'Sec school completed',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.secSchoolCompleted"
+        fallback="Sec school completed"
+      />
+    ),
+  },
+  {
+    value: 'High school completed',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.highSchoolCompleted"
+        fallback="High school completed"
+      />
+    ),
+  },
+  {
+    value: 'University completed',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.universityCompleted"
+        fallback="University completed"
+      />
+    ),
+  },
+  {
+    value: 'Post grad completed',
+    label: (
+      <TranslatedText
+        stringId="patient.form.educationalAttainments.option.postGradCompleted"
+        fallback="Post grad completed"
+      />
+    ),
+  },
 ];
 
 export const SEX_VALUE_INDEX = createValueIndex(sexOptions);

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -635,14 +635,35 @@ export const PLACE_OF_BIRTH_OPTIONS = [
 ];
 
 export const ATTENDANT_OF_BIRTH_OPTIONS = [
-  { value: ATTENDANT_OF_BIRTH_TYPES.DOCTOR, label: 'Doctor' },
-  { value: ATTENDANT_OF_BIRTH_TYPES.MIDWIFE, label: 'Midwife' },
-  { value: ATTENDANT_OF_BIRTH_TYPES.NURSE, label: 'Nurse' },
+  {
+    value: ATTENDANT_OF_BIRTH_TYPES.DOCTOR,
+    label: (
+      <TranslatedText stringId="birth.form.attendantOfBirth.options.doctor" fallback="Doctor" />
+    ),
+  },
+  {
+    value: ATTENDANT_OF_BIRTH_TYPES.MIDWIFE,
+    label: (
+      <TranslatedText stringId="birth.form.attendantOfBirth.options.midwife" fallback="Midwife" />
+    ),
+  },
+  {
+    value: ATTENDANT_OF_BIRTH_TYPES.NURSE,
+    label: <TranslatedText stringId="birth.form.attendantOfBirth.options.nurse" fallback="Nurse" />,
+  },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.TRADITIONAL_BIRTH_ATTENDANT,
-    label: 'Traditional birth attendant',
+    label: (
+      <TranslatedText
+        stringId="birth.form.attendantOfBirth.options.traditionalBirthAttendant"
+        fallback="Traditional birth attendant"
+      />
+    ),
   },
-  { value: ATTENDANT_OF_BIRTH_TYPES.OTHER, label: 'Other' },
+  {
+    value: ATTENDANT_OF_BIRTH_TYPES.OTHER,
+    label: <TranslatedText stringId="birth.form.attendantOfBirth.options.other" fallback="Other" />,
+  },
 ];
 
 export const TEMPLATE_TYPE_OPTIONS = [

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -615,9 +615,23 @@ export const BIRTH_TYPE_OPTIONS = [
 ];
 
 export const PLACE_OF_BIRTH_OPTIONS = [
-  { value: PLACE_OF_BIRTH_TYPES.HEALTH_FACILITY, label: 'Health facility' },
-  { value: PLACE_OF_BIRTH_TYPES.HOME, label: 'Home' },
-  { value: PLACE_OF_BIRTH_TYPES.OTHER, label: 'Other' },
+  {
+    value: PLACE_OF_BIRTH_TYPES.HEALTH_FACILITY,
+    label: (
+      <TranslatedText
+        stringId="birth.form.placeOfBirth.options.healthFacility"
+        fallback="Health facility"
+      />
+    ),
+  },
+  {
+    value: PLACE_OF_BIRTH_TYPES.HOME,
+    label: <TranslatedText stringId="birth.form.placeOfBirth.options.home" fallback="Home" />,
+  },
+  {
+    value: PLACE_OF_BIRTH_TYPES.OTHER,
+    label: <TranslatedText stringId="birth.form.placeOfBirth.options.other" fallback="Other" />,
+  },
 ];
 
 export const ATTENDANT_OF_BIRTH_OPTIONS = [

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -553,13 +553,54 @@ export const INVOICE_PAYMENT_STATUS_OPTIONS = [
 ];
 
 export const BIRTH_DELIVERY_TYPE_OPTIONS = [
-  { value: BIRTH_DELIVERY_TYPES.NORMAL_VAGINAL_DELIVERY, label: 'Normal vaginal delivery' },
-  { value: BIRTH_DELIVERY_TYPES.BREECH, label: 'Breech' },
-  { value: BIRTH_DELIVERY_TYPES.EMERGENCY_C_SECTION, label: 'Emergency C-section' },
-  { value: BIRTH_DELIVERY_TYPES.ELECTIVE_C_SECTION, label: 'Elective C-section' },
-  { value: BIRTH_DELIVERY_TYPES.VACUUM_EXTRACTION, label: 'Vacuum extraction' },
-  { value: BIRTH_DELIVERY_TYPES.FORCEPS, label: 'Forceps' },
-  { value: BIRTH_DELIVERY_TYPES.OTHER, label: 'Other' },
+  {
+    value: BIRTH_DELIVERY_TYPES.NORMAL_VAGINAL_DELIVERY,
+    label: (
+      <TranslatedText
+        stringId="birth.form.deliveryType.options.normalVaginalDelivery"
+        fallback="Normal vaginal delivery"
+      />
+    ),
+  },
+  {
+    value: BIRTH_DELIVERY_TYPES.BREECH,
+    label: <TranslatedText stringId="birth.form.deliveryType.options.breech" fallback="Breech" />,
+  },
+  {
+    value: BIRTH_DELIVERY_TYPES.EMERGENCY_C_SECTION,
+    label: (
+      <TranslatedText
+        stringId="birth.form.deliveryType.options.emergencyCSection"
+        fallback="Emergency C-section"
+      />
+    ),
+  },
+  {
+    value: BIRTH_DELIVERY_TYPES.ELECTIVE_C_SECTION,
+    label: (
+      <TranslatedText
+        stringId="birth.form.deliveryType.options.electiveCSection"
+        fallback="Elective C-section"
+      />
+    ),
+  },
+  {
+    value: BIRTH_DELIVERY_TYPES.VACUUM_EXTRACTION,
+    label: (
+      <TranslatedText
+        stringId="birth.form.deliveryType.options.vacuumExtraction"
+        fallback="Vacuum extraction"
+      />
+    ),
+  },
+  {
+    value: BIRTH_DELIVERY_TYPES.FORCEPS,
+    label: <TranslatedText stringId="birth.form.deliveryType.options.forceps" fallback="Forceps" />,
+  },
+  {
+    value: BIRTH_DELIVERY_TYPES.OTHER,
+    label: <TranslatedText stringId="birth.form.deliveryType.options.other" fallback="Other" />,
+  },
 ];
 
 export const BIRTH_TYPE_OPTIONS = [

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -428,11 +428,6 @@ export const ATTENDANT_OF_BIRTH_OPTIONS = [
   { value: ATTENDANT_OF_BIRTH_TYPES.OTHER, label: 'Other' },
 ];
 
-export const PATIENT_REGISTRY_OPTIONS = [
-  { value: PATIENT_REGISTRY_TYPES.NEW_PATIENT, label: 'Create new patient' },
-  { value: PATIENT_REGISTRY_TYPES.BIRTH_REGISTRY, label: 'Register birth' },
-];
-
 export const TEMPLATE_TYPE_OPTIONS = [
   { value: TEMPLATE_TYPES.PATIENT_LETTER, label: 'Patient Letter' },
 ];

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -238,145 +238,145 @@ export const operativePlanStatusList = Object.values(operativePlanStatuses).map(
 export const bloodOptions = [
   {
     value: 'A+',
-    label: <TranslatedText stringId="patient.form.bloodType.option.a+" fallback="A+" />,
+    label: <TranslatedText stringId="patient.property.bloodType.a+" fallback="A+" />,
   },
   {
     value: 'A-',
-    label: <TranslatedText stringId="patient.form.bloodType.option.a-" fallback="A-" />,
+    label: <TranslatedText stringId="patient.property.bloodType.a-" fallback="A-" />,
   },
   {
     value: 'AB-',
-    label: <TranslatedText stringId="patient.form.bloodType.option.ab-" fallback="AB-" />,
+    label: <TranslatedText stringId="patient.property.bloodType.ab-" fallback="AB-" />,
   },
   {
     value: 'AB+',
-    label: <TranslatedText stringId="patient.form.bloodType.option.ab+" fallback="AB+" />,
+    label: <TranslatedText stringId="patient.property.bloodType.ab+" fallback="AB+" />,
   },
   {
     value: 'B+',
-    label: <TranslatedText stringId="patient.form.bloodType.option.b+" fallback="B+" />,
+    label: <TranslatedText stringId="patient.property.bloodType.b+" fallback="B+" />,
   },
   {
     value: 'B-',
-    label: <TranslatedText stringId="patient.form.bloodType.option.b-" fallback="B-" />,
+    label: <TranslatedText stringId="patient.property.bloodType.b-" fallback="B-" />,
   },
   {
     value: 'O+',
-    label: <TranslatedText stringId="patient.form.bloodType.option.o+" fallback="O+" />,
+    label: <TranslatedText stringId="patient.property.bloodType.o+" fallback="O+" />,
   },
   {
     value: 'O-',
-    label: <TranslatedText stringId="patient.form.bloodType.option.o-" fallback="O-" />,
+    label: <TranslatedText stringId="patient.property.bloodType.o-" fallback="O-" />,
   },
 ];
 
 export const sexOptions = [
   {
     value: 'male',
-    label: <TranslatedText stringId="patient.form.sex.option.male" fallback="Male" />,
+    label: <TranslatedText stringId="patient.property.sex.male" fallback="Male" />,
   },
   {
     value: 'female',
-    label: <TranslatedText stringId="patient.form.sex.option.female" fallback="Female" />,
+    label: <TranslatedText stringId="patient.property.sex.female" fallback="Female" />,
   },
   {
     value: 'other',
-    label: <TranslatedText stringId="patient.form.sex.option.other" fallback="Other" />,
+    label: <TranslatedText stringId="patient.property.sex.other" fallback="Other" />,
   },
 ];
 
 export const titleOptions = [
   {
     value: 'Mr',
-    label: <TranslatedText stringId="patient.form.title.option.mr" fallback="Mr" />,
+    label: <TranslatedText stringId="patient.property.title.mr" fallback="Mr" />,
   },
   {
     value: 'Mrs',
-    label: <TranslatedText stringId="patient.form.title.option.mr" fallback="Mrs" />,
+    label: <TranslatedText stringId="patient.property.title.mr" fallback="Mrs" />,
   },
-  { value: 'Ms', label: <TranslatedText stringId="patient.form.title.option.ms" fallback="Ms" /> },
+  {
+    value: 'Ms',
+    label: <TranslatedText stringId="patient.property.title.ms" fallback="Ms" />,
+  },
   {
     value: 'Miss',
-    label: <TranslatedText stringId="patient.form.title.option.miss" fallback="Miss" />,
+    label: <TranslatedText stringId="patient.property.title.miss" fallback="Miss" />,
   },
-  { value: 'Dr', label: <TranslatedText stringId="patient.form.title.option.dr" fallback="Dr" /> },
-  { value: 'Sr', label: <TranslatedText stringId="patient.form.title.option.sr" fallback="Sr" /> },
-  { value: 'Sn', label: <TranslatedText stringId="patient.form.title.option.sn" fallback="Sn" /> },
+  {
+    value: 'Dr',
+    label: <TranslatedText stringId="patient.property.title.dr" fallback="Dr" />,
+  },
+  {
+    value: 'Sr',
+    label: <TranslatedText stringId="patient.property.title.sr" fallback="Sr" />,
+  },
+  {
+    value: 'Sn',
+    label: <TranslatedText stringId="patient.property.title.sn" fallback="Sn" />,
+  },
 ];
 
 export const socialMediaOptions = [
   {
     value: 'Facebook',
-    label: (
-      <TranslatedText stringId="patient.form.socialMedia.option.facebook" fallback="Facebook" />
-    ),
+    label: <TranslatedText stringId="patient.property.socialMedia.facebook" fallback="Facebook" />,
   },
   {
     value: 'Instagram',
     label: (
-      <TranslatedText stringId="patient.form.socialMedia.option.instagram" fallback="Instagram" />
+      <TranslatedText stringId="patient.property.socialMedia.instagram" fallback="Instagram" />
     ),
   },
   {
     value: 'LinkedIn',
-    label: (
-      <TranslatedText stringId="patient.form.socialMedia.option.linkedIn" fallback="LinkedIn" />
-    ),
+    label: <TranslatedText stringId="patient.property.socialMedia.linkedIn" fallback="LinkedIn" />,
   },
   {
     value: 'Twitter',
-    label: <TranslatedText stringId="patient.form.socialMedia.option.twitter" fallback="Twitter" />,
+    label: <TranslatedText stringId="patient.property.socialMedia.twitter" fallback="Twitter" />,
   },
   {
     value: 'Viber',
-    label: <TranslatedText stringId="patient.form.socialMedia.option.viber" fallback="Viber" />,
+    label: <TranslatedText stringId="patient.property.socialMedia.viber" fallback="Viber" />,
   },
   {
     value: 'WhatsApp',
-    label: (
-      <TranslatedText stringId="patient.form.socialMedia.option.whatsApp" fallback="WhatsApp" />
-    ),
+    label: <TranslatedText stringId="patient.property.socialMedia.whatsApp" fallback="WhatsApp" />,
   },
 ];
 
 export const maritalStatusOptions = [
   {
     value: 'Defacto',
-    label: (
-      <TranslatedText stringId="patient.form.maritalStatus.option.defacto" fallback="De facto" />
-    ),
+    label: <TranslatedText stringId="patient.property.maritalStatus.defacto" fallback="De facto" />,
   },
   {
     value: 'Married',
-    label: (
-      <TranslatedText stringId="patient.form.maritalStatus.option.married" fallback="Married" />
-    ),
+    label: <TranslatedText stringId="patient.property.maritalStatus.married" fallback="Married" />,
   },
   {
     value: 'Single',
-    label: <TranslatedText stringId="patient.form.maritalStatus.option.single" fallback="Single" />,
+    label: <TranslatedText stringId="patient.property.maritalStatus.single" fallback="Single" />,
   },
   {
     value: 'Widow',
-    label: <TranslatedText stringId="patient.form.maritalStatus.option.widow" fallback="Widow" />,
+    label: <TranslatedText stringId="patient.property.maritalStatus.widow" fallback="Widow" />,
   },
   {
     value: 'Divorced',
     label: (
-      <TranslatedText stringId="patient.form.maritalStatus.option.divorced" fallback="Divorced" />
+      <TranslatedText stringId="patient.property.maritalStatus.divorced" fallback="Divorced" />
     ),
   },
   {
     value: 'Separated',
     label: (
-      <TranslatedText stringId="patient.form.maritalStatus.option.separated" fallback="Separated" />
+      <TranslatedText stringId="patient.property.maritalStatus.separated" fallback="Separated" />
     ),
   },
   {
     value: 'Unknown',
-    label: (
-      <TranslatedText stringId="patient.form.maritalStatus.option.unknown" fallback="Unknown" />
-    ),
+    label: <TranslatedText stringId="patient.property.maritalStatus.unknown" fallback="Unknown" />,
   },
 ];
 
@@ -385,7 +385,7 @@ export const educationalAttainmentOptions = [
     value: 'No formal schooling',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.noFormalSchooling"
+        stringId="patient.property.educationalAttainment.noFormalSchooling"
         fallback="No formal schooling"
       />
     ),
@@ -394,7 +394,7 @@ export const educationalAttainmentOptions = [
     value: 'Less than primary school',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.lessThanPrimary"
+        stringId="patient.property.educationalAttainment.lessThanPrimary"
         fallback="Less than primary"
       />
     ),
@@ -403,7 +403,7 @@ export const educationalAttainmentOptions = [
     value: 'Primary school completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.primaryCompleted"
+        stringId="patient.property.educationalAttainment.primaryCompleted"
         fallback="Primary school completed"
       />
     ),
@@ -412,7 +412,7 @@ export const educationalAttainmentOptions = [
     value: 'Sec school completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.secSchoolCompleted"
+        stringId="patient.property.educationalAttainment.secSchoolCompleted"
         fallback="Sec school completed"
       />
     ),
@@ -421,7 +421,7 @@ export const educationalAttainmentOptions = [
     value: 'High school completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.highSchoolCompleted"
+        stringId="patient.property.educationalAttainment.highSchoolCompleted"
         fallback="High school completed"
       />
     ),
@@ -430,7 +430,7 @@ export const educationalAttainmentOptions = [
     value: 'University completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.universityCompleted"
+        stringId="patient.property.educationalAttainment.universityCompleted"
         fallback="University completed"
       />
     ),
@@ -439,7 +439,7 @@ export const educationalAttainmentOptions = [
     value: 'Post grad completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainment.option.postGradCompleted"
+        stringId="patient.property.educationalAttainment.postGradCompleted"
         fallback="Post grad completed"
       />
     ),
@@ -453,17 +453,14 @@ export const pregnancyOutcomes = [
   {
     value: 'liveBirth',
     label: (
-      <TranslatedText
-        stringId="birth.form.pregnancyOutcome.option.liveBirth"
-        fallback="Live birth"
-      />
+      <TranslatedText stringId="birth.property.pregnancyOutcome.liveBirth" fallback="Live birth" />
     ),
   },
   {
     value: 'stillBirth',
     label: (
       <TranslatedText
-        stringId="birth.form.pregnancyOutcome.option.stillBirth"
+        stringId="birth.property.pregnancyOutcome.stillBirth"
         fallback="Still birth"
       />
     ),
@@ -472,7 +469,7 @@ export const pregnancyOutcomes = [
     value: 'fetalDeath',
     label: (
       <TranslatedText
-        stringId="birth.form.pregnancyOutcome.option.fetalDeath"
+        stringId="birth.property.pregnancyOutcome.fetalDeath"
         fallback="Fetal death"
       />
     ),
@@ -581,20 +578,20 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
     value: BIRTH_DELIVERY_TYPES.NORMAL_VAGINAL_DELIVERY,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.option.normalVaginalDelivery"
+        stringId="birth.property.deliveryType.normalVaginalDelivery"
         fallback="Normal vaginal delivery"
       />
     ),
   },
   {
     value: BIRTH_DELIVERY_TYPES.BREECH,
-    label: <TranslatedText stringId="birth.form.deliveryType.option.breech" fallback="Breech" />,
+    label: <TranslatedText stringId="birth.property.deliveryType.breech" fallback="Breech" />,
   },
   {
     value: BIRTH_DELIVERY_TYPES.EMERGENCY_C_SECTION,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.option.emergencyCSection"
+        stringId="birth.property.deliveryType.emergencyCSection"
         fallback="Emergency C-section"
       />
     ),
@@ -603,7 +600,7 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
     value: BIRTH_DELIVERY_TYPES.ELECTIVE_C_SECTION,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.option.electiveCSection"
+        stringId="birth.property.deliveryType.electiveCSection"
         fallback="Elective C-section"
       />
     ),
@@ -612,29 +609,29 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
     value: BIRTH_DELIVERY_TYPES.VACUUM_EXTRACTION,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.option.vacuumExtraction"
+        stringId="birth.property.deliveryType.vacuumExtraction"
         fallback="Vacuum extraction"
       />
     ),
   },
   {
     value: BIRTH_DELIVERY_TYPES.FORCEPS,
-    label: <TranslatedText stringId="birth.form.deliveryType.option.forceps" fallback="Forceps" />,
+    label: <TranslatedText stringId="birth.property.deliveryType.forceps" fallback="Forceps" />,
   },
   {
     value: BIRTH_DELIVERY_TYPES.OTHER,
-    label: <TranslatedText stringId="birth.form.deliveryType.option.other" fallback="Other" />,
+    label: <TranslatedText stringId="birth.property.deliveryType.other" fallback="Other" />,
   },
 ];
 
 export const BIRTH_TYPE_OPTIONS = [
   {
     value: BIRTH_TYPES.SINGLE,
-    label: <TranslatedText stringId="birth.form.birthType.option.single" fallback="Single" />,
+    label: <TranslatedText stringId="birth.property.birthType.single" fallback="Single" />,
   },
   {
     value: BIRTH_TYPES.PLURAL,
-    label: <TranslatedText stringId="birth.form.birthType.option.plural" fallback="Plural" />,
+    label: <TranslatedText stringId="birth.property.birthType.plural" fallback="Plural" />,
   },
 ];
 
@@ -643,50 +640,46 @@ export const PLACE_OF_BIRTH_OPTIONS = [
     value: PLACE_OF_BIRTH_TYPES.HEALTH_FACILITY,
     label: (
       <TranslatedText
-        stringId="birth.form.placeOfBirth.option.healthFacility"
+        stringId="birth.property.placeOfBirth.healthFacility"
         fallback="Health facility"
       />
     ),
   },
   {
     value: PLACE_OF_BIRTH_TYPES.HOME,
-    label: <TranslatedText stringId="birth.form.placeOfBirth.option.home" fallback="Home" />,
+    label: <TranslatedText stringId="birth.property.placeOfBirth.home" fallback="Home" />,
   },
   {
     value: PLACE_OF_BIRTH_TYPES.OTHER,
-    label: <TranslatedText stringId="birth.form.placeOfBirth.option.other" fallback="Other" />,
+    label: <TranslatedText stringId="birth.property.placeOfBirth.other" fallback="Other" />,
   },
 ];
 
 export const ATTENDANT_OF_BIRTH_OPTIONS = [
   {
     value: ATTENDANT_OF_BIRTH_TYPES.DOCTOR,
-    label: (
-      <TranslatedText stringId="birth.form.attendantOfBirth.option.doctor" fallback="Doctor" />
-    ),
+    label: <TranslatedText stringId="birth.property.attendantOfBirth.doctor" fallback="Doctor" />,
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.MIDWIFE,
-    label: (
-      <TranslatedText stringId="birth.form.attendantOfBirth.option.midwife" fallback="Midwife" />
-    ),
+    label: <TranslatedText stringId="birth.property.attendantOfBirth.midwife" fallback="Midwife" />,
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.NURSE,
-    label: <TranslatedText stringId="birth.form.attendantOfBirth.option.nurse" fallback="Nurse" />,
+    label: <TranslatedText stringId="birth.property.attendantOfBirth.nurse" fallback="Nurse" />,
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.TRADITIONAL_BIRTH_ATTENDANT,
     label: (
       <TranslatedText
-        stringId="birth.form.attendantOfBirth.option.traditionalBirthAttendant"
+        stringId="birth.property.attendantOfBirth.traditionalBirthAttendant"
         fallback="Traditional birth attendant"
       />
     ),
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.OTHER,
-    label: <TranslatedText stringId="birth.form.attendantOfBirth.option.other" fallback="Other" />,
+    label: <TranslatedText stringId="birth.property.attendantOfBirth.other" fallback="Other" />,
   },
 ];
 

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -385,7 +385,7 @@ export const educationalAttainmentOptions = [
     value: 'No formal schooling',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.noFormalSchooling"
+        stringId="patient.form.educationalAttainment.option.noFormalSchooling"
         fallback="No formal schooling"
       />
     ),
@@ -394,7 +394,7 @@ export const educationalAttainmentOptions = [
     value: 'Less than primary school',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.lessThanPrimary"
+        stringId="patient.form.educationalAttainment.option.lessThanPrimary"
         fallback="Less than primary"
       />
     ),
@@ -403,7 +403,7 @@ export const educationalAttainmentOptions = [
     value: 'Primary school completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.primaryCompleted"
+        stringId="patient.form.educationalAttainment.option.primaryCompleted"
         fallback="Primary school completed"
       />
     ),
@@ -412,7 +412,7 @@ export const educationalAttainmentOptions = [
     value: 'Sec school completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.secSchoolCompleted"
+        stringId="patient.form.educationalAttainment.option.secSchoolCompleted"
         fallback="Sec school completed"
       />
     ),
@@ -421,7 +421,7 @@ export const educationalAttainmentOptions = [
     value: 'High school completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.highSchoolCompleted"
+        stringId="patient.form.educationalAttainment.option.highSchoolCompleted"
         fallback="High school completed"
       />
     ),
@@ -430,7 +430,7 @@ export const educationalAttainmentOptions = [
     value: 'University completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.universityCompleted"
+        stringId="patient.form.educationalAttainment.option.universityCompleted"
         fallback="University completed"
       />
     ),
@@ -439,7 +439,7 @@ export const educationalAttainmentOptions = [
     value: 'Post grad completed',
     label: (
       <TranslatedText
-        stringId="patient.form.educationalAttainments.option.postGradCompleted"
+        stringId="patient.form.educationalAttainment.option.postGradCompleted"
         fallback="Post grad completed"
       />
     ),
@@ -450,9 +450,33 @@ export const SEX_VALUE_INDEX = createValueIndex(sexOptions);
 
 export const pregnancyOutcomes = [
   { value: '', label: 'N/A' },
-  { value: 'liveBirth', label: 'Live Birth' },
-  { value: 'stillBirth', label: 'Still Birth' },
-  { value: 'fetalDeath', label: 'Fetal Death' },
+  {
+    value: 'liveBirth',
+    label: (
+      <TranslatedText
+        stringId="birth.form.pregnancyOutcome.option.liveBirth"
+        fallback="Live birth"
+      />
+    ),
+  },
+  {
+    value: 'stillBirth',
+    label: (
+      <TranslatedText
+        stringId="birth.form.pregnancyOutcome.option.stillBirth"
+        fallback="Still birth"
+      />
+    ),
+  },
+  {
+    value: 'fetalDeath',
+    label: (
+      <TranslatedText
+        stringId="birth.form.pregnancyOutcome.option.fetalDeath"
+        fallback="Fetal death"
+      />
+    ),
+  },
 ];
 
 export const REPORT_TYPES = {
@@ -557,20 +581,20 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
     value: BIRTH_DELIVERY_TYPES.NORMAL_VAGINAL_DELIVERY,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.options.normalVaginalDelivery"
+        stringId="birth.form.deliveryType.option.normalVaginalDelivery"
         fallback="Normal vaginal delivery"
       />
     ),
   },
   {
     value: BIRTH_DELIVERY_TYPES.BREECH,
-    label: <TranslatedText stringId="birth.form.deliveryType.options.breech" fallback="Breech" />,
+    label: <TranslatedText stringId="birth.form.deliveryType.option.breech" fallback="Breech" />,
   },
   {
     value: BIRTH_DELIVERY_TYPES.EMERGENCY_C_SECTION,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.options.emergencyCSection"
+        stringId="birth.form.deliveryType.option.emergencyCSection"
         fallback="Emergency C-section"
       />
     ),
@@ -579,7 +603,7 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
     value: BIRTH_DELIVERY_TYPES.ELECTIVE_C_SECTION,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.options.electiveCSection"
+        stringId="birth.form.deliveryType.option.electiveCSection"
         fallback="Elective C-section"
       />
     ),
@@ -588,29 +612,29 @@ export const BIRTH_DELIVERY_TYPE_OPTIONS = [
     value: BIRTH_DELIVERY_TYPES.VACUUM_EXTRACTION,
     label: (
       <TranslatedText
-        stringId="birth.form.deliveryType.options.vacuumExtraction"
+        stringId="birth.form.deliveryType.option.vacuumExtraction"
         fallback="Vacuum extraction"
       />
     ),
   },
   {
     value: BIRTH_DELIVERY_TYPES.FORCEPS,
-    label: <TranslatedText stringId="birth.form.deliveryType.options.forceps" fallback="Forceps" />,
+    label: <TranslatedText stringId="birth.form.deliveryType.option.forceps" fallback="Forceps" />,
   },
   {
     value: BIRTH_DELIVERY_TYPES.OTHER,
-    label: <TranslatedText stringId="birth.form.deliveryType.options.other" fallback="Other" />,
+    label: <TranslatedText stringId="birth.form.deliveryType.option.other" fallback="Other" />,
   },
 ];
 
 export const BIRTH_TYPE_OPTIONS = [
   {
     value: BIRTH_TYPES.SINGLE,
-    label: <TranslatedText stringId="birth.form.birthType.options.single" fallback="Single" />,
+    label: <TranslatedText stringId="birth.form.birthType.option.single" fallback="Single" />,
   },
   {
     value: BIRTH_TYPES.PLURAL,
-    label: <TranslatedText stringId="birth.form.birthType.options.plural" fallback="Plural" />,
+    label: <TranslatedText stringId="birth.form.birthType.option.plural" fallback="Plural" />,
   },
 ];
 
@@ -619,18 +643,18 @@ export const PLACE_OF_BIRTH_OPTIONS = [
     value: PLACE_OF_BIRTH_TYPES.HEALTH_FACILITY,
     label: (
       <TranslatedText
-        stringId="birth.form.placeOfBirth.options.healthFacility"
+        stringId="birth.form.placeOfBirth.option.healthFacility"
         fallback="Health facility"
       />
     ),
   },
   {
     value: PLACE_OF_BIRTH_TYPES.HOME,
-    label: <TranslatedText stringId="birth.form.placeOfBirth.options.home" fallback="Home" />,
+    label: <TranslatedText stringId="birth.form.placeOfBirth.option.home" fallback="Home" />,
   },
   {
     value: PLACE_OF_BIRTH_TYPES.OTHER,
-    label: <TranslatedText stringId="birth.form.placeOfBirth.options.other" fallback="Other" />,
+    label: <TranslatedText stringId="birth.form.placeOfBirth.option.other" fallback="Other" />,
   },
 ];
 
@@ -638,31 +662,31 @@ export const ATTENDANT_OF_BIRTH_OPTIONS = [
   {
     value: ATTENDANT_OF_BIRTH_TYPES.DOCTOR,
     label: (
-      <TranslatedText stringId="birth.form.attendantOfBirth.options.doctor" fallback="Doctor" />
+      <TranslatedText stringId="birth.form.attendantOfBirth.option.doctor" fallback="Doctor" />
     ),
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.MIDWIFE,
     label: (
-      <TranslatedText stringId="birth.form.attendantOfBirth.options.midwife" fallback="Midwife" />
+      <TranslatedText stringId="birth.form.attendantOfBirth.option.midwife" fallback="Midwife" />
     ),
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.NURSE,
-    label: <TranslatedText stringId="birth.form.attendantOfBirth.options.nurse" fallback="Nurse" />,
+    label: <TranslatedText stringId="birth.form.attendantOfBirth.option.nurse" fallback="Nurse" />,
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.TRADITIONAL_BIRTH_ATTENDANT,
     label: (
       <TranslatedText
-        stringId="birth.form.attendantOfBirth.options.traditionalBirthAttendant"
+        stringId="birth.form.attendantOfBirth.option.traditionalBirthAttendant"
         fallback="Traditional birth attendant"
       />
     ),
   },
   {
     value: ATTENDANT_OF_BIRTH_TYPES.OTHER,
-    label: <TranslatedText stringId="birth.form.attendantOfBirth.options.other" fallback="Other" />,
+    label: <TranslatedText stringId="birth.form.attendantOfBirth.option.other" fallback="Other" />,
   },
 ];
 

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -1,4 +1,5 @@
 import { capitalize } from 'lodash';
+import React from 'react';
 
 import { createValueIndex } from '@tamanu/shared/utils/valueIndex';
 import {
@@ -9,7 +10,6 @@ import {
   REFERRAL_STATUSES,
   INVOICE_STATUSES,
   INVOICE_PAYMENT_STATUSES,
-  PATIENT_REGISTRY_TYPES,
   BIRTH_DELIVERY_TYPES,
   BIRTH_TYPES,
   PLACE_OF_BIRTH_TYPES,
@@ -32,6 +32,7 @@ import {
   patientIcon,
   vaccineIcon,
 } from './images';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 export const MUI_SPACING_UNIT = 8;
 
@@ -235,49 +236,148 @@ export const operativePlanStatusList = Object.values(operativePlanStatuses).map(
 }));
 
 export const bloodOptions = [
-  { value: 'A+', label: 'A+' },
-  { value: 'A-', label: 'A-' },
-  { value: 'AB-', label: 'AB-' },
-  { value: 'AB+', label: 'AB+' },
-  { value: 'B+', label: 'B+' },
-  { value: 'B-', label: 'B-' },
-  { value: 'O+', label: 'O+' },
-  { value: 'O-', label: 'O-' },
+  {
+    value: 'A+',
+    label: <TranslatedText stringId="patient.form.bloodType.option.a+" fallback="A+" />,
+  },
+  {
+    value: 'A-',
+    label: <TranslatedText stringId="patient.form.bloodType.option.a-" fallback="A-" />,
+  },
+  {
+    value: 'AB-',
+    label: <TranslatedText stringId="patient.form.bloodType.option.ab-" fallback="AB-" />,
+  },
+  {
+    value: 'AB+',
+    label: <TranslatedText stringId="patient.form.bloodType.option.ab+" fallback="AB+" />,
+  },
+  {
+    value: 'B+',
+    label: <TranslatedText stringId="patient.form.bloodType.option.b+" fallback="B+" />,
+  },
+  {
+    value: 'B-',
+    label: <TranslatedText stringId="patient.form.bloodType.option.b-" fallback="B-" />,
+  },
+  {
+    value: 'O+',
+    label: <TranslatedText stringId="patient.form.bloodType.option.o+" faloback="O+" />,
+  },
+  {
+    value: 'O-',
+    label: <TranslatedText stringId="patient.form.bloodType.option.o-" faloback="O-" />,
+  },
 ];
 
 export const sexOptions = [
-  { value: 'male', label: 'Male' },
-  { value: 'female', label: 'Female' },
-  { value: 'other', label: 'Other' },
+  {
+    value: 'male',
+    label: <TranslatedText stringId="patient.form.sex.option.male" fallback="Male" />,
+  },
+  {
+    value: 'female',
+    label: <TranslatedText stringId="patient.form.sex.option.female" fallback="Female" />,
+  },
+  {
+    value: 'other',
+    label: <TranslatedText stringId="patient.form.sex.option.other" fallback="Other" />,
+  },
 ];
 
 export const titleOptions = [
-  { value: 'Mr', label: 'Mr' },
-  { value: 'Mrs', label: 'Mrs' },
-  { value: 'Ms', label: 'Ms' },
-  { value: 'Miss', label: 'Miss' },
-  { value: 'Dr', label: 'Dr' },
-  { value: 'Sr', label: 'Sr' },
-  { value: 'Sn', label: 'Sn' },
+  {
+    value: 'Mr',
+    label: <TranslatedText stringId="patient.form.title.option.mr" fallback="Mr" />,
+  },
+  {
+    value: 'Mrs',
+    label: <TranslatedText stringId="patient.form.title.option.mr" fallback="Mrs" />,
+  },
+  { value: 'Ms', label: <TranslatedText stringId="patient.form.title.option.ms" fallback="Ms" /> },
+  {
+    value: 'Miss',
+    label: <TranslatedText stringId="patient.form.title.option.miss" fallback="Miss" />,
+  },
+  { value: 'Dr', label: <TranslatedText stringId="patient.form.title.option.dr" fallback="Dr" /> },
+  { value: 'Sr', label: <TranslatedText stringId="patient.form.title.option.sr" fallback="Sr" /> },
+  { value: 'Sn', label: <TranslatedText stringId="patient.form.title.option.sn" fallback="Sn" /> },
 ];
 
 export const socialMediaOptions = [
-  { value: 'Facebook', label: 'Facebook' },
-  { value: 'Instagram', label: 'Instagram' },
-  { value: 'LinkedIn', label: 'LinkedIn' },
-  { value: 'Twitter', label: 'Twitter' },
-  { value: 'Viber', label: 'Viber' },
-  { value: 'WhatsApp', label: 'WhatsApp' },
+  {
+    value: 'Facebook',
+    label: (
+      <TranslatedText stringId="patient.form.socialMedia.option.facebook" fallback="Facebook" />
+    ),
+  },
+  {
+    value: 'Instagram',
+    label: (
+      <TranslatedText stringId="patient.form.socialMedia.option.instagram" fallback="Instagram" />
+    ),
+  },
+  {
+    value: 'LinkedIn',
+    label: (
+      <TranslatedText stringId="patient.form.socialMedia.option.linkedIn" fallback="LinkedIn" />
+    ),
+  },
+  {
+    value: 'Twitter',
+    label: <TranslatedText stringId="patient.form.socialMedia.option.twitter" fallback="Twitter" />,
+  },
+  {
+    value: 'Viber',
+    label: <TranslatedText stringId="patient.form.socialMedia.option.viber" fallback="Viber" />,
+  },
+  {
+    value: 'WhatsApp',
+    label: (
+      <TranslatedText stringId="patient.form.socialMedia.option.whatsApp" fallback="WhatsApp" />
+    ),
+  },
 ];
 
 export const maritalStatusOptions = [
-  { value: 'Defacto', label: 'De facto' },
-  { value: 'Married', label: 'Married' },
-  { value: 'Single', label: 'Single' },
-  { value: 'Widow', label: 'Widow' },
-  { value: 'Divorced', label: 'Divorced' },
-  { value: 'Separated', label: 'Separated' },
-  { value: 'Unknown', label: 'Unknown' },
+  {
+    value: 'Defacto',
+    label: (
+      <TranslatedText stringId="patient.form.maritalStatus.option.defacto" fallback="De facto" />
+    ),
+  },
+  {
+    value: 'Married',
+    label: (
+      <TranslatedText stringId="patient.form.maritalStatus.option.married" fallback="Married" />
+    ),
+  },
+  {
+    value: 'Single',
+    label: <TranslatedText stringId="patient.form.maritalStatus.option.single" fallback="Single" />,
+  },
+  {
+    value: 'Widow',
+    label: <TranslatedText stringId="patient.form.maritalStatus.option.widow" fallback="Widow" />,
+  },
+  {
+    value: 'Divorced',
+    label: (
+      <TranslatedText stringId="patient.form.maritalStatus.option.divorced" fallback="Divorced" />
+    ),
+  },
+  {
+    value: 'Separated',
+    label: (
+      <TranslatedText stringId="patient.form.maritalStatus.option.separated" fallback="Separated" />
+    ),
+  },
+  {
+    value: 'Unknown',
+    label: (
+      <TranslatedText stringId="patient.form.maritalStatus.option.unknown" fallback="Unknown" />
+    ),
+  },
 ];
 
 export const educationalAttainmentOptions = [

--- a/packages/desktop/app/forms/NewPatientForm.js
+++ b/packages/desktop/app/forms/NewPatientForm.js
@@ -11,7 +11,7 @@ import { IdField } from '../components/Field/IdField';
 import { ModalActionRow } from '../components/ModalActionRow';
 import { RadioField } from '../components';
 import { IdBanner } from '../components/IdBanner';
-import { Colors, PATIENT_REGISTRY_OPTIONS } from '../constants';
+import { Colors } from '../constants';
 import { getPatientDetailsValidation } from '../validations';
 import {
   PrimaryDetailsGroup,
@@ -25,6 +25,7 @@ import { LoadingIndicator } from '../components/LoadingIndicator';
 import plusCircle from '../assets/images/plus_circle.svg';
 import minusCircle from '../assets/images/minus_circle.svg';
 import { RandomPatientButton } from '../views/patients/components/RandomPatientButton';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const StyledImageButton = styled(Button)`
   min-width: 30px;
@@ -112,7 +113,26 @@ export const NewPatientForm = memo(({ editedObject, onSubmit, onCancel, generate
             value: patientRegistryType,
             onChange: event => setPatientRegistryType(event.target?.value),
           }}
-          options={PATIENT_REGISTRY_OPTIONS}
+          options={[
+            {
+              value: PATIENT_REGISTRY_TYPES.NEW_PATIENT,
+              label: (
+                <TranslatedText
+                  stringId="patient.form.newPatientAction.option.newPatient"
+                  fallback="Create new patient"
+                />
+              ),
+            },
+            {
+              value: PATIENT_REGISTRY_TYPES.BIRTH_REGISTRY,
+              label: (
+                <TranslatedText
+                  stringId="patient.form.newPatientAction.option.birthRegistry"
+                  fallback="Register birth"
+                />
+              ),
+            },
+          ]}
           style={{ gridColumn: '1 / -1' }}
         />
         <PrimaryDetailsGroup />
@@ -127,8 +147,17 @@ export const NewPatientForm = memo(({ editedObject, onSubmit, onCancel, generate
                 <img alt="Plus button" src={plusCircle} />
               </StyledImageButton>
             )}
-            Add additional information
-            <span> (religion, occupation, blood type...)</span>
+            <TranslatedText
+              stringId="patient.form.additionalInformation.label"
+              fallback="Add additional information"
+            />
+            <span>
+              {' '}
+              <TranslatedText
+                stringId="patient.form.additionalInformation.exampleText"
+                fallback="(religion, occupation, blood type...)"
+              />
+            </span>
           </div>
         </AdditionalInformationRow>
         <Collapse in={isExpanded} style={{ gridColumn: 'span 2' }}>
@@ -139,7 +168,7 @@ export const NewPatientForm = memo(({ editedObject, onSubmit, onCancel, generate
             <PatientFieldsGroup fieldDefinitions={fieldDefinitions?.data} />
           )}
         </Collapse>
-        <ModalActionRow confirmText="Confirm" onConfirm={submitForm} onCancel={onCancel} />
+        <ModalActionRow onConfirm={submitForm} onCancel={onCancel} />
       </>
     );
   };

--- a/packages/desktop/app/forms/PatientDetailsForm.js
+++ b/packages/desktop/app/forms/PatientDetailsForm.js
@@ -90,7 +90,9 @@ export const PrimaryDetailsGroup = () => {
         name="email"
         component={TextField}
         type="email"
-        defaultLabel={<TranslatedText stringId="general.form.email" fallback="Email Address" />}
+        defaultLabel={
+          <TranslatedText stringId="general.form.email.label" fallback="Email Address" />
+        }
       />
     </FormGrid>
   );

--- a/packages/desktop/app/forms/PatientDetailsForm.js
+++ b/packages/desktop/app/forms/PatientDetailsForm.js
@@ -42,6 +42,7 @@ import {
   TimeField,
 } from '../components';
 import { LoadingIndicator } from '../components/LoadingIndicator';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const StyledHeading = styled.div`
   font-weight: 500;
@@ -89,7 +90,7 @@ export const PrimaryDetailsGroup = () => {
         name="email"
         component={TextField}
         type="email"
-        defaultLabel="Email address"
+        defaultLabel={<TranslatedText stringId="general.form.email" fallback="Email Address" />}
       />
     </FormGrid>
   );
@@ -115,7 +116,12 @@ export const SecondaryDetailsGroup = ({ patientRegistryType, values = {}, isEdit
     <StyledSecondaryDetailsGroup>
       {patientRegistryType === PATIENT_REGISTRY_TYPES.BIRTH_REGISTRY && (
         <>
-          <StyledHeading>Birth details</StyledHeading>
+          <StyledHeading>
+            <TranslatedText
+              stringId="patient.details.subheading.birthDetails"
+              fallback="Birth details"
+            />
+          </StyledHeading>
           <StyledFormGrid>
             <LocalisedField name="timeOfBirth" component={TimeField} saveDateAsString />
             <LocalisedField name="gestationalAgeEstimate" component={TextField} type="number" />
@@ -152,7 +158,12 @@ export const SecondaryDetailsGroup = ({ patientRegistryType, values = {}, isEdit
         </>
       )}
 
-      <StyledHeading>Identification information</StyledHeading>
+      <StyledHeading>
+        <TranslatedText
+          stringId="patient.details.subheading.identificationInformation"
+          fallback="Identification information"
+        />
+      </StyledHeading>
       <StyledFormGrid>
         {canEditDisplayId && <DisplayIdField />}
         <LocalisedField name="birthCertificate" component={TextField} />
@@ -162,7 +173,12 @@ export const SecondaryDetailsGroup = ({ patientRegistryType, values = {}, isEdit
         <LocalisedField name="passport" component={TextField} />
       </StyledFormGrid>
 
-      <StyledHeading>Contact information</StyledHeading>
+      <StyledHeading>
+        <TranslatedText
+          stringId="patient.details.subheading.contactInformation"
+          fallback="Contact information"
+        />
+      </StyledHeading>
       <StyledFormGrid>
         <LocalisedField name="primaryContactNumber" component={TextField} type="tel" />
         <LocalisedField name="secondaryContactNumber" component={TextField} type="tel" />
@@ -170,7 +186,12 @@ export const SecondaryDetailsGroup = ({ patientRegistryType, values = {}, isEdit
         <LocalisedField name="emergencyContactNumber" component={TextField} type="tel" />
       </StyledFormGrid>
 
-      <StyledHeading>Personal information</StyledHeading>
+      <StyledHeading>
+        <TranslatedText
+          stringId="patient.details.subheading.personalInformation"
+          fallback="Personal information"
+        />
+      </StyledHeading>
       <StyledFormGrid>
         <LocalisedField name="title" component={SelectField} options={titleOptions} />
         {patientRegistryType === PATIENT_REGISTRY_TYPES.NEW_PATIENT && (
@@ -238,7 +259,12 @@ export const SecondaryDetailsGroup = ({ patientRegistryType, values = {}, isEdit
         />
       </StyledFormGrid>
 
-      <StyledHeading>Location information</StyledHeading>
+      <StyledHeading>
+        <TranslatedText
+          stringId="patient.details.subheading.locationInformation"
+          fallback="Location information"
+        />
+      </StyledHeading>
       <StyledFormGrid>
         <LocalisedField name="cityTown" component={TextField} />
         <LocalisedField

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -30,6 +30,7 @@ import {
 } from './columns';
 import { useAuth } from '../../contexts/Auth';
 import { usePatientSearch, PatientSearchKeys } from '../../contexts/PatientSearch';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const PATIENT_SEARCH_ENDPOINT = 'patient';
 
@@ -118,10 +119,9 @@ const NewPatientButton = ({ onCreateNewPatient }) => {
         noun="Patient"
         onClick={showNewPatient}
       >
-        + Add new patient
+        + <TranslatedText stringId="patient.action.addNewPatient" fallback="Add new patient" />
       </ButtonWithPermissionCheck>
       <NewPatientModal
-        title="New patient"
         open={isCreatingPatient}
         onCancel={hideModal}
         onCreateNewPatient={handleCreateNewPatient}

--- a/packages/desktop/app/views/patients/components/NewPatientModal.js
+++ b/packages/desktop/app/views/patients/components/NewPatientModal.js
@@ -5,6 +5,7 @@ import { Modal } from '../../../components';
 import { NewPatientForm } from '../../../forms';
 import { useApi } from '../../../api';
 import { notifyError } from '../../../utils';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 export const NewPatientModal = ({ open, onCancel, onCreateNewPatient, ...formProps }) => {
   const api = useApi();
@@ -20,7 +21,11 @@ export const NewPatientModal = ({ open, onCancel, onCreateNewPatient, ...formPro
     [api, onCreateNewPatient],
   );
   return (
-    <Modal title="Add new patient" onClose={onCancel} open={open}>
+    <Modal
+      title={<TranslatedText stringId="patient.modal.create.title" fallback="Add new patient" />}
+      onClose={onCancel}
+      open={open}
+    >
       <NewPatientForm
         generateId={generateId}
         onCancel={onCancel}


### PR DESCRIPTION
### Changes
- Translate all non localised fields on patient create and register birth

stringIds defined in this PR for considerations
```
birth.property.attendantOfBirth.doctor
birth.property.attendantOfBirth.midwife
birth.property.attendantOfBirth.nurse
birth.property.attendantOfBirth.other
birth.property.attendantOfBirth.traditionalBirthAttendant
birth.property.birthType.plural
birth.property.birthType.single
birth.property.deliveryType.breech
birth.property.deliveryType.electiveCSection
birth.property.deliveryType.emergencyCSection
birth.property.deliveryType.forceps
birth.property.deliveryType.normalVaginalDelivery
birth.property.deliveryType.other
birth.property.deliveryType.vacuumExtraction
birth.property.placeOfBirth.healthFacility
birth.property.placeOfBirth.home
birth.property.placeOfBirth.other
birth.property.pregnancyOutcome.fetalDeath
birth.property.pregnancyOutcome.liveBirth
birth.property.pregnancyOutcome.stillBirth
general.form.email.label
patient.action.addNewPatient
patient.details.subheading.birthDetails
patient.details.subheading.contactInformation
patient.details.subheading.identificationInformation
patient.details.subheading.locationInformation
patient.details.subheading.personalInformation
patient.property.additionalInformation.exampleText
patient.property.additionalInformation.label
patient.property.bloodType.a+
patient.property.bloodType.a-
patient.property.bloodType.ab+
patient.property.bloodType.ab-
patient.property.bloodType.b+
patient.property.bloodType.b-
patient.property.bloodType.o+
patient.property.bloodType.o-
patient.property.educationalAttainment.highSchoolCompleted
patient.property.educationalAttainment.lessThanPrimary
patient.property.educationalAttainment.noFormalSchooling
patient.property.educationalAttainment.postGradCompleted
patient.property.educationalAttainment.primaryCompleted
patient.property.educationalAttainment.secSchoolCompleted
patient.property.educationalAttainment.universityCompleted
patient.form.id.regenerate
patient.property.maritalStatus.defacto
patient.property.maritalStatus.divorced
patient.property.maritalStatus.married
patient.property.maritalStatus.separated
patient.property.maritalStatus.single
patient.property.maritalStatus.unknown
patient.property.maritalStatus.widow
patient.property.newPatientAction.birthRegistry
patient.property.newPatientAction.newPatient
patient.property.sex.female
patient.property.sex.male
patient.property.sex.other
patient.property.socialMedia.facebook
patient.property.socialMedia.instagram
patient.property.socialMedia.linkedIn
patient.property.socialMedia.twitter
patient.property.socialMedia.viber
patient.property.socialMedia.whatsApp
patient.property.title.dr
patient.property.title.miss
patient.property.title.mr
patient.property.title.ms
patient.property.title.sn
patient.property.title.sr
patient.modal.create.title
```

<img width="572" alt="Screenshot 2023-11-07 at 11 00 37 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/8d6dde9f-fc6a-4aea-9c3f-faf7268a68e8">
<img width="875" alt="Screenshot 2023-11-07 at 11 00 22 AM" src="https://github.com/beyondessential/tamanu/assets/38335330/17ea3fe6-b16c-47b2-b6b8-63004c7fb6fb">


### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [x] UI Screenshots added to the Linear issue
- [n/a] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
