### PR TITLE
NASS-1002: Remove 'Test results' field from mobile history

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/historyvitals/tabs/VisitsScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/historyvitals/tabs/VisitsScreen.tsx
@@ -1,12 +1,9 @@
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement } from 'react';
 import { compose } from 'redux';
-import { FullView, StyledSafeAreaView, StyledView } from '/styled/common';
+import { FullView, StyledSafeAreaView } from '/styled/common';
 import { PatientHistoryAccordion } from '~/ui/components/PatientHistoryAccordion';
 import { theme } from '/styled/theme';
-import { Button } from '/components/Button';
-import { FilterIcon } from '/components/Icons';
 import { NOTE_TYPES } from '~/ui/helpers/constants';
-import { screenPercentageToDP, Orientation } from '~/ui/helpers/screen';
 import { useBackendEffect } from '~/ui/hooks';
 import { LoadingScreen } from '~/ui/components/LoadingScreen';
 import { ErrorScreen } from '~/ui/components/ErrorScreen';
@@ -15,21 +12,17 @@ import { IDiagnosis } from '~/types';
 
 const DEFAULT_FIELD_VAL = 'N/A';
 
-const displayNotes = (notes): string => notes
-  .filter(note => note.noteType === NOTE_TYPES.CLINICAL_MOBILE)
-  .map(note => note.content)
-  .join('\n\n')
-  || DEFAULT_FIELD_VAL;
+const displayNotes = (notes): string =>
+  notes
+    .filter(note => note.noteType === NOTE_TYPES.CLINICAL_MOBILE)
+    .map(note => note.content)
+    .join('\n\n') || DEFAULT_FIELD_VAL;
 
 const visitsHistoryRows = {
-  labRequest: {
-    name: 'Test results',
-    accessor: (): string => DEFAULT_FIELD_VAL,
-  },
   diagnoses: {
     name: 'Diagnosis',
-    accessor: (diagnoses: IDiagnosis[]): string => diagnoses.map((d) => `${d.diagnosis?.name} (${d.certainty})`).join('\n\n')
-      || DEFAULT_FIELD_VAL,
+    accessor: (diagnoses: IDiagnosis[]): string =>
+      diagnoses.map(d => `${d.diagnosis?.name} (${d.certainty})`).join('\n\n') || DEFAULT_FIELD_VAL,
   },
   notes: {
     name: 'Clinical Note',

--- a/packages/mobile/App/ui/navigation/screens/historyvitals/tabs/VisitsScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/historyvitals/tabs/VisitsScreen.tsx
@@ -8,11 +8,11 @@ import { useBackendEffect } from '~/ui/hooks';
 import { LoadingScreen } from '~/ui/components/LoadingScreen';
 import { ErrorScreen } from '~/ui/components/ErrorScreen';
 import { withPatient } from '~/ui/containers/Patient';
-import { IDiagnosis } from '~/types';
+import { IDiagnosis, INote } from '~/types';
 
 const DEFAULT_FIELD_VAL = 'N/A';
 
-const displayNotes = (notes): string =>
+const displayNotes = (notes: INote[]): string =>
   notes
     .filter(note => note.noteType === NOTE_TYPES.CLINICAL_MOBILE)
     .map(note => note.content)


### PR DESCRIPTION
### Changes

Removed the 'Test results' field from the mobile `patient` -> `history` -> `visits` view.

<img width="333" alt="image" src="https://github.com/beyondessential/tamanu/assets/108244616/03f025e4-92e4-4b3b-a766-b62be08b148c">

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
