### PR TITLE
Apply vscode settings at repo level

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "cSpell.language": "en-GB",
+  "cSpell.words": ["singularize", "upsert", "upserted"],
+  "eslint.experimental.useFlatConfig": true,
+  "files.exclude": {
+    "packages/": true
+  },
+  "json.schemas": [
+    {
+      "fileMatch": ["*.hl7.json"],
+      "url": "./packages/central-server/__tests__/hl7fhir/fhir.schema.json"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,7 @@
   "cSpell.language": "en-GB",
   "cSpell.words": ["singularize", "upsert", "upserted"],
   "eslint.experimental.useFlatConfig": true,
-  "files.exclude": {
-    "packages/": true
-  },
+  "eslint.lintTask.enable": true,
   "json.schemas": [
     {
       "fileMatch": ["*.hl7.json"],

--- a/tamanu.code-workspace
+++ b/tamanu.code-workspace
@@ -32,5 +32,10 @@
       "name": "central-server",
       "path": "packages/central-server"
     }
-  ]
+  ],
+  "settings": {
+    "files.exclude": {
+      "packages/": true
+    }
+  }
 }

--- a/tamanu.code-workspace
+++ b/tamanu.code-workspace
@@ -32,18 +32,5 @@
       "name": "central-server",
       "path": "packages/central-server"
     }
-  ],
-  "settings": {
-    "cSpell.language": "en-GB",
-    "files.exclude": {
-      "packages/": true
-    },
-    "cSpell.words": ["singularize", "upsert", "upserted"],
-    "json.schemas": [
-      {
-        "fileMatch": ["*.hl7.json"],
-        "url": "./packages/central-server/__tests__/hl7fhir/fhir.schema.json"
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
### Changes

This moves some settings from the `tamanu.code-workspace` to `.vscode/settings.json`, and then enables the (new, current) ESLint config to work in VSCode in that file.

I... don't use the `tamanu.code-workspace`, mostly because I have my own, and I don't like the way the repo's splits the packages up. I loosely suspect but haven't tested that the repo's prevents VSCode's symbol search and symbol linking from working properly, for example.

Anyway, if you don't use the `tamanu.code-workspace`, you miss out on a few settings that are set in there:

```json
{
  "cSpell.language": "en-GB",
  "cSpell.words": ["singularize", "upsert", "upserted"],
  "json.schemas": [
    {
      "fileMatch": ["*.hl7.json"],
      "url": "./packages/central-server/__tests__/hl7fhir/fhir.schema.json"
    }
  ]
}
```

The `.vscode/settings.json` file on the other hand, applies to the repo regardless of the workspace file that's loaded. So I can use my custom workspace file, and still get these settings.

Anyway, so this PR moves these settings to `.vscode/settings.json`.

Then it adds two settings that make VSCode's ESLint extension work, because the extension doesn't support the ESLint "flat" config format we use without these settings.