### PR TITLE
SAV-509: Sync status when shift-clicking user icon is wrong

### DIFF
--- a/packages/desktop/app/components/HiddenSyncAvatar.js
+++ b/packages/desktop/app/components/HiddenSyncAvatar.js
@@ -40,8 +40,8 @@ export const HiddenSyncAvatar = ({ children, onClick, ...props }) => {
 
       toast.info('Starting manual sync...');
       try {
-        await api.post(`sync/run`);
-        toast.success('Manual sync complete');
+        const { message } = await api.post(`sync/run`);
+        toast.success(`Manual sync: ${message}`);
       } catch (error) {
         toast.error(<Error errorMessage={error.message} />);
       } finally {

--- a/packages/lan/__tests__/apiv1/sync.test.js
+++ b/packages/lan/__tests__/apiv1/sync.test.js
@@ -1,0 +1,26 @@
+import { createTestContext } from '../utilities';
+
+describe('sync', () => {
+  let baseApp;
+  let app;
+  let ctx;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    app = await baseApp.asRole('practitioner');
+  });
+  afterAll(() => ctx.close());
+
+  describe('run', () => {
+    it.each([
+      ["Sync was disabled and didn't run", { enabled: false }],
+      ['Sync queued and will run later', { enabled: true, ran: false, queued: true }],
+      ['Sync completed', { enabled: true, ran: true, queued: false }],
+    ])('triggers a sync and returns %s', async (message, info) => {
+      ctx.syncManager.triggerSync = jest.fn().mockResolvedValueOnce(info);
+      const result = await app.post('/v1/sync/run');
+      expect(result).toHaveProperty('body.message', message);
+    });
+  });
+});

--- a/packages/lan/__tests__/utilities.js
+++ b/packages/lan/__tests__/utilities.js
@@ -146,6 +146,8 @@ export async function createTestContext({ enableReportInstances } = {}) {
   // ensure there's a corresponding local system fact for it too
   await models.LocalSystemFact.set('facilityId', facility.id);
 
+  context.syncManager = new FacilitySyncManager(context);
+
   const expressApp = createApp(context);
   const appServer = http.createServer(expressApp);
   const baseApp = supertest(appServer);
@@ -196,7 +198,6 @@ export async function createTestContext({ enableReportInstances } = {}) {
 
   context.centralServer = centralServer;
   context.baseApp = baseApp;
-  context.syncManager = new FacilitySyncManager(context);
 
   return context;
 }

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -34,6 +34,6 @@ sync.post(
     const result = await Promise.race([completeSync(), timeoutAfter(10)]);
     const message = resultToMessage(result);
 
-    res.send({ message, result });
+    res.send({ message });
   }),
 );

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -3,6 +3,14 @@ import asyncHandler from 'express-async-handler';
 
 export const sync = express.Router();
 
+function resultToMessage({ enabled, queued, ran, timedOut }) {
+  if (timedOut) return 'Sync timed out (this is normal for large syncs)';
+  if (!enabled) return "Sync was disabled and didn't run";
+  if (ran) return 'Sync completed';
+  if (queued) return 'Sync queued and will run later';
+  throw new Error('Unknown sync status');
+}
+
 sync.post(
   '/run',
   asyncHandler(async (req, res) => {
@@ -10,31 +18,22 @@ sync.post(
 
     req.flagPermissionChecked(); // no particular permission check for triggering a sync
 
-    if (syncManager.isSyncRunning()) {
-      res.send({ message: 'Sync already underway' });
-      return;
-    }
-
-    const completeSync = async () => {
-      await syncManager.triggerSync({
+    const completeSync = () =>
+      syncManager.triggerSync({
         urgent: true,
         type: 'userRequested',
         userId: user.id,
         userEmail: user.email,
       });
-      return 'Completed sync';
-    };
 
     const timeoutAfter = seconds =>
       new Promise(resolve => {
-        setTimeout(
-          () => resolve('Sync is taking a while, continuing in the background...'),
-          seconds * 1000,
-        );
+        setTimeout(() => resolve({ timedOut: true }), seconds * 1000);
       });
 
-    const message = await Promise.race([completeSync(), timeoutAfter(10)]);
+    const result = await Promise.race([completeSync(), timeoutAfter(10)]);
+    const message = resultToMessage(result);
 
-    res.send({ message });
+    res.send({ message, result });
   }),
 );

--- a/packages/lan/app/routes/apiv1/sync.js
+++ b/packages/lan/app/routes/apiv1/sync.js
@@ -4,7 +4,7 @@ import asyncHandler from 'express-async-handler';
 export const sync = express.Router();
 
 function resultToMessage({ enabled, queued, ran, timedOut }) {
-  if (timedOut) return 'Sync timed out (this is normal for large syncs)';
+  if (timedOut) return 'Sync is taking a while, continuing in the background...';
   if (!enabled) return "Sync was disabled and didn't run";
   if (ran) return 'Sync completed';
   if (queued) return 'Sync queued and will run later';


### PR DESCRIPTION
### Changes

You can shift-click the little user icon in the bottom left of the screen and trigger a sync. At the moment the toast always says it completed, regardless of whether that's true. This PR makes desktop display the actual message from facility, and makes facility return an accurate status.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
