### PR TITLE
SAV-454: Account for queuing in mobile's sync screen

### DIFF
--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -136,7 +136,7 @@ export class MobileSyncManager {
     } catch (error) {
       this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_ERROR, { error });
     } finally {
-      // Set up sync finished values only when sync was started.
+      // Reset all the values to default only if sync actually started, otherwise they should still be default values
       if (this.isSyncing) {
         this.syncStage = null;
         this.isSyncing = false;

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -35,6 +35,8 @@ type SyncOptions = {
 export const SYNC_STAGES_TOTAL = Object.values(STAGE_MAX_PROGRESS).length;
 
 export class MobileSyncManager {
+  isQueuing = false;
+
   isSyncing = false;
 
   progress = 0;
@@ -131,16 +133,17 @@ export class MobileSyncManager {
 
     try {
       await this.runSync({ urgent });
-      this.lastSuccessfulSyncTick = formatDate(new Date(), DateFormats.DATE_AND_TIME);
-      this.setProgress(0, '');
     } catch (error) {
       this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_ERROR, { error });
     } finally {
-      this.syncStage = null;
-      this.isSyncing = false;
-      this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED);
-      this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_ENDED, `time=${Date.now() - startTime}ms`);
-      console.log(`Sync took ${Date.now() - startTime} ms`);
+      // Set up sync finished values only when sync was started.
+      if (this.isSyncing) {
+        this.syncStage = null;
+        this.isSyncing = false;
+        this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED);
+        this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_ENDED, `time=${Date.now() - startTime}ms`);
+        console.log(`Sync took ${Date.now() - startTime} ms`);
+      }
     }
   }
 
@@ -171,8 +174,14 @@ export class MobileSyncManager {
     if (!sessionId) {
       console.log(`MobileSyncManager.runSync(): Sync queue status: ${status}`);
       this.isSyncing = false;
+      this.isQueuing = true;
+      this.progressMessage = 'Sync in progress...';
+      this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE);
       return;
     }
+
+    this.isSyncing = true;
+    this.isQueuing = false;
 
     this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_STARTED);
 
@@ -185,6 +194,9 @@ export class MobileSyncManager {
 
     // clear persisted cache from last session
     await clearPersistedSyncSessionRecords();
+
+    this.lastSuccessfulSyncTick = formatDate(new Date(), DateFormats.DATE_AND_TIME_HHMMSS);
+    this.setProgress(0, '');
   }
 
   /**

--- a/packages/mobile/App/services/sync/types.ts
+++ b/packages/mobile/App/services/sync/types.ts
@@ -49,6 +49,7 @@ export type FetchOptions = {
 };
 
 export enum SYNC_EVENT_ACTIONS {
+  SYNC_IN_QUEUE = 'syncInQueue',
   SYNC_STARTED = 'syncStarted',
   SYNC_STATE_CHANGED = 'syncStateChanged',
   SYNC_ENDED = 'syncEnded',

--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/SyncDataScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/SyncDataScreen.tsx
@@ -27,6 +27,7 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
   const [syncStarted, setSyncStarted] = useState(syncManager.isSyncing);
   const [hasError, setHasError] = useState(false);
   const [isSyncing, setIsSyncing] = useState(syncManager.isSyncing);
+  const [isQueuing, setIsQueuing] = useState(syncManager.isQueuing);
   const [syncStage, setSyncStage] = useState(syncManager.syncStage);
   const [progress, setProgress] = useState(syncManager.progress);
   const [progressMessage, setProgressMessage] = useState(syncManager.progressMessage);
@@ -56,7 +57,13 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
   useEffect(() => {
     const handler = (action: string): void => {
       switch (action) {
+        case SYNC_EVENT_ACTIONS.SYNC_IN_QUEUE:
+          setProgress(0);
+          setIsQueuing(true);
+          setIsSyncing(false);
+          break;
         case SYNC_EVENT_ACTIONS.SYNC_STARTED:
+          setIsQueuing(false);
           setSyncStarted(true);
           setIsSyncing(true);
           setProgress(0);
@@ -65,6 +72,7 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
           activateKeepAwake(); // don't let the device sleep while syncing
           break;
         case SYNC_EVENT_ACTIONS.SYNC_ENDED:
+          setIsQueuing(false);
           setIsSyncing(false);
           setProgress(0);
           setProgressMessage('');
@@ -81,6 +89,7 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
           setLastSyncPulledRecordsCount(syncManager.lastSyncPulledRecordsCount);
           break;
         case SYNC_EVENT_ACTIONS.SYNC_ERROR:
+          setIsQueuing(false);
           setHasError(true);
           break;
         default:
@@ -109,12 +118,23 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
   return (
     <CenterView background={theme.colors.MAIN_SUPER_DARK} flex={1}>
       <StyledView alignItems="center">
-        {isSyncing ? (
+        {/* Circular progress */}
+        {(isSyncing || isQueuing) && !hasError ? (
           <ActivityIndicator
             size="large"
             color={theme.colors.SECONDARY_MAIN}
             style={{ transform: [{ scaleX: 2 }, { scaleY: 2 }] }}
           />
+        ) : null}
+        {/* Queuing message */}
+        {isQueuing ? (
+          <StyledText
+            marginTop={screenPercentageToDP(5, Orientation.Height)}
+            fontSize={screenPercentageToDP(1.7, Orientation.Height)}
+            color={theme.colors.WHITE}
+          >
+            {progressMessage}
+          </StyledText>
         ) : null}
         {syncFinishedSuccessfully ? (
           <GreenTickIcon size={screenPercentageToDP('8', Orientation.Height)} />


### PR DESCRIPTION
### Changes
- Account for queuing in mobile's sync screen

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
