### PR TITLE
NASS-947 Fix previous patient details remaining upon registering another patient

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/registerPatient/NewPatientScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/registerPatient/NewPatientScreen.tsx
@@ -26,12 +26,14 @@ const Screen = ({
   }, []);
 
   const onAddAnotherPatient = useCallback(() => {
-    navigation.navigate(Routes.HomeStack.Index, {
-      screen: Routes.HomeStack.RegisterPatientStack.Index,
-      params: {
-        screen: Routes.HomeStack.RegisterPatientStack.PatientPersonalInfo,
-      },
-    });
+    navigation.navigate(Routes.HomeStack.HomeTabs.Index);
+    navigation.navigate(Routes.HomeStack.RegisterPatientStack.Index);
+    // navigation.navigate(Routes.HomeStack.Index, {
+    //   screen: Routes.HomeStack.RegisterPatientStack.Index,
+    //   params: {
+    //     screen: Routes.HomeStack.RegisterPatientStack.PatientPersonalInfo,
+    //   },
+    // });
   }, []);
 
   const onStartVisit = useCallback(() => {

--- a/packages/mobile/App/ui/navigation/screens/registerPatient/NewPatientScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/registerPatient/NewPatientScreen.tsx
@@ -26,14 +26,9 @@ const Screen = ({
   }, []);
 
   const onAddAnotherPatient = useCallback(() => {
+    // slightly hacky way of resetting the patient info in resgister patient
     navigation.navigate(Routes.HomeStack.HomeTabs.Index);
     navigation.navigate(Routes.HomeStack.RegisterPatientStack.Index);
-    // navigation.navigate(Routes.HomeStack.Index, {
-    //   screen: Routes.HomeStack.RegisterPatientStack.Index,
-    //   params: {
-    //     screen: Routes.HomeStack.RegisterPatientStack.PatientPersonalInfo,
-    //   },
-    // });
   }, []);
 
   const onStartVisit = useCallback(() => {


### PR DESCRIPTION
### Changes

Fixed issue where the previous patient details would remain when adding another patient on the mobile app.

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
