### PR TITLE
NOTAM-49: Node 20 fix tests

### DIFF
--- a/packages/lan/__tests__/uploadAttachment.test.js
+++ b/packages/lan/__tests__/uploadAttachment.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { writeFileSync } from 'fs';
+import { promises as fs } from 'fs';
 import { InvalidParameterError, RemoteCallFailedError } from '@tamanu/shared/errors';
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 
@@ -18,7 +18,7 @@ jest.mock('@tamanu/shared/utils/getUploadedData');
 getUploadedData.mockImplementation(async req => {
   // Create a file that can be used with the FS module, return path
   const fileName = path.resolve(__dirname, 'test-file.jpeg');
-  writeFileSync(fileName, FILEDATA, { encoding: 'base64' });
+  await fs.writeFile(fileName, FILEDATA, { encoding: 'base64' });
   return {
     file: fileName,
     deleteFileAfterImport: true,

--- a/packages/lan/__tests__/uploadAttachment.test.js
+++ b/packages/lan/__tests__/uploadAttachment.test.js
@@ -1,9 +1,9 @@
+import path from 'path';
 import { writeFileSync } from 'fs';
 import { InvalidParameterError, RemoteCallFailedError } from '@tamanu/shared/errors';
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 
 import { CentralServerConnection } from '../app/sync/CentralServerConnection';
-import path from 'path';
 // Get the unmocked function to be able to test it
 const { uploadAttachment } = jest.requireActual('../app/utils/uploadAttachment');
 

--- a/packages/lan/__tests__/uploadAttachment.test.js
+++ b/packages/lan/__tests__/uploadAttachment.test.js
@@ -3,6 +3,7 @@ import { InvalidParameterError, RemoteCallFailedError } from '@tamanu/shared/err
 import { getUploadedData } from '@tamanu/shared/utils/getUploadedData';
 
 import { CentralServerConnection } from '../app/sync/CentralServerConnection';
+import path from 'path';
 // Get the unmocked function to be able to test it
 const { uploadAttachment } = jest.requireActual('../app/utils/uploadAttachment');
 
@@ -16,7 +17,7 @@ const FILEDATA =
 jest.mock('@tamanu/shared/utils/getUploadedData');
 getUploadedData.mockImplementation(async req => {
   // Create a file that can be used with the FS module, return path
-  const fileName = 'test-file.jpeg';
+  const fileName = path.resolve(__dirname, 'test-file.jpeg');
   writeFileSync(fileName, FILEDATA, { encoding: 'base64' });
   return {
     file: fileName,

--- a/packages/sync-server/__tests__/middleware/versionCompatibility.test.js
+++ b/packages/sync-server/__tests__/middleware/versionCompatibility.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import { VERSION_COMPATIBILITY_ERRORS } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
 import { SUPPORTED_CLIENT_VERSIONS } from '../../app/middleware/versionCompatibility';
@@ -10,15 +10,14 @@ const MIN_LAN_VERSION = SUPPORTED_CLIENT_VERSIONS['Tamanu LAN Server'].min;
 describe('Version compatibility', () => {
   let baseApp;
   let app;
-  let close;
+  let ctx;
   beforeAll(async () => {
-    const ctx = await createTestContext();
+    ctx = await createTestContext();
     baseApp = ctx.baseApp;
-    close = ctx.close;
     app = await baseApp.asRole('practitioner');
   });
 
-  afterAll(async () => close());
+  afterAll(() => ctx.close());
 
   describe('LAN server client version checking', () => {
     it('Should allow a supported client', async () => {
@@ -91,29 +90,30 @@ describe('Version compatibility', () => {
   });
 
   describe('Other client version checking', () => {
-    it('Should allow any version of an unspecified client (so that tests work)', async () => {
-      await Promise.all(
-        ['0.0.1', '1.0.0', '1.0.9', '999.999.999'].map(async version => {
-          const response = await app.get('/').unset('X-Tamanu-Client').set({
+    it.each(['0.0.1', '1.0.0', '1.0.9', '999.999.999'])(
+      'Should allow version of an unspecified client (so that tests work)',
+      async version => {
+        const response = await app
+          .get('/')
+          .unset('X-Tamanu-Client')
+          .set({
             'X-Version': version,
           });
-          expect(response).toHaveSucceeded();
-          expect(response.body).toHaveProperty('index', true);
-        }),
-      );
-    });
+        expect(response).toHaveSucceeded();
+        expect(response.body).toHaveProperty('index', true);
+      },
+    );
 
-    it('Should deny an unknown client type of any version', async () => {
-      await Promise.all(
-        ['0.0.1', '1.0.0', '1.0.9', '999.999.999'].map(async version => {
-          const response = await app.get('/').set({
-            'X-Tamanu-Client': 'Unknown Client',
-            'X-Version': version,
-          });
-          expect(response).not.toHaveSucceeded();
-        }),
-      );
-    });
+    it.each(['0.0.1', '1.0.0', '1.0.9', '999.999.999'])(
+      'Should deny version of an an unknown client type of any version',
+      async version => {
+        const response = await app.get('/').set({
+          'X-Tamanu-Client': 'Unknown Client',
+          'X-Version': version,
+        });
+        expect(response).not.toHaveSucceeded();
+      },
+    );
   });
 
   describe('Other packages', () => {
@@ -133,7 +133,7 @@ describe('Version compatibility', () => {
         packageFiles.map(async filePath => {
           const relativePath = `../../../../${filePath}`.split('/');
           const normalisedPath = path.resolve(__dirname, ...relativePath);
-          const content = await fs.promises.readFile(normalisedPath);
+          const content = await fs.readFile(normalisedPath);
           return [filePath, JSON.parse(content).version];
         }),
       );

--- a/packages/sync-server/__tests__/middleware/versionCompatibility.test.js
+++ b/packages/sync-server/__tests__/middleware/versionCompatibility.test.js
@@ -91,7 +91,7 @@ describe('Version compatibility', () => {
 
   describe('Other client version checking', () => {
     it.each(['0.0.1', '1.0.0', '1.0.9', '999.999.999'])(
-      'Should allow version of an unspecified client (so that tests work)',
+      'Should allow version %s of an unspecified client (so that tests work)',
       async version => {
         const response = await app
           .get('/')
@@ -105,7 +105,7 @@ describe('Version compatibility', () => {
     );
 
     it.each(['0.0.1', '1.0.0', '1.0.9', '999.999.999'])(
-      'Should deny version of an an unknown client type of any version',
+      'Should deny version %s of an an unknown client type of any version',
       async version => {
         const response = await app.get('/').set({
           'X-Tamanu-Client': 'Unknown Client',


### PR DESCRIPTION
### Changes
Fix two tests broken by node 20 upgrade
1. uploadAttachments issue required path resolved with __dirname prefix and async version of writeFile to consistently pass
2. versionCompatibility failed due to sequential app requests in promise all within a single test.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
