### PR TITLE
NASS-843: Prevent prescription printing with no prescriber

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
@@ -137,6 +137,7 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
           value={currentUser.id}
           required
           error={prescriberId === undefined}
+          helperText={prescriberId === undefined && "Please select a prescriber"}
         />
       </PrescriberWrapper>
 

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
@@ -112,10 +112,10 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
   );
 
   const handlePrintConfirm = useCallback(() => {
-    if (selectedRows.length > 0) {
+    if (selectedRows.length > 0 && prescriberId !== undefined) {
       setOpenPrintoutModal(true);
     }
-  }, [selectedRows]);
+  }, [prescriberId, selectedRows]);
 
   return (
     <>
@@ -135,6 +135,8 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
           suggester={practitionerSuggester}
           onChange={event => setPrescriberId(event.target.value)}
           value={currentUser.id}
+          required
+          error={prescriberId === undefined}
         />
       </PrescriberWrapper>
 

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.js
@@ -74,6 +74,7 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
   const [openPrintoutModal, setOpenPrintoutModal] = useState(false);
   const [medicationData, setMedicationData] = useState([]);
   const [prescriberId, setPrescriberId] = useState(null);
+  const prescriberSelected = Boolean(prescriberId);
   const api = useApi();
   const practitionerSuggester = useSuggester('practitioner');
   const { data, error, isLoading } = useQuery(['encounterMedication', encounter.id], () =>
@@ -112,10 +113,10 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
   );
 
   const handlePrintConfirm = useCallback(() => {
-    if (selectedRows.length > 0 && prescriberId !== undefined) {
+    if (selectedRows.length > 0 && prescriberSelected) {
       setOpenPrintoutModal(true);
     }
-  }, [prescriberId, selectedRows]);
+  }, [prescriberSelected, selectedRows]);
 
   return (
     <>
@@ -136,8 +137,8 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
           onChange={event => setPrescriberId(event.target.value)}
           value={currentUser.id}
           required
-          error={prescriberId === undefined}
-          helperText={prescriberId === undefined && "Please select a prescriber"}
+          error={!prescriberSelected}
+          helperText={!prescriberSelected && 'Please select a prescriber'}
         />
       </PrescriberWrapper>
 


### PR DESCRIPTION
### Changes

Added check to ensure that a prescriber is set when attempting to print out prescriptions for a patient. 
Additionally, enabled the error outline for the prescriber selector when none is selected.

<img width="793" alt="image" src="https://github.com/beyondessential/tamanu/assets/108244616/04d110a1-ebdb-4e09-a220-9bc8cd5336d9">

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
