### PR TITLE
🔥 HOTFIX 1.33: TAMOC-97: Encounter notes table hotfix

### DIFF
--- a/packages/desktop/app/components/NoteTable.js
+++ b/packages/desktop/app/components/NoteTable.js
@@ -305,6 +305,7 @@ const NoteTable = ({
         hideHeader
         allowExport={false}
         columns={COLUMNS}
+        key={noteType}
         endpoint={`encounter/${encounterId}/notes`}
         fetchOptions={{ noteType }}
         elevated={false}


### PR DESCRIPTION
First hotfixed on 1.34 and has passed testing
this pr for hotfix on 1.33

- Issue is to do with the useEffect in data fetching table which handles the fetch sharing the dependency of `fetchOptionsString` with the smaller useEffect which handles the reseting of page to 0. 
- This lead to an extra fetch being fired with the previous fetchOptions `page` i.e (if you where on page 3 of nursing notes, and clicked to all it would fire an initial fetch of page 3 of all) and then duplicates being concatenated in lazy load pagination logic. 
- Due to react keys on the list it then lead to omitted results see
```
Encountered two children with the same key, `15702c15-bdc7-4406-900b-6597a4972e89`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted 
```
- I had initially made a fix by making it so it relies on the page reset effect to trigger the fetch effect. But this fix is lower touch and also solves issue for now.
- This fixes it by remounting table on noteType change avoiding issue

I will write up a ticket for resolving the larger issue for future. It was not doable in a non hacky and hard to read way.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
