### PR TITLE
NASS-970: Translate desktop 'Results' page

### DIFF
--- a/packages/desktop/app/components/CarePlanNoteForm.js
+++ b/packages/desktop/app/components/CarePlanNoteForm.js
@@ -93,7 +93,7 @@ export function CarePlanNoteForm({
               note ? (
                 <TranslatedText stringId="general.action.save" fallback="Save" />
               ) : (
-                <TranslatedText stringId="carePlan.action.addNote" fallback="Add Note" />
+                <TranslatedText stringId="general.action.addNote" fallback="Add Note" />
               )
             }
           />

--- a/packages/desktop/app/components/ResultsSearchBar.js
+++ b/packages/desktop/app/components/ResultsSearchBar.js
@@ -4,6 +4,7 @@ import { useSuggester } from '../api';
 import { AutocompleteInput } from './Field';
 import { Colors } from '../constants';
 import { Heading3 } from './Typography';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const Container = styled.div`
   padding: 24px 30px 30px;
@@ -45,11 +46,18 @@ export const ResultsSearchBar = React.memo(
     });
     return (
       <Container>
-        <Heading3 mb={2}>Lab results</Heading3>
+        <Heading3 mb={2}>
+          <TranslatedText stringId="patient.results.search.title" fallback="Lab results" />
+        </Heading3>
         <Fields>
           <StyledAutoCompleteInput
             name="category"
-            label="Test category"
+            label={
+              <TranslatedText
+                stringId="patient.results.search.category.label"
+                fallback="Test category"
+              />
+            }
             disabled={disabled}
             suggester={categorySuggester}
             value={searchParameters.categoryId}
@@ -60,7 +68,9 @@ export const ResultsSearchBar = React.memo(
           />
           <StyledAutoCompleteInput
             name="panel"
-            label="Test panel"
+            label={
+              <TranslatedText stringId="patient.results.search.panel.label" fallback="Test panel" />
+            }
             disabled={disabled}
             value={searchParameters.panelId}
             suggester={panelSuggester}

--- a/packages/desktop/app/components/ResultsSearchBar.js
+++ b/packages/desktop/app/components/ResultsSearchBar.js
@@ -70,7 +70,7 @@ export const ResultsSearchBar = React.memo(
             name="panel"
             label={
               <TranslatedText
-                stringId="patient.lab.labrresults.search.panel.label"
+                stringId="patient.lab.results.search.panel.label"
                 fallback="Test panel"
               />
             }

--- a/packages/desktop/app/components/ResultsSearchBar.js
+++ b/packages/desktop/app/components/ResultsSearchBar.js
@@ -47,14 +47,14 @@ export const ResultsSearchBar = React.memo(
     return (
       <Container>
         <Heading3 mb={2}>
-          <TranslatedText stringId="patient.results.search.title" fallback="Lab results" />
+          <TranslatedText stringId="patient.lab.results.search.title" fallback="Lab results" />
         </Heading3>
         <Fields>
           <StyledAutoCompleteInput
             name="category"
             label={
               <TranslatedText
-                stringId="patient.results.search.category.label"
+                stringId="patient.lab.results.search.testCategory.label"
                 fallback="Test category"
               />
             }
@@ -69,7 +69,10 @@ export const ResultsSearchBar = React.memo(
           <StyledAutoCompleteInput
             name="panel"
             label={
-              <TranslatedText stringId="patient.results.search.panel.label" fallback="Test panel" />
+              <TranslatedText
+                stringId="patient.lab.labrresults.search.panel.label"
+                fallback="Test panel"
+              />
             }
             disabled={disabled}
             value={searchParameters.panelId}

--- a/packages/desktop/app/forms/LabRequestNoteForm.js
+++ b/packages/desktop/app/forms/LabRequestNoteForm.js
@@ -144,7 +144,7 @@ export const LabRequestNoteForm = React.memo(({ labRequestId, isReadOnly }) => {
                 </Box>
               ) : (
                 <ShowAddNoteFormButton $underline onClick={() => setActive(true)}>
-                  <TranslatedText stringId="labRequest.action.addNote" fallback="Add note" />
+                  <TranslatedText stringId="general.action.addNote" fallback="Add note" />
                 </ShowAddNoteFormButton>
               );
             }}

--- a/packages/desktop/app/forms/LabRequestNoteForm.js
+++ b/packages/desktop/app/forms/LabRequestNoteForm.js
@@ -16,6 +16,7 @@ import {
   FormSubmitButton,
   FormCancelButton,
 } from '../components';
+import { TranslatedText } from '../components/Translation/TranslatedText';
 
 const Container = styled.div`
   display: flex;
@@ -143,7 +144,7 @@ export const LabRequestNoteForm = React.memo(({ labRequestId, isReadOnly }) => {
                 </Box>
               ) : (
                 <ShowAddNoteFormButton $underline onClick={() => setActive(true)}>
-                  Add note
+                  <TranslatedText stringId="labRequest.action.addNote" fallback="Add note" />
                 </ShowAddNoteFormButton>
               );
             }}

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -196,7 +196,9 @@ export const LabRequestView = () => {
   return (
     <Container>
       <TopContainer>
-        <Heading2>Labs</Heading2>
+        <Heading2>
+          <TranslatedText stringId="labRequest.view.title" fallback="Labs" />
+        </Heading2>
         <LabRequestCard
           labRequest={labRequest}
           isReadOnly={areLabRequestsReadOnly}
@@ -208,7 +210,10 @@ export const LabRequestView = () => {
                   handleChangeModalId(MODAL_IDS.PRINT);
                 }}
               >
-                Print request
+                <TranslatedText
+                  stringId="labRequest.action.printRequest"
+                  fallback="Print request"
+                />
               </OutlinedButton>
               <Menu setModal={handleChangeModalId} status={labRequest.status} disabled={isHidden} />
             </Box>
@@ -218,19 +223,24 @@ export const LabRequestView = () => {
         <FixedTileRow>
           <Tile
             Icon={() => <img src={TestCategoryIcon} alt="test category" />}
-            text="Test Category"
+            text={
+              <TranslatedText
+                stringId="labRequest.view.tile.testCategory.label"
+                fallback="Test Category"
+              />
+            }
             main={labRequest.category?.name || '-'}
           />
           <Tile
             Icon={Timelapse}
-            text="Status"
+            text={<TranslatedText stringId="labRequest.view.tile.status.label" fallback="Status" />}
             main={
               <TileTag $color={LAB_REQUEST_STATUS_CONFIG[labRequest.status]?.color}>
                 {LAB_REQUEST_STATUS_CONFIG[displayStatus]?.label || 'Unknown'}
               </TileTag>
             }
             actions={[
-              ...(!areLabRequestsReadOnly &&
+              !areLabRequestsReadOnly &&
                 canWriteLabRequestStatus && {
                   label: (
                     <TranslatedText
@@ -239,7 +249,7 @@ export const LabRequestView = () => {
                     />
                   ),
                   action: () => handleChangeModalId(MODAL_IDS.CHANGE_STATUS),
-                }),
+                },
               {
                 label: (
                   <TranslatedText
@@ -253,7 +263,12 @@ export const LabRequestView = () => {
           />
           <Tile
             Icon={() => <img src={BeakerIcon} alt="beaker" />}
-            text="Sample collected"
+            text={
+              <TranslatedText
+                stringId="labRequest.view.tile.sampleTime.label"
+                fallback="Sample collected"
+              />
+            }
             isReadOnly={areLabRequestsReadOnly}
             main={
               <>
@@ -268,7 +283,12 @@ export const LabRequestView = () => {
           />
           <Tile
             Icon={Business}
-            text="Laboratory"
+            text={
+              <TranslatedText
+                stringId="labRequest.view.tile.laboratory.label"
+                fallback="Laboratory"
+              />
+            }
             main={labRequest.laboratory?.name || '-'}
             isReadOnly={areLabRequestsReadOnly}
             actions={[
@@ -285,7 +305,9 @@ export const LabRequestView = () => {
           />
           <Tile
             Icon={AssignmentLate}
-            text="Priority"
+            text={
+              <TranslatedText stringId="labRequest.view.tile.priority.label" fallback="Priority" />
+            }
             main={labRequest.priority?.name || '-'}
             isReadOnly={areLabRequestsReadOnly}
             actions={[
@@ -306,7 +328,7 @@ export const LabRequestView = () => {
         {!isPublished && !areLabTestsReadOnly && (
           <Box display="flex" justifyContent="flex-end" marginBottom="20px">
             <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}>
-              Enter results
+              <TranslatedText stringId="labRequest.action.enterResult" fallback="Enter results" />
             </Button>
           </Box>
         )}

--- a/packages/desktop/app/views/patients/LabRequestView.js
+++ b/packages/desktop/app/views/patients/LabRequestView.js
@@ -174,9 +174,7 @@ export const LabRequestView = () => {
     labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
       ? [
           {
-            label: (
-              <TranslatedText stringId="labRequest.action.recordSample" fallback="Record sample" />
-            ),
+            label: <TranslatedText stringId="lab.action.recordSample" fallback="Record sample" />,
             action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
           },
         ]
@@ -186,9 +184,7 @@ export const LabRequestView = () => {
             action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
           },
           {
-            label: (
-              <TranslatedText stringId="labRequest.action.viewDetails" fallback="View details" />
-            ),
+            label: <TranslatedText stringId="lab.action.viewDetails" fallback="View details" />,
             action: () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS),
           },
         ];
@@ -197,7 +193,7 @@ export const LabRequestView = () => {
     <Container>
       <TopContainer>
         <Heading2>
-          <TranslatedText stringId="labRequest.view.title" fallback="Labs" />
+          <TranslatedText stringId="lab.view.title" fallback="Labs" />
         </Heading2>
         <LabRequestCard
           labRequest={labRequest}
@@ -210,10 +206,7 @@ export const LabRequestView = () => {
                   handleChangeModalId(MODAL_IDS.PRINT);
                 }}
               >
-                <TranslatedText
-                  stringId="labRequest.action.printRequest"
-                  fallback="Print request"
-                />
+                <TranslatedText stringId="lab.action.printRequest" fallback="Print request" />
               </OutlinedButton>
               <Menu setModal={handleChangeModalId} status={labRequest.status} disabled={isHidden} />
             </Box>
@@ -225,7 +218,7 @@ export const LabRequestView = () => {
             Icon={() => <img src={TestCategoryIcon} alt="test category" />}
             text={
               <TranslatedText
-                stringId="labRequest.view.tile.testCategory.label"
+                stringId="lab.view.tile.testCategory.label"
                 fallback="Test Category"
               />
             }
@@ -233,7 +226,7 @@ export const LabRequestView = () => {
           />
           <Tile
             Icon={Timelapse}
-            text={<TranslatedText stringId="labRequest.view.tile.status.label" fallback="Status" />}
+            text={<TranslatedText stringId="lab.view.tile.status.label" fallback="Status" />}
             main={
               <TileTag $color={LAB_REQUEST_STATUS_CONFIG[labRequest.status]?.color}>
                 {LAB_REQUEST_STATUS_CONFIG[displayStatus]?.label || 'Unknown'}
@@ -243,19 +236,13 @@ export const LabRequestView = () => {
               !areLabRequestsReadOnly &&
                 canWriteLabRequestStatus && {
                   label: (
-                    <TranslatedText
-                      stringId="labRequest.action.changeStatus"
-                      fallback="Change status"
-                    />
+                    <TranslatedText stringId="lab.action.changeStatus" fallback="Change status" />
                   ),
                   action: () => handleChangeModalId(MODAL_IDS.CHANGE_STATUS),
                 },
               {
                 label: (
-                  <TranslatedText
-                    stringId="labRequest.action.viewStatusLog"
-                    fallback="View status log"
-                  />
+                  <TranslatedText stringId="lab.action.viewStatusLog" fallback="View status log" />
                 ),
                 action: () => handleChangeModalId(MODAL_IDS.VIEW_STATUS_LOG),
               },
@@ -265,7 +252,7 @@ export const LabRequestView = () => {
             Icon={() => <img src={BeakerIcon} alt="beaker" />}
             text={
               <TranslatedText
-                stringId="labRequest.view.tile.sampleTime.label"
+                stringId="lab.view.tile.sampleTime.label"
                 fallback="Sample collected"
               />
             }
@@ -284,10 +271,7 @@ export const LabRequestView = () => {
           <Tile
             Icon={Business}
             text={
-              <TranslatedText
-                stringId="labRequest.view.tile.laboratory.label"
-                fallback="Laboratory"
-              />
+              <TranslatedText stringId="lab.view.tile.laboratory.label" fallback="Laboratory" />
             }
             main={labRequest.laboratory?.name || '-'}
             isReadOnly={areLabRequestsReadOnly}
@@ -295,7 +279,7 @@ export const LabRequestView = () => {
               {
                 label: (
                   <TranslatedText
-                    stringId="labRequest.action.changeLaboratory"
+                    stringId="lab.action.changeLaboratory"
                     fallback="Change laboratory"
                   />
                 ),
@@ -305,18 +289,13 @@ export const LabRequestView = () => {
           />
           <Tile
             Icon={AssignmentLate}
-            text={
-              <TranslatedText stringId="labRequest.view.tile.priority.label" fallback="Priority" />
-            }
+            text={<TranslatedText stringId="lab.view.tile.priority.label" fallback="Priority" />}
             main={labRequest.priority?.name || '-'}
             isReadOnly={areLabRequestsReadOnly}
             actions={[
               {
                 label: (
-                  <TranslatedText
-                    stringId="labRequest.action.changePriority"
-                    fallback="Change priority"
-                  />
+                  <TranslatedText stringId="lab.action.changePriority" fallback="Change priority" />
                 ),
                 action: () => handleChangeModalId(MODAL_IDS.CHANGE_PRIORITY),
               },
@@ -328,7 +307,7 @@ export const LabRequestView = () => {
         {!isPublished && !areLabTestsReadOnly && (
           <Box display="flex" justifyContent="flex-end" marginBottom="20px">
             <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}>
-              <TranslatedText stringId="labRequest.action.enterResult" fallback="Enter results" />
+              <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
             </Button>
           </Box>
         )}

--- a/packages/desktop/app/views/patients/LabTestResultModal.js
+++ b/packages/desktop/app/views/patients/LabTestResultModal.js
@@ -54,7 +54,7 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
       title={
         <ModalHeader>
           <TranslatedText
-            stringId="patient.results.modal.testResult.title"
+            stringId="lab.modal.testResult.title"
             fallback=":testName | Test ID :testId"
             replacements={{
               testName: labTest?.labTestType?.name,
@@ -71,17 +71,14 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
         <div>
           <ValueDisplay
             title={
-              <TranslatedText
-                stringId="patient.results.modal.testResult.value.result"
-                fallback="Result"
-              />
+              <TranslatedText stringId="lab.modal.testResult.value.result" fallback="Result" />
             }
             value={labTest?.result}
           />
           <ValueDisplay
             title={
               <TranslatedText
-                stringId="patient.results.modal.testResult.value.laboratoryOfficer"
+                stringId="lab.modal.testResult.value.laboratoryOfficer"
                 fallback="Laboratory Officer"
               />
             }
@@ -90,7 +87,7 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
           <ValueDisplay
             title={
               <TranslatedText
-                stringId="patient.results.modal.testResult.value.verification"
+                stringId="lab.modal.testResult.value.verification"
                 fallback="Verification"
               />
             }
@@ -102,7 +99,7 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
           <ValueDisplay
             title={
               <TranslatedText
-                stringId="patient.results.modal.testResult.value.completed"
+                stringId="labs.modal.testResult.value.completed"
                 fallback="Completed"
               />
             }
@@ -111,7 +108,7 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
           <ValueDisplay
             title={
               <TranslatedText
-                stringId="patient.results.modal.testResult.value.testMethod"
+                stringId="lab.modal.testResult.value.testMethod"
                 fallback="Test Method"
               />
             }

--- a/packages/desktop/app/views/patients/LabTestResultModal.js
+++ b/packages/desktop/app/views/patients/LabTestResultModal.js
@@ -7,6 +7,7 @@ import { DateDisplay } from '../../components/DateDisplay';
 import { Modal } from '../../components/Modal';
 import { ModalActionRow } from '../../components/ModalActionRow';
 import { BodyText } from '../../components/Typography';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const ModalBody = styled.div`
   display: grid;
@@ -52,7 +53,14 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
     <Modal
       title={
         <ModalHeader>
-          {labTest?.labTestType?.name} | Test ID {labTest?.labRequest?.displayId}
+          <TranslatedText
+            stringId="patient.results.modal.testResult.title"
+            fallback=":testName | Test ID :testId"
+            replacements={{
+              testName: labTest?.labTestType?.name,
+              testId: labTest?.labRequest?.displayId,
+            }}
+          />
         </ModalHeader>
       }
       open={open}
@@ -61,20 +69,60 @@ export const LabTestResultModal = React.memo(({ open, onClose, labTestId }) => {
     >
       <ModalBody>
         <div>
-          <ValueDisplay title="Result" value={labTest?.result} />
-          <ValueDisplay title="Laboratory Officer" value={labTest?.laboratoryOfficer} />
-          <ValueDisplay title="Verification" value={labTest?.verification} />
+          <ValueDisplay
+            title={
+              <TranslatedText
+                stringId="patient.results.modal.testResult.value.result"
+                fallback="Result"
+              />
+            }
+            value={labTest?.result}
+          />
+          <ValueDisplay
+            title={
+              <TranslatedText
+                stringId="patient.results.modal.testResult.value.laboratoryOfficer"
+                fallback="Laboratory Officer"
+              />
+            }
+            value={labTest?.laboratoryOfficer}
+          />
+          <ValueDisplay
+            title={
+              <TranslatedText
+                stringId="patient.results.modal.testResult.value.verification"
+                fallback="Verification"
+              />
+            }
+            value={labTest?.verification}
+          />
         </div>
         <VerticalDivider />
         <div>
           <ValueDisplay
-            title="Completed"
+            title={
+              <TranslatedText
+                stringId="patient.results.modal.testResult.value.completed"
+                fallback="Completed"
+              />
+            }
             value={DateDisplay.stringFormat(labTest?.completedDate)}
           />
-          <ValueDisplay title="Test Method" value={labTest?.labTestMethod?.name} />
+          <ValueDisplay
+            title={
+              <TranslatedText
+                stringId="patient.results.modal.testResult.value.testMethod"
+                fallback="Test Method"
+              />
+            }
+            value={labTest?.labTestMethod?.name}
+          />
         </div>
       </ModalBody>
-      <ModalActionRow confirmText="Close" onConfirm={onClose} />
+      <ModalActionRow
+        confirmText={<TranslatedText stringId="general.action.close" fallback="Close" />}
+        onConfirm={onClose}
+      />
     </Modal>
   );
 });

--- a/packages/desktop/app/views/patients/PatientLabTestsTable.js
+++ b/packages/desktop/app/views/patients/PatientLabTestsTable.js
@@ -133,7 +133,7 @@ export const PatientLabTestsTable = React.memo(
               key: 'testCategory.id',
               title: (
                 <TranslatedText
-                  stringId="patient.results.table.column.testCategory"
+                  stringId="patient.lab.results.table.column.testCategory"
                   fallback="Test category"
                 />
               ),
@@ -145,7 +145,7 @@ export const PatientLabTestsTable = React.memo(
       {
         key: 'testType',
         title: (
-          <TranslatedText stringId="patient.results.table.column.testType" fallback="Test type" />
+          <TranslatedText stringId="patient.lab.results.table.column.testType" fallback="Test type" />
         ),
         accessor: row => (
           <CategoryCell>
@@ -160,7 +160,7 @@ export const PatientLabTestsTable = React.memo(
         key: 'normalRange',
         title: (
           <TranslatedText
-            stringId="patient.results.table.column.normalRange"
+            stringId="patient.lab.results.table.column.normalRange"
             fallback="Normal range"
           />
         ),
@@ -214,7 +214,7 @@ export const PatientLabTestsTable = React.memo(
           isLoading={isLoading}
           noDataMessage={
             <TranslatedText
-              stringId="patient.results.table.noData"
+              stringId="patient.lab.results.table.noData"
               fallback="This patient has no lab results to display. Once lab results are available they will be displayed here."
             />
           }

--- a/packages/desktop/app/views/patients/PatientLabTestsTable.js
+++ b/packages/desktop/app/views/patients/PatientLabTestsTable.js
@@ -145,7 +145,10 @@ export const PatientLabTestsTable = React.memo(
       {
         key: 'testType',
         title: (
-          <TranslatedText stringId="patient.lab.results.table.column.testType" fallback="Test type" />
+          <TranslatedText
+            stringId="patient.lab.results.table.column.testType"
+            fallback="Test type"
+          />
         ),
         accessor: row => (
           <CategoryCell>

--- a/packages/desktop/app/views/patients/PatientLabTestsTable.js
+++ b/packages/desktop/app/views/patients/PatientLabTestsTable.js
@@ -6,6 +6,7 @@ import { RangeValidatedCell, DateHeadCell } from '../../components/FormattedTabl
 import { Colors } from '../../constants';
 import { LabTestResultModal } from './LabTestResultModal';
 import { BodyText, DateDisplay, formatTimeWithSeconds } from '../../components';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const COLUMN_WIDTHS = [150, 120, 120];
 
@@ -130,7 +131,12 @@ export const PatientLabTestsTable = React.memo(
         ? [
             {
               key: 'testCategory.id',
-              title: 'Test category',
+              title: (
+                <TranslatedText
+                  stringId="patient.results.table.column.testCategory"
+                  fallback="Test category"
+                />
+              ),
               accessor: row => <CategoryCell>{row.testCategory}</CategoryCell>,
               sortable: false,
             },
@@ -138,7 +144,9 @@ export const PatientLabTestsTable = React.memo(
         : []),
       {
         key: 'testType',
-        title: 'Test type',
+        title: (
+          <TranslatedText stringId="patient.results.table.column.testType" fallback="Test type" />
+        ),
         accessor: row => (
           <CategoryCell>
             {row.testType}
@@ -150,7 +158,12 @@ export const PatientLabTestsTable = React.memo(
       },
       {
         key: 'normalRange',
-        title: 'Normal range',
+        title: (
+          <TranslatedText
+            stringId="patient.results.table.column.normalRange"
+            fallback="Normal range"
+          />
+        ),
         accessor: row => {
           const range = row.normalRanges[patient?.sex];
           const value = !range.min ? '-' : `${range.min}-${range.max}`;
@@ -199,7 +212,12 @@ export const PatientLabTestsTable = React.memo(
           columns={columns}
           data={labTests}
           isLoading={isLoading}
-          noDataMessage="This patient has no lab results to display. Once lab results are available they will be displayed here."
+          noDataMessage={
+            <TranslatedText
+              stringId="patient.results.table.noData"
+              fallback="This patient has no lab results to display. Once lab results are available they will be displayed here."
+            />
+          }
           count={count}
           allowExport
           exportName="PatientResults"

--- a/packages/desktop/app/views/patients/components/LabRequestCard.js
+++ b/packages/desktop/app/views/patients/components/LabRequestCard.js
@@ -57,7 +57,11 @@ export const LabRequestCard = ({ labRequest, actions }) => {
         <LabIcon src={labsIcon} />
         <CardItem>
           <CardLabel>
-            <TranslatedText stringId="lab.details.card.item.labTestId.label" fallback="Lab test ID" />:
+            <TranslatedText
+              stringId="lab.details.card.item.labTestId.label"
+              fallback="Lab test ID"
+            />
+            :
           </CardLabel>
           <CardValue>{labRequest.displayId}</CardValue>
           <CardLabel>

--- a/packages/desktop/app/views/patients/components/LabRequestCard.js
+++ b/packages/desktop/app/views/patients/components/LabRequestCard.js
@@ -4,6 +4,7 @@ import { Box } from '@material-ui/core';
 import { labsIcon } from '../../../constants/images';
 import { DateDisplay, useLocalisedText } from '../../../components';
 import { Colors } from '../../../constants';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const Container = styled.div`
   display: flex;
@@ -55,9 +56,21 @@ export const LabRequestCard = ({ labRequest, actions }) => {
       <Box display="flex" alignItems="center">
         <LabIcon src={labsIcon} />
         <CardItem>
-          <CardLabel>Lab test ID:</CardLabel>
+          <CardLabel>
+            <TranslatedText
+              stringId="labRequest.view.card.item.labTestId.label"
+              fallback="Lab test ID"
+            />
+            :
+          </CardLabel>
           <CardValue>{labRequest.displayId}</CardValue>
-          <CardLabel>Request date:</CardLabel>
+          <CardLabel>
+            <TranslatedText
+              stringId="labRequest.view.card.item.requestDate.label"
+              fallback="Request date"
+            />
+            :
+          </CardLabel>
           <CardValue>
             <DateDisplay date={labRequest.requestedDate} />
           </CardValue>
@@ -65,7 +78,9 @@ export const LabRequestCard = ({ labRequest, actions }) => {
         <BorderSection>
           <CardLabel>{`Requesting ${clinicianText}:`}</CardLabel>
           <CardValue>{labRequest.requestedBy?.displayName}</CardValue>
-          <CardLabel>Department:</CardLabel>
+          <CardLabel>
+            <TranslatedText stringId="general.card.item.department.label" fallback="Department" />:
+          </CardLabel>
           <CardValue>{labRequest.department?.name}</CardValue>
         </BorderSection>
       </Box>

--- a/packages/desktop/app/views/patients/components/LabRequestCard.js
+++ b/packages/desktop/app/views/patients/components/LabRequestCard.js
@@ -57,12 +57,12 @@ export const LabRequestCard = ({ labRequest, actions }) => {
         <LabIcon src={labsIcon} />
         <CardItem>
           <CardLabel>
-            <TranslatedText stringId="lab.view.card.item.labTestId.label" fallback="Lab test ID" />:
+            <TranslatedText stringId="lab.details.card.item.labTestId.label" fallback="Lab test ID" />:
           </CardLabel>
           <CardValue>{labRequest.displayId}</CardValue>
           <CardLabel>
             <TranslatedText
-              stringId="lab.view.card.item.requestDate.label"
+              stringId="lab.details.card.item.requestDate.label"
               fallback="Request date"
             />
             :

--- a/packages/desktop/app/views/patients/components/LabRequestCard.js
+++ b/packages/desktop/app/views/patients/components/LabRequestCard.js
@@ -57,16 +57,12 @@ export const LabRequestCard = ({ labRequest, actions }) => {
         <LabIcon src={labsIcon} />
         <CardItem>
           <CardLabel>
-            <TranslatedText
-              stringId="labRequest.view.card.item.labTestId.label"
-              fallback="Lab test ID"
-            />
-            :
+            <TranslatedText stringId="lab.view.card.item.labTestId.label" fallback="Lab test ID" />:
           </CardLabel>
           <CardValue>{labRequest.displayId}</CardValue>
           <CardLabel>
             <TranslatedText
-              stringId="labRequest.view.card.item.requestDate.label"
+              stringId="lab.view.card.item.requestDate.label"
               fallback="Request date"
             />
             :

--- a/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
+++ b/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
@@ -51,7 +51,7 @@ const columns = sex => [
     sortable: false,
   },
   {
-    title: <TranslatedText stringId="lab.results.table.column.method" fallback="Method" />,
+    title: <TranslatedText stringId="lab.results.table.column.labTestMethod" fallback="Method" />,
     key: 'labTestMethod',
     accessor: getMethod,
     sortable: false,

--- a/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
+++ b/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
@@ -30,46 +30,51 @@ const makeRangeStringAccessor = sex => ({ labTestType }) => {
 
 const columns = sex => [
   {
-    title: <TranslatedText stringId="labRequest.table.column.testType" fallback="Test type" />,
+    title: <TranslatedText stringId="lab.results.table.column.testType" fallback="Test type" />,
     key: 'labTestType.name',
     accessor: row => row.labTestType.name,
   },
   {
-    title: <TranslatedText stringId="labRequest.table.column.result" fallback="Result" />,
+    title: <TranslatedText stringId="lab.results.table.column.result" fallback="Result" />,
     key: 'result',
     accessor: ({ result }) => result ?? '',
   },
   {
-    title: <TranslatedText stringId="labRequest.table.column.unit" fallback="Units" />,
+    title: <TranslatedText stringId="lab.results.table.column.unit" fallback="Units" />,
     key: 'labTestType.unit',
     accessor: ({ labTestType }) => labTestType?.unit || 'N/A',
   },
   {
-    title: <TranslatedText stringId="labRequest.table.column.reference" fallback="Reference" />,
+    title: <TranslatedText stringId="lab.results.table.column.reference" fallback="Reference" />,
     key: 'reference',
     accessor: makeRangeStringAccessor(sex),
     sortable: false,
   },
   {
-    title: <TranslatedText stringId="labRequest.table.column.method" fallback="Method" />,
+    title: <TranslatedText stringId="lab.results.table.column.method" fallback="Method" />,
     key: 'labTestMethod',
     accessor: getMethod,
     sortable: false,
   },
   {
     title: (
-      <TranslatedText stringId="labRequest.table.column.laboratoryOffier" fallback="Lab officer" />
+      <TranslatedText
+        stringId="lab.results.table.column.laboratoryOfficer"
+        fallback="Lab officer"
+      />
     ),
     key: 'laboratoryOfficer',
   },
   {
     title: (
-      <TranslatedText stringId="labRequest.table.column.verification" fallback="Verification" />
+      <TranslatedText stringId="lab.results.table.column.verification" fallback="Verification" />
     ),
     key: 'verification',
   },
   {
-    title: <TranslatedText stringId="labRequest.table.column.completedDate" fallback="Completed" />,
+    title: (
+      <TranslatedText stringId="lab.results.table.column.completedDate" fallback="Completed" />
+    ),
     key: 'completedDate',
     accessor: getCompletedDate,
     sortable: false,

--- a/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
+++ b/packages/desktop/app/views/patients/components/LabRequestResultsTable.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { DataFetchingTable } from '../../../components';
 
 import { getCompletedDate, getMethod } from '../../../utils/lab';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const StyledDataFetchingTable = styled(DataFetchingTable)`
   table tbody tr:last-child td {
@@ -28,27 +29,51 @@ const makeRangeStringAccessor = sex => ({ labTestType }) => {
 };
 
 const columns = sex => [
-  { title: 'Test type', key: 'labTestType.name', accessor: row => row.labTestType.name },
   {
-    title: 'Result',
+    title: <TranslatedText stringId="labRequest.table.column.testType" fallback="Test type" />,
+    key: 'labTestType.name',
+    accessor: row => row.labTestType.name,
+  },
+  {
+    title: <TranslatedText stringId="labRequest.table.column.result" fallback="Result" />,
     key: 'result',
     accessor: ({ result }) => result ?? '',
   },
   {
-    title: 'Units',
+    title: <TranslatedText stringId="labRequest.table.column.unit" fallback="Units" />,
     key: 'labTestType.unit',
     accessor: ({ labTestType }) => labTestType?.unit || 'N/A',
   },
   {
-    title: 'Reference',
+    title: <TranslatedText stringId="labRequest.table.column.reference" fallback="Reference" />,
     key: 'reference',
     accessor: makeRangeStringAccessor(sex),
     sortable: false,
   },
-  { title: 'Method', key: 'labTestMethod', accessor: getMethod, sortable: false },
-  { title: 'Lab officer', key: 'laboratoryOfficer' },
-  { title: 'Verification', key: 'verification' },
-  { title: 'Completed', key: 'completedDate', accessor: getCompletedDate, sortable: false },
+  {
+    title: <TranslatedText stringId="labRequest.table.column.method" fallback="Method" />,
+    key: 'labTestMethod',
+    accessor: getMethod,
+    sortable: false,
+  },
+  {
+    title: (
+      <TranslatedText stringId="labRequest.table.column.laboratoryOffier" fallback="Lab officer" />
+    ),
+    key: 'laboratoryOfficer',
+  },
+  {
+    title: (
+      <TranslatedText stringId="labRequest.table.column.verification" fallback="Verification" />
+    ),
+    key: 'verification',
+  },
+  {
+    title: <TranslatedText stringId="labRequest.table.column.completedDate" fallback="Completed" />,
+    key: 'completedDate',
+    accessor: getCompletedDate,
+    sortable: false,
+  },
 ];
 
 export const LabRequestResultsTable = React.memo(({ labRequest, patient, refreshCount }) => {

--- a/packages/desktop/app/views/patients/components/LabTestResultsModal.js
+++ b/packages/desktop/app/views/patients/components/LabTestResultsModal.js
@@ -112,7 +112,9 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.VERIFICATION,
-      title: <TranslatedText stringId="lab.results.table.column.verification" fallback="Verification" />,
+      title: (
+        <TranslatedText stringId="lab.results.table.column.verification" fallback="Verification" />
+      ),
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -124,7 +126,9 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.COMPLETED_DATE,
-      title: <TranslatedText stringId="lab.results.table.column.completedDate" fallback="Completed" />,
+      title: (
+        <TranslatedText stringId="lab.results.table.column.completedDate" fallback="Completed" />
+      ),
       width: '260px',
       accessor: (row, i) => (
         <AccessorField
@@ -211,13 +215,13 @@ const ResultsForm = ({
         <div>
           <Heading4 marginBottom="10px">
             <TranslatedText
-              stringId="lab.modal.testResults.heading"
+              stringId="patient.lab.modal.enterResults.heading"
               fallback="Enter test results"
             />
           </Heading4>
           <SmallBodyText color="textTertiary">
             <TranslatedText
-              stringId="lab.modal.testResults.subHeading"
+              stringId="patient.lab.modal.enterResults.subHeading"
               fallback="Please record test results and other test result details."
             />
           </SmallBodyText>
@@ -277,7 +281,7 @@ export const LabTestResultsModal = ({ labRequest, refreshLabTestTable, onClose, 
       width="lg"
       title={
         <TranslatedText
-          stringId="lab.modal.testResults.title"
+          stringId="patient.lab.modal.enterResults.title"
           fallback="Enter results | Test ID :testId"
           replacements={{ testId: displayId }}
         />

--- a/packages/desktop/app/views/patients/components/LabTestResultsModal.js
+++ b/packages/desktop/app/views/patients/components/LabTestResultsModal.js
@@ -15,6 +15,7 @@ import { LabResultAccessorField, AccessorField } from './AccessorField';
 import { ConfirmCancelRow } from '../../../components/ButtonRow';
 import { useApi } from '../../../api';
 import { useAuth } from '../../../contexts/Auth';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const TableContainer = styled.div`
   overflow-y: auto;
@@ -68,13 +69,13 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
   return [
     {
       key: 'labTestType',
-      title: 'Test type',
+      title: <TranslatedText stringId="labRequest.table.column.testType" fallback="Test type" />,
       width: '120px',
       accessor: row => row.labTestType.name,
     },
     {
       key: LAB_TEST_PROPERTIES.RESULT,
-      title: 'Result',
+      title: <TranslatedText stringId="labRequest.table.column.result" fallback="Result" />,
       accessor: (row, i) => {
         const { resultType, options } = row.labTestType;
         return (
@@ -92,13 +93,13 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: 'unit',
-      title: 'Units',
+      title: <TranslatedText stringId="labRequest.table.column.unit" fallback="Units" />,
       width: '80px',
       accessor: row => <BodyText color="textTertiary">{row.labTestType.unit || 'N/A'}</BodyText>,
     },
     {
       key: LAB_TEST_PROPERTIES.LAB_TEST_METHOD_ID,
-      title: 'Method',
+      title: <TranslatedText stringId="labRequest.table.column.method" fallback="Method" />,
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -111,7 +112,9 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.VERIFICATION,
-      title: 'Verification',
+      title: (
+        <TranslatedText stringId="labRequest.table.column.verification" fallback="Verification" />
+      ),
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -123,7 +126,9 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.COMPLETED_DATE,
-      title: 'Completed',
+      title: (
+        <TranslatedText stringId="labRequest.table.column.completedDate" fallback="Completed" />
+      ),
       width: '260px',
       accessor: (row, i) => (
         <AccessorField
@@ -208,9 +213,17 @@ const ResultsForm = ({
     <Box>
       <Box margin="0px 30px" paddingBottom="20px">
         <div>
-          <Heading4 marginBottom="10px">Enter test results</Heading4>
+          <Heading4 marginBottom="10px">
+            <TranslatedText
+              stringId="labRequest.modal.testResults.heading"
+              fallback="Enter test results"
+            />
+          </Heading4>
           <SmallBodyText color="textTertiary">
-            Please record test results and other test result details.
+            <TranslatedText
+              stringId="labRequest.modal.testResults.subHeading"
+              fallback="Please record test results and other test result details."
+            />
           </SmallBodyText>
         </div>
       </Box>
@@ -266,7 +279,13 @@ export const LabTestResultsModal = ({ labRequest, refreshLabTestTable, onClose, 
   return (
     <StyledModal
       width="lg"
-      title={`Enter results | Test ID ${displayId}`}
+      title={
+        <TranslatedText
+          stringId="labRequest.modal.testResults.title"
+          fallback="Enter results | Test ID :testId"
+          replacements={{ testId: displayId }}
+        />
+      }
       open={open}
       onClose={onClose}
       overrideContentPadding

--- a/packages/desktop/app/views/patients/components/LabTestResultsModal.js
+++ b/packages/desktop/app/views/patients/components/LabTestResultsModal.js
@@ -69,13 +69,13 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
   return [
     {
       key: 'labTestType',
-      title: <TranslatedText stringId="labRequest.table.column.testType" fallback="Test type" />,
+      title: <TranslatedText stringId="lab.table.column.testType" fallback="Test type" />,
       width: '120px',
       accessor: row => row.labTestType.name,
     },
     {
       key: LAB_TEST_PROPERTIES.RESULT,
-      title: <TranslatedText stringId="labRequest.table.column.result" fallback="Result" />,
+      title: <TranslatedText stringId="lab.table.column.result" fallback="Result" />,
       accessor: (row, i) => {
         const { resultType, options } = row.labTestType;
         return (
@@ -93,13 +93,13 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: 'unit',
-      title: <TranslatedText stringId="labRequest.table.column.unit" fallback="Units" />,
+      title: <TranslatedText stringId="lab.table.column.unit" fallback="Units" />,
       width: '80px',
       accessor: row => <BodyText color="textTertiary">{row.labTestType.unit || 'N/A'}</BodyText>,
     },
     {
       key: LAB_TEST_PROPERTIES.LAB_TEST_METHOD_ID,
-      title: <TranslatedText stringId="labRequest.table.column.method" fallback="Method" />,
+      title: <TranslatedText stringId="lab.table.column.method" fallback="Method" />,
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -112,9 +112,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.VERIFICATION,
-      title: (
-        <TranslatedText stringId="labRequest.table.column.verification" fallback="Verification" />
-      ),
+      title: <TranslatedText stringId="lab.table.column.verification" fallback="Verification" />,
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -126,9 +124,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.COMPLETED_DATE,
-      title: (
-        <TranslatedText stringId="labRequest.table.column.completedDate" fallback="Completed" />
-      ),
+      title: <TranslatedText stringId="lab.table.column.completedDate" fallback="Completed" />,
       width: '260px',
       accessor: (row, i) => (
         <AccessorField
@@ -215,13 +211,13 @@ const ResultsForm = ({
         <div>
           <Heading4 marginBottom="10px">
             <TranslatedText
-              stringId="labRequest.modal.testResults.heading"
+              stringId="lab.modal.testResults.heading"
               fallback="Enter test results"
             />
           </Heading4>
           <SmallBodyText color="textTertiary">
             <TranslatedText
-              stringId="labRequest.modal.testResults.subHeading"
+              stringId="lab.modal.testResults.subHeading"
               fallback="Please record test results and other test result details."
             />
           </SmallBodyText>
@@ -281,7 +277,7 @@ export const LabTestResultsModal = ({ labRequest, refreshLabTestTable, onClose, 
       width="lg"
       title={
         <TranslatedText
-          stringId="labRequest.modal.testResults.title"
+          stringId="lab.modal.testResults.title"
           fallback="Enter results | Test ID :testId"
           replacements={{ testId: displayId }}
         />

--- a/packages/desktop/app/views/patients/components/LabTestResultsModal.js
+++ b/packages/desktop/app/views/patients/components/LabTestResultsModal.js
@@ -69,13 +69,13 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
   return [
     {
       key: 'labTestType',
-      title: <TranslatedText stringId="lab.table.column.testType" fallback="Test type" />,
+      title: <TranslatedText stringId="lab.results.table.column.testType" fallback="Test type" />,
       width: '120px',
       accessor: row => row.labTestType.name,
     },
     {
       key: LAB_TEST_PROPERTIES.RESULT,
-      title: <TranslatedText stringId="lab.table.column.result" fallback="Result" />,
+      title: <TranslatedText stringId="lab.results.table.column.result" fallback="Result" />,
       accessor: (row, i) => {
         const { resultType, options } = row.labTestType;
         return (
@@ -93,13 +93,13 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: 'unit',
-      title: <TranslatedText stringId="lab.table.column.unit" fallback="Units" />,
+      title: <TranslatedText stringId="lab.results.table.column.unit" fallback="Units" />,
       width: '80px',
       accessor: row => <BodyText color="textTertiary">{row.labTestType.unit || 'N/A'}</BodyText>,
     },
     {
       key: LAB_TEST_PROPERTIES.LAB_TEST_METHOD_ID,
-      title: <TranslatedText stringId="lab.table.column.method" fallback="Method" />,
+      title: <TranslatedText stringId="lab.results.table.column.method" fallback="Method" />,
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -112,7 +112,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.VERIFICATION,
-      title: <TranslatedText stringId="lab.table.column.verification" fallback="Verification" />,
+      title: <TranslatedText stringId="lab.results.table.column.verification" fallback="Verification" />,
       accessor: (row, i) => (
         <AccessorField
           id={row.id}
@@ -124,7 +124,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
     },
     {
       key: LAB_TEST_PROPERTIES.COMPLETED_DATE,
-      title: <TranslatedText stringId="lab.table.column.completedDate" fallback="Completed" />,
+      title: <TranslatedText stringId="lab.results.table.column.completedDate" fallback="Completed" />,
       width: '260px',
       accessor: (row, i) => (
         <AccessorField

--- a/packages/desktop/app/views/patients/panes/PatientResultsPane.js
+++ b/packages/desktop/app/views/patients/panes/PatientResultsPane.js
@@ -9,6 +9,7 @@ import { Colors } from '../../../constants';
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { usePatientSearchParameters } from '../../../contexts/PatientViewSearchParameters';
 import { useAuth } from '../../../contexts/Auth';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const MessageContainer = styled.div`
   padding: 30px;
@@ -37,15 +38,23 @@ const WrongPermissionInner = styled(MessageInner)`
 const NoResultsMessage = () => (
   <MessageContainer>
     <MessageInner>
-      This patient has no lab results to display. Once lab results are available they will be
-      displayed here.
+      <TranslatedText
+        stringId="patient.results.noData"
+        fallback="This patient has no lab results to display. Once lab results are available they will be
+      displayed here."
+      />
     </MessageInner>
   </MessageContainer>
 );
 
 const WrongPermissionMessage = () => (
   <MessageContainer>
-    <WrongPermissionInner>You do not have permission to view lab results</WrongPermissionInner>
+    <WrongPermissionInner>
+      <TranslatedText
+        stringId="patient.results.noPermission"
+        fallback="You do not have permission to view lab results"
+      />
+    </WrongPermissionInner>
   </MessageContainer>
 );
 

--- a/packages/desktop/app/views/patients/panes/PatientResultsPane.js
+++ b/packages/desktop/app/views/patients/panes/PatientResultsPane.js
@@ -39,7 +39,7 @@ const NoResultsMessage = () => (
   <MessageContainer>
     <MessageInner>
       <TranslatedText
-        stringId="patient.results.noData"
+        stringId="patient.lab.testResults.table.noData"
         fallback="This patient has no lab results to display. Once lab results are available they will be
       displayed here."
       />
@@ -51,7 +51,7 @@ const WrongPermissionMessage = () => (
   <MessageContainer>
     <WrongPermissionInner>
       <TranslatedText
-        stringId="patient.results.noPermission"
+        stringId="patient.lab.testResults.noPermission"
         fallback="You do not have permission to view lab results"
       />
     </WrongPermissionInner>

--- a/packages/desktop/app/views/patients/panes/PatientResultsPane.js
+++ b/packages/desktop/app/views/patients/panes/PatientResultsPane.js
@@ -39,7 +39,7 @@ const NoResultsMessage = () => (
   <MessageContainer>
     <MessageInner>
       <TranslatedText
-        stringId="patient.lab.testResults.table.noData"
+        stringId="patient.lab.results.table.noData"
         fallback="This patient has no lab results to display. Once lab results are available they will be
       displayed here."
       />
@@ -51,7 +51,7 @@ const WrongPermissionMessage = () => (
   <MessageContainer>
     <WrongPermissionInner>
       <TranslatedText
-        stringId="patient.lab.testResults.noPermission"
+        stringId="patient.lab.results.table.noPermission"
         fallback="You do not have permission to view lab results"
       />
     </WrongPermissionInner>


### PR DESCRIPTION
### Changes

Translated 'Results' page (incl. patient level results, encounter level labs) using `<TranslatedText />` components.

### Checklist

- [x] Code is finished
- [NA] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
