### PR TITLE
Fix Admin Panel Asset Upload

### DIFF
--- a/packages/web/app/views/administration/AssetUploaderView.jsx
+++ b/packages/web/app/views/administration/AssetUploaderView.jsx
@@ -1,6 +1,5 @@
 import React, { memo, useCallback, useState } from 'react';
 import * as yup from 'yup';
-
 import { ASSET_NAMES } from '@tamanu/constants/importable';
 import { useApi } from '../../api';
 import { Field, Form, SelectField } from '../../components/Field';
@@ -10,7 +9,6 @@ import { FormGrid } from '../../components/FormGrid';
 import { ButtonRow } from '../../components/ButtonRow';
 import { LargeSubmitButton } from '../../components/Button';
 import { AdminViewContainer } from './components/AdminViewContainer';
-import { error } from 'jquery';
 
 const ResultDisplay = ({ result }) => {
   if (!result) return null;
@@ -38,7 +36,12 @@ export const AssetUploaderView = memo(() => {
     new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.readAsDataURL(file);
-      reader.onload = () => resolve(reader.result);
+      reader.onload = () => {
+        // Extract the base64 data from the data url for saving
+        // See note for more details https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
+        const base64Data = reader.result.split('base64,').pop();
+        return resolve(base64Data);
+      };
       reader.onerror = conversionError => reject(conversionError);
     });
 


### PR DESCRIPTION
### Changes

Assets were getting uploaded from the admin panel with the full Data Url rather than just the image data which meant they were not displaying. This fix removes the non data parts of Data Url so that the pure data can be posted to the server and saved in the DB.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
