### PR TITLE
TAN-2460: Fix sql injection vulnerabilities in suggesters

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -289,8 +289,8 @@ describe('Suggestions', () => {
 
     it('should escape the query params', async () => {
       const result = await userApp.get('/v1/suggestions/patientLabTestCategories').query({
-        q: `bobby tables'; drop all '' $$ \\' \\ \' ;`,
-        patientId: `bobby tables'; drop all '' $$ \\' \\ \' ;`,
+        q: `bobby tables'; drop all '' $$ \\';`,
+        patientId: `bobby tables'; drop all '' $$ \\';`,
       });
       expect(result).toHaveSucceeded();
       expect(result?.body?.length).toEqual(0);

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -1,9 +1,15 @@
-import { LOCATION_AVAILABILITY_STATUS, SURVEY_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
+import {
+  LAB_REQUEST_STATUSES,
+  LOCATION_AVAILABILITY_STATUS,
+  SURVEY_TYPES,
+  VISIBILITY_STATUSES,
+} from '@tamanu/constants';
 import {
   buildDiagnosis,
   createDummyEncounter,
   createDummyPatient,
   randomRecords,
+  randomLabRequest,
   splitIds,
 } from '@tamanu/shared/demoData';
 import { fake, findOneOrCreate } from '@tamanu/shared/test-helpers';
@@ -212,6 +218,82 @@ describe('Suggestions', () => {
       expect(result).toHaveSucceeded();
       expect(result?.body?.length).toEqual(1);
       expect(result.body[0].facilityId).toEqual(facility.id);
+    });
+  });
+
+  // Labs has functionality for only returning panels that have results for a patient
+  describe('patientLabTestCategories', () => {
+    let patientId;
+
+    beforeAll(async () => {
+      await models.ReferenceData.destroy({ where: { type: 'labTestCategory' } });
+      await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        name: 'AA-decoy1',
+        type: 'labTestCategory',
+      });
+      await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        name: 'BB-decoy2',
+        type: 'labTestCategory',
+      });
+      const { id: unpublishedCategoryId } = await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        name: 'AA-unpublished',
+        type: 'labTestCategory',
+      });
+      const { id: usedCategoryId } = await models.ReferenceData.create({
+        ...fake(models.ReferenceData),
+        name: 'AA-used',
+        type: 'labTestCategory',
+      });
+      patientId = (await models.Patient.create(await createDummyPatient(models))).id;
+
+      const { id: encounterId } = await models.Encounter.create(
+        await createDummyEncounter(models, { patientId }),
+      );
+
+      await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          labTestCategoryId: unpublishedCategoryId,
+          status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+          encounterId,
+        }),
+      );
+      await models.LabRequest.createWithTests(
+        await randomLabRequest(models, {
+          labTestCategoryId: usedCategoryId,
+          status: LAB_REQUEST_STATUSES.PUBLISHED,
+          encounterId,
+        }),
+      );
+    });
+
+    it('should not filter if there is no patient id', async () => {
+      const result = await userApp
+        .get('/v1/suggestions/patientLabTestCategories')
+        .query({ q: 'AA' });
+      expect(result).toHaveSucceeded();
+      expect(result?.body?.length).toEqual(3);
+    });
+
+    it('should filter lab test categories by use', async () => {
+      const result = await userApp.get('/v1/suggestions/patientLabTestCategories').query({
+        patientId,
+        status: LAB_REQUEST_STATUSES.PUBLISHED,
+      });
+      expect(result).toHaveSucceeded();
+      expect(result?.body?.length).toEqual(1);
+      expect(result.body[0].name).toEqual('AA-used');
+    });
+
+    it('should escape the query params', async () => {
+      const result = await userApp.get('/v1/suggestions/patientLabTestCategories').query({
+        q: `bobby tables'; drop all '' $$ \\' \\ \' ;`,
+        patientId: `bobby tables'; drop all '' $$ \\' \\ \' ;`,
+      });
+      expect(result).toHaveSucceeded();
+      expect(result?.body?.length).toEqual(0);
     });
   });
 

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -221,7 +221,7 @@ describe('Suggestions', () => {
     });
   });
 
-  // Labs has functionality for only returning panels that have results for a patient
+  // Labs has functionality for only returning categories that have results for a particular patient
   describe('patientLabTestCategories', () => {
     let patientId;
 

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -268,7 +268,6 @@ createSuggester(
   'ReferenceData',
   (search, query) => {
     const baseWhere = DEFAULT_WHERE_BUILDER(search);
-    const status = query?.status || 'published';
 
     if (!query.patientId) {
       return { ...baseWhere, type: REFERENCE_TYPES.LAB_TEST_CATEGORY };


### PR DESCRIPTION
### Changes

- https://linear.app/bes/issue/TAN-2460/sql-injection-vulnerabilities-in-suggesters

I know it seems like a lot of changes but it's just a lot of indentation when moving to the new options as an object.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
