### PR TITLE
NASS-955: ID Card uses correct photo

### DIFF
--- a/packages/lan/app/routes/apiv1/patient/patientProfilePicture.js
+++ b/packages/lan/app/routes/apiv1/patient/patientProfilePicture.js
@@ -32,6 +32,8 @@ patientProfilePicture.get(
           WHERE
             encounters.patient_id = :patientId
             AND program_data_elements.code = :photoCode
+          ORDER BY 
+            survey_responses.created_at DESC
         LIMIT 1
       `,
       {


### PR DESCRIPTION
### Changes

Updated SQL query to select the latest uploaded profile photo for the ID card.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
