### PR TITLE
Fix/NASS-977: Encounter summary lab request published date

### DIFF
--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -197,10 +197,10 @@ const COLUMNS = {
       style: { width: '17.5%' },
     },
     {
-      key: 'completedDate',
+      key: 'publishedDate',
       title: 'Published date',
-      accessor: ({ completedDate }) =>
-        completedDate ? getDisplayDate(completedDate, DATE_FORMAT) : '--/--/----',
+      accessor: ({ publishedDate }) =>
+        publishedDate ? getDisplayDate(publishedDate, DATE_FORMAT) : '--/--/----',
       style: { width: '17.5%' },
     },
   ],

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -219,6 +219,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
             testCategory: labRequest.category?.name,
             requestedByName: labRequest.requestedBy?.displayName,
             requestDate: labRequest.requestedDate,
+            publishedDate: labRequest.publishedDate,
             completedDate: test.completedDate,
           });
         });


### PR DESCRIPTION
### Changes

The Encounter summary document was updated to display the Lab Request Published Date instead of the Lab Test Completed Date but only the label was updated. This fix is to update the value to match the label.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
