### PR TITLE
NASS-1091: Properly implement query on vitals form

### DIFF
--- a/packages/web/app/forms/VitalsForm.jsx
+++ b/packages/web/app/forms/VitalsForm.jsx
@@ -19,7 +19,7 @@ export const VitalsForm = React.memo(({ patient, onSubmit, onClose, encounterTyp
     isLoading,
     isError,
     error,
-  } = combineQueries([useVitalsSurveyQuery(), usePatientAdditionalDataQuery()]);
+  } = combineQueries([useVitalsSurveyQuery(), usePatientAdditionalDataQuery(patient.id)]);
   const { encounter } = useEncounter();
   const { components = [] } = vitalsSurvey || {};
   const currentComponents = components.filter(


### PR DESCRIPTION
### Changes

We had a bug where the vitals form was permanently staying in a loading state. It actually turns out that this is because the pad query on this form NEVER actually worked as it was never supplied a patientID. This made the isLoading value always show up as true and therefore never displayed the vitals form

Only after Daniel tweaked the query to not run when not supplied a patientId did this bug actually show itself. So the fix for this bug is actually just properly implementing the pad data query

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
