### PR TITLE
TAN-2295: Fix registry search filters

### DIFF
--- a/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
@@ -226,5 +226,50 @@ describe('ProgramRegistry', () => {
         },
       ]);
     });
+
+    describe('Filtering', () => {
+      const patientFilters = [
+        { filter: 'dateOfBirth', value: '2000-01-01 01:23:45' },
+        { filter: 'displayId', value: 'TEST_DISPLAY_ID' },
+        { filter: 'sex', value: 'male' },
+        { filter: 'sex', value: 'female' },
+        { filter: 'sex', value: 'other' },
+        { filter: 'firstName', value: 'TEST_FIRST_NAME' },
+      ];
+      let registryId = null;
+      
+      beforeAll(async () => {
+        const { id: programRegistryId } = await models.ProgramRegistry.create(
+          fake(models.ProgramRegistry, { programId: testProgram.id }),
+        );
+        registryId = programRegistryId;
+        await Promise.all(patientFilters.map(async ({ filter, value }) => {  
+          const patient = await models.Patient.create(fake(models.Patient, {
+            [filter]: value, 
+          }));
+          await models.PatientProgramRegistration.create(
+            fake(models.PatientProgramRegistration, {
+              programRegistryId,
+              patientId: patient.id,
+            }),
+          );
+        }));
+      });
+
+      it.each(patientFilters)(
+        'Should only include records matching patient filter ($filter: $value)',
+        async ({ filter, value }) => {
+          const result = await app.get(`/v1/programRegistry/${registryId}/registrations`).query({
+            rowsPerPage: 100,
+            [filter]: value,
+          });
+          expect(result).toHaveSucceeded();
+
+          expect(result.body.data).not.toHaveLength(0);
+          result.body.data.map(x => {
+            expect(x.patient).toHaveProperty(filter, value);
+          });
+        });
+    });
   });
 });

--- a/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
@@ -248,7 +248,6 @@ describe('ProgramRegistry', () => {
           const patient = await models.Patient.create(fake(models.Patient, {
             [filter]: value, 
           }));
-          console.log(filter, value, patient);
           await models.PatientProgramRegistration.create(
             fake(models.PatientProgramRegistration, {
               programRegistryId,

--- a/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/lan/__tests__/apiv1/ProgramRegistry.test.js
@@ -229,12 +229,13 @@ describe('ProgramRegistry', () => {
 
     describe('Filtering', () => {
       const patientFilters = [
-        { filter: 'dateOfBirth', value: '2000-01-01 01:23:45' },
+        { filter: 'dateOfBirth', value: '3000-01-01' },
         { filter: 'displayId', value: 'TEST_DISPLAY_ID' },
         { filter: 'sex', value: 'male' },
         { filter: 'sex', value: 'female' },
         { filter: 'sex', value: 'other' },
         { filter: 'firstName', value: 'TEST_FIRST_NAME' },
+        { filter: 'lastName', value: 'TEST_LAST_NAME' },
       ];
       let registryId = null;
       
@@ -247,6 +248,7 @@ describe('ProgramRegistry', () => {
           const patient = await models.Patient.create(fake(models.Patient, {
             [filter]: value, 
           }));
+          console.log(filter, value, patient);
           await models.PatientProgramRegistration.create(
             fake(models.PatientProgramRegistration, {
               programRegistryId,
@@ -270,6 +272,7 @@ describe('ProgramRegistry', () => {
             expect(x.patient).toHaveProperty(filter, value);
           });
         });
+        
     });
   });
 });

--- a/packages/lan/app/routes/apiv1/programRegistry.js
+++ b/packages/lan/app/routes/apiv1/programRegistry.js
@@ -111,9 +111,11 @@ programRegistry.get(
       makePartialTextFilter('displayId', 'patient.display_id'),
       makeSimpleTextFilter('firstName', 'patient.first_name'),
       makeSimpleTextFilter('lastName', 'patient.last_name'),
-      makeFilter(filterParams.sex, 'patient.sex = :sex'),
-      makeFilter(filterParams.dateOfBirth, `patients.date_of_birth = :dateOfBirth`),
-      makeFilter(filterParams.homeVillage, `patients.village_id = :homeVillage`),
+      makeFilter(filterParams.sex, 'patient.sex = :sex', ({ sex }) => ({
+        sex: sex.toLowerCase(),
+      })),
+      makeFilter(filterParams.dateOfBirth, `patient.date_of_birth = :dateOfBirth`),
+      makeFilter(filterParams.homeVillage, `patient.village_id = :homeVillage`),
       makeFilter(
         !filterParams.deceased || filterParams.deceased === 'false',
         'patient.date_of_death IS NULL',

--- a/packages/lan/app/routes/apiv1/programRegistry.js
+++ b/packages/lan/app/routes/apiv1/programRegistry.js
@@ -109,9 +109,9 @@ programRegistry.get(
     const filters = [
       // Patient filters
       makePartialTextFilter('displayId', 'patient.display_id'),
-      makeSimpleTextFilter('sex', 'patient.sex'),
       makeSimpleTextFilter('firstName', 'patient.first_name'),
       makeSimpleTextFilter('lastName', 'patient.last_name'),
+      makeFilter(filterParams.sex, 'patient.sex = :sex'),
       makeFilter(filterParams.dateOfBirth, `patients.date_of_birth = :dateOfBirth`),
       makeFilter(filterParams.homeVillage, `patients.village_id = :homeVillage`),
       makeFilter(
@@ -124,9 +124,6 @@ programRegistry.get(
         filterParams.registeringFacilityId,
         'mrr.registering_facility_id = :registeringFacilityId',
       ),
-      makeFilter(programRegistryId, 'mrr.program_registry_id = :programRegistryId', () => ({
-        programRegistryId,
-      })),
       makeFilter(filterParams.clinicalStatus, 'mrr.clinical_status = :clinicalStatus'),
       makeFilter(
         filterParams.currentlyIn,
@@ -168,42 +165,47 @@ programRegistry.get(
               *,
               ROW_NUMBER() OVER (PARTITION BY patient_id, program_registry_id ORDER BY date DESC, id DESC) AS row_num
             FROM patient_program_registrations
+            WHERE program_registry_id = :programRegistryId
           ) n
           WHERE n.row_num = 1
         ),
         conditions as (
-          SELECT pprc.program_registry_id, patient_id, jsonb_agg(prc."name") condition_list  FROM patient_program_registration_conditions pprc
-          join program_registry_conditions prc
-          on pprc.program_registry_condition_id = prc.id
-          group by pprc.program_registry_id, patient_id
+          SELECT patient_id, jsonb_agg(prc."name") condition_list  
+          FROM patient_program_registration_conditions pprc
+            JOIN program_registry_conditions prc
+              ON pprc.program_registry_condition_id = prc.id
+          WHERE pprc.program_registry_id = :programRegistryId
+          GROUP BY patient_id
         )
     `;
     const from = `
       FROM most_recent_registrations mrr
-      left join patients patient
-      on patient.id = mrr.patient_id
-      left join reference_data patient_village
-      on patient.village_id = patient_village.id
-      left join reference_data currently_at_village
-      on mrr.village_id = currently_at_village.id
-      left join facilities currently_at_facility
-      on mrr.facility_id = currently_at_facility.id
-      left join facilities registering_facility
-      on mrr.registering_facility_id = registering_facility.id
-      left join conditions
-      on conditions.patient_id = mrr.patient_id
-      and conditions.program_registry_id = mrr.program_registry_id
-      left join program_registry_clinical_statuses status
-      on mrr.clinical_status_id = status.id
-      left join program_registries program_registry
-      on mrr.program_registry_id = program_registry.id
-      left join users clinician
-      on mrr.clinician_id = clinician.id
+        LEFT JOIN patients patient
+          ON patient.id = mrr.patient_id
+        LEFT JOIN reference_data patient_village
+          ON patient.village_id = patient_village.id
+        LEFT JOIN reference_data currently_at_village
+          ON mrr.village_id = currently_at_village.id
+        LEFT JOIN facilities currently_at_facility
+          ON mrr.facility_id = currently_at_facility.id
+        LEFT JOIN facilities registering_facility
+          ON mrr.registering_facility_id = registering_facility.id
+        LEFT JOIN conditions
+          ON conditions.patient_id = mrr.patient_id
+        LEFT JOIN program_registry_clinical_statuses status
+          ON mrr.clinical_status_id = status.id
+        LEFT JOIN program_registries program_registry
+          ON mrr.program_registry_id = program_registry.id
+        LEFT JOIN users clinician
+          ON mrr.clinician_id = clinician.id
       ${whereClauses && `WHERE ${whereClauses}`}
     `;
 
     const countResult = await req.db.query(`${withClause} SELECT COUNT(1) AS count ${from}`, {
-      replacements: filterReplacements,
+      replacements: {
+        ...filterReplacements,
+        programRegistryId,
+      },
       type: QueryTypes.SELECT,
     });
 
@@ -269,6 +271,7 @@ programRegistry.get(
       {
         replacements: {
           ...filterReplacements,
+          programRegistryId,
           limit: rowsPerPage,
           offset: page * rowsPerPage,
           sortKey,

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -29,16 +29,21 @@ export class PatientProgramRegistrationCondition extends Model {
   }
 
   static initRelations(models) {
+
+    // Note that we use a kind of composite foreign key here (patientId + programRegistryId)
+    // rather than just a single patientProgramRegistrationId. This is because 
+    // PatientProgramRegistrion is an append-only array rather than a single record,
+    // so the relevant id changes every time a change is made to the relevant registration.
     this.belongsTo(models.Patient, {
       foreignKey: { name: 'patientId', allowNull: false },
       as: 'patient',
     });
-
     this.belongsTo(models.ProgramRegistry, {
       foreignKey: { name: 'programRegistryId', allowNull: false },
       as: 'programRegistry',
     });
 
+    
     this.belongsTo(models.ProgramRegistryCondition, {
       foreignKey: 'programRegistryConditionId',
       as: 'programRegistryCondition',

--- a/packages/shared/src/models/PatientProgramRegistrationCondition.js
+++ b/packages/shared/src/models/PatientProgramRegistrationCondition.js
@@ -29,9 +29,8 @@ export class PatientProgramRegistrationCondition extends Model {
   }
 
   static initRelations(models) {
-
     // Note that we use a kind of composite foreign key here (patientId + programRegistryId)
-    // rather than just a single patientProgramRegistrationId. This is because 
+    // rather than just a single patientProgramRegistrationId. This is because
     // PatientProgramRegistrion is an append-only array rather than a single record,
     // so the relevant id changes every time a change is made to the relevant registration.
     this.belongsTo(models.Patient, {
@@ -43,7 +42,6 @@ export class PatientProgramRegistrationCondition extends Model {
       as: 'programRegistry',
     });
 
-    
     this.belongsTo(models.ProgramRegistryCondition, {
       foreignKey: 'programRegistryConditionId',
       as: 'programRegistryCondition',


### PR DESCRIPTION
### Changes

The core issue was a simpleTextFilter trying to do an uppercase transform on patient.sex, which is currently an enum rather than text. Fixes in this PR:

- transform `sex` to lowercase in JS rather than transforming patient.sex to uppercase in SQL
- fix a performance issue where it was sequencing over the whole db before filtering rather than after (same bug as the notes one!)
- add some (non-exhaustive) tests against patient filtering
- (unrelated) add an explanatory comment to PatientProgramRegistrationConditions

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
