### PR TITLE
Linter fix: Disable sort-imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,7 +48,7 @@ export default [
       // import rules
       'no-useless-rename': 'error',
       'no-duplicate-imports': 'error',
-      'sort-imports': ['warn', { ignoreCase: true }],
+      'sort-imports': 'off',
 
       // static analysis rules
       'no-new-native-nonconstructor': 'error',


### PR DESCRIPTION
### Changes

We don't care about this setting and it's creating a ton of warnings - just switching it off entirely.

