### PR TITLE
NASS-967: Translate desktop 'Documents' module

### DIFF
--- a/packages/desktop/app/components/DocumentModal.js
+++ b/packages/desktop/app/components/DocumentModal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { FormModal } from './FormModal';
 import { DocumentForm } from '../forms/DocumentForm';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const DocumentModal = React.memo(({ open, onClose, endpoint, refreshTable }) => {
   const [preventClose, setPreventClose] = useState(false);
@@ -41,7 +42,12 @@ export const DocumentModal = React.memo(({ open, onClose, endpoint, refreshTable
   }, [preventClose]);
 
   return (
-    <FormModal width="md" title="Add document" open={open} onClose={handleClose}>
+    <FormModal
+      width="md"
+      title={<TranslatedText stringId="documents.addDocument.title" fallback="Add document" />}
+      open={open}
+      onClose={handleClose}
+    >
       <DocumentForm
         onSubmit={onSubmit}
         onStart={onStart}

--- a/packages/desktop/app/components/DocumentPreview/DocumentPreviewModal.js
+++ b/packages/desktop/app/components/DocumentPreview/DocumentPreviewModal.js
@@ -9,14 +9,19 @@ import PhotoPreview from './PhotoPreview';
 import { Button } from '../Button';
 import { SUPPORTED_DOCUMENT_TYPES } from '../../constants';
 import { Modal } from '../Modal';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const getTitle = ({ source, name }) =>
-  source === DOCUMENT_SOURCES.PATIENT_LETTER ? 'Patient letter' : name;
+  source === DOCUMENT_SOURCES.PATIENT_LETTER ? (
+    <TranslatedText stringId="patient.patientLetter.title" fallback="Patient letter" />
+  ) : (
+    name
+  );
 
 const DownloadButton = ({ onClick }) => {
   return (
     <Button variant="outlined" size="small" startIcon={<GetAppIcon />} onClick={onClick}>
-      Download
+      <TranslatedText stringId="general.action.download" fallback="Download" />
     </Button>
   );
 };
@@ -48,9 +53,16 @@ export const DocumentPreviewModal = ({ open, onClose, onDownload, document, onPr
         <div>
           {getTitle(document)}
           <Subtitle>
-            {documentType === SUPPORTED_DOCUMENT_TYPES.PDF
-              ? `Page ${scrollPage} of ${pageCount ?? 'Unknown'}`
-              : null}
+            {documentType === SUPPORTED_DOCUMENT_TYPES.PDF ? (
+              <TranslatedText
+                stringId="documents.preview.pageCount"
+                fallback="Page :scrollPage of :pageCount"
+                replacements={{
+                  scrollPage,
+                  pageCount,
+                }}
+              />
+            ) : null}
           </Subtitle>
         </div>
       }

--- a/packages/desktop/app/components/DocumentsSearchBar.js
+++ b/packages/desktop/app/components/DocumentsSearchBar.js
@@ -7,6 +7,7 @@ import { Form, Field, SearchField } from './Field';
 import { FormGrid } from './FormGrid';
 import { LargeSubmitButton, LargeOutlinedSubmitButton } from './Button';
 import { Colors } from '../constants';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const Container = styled.div`
   padding: 2rem;
@@ -38,10 +39,10 @@ const renderSearchBar = ({ submitForm, clearForm }) => (
     </FormGrid>
     <Box display="flex" alignItems="center" justifyContent="flex-end" mt={2}>
       <LargeOutlinedSubmitButton onClick={clearForm} style={{ marginRight: 12 }}>
-        Clear search
+        <TranslatedText stringId="general.action.clear" fallback="Clear" />
       </LargeOutlinedSubmitButton>
       <LargeSubmitButton onClick={submitForm} type="submit">
-        Search
+        <TranslatedText stringId="general.action.search" fallback="Search" />
       </LargeSubmitButton>
     </Box>
   </>
@@ -50,7 +51,9 @@ const renderSearchBar = ({ submitForm, clearForm }) => (
 export const DocumentsSearchBar = ({ setSearchParameters }) => (
   <Container>
     <HeaderBar>
-      <Typography variant="h3">Documents search</Typography>
+      <Typography variant="h3">
+        <TranslatedText stringId="patient.documents.searchTitle" fallback="Documents search" />
+      </Typography>
     </HeaderBar>
     <Form onSubmit={values => setSearchParameters(values)} render={renderSearchBar} />
   </Container>

--- a/packages/desktop/app/components/DocumentsTable.js
+++ b/packages/desktop/app/components/DocumentsTable.js
@@ -8,6 +8,7 @@ import { IconButton } from '@material-ui/core';
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
 import { Button } from './Button';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const ActionsContainer = styled.div`
   display: flex;
@@ -30,7 +31,7 @@ const StyledIconButton = styled(IconButton)`
 const ActionButtons = React.memo(({ row, onDownload, onClickView }) => (
   <ActionsContainer>
     <Action variant="outlined" size="small" onClick={() => onClickView(row)} key="view">
-      View
+      <TranslatedText stringId="general.actions.view" fallback="View" />
     </Action>
     <StyledIconButton color="primary" onClick={() => onDownload(row)} key="download">
       <GetAppIcon fontSize="small" />
@@ -56,20 +57,40 @@ export const DocumentsTable = React.memo(
     // Define columns inside component to pass callbacks to getActions
     const COLUMNS = useMemo(
       () => [
-        { key: 'name', title: 'Name' },
-        { key: 'type', title: 'Type', accessor: getAttachmentType },
-        { key: 'documentUploadedAt', title: 'Upload', accessor: getUploadedDate },
-        { key: 'documentOwner', title: 'Owner' },
+        {
+          key: 'name',
+          title: <TranslatedText stringId="general.table.header.patientName" fallback="Name" />,
+        },
+        {
+          key: 'type',
+          title: <TranslatedText stringId="general.table.header.type" fallback="Type" />,
+          accessor: getAttachmentType,
+        },
+        {
+          key: 'documentUploadedAt',
+          title: <TranslatedText stringId="general.table.header.uploadDate" fallback="Upload" />,
+          accessor: getUploadedDate,
+        },
+        {
+          key: 'documentOwner',
+          title: <TranslatedText stringId="general.table.header.owner" fallback="Owner" />,
+        },
         {
           key: 'department.name',
-          title: 'Department',
+          title: (
+            <TranslatedText stringId="general.table.header.departmentName" fallback="Department" />
+          ),
           accessor: getDepartmentName,
           sortable: false,
         },
-        { key: 'note', title: 'Comments', sortable: false },
+        {
+          key: 'note',
+          title: <TranslatedText stringId="general.table.header.comments" fallback="Comments" />,
+          sortable: false,
+        },
         {
           key: 'actions',
-          title: 'Actions',
+          title: <TranslatedText stringId="general.table.header.actions" fallback="Actions" />,
           accessor: row => (
             <ActionButtons row={row} onDownload={onDownload} onClickView={openDocumentPreview} />
           ),
@@ -84,7 +105,12 @@ export const DocumentsTable = React.memo(
       <DataFetchingTable
         endpoint={endpoint}
         columns={COLUMNS}
-        noDataMessage="No documents found"
+        noDataMessage={
+          <TranslatedText
+            stringId="patient.documents.table.noDataMessage"
+            fallback="No documents found"
+          />
+        }
         fetchOptions={searchParameters}
         refreshCount={refreshCount}
         allowExport={false}

--- a/packages/desktop/app/components/DocumentsTable.js
+++ b/packages/desktop/app/components/DocumentsTable.js
@@ -59,38 +59,36 @@ export const DocumentsTable = React.memo(
       () => [
         {
           key: 'name',
-          title: <TranslatedText stringId="general.table.header.patientName" fallback="Name" />,
+          title: <TranslatedText stringId="general.form.patientName.label" fallback="Name" />,
         },
         {
           key: 'type',
-          title: <TranslatedText stringId="general.table.header.type" fallback="Type" />,
+          title: <TranslatedText stringId="general.form.type.label" fallback="Type" />,
           accessor: getAttachmentType,
         },
         {
           key: 'documentUploadedAt',
-          title: <TranslatedText stringId="general.table.header.uploadDate" fallback="Upload" />,
+          title: <TranslatedText stringId="general.form.uploadDate.label" fallback="Upload" />,
           accessor: getUploadedDate,
         },
         {
           key: 'documentOwner',
-          title: <TranslatedText stringId="general.table.header.owner" fallback="Owner" />,
+          title: <TranslatedText stringId="documents.form.owner.label" fallback="Owner" />,
         },
         {
           key: 'department.name',
-          title: (
-            <TranslatedText stringId="general.table.header.departmentName" fallback="Department" />
-          ),
+          title: <TranslatedText stringId="general.form.department.label" fallback="Department" />,
           accessor: getDepartmentName,
           sortable: false,
         },
         {
           key: 'note',
-          title: <TranslatedText stringId="general.table.header.comments" fallback="Comments" />,
+          title: <TranslatedText stringId="general.form.comments.label" fallback="Comments" />,
           sortable: false,
         },
         {
           key: 'actions',
-          title: <TranslatedText stringId="general.table.header.actions" fallback="Actions" />,
+          title: <TranslatedText stringId="general.form.actions.label" fallback="Actions" />,
           accessor: row => (
             <ActionButtons row={row} onDownload={onDownload} onClickView={openDocumentPreview} />
           ),
@@ -106,10 +104,7 @@ export const DocumentsTable = React.memo(
         endpoint={endpoint}
         columns={COLUMNS}
         noDataMessage={
-          <TranslatedText
-            stringId="patient.documents.table.noDataMessage"
-            fallback="No documents found"
-          />
+          <TranslatedText stringId="documents.form.noDataMessage" fallback="No documents found" />
         }
         fetchOptions={searchParameters}
         refreshCount={refreshCount}

--- a/packages/desktop/app/components/PatientDetailsCard.js
+++ b/packages/desktop/app/components/PatientDetailsCard.js
@@ -4,6 +4,7 @@ import { Box } from '@material-ui/core';
 
 import { Colors, SEX_VALUE_INDEX } from '../constants';
 import { DateDisplay } from '.';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const Card = styled(Box)`
   background: white;
@@ -54,13 +55,28 @@ const CardItem = ({ label, value, ...props }) => (
 export const PatientDetailsCard = ({ patient }) => (
   <Card mb={4}>
     <Column>
-      <CardItem label="Patient ID" value={patient?.displayId} />
-      <CardItem label="First name" value={patient?.firstName} />
-      <CardItem label="Last name" value={patient?.lastName} />
+      <CardItem
+        label={<TranslatedText stringId="general.form.patientId.label" fallback="Patient ID" />}
+        value={patient?.displayId}
+      />
+      <CardItem
+        label={<TranslatedText stringId="general.form.firstName.label" fallback="First name" />}
+        value={patient?.firstName}
+      />
+      <CardItem
+        label={<TranslatedText stringId="general.form.lastName.label" fallback="Last name" />}
+        value={patient?.lastName}
+      />
     </Column>
     <Column>
-      <CardItem label="DOB" value={<DateDisplay date={patient?.dateOfBirth} />} />
-      <CardItem label="Sex" value={SEX_VALUE_INDEX[patient?.sex]?.label} />
+      <CardItem
+        label={<TranslatedText stringId="general.form.dateOfBirth.label" fallback="DOB" />}
+        value={<DateDisplay date={patient?.dateOfBirth} />}
+      />
+      <CardItem
+        label={<TranslatedText stringId="general.form.sex.label" fallback="Sex" />}
+        value={SEX_VALUE_INDEX[patient?.sex]?.label}
+      />
     </Column>
   </Card>
 );

--- a/packages/desktop/app/components/PatientLetterModal.js
+++ b/packages/desktop/app/components/PatientLetterModal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { FormModal } from './FormModal';
 import { PatientLetterForm } from '../forms/PatientLetterForm';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const PatientLetterModal = React.memo(
   ({ open, onClose, endpoint, refreshTable, patient, openDocumentPreview }) => {
@@ -18,7 +19,12 @@ export const PatientLetterModal = React.memo(
     );
 
     return (
-      <FormModal width="sm" title="Patient letter" open={open} onClose={onClose}>
+      <FormModal
+        width="sm"
+        title={<TranslatedText stringId="patient.patientLetter.title" fallback="Patient letter" />}
+        open={open}
+        onClose={onClose}
+      >
         <PatientLetterForm
           patient={patient}
           onSubmit={onSubmit}

--- a/packages/desktop/app/forms/DocumentForm.js
+++ b/packages/desktop/app/forms/DocumentForm.js
@@ -15,6 +15,7 @@ import { Form, Field, TextField, AutocompleteField } from '../components/Field';
 import { FileChooserField } from '../components/Field/FileChooserField';
 import { FormGrid } from '../components/FormGrid';
 import { ConfirmCancelRow, FormSubmitCancelRow } from '../components/ButtonRow';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const MessageContainer = styled.div`
   margin: 0 auto;
@@ -69,27 +70,42 @@ const DocumentFormContents = ({ submitForm, departmentSuggester, onCancel }) => 
       <Field
         component={FileChooserField}
         filters={FILE_FILTERS}
-        label="Select file"
+        label={<TranslatedText stringId="general.form.selectFile.label" fallback="Select file" />}
         name="file"
         required
         style={{ gridColumn: '1 / -1' }}
       />
       <Field
         name="name"
-        label="File name"
+        label={<TranslatedText stringId="general.form.fileName.label" fallback="File name" />}
         required
         component={TextField}
         style={{ gridColumn: '1 / -1' }}
       />
-      <Field name="documentOwner" label="Document owner" component={TextField} />
+      <Field
+        name="documentOwner"
+        label={
+          <TranslatedText stringId="documents.form.documentOwner.label" fallback="Document owner" />
+        }
+        component={TextField}
+      />
       <Field
         name="departmentId"
-        label="Department"
+        label={<TranslatedText stringId="general.form.department.label" fallback="Department" />}
         component={AutocompleteField}
         suggester={departmentSuggester}
       />
-      <Field name="note" label="Note" component={TextField} style={{ gridColumn: '1 / -1' }} />
-      <FormSubmitCancelRow confirmText="Add" onConfirm={submitForm} onCancel={onCancel} />
+      <Field
+        name="note"
+        label={<TranslatedText stringId="general.form.note.label" fallback="Note" />}
+        component={TextField}
+        style={{ gridColumn: '1 / -1' }}
+      />
+      <FormSubmitCancelRow
+        confirmText={<TranslatedText stringId="general.action.add" fallback="Add" />}
+        onConfirm={submitForm}
+        onCancel={onCancel}
+      />
     </FormGrid>
   );
 };

--- a/packages/desktop/app/forms/PatientLetterForm.js
+++ b/packages/desktop/app/forms/PatientLetterForm.js
@@ -19,6 +19,7 @@ import { ModalLoader } from '../components/BaseModal';
 import { OutlinedButton, Button } from '../components';
 import { PatientDetailsCard } from '../components/PatientDetailsCard';
 import { ModalGenericButtonRow } from '../components/ModalActionRow';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const TallMultilineTextField = props => (
   <MultilineTextField style={{ minHeight: '156px' }} {...props} />
@@ -66,31 +67,46 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
       <FormGrid columns={2} nested>
         <Field
           name="clinicianId"
-          label="Clinician"
+          label={
+            <TranslatedText stringId="patientLetter.form.clinican.label" fallback="Clinician" />
+          }
           required
           component={AutocompleteField}
           suggester={practitionerSuggester}
         />
-        <Field name="date" label="Date" required component={DateField} saveDateAsString />
+        <Field
+          name="date"
+          label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
+          required
+          component={DateField}
+          saveDateAsString
+        />
       </FormGrid>
       <StyledFormGrid columns={1}>
         <Field
           name="templateId"
-          label="Template"
+          label={
+            <TranslatedText stringId="patientLetter.form.template.label" fallback="Template" />
+          }
           suggester={patientLetterTemplateSuggester}
           component={AutocompleteField}
           onChange={e => onChangeTemplate(e.target.value)}
         />
         <Field
           name="title"
-          label="Letter title"
+          label={
+            <TranslatedText
+              stringId="patientLetter.form.letterTitle.label"
+              fallback="Letter title"
+            />
+          }
           required
           component={TextField}
           disabled={templateLoading}
         />
         <Field
           name="body"
-          label="Note"
+          label={<TranslatedText stringId="patientLetter.form.note.label" fallback="Note" />}
           required
           component={TallMultilineTextField}
           disabled={templateLoading}
@@ -98,11 +114,18 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
       </StyledFormGrid>
       <ModalGenericButtonRow>
         <FinaliseAndPrintButton onClick={e => submitForm(e, { printRequested: true })}>
-          Finalise & Print
+          <TranslatedText
+            stringId="patientLetter.form.finaliseAndPrint.label"
+            fallback="Finalise & Print"
+          />
         </FinaliseAndPrintButton>
         <Gap />
-        <OutlinedButton onClick={onCancel}>Cancel</OutlinedButton>
-        <Button onClick={submitForm}>Finalise</Button>
+        <OutlinedButton onClick={onCancel}>
+          <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
+        </OutlinedButton>
+        <Button onClick={submitForm}>
+          <TranslatedText stringId="general.form.finalise.label" fallback="Finalise" />
+        </Button>
       </ModalGenericButtonRow>
     </>
   );
@@ -130,7 +153,14 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
 
   const renderForm = props =>
     props.isSubmitting ? (
-      <ModalLoader loadingText="Please wait while we create your patient letter" />
+      <ModalLoader
+        loadingText={
+          <TranslatedText
+            stringId="patientLetter.form.onCreateLoadingText"
+            fallback="Please wait while we create your patient letter"
+          />
+        }
+      />
     ) : (
       <>
         <PatientDetailsCard patient={patient} />

--- a/packages/desktop/app/views/patients/panes/DocumentsPane.js
+++ b/packages/desktop/app/views/patients/panes/DocumentsPane.js
@@ -111,13 +111,10 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
       <PaneWrapper>
         <TableButtonRow variant="small">
           <OutlinedButton onClick={() => setModalStatus(MODAL_STATES.PATIENT_LETTER_OPEN)}>
-            <TranslatedText
-              stringId="patient.documents.openPatientLetter"
-              fallback="Patient letter"
-            />
+            <TranslatedText stringId="documents.openPatientLetter" fallback="Patient letter" />
           </OutlinedButton>
           <Button onClick={() => setModalStatus(MODAL_STATES.DOCUMENT_OPEN)}>
-            <TranslatedText stringId="patient.documents.addDocument" fallback="Add document" />
+            <TranslatedText stringId="documents.addDocument" fallback="Add document" />
           </Button>
         </TableButtonRow>
         <DocumentsTable

--- a/packages/desktop/app/views/patients/panes/DocumentsPane.js
+++ b/packages/desktop/app/views/patients/panes/DocumentsPane.js
@@ -12,6 +12,7 @@ import { PatientLetterModal } from '../../../components/PatientLetterModal';
 import { DocumentsSearchBar } from '../../../components/DocumentsSearchBar';
 import { TabPane } from '../components';
 import { OutlinedButton, Button, ContentPane, TableButtonRow } from '../../../components';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const MODAL_STATES = {
   DOCUMENT_OPEN: 'document',
@@ -110,9 +111,14 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
       <PaneWrapper>
         <TableButtonRow variant="small">
           <OutlinedButton onClick={() => setModalStatus(MODAL_STATES.PATIENT_LETTER_OPEN)}>
-            Patient letter
+            <TranslatedText
+              stringId="patient.documents.openPatientLetter"
+              fallback="Patient letter"
+            />
           </OutlinedButton>
-          <Button onClick={() => setModalStatus(MODAL_STATES.DOCUMENT_OPEN)}>Add document</Button>
+          <Button onClick={() => setModalStatus(MODAL_STATES.DOCUMENT_OPEN)}>
+            <TranslatedText stringId="patient.documents.addDocument" fallback="Add document" />
+          </Button>
         </TableButtonRow>
         <DocumentsTable
           endpoint={documentMetadataEndpoint}


### PR DESCRIPTION
### Changes

Translated text in the desktop 'Documents' module by exchanging simple strings to `<TranslatedText />` components

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
