### PR TITLE
NASS-1076: Increase default maxConcurrentSyncSessions

### DIFF
--- a/packages/sync-server/config/default.json5
+++ b/packages/sync-server/config/default.json5
@@ -52,7 +52,7 @@
     "level": "info"
   },
   "sync": {
-    "maxConcurrentSessions": 1,
+    "maxConcurrentSessions": 4,
     "persistedCacheBatchSize": 20000,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,
     "adjustDataBatchSize": 20000,


### PR DESCRIPTION
### Changes

Increasing the default maxConcurrentSyncSessions to prevent the blocking up of sync queue.

More details in this card: https://linear.app/bes/issue/NASS-1076/release-138-sync-queue-bug#comment-d3a5c2ba

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
