### PR TITLE
Fix: shim process for misbehaving libraries

### DIFF
--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -16,6 +16,13 @@ export default defineConfig({
         .then(({ version }) => version),
     ),
     NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+    process: JSON.stringify({
+      env: {
+        NODE_ENV: process.env.NODE_ENV,
+      },
+      arch: 'wasm',
+      platform: 'web',
+    })
   },
   worker: {
     format: 'es',


### PR DESCRIPTION
### Changes

Some libraries assume `process` exists as a global and break if it doesn't.