### PR TITLE
Trigger CD Down on unlabeling

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -1,7 +1,6 @@
 name: CD Down
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -20,8 +19,8 @@ jobs:
 
   down:
     needs: info
-    # check once again after normalisation just in case
-    if: github.event_name == 'workflow_dispatch' || (!startsWith(needs.info.outputs.branch, 'release-') && needs.info.outputs.branch != 'main')
+    # check permanent branches once again after normalisation just in case
+    if: (!startsWith(needs.info.outputs.branch, 'release-') && needs.info.outputs.branch != 'main')
     name: Bring down environment
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -2,9 +2,9 @@ name: CD Down
 
 on:
   pull_request_target:
-    types:
-      - closed
-      - unlabeled
+    types: [closed]
+  pull_request:
+    types: [unlabeled]
 
 permissions:
   contents: read

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -21,11 +21,14 @@ jobs:
         && github.ref != 'refs/heads/main' 
         && github.ref_name != 'main'
       ) && (
-        github.event_name == 'pull_request' 
-        && ((
-          github.event.action == 'unlabeled' 
+        (
+          github.event_name == 'pull_request'
+          && github.event.action == 'unlabeled' 
           && !contains(github.event.pull_request.labels.*.name, 'auto-deploy')
-        ) || (github.event.action == 'closed'))
+        ) || (
+          github.event_name == 'pull_request_target'
+          && github.event.action == 'closed'
+        )
       )
     name: Branch info
     uses: ./.github/workflows/branch-info.yml

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -14,7 +14,19 @@ permissions:
 jobs:
   info:
     # only run for non-permanent branches when a PR closes or loses the auto-deploy label
-    if: (!startsWith(github.ref, 'refs/heads/release') && !startsWith(github.head_ref, 'release/') && github.ref != 'refs/heads/main' && github.ref_name != 'main') && (github.event_name == 'pull_request' && (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'auto-deploy')) || (github.event.action == 'closed'))
+    if: >
+      (
+        !startsWith(github.ref, 'refs/heads/release') 
+        && !startsWith(github.head_ref, 'release/') 
+        && github.ref != 'refs/heads/main' 
+        && github.ref_name != 'main'
+      ) && (
+        github.event_name == 'pull_request' 
+        && (
+          github.event.action == 'unlabeled' 
+          && !contains(github.event.pull_request.labels.*.name, 'auto-deploy')
+        ) || (github.event.action == 'closed')
+      )
     name: Branch info
     uses: ./.github/workflows/branch-info.yml
 

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -1,7 +1,7 @@
 name: CD Down
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - unlabeled

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -22,10 +22,10 @@ jobs:
         && github.ref_name != 'main'
       ) && (
         github.event_name == 'pull_request' 
-        && (
+        && ((
           github.event.action == 'unlabeled' 
           && !contains(github.event.pull_request.labels.*.name, 'auto-deploy')
-        ) || (github.event.action == 'closed')
+        ) || (github.event.action == 'closed'))
       )
     name: Branch info
     uses: ./.github/workflows/branch-info.yml

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - closed
+      - unlabeled
 
 permissions:
   contents: read
@@ -12,8 +13,8 @@ permissions:
 
 jobs:
   info:
-    # only run for manual dispatch or for non-permanent branches
-    if: github.event_name == 'workflow_dispatch' || (!startsWith(github.ref, 'refs/heads/release') && !startsWith(github.head_ref, 'release/') && github.ref != 'refs/heads/main' && github.ref_name != 'main')
+    # only run for non-permanent branches when a PR closes or loses the auto-deploy label
+    if: (!startsWith(github.ref, 'refs/heads/release') && !startsWith(github.head_ref, 'release/') && github.ref != 'refs/heads/main' && github.ref_name != 'main') && (github.event_name == 'pull_request' && (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'auto-deploy')) || (github.event.action == 'closed'))
     name: Branch info
     uses: ./.github/workflows/branch-info.yml
 

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -126,7 +126,6 @@ jobs:
           repository: beyondessential/ops
           ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           path: ops
-          ref: tav-913-tamanu-web
       - name: Remove ops/.git so pulumi doesn't get confused
         run: rm -rf ops/.git
 
@@ -167,7 +166,7 @@ jobs:
       - name: Up!
         uses: pulumi/actions@v3
         with:
-          work-dir: ops/pulumi/tamanu-internal
+          work-dir: ops/pulumi/stacks/tamanu/web-on-ecs
           command: up
           stack-name: bes/${{ needs.info.outputs.branch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -1,7 +1,6 @@
 name: CD Up
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -25,7 +24,7 @@ permissions:
 
 jobs:
   info:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'auto-deploy'))
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'auto-deploy'))
     name: Branch info
     uses: ./.github/workflows/branch-info.yml
 


### PR DESCRIPTION
Currently a PR is un-auto-deployed when it closes only, and [there's weird interactions with the github behaviour that means that most of these CD Downs get silently cancelled.](https://github.com/orgs/community/discussions/26657)

Separately, there's a behaviour where adding the `auto-deploy` label deploys a PR, but removing it _doesn't_. This was meant to provide flexibility, being able to control what gets deployed, for example pushing a flurry of review changes to a PR but leaving it in a broken state, then once completely fixed getting the auto-deploy updated again.

However, this has proved confusing. There have been many instances of devs confused that their branches didn't undeploy after removing the label, or worse not noticing that the branch didn't undeploy and blaming something else. There's also a greater need to more easily control undeploying, and removing the label is a decently intuitive UI.

So this PR enables this. It also removes the restriction that draft PRs can't auto-deploy, so now control is purely with the tag. Finally, it removes the `workflow_dispatch` triggers, as those never did work: AWS can't authenticate for `workflow_dispatch` runs, only pull requests and branch pushes.