### PR TITLE
NASS-1043: Tamanu Web file upload

### DIFF
--- a/packages/web/app/api/TamanuApi.js
+++ b/packages/web/app/api/TamanuApi.js
@@ -272,11 +272,8 @@ export class TamanuApi {
     return blob;
   }
 
-  async postWithFileUpload(endpoint, filePath, body, options = {}) {
-    // const fileData = await promises.readFile(filePath);
-    // TODO(web)
-    const fileData = {};
-    const blob = new Blob([fileData]);
+  async postWithFileUpload(endpoint, file, body, options = {}) {
+    const blob = new Blob([file]);
 
     // We have to use multipart/formdata to support sending the file data,
     // but sending the other fields in that format loses type information

--- a/packages/web/app/components/DocumentPreview/PDFPreview.jsx
+++ b/packages/web/app/components/DocumentPreview/PDFPreview.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import * as pdfjsLib from 'pdfjs-dist';
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker?worker&url';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker';
 
 import styled from 'styled-components';
 import { useApi } from '../../api';

--- a/packages/web/app/components/DocumentPreview/PDFPreview.jsx
+++ b/packages/web/app/components/DocumentPreview/PDFPreview.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import * as pdfjsLib from 'pdfjs-dist';
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker?worker&url';
 
 import styled from 'styled-components';
 import { useApi } from '../../api';

--- a/packages/web/app/components/Field/FileChooserField.jsx
+++ b/packages/web/app/components/Field/FileChooserField.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 import MuiTextField from '@material-ui/core/TextField';
 import PublishIcon from '@material-ui/icons/Publish';
@@ -26,48 +26,63 @@ export const FILTER_EXCEL = { name: 'Microsoft Excel files (.xlsx)', extensions:
 export const FILTER_IMAGES = { name: 'Images (.png, .svg)', extensions: ['png', 'svg'] };
 
 export const FileChooserInput = ({ value = '', label, name, filters, onChange, ...props }) => {
+  const inputRef = useRef(null);
+
+  // const browseForFile = useCallback(async () => {
+  //   /*
+  //   const { filePaths, canceled } = await showOpenDialog(null, {
+  //     filters,
+  //   });
+  //   if (canceled) return;
+
+  //   // showOpenDialog gives an array of files, but for this component we only want one,
+  //   // so just take the first element.
+  //   // (if support for multiple files is needed in future it should be in a separate component)
+  //   const [result] = filePaths;
+  //   if (!result) return;
+
+  //   onChange({ target: { name, value: result } });
+  //   */ // TODO(web)
+  // }, [showOpenDialog, filters, name, onChange]);
   const browseForFile = useCallback(async () => {
-    /*
-    const { filePaths, canceled } = await showOpenDialog(null, {
-      filters,
-    });
-    if (canceled) return;
+    inputRef.current.click();
+  }, [inputRef]);
 
-    // showOpenDialog gives an array of files, but for this component we only want one,
-    // so just take the first element.
-    // (if support for multiple files is needed in future it should be in a separate component)
-    const [result] = filePaths;
-    if (!result) return;
+  const selectFile = event => {
+    const file = event.target.files[0];
+    if (!file) return;
 
-    onChange({ target: { name, value: result } });
-    */ // TODO(web)
-  }, [filters, name, onChange]);
+    onChange({ target: { name, value: file } });
+  };
 
   return (
-    <OuterLabelFieldWrapper label={label} {...props}>
-      <FieldButtonRow className={value ? 'has-value' : ''}>
-        {value ? (
-          <>
-            <MuiTextField readOnly value={value} variant="outlined" />
-            <Button onClick={browseForFile} variant="outlined">
-              <PublishIcon />
-              <span style={{ marginLeft: '0.5rem' }}>Change selection</span>
-            </Button>
-          </>
-        ) : (
-          <>
-            <Button onClick={browseForFile} variant="outlined" color="primary">
-              Choose file
-            </Button>
-            <HintText>
-              Max 10 MB
-              <br />
-              Supported file types: {filters.map(filter => filter.name).join(', ')}
-            </HintText>
-          </>
-        )}
-      </FieldButtonRow>
-    </OuterLabelFieldWrapper>
+    <>
+      <input type="file" ref={inputRef} onChange={selectFile} style={{ display: 'none' }} />
+      <OuterLabelFieldWrapper label={label} {...props}>
+        <FieldButtonRow className={value ? 'has-value' : ''}>
+          {value ? (
+            <>
+              <MuiTextField readOnly value={value} variant="outlined" />
+              <Button onClick={browseForFile} variant="outlined">
+                <PublishIcon />
+                <span style={{ marginLeft: '0.5rem' }}>Change selection</span>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button onClick={browseForFile} variant="outlined" color="primary">
+                Choose file
+              </Button>
+              <HintText>
+                Max 10 MB
+                <br />
+                Supported file types: {filters.map(filter => filter.name).join(', ')}
+              </HintText>
+            </>
+          )}
+        </FieldButtonRow>
+      </OuterLabelFieldWrapper>
+    </>
   );
 };
 

--- a/packages/web/app/components/Field/FileChooserField.jsx
+++ b/packages/web/app/components/Field/FileChooserField.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import MuiTextField from '@material-ui/core/TextField';
 import PublishIcon from '@material-ui/icons/Publish';
@@ -28,7 +28,6 @@ export const FILTER_IMAGES = { name: 'Images (.png, .svg)', extensions: ['png', 
 export const FileChooserInput = ({ value = '', label, name, filters, onChange, ...props }) => {
   // Convert the given filters into string format for the accept attribute of file input
   const acceptString = filters.map(filter => `.${filter.extensions.join(', .')}`).join(', ');
-  console.log(acceptString);
 
   const inputRef = useRef(null);
 
@@ -37,7 +36,6 @@ export const FileChooserInput = ({ value = '', label, name, filters, onChange, .
   };
 
   const selectFile = event => {
-    console.log(filters);
     const file = event.target.files[0];
     if (!file) return;
 

--- a/packages/web/app/components/Field/FileChooserField.jsx
+++ b/packages/web/app/components/Field/FileChooserField.jsx
@@ -26,29 +26,18 @@ export const FILTER_EXCEL = { name: 'Microsoft Excel files (.xlsx)', extensions:
 export const FILTER_IMAGES = { name: 'Images (.png, .svg)', extensions: ['png', 'svg'] };
 
 export const FileChooserInput = ({ value = '', label, name, filters, onChange, ...props }) => {
+  // Convert the given filters into string format for the accept attribute of file input
+  const acceptString = filters.map(filter => `.${filter.extensions.join(', .')}`).join(', ');
+  console.log(acceptString);
+
   const inputRef = useRef(null);
 
-  // const browseForFile = useCallback(async () => {
-  //   /*
-  //   const { filePaths, canceled } = await showOpenDialog(null, {
-  //     filters,
-  //   });
-  //   if (canceled) return;
-
-  //   // showOpenDialog gives an array of files, but for this component we only want one,
-  //   // so just take the first element.
-  //   // (if support for multiple files is needed in future it should be in a separate component)
-  //   const [result] = filePaths;
-  //   if (!result) return;
-
-  //   onChange({ target: { name, value: result } });
-  //   */ // TODO(web)
-  // }, [showOpenDialog, filters, name, onChange]);
-  const browseForFile = useCallback(async () => {
+  const showFileDialog = () => {
     inputRef.current.click();
-  }, [inputRef]);
+  };
 
   const selectFile = event => {
+    console.log(filters);
     const file = event.target.files[0];
     if (!file) return;
 
@@ -57,20 +46,26 @@ export const FileChooserInput = ({ value = '', label, name, filters, onChange, .
 
   return (
     <>
-      <input type="file" ref={inputRef} onChange={selectFile} style={{ display: 'none' }} />
+      <input
+        type="file"
+        ref={inputRef}
+        onChange={selectFile}
+        accept={acceptString}
+        style={{ display: 'none' }}
+      />
       <OuterLabelFieldWrapper label={label} {...props}>
         <FieldButtonRow className={value ? 'has-value' : ''}>
           {value ? (
             <>
-              <MuiTextField readOnly value={value} variant="outlined" />
-              <Button onClick={browseForFile} variant="outlined">
+              <MuiTextField readOnly value={value.name} variant="outlined" />
+              <Button onClick={showFileDialog} variant="outlined">
                 <PublishIcon />
                 <span style={{ marginLeft: '0.5rem' }}>Change selection</span>
               </Button>
             </>
           ) : (
             <>
-              <Button onClick={browseForFile} variant="outlined" color="primary">
+              <Button onClick={showFileDialog} variant="outlined" color="primary">
                 Choose file
               </Button>
               <HintText>

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -103,15 +103,12 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
 
   const handleSubmit = useCallback(
     async ({ file, ...data }) => {
-      console.log(file);
-      console.log(data);
       onStart();
-return;
+
       // Read and inject document creation date and type to metadata sent
-      // const { birthtime } = await getFileStatus(file); // TODO(web)
+      // file creation time is not available data for a browser - must remove
       const birthtime = new Date();
       const attachmentType = file.type;
-      console.log(attachmentType);
 
       try {
         await api.postWithFileUpload(endpoint, file, {

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -105,7 +105,7 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
     async ({ file, ...data }) => {
       onStart();
 
-      // Read and inject document creation date and type to metadata sent
+      // Read file metadata
       const birthtime = new Date(file.lastModified);
       const attachmentType = file.type;
 

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -103,12 +103,15 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
 
   const handleSubmit = useCallback(
     async ({ file, ...data }) => {
+      console.log(file);
+      console.log(data);
       onStart();
-
+return;
       // Read and inject document creation date and type to metadata sent
       // const { birthtime } = await getFileStatus(file); // TODO(web)
       const birthtime = new Date();
-      const attachmentType = lookupMimeType(file);
+      const attachmentType = file.type;
+      console.log(attachmentType);
 
       try {
         await api.postWithFileUpload(endpoint, file, {

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -106,8 +106,7 @@ export const DocumentForm = ({ onStart, onSubmit, onError, onCancel, editedObjec
       onStart();
 
       // Read and inject document creation date and type to metadata sent
-      // file creation time is not available data for a browser - must remove
-      const birthtime = new Date();
+      const birthtime = new Date(file.lastModified);
       const attachmentType = file.type;
 
       try {


### PR DESCRIPTION
### Changes

Changed the original `fs` file upload system, which is unsupported on browser, to utilise `<input type="file">` instead.
Additionally, altered how files were converted to binary for uploading assets.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
