### PR TITLE
Fix: Broken long notes

### DIFF
--- a/packages/web/app/components/NoteTable.jsx
+++ b/packages/web/app/components/NoteTable.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState, useRef } from 'react';
+import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import EditIcon from '@material-ui/icons/Edit';
 
@@ -162,6 +162,11 @@ const NoteContent = ({
       ? note.onBehalfOf?.displayName
       : note.revisedBy?.onBehalfOf?.displayName;
 
+  useEffect(() => {
+    const el = noteContentContainerRef.current;
+    if (el) setContentIsClipped(el.offsetHeight < el.scrollHeight);
+  }, [contentIsExpanded]);
+
   return (
     <NoteRowContainer>
       {isNotFilteredByNoteType && (
@@ -170,13 +175,7 @@ const NoteContent = ({
         </NoteHeaderContainer>
       )}
       <NoteBodyContainer>
-        <NoteContentContainer
-          $expanded={contentIsExpanded}
-          ref={el => {
-            noteContentContainerRef.current = el;
-            setContentIsClipped(el?.offsetHeight < el?.scrollHeight);
-          }}
-        >
+        <NoteContentContainer $expanded={contentIsExpanded} ref={noteContentContainerRef}>
           {note?.content?.split('\n').map((line, i, { length }) => {
             const elementRef = contentLineClipping?.current?.[i];
             const contentOffsetHeight = noteContentContainerRef.current?.offsetHeight;


### PR DESCRIPTION
### Changes

It was discovered that some notes were showing up with nothing in the content like this:
![image](https://github.com/beyondessential/tamanu/assets/58054247/913f9895-c39b-4ce4-9057-4ce7e4c4a0a5)
On investigation I discovered that this was a result of an infinite loop that was bugging it out and making the whole table row render nothing. I moved this to a useEffect that listened to suitable variables in order to stop this. Not sure if this is new with tamanu web or not

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
