### PR TITLE
NOTAM-219: fix empty handover notes bug

### DIFF
--- a/packages/desktop/app/components/BedManagement/HandoverNotesModal.js
+++ b/packages/desktop/app/components/BedManagement/HandoverNotesModal.js
@@ -18,6 +18,7 @@ export const HandoverNotesModal = React.memo(({ area: areaId, ...props }) => {
   const {
     data: { data: handoverNotes = [], locationGroup = {} } = {},
     refetch: refetchHandoverNotes,
+    isFetching,
   } = useQuery(
     ['locationGroupHandoverNotes'],
     () => areaId && api.get(`locationGroup/${areaId}/handoverNotes`),
@@ -28,6 +29,8 @@ export const HandoverNotesModal = React.memo(({ area: areaId, ...props }) => {
       refetchHandoverNotes();
     }
   }, [refetchHandoverNotes, areaId]);
+
+  if (isFetching) return null;
 
   return (
     <Modal {...props} title={modalTitle} onPrint={() => printPDF('handover-notes')}>


### PR DESCRIPTION
### Changes

In 1.38 we have been running into some pdf issues where it will render without the fetched data on the first view (likely related to the big node upgrade). This can be fixed by not rendering the pdf until the useQuery "isFetching" property is false. I have applied that fix here

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
