### PR TITLE
NASS-739: fix remove config keys being persisted to settings with null value if explicitly set so

### DIFF
--- a/packages/shared/src/migrations/1691371570736-populateSettingsFromLocalConfig.js
+++ b/packages/shared/src/migrations/1691371570736-populateSettingsFromLocalConfig.js
@@ -67,9 +67,10 @@ const SCOPED_KEY_TRANSFORM_MAPS = {
 const prepareReplacementsForInsert = (settings, serverFacilityId, scope) => {
   // Transform settings that need to be moved or deleted
   Object.entries(SCOPED_KEY_TRANSFORM_MAPS[scope]).forEach(([oldKey, newKey]) => {
-    const value = has(settings, oldKey) && get(settings, oldKey);
-    if (value) {
-      if (newKey) set(settings, newKey, value);
+    const exists = has(settings, oldKey);
+    if (exists) {
+      const value = get(settings, oldKey);
+      if (value && newKey) set(settings, newKey, value);
       unset(settings, oldKey);
     }
   });

--- a/packages/shared/src/migrations/1691371570736-populateSettingsFromLocalConfig.js
+++ b/packages/shared/src/migrations/1691371570736-populateSettingsFromLocalConfig.js
@@ -70,7 +70,7 @@ const prepareReplacementsForInsert = (settings, serverFacilityId, scope) => {
     const exists = has(settings, oldKey);
     if (exists) {
       const value = get(settings, oldKey);
-      if (value && newKey) set(settings, newKey, value);
+      if (newKey) set(settings, newKey, value);
       unset(settings, oldKey);
     }
   });


### PR DESCRIPTION
### Changes

Fix to the bug where null values can show up for keys that are removed

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
