### PR TITLE
NASS-839: Specimen type added to sample label

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/LabRequestPrintLabelModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/LabRequestPrintLabelModal.js
@@ -45,6 +45,7 @@ export const LabRequestPrintLabelModal = ({ open, onClose, labRequests }) => {
                 patientDateOfBirth: patient.dateOfBirth,
                 date: lab.sampleTime,
                 labCategory: lab.category?.name,
+                specimenType: lab.specimenType?.name,
               }}
             />
           </Box>

--- a/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
@@ -29,7 +29,7 @@ const TextContainer = styled.div`
 
   text {
     color: #000;
-    font-size: 11px;
+    font-size: 10px;
     line-height: 1.1;
   }
 
@@ -73,18 +73,27 @@ const BarcodeContainer = styled.div`
  * why the whole component is made with svgs
  */
 export const LabRequestPrintLabel = React.memo(({ data, printWidth }) => {
-  const { patientId, patientName, patientDateOfBirth, testId, labCategory, date } = data;
+  const {
+    patientId,
+    patientName,
+    patientDateOfBirth,
+    testId,
+    labCategory,
+    date,
+    specimenType,
+  } = data;
   return (
     <Container $printWidth={printWidth}>
       <FlexContainer>
         <TextContainer>
           <svg viewBox="0 0 200 120">
-            <Item x="0" y="10" label="Patient Name" value={patientName} />
+            <Item x="0" y="15" label="Patient Name" value={patientName} />
             <Item x="0" y="30" label="Patient ID" value={patientId} />
-            <Item x="0" y="50" label="DOB" value={DateDisplay.stringFormat(patientDateOfBirth)} />
-            <Item x="0" y="70" label="Test ID" value={testId} />
-            <Item x="0" y="90" label="Date collected" value={DateDisplay.stringFormat(date)} />
-            <Item x="0" y="110" label="Lab category" value={labCategory} />
+            <Item x="0" y="45" label="DOB" value={DateDisplay.stringFormat(patientDateOfBirth)} />
+            <Item x="0" y="60" label="Test ID" value={testId} />
+            <Item x="0" y="75" label="Date collected" value={DateDisplay.stringFormat(date)} />
+            <Item x="0" y="90" label="Lab category" value={labCategory} />
+            <Item x="0" y="105" label="Specimen type" value={specimenType} />
           </svg>
         </TextContainer>
         <BarcodeContainer>

--- a/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
+++ b/packages/desktop/app/components/PatientPrinting/printouts/LabRequestPrintLabel.js
@@ -80,7 +80,7 @@ export const LabRequestPrintLabel = React.memo(({ data, printWidth }) => {
     testId,
     labCategory,
     date,
-    specimenType,
+    specimenType = null,
   } = data;
   return (
     <Container $printWidth={printWidth}>


### PR DESCRIPTION
### Changes

Added the `Specimen type` to the lab sample label.

<img width="838" alt="image" src="https://github.com/beyondessential/tamanu/assets/108244616/8556cb3b-a5dc-43ff-92a3-7c7ed5eb2a87">


### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [x] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
