### PR TITLE
Add hint about needing to remove the rewrite: line

### DIFF
--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -54,6 +54,9 @@ export default defineConfig({
         // you can also specify other servers to use as backend, e.g.
         // target: 'https://central.main.internal.tamanu.io',
         // target: 'https://facility-1.main.internal.tamanu.io',
+        //
+        // when using a hosted server, remove the rewrite: line.
+        // that rewrite is already done by routing in test/prod deployments
         changeOrigin: true,
         rewrite: path => path.replace(/^\/api/, '/v1/'),
       },


### PR DESCRIPTION
### Changes

In tester (and later, production/demo/clone) deployments, the rewrite from `/api/` to `/v1/` is done in the deployment routing itself, so doing it in vite breaks the config. In development, there's no such routing layer, so it's necessary.