### PR TITLE
TAN-2448: Program registry sync

### DIFF
--- a/packages/shared/src/models/PatientProgramRegistration.js
+++ b/packages/shared/src/models/PatientProgramRegistration.js
@@ -137,9 +137,10 @@ export class PatientProgramRegistration extends Model {
   }
 
   static buildPatientSyncFilter(patientIds, { syncTheseProgramRegistries }) {
-    const escapedProgramRegistryIds = syncTheseProgramRegistries
-      .map(id => this.sequelize.escape(id))
-      .join(',');
+    const escapedProgramRegistryIds =
+      syncTheseProgramRegistries?.length > 1
+        ? syncTheseProgramRegistries.map(id => this.sequelize.escape(id)).join(',')
+        : '';
 
     if (patientIds.length === 0) {
       return `WHERE program_registry_id IN (${escapedProgramRegistryIds}) AND updated_at_sync_tick > :since`;

--- a/packages/shared/src/models/PatientProgramRegistration.js
+++ b/packages/shared/src/models/PatientProgramRegistration.js
@@ -138,7 +138,7 @@ export class PatientProgramRegistration extends Model {
 
   static buildPatientSyncFilter(patientIds, { syncTheseProgramRegistries }) {
     const escapedProgramRegistryIds =
-      syncTheseProgramRegistries?.length > 1
+      syncTheseProgramRegistries?.length > 0
         ? syncTheseProgramRegistries.map(id => this.sequelize.escape(id)).join(',')
         : "''";
 

--- a/packages/shared/src/models/PatientProgramRegistration.js
+++ b/packages/shared/src/models/PatientProgramRegistration.js
@@ -136,10 +136,15 @@ export class PatientProgramRegistration extends Model {
     });
   }
 
-  // syncs everywhere because for the pilot program,
-  // the number of patients is guaranteed to be low.
-  // https://github.com/beyondessential/tamanu/pull/4773#discussion_r1356087015
-  static buildSyncFilter() {
-    return null;
+  static buildPatientSyncFilter(patientIds, { syncTheseProgramRegistries }) {
+    const escapedProgramRegistryIds = syncTheseProgramRegistries
+      .map(id => this.sequelize.escape(id))
+      .join(',');
+
+    if (patientIds.length === 0) {
+      return `WHERE program_registry_id IN (${escapedProgramRegistryIds}) AND updated_at_sync_tick > :since`;
+    }
+
+    return `WHERE (patient_id IN (:patientIds) OR program_registry_id IN (${escapedProgramRegistryIds})) AND updated_at_sync_tick > :since`;
   }
 }

--- a/packages/shared/src/models/PatientProgramRegistration.js
+++ b/packages/shared/src/models/PatientProgramRegistration.js
@@ -140,7 +140,7 @@ export class PatientProgramRegistration extends Model {
     const escapedProgramRegistryIds =
       syncTheseProgramRegistries?.length > 1
         ? syncTheseProgramRegistries.map(id => this.sequelize.escape(id)).join(',')
-        : '';
+        : "''";
 
     if (patientIds.length === 0) {
       return `WHERE program_registry_id IN (${escapedProgramRegistryIds}) AND updated_at_sync_tick > :since`;

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -61,7 +61,7 @@ export class PatientProgramRegistrationCondition extends Model {
 
   static buildPatientSyncFilter(patientIds, { syncTheseProgramRegistries }) {
     const escapedProgramRegistryIds =
-      syncTheseProgramRegistries?.length > 1
+      syncTheseProgramRegistries?.length > 0
         ? syncTheseProgramRegistries.map(id => this.sequelize.escape(id)).join(',')
         : "''";
 

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -63,7 +63,7 @@ export class PatientProgramRegistrationCondition extends Model {
     const escapedProgramRegistryIds =
       syncTheseProgramRegistries?.length > 1
         ? syncTheseProgramRegistries.map(id => this.sequelize.escape(id)).join(',')
-        : '';
+        : "''";
 
     if (patientIds.length === 0) {
       return `WHERE program_registry_id IN (${escapedProgramRegistryIds}) AND updated_at_sync_tick > :since`;

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -59,10 +59,15 @@ export class PatientProgramRegistrationCondition extends Model {
     return ['programRegistryCondition'];
   }
 
-  // syncs everywhere because for the pilot program,
-  // the number of patients is guaranteed to be low.
-  // https://github.com/beyondessential/tamanu/pull/4773#discussion_r1356087015
-  static buildSyncFilter() {
-    return null;
+  static buildPatientSyncFilter(patientIds, { syncTheseProgramRegistries }) {
+    const escapedProgramRegistryIds = syncTheseProgramRegistries
+      .map(id => this.sequelize.escape(id))
+      .join(',');
+
+    if (patientIds.length === 0) {
+      return `WHERE program_registry_id IN (${escapedProgramRegistryIds}) AND updated_at_sync_tick > :since`;
+    }
+
+    return `WHERE (patient_id IN (:patientIds) OR program_registry_id IN (${escapedProgramRegistryIds})) AND updated_at_sync_tick > :since`;
   }
 }

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -60,9 +60,10 @@ export class PatientProgramRegistrationCondition extends Model {
   }
 
   static buildPatientSyncFilter(patientIds, { syncTheseProgramRegistries }) {
-    const escapedProgramRegistryIds = syncTheseProgramRegistries
-      .map(id => this.sequelize.escape(id))
-      .join(',');
+    const escapedProgramRegistryIds =
+      syncTheseProgramRegistries?.length > 1
+        ? syncTheseProgramRegistries.map(id => this.sequelize.escape(id)).join(',')
+        : '';
 
     if (patientIds.length === 0) {
       return `WHERE program_registry_id IN (${escapedProgramRegistryIds}) AND updated_at_sync_tick > :since`;

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -267,6 +267,10 @@ export class CentralSyncManager {
       const patientIdsForFullSync = newPatientFacilities.map(n => n.patientId);
 
       const syncAllLabRequests = await models.Setting.get('syncAllLabRequests', facilityId);
+      const syncTheseProgramRegistries = await models.Setting.get(
+        'syncTheseProgramRegistries',
+        facilityId,
+      );
       const sessionConfig = {
         // for facilities with a lab, need ongoing lab requests
         // no need for historical ones on initial sync, and no need on mobile
@@ -275,6 +279,7 @@ export class CentralSyncManager {
           ? this.constructor.config.sync.syncAllEncountersForTheseVaccines
           : [],
         isMobile,
+        syncTheseProgramRegistries: isMobile ? [] : syncTheseProgramRegistries,
       };
 
       // snapshot inside a "repeatable read" transaction, so that other changes made while this

--- a/packages/sync-server/app/sync/CentralSyncManager.js
+++ b/packages/sync-server/app/sync/CentralSyncManager.js
@@ -279,7 +279,7 @@ export class CentralSyncManager {
           ? this.constructor.config.sync.syncAllEncountersForTheseVaccines
           : [],
         isMobile,
-        syncTheseProgramRegistries: isMobile ? [] : syncTheseProgramRegistries,
+        syncTheseProgramRegistries: isMobile ? [] : syncTheseProgramRegistries || [],
       };
 
       // snapshot inside a "repeatable read" transaction, so that other changes made while this


### PR DESCRIPTION
### Changes

Okay so I think this is it. After thinking about it for a while, it seems to me that this one should be a patient sync filter and not just a sync filter - the core reason is that we do want to apply the normal patient filter plus added logic, which I think is best represented this way, plus, we already get the `sessionConfig` for free and the sync filter API is not asynchronous.

Also, I've spent quite some time looking at this to see if we could throw in some unit testing but I think that given the urgency, plus the fact that testing sync seems artificial to me, I decided to leave it out!

I'm not completely sure about the setting name, but it seemed appropriate 😅 