### PR TITLE
NASS-960: Translate desktop 'Diagnoses' module

### DIFF
--- a/packages/desktop/app/components/DiagnosisModal.js
+++ b/packages/desktop/app/components/DiagnosisModal.js
@@ -3,6 +3,7 @@ import { useEncounter } from '../contexts/Encounter';
 import { DiagnosisForm } from '../forms/DiagnosisForm';
 import { useApi } from '../api';
 import { FormModal } from './FormModal';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const DiagnosisModal = React.memo(({ diagnosis, onClose, encounterId, ...props }) => {
   const api = useApi();
@@ -21,7 +22,11 @@ export const DiagnosisModal = React.memo(({ diagnosis, onClose, encounterId, ...
   };
 
   return (
-    <FormModal title="Diagnosis" open={!!diagnosis} onClose={onClose}>
+    <FormModal
+      title={<TranslatedText stringId="diagnosis.modal.title" fallback="Diagnosis" />}
+      open={!!diagnosis}
+      onClose={onClose}
+    >
       <DiagnosisForm onCancel={onClose} diagnosis={diagnosis} onSave={onSaveDiagnosis} {...props} />
     </FormModal>
   );

--- a/packages/desktop/app/components/DiagnosisView.js
+++ b/packages/desktop/app/components/DiagnosisView.js
@@ -7,6 +7,7 @@ import { DiagnosisModal } from './DiagnosisModal';
 import { DiagnosisList } from './DiagnosisList';
 import { Colors } from '../constants';
 import { useAuth } from '../contexts/Auth';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const DiagnosisHeading = styled.div`
   margin-right: 1rem;
@@ -17,10 +18,18 @@ const DiagnosisHeading = styled.div`
 
 const DiagnosisLabel = React.memo(({ numberOfDiagnoses }) => {
   if (numberOfDiagnoses === 0) {
-    return <DiagnosisHeading>No diagnoses recorded.</DiagnosisHeading>;
+    return (
+      <DiagnosisHeading>
+        <TranslatedText stringId="diagnosis.noData" fallback="No diagnoses recorded." />
+      </DiagnosisHeading>
+    );
   }
 
-  return <DiagnosisHeading>Diagnosis:</DiagnosisHeading>;
+  return (
+    <DiagnosisHeading>
+      <TranslatedText stringId="diagnosis.label" fallback="Diagnosis" />:
+    </DiagnosisHeading>
+  );
 });
 
 const DiagnosisGrid = styled.div`
@@ -49,7 +58,12 @@ export const DiagnosisView = React.memo(({ encounter, isTriage, readonly }) => {
     <>
       <div />
       <Box display="flex" alignItems="center">
-        <Typography variant="body2">You do not have permission to list diagnoses.</Typography>
+        <Typography variant="body2">
+          <TranslatedText
+            stringId="diagnosis.error.forbiddenMessage"
+            fallback="You do not have permission to list diagnoses."
+          />
+        </Typography>
       </Box>
     </>
   );
@@ -71,7 +85,7 @@ export const DiagnosisView = React.memo(({ encounter, isTriage, readonly }) => {
           color="primary"
           disabled={readonly}
         >
-          Add diagnosis
+          <TranslatedText stringId="diagnosis.action.add" fallback="Add diagnosis" />
         </AddDiagnosisButton>
       </DiagnosisGrid>
     </>

--- a/packages/desktop/app/components/DiagnosisView.js
+++ b/packages/desktop/app/components/DiagnosisView.js
@@ -27,7 +27,7 @@ const DiagnosisLabel = React.memo(({ numberOfDiagnoses }) => {
 
   return (
     <DiagnosisHeading>
-      <TranslatedText stringId="diagnosis.label" fallback="Diagnosis" />:
+      <TranslatedText stringId="diagnosis.heading" fallback="Diagnosis" />:
     </DiagnosisHeading>
   );
 });

--- a/packages/desktop/app/components/DiagnosisView.js
+++ b/packages/desktop/app/components/DiagnosisView.js
@@ -20,14 +20,14 @@ const DiagnosisLabel = React.memo(({ numberOfDiagnoses }) => {
   if (numberOfDiagnoses === 0) {
     return (
       <DiagnosisHeading>
-        <TranslatedText stringId="diagnosis.noData" fallback="No diagnoses recorded." />
+        <TranslatedText stringId="diagnosis.list.noData" fallback="No diagnoses recorded." />
       </DiagnosisHeading>
     );
   }
 
   return (
     <DiagnosisHeading>
-      <TranslatedText stringId="diagnosis.heading" fallback="Diagnosis" />:
+      <TranslatedText stringId="diagnosis.list.heading" fallback="Diagnosis" />:
     </DiagnosisHeading>
   );
 });
@@ -60,7 +60,7 @@ export const DiagnosisView = React.memo(({ encounter, isTriage, readonly }) => {
       <Box display="flex" alignItems="center">
         <Typography variant="body2">
           <TranslatedText
-            stringId="diagnosis.error.forbiddenMessage"
+            stringId="diagnosis.list.error.forbiddenMessage"
             fallback="You do not have permission to list diagnoses."
           />
         </Typography>

--- a/packages/desktop/app/constants/index.js
+++ b/packages/desktop/app/constants/index.js
@@ -149,11 +149,36 @@ export const reportOptions = [
 ];
 
 export const diagnosisCertaintyOptions = [
-  { value: 'emergency', label: 'ED Diagnosis', triageOnly: true },
-  { value: 'suspected', label: 'Suspected' },
-  { value: 'confirmed', label: 'Confirmed' },
-  { value: 'disproven', label: 'Disproven', editOnly: true },
-  { value: 'error', label: 'Recorded in error', editOnly: true },
+  {
+    value: 'emergency',
+    label: (
+      <TranslatedText stringId="diagnosis.certainty.option.edDiagnosis" fallback="ED Diagnosis" />
+    ),
+    triageOnly: true,
+  },
+  {
+    value: 'suspected',
+    label: <TranslatedText stringId="diagnosis.certainty.option.suspected" fallback="Suspected" />,
+  },
+  {
+    value: 'confirmed',
+    label: <TranslatedText stringId="diagnosis.certainty.option.confirmed" fallback="Confirmed" />,
+  },
+  {
+    value: 'disproven',
+    label: <TranslatedText stringId="diagnosis.certainty.option.disproven" fallback="Disproven" />,
+    editOnly: true,
+  },
+  {
+    value: 'error',
+    label: (
+      <TranslatedText
+        stringId="diagnosis.certainty.option.recordedInError"
+        fallback="Recorded in error"
+      />
+    ),
+    editOnly: true,
+  },
 ];
 
 export const CERTAINTY_OPTIONS_BY_VALUE = createValueIndex(diagnosisCertaintyOptions);

--- a/packages/desktop/app/forms/DiagnosisForm.js
+++ b/packages/desktop/app/forms/DiagnosisForm.js
@@ -57,13 +57,7 @@ export const DiagnosisForm = React.memo(
             <div style={{ gridColumn: '1 / -1' }}>
               <Field
                 name="diagnosisId"
-                label={
-                  <TranslatedText
-                    stringId="diagnosis.form.diagnosis.label"
-                    fallback=":diagnosisLabel"
-                    replacements={{ diagnosisLabel: getLocalisation(`fields.diagnosis.longLabel`) }}
-                  />
-                }
+                label={getLocalisation(`fields.diagnosis.longLabel`)}
                 component={AutocompleteField}
                 suggester={icd10Suggester}
                 required
@@ -88,7 +82,7 @@ export const DiagnosisForm = React.memo(
             />
             <Field
               name="date"
-              label={<TranslatedText stringId="diagnosis.form.date.label" fallback="Date" />}
+              label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
               component={DateField}
               required
               saveDateAsString

--- a/packages/desktop/app/forms/DiagnosisForm.js
+++ b/packages/desktop/app/forms/DiagnosisForm.js
@@ -45,12 +45,7 @@ export const DiagnosisForm = React.memo(
           ...diagnosis,
         }}
         validationSchema={yup.object().shape({
-          diagnosisId: foreignKey(
-            <TranslatedText
-              stringId="diagnosis.form.diagnosis.validation"
-              fallback="Diagnosis must be selected"
-            />,
-          ),
+          diagnosisId: foreignKey('Diagnosis must be selected'),
           certainty: yup
             .string()
             .oneOf(certaintyOptions.map(x => x.value))

--- a/packages/desktop/app/forms/DiagnosisForm.js
+++ b/packages/desktop/app/forms/DiagnosisForm.js
@@ -16,6 +16,7 @@ import {
 } from '../components/Field';
 import { useSuggester } from '../api';
 import { useLocalisation } from '../contexts/Localisation';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 export const DiagnosisForm = React.memo(
   ({ isTriage = false, onCancel, onSave, diagnosis, excludeDiagnoses }) => {
@@ -44,7 +45,12 @@ export const DiagnosisForm = React.memo(
           ...diagnosis,
         }}
         validationSchema={yup.object().shape({
-          diagnosisId: foreignKey('Diagnosis must be selected'),
+          diagnosisId: foreignKey(
+            <TranslatedText
+              stringId="diagnosis.form.diagnosis.validation"
+              fallback="Diagnosis must be selected"
+            />,
+          ),
           certainty: yup
             .string()
             .oneOf(certaintyOptions.map(x => x.value))
@@ -65,17 +71,27 @@ export const DiagnosisForm = React.memo(
             <Field
               style={{ gridColumn: '1 / -1' }}
               name="isPrimary"
-              label="Is primary"
+              label={
+                <TranslatedText stringId="diagnosis.form.isPrimary.label" fallback="Is primary" />
+              }
               component={CheckField}
             />
             <Field
               name="certainty"
-              label="Certainty"
+              label={
+                <TranslatedText stringId="diagnosis.form.certainty.label" fallback="Certainty" />
+              }
               component={SelectField}
               options={certaintyOptions}
               required
             />
-            <Field name="date" label="Date" component={DateField} required saveDateAsString />
+            <Field
+              name="date"
+              label={<TranslatedText stringId="diagnosis.form.date.label" fallback="Date" />}
+              component={DateField}
+              required
+              saveDateAsString
+            />
             <FormSubmitCancelRow onConfirm={submitForm} onCancel={onCancel} />
           </FormGrid>
         )}

--- a/packages/desktop/app/forms/DiagnosisForm.js
+++ b/packages/desktop/app/forms/DiagnosisForm.js
@@ -62,7 +62,13 @@ export const DiagnosisForm = React.memo(
             <div style={{ gridColumn: '1 / -1' }}>
               <Field
                 name="diagnosisId"
-                label={getLocalisation(`fields.diagnosis.longLabel`)}
+                label={
+                  <TranslatedText
+                    stringId="diagnosis.form.diagnosis.label"
+                    fallback=":diagnosisLabel"
+                    replacements={{ diagnosisLabel: getLocalisation(`fields.diagnosis.longLabel`) }}
+                  />
+                }
                 component={AutocompleteField}
                 suggester={icd10Suggester}
                 required


### PR DESCRIPTION
### Changes

Replaced strings in the Diagnoses module with the TranslatedText component. The areas covered are described in the linear ticket.

[NASS-960: Translate desktop 'Diagnoses' module](https://linear.app/bes/issue/NASS-960/translate-desktop-diagnoses-module)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
