### PR TITLE
NASS-1048: Newline support for TranslatedText

### DIFF
--- a/packages/desktop/app/components/Translation/TranslatedText.js
+++ b/packages/desktop/app/components/Translation/TranslatedText.js
@@ -33,7 +33,7 @@ export const TranslatedText = ({ stringId, fallback, replacements }) => {
   const [isDebugMode, setIsDebugMode] = useState(false);
   // "setTranslation" is used in future functionality
   // eslint-disable-next-line no-unused-vars
-  const [translation, setTranslation] = useState(fallback);
+  const [translation, setTranslation] = useState(fallback?.split('\\n').join('\n'));
   const [displayElements, setDisplayElements] = useState(fallback);
 
   useEffect(() => {


### PR DESCRIPTION
### Changes

Implemented newline support for `<TranslatedText />` component.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
