### PR TITLE
TAN-2440: Program registry getters

### DIFF
--- a/packages/desktop/app/contexts/ProgramRegistry.js
+++ b/packages/desktop/app/contexts/ProgramRegistry.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 
 export const ProgramRegistryContext = createContext({
   programRegistryId: null,

--- a/packages/desktop/app/views/programRegistry/ActivatePatientProgramRegistry.js
+++ b/packages/desktop/app/views/programRegistry/ActivatePatientProgramRegistry.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as yup from 'yup';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
+import { useQuery } from '@tanstack/react-query';
 import {
   Form,
   Field,
@@ -16,7 +17,6 @@ import { useSuggester } from '../../api';
 import { useAuth } from '../../contexts/Auth';
 import { Modal } from '../../components/Modal';
 import { useApi } from '../../api/useApi';
-import { useQuery } from '@tanstack/react-query';
 
 export const ActivatePatientProgramRegistry = React.memo(
   ({ onCancel, onSubmit, patientProgramRegistration, open }) => {

--- a/packages/desktop/app/views/programRegistry/PatientProgramRegistryForm.js
+++ b/packages/desktop/app/views/programRegistry/PatientProgramRegistryForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import * as yup from 'yup';
 import { REGISTRATION_STATUSES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
+import { useQuery } from '@tanstack/react-query';
 import {
   Form,
   FieldWithTooltip,
@@ -17,7 +18,6 @@ import { foreignKey, optionalForeignKey } from '../../utils/validation';
 import { useSuggester } from '../../api';
 import { useAuth } from '../../contexts/Auth';
 import { useApi } from '../../api/useApi';
-import { useQuery } from '@tanstack/react-query';
 
 export const PatientProgramRegistryForm = ({ onCancel, onSubmit, editedObject, patient }) => {
   const api = useApi();

--- a/packages/lan/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/lan/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -22,31 +22,30 @@ describe('PatientProgramRegistration', () => {
 
   afterAll(() => ctx.close());
 
-  describe('GET patient/:id/programRegistration', () => {
+  const createProgramRegistry = async ({ clinicalStatuses = [], ...params } = {}) => {
+    const program = await models.Program.create(fake(models.Program));
+    return models.ProgramRegistry.create(
+      fake(models.ProgramRegistry, { programId: program.id, ...params }),
+    );
+  };
+
+  describe('Creating and retrieving registrations', () => {
+
     it('fetches most recent registration for each program', async () => {
       const clinician = await models.User.create(fake(models.User));
       const patient = await models.Patient.create(fake(models.Patient));
-      const program1 = await models.Program.create(fake(models.Program));
-      const programRegistry1 = await models.ProgramRegistry.create(
-        fake(models.ProgramRegistry, { programId: program1.id, name: 'a' }),
-      );
+
+      // endpoint returns records in alphabetical order, so the names are relevant here
+      const programRegistry1 = await createProgramRegistry({ name: 'AA-registry1' });
+      const programRegistry2 = await createProgramRegistry({ name: 'BB-registry2' });
+      const programRegistry3 = await createProgramRegistry({ name: 'CC-registry3' });
+      const programRegistry4 = await createProgramRegistry({ name: 'DD-registry4' });
+
       const programRegistryClinicalStatus = await models.ProgramRegistryClinicalStatus.create(
         fake(models.ProgramRegistryClinicalStatus, {
           programRegistryId: programRegistry1.id,
-          name: 'aa',
+          name: 'registry1-clinicalStatus',
         }),
-      );
-      const program2 = await models.Program.create(fake(models.Program));
-      const programRegistry2 = await models.ProgramRegistry.create(
-        fake(models.ProgramRegistry, { programId: program2.id, name: 'b' }),
-      );
-      const program3 = await models.Program.create(fake(models.Program));
-      const programRegistry3 = await models.ProgramRegistry.create(
-        fake(models.ProgramRegistry, { programId: program3.id, name: 'a' }),
-      );
-      const program4 = await models.Program.create(fake(models.Program));
-      const programRegistry4 = await models.ProgramRegistry.create(
-        fake(models.ProgramRegistry, { programId: program4.id, name: 'a' }),
       );
 
       // Registration 1: Should show
@@ -117,10 +116,10 @@ describe('PatientProgramRegistration', () => {
           patientId: patient.id,
           programRegistryId: programRegistry1.id,
           programRegistry: {
-            name: 'a',
+            name: 'AA-registry1',
           },
           clinicalStatus: {
-            name: 'aa',
+            name: 'registry1-clinicalStatus',
           },
         },
         {
@@ -134,9 +133,7 @@ describe('PatientProgramRegistration', () => {
         },
       ]);
     });
-  });
 
-  describe('POST patient/:patientId/programRegistration', () => {
     it('creates a new program registration', async () => {
       const clinician = await models.User.create(fake(models.User));
       const patient = await models.Patient.create(fake(models.Patient));
@@ -179,7 +176,7 @@ describe('PatientProgramRegistration', () => {
       });
     });
 
-    it('edits a program registration', async () => {
+    it('appends a new entry to the history for a program registration', async () => {
       const clinician = await models.User.create(fake(models.User));
       const patient = await models.Patient.create(fake(models.Patient));
       const program1 = await models.Program.create(fake(models.Program));
@@ -219,117 +216,220 @@ describe('PatientProgramRegistration', () => {
       });
       expect(createdRegistration.updatedAt).not.toEqual(existingRegistration.updatedAt);
     });
+
   });
 
-  describe('POST patient/:patientId/programRegistration/:programRegistryId/condition', () => {
-    let patient;
-    let programRegistry;
-    let programRegistryCondition;
+  describe('reading registration information', () => {
 
-    beforeEach(async () => {
-      patient = await models.Patient.create(fake(models.Patient));
-      const program1 = await models.Program.create(fake(models.Program));
-      programRegistry = await models.ProgramRegistry.create(
-        fake(models.ProgramRegistry, { programId: program1.id }),
-      );
-      programRegistryCondition = await models.ProgramRegistryCondition.create(
-        fake(models.ProgramRegistryCondition, { programRegistryId: programRegistry.id }),
-      );
-    });
-
-    afterEach(async () => {
-      await models.PatientProgramRegistrationCondition.truncate({ cascade: true, force: true });
-      await models.ProgramRegistryCondition.truncate({ cascade: true, force: true });
-      await models.Patient.truncate({ cascade: true, force: true });
-      await models.ProgramRegistry.truncate({ cascade: true, force: true });
-      await models.Program.truncate({ cascade: true, force: true });
-    });
-
-    it('creates a new condition', async () => {
-      const result = await app
-        .post(`/v1/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
-        .send({
-          programRegistryConditionId: programRegistryCondition.id,
-          date: '2023-09-02 08:00:00',
-          // clinicianId: clinician.id, // No clinician, just to switch it up
-        });
-
-      expect(result).toHaveSucceeded();
-
-      const createdCondition = await models.PatientProgramRegistrationCondition.findByPk(
-        result.body.id,
-      );
-
-      expect(createdCondition).toMatchObject({
-        programRegistryId: programRegistry.id,
-        patientId: patient.id,
-        programRegistryConditionId: programRegistryCondition.id,
-        date: '2023-09-02 08:00:00',
-      });
-    });
-
-    it('Will not post duplicate conditions', async () => {
-      await models.PatientProgramRegistrationCondition.create(
-        fake(models.PatientProgramRegistrationCondition, {
-          patientId: patient.id,
-          programRegistryId: programRegistry.id,
-          programRegistryConditionId: programRegistryCondition.id,
-          deletionStatus: null,
-        }),
-      );
-      const result = await app
-        .post(`/v1/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
-        .send({
-          programRegistryConditionId: programRegistryCondition.id,
-          date: '2023-09-02 08:00:00',
-          // clinicianId: clinician.id, // No clinician, just to switch it up
-        });
-
-      expect(result).not.toHaveSucceeded();
-    });
-  });
-
-  describe('DELETE patient/:patientId/programRegistration/:programRegistryId/condition', () => {
-    it('Deletes a condition', async () => {
+    const populate = async () => {
       const clinician = await models.User.create(fake(models.User));
       const patient = await models.Patient.create(fake(models.Patient));
-      const program1 = await models.Program.create(fake(models.Program));
-      const programRegistry1 = await models.ProgramRegistry.create(
-        fake(models.ProgramRegistry, { programId: program1.id }),
-      );
-      const programRegistryCondition = await models.ProgramRegistryCondition.create(
-        fake(models.ProgramRegistryCondition, { programRegistryId: programRegistry1.id }),
-      );
-      await models.PatientProgramRegistrationCondition.create(
-        fake(models.PatientProgramRegistrationCondition, {
-          patientId: patient.id,
-          programRegistryId: programRegistry1.id,
-          programRegistryConditionId: programRegistryCondition.id,
-        }),
-      );
-      const result = await app
-        .delete(
-          `/v1/patient/${patient.id}/programRegistration/${programRegistry1.id}/condition/${programRegistryCondition.id}`,
-        )
-        .send({
-          programRegistryConditionId: programRegistryCondition.id,
-          deletionClinicianId: clinician.id,
-          deletionDate: '2023-09-02 08:00:00',
-        });
+      const registry = await createProgramRegistry();
+      const facility = await models.Facility.create(fake(models.Facility));
+      const village = await models.ReferenceData.create(fake(models.ReferenceData, { type: 'village' }));
 
+      const status1 = await models.ProgramRegistryClinicalStatus.create(
+        fake(models.ProgramRegistryClinicalStatus, { programRegistryId: registry.id }),
+      );
+      const status2 = await models.ProgramRegistryClinicalStatus.create(
+        fake(models.ProgramRegistryClinicalStatus, { programRegistryId: registry.id }),
+      );
+
+      const records = [
+        {
+          clinicianId: clinician.id,
+          patientId: patient.id,
+          clinicalStatusId: status1.id,
+          programRegistryId: registry.id,
+          registeringFacilityId: facility.id,
+          registrationStatus: REGISTRATION_STATUSES.INACTIVE,
+          date: '2023-09-02 09:00:00',
+        },
+        {
+          patientId: patient.id,
+          programRegistryId: registry.id,
+          villageId: village.id,
+          registrationStatus: REGISTRATION_STATUSES.INACTIVE,
+          date: '2023-09-02 10:00:00',
+        },  
+        {
+          patientId: patient.id,
+          clinicalStatusId: status2.id,
+          programRegistryId: registry.id,
+          registrationStatus: REGISTRATION_STATUSES.ACTIVE,
+          date: '2023-09-02 11:00:00',
+        },
+      ];
+
+      for (const r of records) {
+        await app.post(`/v1/patient/${patient.id}/programRegistration`).send(r);
+      }
+
+      return { patient, registry, records };
+    };
+
+    it('fetches the registration history for a patient', async () => {
+      const { patient, registry, records } = await populate();
+
+      const result = await app.get(`/v1/patient/${patient.id}/programRegistration/${registry.id}/history`);
+      expect(result).toHaveSucceeded();
+      // it'll give us latest-first, so reverse it
+      const history = [...records].reverse();
+      expect(result.body.data).toMatchObject(history);
+
+      // also check for the correctly-joined info
+      expect(result.body.data[0]).toHaveProperty('clinician.displayName');
+      expect(result.body.data[0]).toHaveProperty('clinicalStatus.name');
+    });
+
+    it('fetches the full detail of the latest registration', async () => {
+      const { patient, registry, records } = await populate();
+      
+      const result = await app.get(`/v1/patient/${patient.id}/programRegistration/${registry.id}`);
       expect(result).toHaveSucceeded();
 
-      const deletedCondition = await models.PatientProgramRegistrationCondition.findByPk(
-        result.body.id,
-      );
+      const record = result.body;
+      expect(record).toMatchObject(records.slice(-1)[0]);
+      expect(record).toHaveProperty('clinician.displayName');
+      expect(record).toHaveProperty('clinicalStatus.name');
+      expect(record).toHaveProperty('registeringFacility.name');
+      expect(record).toHaveProperty('village.name');
+    });
 
-      expect(deletedCondition).toMatchObject({
-        programRegistryId: programRegistry1.id,
-        patientId: patient.id,
-        programRegistryConditionId: programRegistryCondition.id,
-        date: '2023-09-02 08:00:00',
-        deletionStatus: DELETION_STATUSES.DELETED,
+    describe('errors', () => {
+      it('should get a 404 for a non-existent registration', async () => {
+        const patient = await models.Patient.create(fake(models.Patient));
+        const registry = await createProgramRegistry();
+      
+        // real patient, real registry, but not registered
+        const result = await app.get(`/v1/patient/${patient.id}/programRegistration/${registry.id}`);
+        expect(result).toHaveStatus(404);  
+      });
+
+      it('should require a user that can read patient info', async () => {
+        const { patient, registry } = await populate();
+
+        const newApp = await baseApp.asRole('base');
+        const result = await newApp.get(`/v1/patient/${patient.id}/programRegistration/${registry.id}`);
+        expect(result).toBeForbidden();
+      });
+      
+    });
+  });
+
+  describe('Conditions', () => {
+
+    describe('POST patient/:patientId/programRegistration/:programRegistryId/condition', () => {
+      let patient;
+      let programRegistry;
+      let programRegistryCondition;
+
+      beforeEach(async () => {
+        patient = await models.Patient.create(fake(models.Patient));
+        const program1 = await models.Program.create(fake(models.Program));
+        programRegistry = await models.ProgramRegistry.create(
+          fake(models.ProgramRegistry, { programId: program1.id }),
+        );
+        programRegistryCondition = await models.ProgramRegistryCondition.create(
+          fake(models.ProgramRegistryCondition, { programRegistryId: programRegistry.id }),
+        );
+      });
+
+      afterEach(async () => {
+        await models.PatientProgramRegistrationCondition.truncate({ cascade: true, force: true });
+        await models.ProgramRegistryCondition.truncate({ cascade: true, force: true });
+        await models.Patient.truncate({ cascade: true, force: true });
+        await models.ProgramRegistry.truncate({ cascade: true, force: true });
+        await models.Program.truncate({ cascade: true, force: true });
+      });
+
+      it('creates a new condition', async () => {
+        const result = await app
+          .post(`/v1/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
+          .send({
+            programRegistryConditionId: programRegistryCondition.id,
+            date: '2023-09-02 08:00:00',
+            // clinicianId: clinician.id, // No clinician, just to switch it up
+          });
+
+        expect(result).toHaveSucceeded();
+
+        const createdCondition = await models.PatientProgramRegistrationCondition.findByPk(
+          result.body.id,
+        );
+
+        expect(createdCondition).toMatchObject({
+          programRegistryId: programRegistry.id,
+          patientId: patient.id,
+          programRegistryConditionId: programRegistryCondition.id,
+          date: '2023-09-02 08:00:00',
+        });
+      });
+
+      it('Will not post duplicate conditions', async () => {
+        await models.PatientProgramRegistrationCondition.create(
+          fake(models.PatientProgramRegistrationCondition, {
+            patientId: patient.id,
+            programRegistryId: programRegistry.id,
+            programRegistryConditionId: programRegistryCondition.id,
+            deletionStatus: null,
+          }),
+        );
+        const result = await app
+          .post(`/v1/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
+          .send({
+            programRegistryConditionId: programRegistryCondition.id,
+            date: '2023-09-02 08:00:00',
+            // clinicianId: clinician.id, // No clinician, just to switch it up
+          });
+
+        expect(result).not.toHaveSucceeded();
       });
     });
+
+    describe('DELETE patient/:patientId/programRegistration/:programRegistryId/condition', () => {
+      it('Deletes a condition', async () => {
+        const clinician = await models.User.create(fake(models.User));
+        const patient = await models.Patient.create(fake(models.Patient));
+        const program1 = await models.Program.create(fake(models.Program));
+        const programRegistry1 = await models.ProgramRegistry.create(
+          fake(models.ProgramRegistry, { programId: program1.id }),
+        );
+        const programRegistryCondition = await models.ProgramRegistryCondition.create(
+          fake(models.ProgramRegistryCondition, { programRegistryId: programRegistry1.id }),
+        );
+        await models.PatientProgramRegistrationCondition.create(
+          fake(models.PatientProgramRegistrationCondition, {
+            patientId: patient.id,
+            programRegistryId: programRegistry1.id,
+            programRegistryConditionId: programRegistryCondition.id,
+          }),
+        );
+        const result = await app
+          .delete(
+            `/v1/patient/${patient.id}/programRegistration/${programRegistry1.id}/condition/${programRegistryCondition.id}`,
+          )
+          .send({
+            programRegistryConditionId: programRegistryCondition.id,
+            deletionClinicianId: clinician.id,
+            deletionDate: '2023-09-02 08:00:00',
+          });
+
+        expect(result).toHaveSucceeded();
+
+        const deletedCondition = await models.PatientProgramRegistrationCondition.findByPk(
+          result.body.id,
+        );
+
+        expect(deletedCondition).toMatchObject({
+          programRegistryId: programRegistry1.id,
+          patientId: patient.id,
+          programRegistryConditionId: programRegistryCondition.id,
+          date: '2023-09-02 08:00:00',
+          deletionStatus: DELETION_STATUSES.DELETED,
+        });
+      });
+    });
+
   });
 });

--- a/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
@@ -44,13 +44,13 @@ describe('ProgramRegistry', () => {
         fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
       await models.ProgramRegistry.create(
-        ...fake(models.ProgramRegistry, {
+        fake(models.ProgramRegistry, {
           programId: testProgram.id,
           visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
         }),
       );
       await models.ProgramRegistry.create(
-        ...fake(models.ProgramRegistry, { programId: testProgram.id }),
+        fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
 
       const result = await app.get('/v1/programRegistry');
@@ -66,25 +66,25 @@ describe('ProgramRegistry', () => {
 
       // Should show:
       await models.ProgramRegistry.create(
-        ...fake(models.ProgramRegistry, { programId: testProgram.id }),
+        fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
       await models.ProgramRegistry.create(
-        ...fake(models.ProgramRegistry, { programId: testProgram.id }),
+        fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
 
       // Should not show (historical):
       await models.ProgramRegistry.create(
-        ...fake(models.ProgramRegistry, {
+        fake(models.ProgramRegistry, {
           programId: testProgram.id,
           visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
         }),
       );
       // Should not show (patient already has registration):
       const { id: existingRegistrationId } = await models.ProgramRegistry.create(
-        ...fake(models.ProgramRegistry, { programId: testProgram.id }),
+        fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
       await models.PatientProgramRegistration.create(
-        ...fake(models.PatientProgramRegistration, {
+        fake(models.PatientProgramRegistration, {
           patientId: testPatient.id,
           programRegistryId: existingRegistrationId,
         }),
@@ -233,4 +233,5 @@ describe('ProgramRegistry', () => {
       ]);
     });
   });
+
 });

--- a/packages/lan/app/routes/apiv1/patient/patientProgramRegistration.js
+++ b/packages/lan/app/routes/apiv1/patient/patientProgramRegistration.js
@@ -86,6 +86,51 @@ patientProgramRegistration.post(
   }),
 );
 
+patientProgramRegistration.get(
+  '/:patientId/programRegistration/:programRegistryId$',
+  asyncHandler(async (req, res) => {
+    const { models, params } = req;
+    const { patientId, programRegistryId } = params;
+    const { PatientProgramRegistration } = models;
+
+    req.checkPermission('read', 'PatientProgramRegistration', { patientId, programRegistryId });
+
+    const registration = await PatientProgramRegistration.findOne({
+      where: {
+        patientId,
+        programRegistryId,
+      },
+      include: PatientProgramRegistration.getFullAssociations(),
+    });
+
+    res.send(registration);
+  }),
+);
+
+patientProgramRegistration.get(
+  '/:patientId/programRegistration/:programRegistryId/history$',
+  asyncHandler(async (req, res) => {
+    const { models, params } = req;
+    const { patientId, programRegistryId } = params;
+    const { PatientProgramRegistration } = models;
+
+    req.checkPermission('list', 'PatientProgramRegistration', { patientId, programRegistryId });
+
+    const history = await PatientProgramRegistration.findAll({
+      where: {
+        patientId,
+        programRegistryId,
+      },
+      include: PatientProgramRegistration.getListAssociations(),
+    });
+
+    res.send({
+      count: history.length,
+      data: history,
+    });
+  }),
+);
+
 patientProgramRegistration.post(
   '/:patientId/programRegistration/:programRegistryId/condition',
   asyncHandler(async (req, res) => {

--- a/packages/lan/app/routes/apiv1/patient/patientProgramRegistration.js
+++ b/packages/lan/app/routes/apiv1/patient/patientProgramRegistration.js
@@ -87,7 +87,7 @@ patientProgramRegistration.post(
 );
 
 patientProgramRegistration.get(
-  '/:patientId/programRegistration/:programRegistryId$',
+  '/:patientId/programRegistration/:programRegistryId',
   asyncHandler(async (req, res) => {
     const { models, params } = req;
     const { patientId, programRegistryId } = params;
@@ -100,8 +100,13 @@ patientProgramRegistration.get(
         patientId,
         programRegistryId,
       },
-      include: PatientProgramRegistration.getFullAssociations(),
+      include: PatientProgramRegistration.getFullReferenceAssociations(),
+      order: [['date', 'DESC']],
     });
+
+    if (!registration) {
+      throw new NotFoundError();
+    }
 
     res.send(registration);
   }),
@@ -121,7 +126,8 @@ patientProgramRegistration.get(
         patientId,
         programRegistryId,
       },
-      include: PatientProgramRegistration.getListAssociations(),
+      include: PatientProgramRegistration.getListReferenceAssociations(),
+      order: [['date', 'DESC']],
     });
 
     res.send({

--- a/packages/lan/app/routes/apiv1/programRegistry.js
+++ b/packages/lan/app/routes/apiv1/programRegistry.js
@@ -60,10 +60,7 @@ programRegistry.get(
       },
     };
 
-    const count = await ProgramRegistry.count({
-      ...baseQueryOptions,
-      distinct: true,
-    });
+    const count = await ProgramRegistry.count(baseQueryOptions);
 
     const { order = 'ASC', orderBy = 'createdAt', rowsPerPage, page } = query;
     const objects = await ProgramRegistry.findAll({

--- a/packages/lan/app/routes/apiv1/programRegistry.js
+++ b/packages/lan/app/routes/apiv1/programRegistry.js
@@ -4,6 +4,7 @@ import { Sequelize, Op, QueryTypes } from 'sequelize';
 
 import { deepRenameObjectKeys } from '@tamanu/shared/utils';
 import { simpleGet, simpleGetList } from '@tamanu/shared/utils/crudHelpers';
+import { REGISTRATION_STATUSES, VISIBILITY_STATUSES } from '@tamanu/constants';
 import {
   makeFilter,
   makeSimpleTextFilterFactory,
@@ -14,31 +15,68 @@ export const programRegistry = express.Router();
 
 programRegistry.get('/:id', simpleGet('ProgramRegistry'));
 
-// TODO: TAN-2357: reimplement as standalone handler rather than simpleGetList 
 programRegistry.get(
   '/$',
-  simpleGetList('ProgramRegistry', '', {
-    additionalFilters: ({ db, query }) => ({
-      visibilityStatus: VISIBILITY_STATUSES.CURRENT,
-      ...(query.excludePatientId
-        ? {
-            id: {
-              [Op.notIn]: Sequelize.literal(
-                `(
-                    SELECT DISTINCT(pr.id)
-                    FROM program_registries pr
-                    INNER JOIN patient_program_registrations ppr
-                    ON ppr.program_registry_id = pr.id
-                    WHERE
-                      ppr.patient_id = ${db.escape(query.excludePatientId)}
-                    AND
-                      ppr.registration_status != '${REGISTRATION_STATUSES.RECORDED_IN_ERROR}'
-                  )`,
-              ),
-            },
-          }
-        : {}),
-    }),
+  asyncHandler(async (req, res) => {
+    const { models, query } = req;
+
+    req.checkPermission('list', 'ProgramRegistry');
+
+    if (query.excludePatientId) {
+      req.checkPermission('read', 'PatientProgramRegistration', {
+        patientId: query.excludePatientId,
+      });
+    }
+
+    const { ProgramRegistry } = models;
+
+    const patientIdExclusion = query.excludePatientId
+      ? {
+          id: {
+            [Op.notIn]: Sequelize.literal(
+              `(
+                SELECT DISTINCT(pr.id)
+                FROM program_registries pr
+                INNER JOIN patient_program_registrations ppr
+                ON ppr.program_registry_id = pr.id
+                WHERE
+                  ppr.patient_id = :excludePatientId
+                AND
+                  ppr.registration_status != :error
+              )`,
+            ),
+          },
+        }
+      : {};
+
+    const baseQueryOptions = {
+      where: {
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        ...patientIdExclusion,
+      },
+      replacements: {
+        error: REGISTRATION_STATUSES.RECORDED_IN_ERROR,
+        excludePatientId: query.excludePatientId,
+      },
+    };
+
+    const count = await ProgramRegistry.count({
+      ...baseQueryOptions,
+      distinct: true,
+    });
+
+    const { order = 'ASC', orderBy = 'createdAt', rowsPerPage, page } = query;
+    const objects = await ProgramRegistry.findAll({
+      ...baseQueryOptions,
+      include: ProgramRegistry.getListReferenceAssociations(models),
+      order: orderBy ? [[...orderBy.split('.'), order.toUpperCase()]] : undefined,
+      limit: rowsPerPage,
+      offset: page && rowsPerPage ? page * rowsPerPage : undefined,
+    });
+
+    const data = objects.map(x => x.forResponse());
+
+    res.send({ count, data });
   }),
 );
 

--- a/packages/shared/src/models/PatientProgramRegistration.js
+++ b/packages/shared/src/models/PatientProgramRegistration.js
@@ -51,7 +51,7 @@ export class PatientProgramRegistration extends Model {
   }
 
   static getListReferenceAssociations() {
-    return ['clinicalStatus'];
+    return ['clinicalStatus', 'clinician'];
   }
 
   static initRelations(models) {

--- a/packages/shared/src/models/PatientProgramRegistration.js
+++ b/packages/shared/src/models/PatientProgramRegistration.js
@@ -39,6 +39,21 @@ export class PatientProgramRegistration extends Model {
     );
   }
 
+  static getFullReferenceAssociations() {
+    return [
+      'programRegistry',
+      'clinicalStatus',
+      'clinician',
+      'registeringFacility',
+      'facility',
+      'village',
+    ];
+  }
+
+  static getListReferenceAssociations() {
+    return ['clinicalStatus'];
+  }
+
   static initRelations(models) {
     this.belongsTo(models.Patient, {
       foreignKey: { name: 'patientId', allowNull: false },

--- a/packages/shared/src/utils/crudHelpers.js
+++ b/packages/shared/src/utils/crudHelpers.js
@@ -89,9 +89,7 @@ export const getResourceList = async (req, modelName, foreignKey = '', options =
   const baseQueryOptions = {
     where: {
       ...(foreignKey && { [foreignKey]: params.id }),
-      // TAN-2357: revert this change so that additionalFilters is just a static object, ie
-      // ...additionalFilters,
-      ...(typeof additionalFilters === 'function' ? additionalFilters(req) : additionalFilters),
+      ...additionalFilters,
     },
     // ['association', 'column', 'direction'] is the sequlize format to sort by foreign column
     // allow 'association.column' as a valid sort query

--- a/packages/sync-server/__tests__/models/SurveyResponse.test.js
+++ b/packages/sync-server/__tests__/models/SurveyResponse.test.js
@@ -143,15 +143,17 @@ describe('SurveyResponse.createWithAnswers', () => {
 
   it('creates patient program registration from actions', async () => {
     const survey = await createDummySurvey(models);
-    const registry = await models.ProgramRegistry.create({
-      ...fake(models.ProgramRegistry),
-      visibilityStatus: VISIBILITY_STATUSES.CURRENT,
-      programId: survey.programId,
-    });
-    const clinicalStatus = await models.ProgramRegistryClinicalStatus.create({
-      ...fake(models.ProgramRegistryClinicalStatus),
-      programRegistryId: registry.id,
-    });
+    const registry = await models.ProgramRegistry.create(
+      fake(models.ProgramRegistry, {
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        programId: survey.programId,
+      })
+    );
+    const clinicalStatus = await models.ProgramRegistryClinicalStatus.create(
+      fake(models.ProgramRegistryClinicalStatus, {
+        programRegistryId: registry.id,
+      })
+    );
     const { dataElement } = await createDummyDataElement(models, survey, {
       type: PROGRAM_DATA_ELEMENT_TYPES.PATIENT_DATA,
       config: {


### PR DESCRIPTION
### Changes

- Implement getters for program registries (in patientProgramRegistration.js)
- Also includes the refactor to switch the registry list away from simpleGetList and the reversion to that helper.
- Also includes some linter fixes

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
