### PR TITLE
EPI-726: Fix procedure table sort

### DIFF
--- a/packages/web/app/components/ProcedureModal.jsx
+++ b/packages/web/app/components/ProcedureModal.jsx
@@ -6,9 +6,9 @@ import { Suggester } from '../utils/suggester';
 import { FormModal } from './FormModal';
 import { ProcedureForm } from '../forms/ProcedureForm';
 
+// Both date and startTime only keep track of either date or time, accordingly.
+// This grabs both relevant parts for the table.
 const getActualDateTime = ({ date, startTime }) => {
-  // Both date and startTime only keep track of either date or time, accordingly.
-  // This grabs both relevant parts for the table.
   return `${date.slice(0, 10)} ${startTime.slice(-8)}`;
 };
 

--- a/packages/web/app/components/ProcedureModal.jsx
+++ b/packages/web/app/components/ProcedureModal.jsx
@@ -1,15 +1,29 @@
 import React from 'react';
+import { addDays, parseISO } from 'date-fns';
 
 import { useApi } from '../api';
 import { Suggester } from '../utils/suggester';
 
 import { FormModal } from './FormModal';
 import { ProcedureForm } from '../forms/ProcedureForm';
+import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
 
 // Both date and startTime only keep track of either date or time, accordingly.
 // This grabs both relevant parts for the table.
 const getActualDateTime = (date, time) => {
   return `${date.slice(0, 10)} ${time.slice(-8)}`;
+};
+
+// endTime has the same caveat as startTime, this will fix it and
+// make an educated guess if the procedure ended the next day.
+const getEndDateTime = ({ date, startTime, endTime }) => {
+  const actualEndDateTime = getActualDateTime(date, endTime);
+  const startTimeString = startTime.slice(-8);
+  const endTimeString = endTime.slice(-8);
+  const isEndTimeEarlier = endTimeString < startTimeString;
+
+  if (isEndTimeEarlier === false) return actualEndDateTime;
+  return toDateTimeString(addDays(parseISO(actualEndDateTime), 1));
 };
 
 export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure }) => {

--- a/packages/web/app/components/ProcedureModal.jsx
+++ b/packages/web/app/components/ProcedureModal.jsx
@@ -17,6 +17,7 @@ const getActualDateTime = (date, time) => {
 // endTime has the same caveat as startTime, this will fix it and
 // make an educated guess if the procedure ended the next day.
 const getEndDateTime = ({ date, startTime, endTime }) => {
+  if (!endTime) return undefined;
   const actualEndDateTime = getActualDateTime(date, endTime);
   const startTimeString = startTime.slice(-8);
   const endTimeString = endTime.slice(-8);
@@ -49,7 +50,8 @@ export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure 
             ...data,
             date: actualDateTime,
             startTime: actualDateTime,
-            encounterId
+            endTime: getEndDateTime(data),
+            encounterId,
           };
 
           if (updatedData.id) {

--- a/packages/web/app/components/ProcedureModal.jsx
+++ b/packages/web/app/components/ProcedureModal.jsx
@@ -6,6 +6,12 @@ import { Suggester } from '../utils/suggester';
 import { FormModal } from './FormModal';
 import { ProcedureForm } from '../forms/ProcedureForm';
 
+const getActualDateTime = ({ date, startTime }) => {
+  // Both date and startTime only keep track of either date or time, accordingly.
+  // This grabs both relevant parts for the table.
+  return `${date.slice(0, 10)} ${startTime.slice(-8)}`;
+};
+
 export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure }) => {
   const api = useApi();
   const locationSuggester = new Suggester(api, 'location', {
@@ -24,13 +30,18 @@ export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure 
     >
       <ProcedureForm
         onSubmit={async data => {
-          if (data.id) {
-            await api.put(`procedure/${data.id}`, data);
+          const actualDateTime = getActualDateTime(data);
+          const updatedData = {
+            ...data,
+            date: actualDateTime,
+            startTime: actualDateTime,
+            encounterId
+          };
+
+          if (updatedData.id) {
+            await api.put(`procedure/${updatedData.id}`, updatedData);
           } else {
-            await api.post('procedure', {
-              ...data,
-              encounterId,
-            });
+            await api.post('procedure', updatedData);
           }
           onSaved();
         }}

--- a/packages/web/app/components/ProcedureModal.jsx
+++ b/packages/web/app/components/ProcedureModal.jsx
@@ -8,8 +8,8 @@ import { ProcedureForm } from '../forms/ProcedureForm';
 
 // Both date and startTime only keep track of either date or time, accordingly.
 // This grabs both relevant parts for the table.
-const getActualDateTime = ({ date, startTime }) => {
-  return `${date.slice(0, 10)} ${startTime.slice(-8)}`;
+const getActualDateTime = (date, time) => {
+  return `${date.slice(0, 10)} ${time.slice(-8)}`;
 };
 
 export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure }) => {
@@ -30,7 +30,7 @@ export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure 
     >
       <ProcedureForm
         onSubmit={async data => {
-          const actualDateTime = getActualDateTime(data);
+          const actualDateTime = getActualDateTime(data.date, data.startTime);
           const updatedData = {
             ...data,
             date: actualDateTime,

--- a/packages/web/app/components/ProcedureTable.jsx
+++ b/packages/web/app/components/ProcedureTable.jsx
@@ -5,15 +5,9 @@ import { DateDisplay } from './DateDisplay';
 
 const getProcedureLabel = ({ procedureType }) => procedureType.name;
 const getCodeLabel = ({ procedureType }) => procedureType.code;
-const getActualDateTime = ({ date, startTime }) => {
-  // Both date and startTime only keep track of either date or time, accordingly.
-  // This grabs both relevant parts for the table.
-  const actualDateTime = date.slice(0, -8).concat(startTime.slice(-8));
-  return <DateDisplay date={actualDateTime} />
-};
 
 const COLUMNS = [
-  { key: 'date', title: 'Date', accessor: getActualDateTime },
+  { key: 'date', title: 'Date', accessor: ({ date }) => <DateDisplay date={date} /> },
   { key: 'ProcedureType.code', title: 'Code', accessor: getCodeLabel },
   { key: 'ProcedureType.name', title: 'Procedure', accessor: getProcedureLabel },
 ];


### PR DESCRIPTION
### Changes

Take 2... This approach is just a short-to-mid-term fix, as there are discussions to change the procedure form in the future later this year. Here we will just adjust newly submitted procedures to match the current workflow: the date selected should also reflect on the startTime and endTime fields - with an extra heuristic that a procedure might end the next day it was created.