### PR TITLE
EPI-565 Apply deletion status to other models

### DIFF
--- a/packages/lan/app/routeHandlers/notes/noteListHandler.js
+++ b/packages/lan/app/routeHandlers/notes/noteListHandler.js
@@ -51,6 +51,7 @@ export const noteListHandler = recordType =>
               SELECT id, revised_by_id, ROW_NUMBER() OVER (PARTITION BY revised_by_id ORDER BY date DESC, id DESC) AS row_num
               FROM notes
               WHERE revised_by_id IS NOT NULL
+              AND deleted_at IS NULL
             ) n
             WHERE n.row_num != 1
             AND id = "Note"."id"
@@ -62,6 +63,7 @@ export const noteListHandler = recordType =>
             FROM notes
             WHERE revised_by_id IS NOT NULL
             AND revised_by_id = "Note"."id"
+            AND deleted_at IS NULL
           )
         `),
       ],

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -379,14 +379,11 @@ encounterRelations.get(
               )
             )) logs
           FROM survey_response_answers sra
-          INNER JOIN survey_responses sr
-          ON sr.id = sra.response_id
-          LEFT JOIN vital_logs vl
-          ON vl.answer_id = sra.id
-          LEFT JOIN users u
-          ON u.id = vl.recorded_by_id
+          	INNER JOIN survey_responses sr ON sr.id = sra.response_id
+          	LEFT JOIN vital_logs vl ON vl.answer_id = sra.id
+          	LEFT JOIN users u ON u.id = vl.recorded_by_id
           WHERE sr.encounter_id = :encounterId
-          AND sr.deleted_at IS NULL
+          	AND sr.deleted_at IS NULL
           GROUP BY vl.answer_id
         )
 

--- a/packages/lan/app/routes/apiv1/encounter.js
+++ b/packages/lan/app/routes/apiv1/encounter.js
@@ -276,10 +276,9 @@ encounterRelations.get(
             ON (survey_responses.encounter_id = encounters.id)
           LEFT JOIN surveys
             ON (survey_responses.survey_id = surveys.id)
-        WHERE
-          survey_responses.encounter_id = :encounterId
-        AND
-          surveys.survey_type = 'programs'
+        WHERE survey_responses.encounter_id = :encounterId
+        AND surveys.survey_type = 'programs'
+        AND encounters.deleted_at is null
       `,
       `
         SELECT
@@ -299,10 +298,9 @@ encounterRelations.get(
             ON (encounter_user.id = encounters.examiner_id)
           LEFT JOIN users survey_user
             ON (survey_user.id = survey_responses.user_id)
-        WHERE
-          survey_responses.encounter_id = :encounterId
-        AND
-          surveys.survey_type = 'programs'
+        WHERE survey_responses.encounter_id = :encounterId
+        AND surveys.survey_type = 'programs'
+        AND encounters.deleted_at is null
         ORDER BY ${sortKey} ${sortDirection}
       `,
       { encounterId },
@@ -328,18 +326,13 @@ encounterRelations.get(
     const countResult = await db.query(
       `
         SELECT COUNT(1) AS count
-        FROM
-          survey_response_answers
-        INNER JOIN
-          survey_responses response
-        ON
-          response.id = response_id
-        WHERE
-          data_element_id = :dateDataElement
-        AND
-          body IS NOT NULL
-        AND
-          response.encounter_id = :encounterId
+        FROM survey_response_answers
+        INNER JOIN survey_responses response
+        ON response.id = response_id
+        WHERE data_element_id = :dateDataElement
+        AND body IS NOT NULL
+        AND response.encounter_id = :encounterId
+        AND response.deleted_at IS NULL
       `,
       {
         replacements: {
@@ -364,20 +357,14 @@ encounterRelations.get(
       `
         WITH
         date AS (
-          SELECT
-            response_id, body
-          FROM
-            survey_response_answers
-          INNER JOIN
-            survey_responses response
-          ON
-            response.id = response_id
-          WHERE
-            data_element_id = :dateDataElement
-          AND
-            body IS NOT NULL
-          AND
-            response.encounter_id = :encounterId
+          SELECT response_id, body
+          FROM survey_response_answers
+          INNER JOIN survey_responses response
+          ON response.id = response_id
+          WHERE data_element_id = :dateDataElement
+          AND body IS NOT NULL
+          AND response.encounter_id = :encounterId
+          AND response.deleted_at IS NULL
           ORDER BY body ${order} LIMIT :limit OFFSET :offset
         ),
         history AS (
@@ -391,24 +378,16 @@ encounterRelations.get(
                 'userDisplayName', u.display_name
               )
             )) logs
-          FROM
-            survey_response_answers sra
-          INNER JOIN
-            survey_responses sr
-          ON
-            sr.id = sra.response_id
-          LEFT JOIN
-            vital_logs vl
-          ON
-            vl.answer_id = sra.id
-          LEFT JOIN
-            users u
-          ON
-            u.id = vl.recorded_by_id
-          WHERE
-            sr.encounter_id = :encounterId
-          GROUP BY
-            vl.answer_id
+          FROM survey_response_answers sra
+          INNER JOIN survey_responses sr
+          ON sr.id = sra.response_id
+          LEFT JOIN vital_logs vl
+          ON vl.answer_id = sra.id
+          LEFT JOIN users u
+          ON u.id = vl.recorded_by_id
+          WHERE sr.encounter_id = :encounterId
+          AND sr.deleted_at IS NULL
+          GROUP BY vl.answer_id
         )
 
         SELECT

--- a/packages/lan/app/routes/apiv1/invoice/getPotentialInvoiceLineItems.js
+++ b/packages/lan/app/routes/apiv1/invoice/getPotentialInvoiceLineItems.js
@@ -7,6 +7,8 @@ const getInvoiceLineNotExistYetClause = `invoice_line_types.id NOT IN (SELECT in
           ON invoice_line_items.invoice_id = invoices.id
           WHERE invoices.encounter_id = :encounterId
           AND invoice_line_items.status != :invoiceLineItemDeletedStatus
+          AND invoice_line_items.deleted_at IS NULL
+          AND invoices.deleted_at IS NULL
           )`;
 
 /**
@@ -35,6 +37,7 @@ export const getPotentialInvoiceLineItems = async (db, models, encounterId, imag
         INNER JOIN users
         ON users.id = procedures.physician_id
         WHERE procedures.encounter_id = :encounterId
+        AND procedures.deleted_at IS NULL
         AND ${getInvoiceLineNotExistYetClause};
     `,
     {
@@ -69,6 +72,7 @@ export const getPotentialInvoiceLineItems = async (db, models, encounterId, imag
         INNER JOIN users
         ON users.id = imaging_requests.requested_by_id
         WHERE imaging_requests.encounter_id = :encounterId
+        AND imaging_requests.deleted_at IS NULL
         AND ${getInvoiceLineNotExistYetClause};
     `,
     {
@@ -105,6 +109,7 @@ export const getPotentialInvoiceLineItems = async (db, models, encounterId, imag
         INNER JOIN users
         ON users.id = lab_requests.requested_by_id
         WHERE lab_requests.encounter_id = :encounterId
+        AND lab_requests.deleted_at IS NULL
         AND ${getInvoiceLineNotExistYetClause};
     `,
     {

--- a/packages/lan/app/routes/apiv1/locationGroup.js
+++ b/packages/lan/app/routes/apiv1/locationGroup.js
@@ -72,7 +72,8 @@ locationGroup.get(
               FROM notes
               WHERE revised_by_id isnull 
                 AND record_type = 'Encounter' 
-                AND note_type = 'handover') n
+                AND note_type = 'handover'
+                AND deleted_at isnull) n
         WHERE n.row_num = 1
       ),
 
@@ -90,6 +91,7 @@ locationGroup.get(
                 INNER JOIN latest_root_handover_notes ON latest_root_handover_notes.id = notes.revised_by_id
               ) n
         WHERE n.row_num = 1
+        AND n.deleted_at isnull
 
         UNION
 
@@ -101,7 +103,9 @@ locationGroup.get(
           content,
           latest.date as created_date
         FROM latest_root_handover_notes latest
-        WHERE NOT EXISTS (SELECT id FROM notes WHERE revised_by_id = latest.id)
+        WHERE NOT EXISTS (SELECT id FROM notes 
+                          WHERE revised_by_id = latest.id 
+                          AND deleted_at isnull)
       )
     
       SELECT location_groups.name AS area,

--- a/packages/lan/app/routes/apiv1/locationGroup.js
+++ b/packages/lan/app/routes/apiv1/locationGroup.js
@@ -89,9 +89,9 @@ locationGroup.get(
                 ROW_NUMBER() OVER (PARTITION BY revised_by_id ORDER BY notes.date DESC) AS row_num
               FROM notes
                 INNER JOIN latest_root_handover_notes ON latest_root_handover_notes.id = notes.revised_by_id
+              WHERE notes.deleted_at IS NULL
               ) n
         WHERE n.row_num = 1
-        AND n.deleted_at IS NULL
 
         UNION
 

--- a/packages/lan/app/routes/apiv1/locationGroup.js
+++ b/packages/lan/app/routes/apiv1/locationGroup.js
@@ -70,10 +70,10 @@ locationGroup.get(
         FROM (SELECT id, record_id, date, content,
                 ROW_NUMBER() OVER (PARTITION BY record_id ORDER BY date DESC) AS row_num
               FROM notes
-              WHERE revised_by_id isnull 
+              WHERE revised_by_id IS NULL 
                 AND record_type = 'Encounter' 
                 AND note_type = 'handover'
-                AND deleted_at isnull) n
+                AND deleted_at IS NULL) n
         WHERE n.row_num = 1
       ),
 
@@ -91,7 +91,7 @@ locationGroup.get(
                 INNER JOIN latest_root_handover_notes ON latest_root_handover_notes.id = notes.revised_by_id
               ) n
         WHERE n.row_num = 1
-        AND n.deleted_at isnull
+        AND n.deleted_at IS NULL
 
         UNION
 
@@ -105,7 +105,7 @@ locationGroup.get(
         FROM latest_root_handover_notes latest
         WHERE NOT EXISTS (SELECT id FROM notes 
                           WHERE revised_by_id = latest.id 
-                          AND deleted_at isnull)
+                          AND deleted_at IS NULL)
       )
     
       SELECT location_groups.name AS area,

--- a/packages/lan/app/routes/apiv1/locationGroup.js
+++ b/packages/lan/app/routes/apiv1/locationGroup.js
@@ -85,12 +85,18 @@ locationGroup.get(
           n.revised_by_id,
           n.content,
           n.date as created_date
-        FROM (SELECT notes.id, notes.record_id, notes.revised_by_id, notes.content, latest_root_handover_notes.date,
-                ROW_NUMBER() OVER (PARTITION BY revised_by_id ORDER BY notes.date DESC) AS row_num
-              FROM notes
-                INNER JOIN latest_root_handover_notes ON latest_root_handover_notes.id = notes.revised_by_id
-              WHERE notes.deleted_at IS NULL
-              ) n
+        FROM (
+          SELECT
+            notes.id,
+            notes.record_id,
+            notes.revised_by_id,
+            notes.content,
+            latest_root_handover_notes.date,
+            ROW_NUMBER() OVER (PARTITION BY revised_by_id ORDER BY notes.date DESC) AS row_num
+          FROM notes
+            INNER JOIN latest_root_handover_notes ON latest_root_handover_notes.id = notes.revised_by_id
+          WHERE notes.deleted_at IS NULL
+        ) n
         WHERE n.row_num = 1
 
         UNION

--- a/packages/lan/app/routes/apiv1/patient/patientRelations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientRelations.js
@@ -278,8 +278,8 @@ patientRelations.get(
           LEFT JOIN programs
             ON (programs.id = surveys.program_id)
         WHERE encounters.patient_id = :patientId
-        AND encounters.deleted_at is null
-        AND surveys.survey_type = :surveyType
+          AND encounters.deleted_at is null
+          AND surveys.survey_type = :surveyType
           ${surveyId ? 'AND surveys.id = :surveyId' : ''}
         ORDER BY ${sortKey} ${sortDirection}
       `,

--- a/packages/lan/app/routes/apiv1/patient/patientRelations.js
+++ b/packages/lan/app/routes/apiv1/patient/patientRelations.js
@@ -277,9 +277,9 @@ patientRelations.get(
             ON (survey_user.id = survey_responses.user_id)
           LEFT JOIN programs
             ON (programs.id = surveys.program_id)
-        WHERE
-          encounters.patient_id = :patientId
-          AND surveys.survey_type = :surveyType
+        WHERE encounters.patient_id = :patientId
+        AND encounters.deleted_at is null
+        AND surveys.survey_type = :surveyType
           ${surveyId ? 'AND surveys.id = :surveyId' : ''}
         ORDER BY ${sortKey} ${sortDirection}
       `,
@@ -352,6 +352,7 @@ patientRelations.get(
     )
   AND lab_requests.status = :status
   AND lab_requests.sample_time IS NOT NULL
+  AND lab_requests.deleted_at IS NULL
   ${categoryId ? 'AND lab_requests.lab_test_category_id = :categoryId' : ''}
   ${
     panelId

--- a/packages/lan/app/routes/apiv1/suggestions.js
+++ b/packages/lan/app/routes/apiv1/suggestions.js
@@ -278,6 +278,8 @@ createSuggester('patientLabTestCategories', 'ReferenceData', (search, query) => 
             encounters ON encounters.id = lab_requests.encounter_id
           WHERE lab_requests.status = '${status}'
             AND encounters.patient_id = '${query.patientId}'
+            AND encounters.deleted_at is null
+            AND lab_requests.deleted_at is null
         )`,
       ),
     },
@@ -310,6 +312,8 @@ createSuggester('patientLabTestPanelTypes', 'LabTestPanel', (search, query) => {
             encounters ON encounters.id = lab_requests.encounter_id
           WHERE lab_requests.status = '${status}'
             AND encounters.patient_id = '${query.patientId}'
+            AND encounters.deleted_at is null
+            AND lab_requests.deleted_at is null
         )`,
       ),
     },

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -224,9 +224,8 @@ export class Encounter extends Model {
           SELECT e.id, max(lr.updated_at_sync_tick) as lr_updated_at_sync_tick
           FROM encounters e
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
-          WHERE e.updated_at_sync_tick > :since
-          OR lr.updated_at_sync_tick > :since
-          AND lab_requests.deleted_at IS NULL
+          WHERE (e.updated_at_sync_tick > :since OR lr.updated_at_sync_tick > :since)
+          AND lr.deleted_at IS NULL
           AND e.deleted_at IS NULL
           ${
             patientIds.length > 0

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -226,6 +226,8 @@ export class Encounter extends Model {
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
           WHERE e.updated_at_sync_tick > :since
           OR lr.updated_at_sync_tick > :since
+          AND lab_requests.deleted_at IS NULL
+          AND e.deleted_at IS NULL
           ${
             patientIds.length > 0
               ? 'AND e.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway'

--- a/packages/shared/src/models/SurveyResponseAnswer.js
+++ b/packages/shared/src/models/SurveyResponseAnswer.js
@@ -46,21 +46,18 @@ export class SurveyResponseAnswer extends Model {
       return `
         ${joins}
         JOIN surveys ON survey_responses.survey_id = surveys.id
-        WHERE
-          encounters.patient_id in (:patientIds)
-        AND
-          surveys.is_sensitive = FALSE
-        AND
-          ${this.tableName}.updated_at_sync_tick > :since
+        WHERE encounters.patient_id in (:patientIds)
+        AND surveys.is_sensitive = FALSE
+        AND ${this.tableName}.updated_at_sync_tick > :since
+        AND encounters.deleted_at is null
       `;
     }
 
     return `
       ${joins}
-      WHERE
-        encounters.patient_id in (:patientIds)
-      AND
-        ${this.tableName}.updated_at_sync_tick > :since
+      WHERE encounters.patient_id in (:patientIds)
+      AND encounters.deleted_at is null
+      AND ${this.tableName}.updated_at_sync_tick > :since
     `;
   }
 

--- a/packages/shared/src/models/VitalLog.js
+++ b/packages/shared/src/models/VitalLog.js
@@ -69,21 +69,18 @@ export class VitalLog extends Model {
       return `
         ${joins}
         INNER JOIN surveys ON survey_responses.survey_id = surveys.id
-        WHERE
-          encounters.patient_id in (:patientIds)
-        AND
-          surveys.is_sensitive = FALSE
-        AND
-          ${this.tableName}.updated_at_sync_tick > :since
+        WHERE encounters.patient_id in (:patientIds)
+        AND surveys.is_sensitive = FALSE
+        AND ${this.tableName}.updated_at_sync_tick > :since
+        AND encounters.deleted_at is null
       `;
     }
 
     return `
       ${joins}
-      WHERE
-        encounters.patient_id in (:patientIds)
-      AND
-        ${this.tableName}.updated_at_sync_tick > :since
+      WHERE encounters.patient_id in (:patientIds)
+      AND encounters.deleted_at is null
+      AND ${this.tableName}.updated_at_sync_tick > :since
     `;
   }
 }

--- a/packages/shared/src/models/buildEncounterLinkedSyncFilter.js
+++ b/packages/shared/src/models/buildEncounterLinkedSyncFilter.js
@@ -19,5 +19,6 @@ export function buildEncounterLinkedSyncFilter(
     ${joins}
     WHERE encounters.patient_id IN (:patientIds)
     AND ${tablesToTraverse[0]}.updated_at_sync_tick > :since
+    AND encounters.deleted_at IS NULL
   `;
 }

--- a/packages/shared/src/models/buildNoteLinkedSyncFilter.js
+++ b/packages/shared/src/models/buildNoteLinkedSyncFilter.js
@@ -55,5 +55,6 @@ export function buildNoteLinkedSyncFilter(patientIds, sessionConfig) {
       ${whereOrs.join('\nOR ')}
     )
     AND notes.updated_at_sync_tick > :since
+    AND notes.deleted_at isnull
   `;
 }

--- a/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/sync-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -272,8 +272,7 @@ triage_info as (
   select
     encounter_id,
     hours::text || CHR(58) || remaining_minutes::text "waitTimeFollowingTriage"
-  from triages t
-  where t.deleted_at isnull,
+  from triages t,
   lateral (
     select
       case when t.closed_time is null
@@ -283,7 +282,7 @@ triage_info as (
   ) total_minutes,
   lateral (select floor(total_minutes / 60) hours) hours,
   lateral (select floor(total_minutes - hours*60) remaining_minutes) remaining_minutes
-  
+  where t.deleted_at isnull
 ),
 
 discharge_disposition_info as (
@@ -301,7 +300,7 @@ discharge_disposition_info as (
         order by updated_at desc
         LIMIT 1)
   join reference_data disposition on disposition.id = d.disposition_id
-  where t.deleted_at isnull
+  where e.deleted_at isnull
 ),
 
 encounter_history_info as (

--- a/packages/sync-server/app/subCommands/calculateSurveyResults.js
+++ b/packages/sync-server/app/subCommands/calculateSurveyResults.js
@@ -108,6 +108,7 @@ const calculateSurveyResultsInBatch = async (
       survey_responses.encounter_id AS "encounterId"
       FROM survey_responses
       WHERE survey_id = :surveyId
+      AND deleted_at is null
       ORDER BY survey_responses.id ASC
       LIMIT :batchSize
       OFFSET :offset
@@ -204,7 +205,8 @@ async function calculateSurveyResults() {
       `
         SELECT COUNT(*)
         FROM survey_responses
-        WHERE survey_id = :surveyId;
+        WHERE survey_id = :surveyId
+        AND deleted_at is null;
     `,
       {
         replacements: {

--- a/packages/sync-server/app/subCommands/generateInitialVitalLogs.js
+++ b/packages/sync-server/app/subCommands/generateInitialVitalLogs.js
@@ -15,6 +15,7 @@ async function generateVitalLogsInBatch(store, vitalsSurveyId, batchSize, offset
           SELECT id, end_time, start_time, user_id
           FROM survey_responses
           WHERE survey_id = :vitalsSurveyId
+          AND deleted_at is null
           ORDER BY created_at ASC, id ASC
           LIMIT :limit
           OFFSET :offset


### PR DESCRIPTION
### Changes
Review this after #4843.
In https://github.com/beyondessential/tamanu/pull/4843 we apply deletion status to encounter, this PR will do it to other models:
```
  document_metadata
  referrals
  notes
  encounter_medications
  invoices
  vitals
  procedures
  lab_requests
  imaging_requests
  survey_responses
```

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
