### PR TITLE
Tamanu Web: no more desktop build

### DIFF
--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -11,18 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write # for cd-client workflow, unused
-  pull-requests: write # for cd-client workflow, unused
   id-token: write # OIDC token for AWS
 
 jobs:
   info:
     name: Branch info
     uses: ./.github/workflows/branch-info.yml
-
-  desktop:
-    name: Desktop client
-    uses: ./.github/workflows/cd-client.yml
 
   image:
     needs: info
@@ -118,7 +112,6 @@ jobs:
       - info
       - image
       - build
-      - desktop
     strategy:
       fail-fast: false
       matrix:
@@ -161,12 +154,6 @@ jobs:
           set -ex
           yarn config set network-timeout 600000 -g
           yarn install --frozen-lockfile --production
-
-      - name: Download desktop client artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: desktop-client
-          path: ${{ env.BUILD_NAME }}/packages/${{ matrix.package.path }}/upgrade
 
       - name: Prepare final output
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,6 @@ jobs:
       - test-facility-offline
     runs-on: ubuntu-latest
     steps:
-      # fail if ANY dependency has failed or been skipped or cancelled
-      - if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped')
-          || contains(needs.*.result, 'cancelled')"
-        run: exit 1
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build-report": "yarn build-shared && yarn workspace sync-server build && yarn workspace sync-server start report"
   },
   "engines": {
-    "node": "^20.9.0 || ^18.15.0"
+    "node": "^20.9.0"
   },
   "packageManager": "yarn@1.22.19",
   "private": true,

--- a/packages/lan/app/createApp.js
+++ b/packages/lan/app/createApp.js
@@ -54,10 +54,6 @@ export function createApp({ sequelize, reportSchemaStores, models, syncManager, 
 
   app.use('/', routes);
 
-  // Serve the latest desktop in upgrade folder so that desktops with lower versions
-  // can perform auto upgrade when pointing to this endpoint
-  app.use('/upgrade', express.static(path.join(process.cwd(), 'upgrade')));
-
   // Dis-allow all other routes
   app.get('*', (req, res) => {
     res.status(404).end();

--- a/packages/sync-server/app/createApp.js
+++ b/packages/sync-server/app/createApp.js
@@ -63,10 +63,6 @@ export function createApp(ctx) {
   app.use('/v1', constructPermission);
   app.use('/v1', buildRoutes(ctx));
 
-  // Serve the latest desktop in upgrade folder so that desktops with lower versions
-  // can perform auto upgrade when pointing to this endpoint
-  app.use('/upgrade', express.static(path.join(process.cwd(), 'upgrade')));
-
   // Dis-allow all other routes
   app.use('*', (req, res) => {
     res.status(404).end();


### PR DESCRIPTION
### Changes

- completely remove the desktop build process
- remove the `/upgrade` routes on servers
- don't need to allow for node 18 for desktop build either