### PR TITLE
NASS-969: Translate desktop 'Discharge patient' modal

### DIFF
--- a/packages/desktop/app/components/BaseModal.js
+++ b/packages/desktop/app/components/BaseModal.js
@@ -10,6 +10,7 @@ import { Box, CircularProgress, IconButton, Typography } from '@material-ui/core
 import { Colors } from '../constants';
 import { useElectron } from '../contexts/Electron';
 import { Button } from './Button';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const MODAL_PADDING_TOP_AND_BOTTOM = 18;
 export const MODAL_PADDING_LEFT_AND_RIGHT = 32;
@@ -148,7 +149,7 @@ export const BaseModal = memo(
                 startIcon={<PrintIcon />}
                 size="small"
               >
-                Print
+                <TranslatedText stringId="general.action.print" fallback="Print" />
               </StyledButton>
             )}
             {cornerExitButton && (

--- a/packages/desktop/app/components/DischargeModal.js
+++ b/packages/desktop/app/components/DischargeModal.js
@@ -7,6 +7,7 @@ import { useSuggester } from '../api';
 import { DischargeForm } from '../forms/DischargeForm';
 import { useEncounter } from '../contexts/Encounter';
 import { reloadPatient } from '../store/patient';
+import { TranslatedText } from './Translation/TranslatedText';
 
 export const DischargeModal = React.memo(({ open, onClose }) => {
   const dispatch = useDispatch();
@@ -27,7 +28,11 @@ export const DischargeModal = React.memo(({ open, onClose }) => {
   );
 
   return (
-    <FormModal title="Discharge patient" open={open} onClose={onClose}>
+    <FormModal
+      title={<TranslatedText stringId="discharge.modal.title" fallback="Discharge patient" />}
+      open={open}
+      onClose={onClose}
+    >
       <DischargeForm
         onSubmit={handleDischarge}
         onCancel={onClose}

--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -22,6 +22,7 @@ import { LoadingIndicator } from '../../LoadingIndicator';
 import { Colors } from '../../../constants';
 import { ForbiddenErrorModalContents } from '../../ForbiddenErrorModal';
 import { ModalActionRow } from '../../ModalActionRow';
+import { TranslatedText } from '../../Translation/TranslatedText';
 
 // These below functions are used to extract the history of changes made to the encounter that are stored in notes.
 // obviously a better solution needs to be to properly implemented for storing and accessing this data, but this is an ok workaround for now.
@@ -140,7 +141,12 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
   ]);
 
   const modalProps = {
-    title: 'Encounter Record',
+    title: (
+      <TranslatedText
+        stringId="encounter.modal.encounterRecord.title"
+        fallback="Encounter Record"
+      />
+    ),
     color: Colors.white,
     open,
     onClose,

--- a/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
+++ b/packages/desktop/app/components/PatientPrinting/modals/EncounterRecordModal.js
@@ -143,7 +143,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
   const modalProps = {
     title: (
       <TranslatedText
-        stringId="encounter.modal.encounterRecord.title"
+        stringId="patient.modal.print.encounterRecord.title"
         fallback="Encounter Record"
       />
     ),

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -36,6 +36,7 @@ import {
   MODAL_PADDING_TOP_AND_BOTTOM,
   useLocalisedText,
 } from '../components';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const Divider = styled(BaseDivider)`
   margin: 30px -${MODAL_PADDING_LEFT_AND_RIGHT}px;
@@ -107,9 +108,11 @@ const StyledUnorderedList = styled.ul`
 
 const ProcedureList = React.memo(({ procedures }) => (
   <StyledUnorderedList>
-    {procedures.length > 0
-      ? procedures.map(({ procedureType }) => <li key={procedureType.id}>{procedureType.name}</li>)
-      : 'N/a'}
+    {procedures.length > 0 ? (
+      procedures.map(({ procedureType }) => <li key={procedureType.id}>{procedureType.name}</li>)
+    ) : (
+      <TranslatedText stringId="general.fallback.notApplicable" fallback="N/A" />
+    )}
   </StyledUnorderedList>
 ));
 
@@ -178,11 +181,31 @@ const RepeatsAccessor = ({ id }) => (
 const medicationColumns = [
   {
     key: 'drug/prescription',
-    title: 'Drug / Prescription',
+    title: (
+      <TranslatedText
+        stringId="discharge.table.column.drugPrescription"
+        fallback="Drug / Prescription"
+      />
+    ),
     accessor: MedicationAccessor,
   },
-  { key: 'quantity', title: 'Discharge Quantity', accessor: QuantityAccessor, width: '20%' },
-  { key: 'repeats', title: 'Repeats', accessor: RepeatsAccessor, width: '20%' },
+  {
+    key: 'quantity',
+    title: (
+      <TranslatedText
+        stringId="discharge.table.column.dischargeQuantity"
+        fallback="Discharge Quantity"
+      />
+    ),
+    accessor: QuantityAccessor,
+    width: '20%',
+  },
+  {
+    key: 'repeats',
+    title: <TranslatedText stringId="discharge.table.column.repeats" fallback="Repeats" />,
+    accessor: RepeatsAccessor,
+    width: '20%',
+  },
 ];
 
 const EncounterOverview = ({
@@ -195,22 +218,42 @@ const EncounterOverview = ({
 
   return (
     <>
-      <DateTimeInput label="Admission date" value={startDate} disabled />
+      <DateTimeInput
+        label=<TranslatedText
+          stringId="discharge.form.admissionDate.label"
+          fallback="Admission date"
+        />
+        value={startDate}
+        disabled
+      />
       <TextInput
-        label={`Supervising ${clinicianText.toLowerCase()}`}
+        label=<TranslatedText
+          stringId="discharge.form.supervisingClinician.label"
+          fallback="Supervising :clinicianText"
+          replacements={{ clinicianText: clinicianText.toLowerCase() }}
+        />
         value={examiner ? examiner.displayName : '-'}
         disabled
       />
       <TextInput
-        label="Reason for encounter"
+        label=<TranslatedText
+          stringId="discharge.form.encounterReason.label"
+          fallback="Reason for encounter"
+        />
         value={reasonForEncounter}
         disabled
         style={{ gridColumn: '1 / -1' }}
       />
-      <OuterLabelFieldWrapper label="Diagnoses" style={{ gridColumn: '1 / -1' }}>
+      <OuterLabelFieldWrapper
+        label={<TranslatedText stringId="discharge.form.diagnoses.label" fallback="Diagnoses" />}
+        style={{ gridColumn: '1 / -1' }}
+      >
         <DiagnosisList diagnoses={currentDiagnoses} />
       </OuterLabelFieldWrapper>
-      <OuterLabelFieldWrapper label="Procedures" style={{ gridColumn: '1 / -1' }}>
+      <OuterLabelFieldWrapper
+        label={<TranslatedText stringId="discharge.form.procedures.label" fallback="Procedures" />}
+        style={{ gridColumn: '1 / -1' }}
+      >
         <ProcedureList procedures={procedures} />
       </OuterLabelFieldWrapper>
     </>
@@ -236,8 +279,8 @@ const DischargeFormScreen = props => {
               onStepForward();
             }
           }}
-          confirmText="Finalise"
-          cancelText="Cancel"
+          confirmText={<TranslatedText stringId="general.action.finalise" fallback="Finalise" />}
+          cancelText={<TranslatedText stringId="general.action.cancel" fallback="Cancel" />}
         />
       }
       {...props}
@@ -322,7 +365,12 @@ export const DischargeForm = ({
         <EncounterOverview encounter={encounter} />
         <Field
           name="endDate"
-          label="Discharge date"
+          label={
+            <TranslatedText
+              stringId="discharge.form.dischargeDate.label"
+              fallback="Discharge Date"
+            />
+          }
           component={DateTimeField}
           min={format(encounter.startDate, "yyyy-MM-dd'T'HH:mm")}
           required
@@ -330,7 +378,13 @@ export const DischargeForm = ({
         />
         <Field
           name="discharge.dischargerId"
-          label={`Discharging ${clinicianText.toLowerCase()}`}
+          label={
+            <TranslatedText
+              stringId="discharge.form.dischargingClinician.label"
+              fallback="Discharging :clinicianText"
+              replacements={{ clinicianText: clinicianText.toLowerCase() }}
+            />
+          }
           component={AutocompleteField}
           suggester={practitionerSuggester}
           required
@@ -341,20 +395,43 @@ export const DischargeForm = ({
           component={AutocompleteField}
           suggester={dispositionSuggester}
         />
-        <OuterLabelFieldWrapper label="Discharge medications" style={{ gridColumn: '1 / -1' }}>
+        <OuterLabelFieldWrapper
+          label={
+            <TranslatedText
+              stringId="discharge.form.dischargeMedications.label"
+              fallback="Discharge medications"
+            />
+          }
+          style={{ gridColumn: '1 / -1' }}
+        >
           <TableFormFields columns={medicationColumns} data={activeMedications} />
         </OuterLabelFieldWrapper>
         <Field
           name="sendToPharmacy"
-          label="Send prescription to pharmacy"
+          label={
+            <TranslatedText
+              stringId="discharge.form.sendToPharmacy.label"
+              fallback="Send prescription to pharmacy"
+            />
+          }
           component={CheckField}
-          helperText="Requires mSupply"
+          helperText={
+            <TranslatedText
+              stringId="discharge.form.sendToPharmacy.helperText"
+              fallback="Requires mSupply"
+            />
+          }
           style={{ gridColumn: '1 / -1' }}
           disabled
         />
         <Field
           name="discharge.note"
-          label="Discharge treatment plan and follow-up notes"
+          label={
+            <TranslatedText
+              stringId="discharge.form.notes.label"
+              fallback="Discharge treatment plan and follow-up notes"
+            />
+          }
           component={TextField}
           multiline
           rows={4}

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -183,7 +183,7 @@ const medicationColumns = [
     key: 'drug/prescription',
     title: (
       <TranslatedText
-        stringId="discharge.table.column.drugPrescription"
+        stringId="discharge.table.column.drugOrPrescription"
         fallback="Drug / Prescription"
       />
     ),
@@ -299,7 +299,7 @@ const DischargeSummaryScreen = ({ onStepBack, submitForm, onCancel }) => (
       </h3>
       <p>
         <TranslatedText
-          stringId="discharge.modal.confirm.subText"
+          stringId="discharge.modal.confirm.warningText"
           fallback="Are you sure you want to discharge the patient? This action is irreversible."
         />
       </p>

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -359,7 +359,11 @@ export const DischargeForm = ({
           .object()
           .shape({
             dischargerId: foreignKey(
-              `Discharging ${clinicianText.toLowerCase()} is a required field'`,
+              <TranslatedText
+                stringId="discharge.form.dischargingClinician.validation"
+                fallback="Discharging :clinicianText is a required field"
+                replacements={{ clinicianText: clinicianText.toLowerCase() }}
+              />,
             ),
           })
           .shape({

--- a/packages/desktop/app/forms/DischargeForm.js
+++ b/packages/desktop/app/forms/DischargeForm.js
@@ -291,8 +291,18 @@ const DischargeFormScreen = props => {
 const DischargeSummaryScreen = ({ onStepBack, submitForm, onCancel }) => (
   <div className="ConfirmContent">
     <ConfirmContent>
-      <h3>Confirm patient discharge</h3>
-      <p>Are you sure you want to discharge the patient? This action is irreversible.</p>
+      <h3>
+        <TranslatedText
+          stringId="discharge.modal.confirm.heading"
+          fallback="Confirm patient discharge"
+        />
+      </h3>
+      <p>
+        <TranslatedText
+          stringId="discharge.modal.confirm.subText"
+          fallback="Are you sure you want to discharge the patient? This action is irreversible."
+        />
+      </p>
     </ConfirmContent>
     <Divider />
     <FormConfirmCancelBackRow onBack={onStepBack} onConfirm={submitForm} onCancel={onCancel} />
@@ -368,7 +378,7 @@ export const DischargeForm = ({
           label={
             <TranslatedText
               stringId="discharge.form.dischargeDate.label"
-              fallback="Discharge Date"
+              fallback="Discharge date"
             />
           }
           component={DateTimeField}

--- a/packages/desktop/app/routes/PatientRoutes.js
+++ b/packages/desktop/app/routes/PatientRoutes.js
@@ -19,6 +19,7 @@ import {
 import { getEncounterType } from '../views/patients/panes/EncounterInfoPane';
 import { ProgramsView } from '../views/programs/ProgramsView';
 import { ReferralsView } from '../views/referrals/ReferralsView';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 export const usePatientRoutes = () => {
   const { navigateToEncounter, navigateToPatient } = usePatientNavigation();
@@ -50,7 +51,12 @@ export const usePatientRoutes = () => {
             {
               path: `${PATIENT_PATHS.SUMMARY}/view`,
               component: DischargeSummaryView,
-              title: 'Discharge Summary',
+              title: (
+                <TranslatedText
+                  stringId="encounter.dischargeSummary.title"
+                  fallback="Discharge Summary"
+                />
+              ),
             },
             {
               path: `${PATIENT_PATHS.ENCOUNTER}/programs/new`,

--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -392,7 +392,7 @@ export const DischargeSummaryView = React.memo(() => {
           startIcon={<PrintIcon />}
         >
           <TranslatedText
-            stringId="dischargeSummary.action.printSummary"
+            stringId="discharge.action.printSummary"
             fallback="Print summary"
           />
         </Button>

--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -391,10 +391,7 @@ export const DischargeSummaryView = React.memo(() => {
           onClick={() => printPage()}
           startIcon={<PrintIcon />}
         >
-          <TranslatedText
-            stringId="discharge.action.printSummary"
-            fallback="Print summary"
-          />
+          <TranslatedText stringId="discharge.action.printSummary" fallback="Print summary" />
         </Button>
       </NavContainer>
       <SummaryPage encounter={encounter} discharge={discharge} />

--- a/packages/desktop/app/views/patients/DischargeSummaryView.js
+++ b/packages/desktop/app/views/patients/DischargeSummaryView.js
@@ -29,6 +29,7 @@ import {
   LocalisedDisplayValue,
 } from '../../components/PatientPrinting/printouts/reusable/CertificateLabels';
 import { useLocalisedText } from '../../components';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const Container = styled.div`
   background: ${Colors.white};
@@ -390,7 +391,10 @@ export const DischargeSummaryView = React.memo(() => {
           onClick={() => printPage()}
           startIcon={<PrintIcon />}
         >
-          Print Summary
+          <TranslatedText
+            stringId="dischargeSummary.action.printSummary"
+            fallback="Print summary"
+          />
         </Button>
       </NavContainer>
       <SummaryPage encounter={encounter} discharge={discharge} />

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -16,6 +16,7 @@ import { DropdownButton } from '../../../components/DropdownButton';
 import { MoveModal } from './MoveModal';
 import { EncounterRecordModal } from '../../../components/PatientPrinting/modals/EncounterRecordModal';
 import { Colors } from '../../../constants';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const TypographyLink = styled(Typography)`
   color: ${Colors.primary};
@@ -124,7 +125,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
       onClick: onCancelLocationChange,
     },
     {
-      label: 'Discharge',
+      label: <TranslatedText stringId="encounter.action.discharge" fallback="Discharge" />,
       onClick: onDischargeOpen,
       condition: () => encounter.encounterType !== ENCOUNTER_TYPES.TRIAGE,
     },

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -74,10 +74,15 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
     return (
       <div>
         <Button variant="outlined" color="primary" onClick={onViewSummary}>
-          View discharge summary
+          <TranslatedText
+            stringId="encounter.action.viewDischargeSummary"
+            fallback="View discharge summary"
+          />
         </Button>
         <br />
-        <TypographyLink onClick={onViewEncounterRecord}>Encounter record</TypographyLink>
+        <TypographyLink onClick={onViewEncounterRecord}>
+          <TranslatedText stringId="encounter.action.encounterRecord" fallback="Encounter Record" />
+        </TypographyLink>
       </div>
     );
   }

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -81,7 +81,10 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
         </Button>
         <br />
         <TypographyLink onClick={onViewEncounterRecord}>
-          <TranslatedText stringId="encounter.action.encounterRecord" fallback="Encounter record" />
+          <TranslatedText
+            stringId="encounter.action.viewEncounterRecord"
+            fallback="Encounter record"
+          />
         </TypographyLink>
       </div>
     );

--- a/packages/desktop/app/views/patients/components/EncounterActions.js
+++ b/packages/desktop/app/views/patients/components/EncounterActions.js
@@ -81,7 +81,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
         </Button>
         <br />
         <TypographyLink onClick={onViewEncounterRecord}>
-          <TranslatedText stringId="encounter.action.encounterRecord" fallback="Encounter Record" />
+          <TranslatedText stringId="encounter.action.encounterRecord" fallback="Encounter record" />
         </TypographyLink>
       </div>
     );


### PR DESCRIPTION
### Changes

Replaced strings with translated text components in areas described in the linear ticket.

Changed fallback:
'N/a' -> 'N/A' - Assumed that N/A is prefered as its used more in the codebase

[NASS-969: Translate desktop 'Discharge patient' modal](https://linear.app/bes/issue/NASS-969/translate-desktop-discharge-patient-modal)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
