### PR TITLE
NASS-964: Translate desktop labs module

### DIFF
--- a/packages/desktop/app/components/BaseModal.js
+++ b/packages/desktop/app/components/BaseModal.js
@@ -10,6 +10,7 @@ import { Box, CircularProgress, IconButton, Typography } from '@material-ui/core
 import { Colors } from '../constants';
 import { useElectron } from '../contexts/Electron';
 import { Button } from './Button';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const MODAL_PADDING_TOP_AND_BOTTOM = 18;
 export const MODAL_PADDING_LEFT_AND_RIGHT = 32;
@@ -148,7 +149,7 @@ export const BaseModal = memo(
                 startIcon={<PrintIcon />}
                 size="small"
               >
-                Print
+                <TranslatedText stringId="general.action.print" fallback="Print" />
               </StyledButton>
             )}
             {cornerExitButton && (

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -11,7 +11,6 @@ import { Colors } from '../../constants';
 import { OuterLabelFieldWrapper } from './OuterLabelFieldWrapper';
 import { StyledTextField } from './TextField';
 import { FormFieldTag } from '../Tag';
-import { TranslatedText } from '../Translation/TranslatedText';
 
 const StyledFormControl = styled(FormControl)`
   display: flex;

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -202,7 +202,7 @@ export const SelectInput = ({
           menuPosition="fixed"
           styles={customStyleObject || defaultStyles}
           menuShouldBlockScroll="true"
-          placeholder=<TranslatedText stringId="general.action.select" fallback="Select" />
+          placeholder="Select"
           isClearable={value !== '' && isClearable && !props.required && !disabled}
           isSearchable={false}
           tabIndex={inputProps.tabIndex}

--- a/packages/desktop/app/components/Field/SelectField.js
+++ b/packages/desktop/app/components/Field/SelectField.js
@@ -11,6 +11,7 @@ import { Colors } from '../../constants';
 import { OuterLabelFieldWrapper } from './OuterLabelFieldWrapper';
 import { StyledTextField } from './TextField';
 import { FormFieldTag } from '../Tag';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const StyledFormControl = styled(FormControl)`
   display: flex;
@@ -201,7 +202,7 @@ export const SelectInput = ({
           menuPosition="fixed"
           styles={customStyleObject || defaultStyles}
           menuShouldBlockScroll="true"
-          placeholder="Select"
+          placeholder=<TranslatedText stringId="general.action.select" fallback="Select" />
           isClearable={value !== '' && isClearable && !props.required && !disabled}
           isSearchable={false}
           tabIndex={inputProps.tabIndex}

--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -110,7 +110,7 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
           stringId="lab.modal.create.title"
           fallback="New lab request :modalSectionTitle"
           replacements={{
-            modalSectionTitle: `${requestFormType ? ` | ${SECTION_TITLES[requestFormType]}` : ' '}`,
+            modalSectionTitle: requestFormType ? `| ${SECTION_TITLES[requestFormType]}` : ' ',
           }}
         />
       }

--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -107,7 +107,7 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
     <StyledModal
       title={
         <TranslatedText
-          stringId="labs.modal.new.title"
+          stringId="lab.modal.create.title"
           fallback="New lab request :modalSectionTitle"
           replacements={{
             modalSectionTitle: `${requestFormType ? ` | ${SECTION_TITLES[requestFormType]}` : ' '}`,

--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -8,6 +8,7 @@ import { FormModal } from './FormModal';
 import { LabRequestMultiStepForm } from '../forms/LabRequestForm/LabRequestMultiStepForm';
 import { LabRequestSummaryPane } from '../views/patients/components/LabRequestSummaryPane';
 import { useEncounter } from '../contexts/Encounter';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const StyledModal = styled(FormModal)`
   .MuiDialog-paper {
@@ -104,7 +105,15 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
 
   return (
     <StyledModal
-      title={`New lab request${requestFormType ? ` | ${SECTION_TITLES[requestFormType]}` : ''}`}
+      title={
+        <TranslatedText
+          stringId="labs.modal.new.title"
+          fallback="New lab request :modalSectionTitle"
+          replacements={{
+            modalSectionTitle: `${requestFormType ? ` | ${SECTION_TITLES[requestFormType]}` : ' '}`,
+          }}
+        />
+      }
       open={open}
       onClose={handleClose}
       minHeight={800}

--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -110,7 +110,7 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
           stringId="lab.modal.create.title"
           fallback="New lab request :modalSectionTitle"
           replacements={{
-            modalSectionTitle: requestFormType ? `| ${SECTION_TITLES[requestFormType]}` : '',
+            modalSectionTitle: requestFormType ? `| ${SECTION_TITLES[requestFormType]}` : ' ',
           }}
         />
       }

--- a/packages/desktop/app/components/LabRequestModal.js
+++ b/packages/desktop/app/components/LabRequestModal.js
@@ -110,7 +110,7 @@ export const LabRequestModal = React.memo(({ open, onClose, encounter }) => {
           stringId="lab.modal.create.title"
           fallback="New lab request :modalSectionTitle"
           replacements={{
-            modalSectionTitle: requestFormType ? `| ${SECTION_TITLES[requestFormType]}` : ' ',
+            modalSectionTitle: requestFormType ? `| ${SECTION_TITLES[requestFormType]}` : '',
           }}
         />
       }

--- a/packages/desktop/app/components/PatientPrinting/modals/LabRequestPrintLabelModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/LabRequestPrintLabelModal.js
@@ -7,6 +7,7 @@ import { Modal } from '../../Modal';
 import { LabRequestPrintLabel } from '../printouts/LabRequestPrintLabel';
 import { useLocalisation } from '../../../contexts/Localisation';
 import { getPatientNameAsString } from '../../PatientNameDisplay';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 const Container = styled.div`
   display: flex;
@@ -32,7 +33,13 @@ export const LabRequestPrintLabelModal = ({ open, onClose, labRequests }) => {
   const labelWidth = getLocalisation('printMeasures.labRequestPrintLabel.width');
 
   return (
-    <Modal title="Print label" width="md" open={open} onClose={onClose} printable>
+    <Modal
+      title={<TranslatedText stringId="lab.modal.printLabel.title" fallback="Print label" />}
+      width="md"
+      open={open}
+      onClose={onClose}
+      printable
+    >
       <Container>
         {labRequests.map(lab => (
           <Box mb={3}>

--- a/packages/desktop/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.js
@@ -37,7 +37,9 @@ export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open,
 
   return (
     <Modal
-      title={<TranslatedText stringId="lab.modal.printOut.title" fallback="Print lab requests" />}
+      title={
+        <TranslatedText stringId="lab.modal.printMultiple.title" fallback="Print lab requests" />
+      }
       width="md"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.js
@@ -37,7 +37,7 @@ export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open,
 
   return (
     <Modal
-      title={<TranslatedText stringId="labs.modal.printOut.title" fallback="Print lab requests" />}
+      title={<TranslatedText stringId="lab.modal.printOut.title" fallback="Print lab requests" />}
       width="md"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.js
@@ -9,6 +9,7 @@ import { useApi } from '../../../api';
 import { Colors } from '../../../constants';
 
 import { MultipleLabRequestsPrintout } from '../printouts/MultipleLabRequestsPrintout';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open, onClose }) => {
   const certificateData = useCertificate();
@@ -36,7 +37,7 @@ export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open,
 
   return (
     <Modal
-      title="Print lab requests"
+      title={<TranslatedText stringId="labs.modal.printOut.title" fallback="Print lab requests" />}
       width="md"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
@@ -27,24 +27,41 @@ const COLUMN_KEYS = {
 const COLUMNS = [
   {
     key: COLUMN_KEYS.DISPLAY_ID,
-    title: <TranslatedText stringId="lab.print.table.column.testId" fallback="Test ID" />,
+    title: (
+      <TranslatedText stringId="lab.modal.printMultiple.table.column.testId" fallback="Test ID" />
+    ),
     sortable: false,
   },
   {
     key: COLUMN_KEYS.DATE,
-    title: <TranslatedText stringId="lab.print.table.column.requestDate" fallback="Request date" />,
+    title: (
+      <TranslatedText
+        stringId="lab.modal.printMultiple.table.column.requestDate"
+        fallback="Request date"
+      />
+    ),
     sortable: false,
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
   },
   {
     key: COLUMN_KEYS.REQUESTED_BY,
-    title: <TranslatedText stringId="lab.print.table.column.requestedBy" fallback="Requested by" />,
+    title: (
+      <TranslatedText
+        stringId="lab.modal.printMultiple.table.column.requestedBy"
+        fallback="Requested by"
+      />
+    ),
     sortable: false,
     accessor: ({ requestedBy }) => requestedBy?.displayName || '',
   },
   {
     key: COLUMN_KEYS.PRIORITY,
-    title: <TranslatedText stringId="lab.print.table.column.priority" fallback="Priority" />,
+    title: (
+      <TranslatedText
+        stringId="lab.modal.printMultiple.table.column.priority"
+        fallback="Priority"
+      />
+    ),
     sortable: false,
     maxWidth: 70,
     accessor: ({ priority }) => priority?.name || '',
@@ -52,14 +69,19 @@ const COLUMNS = [
   {
     key: COLUMN_KEYS.CATEGORY,
     title: (
-      <TranslatedText stringId="lab.print.table.column.testCategory" fallback="Test category" />
+      <TranslatedText
+        stringId="lab.modal.printMultiple.table.column.testCategory"
+        fallback="Test category"
+      />
     ),
     sortable: false,
     accessor: ({ category }) => category?.name || '',
   },
   {
     key: COLUMN_KEYS.STATUS,
-    title: <TranslatedText stringId="lab.print.table.column.status" fallback="Status" />,
+    title: (
+      <TranslatedText stringId="lab.modal.printMultiple.table.column.status" fallback="Status" />
+    ),
     sortable: false,
     accessor: getStatus,
   },
@@ -101,7 +123,7 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
       />
       <PrintMultipleSelectionTable
         label=<TranslatedText
-          stringId="lab.modal.print.selectText"
+          stringId="lab.modal.printMultiple.selectText"
           fallback="Select the lab requests you would like to print"
         />
         headerColor={Colors.white}
@@ -111,7 +133,7 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
         isLoading={isLoading}
         errorMessage={error?.message}
         noDataMessage=<TranslatedText
-          stringId="lab.print.table.noData"
+          stringId="lab.modal.printMultiple.table.noData"
           fallback="No lab requests found"
         />
         allowExport={false}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
@@ -27,34 +27,24 @@ const COLUMN_KEYS = {
 const COLUMNS = [
   {
     key: COLUMN_KEYS.DISPLAY_ID,
-    title: <TranslatedText stringId="labs.modal.print.table.column.testId" fallback="Test ID" />,
+    title: <TranslatedText stringId="lab.print.table.column.testId" fallback="Test ID" />,
     sortable: false,
   },
   {
     key: COLUMN_KEYS.DATE,
-    title: (
-      <TranslatedText
-        stringId="labs.modal.print.table.column.requestDate"
-        fallback="Request date"
-      />
-    ),
+    title: <TranslatedText stringId="lab.print.table.column.requestDate" fallback="Request date" />,
     sortable: false,
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
   },
   {
     key: COLUMN_KEYS.REQUESTED_BY,
-    title: (
-      <TranslatedText
-        stringId="labs.modal.print.table.column.requestedBy"
-        fallback="Requested by"
-      />
-    ),
+    title: <TranslatedText stringId="lab.print.table.column.requestedBy" fallback="Requested by" />,
     sortable: false,
     accessor: ({ requestedBy }) => requestedBy?.displayName || '',
   },
   {
     key: COLUMN_KEYS.PRIORITY,
-    title: <TranslatedText stringId="labs.modal.print.table.column.priority" fallback="Priority" />,
+    title: <TranslatedText stringId="lab.print.table.column.priority" fallback="Priority" />,
     sortable: false,
     maxWidth: 70,
     accessor: ({ priority }) => priority?.name || '',
@@ -62,17 +52,14 @@ const COLUMNS = [
   {
     key: COLUMN_KEYS.CATEGORY,
     title: (
-      <TranslatedText
-        stringId="labs.modal.print.table.column.testCategory"
-        fallback="Test category"
-      />
+      <TranslatedText stringId="lab.print.table.column.testCategory" fallback="Test category" />
     ),
     sortable: false,
     accessor: ({ category }) => category?.name || '',
   },
   {
     key: COLUMN_KEYS.STATUS,
-    title: <TranslatedText stringId="labs.modal.print.table.column.status" fallback="Status" />,
+    title: <TranslatedText stringId="lab.print.table.column.status" fallback="Status" />,
     sortable: false,
     accessor: getStatus,
   },
@@ -114,7 +101,7 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
       />
       <PrintMultipleSelectionTable
         label=<TranslatedText
-          stringId="labs.modal.print.select"
+          stringId="lab.modal.print.selectText"
           fallback="Select the lab requests you would like to print"
         />
         headerColor={Colors.white}
@@ -124,7 +111,7 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
         isLoading={isLoading}
         errorMessage={error?.message}
         noDataMessage=<TranslatedText
-          stringId="labs.modal.print.table.noData"
+          stringId="lab.print.table.noData"
           fallback="No lab requests found"
         />
         allowExport={false}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionForm.js
@@ -12,6 +12,7 @@ import { Colors } from '../../../constants';
 import { MultipleLabRequestsPrintoutModal } from './MultipleLabRequestsPrintoutModal';
 import { FormDivider, PrintMultipleSelectionTable } from './PrintMultipleSelectionTable';
 import { getStatus } from '../../../utils/lab';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 const COLUMN_KEYS = {
   SELECTED: 'selected',
@@ -26,37 +27,52 @@ const COLUMN_KEYS = {
 const COLUMNS = [
   {
     key: COLUMN_KEYS.DISPLAY_ID,
-    title: 'Test ID',
+    title: <TranslatedText stringId="labs.modal.print.table.column.testId" fallback="Test ID" />,
     sortable: false,
   },
   {
     key: COLUMN_KEYS.DATE,
-    title: 'Request date',
+    title: (
+      <TranslatedText
+        stringId="labs.modal.print.table.column.requestDate"
+        fallback="Request date"
+      />
+    ),
     sortable: false,
     accessor: ({ requestedDate }) => <DateDisplay date={requestedDate} />,
   },
   {
     key: COLUMN_KEYS.REQUESTED_BY,
-    title: 'Requested by',
+    title: (
+      <TranslatedText
+        stringId="labs.modal.print.table.column.requestedBy"
+        fallback="Requested by"
+      />
+    ),
     sortable: false,
     accessor: ({ requestedBy }) => requestedBy?.displayName || '',
   },
   {
     key: COLUMN_KEYS.PRIORITY,
-    title: 'Priority',
+    title: <TranslatedText stringId="labs.modal.print.table.column.priority" fallback="Priority" />,
     sortable: false,
     maxWidth: 70,
     accessor: ({ priority }) => priority?.name || '',
   },
   {
     key: COLUMN_KEYS.CATEGORY,
-    title: 'Test category',
+    title: (
+      <TranslatedText
+        stringId="labs.modal.print.table.column.testCategory"
+        fallback="Test category"
+      />
+    ),
     sortable: false,
     accessor: ({ category }) => category?.name || '',
   },
   {
     key: COLUMN_KEYS.STATUS,
-    title: 'Status',
+    title: <TranslatedText stringId="labs.modal.print.table.column.status" fallback="Status" />,
     sortable: false,
     accessor: getStatus,
   },
@@ -97,20 +113,26 @@ export const PrintMultipleLabRequestsSelectionForm = React.memo(({ encounter, on
         onClose={() => setOpenPrintoutModal(false)}
       />
       <PrintMultipleSelectionTable
-        label="Select the lab requests you would like to print"
+        label=<TranslatedText
+          stringId="labs.modal.print.select"
+          fallback="Select the lab requests you would like to print"
+        />
         headerColor={Colors.white}
         columns={[selectableColumn, ...COLUMNS]}
         data={labRequestsData || []}
         elevated={false}
         isLoading={isLoading}
         errorMessage={error?.message}
-        noDataMessage="No lab requests found"
+        noDataMessage=<TranslatedText
+          stringId="labs.modal.print.table.noData"
+          fallback="No lab requests found"
+        />
         allowExport={false}
       />
       <FormDivider />
       <ConfirmCancelRow
-        cancelText="Close"
-        confirmText="Print"
+        cancelText=<TranslatedText stringId="general.action.close" fallback="Close" />
+        confirmText=<TranslatedText stringId="general.action.print" fallback="Print" />
         onConfirm={handlePrintConfirm}
         onCancel={onClose}
       />

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionModal.js
@@ -8,7 +8,9 @@ import { TranslatedText } from '../../Translation/TranslatedText';
 export const PrintMultipleLabRequestsSelectionModal = ({ encounter, open, onClose }) => {
   return (
     <FormModal
-      title={<TranslatedText stringId="lab.modal.print.title" fallback="Print lab requests" />}
+      title={
+        <TranslatedText stringId="lab.modal.printMultiple.title" fallback="Print lab requests" />
+      }
       width="xl"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionModal.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 
 import { FormModal } from '../../FormModal';
 import { PrintMultipleLabRequestsSelectionForm } from './PrintMultipleLabRequestsSelectionForm';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 export const PrintMultipleLabRequestsSelectionModal = ({ encounter, open, onClose }) => {
   return (
     <FormModal
-      title="Print lab requests"
+      title={<TranslatedText stringId="labs.modal.print.title" fallback="Print lab requests" />}
       width="xl"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/PrintMultipleLabRequestsSelectionModal.js
@@ -8,7 +8,7 @@ import { TranslatedText } from '../../Translation/TranslatedText';
 export const PrintMultipleLabRequestsSelectionModal = ({ encounter, open, onClose }) => {
   return (
     <FormModal
-      title={<TranslatedText stringId="labs.modal.print.title" fallback="Print lab requests" />}
+      title={<TranslatedText stringId="lab.modal.print.title" fallback="Print lab requests" />}
       width="xl"
       open={open}
       onClose={onClose}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -24,14 +24,11 @@ export const LabRequestFormScreen1 = ({
     <>
       <div style={{ gridColumn: '1 / -1' }}>
         <Heading3 mb="12px">
-          <TranslatedText
-            stringId="lab.form.header.newLabRequest"
-            fallback="Creating a new lab request"
-          />
+          <TranslatedText stringId="lab.form.create.header" fallback="Creating a new lab request" />
         </Heading3>
         <BodyText mb="28px" color="textTertiary">
           <TranslatedText
-            stringId="lab.form.instruction.newLabRequest"
+            stringId="lab.form.create.instruction"
             fallback="Please complete the details below and select the lab request type"
           />
         </BodyText>

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -58,7 +58,7 @@ export const LabRequestFormScreen1 = ({
       />
       <Field
         name="departmentId"
-        label=<TranslatedText stringId="lab.form.department.label" fallback="Department" />
+        label=<TranslatedText stringId="general.form.department.label" fallback="Department" />
         component={AutocompleteField}
         suggester={departmentSuggester}
       />

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -25,13 +25,13 @@ export const LabRequestFormScreen1 = ({
       <div style={{ gridColumn: '1 / -1' }}>
         <Heading3 mb="12px">
           <TranslatedText
-            stringId="labs.modal.new.form.screen1.headingText"
+            stringId="lab.form.header.newLabRequest"
             fallback="Creating a new lab request"
           />
         </Heading3>
         <BodyText mb="28px" color="textTertiary">
           <TranslatedText
-            stringId="labs.modal.new.form.screen1.bodyText"
+            stringId="lab.form.instruction.newLabRequest"
             fallback="Please complete the details below and select the lab request type"
           />
         </BodyText>
@@ -40,7 +40,7 @@ export const LabRequestFormScreen1 = ({
         name="requestedById"
         label={
           <TranslatedText
-            stringId="labs.modal.new.form.requestingClinician.label"
+            stringId="lab.form.requestingClinician.label"
             fallback="Requesting :clinician"
             replacements={{ clinician: clinicianText.toLowerCase() }}
           />
@@ -52,7 +52,7 @@ export const LabRequestFormScreen1 = ({
       <Field
         name="requestedDate"
         label=<TranslatedText
-          stringId="labs.modal.new.form.requestDateTime.label"
+          stringId="lab.form.requestDateTime.label"
           fallback="Request date & time"
         />
         required
@@ -61,16 +61,13 @@ export const LabRequestFormScreen1 = ({
       />
       <Field
         name="departmentId"
-        label=<TranslatedText
-          stringId="labs.modal.new.form.department.label"
-          fallback="Department"
-        />
+        label=<TranslatedText stringId="lab.form.department.label" fallback="Department" />
         component={AutocompleteField}
         suggester={departmentSuggester}
       />
       <Field
         name="labTestPriorityId"
-        label=<TranslatedText stringId="labs.modal.new.form.priority.label" fallback="Priority" />
+        label=<TranslatedText stringId="lab.form.priority.label" fallback="Priority" />
         component={SuggesterSelectField}
         endpoint="labTestPriority"
       />

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -9,6 +9,7 @@ import {
   useLocalisedText,
 } from '../../components';
 import { LabRequestFormTypeRadioField } from './LabRequestFormTypeRadioField';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 // If update any fields please update screen1ValidationSchema in LabRequestMultiStepForm.js
 export const LabRequestFormScreen1 = ({
@@ -22,34 +23,57 @@ export const LabRequestFormScreen1 = ({
   return (
     <>
       <div style={{ gridColumn: '1 / -1' }}>
-        <Heading3 mb="12px">Creating a new lab request</Heading3>
+        <Heading3 mb="12px">
+          <TranslatedText
+            stringId="labs.modal.new.form.screen1.headingText"
+            fallback="Creating a new lab request"
+          />
+        </Heading3>
         <BodyText mb="28px" color="textTertiary">
-          Please complete the details below and select the lab request type
+          <TranslatedText
+            stringId="labs.modal.new.form.screen1.bodyText"
+            fallback="Please complete the details below and select the lab request type"
+          />
         </BodyText>
       </div>
       <Field
         name="requestedById"
-        label={`Requesting ${clinicianText.toLowerCase()}`}
+        label={
+          <TranslatedText
+            stringId="labs.modal.new.form.screen1.requestingClinician.label"
+            fallback="Requesting :clinician"
+            replacements={{ clinician: clinicianText.toLowerCase() }}
+          />
+        }
         required
         component={AutocompleteField}
         suggester={practitionerSuggester}
       />
       <Field
         name="requestedDate"
-        label="Request date & time"
+        label=<TranslatedText
+          stringId="labs.modal.new.form.screen1.requestDateTime.label"
+          fallback="Request date & time"
+        />
         required
         component={DateTimeField}
         saveDateAsString
       />
       <Field
         name="departmentId"
-        label="Department"
+        label=<TranslatedText
+          stringId="labs.modal.new.form.screen1.department.label"
+          fallback="Department"
+        />
         component={AutocompleteField}
         suggester={departmentSuggester}
       />
       <Field
         name="labTestPriorityId"
-        label="Priority"
+        label=<TranslatedText
+          stringId="labs.modal.new.form.screen1.priority.label"
+          fallback="Priority"
+        />
         component={SuggesterSelectField}
         endpoint="labTestPriority"
       />

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen1.js
@@ -40,7 +40,7 @@ export const LabRequestFormScreen1 = ({
         name="requestedById"
         label={
           <TranslatedText
-            stringId="labs.modal.new.form.screen1.requestingClinician.label"
+            stringId="labs.modal.new.form.requestingClinician.label"
             fallback="Requesting :clinician"
             replacements={{ clinician: clinicianText.toLowerCase() }}
           />
@@ -52,7 +52,7 @@ export const LabRequestFormScreen1 = ({
       <Field
         name="requestedDate"
         label=<TranslatedText
-          stringId="labs.modal.new.form.screen1.requestDateTime.label"
+          stringId="labs.modal.new.form.requestDateTime.label"
           fallback="Request date & time"
         />
         required
@@ -62,7 +62,7 @@ export const LabRequestFormScreen1 = ({
       <Field
         name="departmentId"
         label=<TranslatedText
-          stringId="labs.modal.new.form.screen1.department.label"
+          stringId="labs.modal.new.form.department.label"
           fallback="Department"
         />
         component={AutocompleteField}
@@ -70,10 +70,7 @@ export const LabRequestFormScreen1 = ({
       />
       <Field
         name="labTestPriorityId"
-        label=<TranslatedText
-          stringId="labs.modal.new.form.screen1.priority.label"
-          fallback="Priority"
-        />
+        label=<TranslatedText stringId="labs.modal.new.form.priority.label" fallback="Priority" />
         component={SuggesterSelectField}
         endpoint="labTestPriority"
       />

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -71,7 +71,9 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
-    subheading: <TranslatedText stringId="lab.form.panel.select.heading" fallback="Select panel" />,
+    subheading: (
+      <TranslatedText stringId="lab.form.testSelect.panel.subheading" fallback="Select panel" />
+    ),
     instructions: (
       <TranslatedText
         stringId="lab.form.testSelect.panel.instruction"

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -51,7 +51,7 @@ export const screen2ValidationSchema = yup.object().shape({
 
 export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
-    subheading: <TranslatedText stringId="lab.form.test.select" fallback="Select tests" />,
+    subheading: <TranslatedText stringId="lab.form.test.select.heading" fallback="Select tests" />,
     instructions: (
       <>
         <TranslatedText
@@ -69,7 +69,7 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
-    subheading: <TranslatedText stringId="lab.form.panel.select" fallback="Select panel" />,
+    subheading: <TranslatedText stringId="lab.form.panel.select.heading" fallback="Select panel" />,
     instructions: (
       <TranslatedText
         stringId="lab.form.panel.select.instruction"
@@ -87,7 +87,9 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
     fieldName: 'panelIds',
   },
   [LAB_REQUEST_FORM_TYPES.SUPERSET]: {
-    subheading: <TranslatedText stringId="lab.form.superset.select" fallback="Select superset" />,
+    subheading: (
+      <TranslatedText stringId="lab.form.superset.select.heading" fallback="Select superset" />
+    ),
     instructions: (
       <>
         <TranslatedText

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Field, TextField } from '../../components';
 import { TestSelectorField } from '../../views/labRequest/TestSelector';
 import { BodyText, Heading3 } from '../../components/Typography';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const StyledBodyText = styled(BodyText)`
   margin-bottom: 28px;
@@ -38,17 +39,41 @@ export const screen2ValidationSchema = yup.object().shape({
 
 export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
-    subheading: 'Select tests',
-    instructions:
-      'Please select the test or tests you would like to request below and add any relevant notes. \nYou can filter test by category using the field below.',
+    subheading: (
+      <TranslatedText stringId="labs.modal.new.form.test.select" fallback="Select tests" />
+    ),
+    instructions: (
+      <>
+        <TranslatedText
+          stringId="labs.modal.new.form.test.instructions1"
+          fallback="Please select the test or tests you would like to request below and add any relevant notes."
+        />
+        {'\n'}
+        <TranslatedText
+          stringId="labs.modal.new.form.test.instructions2"
+          fallback="You can filter test by category using the field below."
+        />
+      </>
+    ),
     selectableName: 'test',
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
-    subheading: 'Select panel',
-    instructions:
-      'Please select the panel or panels you would like to request below and add any relevant notes.',
-    label: 'Select the test panel or panels',
+    subheading: (
+      <TranslatedText stringId="labs.modal.new.form.panel.select" fallback="Select panel" />
+    ),
+    instructions: (
+      <TranslatedText
+        stringId="labs.modal.new.form.panel.instruction"
+        fallback="Please select the panel or panels you would like to request below and add any relevant notes."
+      />
+    ),
+    label: (
+      <TranslatedText
+        stringId="labs.modal.new.form.panel.label"
+        fallback="Select the test panel or panels"
+      />
+    ),
     selectableName: 'panel',
     searchFieldPlaceholder: 'Search panel or category',
     fieldName: 'panelIds',
@@ -97,7 +122,13 @@ export const LabRequestFormScreen2 = props => {
         />
       </div>
       <div style={{ gridColumn: '1 / -1' }}>
-        <Field name="notes" label="Notes" component={TextField} multiline rows={3} />
+        <Field
+          name="notes"
+          label=<TranslatedText stringId="labs.modal.new.form.notes" fallback="Notes" />
+          component={TextField}
+          multiline
+          rows={3}
+        />
       </div>
     </>
   );

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -70,9 +70,7 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
         />
       </>
     ),
-    selectableName: (
-      <TranslatedText stringId="lab.form.testSelect.individual.selectableName" fallback="test" />
-    ), // TODO: Translate selectableName (requires refactoring in TestSelector.js)
+    selectableName: 'test', // TODO: Translate selectableName (requires refactoring in TestSelector.js)
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -51,34 +51,36 @@ export const screen2ValidationSchema = yup.object().shape({
 
 export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
-    subheading: <TranslatedText stringId="lab.form.test.select.heading" fallback="Select tests" />,
+    subheading: (
+      <TranslatedText stringId="lab.form.testSelect.individual.heading" fallback="Select tests" />
+    ),
     instructions: (
       <>
         <TranslatedText
-          stringId="lab.form.test.select.instruction"
+          stringId="lab.form.testSelect.individual.instructionLine1"
           fallback="Please select the test or tests you would like to request below and add any relevant notes."
         />
         {'\n'}
         <TranslatedText
-          stringId="lab.form.test.filter.instruction"
+          stringId="lab.form.testSelect.individual.instructionLine2"
           fallback="You can filter test by category using the field below."
         />
       </>
     ),
-    selectableName: 'test',
+    selectableName: 'test', // TODO: Translate selectableName (requires refactoring in TestSelector.js)
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
     subheading: <TranslatedText stringId="lab.form.panel.select.heading" fallback="Select panel" />,
     instructions: (
       <TranslatedText
-        stringId="lab.form.panel.select.instruction"
+        stringId="lab.form.testSelect.panel.instruction"
         fallback="Please select the panel or panels you would like to request below and add any relevant notes."
       />
     ),
     label: (
       <TranslatedText
-        stringId="lab.form.panel.select.label"
+        stringId="lab.form.testSelect.panel.label"
         fallback="Select the test panel or panels"
       />
     ),
@@ -88,17 +90,17 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
   },
   [LAB_REQUEST_FORM_TYPES.SUPERSET]: {
     subheading: (
-      <TranslatedText stringId="lab.form.superset.select.heading" fallback="Select superset" />
+      <TranslatedText stringId="lab.form.testSelect.superSet.heading" fallback="Select superset" />
     ),
     instructions: (
       <>
         <TranslatedText
-          stringId="lab.form.superset.select.instruction"
+          stringId="lab.form.testSelect.superset.instructionLine1"
           fallback="Please select the superset you would like to request below and add any relevant notes."
         />
         ,{'\n'}
         <TranslatedText
-          stringId="lab.form.superset.add.instruction"
+          stringId="lab.form.testSelect.superset.instructionLine2"
           fallback="You can also remove or add additional panels to your request."
         />
       </>
@@ -145,7 +147,7 @@ export const LabRequestFormScreen2 = props => {
       <div style={{ gridColumn: '1 / -1' }}>
         <Field
           name="notes"
-          label=<TranslatedText stringId="lab.form.notes.label" fallback="Notes" />
+          label=<TranslatedText stringId="general.form.notes.label" fallback="Notes" />
           component={TextField}
           multiline
           rows={3}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -22,7 +22,13 @@ export const screen2ValidationSchema = yup.object().shape({
       then: yup
         .array()
         .of(yup.string())
-        .min(1, 'Please select at least one test type'),
+        .min(
+          1,
+          <TranslatedText
+            stringId="lab.form.test.testType.validation"
+            fallback="Please select at least one test type"
+          />,
+        ),
     }),
   panelIds: yup
     .array()
@@ -32,7 +38,13 @@ export const screen2ValidationSchema = yup.object().shape({
       then: yup
         .array()
         .of(yup.string())
-        .min(1, 'Please select at least one panel'),
+        .min(
+          1,
+          <TranslatedText
+            stringId="lab.form.panel.testType.validation"
+            fallback="Please select at least one panel"
+          />,
+        ),
     }),
   notes: yup.string(),
 });
@@ -48,7 +60,7 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
         />
         {'\n'}
         <TranslatedText
-          stringId="lab.form.test.filter.nstruction"
+          stringId="lab.form.test.filter.instruction"
           fallback="You can filter test by category using the field below."
         />
       </>
@@ -75,9 +87,20 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
     fieldName: 'panelIds',
   },
   [LAB_REQUEST_FORM_TYPES.SUPERSET]: {
-    subheading: 'Select superset',
-    instructions:
-      'Please select the superset you would like to request below and add any relevant notes. \nYou can also remove or add additional panels to your request.',
+    subheading: <TranslatedText stringId="lab.form.superset.select" fallback="Select superset" />,
+    instructions: (
+      <>
+        <TranslatedText
+          stringId="lab.form.superset.select.instruction"
+          fallback="Please select the superset you would like to request below and add any relevant notes."
+        />
+        ,{'\n'}
+        <TranslatedText
+          stringId="lab.form.superset.add.instruction"
+          fallback="You can also remove or add additional panels to your request."
+        />
+      </>
+    ),
     selectableName: 'panel',
   },
 };
@@ -120,7 +143,7 @@ export const LabRequestFormScreen2 = props => {
       <div style={{ gridColumn: '1 / -1' }}>
         <Field
           name="notes"
-          label=<TranslatedText stringId="labs.modal.new.form.notes" fallback="Notes" />
+          label=<TranslatedText stringId="lab.form.notes.label" fallback="Notes" />
           component={TextField}
           multiline
           rows={3}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -39,18 +39,16 @@ export const screen2ValidationSchema = yup.object().shape({
 
 export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
-    subheading: (
-      <TranslatedText stringId="labs.modal.new.form.test.select" fallback="Select tests" />
-    ),
+    subheading: <TranslatedText stringId="lab.form.test.select" fallback="Select tests" />,
     instructions: (
       <>
         <TranslatedText
-          stringId="labs.modal.new.form.test.instructions1"
+          stringId="lab.form.test.select.instruction"
           fallback="Please select the test or tests you would like to request below and add any relevant notes."
         />
         {'\n'}
         <TranslatedText
-          stringId="labs.modal.new.form.test.instructions2"
+          stringId="lab.form.test.filter.nstruction"
           fallback="You can filter test by category using the field below."
         />
       </>
@@ -59,18 +57,16 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
-    subheading: (
-      <TranslatedText stringId="labs.modal.new.form.panel.select" fallback="Select panel" />
-    ),
+    subheading: <TranslatedText stringId="lab.form.panel.select" fallback="Select panel" />,
     instructions: (
       <TranslatedText
-        stringId="labs.modal.new.form.panel.instruction"
+        stringId="lab.form.panel.select.instruction"
         fallback="Please select the panel or panels you would like to request below and add any relevant notes."
       />
     ),
     label: (
       <TranslatedText
-        stringId="labs.modal.new.form.panel.label"
+        stringId="lab.form.panel.select.label"
         fallback="Select the test panel or panels"
       />
     ),

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen2.js
@@ -25,7 +25,7 @@ export const screen2ValidationSchema = yup.object().shape({
         .min(
           1,
           <TranslatedText
-            stringId="lab.form.test.testType.validation"
+            stringId="lab.form.testSelect.individual.testTypes.validation"
             fallback="Please select at least one test type"
           />,
         ),
@@ -41,7 +41,7 @@ export const screen2ValidationSchema = yup.object().shape({
         .min(
           1,
           <TranslatedText
-            stringId="lab.form.panel.testType.validation"
+            stringId="lab.form.testSelect.panel.testTypes.validation"
             fallback="Please select at least one panel"
           />,
         ),
@@ -52,7 +52,10 @@ export const screen2ValidationSchema = yup.object().shape({
 export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
     subheading: (
-      <TranslatedText stringId="lab.form.testSelect.individual.heading" fallback="Select tests" />
+      <TranslatedText
+        stringId="lab.form.testSelect.individual.subheading"
+        fallback="Select tests"
+      />
     ),
     instructions: (
       <>
@@ -67,7 +70,9 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
         />
       </>
     ),
-    selectableName: 'test', // TODO: Translate selectableName (requires refactoring in TestSelector.js)
+    selectableName: (
+      <TranslatedText stringId="lab.form.testSelect.individual.selectableName" fallback="test" />
+    ), // TODO: Translate selectableName (requires refactoring in TestSelector.js)
     fieldName: 'labTestTypeIds',
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
@@ -92,7 +97,10 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
   },
   [LAB_REQUEST_FORM_TYPES.SUPERSET]: {
     subheading: (
-      <TranslatedText stringId="lab.form.testSelect.superSet.heading" fallback="Select superset" />
+      <TranslatedText
+        stringId="lab.form.testSelect.superSet.subheading"
+        fallback="Select superset"
+      />
     ),
     instructions: (
       <>

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen3.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen3.js
@@ -6,6 +6,7 @@ import {
   SampleDetailsField,
   SAMPLE_DETAILS_FIELD_PREFIX,
 } from '../../views/labRequest/SampleDetailsField';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const StyledBodyText = styled(BodyText)`
   margin-bottom: 28px;
@@ -42,10 +43,18 @@ export const LabRequestFormScreen3 = props => {
 
   return (
     <div style={{ gridColumn: '1 / -1' }}>
-      <Heading3 mb="12px">Sample details</Heading3>
+      <Heading3 mb="12px">
+        <TranslatedText
+          stringId="labs.modal.new.form.sampleDetails.heading"
+          fallback="Sample details"
+        />
+      </Heading3>
       <StyledBodyText mb="28px" color="textTertiary">
-        Please record details for the samples that have been collected. Otherwise leave blank and
-        click ‘Finalise’.
+        <TranslatedText
+          stringId="labs.modal.new.form.sampleDetails.instructions"
+          fallback="Please record details for the samples that have been collected. Otherwise leave blank and
+        click ‘Finalise’."
+        />
       </StyledBodyText>
       <Field
         name="sampleDetails"

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen3.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormScreen3.js
@@ -44,14 +44,11 @@ export const LabRequestFormScreen3 = props => {
   return (
     <div style={{ gridColumn: '1 / -1' }}>
       <Heading3 mb="12px">
-        <TranslatedText
-          stringId="labs.modal.new.form.sampleDetails.heading"
-          fallback="Sample details"
-        />
+        <TranslatedText stringId="lab.form.sampleDetails.heading" fallback="Sample details" />
       </Heading3>
       <StyledBodyText mb="28px" color="textTertiary">
         <TranslatedText
-          stringId="labs.modal.new.form.sampleDetails.instructions"
+          stringId="lab.form.sampleDetails.instruction"
           fallback="Please record details for the samples that have been collected. Otherwise leave blank and
         click ‘Finalise’."
         />

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -11,42 +11,30 @@ import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const OPTIONS = {
   INDIVIDUAL: {
-    label: (
-      <TranslatedText
-        stringId="labs.modal.new.form.screen1.formType.individual"
-        fallback="Individual"
-      />
-    ),
+    label: <TranslatedText stringId="lab.form.type.individual" fallback="Individual" />,
     description: (
       <TranslatedText
-        stringId="labs.modal.new.form.screen1.formType.individual.subText"
+        stringId="lab.form.type.individual.description"
         fallback="Select an individual or multiple individual tests"
       />
     ),
     value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
   },
   PANEL: {
-    label: (
-      <TranslatedText stringId="labs.modal.new.form.screen1.formType.panel" fallback="Panel" />
-    ),
+    label: <TranslatedText stringId="lab.form.type.panel" fallback="Panel" />,
     description: (
       <TranslatedText
-        stringId="labs.modal.new.form.screen1.formType.panel.subText"
+        stringId="lab.form.type.panel.description"
         fallback="Select from a list of test panels"
       />
     ),
     value: LAB_REQUEST_FORM_TYPES.PANEL,
   },
   SUPERSET: {
-    label: (
-      <TranslatedText
-        stringId="labs.modal.new.form.screen1.formType.superset"
-        fallback="Superset"
-      />
-    ),
+    label: <TranslatedText stringId="lab.form.type.superset" fallback="Superset" />,
     description: (
       <TranslatedText
-        stringId="labs.modal.new.form.screen1.formType.superset.subText"
+        stringId="lab.form.type.superset.description"
         fallback="Select from a list of supersets"
       />
     ),
@@ -115,7 +103,7 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
       <OuterLabelFieldWrapper
         label={
           <TranslatedText
-            stringId="labs.modal.new.form.screen1.formType.label"
+            stringId="labs.form.requestType.label"
             fallback="Select your request type"
           />
         }

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -11,30 +11,34 @@ import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const OPTIONS = {
   INDIVIDUAL: {
-    label: <TranslatedText stringId="lab.form.type.individual.label" fallback="Individual" />,
+    label: (
+      <TranslatedText stringId="lab.form.formType.option.individual.label" fallback="Individual" />
+    ),
     description: (
       <TranslatedText
-        stringId="lab.form.type.individual.description"
+        stringId="lab.form.formType.option.individual.description"
         fallback="Select an individual or multiple individual tests"
       />
     ),
     value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
   },
   PANEL: {
-    label: <TranslatedText stringId="lab.form.type.panel.label" fallback="Panel" />,
+    label: <TranslatedText stringId="lab.form.formType.option.panel.label" fallback="Panel" />,
     description: (
       <TranslatedText
-        stringId="lab.form.type.panel.description"
+        stringId="lab.form.formType.option.panel.description"
         fallback="Select from a list of test panels"
       />
     ),
     value: LAB_REQUEST_FORM_TYPES.PANEL,
   },
   SUPERSET: {
-    label: <TranslatedText stringId="lab.form.type.superset.label" fallback="Superset" />,
+    label: (
+      <TranslatedText stringId="lab.form.formType.option.superset.label" fallback="Superset" />
+    ),
     description: (
       <TranslatedText
-        stringId="lab.form.type.superset.description"
+        stringId="lab.form.formType.option.superset.description"
         fallback="Select from a list of supersets"
       />
     ),
@@ -102,10 +106,7 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
     <div style={{ gridColumn: '1 / -1' }}>
       <OuterLabelFieldWrapper
         label={
-          <TranslatedText
-            stringId="lab.form.requestType.label"
-            fallback="Select your request type"
-          />
+          <TranslatedText stringId="lab.form.formType.label" fallback="Select your request type" />
         }
         required
       >

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -103,7 +103,7 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
       <OuterLabelFieldWrapper
         label={
           <TranslatedText
-            stringId="labs.form.requestType.label"
+            stringId="lab.form.requestType.label"
             fallback="Select your request type"
           />
         }

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -7,21 +7,49 @@ import { Field, OuterLabelFieldWrapper, RadioField } from '../../components';
 import { useApi } from '../../api';
 import { useLocalisation } from '../../contexts/Localisation';
 import { Colors } from '../../constants';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const OPTIONS = {
   INDIVIDUAL: {
-    label: 'Individual',
-    description: 'Select an individual or multiple individual tests',
+    label: (
+      <TranslatedText
+        stringId="labs.modal.new.form.screen1.formType.individual"
+        fallback="Individual"
+      />
+    ),
+    description: (
+      <TranslatedText
+        stringId="labs.modal.new.form.screen1.formType.individual.subText"
+        fallback="Select an individual or multiple individual tests"
+      />
+    ),
     value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
   },
   PANEL: {
-    label: 'Panel',
-    description: 'Select from a list of test panels',
+    label: (
+      <TranslatedText stringId="labs.modal.new.form.screen1.formType.panel" fallback="Panel" />
+    ),
+    description: (
+      <TranslatedText
+        stringId="labs.modal.new.form.screen1.formType.panel.subText"
+        fallback="Select from a list of test panels"
+      />
+    ),
     value: LAB_REQUEST_FORM_TYPES.PANEL,
   },
   SUPERSET: {
-    label: 'Superset',
-    description: 'Select from a list of supersets',
+    label: (
+      <TranslatedText
+        stringId="labs.modal.new.form.screen1.formType.superset"
+        fallback="Superset"
+      />
+    ),
+    description: (
+      <TranslatedText
+        stringId="labs.modal.new.form.screen1.formType.superset.subText"
+        fallback="Select from a list of supersets"
+      />
+    ),
     value: LAB_REQUEST_FORM_TYPES.SUPERSET,
   },
 };
@@ -84,7 +112,15 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
 
   return (
     <div style={{ gridColumn: '1 / -1' }}>
-      <OuterLabelFieldWrapper label="Select your request type" required>
+      <OuterLabelFieldWrapper
+        label={
+          <TranslatedText
+            stringId="labs.modal.new.form.screen1.formType.label"
+            fallback="Select your request type"
+          />
+        }
+        required
+      >
         {isLoading ? (
           <RadioItemSkeleton itemsLength={POSSIBLE_OPTIONS_LIST.length} />
         ) : (

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestFormTypeRadioField.js
@@ -11,7 +11,7 @@ import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const OPTIONS = {
   INDIVIDUAL: {
-    label: <TranslatedText stringId="lab.form.type.individual" fallback="Individual" />,
+    label: <TranslatedText stringId="lab.form.type.individual.label" fallback="Individual" />,
     description: (
       <TranslatedText
         stringId="lab.form.type.individual.description"
@@ -21,7 +21,7 @@ const OPTIONS = {
     value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
   },
   PANEL: {
-    label: <TranslatedText stringId="lab.form.type.panel" fallback="Panel" />,
+    label: <TranslatedText stringId="lab.form.type.panel.label" fallback="Panel" />,
     description: (
       <TranslatedText
         stringId="lab.form.type.panel.description"
@@ -31,7 +31,7 @@ const OPTIONS = {
     value: LAB_REQUEST_FORM_TYPES.PANEL,
   },
   SUPERSET: {
-    label: <TranslatedText stringId="lab.form.type.superset" fallback="Superset" />,
+    label: <TranslatedText stringId="lab.form.type.superset.label" fallback="Superset" />,
     description: (
       <TranslatedText
         stringId="lab.form.type.superset.description"

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -71,7 +71,7 @@ export const LabRequestMultiStepForm = ({
         />
       </FormStep>
       <FormStep
-        submitButtonText={<TranslatedText stringId="general.action.finalise" fallback="finalise" />}
+        submitButtonText={<TranslatedText stringId="general.action.finalise" fallback="Finalise" />}
       >
         <LabRequestFormScreen3
           practitionerSuggester={practitionerSuggester}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -11,6 +11,7 @@ import { LabRequestFormScreen1 } from './LabRequestFormScreen1';
 import { LabRequestFormScreen2, screen2ValidationSchema } from './LabRequestFormScreen2';
 import { LabRequestFormScreen3 } from './LabRequestFormScreen3';
 import { useLocalisedText } from '../../components';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 export const LabRequestMultiStepForm = ({
   isSubmitting,
@@ -69,7 +70,9 @@ export const LabRequestMultiStepForm = ({
           }}
         />
       </FormStep>
-      <FormStep submitButtonText="Finalise">
+      <FormStep
+        submitButtonText={<TranslatedText stringId="general.action.finalise" fallback="finalise" />}
+      >
         <LabRequestFormScreen3
           practitionerSuggester={practitionerSuggester}
           specimenTypeSuggester={specimenTypeSuggester}

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -33,7 +33,7 @@ export const LabRequestMultiStepForm = ({
   const screen1ValidationSchema = yup.object().shape({
     requestedById: foreignKey(
       <TranslatedText
-        stringId="lab.form.requestedById.validation"
+        stringId="lab.form.requestedBy.validation"
         fallback="Requesting :clinicianText is required"
         replacements={{ clinicianText: clinicianText.toLowerCase() }}
       />,

--- a/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
+++ b/packages/desktop/app/forms/LabRequestForm/LabRequestMultiStepForm.js
@@ -31,12 +31,30 @@ export const LabRequestMultiStepForm = ({
 
   // For fields please see LabRequestFormScreen1.js
   const screen1ValidationSchema = yup.object().shape({
-    requestedById: foreignKey(`Requesting ${clinicianText.toLowerCase()} is required`),
-    requestedDate: yup.date().required('Request date is required'),
+    requestedById: foreignKey(
+      <TranslatedText
+        stringId="lab.form.requestedById.validation"
+        fallback="Requesting :clinicianText is required"
+        replacements={{ clinicianText: clinicianText.toLowerCase() }}
+      />,
+    ),
+    requestedDate: yup
+      .date()
+      .required(
+        <TranslatedText
+          stringId="lab.form.requestedDate.validation"
+          fallback="Request date is required"
+        />,
+      ),
     requestFormType: yup
       .string()
       .oneOf(Object.values(LAB_REQUEST_FORM_TYPES))
-      .required('Request type must be selected'),
+      .required(
+        <TranslatedText
+          stringId="lab.form.requestFormType.validation"
+          fallback="Request type must be selected"
+        />,
+      ),
   });
   const combinedValidationSchema = screen1ValidationSchema.concat(screen2ValidationSchema);
 

--- a/packages/desktop/app/forms/MultiStepForm.js
+++ b/packages/desktop/app/forms/MultiStepForm.js
@@ -8,6 +8,7 @@ import {
   FormSeparatorLine,
   OutlinedButton,
 } from '../components';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const StyledBackButton = styled(OutlinedButton)`
   margin-right: auto;
@@ -74,7 +75,11 @@ export const MultiStepForm = ({ children, initialValues, onSubmit, onCancel, onC
                 <StyledBackButton onClick={() => previous(props.values)}>Back</StyledBackButton>
               )}
               <FormSubmitCancelRow
-                confirmText={step.props.submitButtonText || 'Next'}
+                confirmText={
+                  step.props.submitButtonText || (
+                    <TranslatedText stringId="general.action.next" fallback="Next" />
+                  )
+                }
                 onCancel={onCancel}
               />
             </ButtonRow>

--- a/packages/desktop/app/forms/MultiStepForm.js
+++ b/packages/desktop/app/forms/MultiStepForm.js
@@ -72,7 +72,9 @@ export const MultiStepForm = ({ children, initialValues, onSubmit, onCancel, onC
             <FormSeparatorLine />
             <ButtonRow>
               {stepNumber > 0 && (
-                <StyledBackButton onClick={() => previous(props.values)}>Back</StyledBackButton>
+                <StyledBackButton onClick={() => previous(props.values)}>
+                  <TranslatedText stringId="general.action.back" fallback="Back" />
+                </StyledBackButton>
               )}
               <FormSubmitCancelRow
                 confirmText={

--- a/packages/desktop/app/views/labRequest/SampleDetailsField.js
+++ b/packages/desktop/app/views/labRequest/SampleDetailsField.js
@@ -53,26 +53,17 @@ const StyledField = styled(Field)`
 `;
 
 const HEADERS = [
+  <TranslatedText stringId="lab.sampleDetail.table.column.category" fallback="Category" />,
   <TranslatedText
-    stringId="labs.modal.new.sampleDetails.table.header.category"
-    fallback="Category"
-  />,
-  <TranslatedText
-    stringId="labs.modal.new.sampleDetails.table.header.collectionDateTime"
+    stringId="lab.sampleDetail.table.column.collectionDateTime"
     fallback="Date & time collected"
   />,
-  <TranslatedText
-    stringId="labs.modal.new.sampleDetails.table.header.collectedBy"
-    fallback="Collected by"
-  />,
-  <TranslatedText
-    stringId="labs.modal.new.sampleDetails.table.header.specimenType"
-    fallback="Specimen type"
-  />,
-  <TranslatedText stringId="labs.modal.new.sampleDetails.table.header.site" fallback="Site" />,
+  <TranslatedText stringId="lab.sampleDetail.table.column.collectedBy" fallback="Collected by" />,
+  <TranslatedText stringId="lab.sampleDetail.table.column.specimenType" fallback="Specimen type" />,
+  <TranslatedText stringId="lab.sampleDetail.table.column.site" fallback="Site" />,
 ];
 const WITH_PANELS_HEADERS = [
-  <TranslatedText stringId="labs.modal.new.sampleDetails.table.header.panel" fallback="Panel" />,
+  <TranslatedText stringId="lab.sampleDetail.table.column.panel" fallback="Panel" />,
   ...HEADERS,
 ];
 export const SAMPLE_DETAILS_FIELD_PREFIX = 'sample-details-field-';

--- a/packages/desktop/app/views/labRequest/SampleDetailsField.js
+++ b/packages/desktop/app/views/labRequest/SampleDetailsField.js
@@ -5,6 +5,7 @@ import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { Heading4 } from '../../components';
 import { DateTimeField, Field, AutocompleteField } from '../../components/Field';
 import { Colors } from '../../constants';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const Container = styled.div`
   border: 1px solid ${Colors.outline};
@@ -51,8 +52,29 @@ const StyledField = styled(Field)`
   }
 `;
 
-const HEADERS = ['Category', 'Date & time collected', 'Collected by', 'Specimen type', 'Site'];
-const WITH_PANELS_HEADERS = ['Panel', ...HEADERS];
+const HEADERS = [
+  <TranslatedText
+    stringId="labs.modal.new.sampleDetails.table.header.category"
+    fallback="Category"
+  />,
+  <TranslatedText
+    stringId="labs.modal.new.sampleDetails.table.header.collectionDateTime"
+    fallback="Date & time collected"
+  />,
+  <TranslatedText
+    stringId="labs.modal.new.sampleDetails.table.header.collectedBy"
+    fallback="Collected by"
+  />,
+  <TranslatedText
+    stringId="labs.modal.new.sampleDetails.table.header.specimenType"
+    fallback="Specimen type"
+  />,
+  <TranslatedText stringId="labs.modal.new.sampleDetails.table.header.site" fallback="Site" />,
+];
+const WITH_PANELS_HEADERS = [
+  <TranslatedText stringId="labs.modal.new.sampleDetails.table.header.panel" fallback="Panel" />,
+  ...HEADERS,
+];
 export const SAMPLE_DETAILS_FIELD_PREFIX = 'sample-details-field-';
 
 export const SampleDetailsField = ({

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -215,7 +215,7 @@ export const TestSelectorInput = ({
                 initialOptions={[{ label: 'All', value: '' }]}
                 label={
                   <TranslatedText
-                    stringId="labs.modal.new.form.testCategory"
+                    stringId="labs.form.testCategory.label"
                     fallback="Test category"
                   />
                 }

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -214,7 +214,10 @@ export const TestSelectorInput = ({
                 }}
                 initialOptions={[{ label: 'All', value: '' }]}
                 label={
-                  <TranslatedText stringId="lab.form.testSelect.label" fallback="Test category" />
+                  <TranslatedText
+                    stringId="lab.form.testSelect.testCategory.label"
+                    fallback="Test category"
+                  />
                 }
                 endpoint="labTestCategory"
                 name="labTestCategoryId"

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -212,7 +212,12 @@ export const TestSelectorInput = ({
                   value: searchQuery.labTestCategoryId,
                   onChange: handleChangeSearchQuery,
                 }}
-                initialOptions={[{ label: 'All', value: '' }]}
+                initialOptions={[
+                  {
+                    label: <TranslatedText stringId="general.select.all" fallback="All" />,
+                    value: '',
+                  },
+                ]}
                 label={
                   <TranslatedText
                     stringId="lab.form.testSelect.testCategory.label"

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -214,7 +214,7 @@ export const TestSelectorInput = ({
                 }}
                 initialOptions={[{ label: 'All', value: '' }]}
                 label={
-                  <TranslatedText stringId="lab.form.testCategory.label" fallback="Test category" />
+                  <TranslatedText stringId="lab.form.testSelect.label" fallback="Test category" />
                 }
                 endpoint="labTestCategory"
                 name="labTestCategoryId"

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -158,7 +158,7 @@ export const TestSelectorInput = ({
   const {
     selectableName,
     label = labelConfig.subheading,
-    searchFieldPlaceholder = <TranslatedText stringId="general.action.search" fallback="Search" />,
+    searchFieldPlaceholder = 'Search',
   } = labelConfig;
   const [searchQuery, setSearchQuery] = useState({
     labTestCategoryId: '',
@@ -214,10 +214,7 @@ export const TestSelectorInput = ({
                 }}
                 initialOptions={[{ label: 'All', value: '' }]}
                 label={
-                  <TranslatedText
-                    stringId="labs.form.testCategory.label"
-                    fallback="Test category"
-                  />
+                  <TranslatedText stringId="lab.form.testCategory.label" fallback="Test category" />
                 }
                 endpoint="labTestCategory"
                 name="labTestCategoryId"
@@ -266,7 +263,11 @@ export const TestSelectorInput = ({
         <SelectorContainer>
           <Box display="flex" justifyContent="space-between">
             <SectionHeader>Selected {selectableName}s</SectionHeader>
-            {value.length > 0 && <ClearAllButton onClick={handleClear}>Clear all</ClearAllButton>}
+            {value.length > 0 && (
+              <ClearAllButton onClick={handleClear}>
+                <TranslatedText stringId="general.action.clearAll" fallback="Clear all" />
+              </ClearAllButton>
+            )}
           </Box>
           <FormSeparatorLine />
           <SelectorTable>

--- a/packages/desktop/app/views/labRequest/TestSelector.js
+++ b/packages/desktop/app/views/labRequest/TestSelector.js
@@ -11,6 +11,7 @@ import { SearchField, SuggesterSelectField } from '../../components/Field';
 import { TextButton } from '../../components/Button';
 import { BodyText } from '../../components/Typography';
 import { SelectableTestItem, TestItem } from './TestItem';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const SELECTABLE_DATA_ENDPOINTS = {
   [LAB_REQUEST_FORM_TYPES.PANEL]: 'labTestPanel',
@@ -157,7 +158,7 @@ export const TestSelectorInput = ({
   const {
     selectableName,
     label = labelConfig.subheading,
-    searchFieldPlaceholder = 'Search',
+    searchFieldPlaceholder = <TranslatedText stringId="general.action.search" fallback="Search" />,
   } = labelConfig;
   const [searchQuery, setSearchQuery] = useState({
     labTestCategoryId: '',
@@ -212,7 +213,12 @@ export const TestSelectorInput = ({
                   onChange: handleChangeSearchQuery,
                 }}
                 initialOptions={[{ label: 'All', value: '' }]}
-                label="Test category"
+                label={
+                  <TranslatedText
+                    stringId="labs.modal.new.form.testCategory"
+                    fallback="Test category"
+                  />
+                }
                 endpoint="labTestCategory"
                 name="labTestCategoryId"
               />

--- a/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
+++ b/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
@@ -13,14 +13,44 @@ import {
   getDateWithTimeTooltip,
   getRequestId,
 } from '../../utils/lab';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const columns = [
-  { key: 'requestId', title: 'Test ID', sortable: false, accessor: getRequestId },
-  { key: 'category.name', title: 'Test category', accessor: getRequestType },
-  { key: 'requestedDate', title: 'Requested at time', accessor: getDateWithTimeTooltip },
-  { key: 'displayName', title: 'Requested by', accessor: getRequestedBy, sortable: false },
-  { key: 'priority.name', title: 'Priority', accessor: getPriority },
-  { key: 'status', title: 'Status', accessor: getStatus, maxWidth: 200 },
+  {
+    key: 'requestId',
+    title: <TranslatedText stringId="labs.table.column.testId" fallback="Test ID" />,
+    sortable: false,
+    accessor: getRequestId,
+  },
+  {
+    key: 'category.name',
+    title: <TranslatedText stringId="labs.table.column.testCategory" fallback="Test category" />,
+    accessor: getRequestType,
+  },
+  {
+    key: 'requestedDate',
+    title: (
+      <TranslatedText stringId="labs.table.column.requestedDate" fallback="Requested at time" />
+    ),
+    accessor: getDateWithTimeTooltip,
+  },
+  {
+    key: 'displayName',
+    title: <TranslatedText stringId="labs.table.column.requestedBy" fallback="Requested by" />,
+    accessor: getRequestedBy,
+    sortable: false,
+  },
+  {
+    key: 'priority.name',
+    title: <TranslatedText stringId="labs.table.column.priority" fallback="Priority" />,
+    accessor: getPriority,
+  },
+  {
+    key: 'status',
+    title: <TranslatedText stringId="labs.table.column.status" fallback="Status" />,
+    accessor: getStatus,
+    maxWidth: 200,
+  },
 ];
 
 export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
@@ -40,7 +70,9 @@ export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
     <DataFetchingTable
       endpoint={`encounter/${encounterId}/labRequests`}
       columns={columns}
-      noDataMessage="No lab requests found"
+      noDataMessage={
+        <TranslatedText stringId="labs.table.noData" fallback="No lab requests found" />
+      }
       onRowClick={selectLab}
       initialSort={{ order: 'desc', orderBy: 'requestedDate' }}
     />

--- a/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
+++ b/packages/desktop/app/views/patients/EncounterLabRequestsTable.js
@@ -18,36 +18,36 @@ import { TranslatedText } from '../../components/Translation/TranslatedText';
 const columns = [
   {
     key: 'requestId',
-    title: <TranslatedText stringId="labs.table.column.testId" fallback="Test ID" />,
+    title: <TranslatedText stringId="lab.table.column.testId" fallback="Test ID" />,
     sortable: false,
     accessor: getRequestId,
   },
   {
     key: 'category.name',
-    title: <TranslatedText stringId="labs.table.column.testCategory" fallback="Test category" />,
+    title: <TranslatedText stringId="lab.table.column.testCategory" fallback="Test category" />,
     accessor: getRequestType,
   },
   {
     key: 'requestedDate',
     title: (
-      <TranslatedText stringId="labs.table.column.requestedDate" fallback="Requested at time" />
+      <TranslatedText stringId="lab.table.column.requestedDate" fallback="Requested at time" />
     ),
     accessor: getDateWithTimeTooltip,
   },
   {
     key: 'displayName',
-    title: <TranslatedText stringId="labs.table.column.requestedBy" fallback="Requested by" />,
+    title: <TranslatedText stringId="lab.table.column.requestedBy" fallback="Requested by" />,
     accessor: getRequestedBy,
     sortable: false,
   },
   {
     key: 'priority.name',
-    title: <TranslatedText stringId="labs.table.column.priority" fallback="Priority" />,
+    title: <TranslatedText stringId="lab.table.column.priority" fallback="Priority" />,
     accessor: getPriority,
   },
   {
     key: 'status',
-    title: <TranslatedText stringId="labs.table.column.status" fallback="Status" />,
+    title: <TranslatedText stringId="lab.table.column.status" fallback="Status" />,
     accessor: getStatus,
     maxWidth: 200,
   },
@@ -71,7 +71,7 @@ export const EncounterLabRequestsTable = React.memo(({ encounterId }) => {
       endpoint={`encounter/${encounterId}/labRequests`}
       columns={columns}
       noDataMessage={
-        <TranslatedText stringId="labs.table.noData" fallback="No lab requests found" />
+        <TranslatedText stringId="lab.table.noData" fallback="No lab requests found" />
       }
       onRowClick={selectLab}
       initialSort={{ order: 'desc', orderBy: 'requestedDate' }}

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -29,6 +29,7 @@ import { EncounterActions } from './components';
 import { useReferenceData } from '../../api/queries';
 import { useAuth } from '../../contexts/Auth';
 import { VitalChartDataProvider } from '../../contexts/VitalChartData';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const getIsTriage = encounter => ENCOUNTER_OPTIONS_BY_VALUE[encounter.encounterType].triageFlowOnly;
 
@@ -53,7 +54,7 @@ const TABS = [
     render: props => <ProcedurePane {...props} />,
   },
   {
-    label: 'Labs',
+    label: <TranslatedText stringId="encounter.tabs.labs" fallback="Labs" />,
     key: ENCOUNTER_TAB_NAMES.LABS,
     render: props => <LabsPane {...props} />,
   },

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -54,7 +54,7 @@ const TABS = [
     render: props => <ProcedurePane {...props} />,
   },
   {
-    label: <TranslatedText stringId="encounter.tabs.labs" fallback="Labs" />,
+    label: <TranslatedText stringId="encounter.tab.lab" fallback="Labs" />,
     key: ENCOUNTER_TAB_NAMES.LABS,
     render: props => <LabsPane {...props} />,
   },

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -54,7 +54,7 @@ const TABS = [
     render: props => <ProcedurePane {...props} />,
   },
   {
-    label: <TranslatedText stringId="encounter.tab.lab" fallback="Labs" />,
+    label: <TranslatedText stringId="encounter.tab.labs" fallback="Labs" />,
     key: ENCOUNTER_TAB_NAMES.LABS,
     render: props => <LabsPane {...props} />,
   },

--- a/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
+++ b/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
@@ -84,7 +84,7 @@ const getColumns = type => [
   {
     key: 'labTestCategory',
     title: (
-      <TranslatedText stringId="lab.requestSummary.table.column.category" fallback="Category" />
+      <TranslatedText stringId="lab.requestSummary.table.column.testCategory" fallback="Category" />
     ),
     sortable: false,
     accessor: ({ category }) => category?.name || '',
@@ -103,7 +103,7 @@ const getColumns = type => [
         <DateDisplay showTime date={sampleTime} />
       ) : (
         <TranslatedText
-          stringId="lab.requestSummary.table.sampleDate.noData"
+          stringId="lab.requestSummary.table.column.sampleDate.notCollected"
           fallback="Sample not collected"
         />
       ),
@@ -155,14 +155,16 @@ export const LabRequestSummaryPane = React.memo(
             <InfoCardItem
               label={
                 <TranslatedText
-                  stringId="lab.form.requestDateTime.label"
+                  stringId="general.form.requestDateTime.label"
                   fallback="Request date & time"
                 />
               }
               value={<DateDisplay date={requestedDate} showTime />}
             />
             <InfoCardItem
-              label={<TranslatedText stringId="lab.form.department.label" fallback="Department" />}
+              label={
+                <TranslatedText stringId="general.form.department.label" fallback="Department" />
+              }
               value={department?.name}
             />
             <InfoCardItem

--- a/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
+++ b/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
@@ -18,6 +18,7 @@ import {
 import { LabRequestPrintLabelModal } from '../../../components/PatientPrinting/modals/LabRequestPrintLabelModal';
 import { useLabRequestNotes } from '../../../api/queries';
 import { InfoCard, InfoCardItem } from '../../../components/InfoCard';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const Container = styled.div`
   padding-top: 20px;
@@ -62,31 +63,50 @@ const Actions = styled.div`
 const getColumns = type => [
   {
     key: 'displayId',
-    title: 'Test ID',
+    title: <TranslatedText stringId="lab.requestSummary.table.column.testId" fallback="Test ID" />,
     sortable: false,
   },
   ...(type === LAB_REQUEST_FORM_TYPES.PANEL
     ? [
         {
           key: 'panelId',
-          title: 'Panel',
+          title: (
+            <TranslatedText stringId="lab.requestSummary.table.column.panel" fallback="Panel" />
+          ),
           sortable: false,
-          accessor: ({ labTestPanelRequest }) => labTestPanelRequest?.labTestPanel?.name || 'N/A',
+          accessor: ({ labTestPanelRequest }) =>
+            labTestPanelRequest?.labTestPanel?.name || (
+              <TranslatedText stringId="general.fallback,notApplicable" fallback="N/A" />
+            ),
         },
       ]
     : []),
   {
     key: 'labTestCategory',
-    title: 'Category',
+    title: (
+      <TranslatedText stringId="lab.requestSummary.table.column.category" fallback="Category" />
+    ),
     sortable: false,
     accessor: ({ category }) => category?.name || '',
   },
   {
     key: 'sampleDate',
-    title: 'Sample date',
+    title: (
+      <TranslatedText
+        stringId="lab.requestSummary.table.column.sampleDate"
+        fallback="Sample date"
+      />
+    ),
     sortable: false,
     accessor: ({ sampleTime }) =>
-      sampleTime ? <DateDisplay showTime date={sampleTime} /> : 'Sample not collected',
+      sampleTime ? (
+        <DateDisplay showTime date={sampleTime} />
+      ) : (
+        <TranslatedText
+          stringId="lab.requestSummary.table.sampleDate.noData"
+          fallback="Sample not collected"
+        />
+      ),
   },
 ];
 
@@ -110,30 +130,52 @@ export const LabRequestSummaryPane = React.memo(
 
     return (
       <Container>
-        <Heading3 mb="12px">Request finalised</Heading3>
+        <Heading3 mb="12px">
+          <TranslatedText stringId="lab.form.requestSummary.heading" fallback="Request finalised" />
+        </Heading3>
         <BodyText mb="28px" color="textTertiary">
-          Your lab request has been finalised. Please select items from the list below to print
-          requests or sample labels.
+          <TranslatedText
+            stringId="lab.form.requestSummary.instruction"
+            fallback="Your lab request has been finalised. Please select items from the list below to print
+          requests or sample labels."
+          />
         </BodyText>
         <Card>
           <StyledInfoCard gridRowGap={10} elevated={false}>
             <InfoCardItem
-              label={`Requesting ${clinicianText.toLowerCase()}`}
+              label={
+                <TranslatedText
+                  stringId="lab.form.requestingClinician.label"
+                  fallback="Requesting :clinicianText"
+                  replacements={{ clinicianText: clinicianText.toLowerCase() }}
+                />
+              }
               value={requestedBy?.displayName}
             />
             <InfoCardItem
-              label="Request date & time"
+              label={
+                <TranslatedText
+                  stringId="lab.form.requestDateTime.label"
+                  fallback="Request date & time"
+                />
+              }
               value={<DateDisplay date={requestedDate} showTime />}
             />
-            <InfoCardItem label="Department" value={department?.name} />
-            <InfoCardItem label="Priority" value={priority ? priority.name : '-'} />
+            <InfoCardItem
+              label={<TranslatedText stringId="lab.form.department.label" fallback="Department" />}
+              value={department?.name}
+            />
+            <InfoCardItem
+              label={<TranslatedText stringId="lab.form.priority.label" fallback="Priority" />}
+              value={priority ? priority.name : '-'}
+            />
           </StyledInfoCard>
           <CardTable
             headerColor={Colors.white}
             columns={[selectableColumn, ...getColumns(requestFormType)]}
             data={labRequests}
             elevated={false}
-            noDataMessage="No lab requests found"
+            noDataMessage=<TranslatedText stringId="lab.requestSummary.table.noData" />
             allowExport={false}
           />
         </Card>
@@ -143,7 +185,7 @@ export const LabRequestSummaryPane = React.memo(
             onClick={() => setIsOpen(MODALS.LABEL_PRINT)}
             disabled={noRowSelected}
           >
-            Print label
+            <TranslatedText stringId="lab.action.printLabel" fallback="Print label" />
           </OutlinedButton>
           <LabRequestPrintLabelModal
             labRequests={selectedRows}
@@ -155,7 +197,7 @@ export const LabRequestSummaryPane = React.memo(
             size="small"
             onClick={() => setIsOpen(MODALS.PRINT)}
           >
-            Print request
+            <TranslatedText stringId="lab.action.printRequest" fallback="Print request" />
           </OutlinedButton>
           <MultipleLabRequestsPrintoutModal
             encounter={encounter}
@@ -169,7 +211,9 @@ export const LabRequestSummaryPane = React.memo(
         </Actions>
         <FormSeparatorLine />
         <Box display="flex" justifyContent="flex-end" pt={3}>
-          <Button onClick={onClose}>Close</Button>
+          <Button onClick={onClose}>
+            <TranslatedText stringId="general.action.close" fallback="Close" />
+          </Button>
         </Box>
       </Container>
     );

--- a/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
+++ b/packages/desktop/app/views/patients/components/LabRequestSummaryPane.js
@@ -76,7 +76,7 @@ const getColumns = type => [
           sortable: false,
           accessor: ({ labTestPanelRequest }) =>
             labTestPanelRequest?.labTestPanel?.name || (
-              <TranslatedText stringId="general.fallback,notApplicable" fallback="N/A" />
+              <TranslatedText stringId="general.fallback.notApplicable" fallback="N/A" />
             ),
         },
       ]

--- a/packages/desktop/app/views/patients/panes/LabsPane.js
+++ b/packages/desktop/app/views/patients/panes/LabsPane.js
@@ -4,6 +4,7 @@ import { EncounterLabRequestsTable } from '../EncounterLabRequestsTable';
 import { TableButtonRow, ButtonWithPermissionCheck } from '../../../components';
 import { PrintMultipleLabRequestsSelectionModal } from '../../../components/PatientPrinting';
 import { TabPane } from '../components';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 export const LabsPane = React.memo(({ encounter, readonly }) => {
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
@@ -31,7 +32,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
           color="primary"
           size="small"
         >
-          Print
+          <TranslatedText stringId="labs.action.print" fallback="Print" />
         </ButtonWithPermissionCheck>
         <ButtonWithPermissionCheck
           onClick={() => setNewRequestModalOpen(true)}
@@ -40,7 +41,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
           noun="LabRequest"
           size="small"
         >
-          New lab request
+          <TranslatedText stringId="labs.action.new" fallback="New lab request" />
         </ButtonWithPermissionCheck>
       </TableButtonRow>
       <EncounterLabRequestsTable encounterId={encounter.id} />

--- a/packages/desktop/app/views/patients/panes/LabsPane.js
+++ b/packages/desktop/app/views/patients/panes/LabsPane.js
@@ -32,7 +32,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
           color="primary"
           size="small"
         >
-          <TranslatedText stringId="labs.action.print" fallback="Print" />
+          <TranslatedText stringId="lab.action.print" fallback="Print" />
         </ButtonWithPermissionCheck>
         <ButtonWithPermissionCheck
           onClick={() => setNewRequestModalOpen(true)}
@@ -41,7 +41,7 @@ export const LabsPane = React.memo(({ encounter, readonly }) => {
           noun="LabRequest"
           size="small"
         >
-          <TranslatedText stringId="labs.action.new" fallback="New lab request" />
+          <TranslatedText stringId="lab.action.create" fallback="New lab request" />
         </ButtonWithPermissionCheck>
       </TableButtonRow>
       <EncounterLabRequestsTable encounterId={encounter.id} />


### PR DESCRIPTION
### Changes

Replaced non-reference data strings in the labs module with translated text components. 
Strings that were unable to translate with simple replacements are described in the linear ticket.
[NASS-964: Translate desktop labs module](https://linear.app/bes/issue/NASS-964/translate-desktop-labs-module)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
