### PR TITLE
NASS-1051: Desktop login page: Update to remember me workflow

### DIFF
--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { USER_DEACTIVATED_ERROR_MESSAGE } from '@tamanu/constants';
 
+import { Typography } from '@material-ui/core';
 import { FormGrid } from '../components/FormGrid';
 import {
   BodyText,
@@ -19,6 +20,18 @@ import { Colors } from '../constants';
 const FormSubtext = styled(BodyText)`
   color: ${Colors.midText};
   padding: 10px 0;
+`;
+
+const LoginHeading = styled(Typography)`
+  color: ${Colors.darkestText};
+  font-weight: 500;
+  font-size: 38px;
+  line-height: 32px;
+`;
+
+const LoginSubtext = styled(BodyText)`
+  color: ${Colors.midText};
+  padding-top: 10px;
 `;
 
 const LoginButton = styled(FormSubmitButton)`
@@ -70,7 +83,12 @@ const StyledCheckboxField = styled(Field)`
   }
 `;
 
-const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError }) => {
+const LoginFormComponent = ({
+  errorMessage,
+  onNavToResetPassword,
+  setFieldError,
+  rememberEmail,
+}) => {
   const [genericMessage, setGenericMessage] = useState(null);
 
   useEffect(() => {
@@ -86,6 +104,10 @@ const LoginFormComponent = ({ errorMessage, onNavToResetPassword, setFieldError 
 
   return (
     <FormGrid columns={1}>
+      <div>
+        <LoginHeading>{rememberEmail ? 'Welcome back' : 'Log in'}</LoginHeading>
+        <LoginSubtext>Enter your details below to log in</LoginSubtext>
+      </div>
       {!!genericMessage && <FormSubtext>{genericMessage}</FormSubtext>}
       <StyledField
         name="email"
@@ -134,6 +156,7 @@ export const LoginForm = React.memo(
         setFieldValue={setFieldValue}
         onNavToResetPassword={onNavToResetPassword}
         setFieldError={setFieldError}
+        rememberEmail={rememberEmail}
       />
     );
 

--- a/packages/web/app/views/LoginView.jsx
+++ b/packages/web/app/views/LoginView.jsx
@@ -91,18 +91,6 @@ const LoginFormContainer = styled.div`
   padding-top: 40px;
 `;
 
-const LoginHeading = styled(Typography)`
-  color: ${Colors.darkestText};
-  font-weight: 500;
-  font-size: 38px;
-  line-height: 32px;
-`;
-
-const LoginSubtext = styled(BodyText)`
-  color: ${Colors.midText};
-  padding-top: 10px;
-`;
-
 const DesktopVersionText = styled(Typography)`
   font-size: 9px;
   color: ${Colors.midText};

--- a/packages/web/app/views/LoginView.jsx
+++ b/packages/web/app/views/LoginView.jsx
@@ -165,8 +165,6 @@ export const LoginView = () => {
         <LoginFormContainer>
           {screen === 'login' && (
             <>
-              <LoginHeading>Log in</LoginHeading>
-              <LoginSubtext>Enter your details below to log in</LoginSubtext>
               <LoginForm
                 onSubmit={submitLogin}
                 errorMessage={loginError}


### PR DESCRIPTION
### Changes

Updated the remember workflow so that the header text changes from 'Log in' to 'Welcome back' after the user has logged into Tamanu where the remember me field is ticked.

Also moved login headers for the login screen to the login form for consistency.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
