### PR TITLE
deps: NASS-979: Remove HL7 search usage of moment

### DIFF
--- a/packages/central-server/app/hl7fhir/hl7PatientFields.js
+++ b/packages/central-server/app/hl7fhir/hl7PatientFields.js
@@ -6,8 +6,8 @@ import { VISIBILITY_STATUSES } from '@tamanu/constants';
 import { hl7ParameterTypes, stringTypeModifiers } from './hl7Parameters';
 
 // Import directly from file instead of index to avoid dependency cycle
-import { decodeIdentifier, isValidIdentifier } from './utils/identifier';
-import { parseHL7Date } from './utils/search';
+import { isValidIdentifier, decodeIdentifier } from './utils/identifier';
+import { isValidHl7Date } from './utils/search';
 
 // HL7 Patient resource mapping to Tamanu.
 // (only supported params are in)
@@ -63,7 +63,7 @@ export const hl7PatientFields = {
       // eslint-disable-next-line no-template-curly-in-string
       .test('is-valid-date', 'Invalid date/time format: ${value}', value => {
         if (!value) return true;
-        return parseHL7Date(value).isValid();
+        return isValidHl7Date(value);
       }),
     sortable: true,
   },

--- a/packages/central-server/app/hl7fhir/utils/search.js
+++ b/packages/central-server/app/hl7fhir/utils/search.js
@@ -90,7 +90,7 @@ export function isValidHl7Date(dateString) {
 
 // Returns the smallest time unit used on the date string format.
 // Only supports HL7 formats.
-export function getStartEndOfFns(dateString) {
+function getStartEndOfFns(dateString) {
   switch (dateString.length) {
     case 4:
       return [startOfYear, endOfYear];

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -81,7 +81,6 @@
     "mailgun.js": "^8.0.2",
     "mathjs": "^9.3.0",
     "mkdirp": "^1.0.4",
-    "moment": "^2.21.0",
     "mongodb": "^3.6.2",
     "morgan": "^1.9.0",
     "nanoid": "^3.1.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16198,7 +16198,7 @@ moment-timezone@^0.5.43, moment-timezone@^0.5.x:
   dependencies:
     moment "^2.29.4"
 
-moment@^2.21.0, moment@^2.29.4:
+moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
### Changes
Last reference to moment - this one is quite scary.

I came to this solution by trying to match the results of previous version with this version exactly which was tricky

This method was the only way I could find to get consistently matching the final dates returned by previous version.
`zonedTimeToUtc(startOf(parseISO(dateString)), 'UTC'),`

Given `2034` output is `2034-01-01T00:00:00.000Z, 2034-12-31T23:59:59.999Z`
Given `2022-04` output is  `2022-04-01T00:00:00.000Z, 2022-04-30T23:59:59.999Z`
Given `2022-04-01` output is `2022-04-01T00:00:00.000Z, 2022-04-01T23:59:59.999Z`

I need some input from the HL7 folks re this one as it is an area of sensitivity

### Checklist

- [x] Code is finished
- [x] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
