### PR TITLE
Fix 1.38 server-packager for Node 20

### DIFF
--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20.x
           cache: yarn
 
       - name: Create container
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20.x
           cache: yarn
 
       - name: Download artifact from build job

--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -195,15 +195,6 @@ jobs:
             '${{ env.OUTPUT_NAME }}.tar.zst'
           rm minisign.*
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.OUTPUT_NAME }}
-          path: |
-            ${{ env.OUTPUT_NAME }}.tar.zst
-            ${{ env.OUTPUT_NAME }}.tar.zst.sig
-          retention-days: 1
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -195,6 +195,15 @@ jobs:
             '${{ env.OUTPUT_NAME }}.tar.zst'
           rm minisign.*
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.OUTPUT_NAME }}
+          path: |
+            ${{ env.OUTPUT_NAME }}.tar.zst
+            ${{ env.OUTPUT_NAME }}.tar.zst.sig
+          retention-days: 1
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "This repo contains all the packages for Tamanu",
   "main": "index.js",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/build-tooling",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Build tooling for Tamanu packages",
   "main": "index.mjs",
   "type": "module",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/constants",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "description": "Shared constants",
   "exports": {

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csca",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "description": "CSCA tooling for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/app/package.json
+++ b/packages/desktop/app/package.json
@@ -3,7 +3,7 @@
   "main": "./dist/main.prod.js",
   "name": "Tamanu",
   "productName": "Tamanu",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Tamanu",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Tamanu Desktop application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/lan/package.json
+++ b/packages/lan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lan",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "description": "Facility server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-server",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "description": "Meta server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/qr-tester/package.json
+++ b/packages/qr-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-tester",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "description": "BES QR Code Tester App / Website",
   "author": "",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "main": "index.js",
   "license": "SEE LICENSE IN license",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/shared",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Common code across Tamanu packages",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-server",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "private": true,
   "description": "Sync server for Tamanu desktop app",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",


### PR DESCRIPTION
Fixes the packaging workflows.

Then we bump the version of the next release to 1.38.2 (skipping .1) so that we don't overwrite the 1.38.1 servers (which are really the 1.38.0 servers) if/when we need to hotfix something.