### PR TITLE
NASS-965: Translate desktop 'Imaging' module

### DIFF
--- a/packages/desktop/app/components/BaseModal.js
+++ b/packages/desktop/app/components/BaseModal.js
@@ -10,6 +10,7 @@ import { Box, CircularProgress, IconButton, Typography } from '@material-ui/core
 import { Colors } from '../constants';
 import { useElectron } from '../contexts/Electron';
 import { Button } from './Button';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const MODAL_PADDING_TOP_AND_BOTTOM = 18;
 export const MODAL_PADDING_LEFT_AND_RIGHT = 32;
@@ -148,7 +149,7 @@ export const BaseModal = memo(
                 startIcon={<PrintIcon />}
                 size="small"
               >
-                Print
+                <TranslatedText stringId="general.action.print" fallback="Print" />
               </StyledButton>
             )}
             {cornerExitButton && (

--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -5,6 +5,7 @@ import { FormModal } from './FormModal';
 import { FormSubmitCancelRow } from './ButtonRow';
 import { SelectField, Form, Field } from './Field';
 import { BodyText } from './Typography';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const ModalBody = styled.div`
   margin-top: 30px;
@@ -36,7 +37,12 @@ export const CancelModal = React.memo(
               <Field
                 required
                 component={SelectField}
-                label="Reason for cancellation"
+                label={
+                  <TranslatedText
+                    stringId="general.cancel.reasonForCancel"
+                    fallback="Reason for cancellation"
+                  />
+                }
                 name="reasonForCancellation"
                 options={options}
                 helperText={isReasonForDelete(values.reasonForCancellation) ? helperText : null}

--- a/packages/desktop/app/components/CancelModal.js
+++ b/packages/desktop/app/components/CancelModal.js
@@ -48,7 +48,11 @@ export const CancelModal = React.memo(
                 helperText={isReasonForDelete(values.reasonForCancellation) ? helperText : null}
               />
             </Wrapper>
-            <FormSubmitCancelRow onCancel={onClose} onConfirm={submitForm} cancelText="Close" />
+            <FormSubmitCancelRow
+              onCancel={onClose}
+              onConfirm={submitForm}
+              cancelText={<TranslatedText stringId="general.action.close" fallback="Close" />}
+            />
           </ModalBody>
         )}
       />

--- a/packages/desktop/app/components/Field/ImagingPriorityField.js
+++ b/packages/desktop/app/components/Field/ImagingPriorityField.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Field } from './Field';
 import { SelectField } from './SelectField';
 import { useLocalisation } from '../../contexts/Localisation';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 export const ImagingPriorityField = ({ name = 'priority', required }) => {
   const { getLocalisation } = useLocalisation();
@@ -11,7 +12,7 @@ export const ImagingPriorityField = ({ name = 'priority', required }) => {
   return (
     <Field
       name={name}
-      label="Priority"
+      label={<TranslatedText stringId="imaging.form.priority.label" fallback="Priority" />}
       component={SelectField}
       options={imagingPriorities}
       required={required}

--- a/packages/desktop/app/components/ImagingRequestModal.js
+++ b/packages/desktop/app/components/ImagingRequestModal.js
@@ -7,6 +7,7 @@ import { Suggester } from '../utils/suggester';
 import { FormModal } from './FormModal';
 import { ImagingRequestForm } from '../forms/ImagingRequestForm';
 import { ALPHABET_FOR_ID } from '../constants';
+import { TranslatedText } from './Translation/TranslatedText';
 
 // Todo: move the generating of display id to the model default to match LabRequests
 // generates 8 character id (while excluding 0, O, I, 1 and L)
@@ -19,7 +20,12 @@ export const ImagingRequestModal = ({ open, onClose, encounter }) => {
   const [requestId, setRequestId] = useState();
 
   return (
-    <FormModal width="md" title="New imaging request" open={open} onClose={onClose}>
+    <FormModal
+      width="md"
+      title={<TranslatedText stringId="imaging.form.title" fallback="New imaging request" />}
+      open={open}
+      onClose={onClose}
+    >
       <ImagingRequestForm
         onSubmit={async data => {
           const newRequest = await api.post(`imagingRequest`, {

--- a/packages/desktop/app/components/PatientPrinting/modals/MultipleImagingRequestsPrintoutModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/MultipleImagingRequestsPrintoutModal.js
@@ -4,6 +4,7 @@ import { Colors } from '../../../constants';
 import { Modal } from '../../Modal';
 
 import { MultipleImagingRequestsPrintout } from '../printouts/MultipleImagingRequestsPrintout';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 export const MultipleImagingRequestsPrintoutModal = ({
   open,
@@ -13,7 +14,12 @@ export const MultipleImagingRequestsPrintoutModal = ({
 }) => {
   return (
     <Modal
-      title="Print imaging requests"
+      title={
+        <TranslatedText
+          stringId="imaging.print.multipleRequests.title"
+          fallback="Print imaging requests"
+        />
+      }
       width="md"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionForm.js
@@ -11,6 +11,7 @@ import { Colors } from '../../../constants';
 import { MultipleImagingRequestsPrintoutModal } from './MultipleImagingRequestsPrintoutModal';
 import { COLUMN_KEYS, FORM_COLUMNS } from './multipleImagingRequestsColumns';
 import { FormDivider, PrintMultipleSelectionTable } from './PrintMultipleSelectionTable';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter, onClose }) => {
   const [openPrintoutModal, setOpenPrintoutModal] = useState(false);
@@ -52,20 +53,30 @@ export const PrintMultipleImagingRequestsSelectionForm = React.memo(({ encounter
         onClose={() => setOpenPrintoutModal(false)}
       />
       <PrintMultipleSelectionTable
-        label="Select the imaging requests you would like to print"
+        label={
+          <TranslatedText
+            stringId="imaging.print.select.label"
+            fallback="Select the imaging requests you would like to print"
+          />
+        }
         headerColor={Colors.white}
         columns={columns}
         data={imagingRequestsData || []}
         elevated={false}
         isLoading={isLoading}
         errorMessage={error?.message}
-        noDataMessage="No imaging requests found"
+        noDataMessage={
+          <TranslatedText
+            stringId="imaging.print.noDataMessage"
+            fallback="No imaging requests found"
+          />
+        }
         allowExport={false}
       />
       <FormDivider />
       <ConfirmCancelRow
-        cancelText="Close"
-        confirmText="Print"
+        cancelText={<TranslatedText stringId="general.action.close" fallback="Close" />}
+        confirmText={<TranslatedText stringId="general.action.print" fallback="Print" />}
         confirmDisabled={selectedRows.length === 0}
         onConfirm={handlePrintConfirm}
         onCancel={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleImagingRequestsSelectionModal.js
@@ -3,10 +3,16 @@ import PropTypes from 'prop-types';
 
 import { FormModal } from '../../FormModal';
 import { PrintMultipleImagingRequestsSelectionForm } from './PrintMultipleImagingRequestsSelectionForm';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 export const PrintMultipleImagingRequestsSelectionModal = ({ encounter, open, onClose }) => {
   return (
-    <FormModal title="Print imaging request/s" width="md" open={open} onClose={onClose}>
+    <FormModal
+      title={<TranslatedText stringId="imaging.print.title" fallback="Print imaging request/s" />}
+      width="md"
+      open={open}
+      onClose={onClose}
+    >
       <PrintMultipleImagingRequestsSelectionForm encounter={encounter} onClose={onClose} />
     </FormModal>
   );

--- a/packages/desktop/app/forms/ImagingRequestForm.js
+++ b/packages/desktop/app/forms/ImagingRequestForm.js
@@ -30,6 +30,7 @@ import { DateDisplay } from '../components/DateDisplay';
 import { FormSeparatorLine } from '../components/FormSeparatorLine';
 import { FormSubmitDropdownButton } from '../components/DropdownButton';
 import { useLocalisedText } from '../components';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 function getEncounterTypeLabel(type) {
   return encounterOptions.find(x => x.value === type).label;
@@ -68,8 +69,19 @@ const FormSubmitActionDropdown = React.memo(({ requestId, encounter, submitForm 
   };
 
   const actions = [
-    { label: 'Finalise', onClick: finalise },
-    { label: 'Finalise & print', onClick: finaliseAndPrint },
+    {
+      label: <TranslatedText stringId="general.form.action.finalise" fallback="Finalise" />,
+      onClick: finalise,
+    },
+    {
+      label: (
+        <TranslatedText
+          stringId="general.form.action.finaliseAndPrint"
+          fallback="Finalise & print"
+        />
+      ),
+      onClick: finaliseAndPrint,
+    },
   ];
 
   return <FormSubmitDropdownButton actions={actions} />;
@@ -113,10 +125,25 @@ export const ImagingRequestForm = React.memo(
           const imagingAreas = getAreasForImagingType(values.imagingType);
           return (
             <FormGrid>
-              <Field name="displayId" label="Imaging request code" disabled component={TextField} />
+              <Field
+                name="displayId"
+                label={
+                  <TranslatedText
+                    stringId="imaging.form.requestCode.label"
+                    fallback="Imaging request code"
+                  />
+                }
+                disabled
+                component={TextField}
+              />
               <Field
                 name="requestedDate"
-                label="Order date and time"
+                label={
+                  <TranslatedText
+                    stringId="imaging.form.orderDate.label"
+                    fallback="Order date and time"
+                  />
+                }
                 required
                 component={DateTimeField}
                 saveDateAsString
@@ -137,10 +164,21 @@ export const ImagingRequestForm = React.memo(
                 <ImagingPriorityField name="priority" />
               </div>
               <FormSeparatorLine />
-              <TextInput label="Encounter" disabled value={encounterLabel} />
+              <TextInput
+                label={
+                  <TranslatedText stringId="imaging.form.encounter.label" fallback="Encounter" />
+                }
+                disabled
+                value={encounterLabel}
+              />
               <Field
                 name="imagingType"
-                label="Imaging request type"
+                label={
+                  <TranslatedText
+                    stringId="imaging.form.requestType.label"
+                    fallback="Imaging request type"
+                  />
+                }
                 required
                 component={SelectField}
                 options={imagingTypeOptions}
@@ -152,13 +190,23 @@ export const ImagingRequestForm = React.memo(
                     value: area.id,
                   }))}
                   name="areas"
-                  label="Areas to be imaged"
+                  label={
+                    <TranslatedText
+                      stringId="imaging.form.imagingAreas.label"
+                      fallback="Areas to be imaged"
+                    />
+                  }
                   component={MultiselectField}
                 />
               ) : (
                 <Field
                   name="areaNote"
-                  label="Areas to be imaged"
+                  label={
+                    <TranslatedText
+                      stringId="imaging.form.imagingAreas.label"
+                      fallback="Areas to be imaged"
+                    />
+                  }
                   component={TextField}
                   multiline
                   style={{ gridColumn: '1 / -1' }}
@@ -167,14 +215,16 @@ export const ImagingRequestForm = React.memo(
               )}
               <Field
                 name="note"
-                label="Notes"
+                label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
                 component={TextField}
                 multiline
                 style={{ gridColumn: '1 / -1' }}
                 rows={3}
               />
               <ButtonRow>
-                <FormCancelButton onClick={onCancel}>Cancel</FormCancelButton>
+                <FormCancelButton onClick={onCancel}>
+                  <TranslatedText stringId="general.actions.cancel" fallback="Cancel" />
+                </FormCancelButton>
                 <FormSubmitActionDropdown
                   requestId={requestId}
                   encounter={encounter}

--- a/packages/desktop/app/views/patients/imagingRequest/CancelModalButton.js
+++ b/packages/desktop/app/views/patients/imagingRequest/CancelModalButton.js
@@ -6,6 +6,7 @@ import { CancelModal } from '../../../components/CancelModal';
 import { Button } from '../../../components/Button';
 import { useApi } from '../../../api';
 import { useLocalisation } from '../../../contexts/Localisation';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 function getReasonForCancellationStatus(reasonForCancellation) {
   // these values are set in localisation
@@ -41,12 +42,27 @@ export const CancelModalButton = ({ imagingRequest, onCancel }) => {
   return (
     <>
       <Button variant="text" onClick={() => setIsOpen(true)}>
-        Cancel request
+        <TranslatedText stringId="imaging.request.action.cancelRequest" fallback="Cancel request" />
       </Button>
       <CancelModal
-        title="Cancel imaging request"
-        helperText="This reason will permanently delete the imaging request record"
-        bodyText="Please select reason for cancelling imaging request and click 'Confirm'"
+        title={
+          <TranslatedText
+            stringId="imaging.request.cancel.title"
+            fallback="Cancel imaging request"
+          />
+        }
+        helperText={
+          <TranslatedText
+            stringId="imaging.request.cancel.helper"
+            fallback="This reason will permanently delete the imaging request record"
+          />
+        }
+        bodyText={
+          <TranslatedText
+            stringId="imaging.request.cancel.reason"
+            fallback="Please select reason for cancelling imaging request and click 'Confirm'"
+          />
+        }
         options={cancellationReasonOptions}
         open={isOpen}
         onClose={() => setIsOpen(false)}

--- a/packages/desktop/app/views/patients/imagingRequest/ImagingRequestView.js
+++ b/packages/desktop/app/views/patients/imagingRequest/ImagingRequestView.js
@@ -35,6 +35,7 @@ import { SimpleTopBar } from '../../../components';
 
 import { CancelModalButton } from './CancelModalButton';
 import { PrintModalButton } from './PrintModalButton';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
   const { getLocalisation } = useLocalisation();
@@ -58,30 +59,43 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
 
   return (
     <FormGrid columns={3}>
-      <TextInput value={imagingRequest.displayId} label="Request ID" disabled />
+      <TextInput
+        value={imagingRequest.displayId}
+        label={<TranslatedText stringId="imaging.form.requestId.label" fallback="Request ID" />}
+        disabled
+      />
       <TextInput
         value={imagingTypes[imagingRequest.imagingType]?.label || 'Unknown'}
-        label="Request type"
+        label={<TranslatedText stringId="imaging.form.requestType.label" fallback="Request type" />}
         disabled
       />
       <TextInput
         value={imagingPriorities.find(p => p.value === imagingRequest.priority)?.label || ''}
-        label="Priority"
+        label={<TranslatedText stringId="imaging.form.priority.label" fallback="Priority" />}
         disabled
       />
       <Field
         name="status"
-        label="Status"
+        label={<TranslatedText stringId="imaging.form.status.label" fallback="Status" />}
         component={SelectField}
         options={isCancelled ? cancelledOption : IMAGING_REQUEST_STATUS_OPTIONS}
         disabled={isCancelled}
         isClearable={false}
         required
       />
-      <DateTimeInput value={imagingRequest.requestedDate} label="Request date and time" disabled />
+      <DateTimeInput
+        value={imagingRequest.requestedDate}
+        label={
+          <TranslatedText
+            stringId="imaging.form.requestDate.label"
+            fallback="Request date and time"
+          />
+        }
+        disabled
+      />
       {allowLocationChange && (
         <Field
-          label="Facility area"
+          label={<TranslatedText stringId="imaging.form.facility.label" fallback="Facility area" />}
           name="locationGroupId"
           component={AutocompleteField}
           suggester={locationGroupSuggester}
@@ -95,14 +109,19 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
             ? imagingRequest.areas.map(area => area.name).join(', ')
             : imagingRequest.areaNote
         }
-        label="Areas to be imaged"
+        label={
+          <TranslatedText
+            stringId="imaging.form.imagingAreas.label"
+            fallback="Areas to be imaged"
+          />
+        }
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled
       />
       <TextInput
         multiline
         value={imagingRequest.note}
-        label="Notes"
+        label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled
       />
@@ -124,7 +143,9 @@ const NewResultSection = ({ disabled = false }) => {
   return (
     <FormGrid columns={2}>
       <Field
-        label="Completed by"
+        label={
+          <TranslatedText stringId="imaging.result.completedBy.label" fallback="Completed by" />
+        }
         name="newResult.completedById"
         placeholder="Search"
         component={AutocompleteField}
@@ -132,14 +153,18 @@ const NewResultSection = ({ disabled = false }) => {
         disabled={disabled}
       />
       <Field
-        label="Completed"
+        label={
+          <TranslatedText stringId="imaging.result.completedDate.label" fallback="Completed" />
+        }
         name="newResult.completedAt"
         saveDateAsString
         component={DateTimeField}
         disabled={disabled}
       />
       <Field
-        label="Result description"
+        label={
+          <TranslatedText stringId="imaging.result.completedBy.label" fallback="Completed by" />
+        }
         name="newResult.description"
         placeholder="Result description..."
         multiline
@@ -232,10 +257,23 @@ const ImagingRequestInfoPane = React.memo(({ imagingRequest, onSubmit }) => {
           <>
             <ImagingRequestSection currentStatus={values.status} imagingRequest={imagingRequest} />
             <ImagingResultsSection results={imagingRequest.results} />
-            <h4>{imagingRequest.results.length > 0 ? 'Add additional result' : 'Add result'}</h4>
+            <h4>
+              {imagingRequest.results.length > 0 ? (
+                <TranslatedText
+                  stringId="imaging.request.addAdditionalResult.title"
+                  fallback="Add additional result"
+                />
+              ) : (
+                <TranslatedText stringId="imaging.request.addResult.title" fallback="Add result" />
+              )}
+            </h4>
             <NewResultSection disabled={!canAddResult} />
             <ButtonRow style={{ marginTop: 20 }}>
-              {!isCancelled && <FormSubmitButton text="Save" />}
+              {!isCancelled && (
+                <FormSubmitButton
+                  text={<TranslatedText stringId="general.action.save" fallback="Save" />}
+                />
+              )}
             </ButtonRow>
           </>
         );
@@ -268,7 +306,9 @@ export const ImagingRequestView = () => {
 
   return (
     <>
-      <SimpleTopBar title="Imaging request">
+      <SimpleTopBar
+        title={<TranslatedText stringId="imaging.request.title" fallback="Imaging request" />}
+      >
         {isCancellable && (
           <CancelModalButton imagingRequest={imagingRequest} onCancel={onNavigateBackToImaging} />
         )}

--- a/packages/desktop/app/views/patients/imagingRequest/PrintModalButton.js
+++ b/packages/desktop/app/views/patients/imagingRequest/PrintModalButton.js
@@ -6,6 +6,7 @@ import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { Modal } from '../../../components/Modal';
 import { useEncounterData } from '../../../api/queries';
 import { MultipleImagingRequestsPrintout } from '../../../components/PatientPrinting';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const PrintModalInternals = ({ imagingRequest }) => {
   const encounterQuery = useEncounterData(imagingRequest.encounterId);
@@ -38,7 +39,7 @@ export const PrintModalButton = props => {
   return (
     <>
       <Modal
-        title="Imaging Request"
+        title={<TranslatedText stringId="imaging.request.print.title" fallback="Imaging Request" />}
         open={isModalOpen}
         onClose={closeModal}
         width="md"
@@ -48,7 +49,7 @@ export const PrintModalButton = props => {
         <PrintModalInternals {...props} />
       </Modal>
       <Button variant="outlined" onClick={openModal} style={{ marginLeft: '0.5rem' }}>
-        Print request
+        <TranslatedText stringId="imaging.request.action.print" fallback="Print request" />
       </Button>
     </>
   );

--- a/packages/desktop/app/views/patients/panes/ImagingPane.js
+++ b/packages/desktop/app/views/patients/panes/ImagingPane.js
@@ -4,6 +4,7 @@ import { ImagingRequestsTable } from '../../../components/ImagingRequestsTable';
 import { PrintMultipleImagingRequestsSelectionModal } from '../../../components/PatientPrinting';
 import { TableButtonRow, Button } from '../../../components';
 import { TabPane } from '../components';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 export const ImagingPane = React.memo(({ encounter, readonly }) => {
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
@@ -29,10 +30,10 @@ export const ImagingPane = React.memo(({ encounter, readonly }) => {
           variant="outlined"
           color="primary"
         >
-          Print
+          <TranslatedText stringId="general.action.print" fallback="Print" />
         </Button>
         <Button onClick={() => setNewRequestModalOpen(true)} disabled={readonly}>
-          New imaging request
+          <TranslatedText stringId="imaging.action.newRequest" fallback="New imaging request" />
         </Button>
       </TableButtonRow>
       <ImagingRequestsTable encounterId={encounter.id} />


### PR DESCRIPTION
### Changes

Translated the 'Imaging' module on desktop with `<TranslatedText />` components replacing basic strings. 

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
