### PR TITLE
Use main branch of ops

### DIFF
--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Up!
         uses: pulumi/actions@v5
         with:
-          work-dir: ops/pulumi/stacks/tamanu/web-on-ecs
+          work-dir: ops/pulumi/stacks/tamanu/on-ecs
           command: up
           stack-name: bes/${{ needs.info.outputs.branch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -147,7 +147,7 @@ jobs:
           secret-ids: "INTERNAL_DB, ${{ vars.INTERNAL_DB_SECRET_ARN }}"
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v5
         with:
           oauth-secret: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
           tags: tag:infra,tag:infra-gha-deploy

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -126,6 +126,7 @@ jobs:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           path: ops
+          ref: main
       - name: Remove ops/.git so pulumi doesn't get confused
         run: rm -rf ops/.git
 

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -126,7 +126,6 @@ jobs:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           path: ops
-          ref: tav-913-tamanu-web
       - name: Remove ops/.git so pulumi doesn't get confused
         run: rm -rf ops/.git
 
@@ -167,7 +166,7 @@ jobs:
       - name: Up!
         uses: pulumi/actions@v3
         with:
-          work-dir: ops/pulumi/tamanu-internal
+          work-dir: ops/pulumi/stacks/tamanu/web-on-ecs
           command: up
           stack-name: bes/${{ needs.info.outputs.branch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -147,7 +147,7 @@ jobs:
           secret-ids: "INTERNAL_DB, ${{ vars.INTERNAL_DB_SECRET_ARN }}"
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v5
+        uses: tailscale/github-action@v2
         with:
           oauth-secret: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
           tags: tag:infra,tag:infra-gha-deploy
@@ -165,7 +165,7 @@ jobs:
           echo "salt=$salt" >> $GITHUB_OUTPUT
 
       - name: Up!
-        uses: pulumi/actions@v3
+        uses: pulumi/actions@v5
         with:
           work-dir: ops/pulumi/stacks/tamanu/web-on-ecs
           command: up


### PR DESCRIPTION
Currently the auto-deploy is using a separate branch of the `ops` repo (which contains the deploy scripts) so that the old 1.x branches can still deploy if needed without changing them.

Recently I changed this in the `ops` repo directly so that the path that the 1.x branches use to auto-deploy points to legacy code within the `main` ops branch (duplicating a bit of the code); this change makes it so that the 2.x branches point to the `main` ops branch, but at the new (web-compatible) code.

Nothing should change, this is really just the one tamanu-visible change to a reorganisation of the ops repo.