### PR TITLE
NASS-1074: Desktop login page: Update to 'Forgot Password' design

### DIFF
--- a/packages/central-server/app/auth/changePassword.js
+++ b/packages/central-server/app/auth/changePassword.js
@@ -30,8 +30,6 @@ changePassword.post(
   asyncHandler(async (req, res) => {
     const { store, body } = req;
 
-    log.info(body.newPassword);
-
     await schema.validate(body);
 
     await doChangePassword(store, body);

--- a/packages/central-server/app/auth/changePassword.js
+++ b/packages/central-server/app/auth/changePassword.js
@@ -100,7 +100,7 @@ const validateResetCode = async (store, { email, token }) => {
   });
 
   if (!oneTimeLogin) {
-    log.info(`One time login for this user and token ${token} not found`);
+    log.info('oneTimeLogin.tokenNotFound', { token });
     throw new ValidationError('Token not found for this user');
   }
 };

--- a/packages/central-server/app/auth/resetPassword.js
+++ b/packages/central-server/app/auth/resetPassword.js
@@ -38,11 +38,10 @@ resetPassword.post(
       // any information about the system. In this case, a hacker can use a "not found"
       // error message to figure out which emails are really in use.
       // So, we just return an "OK" response no matter what information is provided,
-      // regardless of whether it's valid or not. 
+      // regardless of whether it's valid or not.
     } else {
       const token = await createOneTimeLogin(models, user);
-      log.info(`Token for ${email} is ${token}`);
-      // await sendResetEmail(req.emailService, user, token);
+      await sendResetEmail(req.emailService, user, token);
     }
 
     return res.send({ ok: 'ok' });

--- a/packages/central-server/app/auth/resetPassword.js
+++ b/packages/central-server/app/auth/resetPassword.js
@@ -33,13 +33,10 @@ resetPassword.post(
 
     if (!user) {
       log.info(`Password reset request: No user found with email ${email}`);
-      // An attacker could use this to get a list of user accounts
-      // so we return the same ok result
       throw new ValidationError('User not found');
     } else {
       const token = await createOneTimeLogin(models, user);
-      log.info(`Token for ${email} is ${token}`);
-      // await sendResetEmail(req.emailService, user, token);
+      await sendResetEmail(req.emailService, user, token);
     }
 
     return res.send({ ok: 'ok' });

--- a/packages/central-server/app/auth/resetPassword.js
+++ b/packages/central-server/app/auth/resetPassword.js
@@ -6,6 +6,7 @@ import { addMinutes } from 'date-fns';
 
 import { COMMUNICATION_STATUSES } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
+import { ValidationError } from 'yup';
 import { findUser, getRandomBase64String } from './utils';
 
 export const resetPassword = express.Router();
@@ -34,9 +35,11 @@ resetPassword.post(
       log.info(`Password reset request: No user found with email ${email}`);
       // An attacker could use this to get a list of user accounts
       // so we return the same ok result
+      throw new ValidationError('User not found');
     } else {
       const token = await createOneTimeLogin(models, user);
-      await sendResetEmail(req.emailService, user, token);
+      log.info(`Token for ${email} is ${token}`);
+      // await sendResetEmail(req.emailService, user, token);
     }
 
     return res.send({ ok: 'ok' });

--- a/packages/central-server/app/auth/resetPassword.js
+++ b/packages/central-server/app/auth/resetPassword.js
@@ -33,7 +33,12 @@ resetPassword.post(
 
     if (!user) {
       log.info(`Password reset request: No user found with email ${email}`);
-      throw new ValidationError('User not found');
+      // ⚠️ SECURITY INFO:
+      // This logic is available to anonymous users, so it's important it doesn't give out
+      // any information about the system. In this case, a hacker can use a "not found"
+      // error message to figure out which emails are really in use.
+      // So, we just return an "OK" response no matter what information is provided,
+      // regardless of whether it's valid or not. 
     } else {
       const token = await createOneTimeLogin(models, user);
       await sendResetEmail(req.emailService, user, token);

--- a/packages/central-server/app/auth/resetPassword.js
+++ b/packages/central-server/app/auth/resetPassword.js
@@ -41,7 +41,8 @@ resetPassword.post(
       // regardless of whether it's valid or not. 
     } else {
       const token = await createOneTimeLogin(models, user);
-      await sendResetEmail(req.emailService, user, token);
+      log.info(`Token for ${email} is ${token}`);
+      // await sendResetEmail(req.emailService, user, token);
     }
 
     return res.send({ ok: 'ok' });

--- a/packages/facility-server/app/routes/apiv1/changePassword.js
+++ b/packages/facility-server/app/routes/apiv1/changePassword.js
@@ -22,6 +22,20 @@ changePassword.post(
   }),
 );
 
+changePassword.post(
+  '/validate-reset-code',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+
+    const { deviceId } = req;
+
+    const centralServer = new CentralServerConnection({ deviceId });
+    const response = await centralServer.forwardRequest(req, 'changePassword/validate-reset-code');
+
+    res.send(response);
+  }),
+);
+
 const updatePasswordOnFacilityServer = async (models, { email, newPassword }) => {
   await models.User.update(
     {

--- a/packages/web/app/api/TamanuApi.js
+++ b/packages/web/app/api/TamanuApi.js
@@ -26,7 +26,11 @@ const getVersionIncompatibleMessage = (error, response) => {
   }
 
   if (error.message === VERSION_COMPATIBILITY_ERRORS.HIGH) {
-    const maxAppVersion = response.headers.get('X-Max-Client-Version').split('.', 3).slice(0, 2).join('.');
+    const maxAppVersion = response.headers
+      .get('X-Max-Client-Version')
+      .split('.', 3)
+      .slice(0, 2)
+      .join('.');
     return `The Tamanu Facility Server only supports up to v${maxAppVersion}, and needs to be upgraded. Please contact your system administrator.`;
   }
 
@@ -179,6 +183,10 @@ export class TamanuApi {
 
   async changePassword(data) {
     return this.post('changePassword', data);
+  }
+
+  async validateResetCode(data) {
+    return this.post('changePassword/validate-reset-code', data);
   }
 
   async refreshToken() {

--- a/packages/web/app/api/TamanuApi.js
+++ b/packages/web/app/api/TamanuApi.js
@@ -185,10 +185,6 @@ export class TamanuApi {
     return this.post('changePassword', data);
   }
 
-  async validateResetCode(data) {
-    return this.post('changePassword/validate-reset-code', data);
-  }
-
   async refreshToken() {
     try {
       const response = await this.post('refresh');

--- a/packages/web/app/components/Field/Form.jsx
+++ b/packages/web/app/components/Field/Form.jsx
@@ -254,7 +254,7 @@ export class Form extends React.PureComponent {
       validateOnChange,
       validateOnBlur,
       initialValues,
-      showErrorDialog = true,
+      suppressErrorDialog = false,
       ...props
     } = this.props;
     const { validationErrors } = this.state;
@@ -265,7 +265,7 @@ export class Form extends React.PureComponent {
       throw new Error('Form must not have any children -- use the `render` prop instead please!');
     }
 
-    const displayErrorDialog = Object.keys(validationErrors).length > 0;
+    const hasErrors = Object.keys(validationErrors).length > 0;
 
     return (
       <>
@@ -280,9 +280,9 @@ export class Form extends React.PureComponent {
           {...props}
           render={this.renderFormContents}
         />
-        {showErrorDialog && (
+        {!suppressErrorDialog && (
           <Dialog
-            isVisible={displayErrorDialog}
+            isVisible={hasErrors}
             onClose={this.hideErrorDialog}
             headerTitle="Please fix below errors to continue"
             disableDevWarning

--- a/packages/web/app/components/Field/Form.jsx
+++ b/packages/web/app/components/Field/Form.jsx
@@ -254,6 +254,7 @@ export class Form extends React.PureComponent {
       validateOnChange,
       validateOnBlur,
       initialValues,
+      showErrorDialog = true,
       ...props
     } = this.props;
     const { validationErrors } = this.state;
@@ -279,13 +280,15 @@ export class Form extends React.PureComponent {
           {...props}
           render={this.renderFormContents}
         />
-        <Dialog
-          isVisible={displayErrorDialog}
-          onClose={this.hideErrorDialog}
-          headerTitle="Please fix below errors to continue"
-          disableDevWarning
-          contentText={<FormErrors errors={validationErrors} />}
-        />
+        {showErrorDialog && (
+          <Dialog
+            isVisible={displayErrorDialog}
+            onClose={this.hideErrorDialog}
+            headerTitle="Please fix below errors to continue"
+            disableDevWarning
+            contentText={<FormErrors errors={validationErrors} />}
+          />
+        )}
       </>
     );
   }

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -184,6 +184,7 @@ export const ChangePasswordForm = React.memo(
             .oneOf([yup.ref('newPassword'), null], `Passwords don't match`)
             .required('*Required'),
         })}
+        showErrorDialog={false}
       />
     );
   },

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -108,7 +108,7 @@ export const ChangePasswordForm = React.memo(
           <StyledField
             name="token"
             type="text"
-            label="Reset Code"
+            label="Reset code"
             required
             component={TextField}
             placeholder="Reset code"

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -45,11 +45,15 @@ const ActionButtonContainer = styled.div`
 const FieldContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 30px;
+  gap: 25px;
 `;
 
 const SuccessSubtext = styled(FormSubtext)`
   margin: 10px 0 30px 0;
+`;
+
+const HorizontalDivider = styled.div`
+  border-bottom: 1px solid #dedede;
 `;
 
 export const ChangePasswordForm = React.memo(
@@ -58,8 +62,11 @@ export const ChangePasswordForm = React.memo(
       <FormGrid columns={1}>
         <div>
           <FormHeading>Reset password</FormHeading>
-          <FormSubtext>Please enter the reset code you have received in your email</FormSubtext>
-          {!!errorMessage && <FormSubtext>{errorMessage}</FormSubtext>}
+          <FormSubtext>
+            We have emailed you a reset coe. Please enter the code and your new password below to
+            reset your password.
+          </FormSubtext>
+          <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>
         </div>
         <FieldContainer>
           <Field
@@ -70,13 +77,22 @@ export const ChangePasswordForm = React.memo(
             component={TextField}
             placeholder="Reset code"
           />
+          <HorizontalDivider />
           <Field
             name="newPassword"
             type="password"
-            label="Enter a new password"
+            label="New password"
             required
             component={TextField}
             placeholder="New password"
+          />
+          <Field
+            name="confirmNewPassword"
+            type="password"
+            label="Confirm new password"
+            required
+            component={TextField}
+            placeholder="Confirm new password"
           />
         </FieldContainer>
         <ActionButtonContainer>

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -85,6 +85,7 @@ const StyledField = styled(Field)`
 `;
 
 const INCORRECT_TOKEN_ERROR_MESSAGE = 'Facility server error response: User or token not found';
+const REQUIRED_VALIDATION_MESSAGE = '*Required';
 
 const ChangePasswordFormComponent = ({
   onRestartFlow,
@@ -94,7 +95,10 @@ const ChangePasswordFormComponent = ({
   onNavToResetPassword,
   onValidateResetCode,
   setFieldError,
+  errors,
 }) => {
+  // const [newPasswordErrorText, setNewPasswordErrorText] = useState(null);
+  // const [confirmPasswordErrorText, setConfirmPasswordErrorText] = useState(null);
   useEffect(() => {
     if (errorMessage === INCORRECT_TOKEN_ERROR_MESSAGE) {
       setFieldError('token', 'Code incorrect');
@@ -130,6 +134,11 @@ const ChangePasswordFormComponent = ({
           required
           component={TextField}
           placeholder="New password"
+          onChange={() => {
+            if (errors.newPassword === REQUIRED_VALIDATION_MESSAGE) {
+              setFieldError('newPassword', '');
+            }
+          }}
         />
         <StyledField
           name="confirmNewPassword"
@@ -138,6 +147,11 @@ const ChangePasswordFormComponent = ({
           required
           component={TextField}
           placeholder="Confirm new password"
+          onChange={() => {
+            if (errors.confirmNewPassword === REQUIRED_VALIDATION_MESSAGE) {
+              setFieldError('confirmNewPassword', '');
+            }
+          }}
         />
       </FieldContainer>
       <ActionButtonContainer>
@@ -169,7 +183,7 @@ export const ChangePasswordForm = React.memo(
     onNavToResetPassword,
     onValidateResetCode,
   }) => {
-    const renderForm = ({ setFieldError }) => (
+    const renderForm = ({ setFieldError, errors }) => (
       <ChangePasswordFormComponent
         onRestartFlow={onRestartFlow}
         errorMessage={errorMessage}
@@ -178,6 +192,7 @@ export const ChangePasswordForm = React.memo(
         onNavToResetPassword={onNavToResetPassword}
         onValidateResetCode={onValidateResetCode}
         setFieldError={setFieldError}
+        errors={errors}
       />
     );
 
@@ -206,16 +221,16 @@ export const ChangePasswordForm = React.memo(
           email,
         }}
         validationSchema={yup.object().shape({
-          token: yup.string().required('*Required'),
+          token: yup.string().required(REQUIRED_VALIDATION_MESSAGE),
           newPassword: yup
             .string()
             .min(5, 'Must be at least 5 characters')
             .oneOf([yup.ref('confirmNewPassword'), null], `Passwords don't match`)
-            .required('*Required'),
+            .required(REQUIRED_VALIDATION_MESSAGE),
           confirmNewPassword: yup
             .string()
             .oneOf([yup.ref('newPassword'), null], `Passwords don't match`)
-            .required('*Required'),
+            .required(REQUIRED_VALIDATION_MESSAGE),
         })}
         showErrorDialog={false}
       />

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -94,59 +94,73 @@ export const ChangePasswordForm = React.memo(
     onNavToLogin,
     onNavToResetPassword,
   }) => {
-    const renderForm = ({ setFieldValue }) => (
-      <FormGrid columns={1}>
-        <div>
-          <FormHeading>Reset password</FormHeading>
-          <FormSubtext>
-            We have emailed you a reset code. Please enter the code and your new password below to
-            reset your password.
-          </FormSubtext>
-          <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>
-        </div>
-        <FieldContainer>
-          <StyledField
-            name="token"
-            type="text"
-            label="Reset code"
-            required
-            component={TextField}
-            placeholder="Reset code"
-          />
-          <HorizontalDivider />
-          <StyledField
-            name="newPassword"
-            type="password"
-            label="New password"
-            required
-            component={TextField}
-            placeholder="New password"
-          />
-          <StyledField
-            name="confirmNewPassword"
-            type="password"
-            label="Confirm new password"
-            required
-            component={TextField}
-            placeholder="Confirm new password"
-          />
-        </FieldContainer>
-        <ActionButtonContainer>
-          <ChangePasswordButton type="submit">Reset Password</ChangePasswordButton>
-          <BackToLoginButton onClick={onNavToLogin} variant="outlined">
-            Back to login
-          </BackToLoginButton>
-        </ActionButtonContainer>
-        <ResendCodeButton
-          onClick={() => {
-            onRestartFlow();
-            onNavToResetPassword();
-          }}
-        >
-          Resend reset code
-        </ResendCodeButton>
-      </FormGrid>
-    );
+    const [isTokenValid, setIsTokenValid] = useState(false);
+
+    const renderForm = ({ setFieldValue }) => {
+      return (
+        <FormGrid columns={1}>
+          <div>
+            <FormHeading>Reset password</FormHeading>
+            <FormSubtext>
+              We have emailed you a reset code. Please enter the code and your new password below to
+              reset your password.
+            </FormSubtext>
+            <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>
+          </div>
+          <FieldContainer>
+            <StyledField
+              name="token"
+              type="text"
+              label="Reset code"
+              required
+              component={TextField}
+              placeholder="Reset code"
+              // onBlur={data => {
+              //   console.log('tsatrt');
+              //   onValidateResetCode(data);
+              //   console.log('ebd');
+              // }}
+              onBlur={() => {
+                setIsTokenValid(true);
+              }}
+            />
+            <HorizontalDivider />
+            <StyledField
+              name="newPassword"
+              type="password"
+              label="New password"
+              required
+              component={TextField}
+              placeholder="New password"
+              disabled={!isTokenValid}
+            />
+            <StyledField
+              name="confirmNewPassword"
+              type="password"
+              label="Confirm new password"
+              required
+              component={TextField}
+              placeholder="Confirm new password"
+              disabled={!isTokenValid}
+            />
+          </FieldContainer>
+          <ActionButtonContainer>
+            <ChangePasswordButton type="submit">Reset Password</ChangePasswordButton>
+            <BackToLoginButton onClick={onNavToLogin} variant="outlined">
+              Back to login
+            </BackToLoginButton>
+          </ActionButtonContainer>
+          <ResendCodeButton
+            onClick={() => {
+              onRestartFlow();
+              onNavToResetPassword();
+            }}
+          >
+            Resend reset code
+          </ResendCodeButton>
+        </FormGrid>
+      );
+    };
 
     if (success) {
       return (

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -245,7 +245,7 @@ export const ChangePasswordForm = React.memo(
             .oneOf([yup.ref('newPassword'), null], `Passwords don't match`)
             .required(REQUIRED_VALIDATION_MESSAGE),
         })}
-        showErrorDialog={false}
+        suppressErrorDialog
       />
     );
   },

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -102,7 +102,7 @@ const ChangePasswordFormComponent = ({
       setFieldError('token', 'Code incorrect');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resetCodeErrorMessage]);
+  }, [resetCodeErrorMessage, errors.token]);
 
   return (
     <FormGrid columns={1}>

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -3,7 +3,16 @@ import * as yup from 'yup';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { FormGrid } from '../components/FormGrid';
-import { BodyText, Button, Field, Form, FormSubmitButton, TextField } from '../components';
+import {
+  BodyText,
+  Button,
+  Field,
+  Form,
+  FormSubmitButton,
+  TextButton,
+  TextField,
+  StyledPrimarySubmitButton,
+} from '../components';
 import { Colors } from '../constants';
 import ApprovedIcon from '../assets/images/approved.svg';
 
@@ -56,8 +65,28 @@ const HorizontalDivider = styled.div`
   border-bottom: 1px solid #dedede;
 `;
 
+const ResendCodeButton = styled(TextButton)`
+  font-size: 11px;
+  color: black;
+  font-weight: 400;
+
+  :hover {
+    color: ${Colors.primary};
+    font-weight: 500;
+    text-decoration: underline;
+  }
+`;
+
 export const ChangePasswordForm = React.memo(
-  ({ onSubmit, errorMessage, success, email, onNavToLogin, onNavToResetPassword }) => {
+  ({
+    onSubmit,
+    onRestartFlow,
+    errorMessage,
+    success,
+    email,
+    onNavToLogin,
+    onNavToResetPassword,
+  }) => {
     const renderForm = ({ setFieldValue }) => (
       <FormGrid columns={1}>
         <div>
@@ -101,6 +130,14 @@ export const ChangePasswordForm = React.memo(
             Back to login
           </BackToLoginButton>
         </ActionButtonContainer>
+        <ResendCodeButton
+          onClick={() => {
+            onRestartFlow();
+            onNavToResetPassword();
+          }}
+        >
+          Resend reset code
+        </ResendCodeButton>
       </FormGrid>
     );
 

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -77,6 +77,13 @@ const ResendCodeButton = styled(TextButton)`
   }
 `;
 
+const StyledField = styled(Field)`
+  .MuiFormHelperText-root {
+    position: absolute;
+    bottom: -20px;
+  }
+`;
+
 export const ChangePasswordForm = React.memo(
   ({
     onSubmit,
@@ -98,7 +105,7 @@ export const ChangePasswordForm = React.memo(
           <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>
         </div>
         <FieldContainer>
-          <Field
+          <StyledField
             name="token"
             type="text"
             label="Reset Code"
@@ -107,7 +114,7 @@ export const ChangePasswordForm = React.memo(
             placeholder="Reset code"
           />
           <HorizontalDivider />
-          <Field
+          <StyledField
             name="newPassword"
             type="password"
             label="New password"
@@ -115,7 +122,7 @@ export const ChangePasswordForm = React.memo(
             component={TextField}
             placeholder="New password"
           />
-          <Field
+          <StyledField
             name="confirmNewPassword"
             type="password"
             label="Confirm new password"
@@ -125,7 +132,7 @@ export const ChangePasswordForm = React.memo(
           />
         </FieldContainer>
         <ActionButtonContainer>
-          <ChangePasswordButton type="submit">Change Password</ChangePasswordButton>
+          <ChangePasswordButton type="submit">Reset Password</ChangePasswordButton>
           <BackToLoginButton onClick={onNavToLogin} variant="outlined">
             Back to login
           </BackToLoginButton>
@@ -166,11 +173,16 @@ export const ChangePasswordForm = React.memo(
           email,
         }}
         validationSchema={yup.object().shape({
-          token: yup.string().required(),
+          token: yup.string().required('*Required'),
           newPassword: yup
             .string()
             .min(5, 'Must be at least 5 characters')
-            .required(),
+            .oneOf([yup.ref('confirmNewPassword'), null], `Passwords don't match`)
+            .required('*Required'),
+          confirmNewPassword: yup
+            .string()
+            .oneOf([yup.ref('newPassword'), null], `Passwords don't match`)
+            .required('*Required'),
         })}
       />
     );

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
@@ -84,6 +84,80 @@ const StyledField = styled(Field)`
   }
 `;
 
+const INCORRECT_TOKEN_ERROR_MESSAGE = 'Facility server error response: User or token not found';
+
+const ChangePasswordFormComponent = ({
+  onRestartFlow,
+  errorMessage,
+  email,
+  onNavToLogin,
+  onNavToResetPassword,
+  onValidateResetCode,
+  setFieldError,
+}) => {
+  useEffect(() => {
+    if (errorMessage === INCORRECT_TOKEN_ERROR_MESSAGE) {
+      setFieldError('token', 'Code incorrect');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errorMessage]);
+
+  return (
+    <FormGrid columns={1}>
+      <div>
+        <FormHeading>Reset password</FormHeading>
+        <FormSubtext>
+          We have emailed you a reset code. Please enter the code and your new password below to
+          reset your password.
+        </FormSubtext>
+        <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>
+      </div>
+      <FieldContainer>
+        <StyledField
+          name="token"
+          type="text"
+          label="Reset code"
+          required
+          component={TextField}
+          placeholder="Reset code"
+          onChange={() => !errorMessage && setFieldError('token', '')}
+        />
+        <HorizontalDivider />
+        <StyledField
+          name="newPassword"
+          type="password"
+          label="New password"
+          required
+          component={TextField}
+          placeholder="New password"
+        />
+        <StyledField
+          name="confirmNewPassword"
+          type="password"
+          label="Confirm new password"
+          required
+          component={TextField}
+          placeholder="Confirm new password"
+        />
+      </FieldContainer>
+      <ActionButtonContainer>
+        <ChangePasswordButton type="submit">Reset Password</ChangePasswordButton>
+        <BackToLoginButton onClick={onNavToLogin} variant="outlined">
+          Back to login
+        </BackToLoginButton>
+      </ActionButtonContainer>
+      <ResendCodeButton
+        onClick={() => {
+          onRestartFlow();
+          onNavToResetPassword();
+        }}
+      >
+        Resend reset code
+      </ResendCodeButton>
+    </FormGrid>
+  );
+};
+
 export const ChangePasswordForm = React.memo(
   ({
     onSubmit,
@@ -93,74 +167,19 @@ export const ChangePasswordForm = React.memo(
     email,
     onNavToLogin,
     onNavToResetPassword,
+    onValidateResetCode,
   }) => {
-    const [isTokenValid, setIsTokenValid] = useState(false);
-
-    const renderForm = ({ setFieldValue }) => {
-      return (
-        <FormGrid columns={1}>
-          <div>
-            <FormHeading>Reset password</FormHeading>
-            <FormSubtext>
-              We have emailed you a reset code. Please enter the code and your new password below to
-              reset your password.
-            </FormSubtext>
-            <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>
-          </div>
-          <FieldContainer>
-            <StyledField
-              name="token"
-              type="text"
-              label="Reset code"
-              required
-              component={TextField}
-              placeholder="Reset code"
-              // onBlur={data => {
-              //   console.log('tsatrt');
-              //   onValidateResetCode(data);
-              //   console.log('ebd');
-              // }}
-              onBlur={() => {
-                setIsTokenValid(true);
-              }}
-            />
-            <HorizontalDivider />
-            <StyledField
-              name="newPassword"
-              type="password"
-              label="New password"
-              required
-              component={TextField}
-              placeholder="New password"
-              disabled={!isTokenValid}
-            />
-            <StyledField
-              name="confirmNewPassword"
-              type="password"
-              label="Confirm new password"
-              required
-              component={TextField}
-              placeholder="Confirm new password"
-              disabled={!isTokenValid}
-            />
-          </FieldContainer>
-          <ActionButtonContainer>
-            <ChangePasswordButton type="submit">Reset Password</ChangePasswordButton>
-            <BackToLoginButton onClick={onNavToLogin} variant="outlined">
-              Back to login
-            </BackToLoginButton>
-          </ActionButtonContainer>
-          <ResendCodeButton
-            onClick={() => {
-              onRestartFlow();
-              onNavToResetPassword();
-            }}
-          >
-            Resend reset code
-          </ResendCodeButton>
-        </FormGrid>
-      );
-    };
+    const renderForm = ({ setFieldError }) => (
+      <ChangePasswordFormComponent
+        onRestartFlow={onRestartFlow}
+        errorMessage={errorMessage}
+        email={email}
+        onNavToLogin={onNavToLogin}
+        onNavToResetPassword={onNavToResetPassword}
+        onValidateResetCode={onValidateResetCode}
+        setFieldError={setFieldError}
+      />
+    );
 
     if (success) {
       return (

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -63,7 +63,7 @@ export const ChangePasswordForm = React.memo(
         <div>
           <FormHeading>Reset password</FormHeading>
           <FormSubtext>
-            We have emailed you a reset coe. Please enter the code and your new password below to
+            We have emailed you a reset code. Please enter the code and your new password below to
             reset your password.
           </FormSubtext>
           <ErrorText $isError={!!errorMessage}>{errorMessage}</ErrorText>

--- a/packages/web/app/forms/ResetPasswordForm.jsx
+++ b/packages/web/app/forms/ResetPasswordForm.jsx
@@ -3,15 +3,7 @@ import * as yup from 'yup';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 import { FormGrid } from '../components/FormGrid';
-import {
-  BodyText,
-  Button,
-  Field,
-  Form,
-  FormSubmitButton,
-  TextButton,
-  TextField,
-} from '../components';
+import { BodyText, Button, Field, Form, FormSubmitButton, TextField } from '../components';
 import { Colors } from '../constants';
 
 const ResetPasswordButton = styled(FormSubmitButton)`
@@ -108,6 +100,7 @@ export const ResetPasswordForm = React.memo(
             .email('Must enter a valid email')
             .required('*Required'),
         })}
+        showErrorDialog={false}
       />
     );
   },

--- a/packages/web/app/forms/ResetPasswordForm.jsx
+++ b/packages/web/app/forms/ResetPasswordForm.jsx
@@ -100,7 +100,7 @@ export const ResetPasswordForm = React.memo(
             .email('Must enter a valid email')
             .required('*Required'),
         })}
-        showErrorDialog={false}
+        suppressErrorDialog
       />
     );
   },

--- a/packages/web/app/forms/ResetPasswordForm.jsx
+++ b/packages/web/app/forms/ResetPasswordForm.jsx
@@ -38,29 +38,14 @@ const FormSubtext = styled(BodyText)`
   padding: 10px 0;
 `;
 
-const ResendCodeButton = styled(TextButton)`
-  font-size: 11px;
-  color: ${Colors.darkestText};
-  font-weight: 400;
-  text-transform: none;
-
-  :hover {
-    color: ${Colors.primary};
-    font-weight: 500;
-    text-decoration: underline;
-  }
+const ErrorText = styled(BodyText)`
+  color: ${Colors.midText};
+  padding: 10px 0;
+  ${props => (props.$isError ? '' : `display: none;`)}
 `;
 
 export const ResetPasswordForm = React.memo(
-  ({
-    onSubmit,
-    errorMessage,
-    success,
-    initialEmail,
-    onRestartFlow,
-    onNavToChangePassword,
-    onNavToLogin,
-  }) => {
+  ({ onSubmit, errorMessage, success, initialEmail, onNavToChangePassword, onNavToLogin }) => {
     const renderForm = () => (
       <FormGrid columns={1}>
         <div>

--- a/packages/web/app/forms/ResetPasswordForm.jsx
+++ b/packages/web/app/forms/ResetPasswordForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
@@ -44,30 +44,51 @@ const ErrorText = styled(BodyText)`
   ${props => (props.$isError ? '' : `display: none;`)}
 `;
 
+const INVALID_USER_ERROR_MESSAGE = 'Facility server error response: User not found';
+
+const ResetPasswordFormComponent = ({ errorMessage, onNavToLogin, setFieldError }) => {
+  const [genericMessage, setGenericMessage] = useState(null);
+
+  useEffect(() => {
+    if (errorMessage === INVALID_USER_ERROR_MESSAGE) {
+      setFieldError('email', 'User does not exist');
+    } else {
+      setGenericMessage(errorMessage);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errorMessage]);
+
+  return (
+    <FormGrid columns={1}>
+      <div>
+        <FormHeading>Forgot password</FormHeading>
+        <FormSubtext>Enter your email address below and we will send you a reset code.</FormSubtext>
+        <ErrorText $isError={!!genericMessage}>{genericMessage}</ErrorText>
+      </div>
+      <Field
+        name="email"
+        type="email"
+        label="Email"
+        required
+        component={TextField}
+        placeholder="Enter your email address"
+      />
+      <ResetPasswordButton text="Send reset code" />
+      <BackToLoginButton onClick={onNavToLogin} variant="outlined">
+        Back to login
+      </BackToLoginButton>
+    </FormGrid>
+  );
+};
+
 export const ResetPasswordForm = React.memo(
   ({ onSubmit, errorMessage, success, initialEmail, onNavToChangePassword, onNavToLogin }) => {
-    const renderForm = () => (
-      <FormGrid columns={1}>
-        <div>
-          <FormHeading>Forgot password</FormHeading>
-          <FormSubtext>
-            Enter your email address below and we will send you a reset code.
-          </FormSubtext>
-          {!!errorMessage && <FormSubtext>{errorMessage}</FormSubtext>}
-        </div>
-        <Field
-          name="email"
-          type="email"
-          label="Email"
-          required
-          component={TextField}
-          placeholder="Enter your email address"
-        />
-        <ResetPasswordButton text="Send reset code" />
-        <BackToLoginButton onClick={onNavToLogin} variant="outlined">
-          Back to login
-        </BackToLoginButton>
-      </FormGrid>
+    const renderForm = ({ setFieldError }) => (
+      <ResetPasswordFormComponent
+        errorMessage={errorMessage}
+        onNavToLogin={onNavToLogin}
+        setFieldError={setFieldError}
+      />
     );
 
     if (success) {
@@ -85,7 +106,7 @@ export const ResetPasswordForm = React.memo(
           email: yup
             .string()
             .email('Must enter a valid email')
-            .required(),
+            .required('*Required'),
         })}
       />
     );

--- a/packages/web/app/forms/ResetPasswordForm.jsx
+++ b/packages/web/app/forms/ResetPasswordForm.jsx
@@ -86,29 +86,7 @@ export const ResetPasswordForm = React.memo(
     );
 
     if (success) {
-      return (
-        <FormGrid columns={1}>
-          <div>
-            <FormHeading>Reset code sent.</FormHeading>
-            <FormSubtext>
-              We have emailed you a reset code. Please enter the code below to continue to reset
-              your password
-            </FormSubtext>
-          </div>
-          <ResetPasswordButton
-            fullWidth
-            variant="contained"
-            color="primary"
-            onClick={onNavToChangePassword}
-          >
-            Continue
-          </ResetPasswordButton>
-          <BackToLoginButton onClick={onNavToLogin} variant="outlined">
-            Back to login
-          </BackToLoginButton>
-          <ResendCodeButton onClick={onRestartFlow}>Resend reset code</ResendCodeButton>
-        </FormGrid>
-      );
+      onNavToChangePassword();
     }
 
     return (

--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -1,4 +1,3 @@
-import { ValidationError } from 'yup';
 import { createStatePreservingReducer } from '../utils/createStatePreservingReducer';
 
 // actions
@@ -15,8 +14,7 @@ const CHANGE_PASSWORD_START = 'CHANGE_PASSWORD_START';
 const CHANGE_PASSWORD_SUCCESS = 'CHANGE_PASSWORD_SUCCESS';
 const CHANGE_PASSWORD_FAILURE = 'CHANGE_PASSWORD_FAILURE';
 const VALIDATE_RESET_CODE_START = 'VALIDATE_RESET_CODE_START';
-const VALIDATE_RESET_CODE_SUCCESS = 'VALIDATE_RESET_CODE_SUCCESS';
-const VALIDATE_RESET_CODE_FAILURE = 'VALIDATE_RESET_CODE_FAILURE';
+const VALIDATE_RESET_CODE_COMPLETE = 'VALIDATE_RESET_CODE_COMPLETE';
 
 export const restoreSession = () => async (dispatch, getState, { api }) => {
   try {
@@ -79,12 +77,8 @@ export const restartPasswordResetFlow = () => async dispatch => {
 export const validateResetCode = data => async (dispatch, getState, { api }) => {
   dispatch({ type: VALIDATE_RESET_CODE_START });
 
-  try {
-    await api.post('changePassword/validate-reset-code', data);
-    dispatch({ type: VALIDATE_RESET_CODE_SUCCESS });
-  } catch (error) {
-    dispatch({ type: VALIDATE_RESET_CODE_FAILURE, error: error.message });
-  }
+  await api.post('changePassword/validate-reset-code', data);
+  dispatch({ type: VALIDATE_RESET_CODE_COMPLETE });
 };
 
 export const changePassword = data => async (dispatch, getState, { api }) => {
@@ -216,16 +210,10 @@ const actionHandlers = {
       loading: true,
     },
   }),
-  [VALIDATE_RESET_CODE_SUCCESS]: () => ({
+  [VALIDATE_RESET_CODE_COMPLETE]: () => ({
     validateResetCode: {
       ...defaultState.validateResetCode,
-      valid: true,
-    },
-  }),
-  [VALIDATE_RESET_CODE_FAILURE]: action => ({
-    validateResetCode: {
-      ...defaultState.validateResetCode,
-      error: action.error,
+      completed: true,
     },
   }),
 };

--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -80,7 +80,7 @@ export const validateResetCode = data => async (dispatch, getState, { api }) => 
   dispatch({ type: VALIDATE_RESET_CODE_START });
 
   try {
-    await api.validateResetCode(data);
+    await api.post('changePassword/validate-reset-code', data);
     dispatch({ type: VALIDATE_RESET_CODE_SUCCESS });
   } catch (error) {
     dispatch({ type: VALIDATE_RESET_CODE_FAILURE, error: error.message });
@@ -119,6 +119,11 @@ const defaultState = {
     lastEmailUsed: null,
   },
   changePassword: {
+    loading: false,
+    success: false,
+    error: null,
+  },
+  validateResetCode: {
     loading: false,
     success: false,
     error: null,

--- a/packages/web/app/views/LoginView.jsx
+++ b/packages/web/app/views/LoginView.jsx
@@ -195,6 +195,7 @@ export const LoginView = () => {
           {screen === 'changePassword' && (
             <ChangePasswordForm
               onSubmit={data => dispatch(changePassword(data))}
+              onRestartFlow={() => dispatch(restartPasswordResetFlow())}
               errorMessage={changePasswordError}
               success={changePasswordSuccess}
               email={resetPasswordEmail}

--- a/packages/web/app/views/LoginView.jsx
+++ b/packages/web/app/views/LoginView.jsx
@@ -17,6 +17,7 @@ import {
   requestPasswordReset,
   restartPasswordResetFlow,
   clearPatient,
+  validateResetCode,
 } from '../store';
 import { useApi } from '../api';
 
@@ -120,6 +121,8 @@ export const LoginView = () => {
   const resetPasswordEmail = useSelector(state => state.auth.resetPassword.lastEmailUsed);
   const changePasswordError = useSelector(state => state.auth.changePassword.error);
   const changePasswordSuccess = useSelector(state => state.auth.changePassword.success);
+  const validateResetCodeError = useSelector(state => state.auth.validateResetCode.error);
+
   const { getLocalisation } = useLocalisation();
 
   const rememberEmail = localStorage.getItem(REMEMBER_EMAIL);
@@ -203,6 +206,8 @@ export const LoginView = () => {
                 setScreen('login');
               }}
               onNavToResetPassword={() => setScreen('resetPassword')}
+              onValidateResetCode={data => dispatch(validateResetCode(data))}
+              resetCodeErrorMessage={validateResetCodeError}
             />
           )}
         </LoginFormContainer>

--- a/packages/web/app/views/LoginView.jsx
+++ b/packages/web/app/views/LoginView.jsx
@@ -121,7 +121,6 @@ export const LoginView = () => {
   const resetPasswordEmail = useSelector(state => state.auth.resetPassword.lastEmailUsed);
   const changePasswordError = useSelector(state => state.auth.changePassword.error);
   const changePasswordSuccess = useSelector(state => state.auth.changePassword.success);
-  const validateResetCodeError = useSelector(state => state.auth.validateResetCode.error);
 
   const { getLocalisation } = useLocalisation();
 
@@ -207,7 +206,6 @@ export const LoginView = () => {
               }}
               onNavToResetPassword={() => setScreen('resetPassword')}
               onValidateResetCode={data => dispatch(validateResetCode(data))}
-              resetCodeErrorMessage={validateResetCodeError}
             />
           )}
         </LoginFormContainer>


### PR DESCRIPTION
### Changes

Implemented new design to 'Forgot password' workflow.
Changes include form validations and message updating, endpoint for validating the reset token.
Validations should be accurate to the Figma design.

UI Changes:
![Screenshot 2024-01-08 at 11 20 17 AM](https://github.com/beyondessential/tamanu/assets/100409601/86a79d14-9d11-483b-b83b-0d12f0c98f8e)
![Screenshot 2024-01-08 at 11 21 46 AM](https://github.com/beyondessential/tamanu/assets/100409601/65d5dcfb-8145-4c22-b914-6cb945c52294)
![Screenshot 2024-01-08 at 11 22 14 AM](https://github.com/beyondessential/tamanu/assets/100409601/b59432e0-ad33-4148-af18-c2d3030b8156)


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
