### PR TITLE
NASS-975: Translate desktop 'Bed management' page

### DIFF
--- a/packages/desktop/app/components/BedManagement/HandoverNotesModal.js
+++ b/packages/desktop/app/components/BedManagement/HandoverNotesModal.js
@@ -7,13 +7,20 @@ import { useApi } from '../../api';
 import { useLocalisation } from '../../contexts/Localisation';
 import { useCertificate } from '../../utils/useCertificate';
 import { PDFViewer, printPDF } from '../PatientPrinting/PDFViewer';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 export const HandoverNotesModal = React.memo(({ area: areaId, ...props }) => {
   const { getLocalisation } = useLocalisation();
   const api = useApi();
   const { title, subTitle, logo } = useCertificate();
   const letterheadConfig = { title, subTitle };
-  const modalTitle = `Handover notes ${getDisplayDate(new Date(), 'dd/MM/yy')}`;
+  const modalTitle = (
+    <TranslatedText
+      stringId="bedManagement.modal.handoverNotes.title"
+      fallback="Handover notes :date"
+      replacements={{ date: getDisplayDate(new Date(), 'dd/MM/yy') }}
+    />
+  );
 
   const {
     data: { data: handoverNotes = [], locationGroup = {} } = {},

--- a/packages/desktop/app/components/SearchBar/BedManagementSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/BedManagementSearchBar.js
@@ -8,6 +8,7 @@ import { AutocompleteField, LocalisedField, SelectField } from '../Field';
 import { HandoverNotesModal } from '../BedManagement/HandoverNotesModal';
 import { CustomisableSearchBar } from './CustomisableSearchBar';
 import { ThemedTooltip } from '../Tooltip';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const HandoverNotesButton = styled(Button)`
   font-weight: 500;
@@ -47,7 +48,7 @@ export const BedManagementSearchBar = React.memo(({ onSearch, searchParameters }
   return (
     <>
       <CustomisableSearchBar
-        title="Search Locations"
+        title={<TranslatedText stringId="bedManagement.search.title" fallback="Search Locations" />}
         onSearch={onSearch}
         initialValues={searchParameters}
       >
@@ -59,11 +60,26 @@ export const BedManagementSearchBar = React.memo(({ onSearch, searchParameters }
           onClick={handleHandoverNotesButtonClick}
         >
           {handoverNotesButtonDisabled ? (
-            <ThemedTooltip title="Select an 'Area' to create handover notes">
-              <span>Handover notes</span>
+            <ThemedTooltip
+              title={
+                <TranslatedText
+                  stringId="bedManagement.search.handoverNotes.tooltip"
+                  fallback="Select an 'Area' to create handover notes"
+                />
+              }
+            >
+              <span>
+                <TranslatedText
+                  stringId="bedManagement.search.handoverNotes.text"
+                  fallback="Handover notes"
+                />
+              </span>
             </ThemedTooltip>
           ) : (
-            'Handover notes'
+            <TranslatedText
+              stringId="bedManagement.search.handoverNotes.text"
+              fallback="Handover notes"
+            />
           )}
         </HandoverNotesButton>
 

--- a/packages/desktop/app/components/SearchBar/BedManagementSearchBar.js
+++ b/packages/desktop/app/components/SearchBar/BedManagementSearchBar.js
@@ -70,14 +70,14 @@ export const BedManagementSearchBar = React.memo(({ onSearch, searchParameters }
             >
               <span>
                 <TranslatedText
-                  stringId="bedManagement.search.handoverNotes.text"
+                  stringId="bedManagement.search.handoverNotes.button.label"
                   fallback="Handover notes"
                 />
               </span>
             </ThemedTooltip>
           ) : (
             <TranslatedText
-              stringId="bedManagement.search.handoverNotes.text"
+              stringId="bedManagement.search.handoverNotes.button.label"
               fallback="Handover notes"
             />
           )}

--- a/packages/desktop/app/views/facility/BedManagement.js
+++ b/packages/desktop/app/views/facility/BedManagement.js
@@ -141,19 +141,19 @@ const DetailedDashboardItem = ({ api }) => {
         <DetailedDashboardItemSection>
           <DetailedDashboardItemText>
             <TranslatedText
-              stringId="facilityAdmin.bedManagement.dashboard.detailedItem.locationsAvailable.description"
+              stringId="bedManagement.dashboard.detailedItem.locationsAvailable.label"
               fallback="No. of locations available"
             />
           </DetailedDashboardItemText>
           <DetailedDashboardItemText>
             <TranslatedText
-              stringId="facilityAdmin.bedManagement.dashboard.detailedItem.locationsReserved.description"
+              stringId="bedManagement.dashboard.detailedItem.locationsReserved.label"
               fallback="No. of locations reserved"
             />
           </DetailedDashboardItemText>
           <DetailedDashboardItemText>
             <TranslatedText
-              stringId="facilityAdmin.bedManagement.dashboard.detailedItem.locationsOccupied.description"
+              stringId="bedManagement.dashboard.detailedItem.locationsOccupied.label"
               fallback="No. of locations occupied"
             />
           </DetailedDashboardItemText>
@@ -227,9 +227,7 @@ export const BedManagement = () => {
   return (
     <PageContainer>
       <TopBar
-        title={
-          <TranslatedText stringId="facilityAdmin.bedManagement.title" fallback="Bed management" />
-        }
+        title={<TranslatedText stringId="bedManagement.title" fallback="Bed management" />}
         subTitle={facility.name}
       />
       <ContentPane>
@@ -240,7 +238,7 @@ export const BedManagement = () => {
               loading={totalCurrentPatientsCountLoading}
               description={
                 <TranslatedText
-                  stringId="facilityAdmin.bedManagement.dashboard.item.currentPatients.description"
+                  stringId="bedManagement.dashboard.item.currentPatients.label"
                   fallback="Total current\npatients"
                 />
               }
@@ -251,7 +249,7 @@ export const BedManagement = () => {
               loading={currentInpatientsCountLoading}
               description={
                 <TranslatedText
-                  stringId="facilityAdmin.bedManagement.dashboard.item.currentInpatients.description"
+                  stringId="bedManagement.dashboard.item.currentInpatients.label"
                   fallback="Current inpatient\nadmissions"
                 />
               }
@@ -262,7 +260,7 @@ export const BedManagement = () => {
               loading={alosLoading}
               description={
                 <TranslatedText
-                  stringId="facilityAdmin.bedManagement.dashboard.item.averageStayDuration.description"
+                  stringId="bedManagement.dashboard.item.averageStayDuration.label"
                   fallback="Average length of\nstay (last 30 days)"
                 />
               }
@@ -273,7 +271,7 @@ export const BedManagement = () => {
               loading={currentOccupancyLoading}
               description={
                 <TranslatedText
-                  stringId="facilityAdmin.bedManagement.dashboard.item.currentOccupancy.description"
+                  stringId="bedManagement.dashboard.item.currentOccupancy.label"
                   fallback="Current\noccupancy"
                 />
               }
@@ -284,7 +282,7 @@ export const BedManagement = () => {
               loading={readmissionsCountLoading}
               description={
                 <TranslatedText
-                  stringId="facilityAdmin.bedManagement.dashboard.item.readmission.description"
+                  stringId="bedManagement.dashboard.item.readmission.label"
                   fallback="Readmission in\nlast 30 days"
                 />
               }
@@ -301,10 +299,7 @@ export const BedManagement = () => {
         <SearchTable
           columns={columns}
           noDataMessage={
-            <TranslatedText
-              stringId="facilityAdmin.bedManagement.table.noData"
-              fallback="No locations found"
-            />
+            <TranslatedText stringId="bedManagement.table.noData" fallback="No locations found" />
           }
           onRowClick={handleViewPatient}
           rowStyle={rowStyle}

--- a/packages/desktop/app/views/facility/BedManagement.js
+++ b/packages/desktop/app/views/facility/BedManagement.js
@@ -19,6 +19,7 @@ import {
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { usePatientSearch, PatientSearchKeys } from '../../contexts/PatientSearch';
 import { columns } from './bedManagementColumns';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const DashboardContainer = styled.div`
   display: flex;
@@ -138,9 +139,24 @@ const DetailedDashboardItem = ({ api }) => {
           />
         </div>
         <DetailedDashboardItemSection>
-          <DetailedDashboardItemText>No. of locations available</DetailedDashboardItemText>
-          <DetailedDashboardItemText>No. of locations reserved</DetailedDashboardItemText>
-          <DetailedDashboardItemText>No. of locations occupied</DetailedDashboardItemText>
+          <DetailedDashboardItemText>
+            <TranslatedText
+              stringId="facilityAdmin.bedManagement.dashboard.detailedItem.locationsAvailable.description"
+              fallback="No. of locations available"
+            />
+          </DetailedDashboardItemText>
+          <DetailedDashboardItemText>
+            <TranslatedText
+              stringId="facilityAdmin.bedManagement.dashboard.detailedItem.locationsReserved.description"
+              fallback="No. of locations reserved"
+            />
+          </DetailedDashboardItemText>
+          <DetailedDashboardItemText>
+            <TranslatedText
+              stringId="facilityAdmin.bedManagement.dashboard.detailedItem.locationsOccupied.description"
+              fallback="No. of locations occupied"
+            />
+          </DetailedDashboardItemText>
         </DetailedDashboardItemSection>
       </DetailedDashboardItemTextContainer>
     </DetailedDashboardItemContainer>
@@ -210,38 +226,68 @@ export const BedManagement = () => {
 
   return (
     <PageContainer>
-      <TopBar title="Bed management" subTitle={facility.name} />
+      <TopBar
+        title={
+          <TranslatedText stringId="facilityAdmin.bedManagement.title" fallback="Bed management" />
+        }
+        subTitle={facility.name}
+      />
       <ContentPane>
         <DashboardContainer>
           <DashboardItemListContainer>
             <DashboardItem
               title={totalCurrentPatientsCount || 0}
               loading={totalCurrentPatientsCountLoading}
-              description={`Total current\npatients`}
+              description={
+                <TranslatedText
+                  stringId="facilityAdmin.bedManagement.dashboard.item.currentPatients.description"
+                  fallback="Total current\npatients"
+                />
+              }
             />
             <DashboardItem
               color={Colors.green}
               title={currentInpatientsCount || 0}
               loading={currentInpatientsCountLoading}
-              description={`Current inpatient\nadmissions`}
+              description={
+                <TranslatedText
+                  stringId="facilityAdmin.bedManagement.dashboard.item.currentInpatients.description"
+                  fallback="Current inpatient\nadmissions"
+                />
+              }
             />
             <DashboardItem
               color={Colors.purple}
               title={`${Math.round((alos || 0) * 10) / 10} days`}
               loading={alosLoading}
-              description={`Average length of\nstay (last 30 days)`}
+              description={
+                <TranslatedText
+                  stringId="facilityAdmin.bedManagement.dashboard.item.averageStayDuration.description"
+                  fallback="Average length of\nstay (last 30 days)"
+                />
+              }
             />
             <DashboardItem
               color={Colors.pink}
               title={`${Math.round((currentOccupancy || 0) * 10) / 10}%`}
               loading={currentOccupancyLoading}
-              description={`Current\noccupancy`}
+              description={
+                <TranslatedText
+                  stringId="facilityAdmin.bedManagement.dashboard.item.currentOccupancy.description"
+                  fallback="Current\noccupancy"
+                />
+              }
             />
             <DashboardItem
               color={Colors.metallicYellow}
               title={readmissionsCount || 0}
               loading={readmissionsCountLoading}
-              description={`Readmission in\nlast 30 days`}
+              description={
+                <TranslatedText
+                  stringId="facilityAdmin.bedManagement.dashboard.item.readmission.description"
+                  fallback="Readmission in\nlast 30 days"
+                />
+              }
             />
           </DashboardItemListContainer>
           <DetailedDashboardItem api={api} />
@@ -254,7 +300,12 @@ export const BedManagement = () => {
         />
         <SearchTable
           columns={columns}
-          noDataMessage="No locations found"
+          noDataMessage={
+            <TranslatedText
+              stringId="facilityAdmin.bedManagement.table.noData"
+              fallback="No locations found"
+            />
+          }
           onRowClick={handleViewPatient}
           rowStyle={rowStyle}
           fetchOptions={searchParameters}

--- a/packages/desktop/app/views/facility/BedManagement.js
+++ b/packages/desktop/app/views/facility/BedManagement.js
@@ -241,7 +241,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.currentPatients.description"
-                  fallback="Total current \n patients"
+                  fallback="Total current\npatients"
                 />
               }
             />
@@ -252,7 +252,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.currentInpatients.description"
-                  fallback="Current inpatient \n admissions"
+                  fallback="Current inpatient\nadmissions"
                 />
               }
             />
@@ -263,7 +263,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.averageStayDuration.description"
-                  fallback="Average length of \n stay (last 30 days)"
+                  fallback="Average length of\nstay (last 30 days)"
                 />
               }
             />
@@ -274,7 +274,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.currentOccupancy.description"
-                  fallback="Current \n occupancy"
+                  fallback="Current\noccupancy"
                 />
               }
             />
@@ -285,7 +285,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.readmission.description"
-                  fallback="Readmission in \n last 30 days"
+                  fallback="Readmission in\nlast 30 days"
                 />
               }
             />

--- a/packages/desktop/app/views/facility/BedManagement.js
+++ b/packages/desktop/app/views/facility/BedManagement.js
@@ -241,7 +241,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.currentPatients.description"
-                  fallback="Total current\npatients"
+                  fallback="Total current \n patients"
                 />
               }
             />
@@ -252,7 +252,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.currentInpatients.description"
-                  fallback="Current inpatient\nadmissions"
+                  fallback="Current inpatient \n admissions"
                 />
               }
             />
@@ -263,7 +263,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.averageStayDuration.description"
-                  fallback="Average length of\nstay (last 30 days)"
+                  fallback="Average length of \n stay (last 30 days)"
                 />
               }
             />
@@ -274,7 +274,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.currentOccupancy.description"
-                  fallback="Current\noccupancy"
+                  fallback="Current \n occupancy"
                 />
               }
             />
@@ -285,7 +285,7 @@ export const BedManagement = () => {
               description={
                 <TranslatedText
                   stringId="facilityAdmin.bedManagement.dashboard.item.readmission.description"
-                  fallback="Readmission in\nlast 30 days"
+                  fallback="Readmission in \n last 30 days"
                 />
               }
             />

--- a/packages/desktop/app/views/facility/bedManagementColumns.js
+++ b/packages/desktop/app/views/facility/bedManagementColumns.js
@@ -49,33 +49,26 @@ export const columns = [
   },
   {
     key: 'alos',
-    title: (
-      <TranslatedText stringId="facilityAdmin.bedManagement.table.column.alos" fallback="ALOS" />
-    ),
+    title: <TranslatedText stringId="bedManagement.table.column.alos" fallback="ALOS" />,
     minWidth: 30,
     accessor: ({ alos }) => `${Math.round((alos || 0) * 10) / 10} days`,
     sortable: false,
     tooltip: (
       <TranslatedText
-        stringId="facilityAdmin.bedManagement.table.column.alos.tooltip"
+        stringId="bedManagement.table.column.alos.tooltip"
         fallback="Average length of stay, last 30 days"
       />
     ),
   },
   {
     key: 'occupancy',
-    title: (
-      <TranslatedText
-        stringId="facilityAdmin.bedManagement.table.column.occupancy"
-        fallback="Occupancy"
-      />
-    ),
+    title: <TranslatedText stringId="bedManagement.table.column.occupancy" fallback="Occupancy" />,
     minWidth: 30,
     accessor: occupancyAccessor,
     sortable: false,
     tooltip: (
       <TranslatedText
-        stringId="facilityAdmin.bedManagement.table.column.occupancy.tooltip"
+        stringId="bedManagement.table.column.occupancy.tooltip"
         fallback="Bed occupancy, last 30 days"
       />
     ),
@@ -84,7 +77,7 @@ export const columns = [
     key: 'numberOfOccupants',
     title: (
       <TranslatedText
-        stringId="facilityAdmin.bedManagement.table.column.numberOfOccupants"
+        stringId="bedManagement.table.column.numberOfOccupants"
         fallback="No. occupants"
       />
     ),
@@ -92,7 +85,7 @@ export const columns = [
     sortable: false,
     tooltip: (
       <TranslatedText
-        stringId="facilityAdmin.bedManagement.table.column.numberOfOccupants.tooltip"
+        stringId="bedManagement.table.column.numberOfOccupants.tooltip"
         fallback="Current number of occupants"
       />
     ),

--- a/packages/desktop/app/views/facility/bedManagementColumns.js
+++ b/packages/desktop/app/views/facility/bedManagementColumns.js
@@ -38,20 +38,13 @@ const occupancyAccessor = showIfSinglePatient(
 export const columns = [
   {
     key: 'area',
-    title: (
-      <TranslatedText stringId="facilityAdmin.bedManagement.table.column.area" fallback="Area" />
-    ),
+    title: <TranslatedText stringId="general.table.column.area" fallback="Area" />,
     minWidth: 100,
     accessor: ({ area }) => area || '-',
   },
   {
     key: 'location',
-    title: (
-      <TranslatedText
-        stringId="facilityAdmin.bedManagement.table.column.location"
-        fallback="Location"
-      />
-    ),
+    title: <TranslatedText stringId="general.table.column.location" fallback="Location" />,
     minWidth: 100,
   },
   {

--- a/packages/desktop/app/views/facility/bedManagementColumns.js
+++ b/packages/desktop/app/views/facility/bedManagementColumns.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { LOCATION_AVAILABILITY_TAG_CONFIG } from '@tamanu/constants';
 import { Tag } from '../../components';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const BiggerTag = styled(Tag)`
   padding-top: 8px;
@@ -37,53 +38,89 @@ const occupancyAccessor = showIfSinglePatient(
 export const columns = [
   {
     key: 'area',
-    title: 'Area',
+    title: (
+      <TranslatedText stringId="facilityAdmin.bedManagement.table.column.area" fallback="Area" />
+    ),
     minWidth: 100,
     accessor: ({ area }) => area || '-',
   },
   {
     key: 'location',
-    title: 'Location',
+    title: (
+      <TranslatedText
+        stringId="facilityAdmin.bedManagement.table.column.location"
+        fallback="Location"
+      />
+    ),
     minWidth: 100,
   },
   {
     key: 'alos',
-    title: 'ALOS',
+    title: (
+      <TranslatedText stringId="facilityAdmin.bedManagement.table.column.alos" fallback="ALOS" />
+    ),
     minWidth: 30,
     accessor: ({ alos }) => `${Math.round((alos || 0) * 10) / 10} days`,
     sortable: false,
-    tooltip: 'Average length of stay, last 30 days',
+    tooltip: (
+      <TranslatedText
+        stringId="facilityAdmin.bedManagement.table.column.alos.tooltip"
+        fallback="Average length of stay, last 30 days"
+      />
+    ),
   },
   {
     key: 'occupancy',
-    title: 'Occupancy',
+    title: (
+      <TranslatedText
+        stringId="facilityAdmin.bedManagement.table.column.occupancy"
+        fallback="Occupancy"
+      />
+    ),
     minWidth: 30,
     accessor: occupancyAccessor,
     sortable: false,
-    tooltip: 'Bed occupancy, last 30 days',
+    tooltip: (
+      <TranslatedText
+        stringId="facilityAdmin.bedManagement.table.column.occupancy.tooltip"
+        fallback="Bed occupancy, last 30 days"
+      />
+    ),
   },
   {
     key: 'numberOfOccupants',
-    title: 'No. occupants',
+    title: (
+      <TranslatedText
+        stringId="facilityAdmin.bedManagement.table.column.numberOfOccupants"
+        fallback="No. occupants"
+      />
+    ),
     minWidth: 30,
     sortable: false,
-    tooltip: 'Current number of occupants',
+    tooltip: (
+      <TranslatedText
+        stringId="facilityAdmin.bedManagement.table.column.numberOfOccupants.tooltip"
+        fallback="Current number of occupants"
+      />
+    ),
   },
   {
     key: 'patientFirstName',
-    title: 'First Name',
+    title: (
+      <TranslatedText stringId="general.table.column.patientFirstName" fallback="First Name" />
+    ),
     minWidth: 100,
     accessor: patientFirstNameAccessor,
   },
   {
     key: 'patientLastName',
-    title: 'Last Name',
+    title: <TranslatedText stringId="general.table.column.patientLastName" fallback="Last name" />,
     minWidth: 100,
     accessor: patientLastNameAccessor,
   },
   {
     key: 'status',
-    title: 'Status',
+    title: <TranslatedText stringId="general.table.column.status" fallback="Status" />,
     minWidth: 100,
     CellComponent: StatusCell,
   },

--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -30,13 +30,10 @@ const fetchServers = async (): Promise<SelectOption[]> => {
   const response = await fetch(`${metaServer}/servers`);
   const servers: Server[] = await response.json();
 
-  return [...servers.map(s => ({
+  return servers.map(s => ({
     label: s.name,
     value: s.host,
-  })), {
-    label: 'Local',
-    value: 'http://172.23.118.138:3000'
-  }];
+  }));
 };
 
 export const ServerSelector = ({ onChange, label, value, error }): ReactElement => {

--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -30,10 +30,13 @@ const fetchServers = async (): Promise<SelectOption[]> => {
   const response = await fetch(`${metaServer}/servers`);
   const servers: Server[] = await response.json();
 
-  return servers.map(s => ({
+  return [...servers.map(s => ({
     label: s.name,
     value: s.host,
-  }));
+  })), {
+    label: 'Local',
+    value: 'http://172.23.118.138:3000'
+  }];
 };
 
 export const ServerSelector = ({ onChange, label, value, error }): ReactElement => {


### PR DESCRIPTION
### Changes

Translated facility admin 'Bed management' page on desktop using `<TranslatedText />` components.

**Issues with line break & `<TranslatedText />` encountered**

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
