### PR TITLE
no-issue: use en dash for separating ranges

### DIFF
--- a/packages/desktop/app/components/FormattedTableCell.js
+++ b/packages/desktop/app/components/FormattedTableCell.js
@@ -144,7 +144,7 @@ export const RangeTooltipCell = React.memo(({ value, config, validationCriteria 
   const { unit = '' } = config || {};
   const { normalRange } = validationCriteria || {};
   const tooltip =
-    normalRange && `Normal range ${normalRange.min}${unit} - ${normalRange.max}${unit}`;
+    normalRange && `Normal range ${normalRange.min}${unit} – ${normalRange.max}${unit}`;
   return tooltip ? (
     <TableTooltip title={tooltip}>
       <CellWrapper>{value}</CellWrapper>

--- a/packages/desktop/app/components/Table/Paginator.js
+++ b/packages/desktop/app/components/Table/Paginator.js
@@ -123,7 +123,7 @@ export const Paginator = React.memo(
       <PaginatorWrapper colSpan={colSpan}>
         <FooterContent>
           <PageRecordCount>
-            {lowerRange}-{upperRange} of {count}
+            {lowerRange}–{upperRange} of {count}
           </PageRecordCount>
           <StyledSelectField
             label="Rows per page"

--- a/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
+++ b/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
@@ -21,7 +21,7 @@ const makeRangeStringAccessor = sex => ({ labTestType }) => {
   const hasMax = max || max === 0;
   const hasMin = min || min === 0;
 
-  if (hasMin && hasMax) return `${min} - ${max}`;
+  if (hasMin && hasMax) return `${min} – ${max}`;
   if (hasMin) return `>${min}`;
   if (hasMax) return `<${max}`;
   return 'N/A';


### PR DESCRIPTION
### Changes
Great suggestion from @jaskfla 
change desktop range text to use “–” instead of “-”
because: `The shorter en dash (–) is used to mark ranges and with the meaning “to” in phrases like “Dover–Calais crossing.`
Only changed desktop usages

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
