### PR TITLE
HOT FIX - SAV-537: Improve performance of ReformatMultiSelectSurveyResponses sub command

### DIFF
--- a/packages/sync-server/app/subCommands/migrateDataInBatches/dataMigrations/ReformatMultiSelectSurveyResponses.js
+++ b/packages/sync-server/app/subCommands/migrateDataInBatches/dataMigrations/ReformatMultiSelectSurveyResponses.js
@@ -12,17 +12,17 @@ export class ReformatMultiSelectSurveyResponses extends CursorDataMigration {
       WITH updated AS (
         UPDATE survey_response_answers as sra
         SET body = ('["' || REPLACE(sra.body, ', ', '","') || '"]') 
-        WHERE data_element_id IN (
-            SELECT survey_response_answers.data_element_id
+        WHERE id IN (
+            SELECT survey_response_answers.id
             FROM survey_response_answers
             JOIN program_data_elements ON survey_response_answers.data_element_id = program_data_elements.id
             WHERE program_data_elements.type = 'MultiSelect'
             AND survey_response_answers.id > $fromId
-            AND NOT LIKE (sra.body, '["%"]')
+            AND survey_response_answers.body NOT LIKE '["%"]'
             ORDER BY survey_response_answers.id
             LIMIT $limit
         )
-          RETURNING id
+        RETURNING id
       )
       SELECT 
         MAX(id::text) AS "maxId",


### PR DESCRIPTION
### Changes
- Improve performance of ReformatMultiSelectSurveyResponses sub command

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
