### PR TITLE
NASS-1088: Fix covid-19 test cert printout rendering before data available

### DIFF
--- a/packages/web/app/api/queries/useCovidLabTestsQuery.js
+++ b/packages/web/app/api/queries/useCovidLabTestsQuery.js
@@ -2,14 +2,14 @@ import { useApi } from '../useApi';
 import { useQuery } from '@tanstack/react-query';
 import { CertificateTypes } from '@tamanu/shared/utils/patientCertificates';
 
-export const useCovidLabTestQuery = patientId => {
+export const useCovidLabTestQuery = (patientId, certType = CertificateTypes.test) => {
   const api = useApi();
 
   return useQuery(
-    ['covidLabTests', patientId],
-    () => api.get(`patient/${patientId}/covidLabTests`, { certType: CertificateTypes.test }),
+    ['covidLabTests', patientId, certType],
+    () => api.get(`patient/${patientId}/covidLabTests`, { certType }),
     {
-      enabled: !!patientId,
+      enabled: !!(patientId && certType),
     },
   );
 };

--- a/packages/web/app/api/queries/useCovidLabTestsQuery.js
+++ b/packages/web/app/api/queries/useCovidLabTestsQuery.js
@@ -1,0 +1,15 @@
+import { useApi } from '../useApi';
+import { useQuery } from '@tanstack/react-query';
+import { CertificateTypes } from '@tamanu/shared/utils/patientCertificates';
+
+export const useCovidLabTestQuery = patientId => {
+  const api = useApi();
+
+  return useQuery(
+    ['covidLabTests', patientId],
+    () => api.get(`patient/${patientId}/covidLabTests`, { certType: CertificateTypes.test }),
+    {
+      enabled: !!patientId,
+    },
+  );
+};

--- a/packages/web/app/api/queries/usePatientAdditionalDataQuery.js
+++ b/packages/web/app/api/queries/usePatientAdditionalDataQuery.js
@@ -4,7 +4,11 @@ import { useApi } from '../useApi';
 export const usePatientAdditionalDataQuery = patientId => {
   const api = useApi();
 
-  return useQuery(['additionalData', patientId], () =>
-    api.get(`patient/${encodeURIComponent(patientId)}/additionalData`),
+  return useQuery(
+    ['additionalData', patientId],
+    () => api.get(`patient/${encodeURIComponent(patientId)}/additionalData`),
+    {
+      enabled: !!patientId,
+    },
   );
 };

--- a/packages/web/app/components/PatientPrinting/modals/CovidClearanceCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidClearanceCertificateModal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { CertificateTypes, CovidLabCertificate } from '@tamanu/shared/utils/patientCertificates';
 import { ASSET_NAMES, COVID_19_CLEARANCE_CERTIFICATE } from '@tamanu/constants';
@@ -11,24 +11,26 @@ import { useCertificate } from '../../../utils/useCertificate';
 import { usePatientAdditionalDataQuery } from '../../../api/queries';
 
 import { PDFViewer, printPDF } from '../PDFViewer';
+import { LoadingIndicator } from '../../LoadingIndicator';
+import { useCovidLabTestQuery } from '../../../api/queries/useCovidLabTestsQuery';
 
 export const CovidClearanceCertificateModal = React.memo(({ patient }) => {
   const [open, setOpen] = useState(true);
-  const [labs, setLabs] = useState([]);
   const { getLocalisation } = useLocalisation();
   const api = useApi();
   const { watermark, logo, footerImg, printedBy } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_CLEARANCE_CERTIFICATE_FOOTER,
   });
-  const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
+  const {
+    data: additionalData,
+    isLoading: isAdditionalDataLoading,
+  } = usePatientAdditionalDataQuery(patient.id);
+  const { data: labTestsResponse, isLoading: isLabTestsLoading } = useCovidLabTestQuery(
+    patient.id,
+    CertificateTypes.clearance,
+  );
 
-  useEffect(() => {
-    api
-      .get(`patient/${patient.id}/covidLabTests`, { certType: CertificateTypes.clearance })
-      .then(response => {
-        setLabs(response.data);
-      });
-  }, [api, patient.id]);
+  const isLoading = isLabTestsLoading || isAdditionalDataLoading;
 
   const createCovidTestCertNotification = useCallback(
     data =>
@@ -54,18 +56,22 @@ export const CovidClearanceCertificateModal = React.memo(({ patient }) => {
       onPrint={() => printPDF('clearance-certificate')}
       additionalActions={<EmailButton onEmail={createCovidTestCertNotification} />}
     >
-      <PDFViewer id="clearance-certificate">
-        <CovidLabCertificate
-          patient={patientData}
-          labs={labs}
-          watermarkSrc={watermark}
-          signingSrc={footerImg}
-          logoSrc={logo}
-          getLocalisation={getLocalisation}
-          printedBy={printedBy}
-          certType={CertificateTypes.clearance}
-        />
-      </PDFViewer>
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <PDFViewer id="clearance-certificate">
+          <CovidLabCertificate
+            patient={patientData}
+            labs={labTestsResponse.data}
+            watermarkSrc={watermark}
+            signingSrc={footerImg}
+            logoSrc={logo}
+            getLocalisation={getLocalisation}
+            printedBy={printedBy}
+            certType={CertificateTypes.clearance}
+          />
+        </PDFViewer>
+      )}
     </Modal>
   );
 });

--- a/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
@@ -21,8 +21,13 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
     footerAssetName: ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER,
   });
 
-  const { data: labTestResponse, isLoading } = useCovidLabTestQuery(patient.id);
-  const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
+  const { data: labTestsResponse, isLoading: isLabTestsLoading } = useCovidLabTestQuery(patient.id);
+  const {
+    data: additionalData,
+    isLoading: isAdditionalDataLoading,
+  } = usePatientAdditionalDataQuery(patient.id);
+
+  const isLoading = isLabTestsLoading || isAdditionalDataLoading;
 
   const createCovidTestCertNotification = useCallback(
     data =>
@@ -54,7 +59,7 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
         <PDFViewer id="test-certificate">
           <CovidLabCertificate
             patient={patientData}
-            labs={labTestResponse.data}
+            labs={labTestsResponse.data}
             watermarkSrc={watermark}
             signingSrc={footerImg}
             logoSrc={logo}

--- a/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
@@ -21,7 +21,10 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
     footerAssetName: ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER,
   });
 
-  const { data: labTestsResponse, isLoading: isLabTestsLoading } = useCovidLabTestQuery(patient.id);
+  const { data: labTestsResponse, isLoading: isLabTestsLoading } = useCovidLabTestQuery(
+    patient.id,
+    CertificateTypes.test,
+  );
   const {
     data: additionalData,
     isLoading: isAdditionalDataLoading,

--- a/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { CertificateTypes, CovidLabCertificate } from '@tamanu/shared/utils/patientCertificates';
 import { ASSET_NAMES, ICAO_DOCUMENT_TYPES } from '@tamanu/constants';
 
@@ -10,24 +10,19 @@ import { useCertificate } from '../../../utils/useCertificate';
 import { usePatientAdditionalDataQuery } from '../../../api/queries';
 
 import { PDFViewer, printPDF } from '../PDFViewer';
+import { useCovidLabTestQuery } from '../../../api/queries/useCovidLabTestsQuery';
+import { LoadingIndicator } from '../../LoadingIndicator';
 
 export const CovidTestCertificateModal = React.memo(({ patient }) => {
   const [open, setOpen] = useState(true);
-  const [labs, setLabs] = useState([]);
   const { getLocalisation } = useLocalisation();
   const api = useApi();
   const { watermark, logo, footerImg, printedBy } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER,
   });
-  const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
-  useEffect(() => {
-    api
-      .get(`patient/${patient.id}/covidLabTests`, { certType: CertificateTypes.test })
-      .then(response => {
-        setLabs(response.data);
-      });
-  }, [api, patient.id]);
+  const { data: labTestResponse, isLoading } = useCovidLabTestQuery(patient.id);
+  const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
   const createCovidTestCertNotification = useCallback(
     data =>
@@ -53,18 +48,22 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
       onPrint={() => printPDF('test-certificate')}
       additionalActions={<EmailButton onEmail={createCovidTestCertNotification} />}
     >
-      <PDFViewer id="test-certificate">
-        <CovidLabCertificate
-          patient={patientData}
-          labs={labs}
-          watermarkSrc={watermark}
-          signingSrc={footerImg}
-          logoSrc={logo}
-          getLocalisation={getLocalisation}
-          printedBy={printedBy}
-          certType={CertificateTypes.test}
-        />
-      </PDFViewer>
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <PDFViewer id="test-certificate">
+          <CovidLabCertificate
+            patient={patientData}
+            labs={labTestResponse.data}
+            watermarkSrc={watermark}
+            signingSrc={footerImg}
+            logoSrc={logo}
+            getLocalisation={getLocalisation}
+            printedBy={printedBy}
+            certType={CertificateTypes.test}
+          />
+        </PDFViewer>
+      )}
     </Modal>
   );
 });


### PR DESCRIPTION
2.0 web regression

Previously maybe data fetch triggered a re-render but no longer

- Replace useEffect with useQuery
- Show indicator if data not available

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
