### PR TITLE
NASS-973: Translate desktop encounter patient listing pages

### DIFF
--- a/packages/desktop/app/components/Field/DOBFields.js
+++ b/packages/desktop/app/components/Field/DOBFields.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { getCurrentDateString } from '@tamanu/shared/utils/dateTime';
 import { DateField } from './DateField';
 import { Field } from './Field';
+import { TranslatedText } from '../Translation/TranslatedText';
 
 const JoinedField = styled(Field)`
   position: relative;
@@ -33,14 +34,14 @@ export const DOBFields = ({ showExactBirth = true }) => (
       name="dateOfBirthFrom"
       component={DateField}
       saveDateAsString
-      label="DOB from"
+      label={<TranslatedText stringId="general.form.dateOfBirthFrom.label" fallback="DOB from" />}
       max={getCurrentDateString()}
     />
     <Field
       name="dateOfBirthTo"
       component={DateField}
       saveDateAsString
-      label="DOB to"
+      label={<TranslatedText stringId="general.form.dateOfBirthTo.label" fallback="DOB to" />}
       max={getCurrentDateString()}
     />
   </>

--- a/packages/desktop/app/components/TriageDashboard.js
+++ b/packages/desktop/app/components/TriageDashboard.js
@@ -89,7 +89,7 @@ const CardFooter = ({ averageWaitTime, color }) => {
         <AccessTime htmlColor={color} />
         <FooterLabel>
           <TranslatedText
-            stringId="patientList.emergency.card.footer.waitTime"
+            stringId="patientList.triage.card.footer.avgWaitTime"
             fallback="Avg. wait time"
           />
           :{' '}
@@ -116,7 +116,7 @@ export const TriageDashboard = () => {
           color={color}
           title={
             <TranslatedText
-              stringId="patientList.emergency.card.patientLevel"
+              stringId="patientList.triage.card.patientLevel"
               fallback="Level :level patient"
               replacements={{ level }}
             />

--- a/packages/desktop/app/components/TriageDashboard.js
+++ b/packages/desktop/app/components/TriageDashboard.js
@@ -6,6 +6,7 @@ import { useApi } from '../api';
 import { StatisticsCard, StatisticsCardContainer } from './StatisticsCard';
 import { Colors } from '../constants';
 import { useLocalisation } from '../contexts/Localisation';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const getAverageWaitTime = categoryData => {
   if (categoryData.length === 0) {
@@ -86,7 +87,13 @@ const CardFooter = ({ averageWaitTime, color }) => {
     <>
       <Row>
         <AccessTime htmlColor={color} />
-        <FooterLabel>Avg. wait time: </FooterLabel>
+        <FooterLabel>
+          <TranslatedText
+            stringId="patientList.emergency.card.footer.waitTime"
+            fallback="Avg. wait time"
+          />
+          :{' '}
+        </FooterLabel>
         <FooterTime>{averageHrs}</FooterTime>
       </Row>
       <FooterTime>{averageMins}</FooterTime>
@@ -107,7 +114,13 @@ export const TriageDashboard = () => {
         <StatisticsCard
           key={level}
           color={color}
-          title={`Level ${level} patient`}
+          title={
+            <TranslatedText
+              stringId="patientList.emergency.card.patientLevel"
+              fallback="Level :level patient"
+              replacements={{ level }}
+            />
+          }
           value={numberOfPatients}
           Footer={<CardFooter color={color} averageWaitTime={averageWaitTime} />}
         />

--- a/packages/desktop/app/components/TriageTable.js
+++ b/packages/desktop/app/components/TriageTable.js
@@ -48,7 +48,9 @@ const useColumns = () => {
         />
       ),
     },
-    { key: 'displayId' },
+    {
+      key: 'displayId',
+    },
     {
       key: 'patientName',
       title: (
@@ -56,7 +58,10 @@ const useColumns = () => {
       ),
       accessor: row => `${row.firstName} ${row.lastName}`,
     },
-    { key: 'dateOfBirth', accessor: row => <DateDisplay date={row.dateOfBirth} /> },
+    {
+      key: 'dateOfBirth',
+      accessor: row => <DateDisplay date={row.dateOfBirth} />,
+    },
     {
       key: 'sex',
       accessor: row => <span style={{ textTransform: 'capitalize' }}>{row.sex || ''}</span>,
@@ -90,7 +95,9 @@ export const TriageTable = React.memo(() => {
     <DataFetchingTable
       endpoint="triage"
       columns={columns}
-      noDataMessage="No patients found"
+      noDataMessage={
+        <TranslatedText stringId="patientListing.table.noData" fallback="No patients found" />
+      }
       onRowClick={viewEncounter}
     />
   );

--- a/packages/desktop/app/components/TriageTable.js
+++ b/packages/desktop/app/components/TriageTable.js
@@ -9,6 +9,7 @@ import { LocationCell, LocationGroupCell } from './LocationCell';
 import { TriageWaitTimeCell } from './TriageWaitTimeCell';
 import { useLocalisation } from '../contexts/Localisation';
 import { reloadPatient } from '../store';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const ADMITTED_PRIORITY_COLOR = '#bdbdbd';
 
@@ -19,7 +20,12 @@ const useColumns = () => {
   return [
     {
       key: 'arrivalTime',
-      title: 'Wait time',
+      title: (
+        <TranslatedText
+          stringId="patientList.emergency.table.column.waitTime"
+          fallback="Wait time"
+        />
+      ),
       // Cell color cannot be set on the component due to the way table cells are configured so the
       // cell color must be calculated and set in the table config separately
       cellColor: ({ score, encounterType }) => {
@@ -33,16 +39,38 @@ const useColumns = () => {
       accessor: TriageWaitTimeCell,
       isExportable: false,
     },
-    { key: 'chiefComplaint', title: 'Chief complaint' },
+    {
+      key: 'chiefComplaint',
+      title: (
+        <TranslatedText
+          stringId="patientList.emergency.table.column.chiefComplaint"
+          fallback="Chief complaint"
+        />
+      ),
+    },
     { key: 'displayId' },
-    { key: 'patientName', title: 'Patient', accessor: row => `${row.firstName} ${row.lastName}` },
+    {
+      key: 'patientName',
+      title: (
+        <TranslatedText stringId="patientList.emergency.table.column.patient" fallback="Patient" />
+      ),
+      accessor: row => `${row.firstName} ${row.lastName}`,
+    },
     { key: 'dateOfBirth', accessor: row => <DateDisplay date={row.dateOfBirth} /> },
     {
       key: 'sex',
       accessor: row => <span style={{ textTransform: 'capitalize' }}>{row.sex || ''}</span>,
     },
-    { key: 'locationGroupName', title: 'Area', accessor: LocationGroupCell },
-    { key: 'locationName', title: 'Location', accessor: LocationCell },
+    {
+      key: 'locationGroupName',
+      title: <TranslatedText stringId="general.table.column.area" fallback="Area" />,
+      accessor: LocationGroupCell,
+    },
+    {
+      key: 'locationName',
+      title: <TranslatedText stringId="general.table.column.location" fallback="Location" />,
+      accessor: LocationCell,
+    },
   ];
 };
 

--- a/packages/desktop/app/components/TriageTable.js
+++ b/packages/desktop/app/components/TriageTable.js
@@ -21,10 +21,7 @@ const useColumns = () => {
     {
       key: 'arrivalTime',
       title: (
-        <TranslatedText
-          stringId="patientList.emergency.table.column.waitTime"
-          fallback="Wait time"
-        />
+        <TranslatedText stringId="patientList.triage.table.column.waitTime" fallback="Wait time" />
       ),
       // Cell color cannot be set on the component due to the way table cells are configured so the
       // cell color must be calculated and set in the table config separately
@@ -43,7 +40,7 @@ const useColumns = () => {
       key: 'chiefComplaint',
       title: (
         <TranslatedText
-          stringId="patientList.emergency.table.column.chiefComplaint"
+          stringId="patientList.triage.table.column.chiefComplaint"
           fallback="Chief complaint"
         />
       ),
@@ -54,7 +51,7 @@ const useColumns = () => {
     {
       key: 'patientName',
       title: (
-        <TranslatedText stringId="patientList.emergency.table.column.patient" fallback="Patient" />
+        <TranslatedText stringId="patientList.triage.table.column.patient" fallback="Patient" />
       ),
       accessor: row => `${row.firstName} ${row.lastName}`,
     },
@@ -96,7 +93,7 @@ export const TriageTable = React.memo(() => {
       endpoint="triage"
       columns={columns}
       noDataMessage={
-        <TranslatedText stringId="patientListing.table.noData" fallback="No patients found" />
+        <TranslatedText stringId="patientList.table.noData" fallback="No patients found" />
       }
       onRowClick={viewEncounter}
     />

--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -26,7 +26,18 @@ const ColourCell = styled(PlainCell)`
 `;
 
 const TriageCell = ({ arrivalTime, children }) => (
-  <Tooltip title={`Arrival time: ${arrivalTime}`} arrow placement="top">
+  // `Arrival time: ${arrivalTime}`
+  <Tooltip
+    title={
+      <TranslatedText
+        stringId="patientList.triage.table.waitTime.arrivalTime.toolTip"
+        fallback="Arrival time: :arrivalTime"
+        replacements={{ arrivalTime }}
+      />
+    }
+    arrow
+    placement="top"
+  >
     <ColourCell>{children}</ColourCell>
   </Tooltip>
 );

--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -67,7 +67,7 @@ export const TriageWaitTimeCell = React.memo(
             <div>{getDuration(assumedArrivalTime)}</div>
             <div>
               <TranslatedText
-                stringId="patientList.emergency.table.waitTime.cell.triageTime"
+                stringId="patientList.triage.table.waitTime.cell.triageTime"
                 fallback="Triage at :triageDate"
                 replacements={{ triageDate: format(new Date(triageTime), 'h:mma') }}
               />
@@ -79,7 +79,7 @@ export const TriageWaitTimeCell = React.memo(
         return (
           <TriageCell arrivalTime={assumedArrivalTime}>
             <TranslatedText
-              stringId="patientList.emergency.table.waitTime.cell.closedTime"
+              stringId="patientList.triage.table.waitTime.cell.closedTime"
               fallback="Seen at :triageDate"
               replacements={{ triageDate: format(new Date(closedTime), 'h:mma') }}
             />
@@ -89,7 +89,7 @@ export const TriageWaitTimeCell = React.memo(
         return (
           <PlainCell>
             <TranslatedText
-              stringId="patientList.emergency.table.waitTime.cell.admitted"
+              stringId="patientList.triage.table.waitTime.cell.admitted"
               fallback="Admitted"
             />
           </PlainCell>

--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { format } from 'date-fns';
 import Tooltip from '@material-ui/core/Tooltip';
 import { ENCOUNTER_TYPES } from '@tamanu/constants/encounters';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const MINUTE = 60 * 1000;
 const HOUR = 60 * MINUTE;
@@ -53,18 +54,35 @@ export const TriageWaitTimeCell = React.memo(
         return (
           <TriageCell arrivalTime={assumedArrivalTime}>
             <div>{getDuration(assumedArrivalTime)}</div>
-            <div>{`Triage at ${format(new Date(triageTime), 'h:mma')}`}</div>
+            <div>
+              <TranslatedText
+                stringId="patientList.emergency.table.waitTime.cell.triageTime"
+                fallback="Triage at :triageDate"
+                replacements={{ triageDate: format(new Date(triageTime), 'h:mma') }}
+              />
+            </div>
           </TriageCell>
         );
       case ENCOUNTER_TYPES.OBSERVATION:
       case ENCOUNTER_TYPES.EMERGENCY:
         return (
           <TriageCell arrivalTime={assumedArrivalTime}>
-            {`Seen at ${format(new Date(closedTime), 'h:mma')}`}
+            <TranslatedText
+              stringId="patientList.emergency.table.waitTime.cell.closedTime"
+              fallback="Seen at :triageDate"
+              replacements={{ triageDate: format(new Date(closedTime), 'h:mma') }}
+            />
           </TriageCell>
         );
       default:
-        return <PlainCell>Admitted</PlainCell>;
+        return (
+          <PlainCell>
+            <TranslatedText
+              stringId="patientList.emergency.table.waitTime.cell.admitted"
+              fallback="Admitted"
+            />
+          </PlainCell>
+        );
     }
   },
 );

--- a/packages/desktop/app/components/TriageWaitTimeCell.js
+++ b/packages/desktop/app/components/TriageWaitTimeCell.js
@@ -26,7 +26,6 @@ const ColourCell = styled(PlainCell)`
 `;
 
 const TriageCell = ({ arrivalTime, children }) => (
-  // `Arrival time: ${arrivalTime}`
   <Tooltip
     title={
       <TranslatedText

--- a/packages/desktop/app/views/TriageListingView.js
+++ b/packages/desktop/app/views/TriageListingView.js
@@ -4,6 +4,7 @@ import { TopBar, PageContainer, ContentPane } from '../components';
 import { TriageTable } from '../components/TriageTable';
 import { TriageDashboard } from '../components/TriageDashboard';
 import { Colors } from '../constants';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const Section = styled.div`
   background: white;
@@ -12,7 +13,9 @@ const Section = styled.div`
 
 export const TriageListingView = () => (
   <PageContainer>
-    <TopBar title="Emergency patients" />
+    <TopBar
+      title=<TranslatedText stringId="patientList.emergency.title" fallback="Emergency patients" />
+    />
     <Section>
       <ContentPane>
         <TriageDashboard />

--- a/packages/desktop/app/views/TriageListingView.js
+++ b/packages/desktop/app/views/TriageListingView.js
@@ -14,7 +14,7 @@ const Section = styled.div`
 export const TriageListingView = () => (
   <PageContainer>
     <TopBar
-      title=<TranslatedText stringId="patientList.emergency.title" fallback="Emergency patients" />
+      title=<TranslatedText stringId="patientList.triage.title" fallback="Emergency patients" />
     />
     <Section>
       <ContentPane>

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -48,13 +48,13 @@ const LISTING_COLUMNS = [
 
 const location = {
   key: 'locationName',
-  title: 'Location',
+  title: <TranslatedText stringId="general.table.column.location" fallback="Location" />,
   accessor: LocationCell,
 };
 
 const locationGroup = {
   key: 'locationGroupName',
-  title: 'Area',
+  title: <TranslatedText stringId="general.table.column.area" fallback="Area" />,
   accessor: LocationGroupCell,
 };
 
@@ -78,7 +78,9 @@ const PatientTable = ({ columns, fetchOptions, searchParameters }) => {
   return (
     <SearchTable
       columns={columns}
-      noDataMessage="No patients found"
+      noDataMessage={
+        <TranslatedText stringId="patientListing.table.noData" fallback="No patients found" />
+      }
       onRowClick={handleViewPatient}
       rowStyle={({ dateOfDeath }) => {
         // Style rows for deceased patients red

--- a/packages/desktop/app/views/patients/PatientListingView.js
+++ b/packages/desktop/app/views/patients/PatientListingView.js
@@ -79,7 +79,7 @@ const PatientTable = ({ columns, fetchOptions, searchParameters }) => {
     <SearchTable
       columns={columns}
       noDataMessage={
-        <TranslatedText stringId="patientListing.table.noData" fallback="No patients found" />
+        <TranslatedText stringId="patientList.table.noData" fallback="No patients found" />
       }
       onRowClick={handleViewPatient}
       rowStyle={({ dateOfDeath }) => {


### PR DESCRIPTION
### Changes

Replaced strings from patient listing pages with Translated Text components as described in the ticket. Most have previously been translated already.


Ticket: [NASS-973: Translate desktop encounter patient listing pages](https://linear.app/bes/issue/NASS-973/translate-desktop-encounter-patient-listing-pages)


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
