### PR TITLE
NASS-971: Translate desktop 'Referrals' page

### DIFF
--- a/packages/desktop/app/components/ReferralTable.js
+++ b/packages/desktop/app/components/ReferralTable.js
@@ -13,6 +13,7 @@ import { useApi, isErrorUnknownAllow404s } from '../api';
 import { SurveyResponseDetailsModal } from './SurveyResponseDetailsModal';
 import { DeleteButton } from './Button';
 import { ConfirmModal } from './ConfirmModal';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const ACTION_MODAL_STATES = {
   CLOSED: 'closed',
@@ -46,23 +47,23 @@ const ActionDropdown = React.memo(({ row, refreshTable }) => {
 
   const actions = [
     {
-      label: 'Admit',
+      label: <TranslatedText stringId="referral.action.admit" fallback="Admit" />,
       condition: () => row.status === REFERRAL_STATUSES.PENDING,
       onClick: () => setModalStatus(ACTION_MODAL_STATES.ENCOUNTER_OPEN),
     },
     // Worth keeping around to address in proper linear card
     {
-      label: 'View',
+      label: <TranslatedText stringId="general.action.view" fallback="View" />,
       condition: () => !!row.encounterId, // always false, field no longer exists.
       onClick: onViewEncounter,
     },
     {
-      label: 'Complete',
+      label: <TranslatedText stringId="referral.action.complete" fallback="Complete" />,
       condition: () => row.status === REFERRAL_STATUSES.PENDING,
       onClick: onCompleteReferral,
     },
     {
-      label: 'Cancel',
+      label: <TranslatedText stringId="general.action.cancel" fallback="Cancel" />,
       condition: () => row.status === REFERRAL_STATUSES.PENDING,
       onClick: () => setModalStatus(ACTION_MODAL_STATES.WARNING_OPEN),
     },
@@ -79,11 +80,21 @@ const ActionDropdown = React.memo(({ row, refreshTable }) => {
       />
       <ConfirmModal
         open={modalStatus === ACTION_MODAL_STATES.WARNING_OPEN}
-        title="Cancel referral"
-        text="WARNING: This action is irreversible!"
-        subText="Are you sure you want to cancel this referral?"
-        cancelButtonText="No"
-        confirmButtonText="Yes"
+        title={<TranslatedText stringId="referral.modal.cancel.title" fallback="Cancel referral" />]
+        text={
+          <TranslatedText
+            stringId="referral.modal.cancel.warningText1"
+            fallback="WARNING: This action is irreversible!"
+          />
+        }
+        subText={
+          <TranslatedText
+            stringId="referral.modal.cancel.warningText2"
+            fallback="Are you sure you want to cancel this referral?"
+          />
+        }
+        cancelButtonText={<TranslatedText stringId="general.action.no" fallback="No" />}
+        confirmButtonText={<TranslatedText stringId="general.action.yes" fallback="Yes" />}
         ConfirmButton={DeleteButton}
         onConfirm={onCancelReferral}
         onCancel={onCloseModal}
@@ -95,7 +106,9 @@ const ActionDropdown = React.memo(({ row, refreshTable }) => {
 const fieldNames = ['Referring doctor', 'Referral completed by'];
 const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
   const api = useApi();
-  const [name, setName] = useState('N/A');
+  const [name, setName] = useState(
+    <TranslatedText stringId="general.fallback.notApplicatble" fallback="N/A" />,
+  );
 
   useEffect(() => {
     (async () => {
@@ -144,13 +157,38 @@ const getActions = ({ refreshTable, ...row }) => (
 );
 
 const columns = [
-  { key: 'date', title: 'Referral date', accessor: getDate },
-  { key: 'referralType', title: 'Referral type', accessor: getReferralType },
-  { key: 'referredBy', title: 'Referral completed by', accessor: getReferralBy },
-  { key: 'status', title: 'Status', accessor: getStatus },
+  {
+    key: 'date',
+    title: (
+      <TranslatedText stringId="referral.table.column.referralDate" fallback="Referral date" />
+    ),
+    accessor: getDate,
+  },
+  {
+    key: 'referralType',
+    title: (
+      <TranslatedText stringId="referral.table.column.referralType" fallback="Referral type" />
+    ),
+    accessor: getReferralType,
+  },
+  {
+    key: 'referredBy',
+    title: (
+      <TranslatedText
+        stringId="referral.table.column.referralCompletedBy"
+        fallback="Referral completed by"
+      />
+    ),
+    accessor: getReferralBy,
+  },
+  {
+    key: 'status',
+    title: <TranslatedText stringId="referral.table.column.status" fallback="Status" />,
+    accessor: getStatus,
+  },
   {
     key: 'actions',
-    title: 'Actions',
+    title: <TranslatedText stringId="referral.table.column.actions" fallback="Actions" />,
     accessor: getActions,
     dontCallRowInput: true,
   },
@@ -173,7 +211,9 @@ export const ReferralTable = React.memo(({ patientId }) => {
           orderBy: 'date',
           order: 'asc',
         }}
-        noDataMessage="No referrals found"
+        noDataMessage={
+          <TranslatedText stringId="referral.table.noData" fallback="No referrals found" />
+        }
         onRowClick={onSelectReferral}
         allowExport={false}
       />

--- a/packages/desktop/app/components/ReferralTable.js
+++ b/packages/desktop/app/components/ReferralTable.js
@@ -80,7 +80,7 @@ const ActionDropdown = React.memo(({ row, refreshTable }) => {
       />
       <ConfirmModal
         open={modalStatus === ACTION_MODAL_STATES.WARNING_OPEN}
-        title={<TranslatedText stringId="referral.modal.cancel.title" fallback="Cancel referral" />]
+        title={<TranslatedText stringId="referral.modal.cancel.title" fallback="Cancel referral" />}
         text={
           <TranslatedText
             stringId="referral.modal.cancel.warningText1"

--- a/packages/desktop/app/components/ReferralTable.js
+++ b/packages/desktop/app/components/ReferralTable.js
@@ -107,7 +107,7 @@ const fieldNames = ['Referring doctor', 'Referral completed by'];
 const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
   const api = useApi();
   const [name, setName] = useState(
-    <TranslatedText stringId="general.fallback.notApplicatble" fallback="N/A" />,
+    <TranslatedText stringId="general.fallback.notApplicable" fallback="N/A" />,
   );
 
   useEffect(() => {

--- a/packages/desktop/app/components/ReferralTable.js
+++ b/packages/desktop/app/components/ReferralTable.js
@@ -47,7 +47,7 @@ const ActionDropdown = React.memo(({ row, refreshTable }) => {
 
   const actions = [
     {
-      label: <TranslatedText stringId="referral.action.admit" fallback="Admit" />,
+      label: <TranslatedText stringId="patient.referral.action.admit" fallback="Admit" />,
       condition: () => row.status === REFERRAL_STATUSES.PENDING,
       onClick: () => setModalStatus(ACTION_MODAL_STATES.ENCOUNTER_OPEN),
     },
@@ -58,7 +58,7 @@ const ActionDropdown = React.memo(({ row, refreshTable }) => {
       onClick: onViewEncounter,
     },
     {
-      label: <TranslatedText stringId="referral.action.complete" fallback="Complete" />,
+      label: <TranslatedText stringId="patient.referral.action.complete" fallback="Complete" />,
       condition: () => row.status === REFERRAL_STATUSES.PENDING,
       onClick: onCompleteReferral,
     },

--- a/packages/desktop/app/components/SurveyResponseDetailsModal.js
+++ b/packages/desktop/app/components/SurveyResponseDetailsModal.js
@@ -8,6 +8,7 @@ import { SurveyResultBadge } from './SurveyResultBadge';
 import { ViewPhotoLink } from './ViewPhotoLink';
 import { useApi } from '../api';
 import { Button } from './Button';
+import { TranslatedText } from './Translation/TranslatedText';
 
 const convertBinaryToYesNo = value => {
   switch (value) {
@@ -23,10 +24,14 @@ const convertBinaryToYesNo = value => {
 };
 
 const COLUMNS = [
-  { key: 'text', title: 'Indicator', accessor: ({ name }) => name },
+  {
+    key: 'text',
+    title: <TranslatedText stringId="formResponse.table.column.indicator" fallback="Indicator" />,
+    accessor: ({ name }) => name,
+  },
   {
     key: 'value',
-    title: 'Value',
+    title: <TranslatedText stringId="formResponse.table.column.value" fallback="Value" />,
     accessor: ({ answer, type }) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const [surveyLink, setSurveyLink] = useState(null);
@@ -88,8 +93,17 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
 
   if (error) {
     return (
-      <Modal title="Form response" open={!!surveyResponseId} onClose={onClose}>
-        <h3>Error fetching response details</h3>
+      <Modal
+        title={<TranslatedText stringId="formResponse.modal.title" fallback="Form response" />}
+        open={!!surveyResponseId}
+        onClose={onClose}
+      >
+        <h3>
+          <TranslatedText
+            stringId="formResponse.modal.errorMessage"
+            fallback="Error fetching response details"
+          />
+        </h3>
         <pre>{error.stack}</pre>
       </Modal>
     );
@@ -97,8 +111,12 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
 
   if (isLoading || !surveyDetails) {
     return (
-      <Modal title="Form response" open={!!surveyResponseId} onClose={onClose}>
-        Loading...
+      <Modal
+        title={<TranslatedText stringId="formResponse.modal.title" fallback="Form response" />}
+        open={!!surveyResponseId}
+        onClose={onClose}
+      >
+        <TranslatedText stringId="general.table.loading" fallback="Loading..." />
       </Modal>
     );
   }
@@ -121,7 +139,11 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
     .filter(r => r.answer !== undefined);
 
   return (
-    <Modal title="Form response" open={!!surveyResponseId} onClose={onClose}>
+    <Modal
+      title={<TranslatedText stringId="formResponse.modal.title" fallback="Form response" />}
+      open={!!surveyResponseId}
+      onClose={onClose}
+    >
       <Table data={answerRows} columns={COLUMNS} allowExport={false} />
     </Modal>
   );

--- a/packages/desktop/app/components/SurveyResponseDetailsModal.js
+++ b/packages/desktop/app/components/SurveyResponseDetailsModal.js
@@ -99,13 +99,15 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
   if (error) {
     return (
       <Modal
-        title={<TranslatedText stringId="surveyResponse.modal.title" fallback="Form response" />}
+        title={
+          <TranslatedText stringId="surveyResponse.modal.details.title" fallback="Form response" />
+        }
         open={!!surveyResponseId}
         onClose={onClose}
       >
         <h3>
           <TranslatedText
-            stringId="surveyResponse.modal.error.fetchErrorMessage"
+            stringId="surveyResponse.modal.details.error.fetchErrorMessage"
             fallback="Error fetching response details"
           />
         </h3>
@@ -117,7 +119,9 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
   if (isLoading || !surveyDetails) {
     return (
       <Modal
-        title={<TranslatedText stringId="formResponse.modal.title" fallback="Form response" />}
+        title={
+          <TranslatedText stringId="surveyResponse.modal.details.title" fallback="Form response" />
+        }
         open={!!surveyResponseId}
         onClose={onClose}
       >
@@ -145,7 +149,9 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
 
   return (
     <Modal
-      title={<TranslatedText stringId="formResponse.modal.title" fallback="Form response" />}
+      title={
+        <TranslatedText stringId="surveyResponse.modal.details.title" fallback="Form response" />
+      }
       open={!!surveyResponseId}
       onClose={onClose}
     >

--- a/packages/desktop/app/components/SurveyResponseDetailsModal.js
+++ b/packages/desktop/app/components/SurveyResponseDetailsModal.js
@@ -26,12 +26,17 @@ const convertBinaryToYesNo = value => {
 const COLUMNS = [
   {
     key: 'text',
-    title: <TranslatedText stringId="formResponse.table.column.indicator" fallback="Indicator" />,
+    title: (
+      <TranslatedText
+        stringId="surveyResponse.details.table.column.indicator"
+        fallback="Indicator"
+      />
+    ),
     accessor: ({ name }) => name,
   },
   {
     key: 'value',
-    title: <TranslatedText stringId="formResponse.table.column.value" fallback="Value" />,
+    title: <TranslatedText stringId="surveyResponse.details.table.column.value" fallback="Value" />,
     accessor: ({ answer, type }) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const [surveyLink, setSurveyLink] = useState(null);
@@ -94,13 +99,13 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose }) => {
   if (error) {
     return (
       <Modal
-        title={<TranslatedText stringId="formResponse.modal.title" fallback="Form response" />}
+        title={<TranslatedText stringId="surveyResponse.modal.title" fallback="Form response" />}
         open={!!surveyResponseId}
         onClose={onClose}
       >
         <h3>
           <TranslatedText
-            stringId="formResponse.modal.errorMessage"
+            stringId="surveyResponse.modal.error.fetchErrorMessage"
             fallback="Error fetching response details"
           />
         </h3>

--- a/packages/desktop/app/views/patients/panes/ReferralPane.js
+++ b/packages/desktop/app/views/patients/panes/ReferralPane.js
@@ -17,7 +17,7 @@ export const ReferralPane = React.memo(({ patient }) => {
     <ContentPane>
       <TableButtonRow variant="small">
         <Button onClick={handleNewReferral}>
-          <TranslatedText stringId="referral.action.create" fallback="New referral" />
+          <TranslatedText stringId="patient.referral.action.create" fallback="New referral" />
         </Button>
       </TableButtonRow>
       <ReferralTable patientId={patient.id} />

--- a/packages/desktop/app/views/patients/panes/ReferralPane.js
+++ b/packages/desktop/app/views/patients/panes/ReferralPane.js
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 
 import { TableButtonRow, Button, ContentPane } from '../../../components';
 import { ReferralTable } from '../../../components/ReferralTable';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 export const ReferralPane = React.memo(({ patient }) => {
   const dispatch = useDispatch();
@@ -15,7 +16,9 @@ export const ReferralPane = React.memo(({ patient }) => {
   return (
     <ContentPane>
       <TableButtonRow variant="small">
-        <Button onClick={handleNewReferral}>New referral</Button>
+        <Button onClick={handleNewReferral}>
+          <TranslatedText stringId="referral.action.create" fallback="New referral" />
+        </Button>
       </TableButtonRow>
       <ReferralTable patientId={patient.id} />
     </ContentPane>


### PR DESCRIPTION
### Changes

Added translated text components to the referrals page in areas as described in the linear ticket.

[NASS-971: Translate desktop 'Referrals' page](https://linear.app/bes/issue/NASS-971/translate-desktop-referrals-page)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
