### PR TITLE
Fix: Empty vaccine certificate on first render

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
@@ -21,7 +21,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
   });
   const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
-  const { data: vaccineData } = useAdministeredVaccines(patient.id, {
+  const { data: vaccineData, isLoading } = useAdministeredVaccines(patient.id, {
     orderBy: 'date',
     order: 'ASC',
     invertNullDateOrdering: true,
@@ -44,7 +44,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
 
   const patientData = { ...patient, additionalData };
 
-  if (!vaccinations.length) return null;
+  if (isLoading) return null;
 
   return (
     <Modal

--- a/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
@@ -44,6 +44,8 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
 
   const patientData = { ...patient, additionalData };
 
+  if (!vaccinations.length) return null;
+
   return (
     <Modal
       title="COVID-19 Vaccine Certificate"

--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -21,7 +21,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
   });
   const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
-  const { data: vaccineData } = useAdministeredVaccines(patient.id, {
+  const { data: vaccineData, isLoading } = useAdministeredVaccines(patient.id, {
     orderBy: 'date',
     order: 'ASC',
     invertNullDateOrdering: true,
@@ -44,7 +44,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
 
   const patientData = { ...patient, additionalData };
 
-  if (!vaccinations.length) return null;
+  if (isLoading) return null;
 
   return (
     <Modal

--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -44,6 +44,8 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
 
   const patientData = { ...patient, additionalData };
 
+  if (!vaccinations.length) return null;
+
   return (
     <Modal
       title="Vaccine Certificate"


### PR DESCRIPTION
### Changes

In regression testing for release 1.38, we discovered that vaccine certificates were showing up empty on the first render of a patient certificate after login. This was an interesting error as there weren't any changes in the release related to vaccines or pdfs. I think it is almost definitely a side effect of the huge node upgrade but not sure exactly why. 

I have resolved by just holding off on generating the pdf until the vaccines are loaded from the DB

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
