### PR TITLE
Fix: Advanced search filter button not working

### DIFF
--- a/packages/web/app/components/SearchBar/CustomisableSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/CustomisableSearchBar.jsx
@@ -74,9 +74,7 @@ export const CustomisableSearchBar = ({
   hiddenFields,
 }) => {
   const switchExpandValue = useCallback(() => {
-    setIsExpanded(previous => {
-      setIsExpanded(!previous);
-    });
+    setIsExpanded(previous => !previous);
   }, [setIsExpanded]);
 
   const handleSubmit = values => {


### PR DESCRIPTION
### Changes

A small bugfix to some logic that im not sure how it ever worked. This only started breaking after the web 2.0 upgrade

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
