### PR TITLE
TAN-2449: Registries additional backend logic

### DIFF
--- a/packages/lan/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/lan/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -269,6 +269,13 @@ describe('PatientProgramRegistration', () => {
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
           date: '2023-09-02 11:00:00',
         },
+        {
+          patientId: patient.id,
+          clinicalStatusId: status2.id,
+          programRegistryId: registry.id,
+          registrationStatus: REGISTRATION_STATUSES.INACTIVE,
+          date: '2023-09-02 11:30:00',
+        },
       ];
 
       for (const r of records) {
@@ -295,11 +302,12 @@ describe('PatientProgramRegistration', () => {
 
       // Check for correct registrationDates
       expect(result.body.data[0]).toHaveProperty('registrationDate');
-      // In chronological order:
-      expect(result.body.data[3].registrationDate).toEqual(history[3].date);
-      expect(result.body.data[2].registrationDate).toEqual(history[3].date);
-      expect(result.body.data[1].registrationDate).toEqual(history[1].date);
-      expect(result.body.data[0].registrationDate).toEqual(history[1].date);
+      // In chronological order (numbers are negative because the result is reversed):
+      expect(result.body.data.at(-1).registrationDate).toEqual(history.at(-1).date);
+      expect(result.body.data.at(-2).registrationDate).toEqual(history.at(-1).date);
+      expect(result.body.data.at(-3).registrationDate).toEqual(history.at(-3).date);
+      expect(result.body.data.at(-4).registrationDate).toEqual(history.at(-3).date);
+      expect(result.body.data.at(-5).registrationDate).toEqual(history.at(-3).date);
     });
 
     it('fetches the full detail of the latest registration', async () => {
@@ -314,6 +322,12 @@ describe('PatientProgramRegistration', () => {
       expect(record).toHaveProperty('clinicalStatus.name');
       expect(record).toHaveProperty('registeringFacility.name');
       expect(record).toHaveProperty('village.name');
+
+      // Check for derived info:
+      expect(record).toHaveProperty('registrationDate', records[2].date);
+      expect(record).toHaveProperty('registrationClinician.displayName');
+      expect(record).toHaveProperty('dateRemoved', records.at(-1).date);
+      expect(record).toHaveProperty('removedBy.displayName');
     });
 
     describe('errors', () => {

--- a/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
@@ -80,13 +80,25 @@ describe('ProgramRegistry', () => {
         }),
       );
       // Should not show (patient already has registration):
-      const { id: existingRegistrationId } = await models.ProgramRegistry.create(
+      const { id: registryId1 } = await models.ProgramRegistry.create(
         fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
       await models.PatientProgramRegistration.create(
         fake(models.PatientProgramRegistration, {
           patientId: testPatient.id,
-          programRegistryId: existingRegistrationId,
+          programRegistryId: registryId1,
+        }),
+      );
+
+      // Should show (patient already has registration but it's deleted):
+      const { id: registryId2 } = await models.ProgramRegistry.create(
+        fake(models.ProgramRegistry, { programId: testProgram.id }),
+      );
+      await models.PatientProgramRegistration.create(
+        fake(models.PatientProgramRegistration, {
+          patientId: testPatient.id,
+          registrationStatus: REGISTRATION_STATUSES.RECORDED_IN_ERROR,
+          programRegistryId: registryId2,
         }),
       );
 
@@ -94,7 +106,7 @@ describe('ProgramRegistry', () => {
         .get('/v1/programRegistry')
         .query({ excludePatientId: testPatient.id });
       expect(result).toHaveSucceeded();
-      expect(result.body.data.length).toBe(2);
+      expect(result.body.data.length).toBe(3);
     });
 
     it('should escape the excludePatientId parameter', async () => {

--- a/packages/lan/app/routes/apiv1/patient/patientProgramRegistration.js
+++ b/packages/lan/app/routes/apiv1/patient/patientProgramRegistration.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { isBefore, isAfter } from 'date-fns';
+import { isAfter } from 'date-fns';
 import { NotFoundError, ValidationError } from '@tamanu/shared/errors';
 import { DELETION_STATUSES, REGISTRATION_STATUSES } from '@tamanu/constants';
 


### PR DESCRIPTION
### Changes
Add the following derived fields to various endpoints:
- dateRegistered
- registeredBy
- dateRemoved
- removedBy
- dateRegistered (in the status history table)


Massive shoutout to @mcccclean for making the tests so easy to modify - very very clean
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
