### PR TITLE
No issue: more aggressive yarn cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,22 @@ jobs:
         with:
           node-version: 20.x
           cache: yarn
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
       - run: yarn
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
+
       - run: yarn build-shared
 
       - name: Install and start postgres if needed
@@ -65,7 +80,22 @@ jobs:
         with:
           node-version: 20.x
           cache: yarn
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
       - run: yarn
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
+
       - run: yarn build
 
   lint:
@@ -73,14 +103,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 20.x
           cache: yarn
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
       - run: yarn
-      - run: yarn build-shared
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
 
+      - run: yarn build-shared
       - run: yarn lint-all
         env:
           CONTINUE_ON_ERROR: true
@@ -94,12 +137,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 20.x
           cache: yarn
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
       - run: yarn
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
+
       - run: yarn build-shared
       - run: yarn workspace desktop run verify-storybook
 
@@ -124,7 +181,22 @@ jobs:
         with:
           node-version: 20.x
           cache: yarn
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
       - run: yarn
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
+
       - run: yarn build-shared
 
       - name: Install and start postgres ${{ matrix.postgres }}
@@ -139,14 +211,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 12.x
           cache: yarn
-
-      - run: yarn install --frozen-lockfile
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarnmobile-${{ hashFiles('mobile/yarn.lock') }}
+          path: mobile/node_modules
+      - run: yarn
         working-directory: packages/mobile
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarnmobile-${{ hashFiles('mobile/yarn.lock') }}
+          path: mobile/node_modules
 
       - run: yarn test
         working-directory: packages/mobile
@@ -160,6 +238,21 @@ jobs:
         with:
           node-version: 20.x
           cache: yarn
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
+      - run: yarn
+      - uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+            !packages/mobile/node_modules
 
       - name: Install and start postgres
         run: |
@@ -176,6 +269,25 @@ jobs:
       - name: Start a facility server again without a central one
         run: .github/scripts/test-facility-offline.sh facility-start-again
 
+  test-yarn-lock:
+    strategy:
+      fail-fast: false
+      matrix:
+        workdir:
+          - .
+          - packages/mobile
+    name: Check ${{ matrix.workdir }}/yarn.lock is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn
+        working-directory: ${{ matrix.workdir }}
+      - run: git diff --exit-code
+
   # Dummy job to have a stable name for PR requirements
   tests-pass:
     if: always() # always run even if dependencies fail
@@ -187,6 +299,7 @@ jobs:
       - migrations
       - test-mobile
       - test-facility-offline
+      - test-yarn-lock
     runs-on: ubuntu-latest
     steps:
       # fail if ANY dependency has failed or been skipped or cancelled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.workdir == '.' && '20.x' || '12.x' }}
           cache: yarn
       - run: yarn
         working-directory: ${{ matrix.workdir }}


### PR DESCRIPTION
### Changes

- Cache the content of node_modules in an attempt to cut down on recompute
- Add an explicit check for the yarn.locks being out of date

#### Before

![image](https://github.com/beyondessential/tamanu/assets/155787/ddc5b172-3e8c-4385-bc52-988a3f3bd72e)

![image](https://github.com/beyondessential/tamanu/assets/155787/78ab1179-0c77-4a02-87d8-925ed97e01e7)

#### After

![image](https://github.com/beyondessential/tamanu/assets/155787/599ce162-0253-4475-9e69-4147a1865c45)

![image](https://github.com/beyondessential/tamanu/assets/155787/1c5ec74f-9675-4aac-b227-2acbb91d218b)

### Checklist

- [x] Code is finished
