### PR TITLE
Fix: pad data not immediately updating

### DIFF
--- a/packages/web/app/utils/invalidatePatientDataQueries.js
+++ b/packages/web/app/utils/invalidatePatientDataQueries.js
@@ -1,5 +1,7 @@
-export const invalidatePatientDataQueries = (queryClient, patientId) => {
-  queryClient.invalidateQueries(['additionalData', patientId]);
-  queryClient.invalidateQueries(['birthData', patientId]);
-  queryClient.invalidateQueries(['patientFields', patientId]);
+export const invalidatePatientDataQueries = async (queryClient, patientId) => {
+  return Promise.all([
+    queryClient.invalidateQueries(['additionalData', patientId]),
+    queryClient.invalidateQueries(['birthData', patientId]),
+    queryClient.invalidateQueries(['patientFields', patientId]),
+  ])
 };

--- a/packages/web/app/views/patients/panes/DetailsPane.jsx
+++ b/packages/web/app/views/patients/panes/DetailsPane.jsx
@@ -36,7 +36,7 @@ export const PatientDetailsPane = React.memo(
       }
 
       // invalidate the cache of patient data queries to reload the patient data
-      invalidatePatientDataQueries(queryClient, patient.id);
+      await invalidatePatientDataQueries(queryClient, patient.id);
       dispatch(reloadPatient(patient.id));
     };
 


### PR DESCRIPTION
### Changes

We were having slightly strange behaviour where on the release/2.0 branch the pad data was not updating immediately on save. You actually had to move away from the screen and back again in order to show the new data. When testing on my local, it seemed that it would work about 50% of the time. 

On some further investigation and testing it seems like this was caused by a race condition where the queries weren't being invalidated before the patient reload was triggered. Still not exactly sure why we had slightly different behaviour on the release branch vs the local deployment though 🤔 

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
