### PR TITLE
NASS-1053: Desktop login page: update to incorrect credentials validation messaging

### DIFF
--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -72,10 +72,15 @@ const StyledCheckboxField = styled(Field)`
 
 const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError }) => {
   const [genericMessage, setGenericMessage] = useState(null);
+  const INCORRECT_CREDENTIALS_ERROR_MESSAGE =
+    'Facility server error response: Incorrect username or password, please try again';
 
   useEffect(() => {
     if (errorMessage === USER_DEACTIVATED_ERROR_MESSAGE) {
       setFieldError('email', `*${errorMessage}`);
+    } else if (errorMessage === INCORRECT_CREDENTIALS_ERROR_MESSAGE) {
+      setFieldError('email', 'Incorrect credentials');
+      setFieldError('password', 'Incorrect credentials');
     } else {
       setGenericMessage(errorMessage);
     }
@@ -83,6 +88,11 @@ const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError 
     // only run this logic when error message is updated
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errorMessage]);
+
+  const removeValidation = () => {
+    setFieldError('email', '');
+    setFieldError('password', '');
+  };
 
   return (
     <FormGrid columns={1}>
@@ -94,6 +104,7 @@ const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError 
         required
         component={TextField}
         placeholder="Enter your email address"
+        onChange={() => removeValidation()}
       />
       <div>
         <StyledField
@@ -103,6 +114,7 @@ const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError 
           required
           component={TextField}
           placeholder="Enter your password"
+          onChange={() => removeValidation()}
         />
         <RememberMeRow>
           <StyledCheckboxField name="rememberMe" label="Remember me" component={CheckField} />

--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -70,10 +70,11 @@ const StyledCheckboxField = styled(Field)`
   }
 `;
 
+const INCORRECT_CREDENTIALS_ERROR_MESSAGE =
+  'Facility server error response: Incorrect username or password, please try again';
+
 const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError }) => {
   const [genericMessage, setGenericMessage] = useState(null);
-  const INCORRECT_CREDENTIALS_ERROR_MESSAGE =
-    'Facility server error response: Incorrect username or password, please try again';
 
   useEffect(() => {
     if (errorMessage === USER_DEACTIVATED_ERROR_MESSAGE) {


### PR DESCRIPTION
### Changes

Updated the validation messaging of the login form where the user has entered incorrect credentials. When the field value of either the email field or password field are changed while the fields are in error state, both fields will revert to its original state.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
