### PR TITLE
NOTAM-216: Patient sync button style tweaks

### DIFF
--- a/packages/desktop/app/components/MarkPatientForSync.js
+++ b/packages/desktop/app/components/MarkPatientForSync.js
@@ -9,10 +9,12 @@ import { syncPatient } from '../store/patient';
 
 const MarkPatientForSyncButton = styled(Button)`
   background: ${Colors.white};
-  display: grid;
-  justify-content: center;
-  text-align: -webkit-center;
   height: 9rem;
+  .MuiButton-label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 `;
 
 const MarkPatientForSyncIcon = styled(Loop)`


### PR DESCRIPTION
### Changes

Some styling on the sync button seems to have broken. Likely related to the electron upgrade? 

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
