### PR TITLE
TAN-2340: Update model datetimestring field name

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/lan/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -402,6 +402,7 @@ describe('PatientProgramRegistration', () => {
         );
         const createdCondition = await models.PatientProgramRegistrationCondition.create(
           fake(models.PatientProgramRegistrationCondition, {
+            date: '2023-09-01 08:00:00',
             patientId: patient.id,
             programRegistryId: programRegistry1.id,
             programRegistryConditionId: programRegistryCondition.id,
@@ -427,7 +428,8 @@ describe('PatientProgramRegistration', () => {
           programRegistryId: programRegistry1.id,
           patientId: patient.id,
           programRegistryConditionId: programRegistryCondition.id,
-          date: '2023-09-02 08:00:00',
+          date: '2023-09-01 08:00:00',
+          deletionDate: '2023-09-02 08:00:00',
           deletionStatus: DELETION_STATUSES.DELETED,
         });
       });

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -17,7 +17,7 @@ export class PatientProgramRegistrationCondition extends Model {
           type: Sequelize.TEXT,
           defaultValue: null,
         },
-        deletionDate: dateTimeType('date', {
+        deletionDate: dateTimeType('deletionDate', {
           defaultValue: null,
         }),
       },


### PR DESCRIPTION
### Changes

Just a minor typo, things happen. Because both fields were named the same, this caused an error on sync - with proper names, now nothing gets mixed up.

I've noticed that there are some linting issues from the epic branch. I will push these after the review is done