### PR TITLE
Fix watch-shared-and build script

### DIFF
--- a/scripts/watch-shared-and.js
+++ b/scripts/watch-shared-and.js
@@ -1,4 +1,4 @@
-const concurrently = require('concurrently');
+import concurrently from 'concurrently';
 
 const [workspace, command] = process.argv.slice(2);
 


### PR DESCRIPTION
### Changes

Fixes node complaining about an invalid module format when running one of the "-start-dev" or "-test-watch" npm commands.

### Checklist

- [x] Code is finished
