### PR TITLE
NASS-1074: Fix form to stop Chrome from trying to save the reset code as a user

### DIFF
--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -123,9 +123,9 @@ const ChangePasswordFormComponent = ({
           autoComplete="off"
         />
         <HorizontalDivider />
-        <PasswordField
+        <Field
           name="newPassword"
-          type="text"
+          type="password"
           label="New password"
           required
           component={TextField}
@@ -135,11 +135,11 @@ const ChangePasswordFormComponent = ({
               setFieldError('newPassword', '');
             }
           }}
-          autoComplete="new-password"
+          autoComplete="new-password off"
         />
-        <PasswordField
+        <Field
           name="confirmNewPassword"
-          type="text"
+          type="password"
           label="Confirm new password"
           required
           component={TextField}
@@ -149,6 +149,7 @@ const ChangePasswordFormComponent = ({
               setFieldError('confirmNewPassword', '');
             }
           }}
+          autoComplete="off"
         />
       </FieldContainer>
       <ActionButtonContainer>

--- a/packages/web/app/forms/ChangePasswordForm.jsx
+++ b/packages/web/app/forms/ChangePasswordForm.jsx
@@ -81,6 +81,12 @@ const ResendCodeButton = styled(TextButton)`
   }
 `;
 
+const PasswordField = styled(Field)`
+  .MuiInputBase-input {
+    -webkit-text-security: disc;
+  }
+`;
+
 const REQUIRED_VALIDATION_MESSAGE = '*Required';
 
 const ChangePasswordFormComponent = ({
@@ -117,9 +123,9 @@ const ChangePasswordFormComponent = ({
           autoComplete="off"
         />
         <HorizontalDivider />
-        <Field
+        <PasswordField
           name="newPassword"
-          type="password"
+          type="text"
           label="New password"
           required
           component={TextField}
@@ -131,9 +137,9 @@ const ChangePasswordFormComponent = ({
           }}
           autoComplete="new-password"
         />
-        <Field
+        <PasswordField
           name="confirmNewPassword"
-          type="password"
+          type="text"
           label="Confirm new password"
           required
           component={TextField}


### PR DESCRIPTION
### Changes

Changed input type so that Chrome doesn't detect a username and password

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
