### PR TITLE
Don't cancel any cd-down flows

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -6,10 +6,6 @@ on:
     types:
       - closed
 
-concurrency:
-  # only one build or destroy at a time, per PR/branch, but don't cancel existing runs
-  group: cd-${{ github.pull_request.id || github.ref }}
-
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
### Changes

Some CD Down workflows are getting cancelled due to overzealous concurrency control. This might be a bit too heavy-handed in return, but as a starting point let's remove the concurrency control and see how that goes.

### Checklist

- [x] Code is finished