### PR TITLE
NASS-959: Translate desktop 'Check-in' & 'Encounter details' components

### DIFF
--- a/packages/desktop/app/components/CheckInModal.js
+++ b/packages/desktop/app/components/CheckInModal.js
@@ -14,12 +14,12 @@ function getEncounterTypeLabel(encounterType) {
     case ENCOUNTER_TYPES.ADMISSION:
       return (
         <TranslatedText
-          stringId="patient.encounter.type.admission.label"
+          stringId="encounter.property.type.admission"
           fallback="Hospital admission"
         />
       );
     case ENCOUNTER_TYPES.CLINIC:
-      return <TranslatedText stringId="patient.encounter.type.clinic.label" fallback="Clinic" />;
+      return <TranslatedText stringId="encounter.property.type.clinic" fallback="Clinic" />;
     default:
       return '';
   }
@@ -59,7 +59,7 @@ export const CheckInModal = React.memo(
         // using replacements avoids [Object object] in the title
         title={
           <TranslatedText
-            stringId="patient.modal.admit.title"
+            stringId="patient.modal.checkIn.title"
             fallback="Admit or check-in | :encounterType"
             replacements={{ encounterType: getEncounterTypeLabel(props?.encounterType) }}
           />

--- a/packages/desktop/app/components/CheckInModal.js
+++ b/packages/desktop/app/components/CheckInModal.js
@@ -7,6 +7,23 @@ import { FormModal } from './FormModal';
 import { reloadPatient } from '../store/patient';
 import { EncounterForm } from '../forms/EncounterForm';
 import { useEncounter } from '../contexts/Encounter';
+import { TranslatedText } from './Translation/TranslatedText';
+
+function getEncounterTypeLabel(encounterType) {
+  switch (encounterType) {
+    case ENCOUNTER_TYPES.ADMISSION:
+      return (
+        <TranslatedText
+          stringId="patient.encounter.type.admission.label"
+          fallback="Hospital admission"
+        />
+      );
+    case ENCOUNTER_TYPES.CLINIC:
+      return <TranslatedText stringId="patient.encounter.type.clinic.label" fallback="Clinic" />;
+    default:
+      return '';
+  }
+}
 
 export const CheckInModal = React.memo(
   ({ open, onClose, onSubmitEncounter, patientId, referral, patientBillingTypeId, ...props }) => {
@@ -37,12 +54,16 @@ export const CheckInModal = React.memo(
       },
       [dispatch, patientId, api, createEncounter, onSubmitEncounter, onClose, referral],
     );
-
     return (
       <FormModal
-        title={`Admit or check-in | ${
-          props?.encounterType === ENCOUNTER_TYPES.ADMISSION ? 'Hospital admission' : ''
-        }${props?.encounterType === ENCOUNTER_TYPES.CLINIC ? 'Clinic' : ''}`}
+        // using replacements avoids [Object object] in the title
+        title={
+          <TranslatedText
+            stringId="patient.modal.admit.title"
+            fallback="Admit or check-in | :encounterType"
+            replacements={{ encounterType: getEncounterTypeLabel(props?.encounterType) }}
+          />
+        }
         open={open}
         onClose={onClose}
       >

--- a/packages/desktop/app/components/TopBar.js
+++ b/packages/desktop/app/components/TopBar.js
@@ -5,6 +5,7 @@ import { Typography, Toolbar } from '@material-ui/core';
 import { DateDisplay } from './DateDisplay';
 import { Colors } from '../constants';
 import { useLocalisedText } from './LocalisedText';
+import { TranslatedText } from './Translation/TranslatedText';
 
 // Default height of the top bar
 export const TOP_BAR_HEIGHT = 97;
@@ -141,13 +142,25 @@ export const EncounterTopBar = ({ title, subTitle, encounter, children }) => {
       <Container>
         <div>
           <Cell>
-            <Label>Arrival Date:</Label>
+            <Label>
+              <TranslatedText
+                stringId="patient.encounter.details.topbar.arrivalDate.label"
+                fallback="Arrival Date"
+              />
+            </Label>
             <Value>
               <DateDisplay date={encounter.startDate} />
             </Value>
           </Cell>
           <Cell>
-            <Label>{`Supervising ${clinicianText.toLowerCase()}:`}</Label>
+            <Label>
+              <TranslatedText
+                stringId="patient.encounter.details.topbar.practitioner.label"
+                fallback="Supervising :practitioner"
+                replacements={{ practitioner: clinicianText.toLowerCase() }}
+              />
+              :
+            </Label>
             <Value>{encounter.examiner?.displayName || 'Unknown'}</Value>
           </Cell>
         </div>

--- a/packages/desktop/app/components/TopBar.js
+++ b/packages/desktop/app/components/TopBar.js
@@ -147,20 +147,14 @@ export const EncounterTopBar = ({ title, subTitle, encounter, children }) => {
                 stringId="patient.encounter.details.topbar.arrivalDate.label"
                 fallback="Arrival Date"
               />
+              :
             </Label>
             <Value>
               <DateDisplay date={encounter.startDate} />
             </Value>
           </Cell>
           <Cell>
-            <Label>
-              <TranslatedText
-                stringId="patient.encounter.details.topbar.practitioner.label"
-                fallback="Supervising :practitioner"
-                replacements={{ practitioner: clinicianText.toLowerCase() }}
-              />
-              :
-            </Label>
+            <Label>{`Supervising ${clinicianText.toLowerCase()}:`}</Label>
             <Value>{encounter.examiner?.displayName || 'Unknown'}</Value>
           </Cell>
         </div>

--- a/packages/desktop/app/components/TriageModal.js
+++ b/packages/desktop/app/components/TriageModal.js
@@ -5,6 +5,7 @@ import { FormModal } from './FormModal';
 import { Colors } from '../constants';
 import { TriageForm } from '../forms/TriageForm';
 import { DateDisplay } from './DateDisplay';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const Header = styled.div`
   font-weight: 500;
@@ -68,8 +69,20 @@ export const TriageModal = React.memo(
     ));
 
     return (
-      <FormModal title="New emergency triage" open={open} width="md" onClose={onClose}>
-        <Header>Patient details</Header>
+      <FormModal
+        title={
+          <TranslatedText stringId="patient.modal.triage.title" fallback="New emergency triage" />
+        }
+        open={open}
+        width="md"
+        onClose={onClose}
+      >
+        <Header>
+          <TranslatedText
+            stringId="patient.modal.triage.patientDetails.heading"
+            fallback="Patient details"
+          />
+        </Header>
         <PatientDetails>
           <Grid>{detailsFields}</Grid>
           <DisplayIdLabel>{displayId}</DisplayIdLabel>

--- a/packages/desktop/app/forms/EncounterForm.js
+++ b/packages/desktop/app/forms/EncounterForm.js
@@ -20,6 +20,7 @@ import {
 } from '../components';
 import { encounterOptions } from '../constants';
 import { useSuggester } from '../api';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 export const EncounterForm = React.memo(
   ({ editedObject, onSubmit, patientBillingTypeId, encounterType }) => {
@@ -37,14 +38,24 @@ export const EncounterForm = React.memo(
         <FormGrid>
           <Field
             name="encounterType"
-            label="Encounter type"
+            label={
+              <TranslatedText
+                stringId="patient.modal.admit.form.encounterType.label"
+                fallback="Encounter type"
+              />
+            }
             disabled
             component={SelectField}
             options={encounterOptions}
           />
           <Field
             name="startDate"
-            label="Check-in date"
+            label={
+              <TranslatedText
+                stringId="patient.modal.admit.form.startDate.label"
+                fallback="Check-in date"
+              />
+            }
             required
             min="1970-01-01T00:00"
             component={DateTimeField}
@@ -52,7 +63,9 @@ export const EncounterForm = React.memo(
           />
           <Field
             name="departmentId"
-            label="Department"
+            label={
+              <TranslatedText stringId="general.form.department.label" fallback="Department" />
+            }
             required
             component={AutocompleteField}
             suggester={departmentSuggester}
@@ -85,7 +98,12 @@ export const EncounterForm = React.memo(
           />
           <Field
             name="reasonForEncounter"
-            label="Reason for encounter"
+            label={
+              <TranslatedText
+                stringId="modal.admit.form.reason.label"
+                fallback="Reason for encounter"
+              />
+            }
             component={TextField}
             multiline
             rows={2}

--- a/packages/desktop/app/forms/EncounterForm.js
+++ b/packages/desktop/app/forms/EncounterForm.js
@@ -33,7 +33,10 @@ export const EncounterForm = React.memo(
 
     const renderForm = ({ submitForm, values }) => {
       const buttonText = editedObject ? (
-        <TranslatedText stringId="patient.modal.admit.action.update" fallback="Update encounter" />
+        <TranslatedText
+          stringId="patient.modal.checkIn.action.update"
+          fallback="Update encounter"
+        />
       ) : (
         <TranslatedText stringId="general.action.confirm" fallback="Confirm" />
       );
@@ -44,7 +47,7 @@ export const EncounterForm = React.memo(
             name="encounterType"
             label={
               <TranslatedText
-                stringId="patient.modal.admit.form.encounterType.label"
+                stringId="patient.modal.checkIn.form.encounterType.label"
                 fallback="Encounter type"
               />
             }
@@ -56,7 +59,7 @@ export const EncounterForm = React.memo(
             name="startDate"
             label={
               <TranslatedText
-                stringId="patient.modal.admit.form.startDate.label"
+                stringId="patient.modal.checkIn.form.checkInDate.label"
                 fallback="Check-in date"
               />
             }
@@ -104,7 +107,7 @@ export const EncounterForm = React.memo(
             name="reasonForEncounter"
             label={
               <TranslatedText
-                stringId="modal.admit.form.reason.label"
+                stringId="modal.checkIn.form.reasonForEncounter.label"
                 fallback="Reason for encounter"
               />
             }

--- a/packages/desktop/app/forms/EncounterForm.js
+++ b/packages/desktop/app/forms/EncounterForm.js
@@ -32,7 +32,11 @@ export const EncounterForm = React.memo(
     const clinicianText = useLocalisedText({ path: 'fields.clinician.shortLabel' });
 
     const renderForm = ({ submitForm, values }) => {
-      const buttonText = editedObject ? 'Update encounter' : 'Confirm';
+      const buttonText = editedObject ? (
+        <TranslatedText stringId="patient.modal.admit.action.update" fallback="Update encounter" />
+      ) : (
+        <TranslatedText stringId="general.action.confirm" fallback="Confirm" />
+      );
 
       return (
         <FormGrid>

--- a/packages/desktop/app/forms/TriageForm.js
+++ b/packages/desktop/app/forms/TriageForm.js
@@ -154,7 +154,7 @@ export const TriageForm = ({
           suggester={practitionerSuggester}
         />
         <ModalFormActionRow
-          confirmText={<TranslatedText stringId="general.action.submit" fallback="submit" />}
+          confirmText={<TranslatedText stringId="general.action.submit" fallback="Submit" />}
           onConfirm={submitForm}
           onCancel={onCancel}
         />

--- a/packages/desktop/app/forms/TriageForm.js
+++ b/packages/desktop/app/forms/TriageForm.js
@@ -75,7 +75,7 @@ export const TriageForm = ({
           name="triageTime"
           label={
             <TranslatedText
-              stringId="patient.modal.triage.form.triageTime.label"
+              stringId="patient.modal.triage.form.triageDateTime.label"
               fallback="Triage date & time"
             />
           }

--- a/packages/desktop/app/forms/TriageForm.js
+++ b/packages/desktop/app/forms/TriageForm.js
@@ -29,7 +29,12 @@ import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const InfoPopupLabel = React.memo(() => (
   <span>
-    <span>Triage score </span>
+    <span>
+      <TranslatedText
+        stringId="patient.modal.triage.form.score.infoPopup"
+        fallback="Triage score"
+      />
+    </span>
     {/* Todo: convert triage flow chart to a configurable asset */}
     {/* <ImageInfoModal src={triageFlowchart} /> */}
   </span>
@@ -137,12 +142,22 @@ export const TriageForm = ({
         </FormGrid>
         <Field
           name="practitionerId"
-          label={`Triage ${clinicianText.toLowerCase()}`}
+          label={
+            <TranslatedText
+              stringId="patient.modal.triage.form.practitioner.label"
+              fallback="Triage :practitioner"
+              replacements={{ practitioner: clinicianText.toLowerCase() }}
+            />
+          }
           required
           component={AutocompleteField}
           suggester={practitionerSuggester}
         />
-        <ModalFormActionRow confirmText="Submit" onConfirm={submitForm} onCancel={onCancel} />
+        <ModalFormActionRow
+          confirmText={<TranslatedText stringId="general.action.submit" fallback="submit" />}
+          onConfirm={submitForm}
+          onCancel={onCancel}
+        />
       </FormGrid>
     );
   };

--- a/packages/desktop/app/forms/TriageForm.js
+++ b/packages/desktop/app/forms/TriageForm.js
@@ -31,7 +31,7 @@ const InfoPopupLabel = React.memo(() => (
   <span>
     <span>
       <TranslatedText
-        stringId="patient.modal.triage.form.score.infoPopup"
+        stringId="patient.modal.triage.form.triageScore.label"
         fallback="Triage score"
       />
     </span>
@@ -142,13 +142,7 @@ export const TriageForm = ({
         </FormGrid>
         <Field
           name="practitionerId"
-          label={
-            <TranslatedText
-              stringId="patient.modal.triage.form.practitioner.label"
-              fallback="Triage :practitioner"
-              replacements={{ practitioner: clinicianText.toLowerCase() }}
-            />
-          }
+          label={`Triage ${clinicianText.toLowerCase()}`}
           required
           component={AutocompleteField}
           suggester={practitionerSuggester}

--- a/packages/desktop/app/forms/TriageForm.js
+++ b/packages/desktop/app/forms/TriageForm.js
@@ -25,6 +25,7 @@ import { useApi, useSuggester } from '../api';
 import { useLocalisation } from '../contexts/Localisation';
 import { getActionsFromData, getAnswersFromData } from '../utils';
 import { useLocalisedText } from '../components';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const InfoPopupLabel = React.memo(() => (
   <span>
@@ -54,7 +55,12 @@ export const TriageForm = ({
       <FormGrid>
         <Field
           name="arrivalTime"
-          label="Arrival date & time"
+          label={
+            <TranslatedText
+              stringId="patient.modal.triage.form.arrivalTime.label"
+              fallback="Arrival date & time"
+            />
+          }
           component={DateTimeField}
           max={format(endOfDay(new Date()), `yyyy-MM-dd'T'HH:mm`)} // Weird time picker behaviour with date.now(), so using end of day. It will be also validated on submit.
           helperText="If different from triage time"
@@ -62,7 +68,12 @@ export const TriageForm = ({
         />
         <Field
           name="triageTime"
-          label="Triage date & time"
+          label={
+            <TranslatedText
+              stringId="patient.modal.triage.form.triageTime.label"
+              fallback="Triage date & time"
+            />
+          }
           required
           max={format(endOfDay(new Date()), `yyyy-MM-dd'T'HH:mm`)} // Weird time picker behaviour with date.now(), so using end of day. It will be also validated on submit.
           component={DateTimeField}
@@ -94,14 +105,24 @@ export const TriageForm = ({
         <FormGrid columns={1} style={{ gridColumn: '1 / -1' }}>
           <Field
             name="chiefComplaintId"
-            label="Chief complaint"
+            label={
+              <TranslatedText
+                stringId="patient.modal.triage.form.chiefComplaint.label"
+                fallback="Chief complaint"
+              />
+            }
             component={AutocompleteField}
             suggester={triageReasonSuggester}
             required
           />
           <Field
             name="secondaryComplaintId"
-            label="Secondary complaint"
+            label={
+              <TranslatedText
+                stringId="patient.modal.triage.form.secondaryComplaint.label"
+                fallback="Secondary complaint"
+              />
+            }
             component={AutocompleteField}
             suggester={triageReasonSuggester}
           />

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -89,22 +89,20 @@ const TABS = [
 function getHeaderText({ encounterType }) {
   switch (encounterType) {
     case ENCOUNTER_TYPES.TRIAGE:
-      return <TranslatedText stringId="patient.encounter.type.triage" fallback="Triage" />;
+      return <TranslatedText stringId="encounter.header.triage" fallback="Triage" />;
     case ENCOUNTER_TYPES.OBSERVATION:
-      return (
-        <TranslatedText stringId="patient.encounter.type.edPatient" fallback="Active ED patient" />
-      );
+      return <TranslatedText stringId="encounter.header.edPatient" fallback="Active ED patient" />;
     case ENCOUNTER_TYPES.EMERGENCY:
       return (
         <TranslatedText
-          stringId="patient.encounter.type.emergencyShortStay"
+          stringId="encounter.header.emergencyShortStay"
           fallback="Emergency Short Stay"
         />
       );
     case ENCOUNTER_TYPES.ADMISSION:
       return (
         <TranslatedText
-          stringId="patient.encounter.type.hospitalAdmission"
+          stringId="encounter.header.hospitalAdmission"
           fallback="Hospital Admission"
         />
       );
@@ -112,10 +110,7 @@ function getHeaderText({ encounterType }) {
     case ENCOUNTER_TYPES.IMAGING:
     default:
       return (
-        <TranslatedText
-          stringId="patient.encounter.type.patientEncounter"
-          fallback="Patient Encounter"
-        />
+        <TranslatedText stringId="encounter.header.patientEncounter" fallback="Patient Encounter" />
       );
   }
 }

--- a/packages/desktop/app/views/patients/EncounterView.js
+++ b/packages/desktop/app/views/patients/EncounterView.js
@@ -29,6 +29,7 @@ import { EncounterActions } from './components';
 import { useReferenceData } from '../../api/queries';
 import { useAuth } from '../../contexts/Auth';
 import { VitalChartDataProvider } from '../../contexts/VitalChartData';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const getIsTriage = encounter => ENCOUNTER_OPTIONS_BY_VALUE[encounter.encounterType].triageFlowOnly;
 
@@ -88,17 +89,34 @@ const TABS = [
 function getHeaderText({ encounterType }) {
   switch (encounterType) {
     case ENCOUNTER_TYPES.TRIAGE:
-      return 'Triage';
+      return <TranslatedText stringId="patient.encounter.type.triage" fallback="Triage" />;
     case ENCOUNTER_TYPES.OBSERVATION:
-      return 'Active ED patient';
+      return (
+        <TranslatedText stringId="patient.encounter.type.edPatient" fallback="Active ED patient" />
+      );
     case ENCOUNTER_TYPES.EMERGENCY:
-      return 'Emergency Short Stay';
+      return (
+        <TranslatedText
+          stringId="patient.encounter.type.emergencyShortStay"
+          fallback="Emergency Short Stay"
+        />
+      );
     case ENCOUNTER_TYPES.ADMISSION:
-      return 'Hospital Admission';
+      return (
+        <TranslatedText
+          stringId="patient.encounter.type.hospitalAdmission"
+          fallback="Hospital Admission"
+        />
+      );
     case ENCOUNTER_TYPES.CLINIC:
     case ENCOUNTER_TYPES.IMAGING:
     default:
-      return 'Patient Encounter';
+      return (
+        <TranslatedText
+          stringId="patient.encounter.type.patientEncounter"
+          fallback="Patient Encounter"
+        />
+      );
   }
 }
 

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -135,7 +135,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
     {
       label: (
         <TranslatedText
-          stringId="patient.encounter.action.dischargeWithoutSeen"
+          stringId="patient.encounter.action.dischargeWithoutBeingSeen"
           fallback="Discharge without being seen"
         />
       ),
@@ -195,13 +195,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
       onClick: onChangeDepartment,
     },
     {
-      label: (
-        <TranslatedText
-          stringId="patient.encounter.action.changePractitioner"
-          fallback="Change :practitioner"
-          replacements={{ practitioner: clinicianText.toLowerCase() }}
-        />
-      ),
+      label: `Change ${clinicianText.toLowerCase()}`,
       onClick: onChangeClinician,
     },
     {

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -16,6 +16,7 @@ import { DropdownButton } from '../../../components/DropdownButton';
 import { MoveModal } from './MoveModal';
 import { EncounterRecordModal } from '../../../components/PatientPrinting/modals/EncounterRecordModal';
 import { Colors } from '../../../constants';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const TypographyLink = styled(Typography)`
   color: ${Colors.primary};
@@ -73,10 +74,18 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
     return (
       <div>
         <Button variant="outlined" color="primary" onClick={onViewSummary}>
-          View discharge summary
+          <TranslatedText
+            stringId="patient.encounter.action.viewDischargeSummary"
+            fallback="View discharge summary"
+          />
         </Button>
         <br />
-        <TypographyLink onClick={onViewEncounterRecord}>Encounter record</TypographyLink>
+        <TypographyLink onClick={onViewEncounterRecord}>
+          <TranslatedText
+            stringId="patient.encounter.action.viewEncounterRecord"
+            fallback="Encounter record"
+          />
+        </TypographyLink>
       </div>
     );
   }
@@ -94,61 +103,114 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
 
   const actions = [
     {
-      label: 'Move to active ED care',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.moveToEdCare"
+          fallback="Move to active ED care"
+        />
+      ),
       onClick: () => onChangeEncounterType(ENCOUNTER_TYPES.OBSERVATION),
       condition: () => isProgressionForward(encounter.encounterType, ENCOUNTER_TYPES.OBSERVATION),
     },
     {
-      label: 'Move to emergency short stay',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.moveToShortStay"
+          fallback="Move to emergency short stay"
+        />
+      ),
       onClick: () => onChangeEncounterType(ENCOUNTER_TYPES.EMERGENCY),
       condition: () => isProgressionForward(encounter.encounterType, ENCOUNTER_TYPES.EMERGENCY),
     },
     {
-      label: 'Admit to hospital',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.admitToHospital"
+          fallback="Admit to hospital"
+        />
+      ),
       onClick: () => onChangeEncounterType(ENCOUNTER_TYPES.ADMISSION),
       condition: () => isProgressionForward(encounter.encounterType, ENCOUNTER_TYPES.ADMISSION),
     },
     {
-      label: 'Discharge without being seen',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.dischargeWithoutSeen"
+          fallback="Discharge without being seen"
+        />
+      ),
       onClick: onDischargeOpen,
       condition: () => encounter.encounterType === ENCOUNTER_TYPES.TRIAGE,
     },
     {
-      label: 'Finalise patient move',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.finalisePatientMove"
+          fallback="Finalise patient move"
+        />
+      ),
       condition: () => enablePatientMoveActions && encounter.plannedLocation,
       onClick: onFinaliseLocationChange,
     },
     {
-      label: 'Cancel patient move',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.cancelPatientMove"
+          fallback="Cancel patient move"
+        />
+      ),
       condition: () => enablePatientMoveActions && encounter.plannedLocation,
       onClick: onCancelLocationChange,
     },
     {
-      label: 'Discharge',
+      label: <TranslatedText stringId="patient.encounter.action.discharge" fallback="Discharge" />,
       onClick: onDischargeOpen,
       condition: () => encounter.encounterType !== ENCOUNTER_TYPES.TRIAGE,
     },
     {
       // Duplicate "Admit to hospital" as it should display below "Discharge".
-      label: 'Admit to hospital',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.admitToHospital"
+          fallback="Admit to hospital"
+        />
+      ),
       onClick: () => onChangeEncounterType(ENCOUNTER_TYPES.ADMISSION),
       condition: () => encounter.encounterType === ENCOUNTER_TYPES.CLINIC,
     },
     {
-      label: 'Move patient',
+      label: (
+        <TranslatedText stringId="patient.encounter.action.movePatient" fallback="Move patient" />
+      ),
       condition: () => enablePatientMoveActions && !encounter.plannedLocation,
       onClick: onPlanLocationChange,
     },
     {
-      label: 'Change department',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.changeDepartment"
+          fallback="Change department"
+        />
+      ),
       onClick: onChangeDepartment,
     },
     {
-      label: `Change ${clinicianText.toLowerCase()}`,
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.changePractitioner"
+          fallback="Change :practitioner"
+          replacements={{ practitioner: clinicianText.toLowerCase() }}
+        />
+      ),
       onClick: onChangeClinician,
     },
     {
-      label: 'Change location',
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.changeLocation"
+          fallback="Change location"
+        />
+      ),
       condition: () => !enablePatientMoveActions && !encounter.plannedLocation,
       onClick: onChangeLocation,
     },

--- a/packages/desktop/app/views/patients/panes/EncounterInfoPane.js
+++ b/packages/desktop/app/views/patients/panes/EncounterInfoPane.js
@@ -4,6 +4,7 @@ import { ENCOUNTER_OPTIONS_BY_VALUE } from '../../../constants';
 import { getFullLocationName } from '../../../utils/location';
 import { InfoCard, InfoCardItem, InfoCardHeader } from '../../../components/InfoCard';
 import { getDepartmentName } from '../../../utils/department';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const getReferralSource = ({ referralSource }) =>
   referralSource ? referralSource.name : 'Unknown';
@@ -20,26 +21,69 @@ export const EncounterInfoPane = React.memo(
       headerContent={
         encounter.plannedLocation && (
           <InfoCardHeader
-            label="Planned move"
+            label={
+              <TranslatedText
+                stringId="patient.encounter.details.card.plannedMove.label"
+                fallback="Planned move"
+              />
+            }
             value={getFullLocationName(encounter.plannedLocation)}
           />
         )
       }
     >
-      <InfoCardItem label="Department" value={getDepartmentName(encounter)} />
-      <InfoCardItem label="Patient type" value={patientBillingType} />
-      <InfoCardItem label="Location" value={getFullLocationName(encounter?.location)} />
+      <InfoCardItem
+        label={<TranslatedText stringId="general.card.department.label" fallback="Department" />}
+        value={getDepartmentName(encounter)}
+      />
+      <InfoCardItem
+        label={
+          <TranslatedText
+            stringId="patient.encounter.details.card.patientType.label"
+            fallback="Patient type"
+          />
+        }
+        value={patientBillingType}
+      />
+      <InfoCardItem
+        label={<TranslatedText stringId="general.card.location.label" fallback="Location" />}
+        value={getFullLocationName(encounter?.location)}
+      />
       {!getLocalisation(`${referralSourcePath}.hidden`) && (
         <InfoCardItem
           label={getLocalisation(`${referralSourcePath}.shortLabel`)}
           value={getReferralSource(encounter)}
         />
       )}
-      <InfoCardItem label="Encounter type" value={getEncounterType(encounter)} />
+      <InfoCardItem
+        label={
+          <TranslatedText
+            stringId="patient.encounter.details.card.encounterType.label"
+            fallback="Encounter type"
+          />
+        }
+        value={getEncounterType(encounter)}
+      />
       {encounter.endDate && (
-        <InfoCardItem label="Discharge date" value={DateDisplay.stringFormat(encounter.endDate)} />
+        <InfoCardItem
+          label={
+            <TranslatedText
+              stringId="patient.encounter.details.card.dischargeDate.label"
+              fallback="Discharge date"
+            />
+          }
+          value={DateDisplay.stringFormat(encounter.endDate)}
+        />
       )}
-      <InfoCardItem label="Reason for encounter" value={encounter.reasonForEncounter} />
+      <InfoCardItem
+        label={
+          <TranslatedText
+            stringId="patient.encounter.details.card.encounterReason.label"
+            fallback="Reason for encounter"
+          />
+        }
+        value={encounter.reasonForEncounter}
+      />
     </InfoCard>
   ),
 );


### PR DESCRIPTION
### Changes

Translated both the admission/check-in and encounter details modules, utilising `<TranslatedText />` components.

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
