### PR TITLE
NASS-963: Translate desktop 'Procedures' module

### DIFF
--- a/packages/desktop/app/components/ProcedureModal.js
+++ b/packages/desktop/app/components/ProcedureModal.js
@@ -5,6 +5,7 @@ import { Suggester } from '../utils/suggester';
 
 import { FormModal } from './FormModal';
 import { ProcedureForm } from '../forms/ProcedureForm';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure }) => {
   const api = useApi();
@@ -18,7 +19,19 @@ export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure 
   return (
     <FormModal
       width="md"
-      title={`${editedProcedure?.id ? 'Edit' : 'New'} procedure`}
+      title={
+        <TranslatedText
+          stringId="procedure.modal.title"
+          fallback=":action procedure"
+          replacements={{
+            action: editedProcedure?.id ? (
+              <TranslatedText stringId="general.action.edit" fallback="Edit" />
+            ) : (
+              <TranslatedText stringId="general.action.new" fallback="New" />
+            ),
+          }}
+        />
+      }
       open={!!editedProcedure}
       onClose={onClose}
     >

--- a/packages/desktop/app/components/ProcedureTable.js
+++ b/packages/desktop/app/components/ProcedureTable.js
@@ -2,14 +2,27 @@ import React from 'react';
 
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const getProcedureLabel = ({ procedureType }) => procedureType.name;
 const getCodeLabel = ({ procedureType }) => procedureType.code;
 
 const COLUMNS = [
-  { key: 'date', title: 'Date', accessor: ({ date }) => <DateDisplay date={date} /> },
-  { key: 'ProcedureType.code', title: 'Code', accessor: getCodeLabel },
-  { key: 'ProcedureType.name', title: 'Procedure', accessor: getProcedureLabel },
+  {
+    key: 'date',
+    title: <TranslatedText stringId="general.table.column.date" fallback="date" />,
+    accessor: ({ date }) => <DateDisplay date={date} />,
+  },
+  {
+    key: 'ProcedureType.code',
+    title: <TranslatedText stringId="procedure.table.column.code" fallback="Code" />,
+    accessor: getCodeLabel,
+  },
+  {
+    key: 'ProcedureType.name',
+    title: <TranslatedText stringId="procedure.table.column.procedure" fallback="Procedure" />,
+    accessor: getProcedureLabel,
+  },
 ];
 
 export const ProcedureTable = React.memo(({ encounterId, onItemClick }) => (

--- a/packages/desktop/app/components/ProcedureTable.js
+++ b/packages/desktop/app/components/ProcedureTable.js
@@ -20,7 +20,7 @@ const COLUMNS = [
   },
   {
     key: 'ProcedureType.name',
-    title: <TranslatedText stringId="procedure.table.column.procedure" fallback="Procedure" />,
+    title: <TranslatedText stringId="procedure.table.column.name" fallback="Procedure" />,
     accessor: getProcedureLabel,
   },
 ];

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -60,7 +60,7 @@ export const ProcedureForm = React.memo(
                     name="procedureTypeId"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.procedureType.label"
+                        stringId="procedure.form.procedureType.label"
                         fallback="Procedure"
                       />
                     }
@@ -81,7 +81,7 @@ export const ProcedureForm = React.memo(
                     name="date"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.date.label"
+                        stringId="procedure.form.date.label"
                         fallback="Procedure date"
                       />
                     }
@@ -92,13 +92,13 @@ export const ProcedureForm = React.memo(
                   <Field
                     locationGroupLabel={
                       <TranslatedText
-                        stringId="procedure.modal.form.area.label"
+                        stringId="procedure.form.area.label"
                         fallback="Procedure area"
                       />
                     }
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.location.label"
+                        stringId="procedure.form.location.label"
                         fallback="Procedure location"
                       />
                     }
@@ -113,7 +113,7 @@ export const ProcedureForm = React.memo(
                     name="startTime"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.startTime.label"
+                        stringId="procedure.form.startTime.label"
                         fallback="Time started"
                       />
                     }
@@ -124,7 +124,7 @@ export const ProcedureForm = React.memo(
                     name="endTime"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.endTime.label"
+                        stringId="procedure.form.endTime.label"
                         fallback="Time ended"
                       />
                     }
@@ -137,7 +137,7 @@ export const ProcedureForm = React.memo(
                   name="anaesthetistId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.aneasthetistId.label"
+                      stringId="procedure.form.aneasthetistId.label"
                       fallback="Anaesthetist"
                     />
                   }
@@ -148,7 +148,7 @@ export const ProcedureForm = React.memo(
                   name="anaestheticId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.anaestheticId.label"
+                      stringId="procedure.form.anaestheticId.label"
                       fallback="Anaesthetic type"
                     />
                   }
@@ -161,7 +161,7 @@ export const ProcedureForm = React.memo(
                   name="assistantId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.assistantId.label"
+                      stringId="procedure.form.assistantId.label"
                       fallback="Assistant"
                     />
                   }
@@ -172,7 +172,7 @@ export const ProcedureForm = React.memo(
                   name="note"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.note.label"
+                      stringId="procedure.form.note.label"
                       fallback="Notes or additional instructions"
                     />
                   }
@@ -185,7 +185,7 @@ export const ProcedureForm = React.memo(
                   name="completed"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.completed.label"
+                      stringId="procedure.form.completed.label"
                       fallback="Completed"
                     />
                   }
@@ -196,7 +196,7 @@ export const ProcedureForm = React.memo(
                     name="completedNote"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.completedNote.label"
+                        stringId="procedure.form.completedNote.label"
                         fallback="Notes on completed procedure"
                       />
                     }

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -60,7 +60,7 @@ export const ProcedureForm = React.memo(
                     name="procedureTypeId"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.procedure.label"
+                        stringId="procedure.modal.form.procedureType.label"
                         fallback="Procedure"
                       />
                     }
@@ -137,7 +137,7 @@ export const ProcedureForm = React.memo(
                   name="anaesthetistId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.aneasthetist.label"
+                      stringId="procedure.modal.form.aneasthetistId.label"
                       fallback="Anaesthetist"
                     />
                   }
@@ -148,7 +148,7 @@ export const ProcedureForm = React.memo(
                   name="anaestheticId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.anaestheticType.label"
+                      stringId="procedure.modal.form.anaestheticId.label"
                       fallback="Anaesthetic type"
                     />
                   }
@@ -161,7 +161,7 @@ export const ProcedureForm = React.memo(
                   name="assistantId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.assistant.label"
+                      stringId="procedure.modal.form.assistantId.label"
                       fallback="Assistant"
                     />
                   }
@@ -172,7 +172,7 @@ export const ProcedureForm = React.memo(
                   name="note"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.notes.label"
+                      stringId="procedure.modal.form.note.label"
                       fallback="Notes or additional instructions"
                     />
                   }
@@ -196,7 +196,7 @@ export const ProcedureForm = React.memo(
                     name="completedNote"
                     label={
                       <TranslatedText
-                        stringId="procedure.modal.form.completedNotes.label"
+                        stringId="procedure.modal.form.completedNote.label"
                         fallback="Notes on completed procedure"
                       />
                     }

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -148,7 +148,7 @@ export const ProcedureForm = React.memo(
                   name="anaestheticId"
                   label={
                     <TranslatedText
-                      stringId="procedure.modal.form.anaesthetistType.label"
+                      stringId="procedure.modal.form.anaestheticType.label"
                       fallback="Anaesthetic type"
                     />
                   }

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -137,7 +137,7 @@ export const ProcedureForm = React.memo(
                   name="anaesthetistId"
                   label={
                     <TranslatedText
-                      stringId="procedure.form.aneasthetistId.label"
+                      stringId="procedure.form.aneasthetist.label"
                       fallback="Anaesthetist"
                     />
                   }
@@ -148,7 +148,7 @@ export const ProcedureForm = React.memo(
                   name="anaestheticId"
                   label={
                     <TranslatedText
-                      stringId="procedure.form.anaestheticId.label"
+                      stringId="procedure.form.anaesthetic.label"
                       fallback="Anaesthetic type"
                     />
                   }
@@ -161,7 +161,7 @@ export const ProcedureForm = React.memo(
                   name="assistantId"
                   label={
                     <TranslatedText
-                      stringId="procedure.form.assistantId.label"
+                      stringId="procedure.form.assistant.label"
                       fallback="Assistant"
                     />
                   }

--- a/packages/desktop/app/forms/ProcedureForm.js
+++ b/packages/desktop/app/forms/ProcedureForm.js
@@ -19,6 +19,7 @@ import { FormSubmitCancelRow } from '../components/ButtonRow';
 
 import { foreignKey, optionalForeignKey } from '../utils/validation';
 import { useLocalisedText } from '../components';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const suggesterType = PropTypes.shape({
   fetchSuggestions: PropTypes.func,
@@ -42,9 +43,11 @@ export const ProcedureForm = React.memo(
         render={({ submitForm, values }) => {
           const handleCancel = () => onCancel && onCancel();
           const getButtonText = isCompleted => {
-            if (isCompleted) return 'Finalise';
-            if (editedObject?.id) return 'Update';
-            return 'Submit';
+            if (isCompleted)
+              return <TranslatedText stringId="general.action.finalise" fallback="Finalise" />;
+            if (editedObject?.id)
+              return <TranslatedText stringId="general.action.update" fallback="Update" />;
+            return <TranslatedText stringId="general.action.submit" fallback="Submit" />;
           };
 
           const isCompleted = !!values.completed;
@@ -55,7 +58,12 @@ export const ProcedureForm = React.memo(
                 <div style={{ gridColumn: 'span 2' }}>
                   <Field
                     name="procedureTypeId"
-                    label="Procedure"
+                    label={
+                      <TranslatedText
+                        stringId="procedure.modal.form.procedure.label"
+                        fallback="Procedure"
+                      />
+                    }
                     required
                     component={AutocompleteField}
                     suggester={procedureSuggester}
@@ -71,14 +79,29 @@ export const ProcedureForm = React.memo(
                   />
                   <Field
                     name="date"
-                    label="Procedure date"
+                    label={
+                      <TranslatedText
+                        stringId="procedure.modal.form.date.label"
+                        fallback="Procedure date"
+                      />
+                    }
                     saveDateAsString
                     required
                     component={DateField}
                   />
                   <Field
-                    locationGroupLabel="Procedure area"
-                    label="Procedure location"
+                    locationGroupLabel={
+                      <TranslatedText
+                        stringId="procedure.modal.form.area.label"
+                        fallback="Procedure area"
+                      />
+                    }
+                    label={
+                      <TranslatedText
+                        stringId="procedure.modal.form.location.label"
+                        fallback="Procedure location"
+                      />
+                    }
                     name="locationId"
                     enableLocationStatus={false}
                     required
@@ -88,22 +111,47 @@ export const ProcedureForm = React.memo(
                 <FormGrid style={{ gridColumn: 'span 2' }}>
                   <Field
                     name="startTime"
-                    label="Time started"
+                    label={
+                      <TranslatedText
+                        stringId="procedure.modal.form.startTime.label"
+                        fallback="Time started"
+                      />
+                    }
                     component={TimeField}
                     saveDateAsString
                   />
-                  <Field name="endTime" label="Time ended" component={TimeField} saveDateAsString />
+                  <Field
+                    name="endTime"
+                    label={
+                      <TranslatedText
+                        stringId="procedure.modal.form.endTime.label"
+                        fallback="Time ended"
+                      />
+                    }
+                    component={TimeField}
+                    saveDateAsString
+                  />
                 </FormGrid>
 
                 <Field
                   name="anaesthetistId"
-                  label="Anaesthetist"
+                  label={
+                    <TranslatedText
+                      stringId="procedure.modal.form.aneasthetist.label"
+                      fallback="Anaesthetist"
+                    />
+                  }
                   component={AutocompleteField}
                   suggester={practitionerSuggester}
                 />
                 <Field
                   name="anaestheticId"
-                  label="Anaesthetic type"
+                  label={
+                    <TranslatedText
+                      stringId="procedure.modal.form.anaesthetistType.label"
+                      fallback="Anaesthetic type"
+                    />
+                  }
                   component={AutocompleteField}
                   suggester={anaestheticSuggester}
                   rows={4}
@@ -111,23 +159,47 @@ export const ProcedureForm = React.memo(
                 />
                 <Field
                   name="assistantId"
-                  label="Assistant"
+                  label={
+                    <TranslatedText
+                      stringId="procedure.modal.form.assistant.label"
+                      fallback="Assistant"
+                    />
+                  }
                   component={AutocompleteField}
                   suggester={practitionerSuggester}
                 />
                 <Field
                   name="note"
-                  label="Notes or additional instructions"
+                  label={
+                    <TranslatedText
+                      stringId="procedure.modal.form.notes.label"
+                      fallback="Notes or additional instructions"
+                    />
+                  }
                   component={TextField}
                   multiline
                   rows={4}
                   style={{ gridColumn: 'span 2' }}
                 />
-                <Field name="completed" label="Completed" component={CheckField} />
+                <Field
+                  name="completed"
+                  label={
+                    <TranslatedText
+                      stringId="procedure.modal.form.completed.label"
+                      fallback="Completed"
+                    />
+                  }
+                  component={CheckField}
+                />
                 <Collapse in={isCompleted} style={{ gridColumn: 'span 2' }}>
                   <Field
                     name="completedNote"
-                    label="Notes on completed procedure"
+                    label={
+                      <TranslatedText
+                        stringId="procedure.modal.form.completedNotes.label"
+                        fallback="Notes on completed procedure"
+                      />
+                    }
                     component={TextField}
                     multiline
                     rows={4}

--- a/packages/desktop/app/views/patients/panes/ProcedurePane.js
+++ b/packages/desktop/app/views/patients/panes/ProcedurePane.js
@@ -23,7 +23,7 @@ export const ProcedurePane = React.memo(({ encounter, readonly }) => {
       />
       <TableButtonRow variant="small">
         <Button onClick={() => setEditedProcedure({})} disabled={readonly}>
-          <TranslatedText stringId="procedure.action.newProcedure" fallback="New procedure" />
+          <TranslatedText stringId="procedure.action.create" fallback="New procedure" />
         </Button>
       </TableButtonRow>
       <ProcedureTable encounterId={encounter.id} onItemClick={item => setEditedProcedure(item)} />

--- a/packages/desktop/app/views/patients/panes/ProcedurePane.js
+++ b/packages/desktop/app/views/patients/panes/ProcedurePane.js
@@ -4,6 +4,7 @@ import { ProcedureModal } from '../../../components/ProcedureModal';
 import { ProcedureTable } from '../../../components/ProcedureTable';
 import { TableButtonRow, Button } from '../../../components';
 import { TabPane } from '../components';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 export const ProcedurePane = React.memo(({ encounter, readonly }) => {
   const [editedProcedure, setEditedProcedure] = useState(null);
@@ -22,7 +23,7 @@ export const ProcedurePane = React.memo(({ encounter, readonly }) => {
       />
       <TableButtonRow variant="small">
         <Button onClick={() => setEditedProcedure({})} disabled={readonly}>
-          New procedure
+          <TranslatedText stringId="procedure.action.newProcedure" fallback="New procedure" />
         </Button>
       </TableButtonRow>
       <ProcedureTable encounterId={encounter.id} onItemClick={item => setEditedProcedure(item)} />


### PR DESCRIPTION
### Changes

Translated the procedures module on desktop with `<TranslatedText />` components.

Notes:
- Could not translate `Clinician` field label, as this uses `useLocalisedText` 
![image](https://github.com/beyondessential/tamanu/assets/108244616/7cae4f91-df52-48a9-ab4c-3522e229d118)

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
