### PR TITLE
🔥HOTFIX 1.36 - TAMOC-81: Give sync pull 5 minutes on mobile

### DIFF
--- a/packages/mobile/App/services/sync/CentralServerConnection.test.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.test.ts
@@ -79,7 +79,7 @@ describe('CentralServerConnection', () => {
       expect(getSpy).toBeCalledWith(expect.stringContaining(mockSessionId), {
         fromId: 'test-from-id',
         limit: 1,
-      });
+      }, { timeout: expect.any(Number) });
     });
   });
   describe('push', () => {

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -108,8 +108,8 @@ export class CentralServerConnection {
       }
   }
 
-  async get(path: string, query: Record<string, string | number | boolean>) {
-    return this.fetch(path, query, { method: 'GET' });
+  async get(path: string, query: Record<string, string | number | boolean>, options?: FetchOptions) {
+    return this.fetch(path, query, { ...options, method: 'GET' });
   }
 
   async post(path: string, query: Record<string, string | number>, body, options?: FetchOptions) {
@@ -189,7 +189,11 @@ export class CentralServerConnection {
     if (fromId) {
       query.fromId = fromId;
     }
-    return this.get(`sync/${sessionId}/pull`, query);
+    return this.get(`sync/${sessionId}/pull`, query, {
+      // allow 5 minutes for the sync pull as it can take a while
+      // (the full 5 minutes would be pretty unusual! but just to be safe)
+      timeout: 5 * 60 * 1000, 
+    });
   }
 
   async push(sessionId: string, changes): Promise<void> {

--- a/packages/mobile/App/services/sync/types.ts
+++ b/packages/mobile/App/services/sync/types.ts
@@ -44,6 +44,7 @@ export interface LoginResponse {
 export type FetchOptions = {
   backoff?: callWithBackoffOptions;
   skipAttemptRefresh?: boolean;
+  timeout?: number;
   [key: string]: any;
 };
 

--- a/packages/mobile/App/services/sync/utils/fetchWithTimeout.ts
+++ b/packages/mobile/App/services/sync/utils/fetchWithTimeout.ts
@@ -1,3 +1,5 @@
+import { FetchOptions } from "..";
+
 const MAX_FETCH_WAIT_TIME = 45 * 1000; // 45 seconds in milliseconds
 
 type TimeoutPromiseResponse = {
@@ -5,13 +7,13 @@ type TimeoutPromiseResponse = {
   cleanup: () => void;
 };
 
-const createTimeoutPromise = (): TimeoutPromiseResponse => {
+const createTimeoutPromise = (timeout?: number): TimeoutPromiseResponse => {
   let cleanup: () => void;
   const promise: Promise<void> = new Promise((resolve, reject) => {
     const id = setTimeout(() => {
       clearTimeout(id);
       reject(new Error('Network request timed out'));
-    }, MAX_FETCH_WAIT_TIME);
+    }, timeout || MAX_FETCH_WAIT_TIME);
     cleanup = (): void => {
       clearTimeout(id);
       resolve();
@@ -21,10 +23,11 @@ const createTimeoutPromise = (): TimeoutPromiseResponse => {
   return { promise, cleanup };
 };
 
-export const fetchWithTimeout = async (url: string, config?: object): Promise<Response> => {
-  const { cleanup, promise: timeoutPromise } = createTimeoutPromise();
+export const fetchWithTimeout = async (url: string, config?: FetchOptions): Promise<Response> => {
+  const { timeout, ...otherConfig } = config || {};
+  const { cleanup, promise: timeoutPromise } = createTimeoutPromise(timeout);
   try {
-    const response = await Promise.race([fetch(url, config), timeoutPromise]);
+    const response = await Promise.race([fetch(url, otherConfig), timeoutPromise]);
     // assert type because timeoutPromise is guaranteed not to resolve unless cleaned up
     return response as Response;
   } finally {


### PR DESCRIPTION
### Changes
It was discussed that we might need to hotfix this into 1.36 if the timeouts on initial sync came up in production.
It has been reported on fiji prime upgrade so I am opening this hotfix to address

See: https://github.com/beyondessential/tamanu/pull/4839 for original pr

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
