### PR TITLE
Restrict codeship to the deploy-meta branch

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,7 +1,7 @@
 - name: tamanu deployment
   type: serial
   encrypted_dockercfg_path: dockercfg.encrypted
-  tag: ^(main$|ci-|uat-|uatrispacs-|uatpmi-|release-desktop-|klaus-|sima-|sepi-|da-|deploy-meta$|deploy-nauru-demo$)
+  tag: ^deploy-meta$
   steps:
     - name: copy files
       service: build


### PR DESCRIPTION
### Changes

This is the only place it's still in use.