### PR TITLE
no-issue: fix dev tools opening up in prod builds after electron upgrade

### DIFF
--- a/packages/desktop/app/main.dev.js
+++ b/packages/desktop/app/main.dev.js
@@ -37,9 +37,9 @@ if (isProduction) {
 
 require('@electron/remote/main').initialize();
 
-// if (isDebug) { temporarily allowing debug on prod
-electronDebug({ isEnabled: true });
-// }
+if (isDebug) {
+  electronDebug({ isEnabled: true });
+}
 
 /**
  * Add event listeners...
@@ -145,12 +145,12 @@ app.on('second-instance', () => {
   }
 });
 
-// if (isDebug) {
-app.whenReady().then(() => {
-  installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS])
-    .then(name => console.log(`Added Extension:  ${name}`))
-    .catch(err => console.log('An error occurred: ', err));
-});
-// }
+if (isDebug) {
+  app.whenReady().then(() => {
+    installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS])
+      .then(name => console.log(`Added Extension:  ${name}`))
+      .catch(err => console.log('An error occurred: ', err));
+  });
+}
 
 registerPrintListener();


### PR DESCRIPTION
### Changes
Prod build utilizes main.dev see 
In `packages/desktop/webpack.config.main.prod.js`
```
  entry: './app/main.dev',

  output: {
    path: __dirname,
    filename: './app/dist/main.prod.js',
  },
```
After upgrade `electronDebug` opens dev tools

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
