### PR TITLE
Fix: Lab request printout fix

### DIFF
--- a/packages/shared/src/models/LabRequest.js
+++ b/packages/shared/src/models/LabRequest.js
@@ -177,13 +177,11 @@ export class LabRequest extends Model {
       'priority',
       'laboratory',
       'site',
+      'collectedBy',
+      'specimenType',
       { association: 'labTestPanelRequest', include: ['labTestPanel'] },
       { association: 'tests', include: ['labTestType'] },
     ];
-  }
-
-  static getFullReferenceAssociations() {
-    return [...LabRequest.getListReferenceAssociations(), 'collectedBy', 'specimenType'];
   }
 
   static buildPatientSyncFilter(patientIds, sessionConfig) {


### PR DESCRIPTION
### Changes

Fix for populating `Specimen` & `Collected by` fields on multi-printouts. 

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
