### PR TITLE
TAMOC-103: Improve performance of fetching notes for an encounter (HOTFIX)

### DIFF
--- a/packages/lan/__tests__/apiv1/Note.test.js
+++ b/packages/lan/__tests__/apiv1/Note.test.js
@@ -3,9 +3,13 @@ import {
   createDummyEncounter,
   randomReferenceId,
 } from '@tamanu/shared/demoData/patients';
-import { NOTE_RECORD_TYPES, NOTE_TYPES } from '@tamanu/constants';
+import { NOTE_RECORD_TYPES, NOTE_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { chance } from '@tamanu/shared/test-helpers';
+import { fake } from '@tamanu/shared/test-helpers/fake';
 import { createTestContext } from '../utilities';
+import { addMinutes } from 'date-fns';
+import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
+import { forEach } from 'lodash';
 
 const randomLabTests = (models, labTestCategoryId, amount) =>
   models.LabTestType.findAll({
@@ -183,6 +187,163 @@ describe('Note', () => {
       expect(response).toHaveSucceeded();
       expect(response.body.id).toEqual(note.id);
       expect(response.body.content).toEqual('updated');
+    });
+  });
+
+  describe('Revisions', () => {
+
+    let encounter = null;
+    let noteGroups = [];
+    let noteGroupCount = 0;
+
+    // this one needs a fair bit of data to test meaningfully, so, brace
+    // yourself for a big chunk of utility functions to get that all together!
+
+    const postEncounterNote = async props => {
+      const response = await app.post(`/v1/encounter/${encounter.id}/notes`).send(fake(models.Note, props));
+      expect(response).toHaveSucceeded();
+      return response.body;
+    };
+    
+    const postRevision = async (base, update) => {
+      return postEncounterNote({
+        ...base,
+        id: undefined,
+        date: generateDate(),
+        revisedById: base.id,
+        ...update,
+      });
+    };
+
+    // note edits are distinguished by date, so they need to be steadily incrementing
+    // this function will return a date one minute later each time it's called
+    let date = new Date(2023, 1, 1);
+    const generateDate = () => {
+      date = addMinutes(date, 1);
+      return toDateTimeString(date);
+    };
+
+    // function to quickly create a note & a bunch of edits to it
+    const postEncounterNoteWithRevisions = async (count, props) => {
+      const base = await postEncounterNote({
+        ...props,
+        id: undefined,
+        date: generateDate(),
+      });
+      const edits = [];
+
+      for (let i = 0; i < count; ++i) {
+        edits.push(await postRevision(base, {
+          content: [base.content, 'EDIT', i, (i === count - 1) && 'LATEST'].filter(Boolean).join(' '),
+        }));
+      }
+      return [base, ...edits];
+    }
+
+    beforeAll(async () => {
+      encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient.id,
+      });
+    
+      // Create a bunch of notes, with a few edits each.
+      // These notes will be used in sort/filter later in this describe block.
+      // Ideally each test would create its own notes but each test kind of needs 
+      // a bunch of other unrelated notes to filter out, and so in the interest 
+      // of speed let's just create all the records in one hit rather than 
+      // once for every test.
+      const data = [
+        // some random notes
+        ...(new Array(12).fill(0)),
+
+        // some notes to test filtering by note type
+        { noteType: NOTE_TYPES.MEDICAL, content: 'NOTE FILTER 1' },
+        { noteType: NOTE_TYPES.MEDICAL, content: 'NOTE FILTER 2' },
+        { noteType: NOTE_TYPES.MEDICAL, content: 'NOTE FILTER 3' },
+
+        // one to check that treatment plans get sorted to the top
+        { noteType: NOTE_TYPES.TREATMENT_PLAN, content: 'TREATMENT' },
+
+        // for testing making notes historical
+        { content: 'TO BE HISTORICAL' }, 
+        
+        // and a few other random notes after so that the test targets
+        // aren't all at the start or end
+        ...(new Array(11).fill(0)),
+      ];
+      noteGroups = [];
+      for (let i = 0; i < data.length; ++i) {
+        const content = `Test note ${i}`;
+        const group = await postEncounterNoteWithRevisions(chance.integer({ min: 1, max: 6 }), { content, ...data[i] });
+        noteGroups.push(group);
+      }
+      noteGroupCount = noteGroups.length;
+    });
+
+    it('should create a new revision of a note', async () => {
+      noteGroups.forEach(([base, ...revisions]) => {
+        expect(base).not.toHaveProperty('revisedById', expect.anything());
+        revisions.forEach(r => expect(r).toHaveProperty('revisedById', base.id));
+      });
+    });
+
+    it('should list the latest revision of each note', async () => {
+      const response = await app.get(`/v1/encounter/${encounter.id}/notes?rowsPerPage=${noteGroupCount}`);
+      expect(response).toHaveSucceeded();
+      expect(response.body).toHaveProperty('count', noteGroups.length);
+      response.body.data.forEach(n => {
+        expect(n.content).toMatch('LATEST');
+      });
+    });
+
+    it('should paginate notes correctly when they have revisions', async () => {
+      // grab the first two pages - they should have the right counts & no duplicates
+      const firstPage = await app.get(`/v1/encounter/${encounter.id}/notes?rowsPerPage=5`);
+      expect(firstPage).toHaveSucceeded();
+      expect(firstPage.body.data).toHaveLength(5);
+
+      const secondPage = await app.get(`/v1/encounter/${encounter.id}/notes?rowsPerPage=5&page=1`);
+      expect(secondPage).toHaveSucceeded();
+      expect(secondPage.body.data).toHaveLength(5);
+
+      const returnedRecords = [...firstPage.body.data, ...secondPage.body.data];
+      const firstNonTreatment = returnedRecords.findIndex(x => x.noteType !== NOTE_TYPES.TREATMENT_PLAN);
+      
+      // treatment plans should be first, in descending date order
+      const treatmentNotes = returnedRecords.slice(0, firstNonTreatment)
+      const treatmentDates = treatmentNotes.map(x => x.revisedBy?.date || x.date);
+
+      // then other notes, same
+      const otherNotes = returnedRecords.slice(firstNonTreatment)
+      const otherDates = otherNotes.map(x => x.revisedBy?.date || x.date);
+
+      expect(treatmentDates).toEqual([...treatmentDates].sort().reverse());
+      expect(otherDates).toEqual([...otherDates].sort().reverse());
+    });
+
+    it('should filter notes correctly when they have revisions', async () => {
+      const results = await app.get(`/v1/encounter/${encounter.id}/notes?noteType=${NOTE_TYPES.MEDICAL}&rowsPerPage=10`);
+      expect(results).toHaveSucceeded();
+      results.body.data.forEach(note => {
+        expect(note).toHaveProperty('noteType', NOTE_TYPES.MEDICAL);
+        expect(note.content).toMatch('LATEST');
+      });
+    });
+
+    // currently (2023-11-22) notes are not sortable even though the API supports it, omitting this test for now
+    it.todo('should sort notes correctly when they have revisions');
+    
+    it('should exclude a historical note even if its earlier revisions are not historical', async () => {
+      const [historicalNote] = noteGroups.find(([base]) => base.content === "TO BE HISTORICAL");
+      await postRevision(historicalNote, { content: 'HISTORICAL', visibilityStatus: VISIBILITY_STATUSES.HISTORICAL });
+
+      const response = await app.get(`/v1/encounter/${encounter.id}/notes?rowsPerPage=${noteGroupCount}`);
+      expect(response).toHaveSucceeded();
+      expect(response.body).toHaveProperty('count', noteGroups.length - 1);
+      response.body.data.forEach(n => {
+        expect(n.content).not.toMatch('HISTORICAL');
+        expect(n.content).toMatch('LATEST');
+      });
     });
   });
 });

--- a/packages/lan/app/routeHandlers/notes/noteListHandler.js
+++ b/packages/lan/app/routeHandlers/notes/noteListHandler.js
@@ -39,7 +39,8 @@ export const noteListHandler = recordType =>
       },
     ];
 
-    const idRows = await models.Note.sequelize.query(`
+    const idRows = await models.Note.sequelize.query(
+      `
       WITH
 
       -- first create a sub-table with only the notes for this record.
@@ -58,13 +59,16 @@ export const noteListHandler = recordType =>
         id
       FROM this_record_notes n
       ORDER BY edit_chain, date DESC
-    `, {
-      type: QueryTypes.SELECT,
-      replacements: {
-        recordType, recordId, 
-      }
-    });
-  
+    `,
+      {
+        type: QueryTypes.SELECT,
+        replacements: {
+          recordType,
+          recordId,
+        },
+      },
+    );
+
     // any other filtering should happen after the edits have been determined
     // (if we do it all in the same step, we risk including earlier versions of
     // a record that was excluded later, which we absolutely do not want)
@@ -104,7 +108,7 @@ export const noteListHandler = recordType =>
     const totalCount = await models.Note.count({
       where,
     });
-    
+
     res.send({ data: rows, count: totalCount });
   });
 

--- a/packages/lan/app/routeHandlers/notes/noteListHandler.js
+++ b/packages/lan/app/routeHandlers/notes/noteListHandler.js
@@ -1,4 +1,4 @@
-import Sequelize, { Op } from 'sequelize';
+import Sequelize, { Op, QueryTypes } from 'sequelize';
 import asyncHandler from 'express-async-handler';
 import { NOTE_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
 
@@ -39,35 +39,41 @@ export const noteListHandler = recordType =>
       },
     ];
 
-    // All notes, filtered by recordId, recordType & visibilityStatus are loaded excluding:
-    // 1- (1st notIn) Notes that have another more recent note with the same root (revisedById)
-    // 2- (2nd notIn) Root notes that have been revised by another note
-    const baseWhere = {
-      [Op.and]: [
-        Sequelize.literal(`
-          NOT EXISTS (
-            SELECT id
-            FROM (
-              SELECT id, revised_by_id, ROW_NUMBER() OVER (PARTITION BY revised_by_id ORDER BY date DESC, id DESC) AS row_num
-              FROM notes
-              WHERE revised_by_id IS NOT NULL
-            ) n
-            WHERE n.row_num != 1
-            AND id = "Note"."id"
-          )
-        `),
-        Sequelize.literal(`
-          NOT EXISTS (
-            SELECT revised_by_id
-            FROM notes
-            WHERE revised_by_id IS NOT NULL
-            AND revised_by_id = "Note"."id"
-          )
-        `),
-      ],
-      recordType,
-      recordId,
+    const idRows = await models.Note.sequelize.query(`
+      WITH
+
+      -- first create a sub-table with only the notes for this record.
+      -- this will make the DISTINCT stuff way faster
+      this_record_notes AS (
+        SELECT 
+          *,
+          CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END edit_chain
+        FROM notes n
+        WHERE record_type = :recordType
+          AND record_id = :recordId
+      )
+
+      -- now filter out anything except the latest revision for each note
+      SELECT DISTINCT ON (edit_chain)
+        id
+      FROM this_record_notes n
+      ORDER BY edit_chain, date DESC
+    `, {
+      type: QueryTypes.SELECT,
+      replacements: {
+        recordType, recordId, 
+      }
+    });
+  
+    // any other filtering should happen after the edits have been determined
+    // (if we do it all in the same step, we risk including earlier versions of
+    // a record that was excluded later, which we absolutely do not want)
+    const where = {
+      id: {
+        [Op.in]: idRows.map(x => x.id),
+      },
       visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+      ...(noteType ? { noteType } : {}),
     };
 
     const queryOrder = orderBy
@@ -88,12 +94,6 @@ export const noteListHandler = recordType =>
           ],
         ];
 
-    const where = noteType
-      ? {
-          ...baseWhere,
-          noteType,
-        }
-      : baseWhere;
     const rows = await models.Note.findAll({
       include,
       where,
@@ -104,7 +104,7 @@ export const noteListHandler = recordType =>
     const totalCount = await models.Note.count({
       where,
     });
-
+    
     res.send({ data: rows, count: totalCount });
   });
 

--- a/packages/shared/src/test-helpers/fake.js
+++ b/packages/shared/src/test-helpers/fake.js
@@ -363,6 +363,7 @@ const MODEL_SPECIFIC_OVERRIDES = {
     // It will be fixed properly as part of EPI-160
     id: undefined,
     noteType: chance.pickone(NOTE_TYPE_VALUES),
+    revisedById: undefined,
   }),
   Location: () => ({
     maxOccupancy: 1,


### PR DESCRIPTION
### Changes

Previously the query was doing a `ROW_NUMBER() OVER (PARTITION BY ...)` over the entire Notes table to determine which notes were the latest. This was logically sound but slowed to a crawl when running on 100k's of notes.

This updates the query logic to first filter for the current `recordId`'s notes (reliably reducing the data set to a matter of 100s) and determining the current notes based on that subset. Then it does the rest of the filtering using the returned IDs for that query. It should be much faster.

Most of this PR is tests, as it turns out coverage was pretty sparse and I didn't want to break anything with the logic change.


### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
