### PR TITLE
NASS-964: Translate desktop 'Documents' module

### DIFF
--- a/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
+++ b/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
@@ -13,14 +13,44 @@ import {
   getDateWithTimeTooltip,
   getRequestId,
 } from '../../utils/lab';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const columns = [
-  { key: 'requestId', title: 'Test ID', sortable: false, accessor: getRequestId },
-  { key: 'category.name', title: 'Test category', accessor: getRequestType },
-  { key: 'requestedDate', title: 'Requested at time', accessor: getDateWithTimeTooltip },
-  { key: 'displayName', title: 'Requested by', accessor: getRequestedBy, sortable: false },
-  { key: 'priority.name', title: 'Priority', accessor: getPriority },
-  { key: 'status', title: 'Status', accessor: getStatus, maxWidth: 200 },
+  {
+    key: 'requestId',
+    title: <TranslatedText stringId="labs.table.column.testId" fallback="Test ID" />,
+    sortable: false,
+    accessor: getRequestId,
+  },
+  {
+    key: 'category.name',
+    title: <TranslatedText stringId="labs.table.column.testCategory" fallback="Test category" />,
+    accessor: getRequestType,
+  },
+  {
+    key: 'requestedDate',
+    title: (
+      <TranslatedText stringId="labs.table.column.requestedDate" fallback="Requested at time" />
+    ),
+    accessor: getDateWithTimeTooltip,
+  },
+  {
+    key: 'displayName',
+    title: <TranslatedText stringId="labs.table.column.requestedBy" fallback="Requested by" />,
+    accessor: getRequestedBy,
+    sortable: false,
+  },
+  {
+    key: 'priority.name',
+    title: <TranslatedText stringId="labs.table.column.priority" fallback="Priority" />,
+    accessor: getPriority,
+  },
+  {
+    key: 'status',
+    title: <TranslatedText stringId="labs.table.column.status" fallback="Status" />,
+    accessor: getStatus,
+    maxWidth: 200,
+  },
 ];
 
 export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
@@ -40,7 +70,9 @@ export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
     <DataFetchingTable
       endpoint={`encounter/${encounterId}/labRequests`}
       columns={columns}
-      noDataMessage="No lab requests found"
+      noDataMessage={
+        <TranslatedText stringId="labs.table.noData" fallback="No lab requests found" />
+      }
       onRowClick={selectLab}
       initialSort={{ order: 'desc', orderBy: 'requestedDate' }}
     />

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -29,6 +29,7 @@ import { EncounterActions } from './components';
 import { useReferenceData } from '../../api/queries';
 import { useAuth } from '../../contexts/Auth';
 import { VitalChartDataProvider } from '../../contexts/VitalChartData';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const getIsTriage = encounter => ENCOUNTER_OPTIONS_BY_VALUE[encounter.encounterType].triageFlowOnly;
 
@@ -53,7 +54,7 @@ const TABS = [
     render: props => <ProcedurePane {...props} />,
   },
   {
-    label: 'Labs',
+    label: <TranslatedText stringId="encounter.tabs.labs" fallback="Labs" />,
     key: ENCOUNTER_TAB_NAMES.LABS,
     render: props => <LabsPane {...props} />,
   },

--- a/packages/desktop/app/views/patients/panes/LabsPane.js
+++ b/packages/desktop/app/views/patients/panes/LabsPane.js
@@ -4,6 +4,7 @@ import { EncounterLabRequestsTable } from '../EncounterLabRequestsTable';
 import { TableButtonRow, ButtonWithPermissionCheck } from '../../../components';
 import { PrintMultipleLabRequestsSelectionModal } from '../../../components/PatientPrinting';
 import { TabPane } from '../components';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 export const LabsPane = React.memo(({ encounter, readonly }) => {
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
@@ -31,7 +32,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
           color="primary"
           size="small"
         >
-          Print
+          <TranslatedText stringId="labs.action.print" fallback="Print" />
         </ButtonWithPermissionCheck>
         <ButtonWithPermissionCheck
           onClick={() => setNewRequestModalOpen(true)}
@@ -40,7 +41,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
           noun="LabRequest"
           size="small"
         >
-          New lab request
+          <TranslatedText stringId="labs.action.new" fallback="New lab request" />
         </ButtonWithPermissionCheck>
       </TableButtonRow>
       <EncounterLabRequestsTable encounterId={encounter.id} />


### PR DESCRIPTION
### Changes

Translated documents module on desktop by exchanging simple text strings for `<TranslatedText />` components.

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
