### PR TITLE
NASS-878: Fix circumstance edit bug

### DIFF
--- a/packages/desktop/app/forms/VaccineForm.js
+++ b/packages/desktop/app/forms/VaccineForm.js
@@ -156,6 +156,7 @@ export const VaccineForm = ({
             }
           : {
               ...currentVaccineRecordValues,
+              circumstanceIds: JSON.stringify(currentVaccineRecordValues.circumstanceIds),
             }
       }
       validationSchema={baseSchemeValidation.shape({

--- a/packages/desktop/app/forms/VaccineForm.js
+++ b/packages/desktop/app/forms/VaccineForm.js
@@ -156,7 +156,9 @@ export const VaccineForm = ({
             }
           : {
               ...currentVaccineRecordValues,
-              circumstanceIds: JSON.stringify(currentVaccineRecordValues.circumstanceIds),
+              ...(currentVaccineRecordValues.circumstanceIds
+                ? { circumstanceIds: JSON.stringify(currentVaccineRecordValues.circumstanceIds) }
+                : {}),
             }
       }
       validationSchema={baseSchemeValidation.shape({


### PR DESCRIPTION
### Changes

Circumstance field was previously throwing a validation error when you tried to edit an existing vaccine record without changing the prepopulated circumstance multiselect field. This was because the initial values are not correctly populated to the formik values object when opening the edit vaccine form. Only when interacting with it does the onchange format the values correctly. Here I just needed to stringify the value when initialised so that we don't need to interact with the field in order to turn it into a string.

Maybe there is room to clean up some of this logic of stringifying and parsing multiselect values as they travel around but I feel it is out of scope of this card to change a core field as late in release.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
