### PR TITLE
Fix viewing survey responses

### DIFF
--- a/packages/shared/src/reports/utilities/transformAnswers.js
+++ b/packages/shared/src/reports/utilities/transformAnswers.js
@@ -60,6 +60,7 @@ export const getAnswerBody = async (models, componentConfig, type, answer, trans
 
 export const getAutocompleteComponentMap = surveyComponents => {
   const autocompleteComponents = surveyComponents
+    .filter(c => c.dataElement.type === 'Autocomplete')
     .map(({ dataElementId, config: componentConfig }) => [
       dataElementId,
       componentConfig ? JSON.parse(componentConfig) : {},


### PR DESCRIPTION
### Changes

Fix viewing survey responses.

Trying to display non auto complete questions as autocomplete questions in the survey response breaks the form.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
