### PR TITLE
SAV-507: Sync subcommand should wait in queue

### DIFF
--- a/packages/lan/app/subCommands/sync.js
+++ b/packages/lan/app/subCommands/sync.js
@@ -1,10 +1,16 @@
 import { Command } from 'commander';
 
+import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
+import { log } from '@tamanu/shared/services/logging';
 import { initDeviceId } from '../sync/initDeviceId';
 import { FacilitySyncManager, CentralServerConnection } from '../sync';
 import { ApplicationContext } from '../ApplicationContext';
 
-async function sync() {
+async function sync({ delay: delaySecondsStr }) {
+  const delaySeconds = parseInt(delaySecondsStr, 10);
+  if (!Number.isFinite(delaySeconds) || delaySeconds < 0) {
+    throw new Error('invalid option for delay');
+  }
   const context = await new ApplicationContext().init();
 
   await initDeviceId(context);
@@ -13,10 +19,31 @@ async function sync() {
   context.centralServer.connect(); // preemptively connect central server to speed up sync
   context.syncManager = new FacilitySyncManager(context);
 
-  await context.syncManager.triggerSync({
-    type: 'subcommand',
-    urgent: true,
-  });
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    log.info('Sync subcommand: beginning sync');
+    const { ran, enabled, queued } = await context.syncManager.triggerSync({
+      type: 'subcommand',
+      urgent: true,
+    });
+    if (!enabled) {
+      throw new Error('sync is not enabled, check config');
+    }
+    if (ran) {
+      log.info('Sync subcommand: ran successfully');
+      break;
+    }
+    if (queued) {
+      log.info('Sync subcommand: sync queued, retrying', { delaySeconds });
+      await sleepAsync(delaySeconds * 1000);
+      continue;
+    }
+    // sync is enabled, did not run, and was not queued - error!
+    throw new Error('sync is in an unknown state');
+  }
 }
 
-export const syncCommand = new Command('sync').description('Sync with central server').action(sync);
+export const syncCommand = new Command('sync')
+  .description('Sync with central server')
+  .option('-d, --delay <delay>', 'Delay in seconds between retries if queued', '15')
+  .action(sync);

--- a/packages/lan/config/development.json5
+++ b/packages/lan/config/development.json5
@@ -1,15 +1,20 @@
 {
-  "admin": {
-    "allowAdminRoutes": true
-  },
-  "log": {
-    "console": "debug"
-  },
-  "discovery": {
-    "protocol": "http"
+  "serverFacilityId": "tamanuFijiGenerate-facility-0",
+  "auth": {
+    "useHardcodedPermissions": false,
+    "secret": "insecure"
   },
   "db": {
-    "name": "develop"
+    "migrateOnStartup": true,
+    "name": "tamanu-lan"
   },
-  "countryTimeZone": "Pacific/Auckland"
+  "sync": {
+    "host": "http://localhost:3000",
+    "email": "admin@tamanu.io",
+    "password": "admin",
+    "enabled": true
+  },
+  "log": {
+    "consoleLevel": "http"
+  }
 }

--- a/packages/sync-server/config/development.json5
+++ b/packages/sync-server/config/development.json5
@@ -2,8 +2,13 @@
   "auth": {
     "reportNoUserError": true
   },
+  "db": {
+    "name": "tamanu-sync-generate",
+    "migrateOnStartup": true,
+    "verbose": false
+  },
   "log": {
-    "consoleLevel": "debug"
+    "consoleLevel": "info"
   },
   "localisation": {
     "data": {
@@ -12,6 +17,9 @@
         "name": "Utopia",
         "alpha-2": "UT",
         "alpha-3": "UTO"
+      },
+      "features": {
+        "enablePatientDeaths": true
       }
     }
   },
@@ -22,6 +30,12 @@
     "signer": {
       "enabled": true,
       "keySecret": "dTk8mJ0t+xszGxohhMq1Y7UEE9h1Pzvb+1r+YHVf+Y4="
+    },
+    "fhir": {
+      "enabled": true, // the HTTP routes
+      "worker": {
+        "enabled": true
+      }
     }
   },
   "countryTimeZone": "Pacific/Auckland"


### PR DESCRIPTION
### Changes

Because `triggerSync` returns instantly now, this PR retries it until it completes.

This needs a dev to test it. If the reviewer could pull the branch, run `yarn && yarn build-shared && yarn workspace lan build && yarn workspace lan start sync` while a sync is happening, and make sure it works, I'd appreciate it.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
