### PR TITLE
Fix: Empty vaccine certificate bug fix tweak

### DIFF
--- a/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.js
@@ -21,7 +21,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
   });
   const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
-  const { data: vaccineData, isLoading } = useAdministeredVaccines(patient.id, {
+  const { data: vaccineData, isFetching } = useAdministeredVaccines(patient.id, {
     orderBy: 'date',
     order: 'ASC',
     invertNullDateOrdering: true,
@@ -44,7 +44,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
 
   const patientData = { ...patient, additionalData };
 
-  if (isLoading) return null;
+  if (isFetching) return null;
 
   return (
     <Modal

--- a/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/VaccineCertificateModal.js
@@ -21,7 +21,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
   });
   const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
-  const { data: vaccineData, isLoading } = useAdministeredVaccines(patient.id, {
+  const { data: vaccineData, isFetching } = useAdministeredVaccines(patient.id, {
     orderBy: 'date',
     order: 'ASC',
     invertNullDateOrdering: true,
@@ -44,7 +44,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
 
   const patientData = { ...patient, additionalData };
 
-  if (isLoading) return null;
+  if (isFetching) return null;
 
   return (
     <Modal


### PR DESCRIPTION
### Changes

Fixed this just before but used the wrong react query property. isLoading only works for the inital load but isFetching works for subsequent fetches which we need when we add a new vaccine and reload

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
