### PR TITLE
NASS-1083: Saving files on browser

### DIFF
--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -5,6 +5,7 @@ import { getCurrentDateString } from '@tamanu/shared/utils/dateTime';
 import cheerio from 'cheerio';
 import XLSX from 'xlsx';
 
+import { sanitizeFileName } from '../../utils/sanitizeFileName';
 import { GreyOutlinedButton } from '../Button';
 
 function getHeaderValue(column) {
@@ -78,7 +79,7 @@ export function DownloadDataButton({ exportName, columns, data }) {
     XLSX.utils.book_append_sheet(wb, ws, exportName);
 
     const fileHandle = await window.showSaveFilePicker({
-      suggestedName: `${exportName}-${getCurrentDateString()}.xlsx`,
+      suggestedName: sanitizeFileName(`${exportName}-${getCurrentDateString()}.xlsx`),
     });
 
     const writable = await fileHandle.createWritable();

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -83,9 +83,9 @@ export function DownloadDataButton({ exportName, columns, data }) {
 
     const writable = await fileHandle.createWritable();
 
-    const xlsxBinary = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const xlsxDataArray = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
 
-    await writable.write(xlsxBinary);
+    await writable.write(xlsxDataArray);
     await writable.close();
   };
 

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -1,6 +1,7 @@
 import React, { isValidElement } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import GetAppIcon from '@material-ui/icons/GetApp';
+import { getCurrentDateString } from '@tamanu/shared/utils/dateTime';
 import cheerio from 'cheerio';
 import XLSX from 'xlsx';
 
@@ -76,12 +77,16 @@ export function DownloadDataButton({ exportName, columns, data }) {
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, ws, exportName);
 
-    // show a file-save dialog and write the workbook
-    // const path = await showSaveDialog(); // TODO(web)
-    const path = {};
-    if (path.canceled) return; // Dialog was cancelled - don't write file.
-    XLSX.writeFile(wb, `${path.filePath}.xlsx`);
-    // openPath(`${path.filePath}.xlsx`);
+    const fileHandle = await window.showSaveFilePicker({
+      suggestedName: `table-export-${getCurrentDateString()}.xlsx`,
+    });
+
+    const writable = await fileHandle.createWritable();
+
+    const xlsxBinary = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+
+    await writable.write(xlsxBinary);
+    await writable.close();
   };
 
   return (

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -78,7 +78,7 @@ export function DownloadDataButton({ exportName, columns, data }) {
     XLSX.utils.book_append_sheet(wb, ws, exportName);
 
     const fileHandle = await window.showSaveFilePicker({
-      suggestedName: `table-export-${getCurrentDateString()}.xlsx`,
+      suggestedName: `${exportName}-${getCurrentDateString()}.xlsx`,
     });
 
     const writable = await fileHandle.createWritable();

--- a/packages/web/app/utils/sanitizeFileName.js
+++ b/packages/web/app/utils/sanitizeFileName.js
@@ -1,0 +1,3 @@
+export const sanitizeFileName = fileName => {
+  return filename.replace(/[-<>:"\/\\|?*\s]+/g, '-');
+};

--- a/packages/web/app/utils/sanitizeFileName.js
+++ b/packages/web/app/utils/sanitizeFileName.js
@@ -1,3 +1,6 @@
 export const sanitizeFileName = fileName => {
-  return filename.replace(/[-<>:"\/\\|?*\s]+/g, '-');
+  return fileName
+    .replace(/CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9]/g, 'download') // replace windows reserved filenames
+    .replace(/[-<>:"\/\\|?*\s]+/g, '-') // replace any consecutive windows reserved characters
+    .trim('-'); // prevent leading or trailing hyphen
 };

--- a/packages/web/app/utils/sanitizeFileName.js
+++ b/packages/web/app/utils/sanitizeFileName.js
@@ -1,6 +1,6 @@
 export const sanitizeFileName = fileName => {
   return fileName
     .replace(/CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9]/g, 'download') // replace windows reserved filenames
-    .replace(/[-<>:"\/\\|?*\s]+/g, '-') // replace any consecutive windows reserved characters
+    .replace(/[-<>:"/\\|?*\s]+/g, '-') // replace any consecutive windows reserved characters
     .trim('-'); // prevent leading or trailing hyphen
 };

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -25,9 +25,9 @@ export async function saveExcelFile(
 
   const writable = await fileHandle.createWritable();
 
-  const xlsxBinary = XLSX.write(book, { bookType, type: 'array' });
+  const xlsxDataArray = XLSX.write(book, { bookType, type: 'array' });
 
-  await writable.write(xlsxBinary);
+  await writable.write(xlsxDataArray);
   await writable.close();
   return true;
 }

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -5,7 +5,7 @@ const stringifyIfNonDateObject = val =>
 
 export async function saveExcelFile(
   { data, metadata },
-  { defaultFileName = '' },
+  { defaultFileName = '', bookType },
 ) {
   const stringifiedData = data.map(row => row.map(stringifyIfNonDateObject));
 
@@ -20,12 +20,12 @@ export async function saveExcelFile(
   XLSX.utils.book_append_sheet(book, metadataSheet, 'metadata');
 
   const fileHandle = await window.showSaveFilePicker({
-    suggestedName: `${defaultFileName}.xlsx`,
+    suggestedName: `${defaultFileName}.${bookType}`,
   });
 
   const writable = await fileHandle.createWritable();
 
-  const xlsxBinary = XLSX.write(book, { bookType: 'xlsx', type: 'array' });
+  const xlsxBinary = XLSX.write(book, { bookType, type: 'array' });
 
   await writable.write(xlsxBinary);
   await writable.close();

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -1,4 +1,5 @@
 import XLSX from 'xlsx';
+import { sanitizeFileName } from './sanitizeFileName';
 
 const stringifyIfNonDateObject = val =>
   typeof val === 'object' && !(val instanceof Date) && val !== null ? JSON.stringify(val) : val;
@@ -17,7 +18,7 @@ export async function saveExcelFile({ data, metadata, defaultFileName = '', book
   XLSX.utils.book_append_sheet(book, metadataSheet, 'metadata');
 
   const fileHandle = await window.showSaveFilePicker({
-    suggestedName: `${defaultFileName}.${bookType}`,
+    suggestedName: sanitizeFileName(`${defaultFileName}.${bookType}`),
   });
 
   const writable = await fileHandle.createWritable();

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -5,25 +5,8 @@ const stringifyIfNonDateObject = val =>
 
 export async function saveExcelFile(
   { data, metadata },
-  { promptForFilePath, filePath, defaultFileName = '', bookType },
+  { defaultFileName = '' },
 ) {
-  let path;
-  if (promptForFilePath) {
-    // TODO(web)
-    // path = await showFileDialog(
-    //   [{ name: `Excel spreadsheet (${bookType})`, extensions: [bookType] }],
-    //   defaultFileName,
-    // );
-    if (!path) {
-      // user cancelled
-      return '';
-    }
-  } else {
-    path = filePath;
-  }
-  if (!path) {
-    throw Error('No path found');
-  }
   const stringifiedData = data.map(row => row.map(stringifyIfNonDateObject));
 
   const book = XLSX.utils.book_new();
@@ -36,13 +19,15 @@ export async function saveExcelFile(
   XLSX.utils.book_append_sheet(book, dataSheet, 'report');
   XLSX.utils.book_append_sheet(book, metadataSheet, 'metadata');
 
-  return new Promise((resolve, reject) => {
-    XLSX.writeFileAsync(path, book, { type: bookType }, err => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(path);
-      }
-    });
+  const fileHandle = await window.showSaveFilePicker({
+    suggestedName: `${defaultFileName}.xlsx`,
   });
+
+  const writable = await fileHandle.createWritable();
+
+  const xlsxBinary = XLSX.write(book, { bookType: 'xlsx', type: 'array' });
+
+  await writable.write(xlsxBinary);
+  await writable.close();
+  return true;
 }

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -3,10 +3,7 @@ import XLSX from 'xlsx';
 const stringifyIfNonDateObject = val =>
   typeof val === 'object' && !(val instanceof Date) && val !== null ? JSON.stringify(val) : val;
 
-export async function saveExcelFile(
-  { data, metadata },
-  { defaultFileName = '', bookType },
-) {
+export async function saveExcelFile({ data, metadata, defaultFileName = '', bookType }) {
   const stringifiedData = data.map(row => row.map(stringifyIfNonDateObject));
 
   const book = XLSX.utils.book_new();
@@ -29,5 +26,4 @@ export async function saveExcelFile(
 
   await writable.write(xlsxDataArray);
   await writable.close();
-  return true;
 }

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -11,7 +11,7 @@ import { PatientLetterModal } from '../../../components/PatientLetterModal';
 import { DocumentsSearchBar } from '../../../components/DocumentsSearchBar';
 import { TabPane } from '../components';
 import { OutlinedButton, Button, ContentPane, TableButtonRow } from '../../../components';
-
+import { sanitizeFileName } from '../../../utils/sanitizeFileName';
 
 const MODAL_STATES = {
   DOCUMENT_OPEN: 'document',
@@ -61,7 +61,7 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
         const fileExtension = extension(document.type);
 
         const fileHandle = await window.showSaveFilePicker({
-          suggestedName: `${document.name.replaceAll(' ', '-').toLowerCase()}.${fileExtension}`,
+          suggestedName: sanitizeFileName(`${document.name}.${fileExtension}`),
         });
 
         const writable = await fileHandle.createWritable();

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -12,6 +12,7 @@ import { DocumentsSearchBar } from '../../../components/DocumentsSearchBar';
 import { TabPane } from '../components';
 import { OutlinedButton, Button, ContentPane, TableButtonRow } from '../../../components';
 
+
 const MODAL_STATES = {
   DOCUMENT_OPEN: 'document',
   PATIENT_LETTER_OPEN: 'patient_letter',
@@ -60,7 +61,7 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
         const fileExtension = extension(document.type);
 
         const fileHandle = await window.showSaveFilePicker({
-          suggestedName: `table-export.${fileExtension}`,
+          suggestedName: `${document.name.replaceAll(' ', '-').toLowerCase()}.${fileExtension}`,
         });
 
         const writable = await fileHandle.createWritable();

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -20,16 +20,9 @@ const MODAL_STATES = {
   CLOSED: 'closed',
 };
 
-function base64ToUint8Array(base64) {
-  const binaryString = atob(base64);
-  const length = binaryString.length;
-  const uint8Array = new Uint8Array(length);
-
-  for (let i = 0; i < length; i++) {
-    uint8Array[i] = binaryString.charCodeAt(i);
-  }
-
-  return uint8Array;
+const base64ToUint8Array = (base64) => {
+  const binString = atob(base64);
+  return Uint8Array.from(binString, (m) => m.codePointAt(0));
 }
 
 export const DocumentsPane = React.memo(({ encounter, patient }) => {

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -66,9 +66,9 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
 
         const writable = await fileHandle.createWritable();
 
-        const pdfUint8Array = base64ToUint8Array(data);
+        const fileUint8Array = base64ToUint8Array(data);
 
-        await writable.write(pdfUint8Array);
+        await writable.write(fileUint8Array);
         await writable.close();
         notifySuccess(`Successfully downloaded file`);
       } catch (error) {

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -190,16 +190,14 @@ export const ReportGeneratorForm = () => {
           ['Filters:', filterString],
         ];
 
-        const filePath = await saveExcelFile(
+        const response = await saveExcelFile(
           { data: excelData, metadata },
           {
-            promptForFilePath: true,
             defaultFileName: getFileName(reportName),
-            bookType,
           },
         );
-        if (filePath) {
-          setSuccessMessage(`Report successfully exported. File saved at: ${filePath}.`);
+        if (response) {
+          setSuccessMessage(`Report successfully exported`);
         }
       } else {
         await api.post(`reportRequest`, {

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -194,6 +194,7 @@ export const ReportGeneratorForm = () => {
           { data: excelData, metadata },
           {
             defaultFileName: getFileName(reportName),
+            bookType
           },
         );
         if (response) {

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -190,15 +190,16 @@ export const ReportGeneratorForm = () => {
           ['Filters:', filterString],
         ];
 
-        const response = await saveExcelFile(
-          { data: excelData, metadata },
-          {
+        try {
+          await saveExcelFile({
+            data: excelData,
+            metadata,
             defaultFileName: getFileName(reportName),
-            bookType
-          },
-        );
-        if (response) {
+            bookType,
+          });
           setSuccessMessage(`Report successfully exported`);
+        } catch (error) {
+          setRequestError(`Unable to export report - ${error.message}`);
         }
       } else {
         await api.post(`reportRequest`, {


### PR DESCRIPTION
### Changes

After the electron upgrade, we discovered that saving of files is broken in a few places as it relied on a built in electron save dialog. I have replaced this with the FileSystemAccessApi used by the browser.

Addressed in this pr:
- Document PDF/jpeg download
- Report xlsx/csv download
- Table xlsx export

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
