### PR TITLE
TAN-2320: Improve where config validation programs importer

### DIFF
--- a/packages/central-server/app/admin/importSchemas/questionSchemas.js
+++ b/packages/central-server/app/admin/importSchemas/questionSchemas.js
@@ -55,12 +55,36 @@ const patientDataColumnString = () =>
       return true;
     });
 
+// Note this config needs "source" as a sibling
+const whereConfig = () =>
+  yup
+    .object()
+    .when('source', {
+      is: 'ReferenceData',
+      then: yup
+        .object()
+        .shape({
+          type: yup.string().required(),
+        })
+        .required(),
+    })
+    .default(null)
+    .test(
+      'only-where-on-referenceData',
+      "where field only used for when source='ReferenceData'",
+      (where, context) => {
+        if (where) {
+          return context.options.parent.source === 'ReferenceData';
+        }
+        return true;
+      },
+    );
+
 export const SSCPatientData = SurveyScreenComponent.shape({
   config: configString(
     columnReferenceConfig.shape({
       source: yup.string(),
-      // Note that it would be nice to validate the where parameter here
-      where: yup.string(),
+      where: whereConfig(),
       column: patientDataColumnString(),
       writeToPatient: yup
         .object()
@@ -93,32 +117,10 @@ export const SSCSurveyAnswer = SurveyScreenComponent.shape({
 });
 export const SSCAutocomplete = SurveyScreenComponent.shape({
   config: configString(
-    sourceReferenceConfig
-      .shape({
-        scope: yup.string(),
-        where: yup
-          .object()
-          .when('source', {
-            is: 'ReferenceData',
-            then: yup
-              .object()
-              .shape({
-                type: yup.string().required(),
-              })
-              .required(),
-          })
-          .default(null),
-      })
-      .test(
-        'only-where-on-referenceData',
-        "where field only used for when source='ReferenceData'",
-        ({ source, where }) => {
-          if (where) {
-            return source === 'ReferenceData';
-          }
-          return true;
-        },
-      ),
+    sourceReferenceConfig.shape({
+      scope: yup.string(),
+      where: whereConfig(),
+    }),
   ),
 });
 


### PR DESCRIPTION
### Changes

- https://linear.app/bes/issue/TAN-2320/program-registry-validation-steps-when-importing-program-registry#comment-5395f857

Really really strange, I wasn't able to reproduce the issue linked above and the tests still passed (although they'd fail if I put .required(), so they were running correctly). However, this should fix it anyway and add some more validation.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
