### PR TITLE
KAM-127: Add /api as duplicate of /v1 route

### DIFF
--- a/docs/Surveys.md
+++ b/docs/Surveys.md
@@ -27,7 +27,7 @@ machine.
 
 ```
 ###
-POST http://localhost:4000/v1/admin/importSurvey
+POST http://localhost:4000/api/admin/importSurvey
 Content-Type: application/json
 
 {

--- a/docs/api/central.md
+++ b/docs/api/central.md
@@ -5,7 +5,7 @@
 ### Login
 
 ```
-POST /v1/login
+POST /api/login
 ```
 
 Expects a JSON-formatted body containing `email` and `password` fields. 
@@ -28,7 +28,7 @@ Will respond with a payload containing an authentication token to be attached to
 ```
 
 ```
-GET /v1/whoami
+GET /api/whoami
 ```
 
 This is a utility route to verify a token. If the token is valid, this will respond with information about the currently logged-in user.
@@ -36,20 +36,20 @@ This is a utility route to verify a token. If the token is valid, this will resp
 ### Attachment
 
 ```
-GET /v1/attachment
+GET /api/attachment
 ```
 
 ## Sync routes
 
 ```
-POST /v1/sync/channels
+POST /api/sync/channels
 ```
 
 ```
-GET /v1/sync/:channelId
-POST /v1/sync/:channelId
+GET /api/sync/:channelId
+POST /api/sync/:channelId
 ```
 
 ```
-DELETE /v1/sync/:channelId/:recordId
+DELETE /api/sync/:channelId/:recordId
 ```

--- a/docs/api/facility.md
+++ b/docs/api/facility.md
@@ -6,33 +6,33 @@ TODO: Add explanation of how route permissions work.
 
 ### Suggestions
 
-route: `/v1/suggestions`
+route: `/api/suggestions`
 
 Used by the web app `Suggester` class to add auto completing search functionality to form fields.
 
 ### User
 
-route: `/v1/user`
+route: `/api/user`
 
 Query user data
 
 ### Patient
 
-route: `/v1/patient`
+route: `/api/patient`
 
 Query patient data, including all models with patient relations
 i.e. GET all patient referrals
 
 ### Encounter
 
-route: `/v1/encounter`
+route: `/api/encounter`
 
 Query encounter data, including all models with encounter relations.
 i.e. GET all encounter diagnoses
 
 ### Survey
 
-route: `/v1/survey`
+route: `/api/survey`
 
 Query and save survey data, this includes referrals.
 
@@ -41,50 +41,50 @@ Query and save survey data, this includes referrals.
 The following endpoints all have basic create, read and update endpoints through the
 handlers found in `packages/shared-src/src/utils/crudHelpers.js`
 
-`/v1/procedure`
+`/api/procedure`
 
-`/v1/triage`
+`/api/triage`
 
-`/v1/referenceData`
+`/api/referenceData`
 
-`/v1/diagnosis`
+`/api/diagnosis`
 
-`/v1/patientIssue`
+`/api/patientIssue`
 
-`/v1/familyHistory`
+`/api/familyHistory`
 
-`/v1/additionalData`
+`/api/additionalData`
 
-`/v1/allergy`
+`/api/allergy`
 
-`/v1/ongoingCondition`
+`/api/ongoingCondition`
 
-`/v1/medication`
+`/api/medication`
 
-`/v1/note`
+`/api/note`
 
-`/v1/labRequest`
+`/api/labRequest`
 
-`/v1/labTest`
+`/api/labTest`
 
-`/v1/referral`
+`/api/referral`
 
-`/v1/imagingRequest`
+`/api/imagingRequest`
 
-`/v1/program`
+`/api/program`
 
-`/v1/surveyResponse`
+`/api/surveyResponse`
 
-`/v1/reports`
+`/api/reports`
 
-`/v1/reportRequest`
+`/api/reportRequest`
 
-`/v1/patientCarePlan`
+`/api/patientCarePlan`
 
-`/v1/admin`
+`/api/admin`
 
-`/v1/setting`
+`/api/setting`
 
-`/v1/location`
+`/api/location`
 
-`/v1/attachment`
+`/api/attachment`

--- a/docs/requests/accounts.http
+++ b/docs/requests/accounts.http
@@ -3,7 +3,7 @@
 @since=0
 
 ### Log in
-POST {{server}}/v1/login
+POST {{server}}/api/login
 Content-Type: application/json
 
 {
@@ -12,16 +12,16 @@ Content-Type: application/json
 }
 
 ### Get current user details
-GET {{server}}/v1/whoami
+GET {{server}}/api/whoami
 Authorization: Bearer {{token}}
 
 ### List users
-GET {{server}}/v1/sync/user?since={{since}}
+GET {{server}}/api/sync/user?since={{since}}
 Authorization: Bearer {{token}}
 
 ### Create an account
 # The server will hash the password if provided
-POST {{server}}/v1/sync/user
+POST {{server}}/api/sync/user
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
@@ -35,7 +35,7 @@ Authorization: Bearer {{token}}
 }]
 
 ### Update user details (including changing a password)
-POST {{server}}/v1/sync/user
+POST {{server}}/api/sync/user
 Content-Type: application/json
 Authorization: Bearer {{token}}
 

--- a/docs/requests/assets.http
+++ b/docs/requests/assets.http
@@ -5,7 +5,7 @@
 ### For type column, please insert mime type of the asset
 ### For data column, please insert base64 encoded string of the asset
 ### Insert existing "id" if you want to update the asset
-POST {{server}}/v1/sync/asset  HTTP/1.1
+POST {{server}}/api/sync/asset  HTTP/1.1
 Authorization: Bearer {{token}}
 Content-Type: application/json
 

--- a/docs/requests/deletion.http
+++ b/docs/requests/deletion.http
@@ -2,5 +2,5 @@
 @server=https://central.main.internal.tamanu.io
 
 ### Delete a survey screen component
-DELETE {{server}}/v1/sync/surveyScreenComponent/program-snap-fiji-2%2Fsurvey-snap-fiji-2%2Fcomponent-FijSNAP_18  HTTP/1.1
+DELETE {{server}}/api/sync/surveyScreenComponent/program-snap-fiji-2%2Fsurvey-snap-fiji-2%2Fcomponent-FijSNAP_18  HTTP/1.1
 Authorization: Bearer {{token}}

--- a/docs/requests/exporters.http
+++ b/docs/requests/exporters.http
@@ -4,7 +4,7 @@
 ### ----------------------------------------
 # Obtain a token
 # @name login
-POST {{syncserver}}/v1/login
+POST {{syncserver}}/api/login
 Content-Type: application/json
 
 {
@@ -15,5 +15,5 @@ Content-Type: application/json
 ### ----------------------------------------
 # Export reference data
 # @name exportReferenceData
-GET {{syncserver}}/v1/admin/export/referenceData?include=Patient,Facility
+GET {{syncserver}}/api/admin/export/referenceData?include=Patient,Facility
 Authorization: Bearer {{token}}

--- a/docs/requests/importers.http
+++ b/docs/requests/importers.http
@@ -12,7 +12,7 @@
 
 ##-------
 ### Obtain a token
-POST {{syncserver}}/v1/login
+POST {{syncserver}}/api/login
 Content-Type: application/json
 
 {
@@ -23,7 +23,7 @@ Content-Type: application/json
 
 ##--------------------------------------------
 ### Import a survey definition
-POST {{syncserver}}/v1/admin/importProgram
+POST {{syncserver}}/api/admin/importProgram
 Content-Type: multipart/form-data; boundary={{boundary}}
 Authorization: Bearer {{token}}
 
@@ -48,7 +48,7 @@ Content-Type: application/vnd.ms-excel
 
 ##--------------------------------------------
 ### Import a data definition document
-POST {{syncserver}}/v1/admin/import/referenceData
+POST {{syncserver}}/api/admin/import/referenceData
 Content-Type: multipart/form-data; boundary={{boundary}}
 Authorization: Bearer {{token}}
 

--- a/docs/requests/labResultWidget.http
+++ b/docs/requests/labResultWidget.http
@@ -1,12 +1,12 @@
 
 # No token as labResultWidget is a public route.
-# @token=fake-token 
+# @token=fake-token
 @server=http://localhost:3000
 
 ### Get a list of reference data
-GET {{server}}/v1/sync/reference?since=0  HTTP/1.1
+GET {{server}}/api/sync/reference?since=0  HTTP/1.1
 # Authorization: Bearer {{token}}
 
 ### Get the endpoint we're interested in
-GET {{server}}/v1/public/labResultWidget/3TTW49  HTTP/1.1
+GET {{server}}/api/public/labResultWidget/3TTW49  HTTP/1.1
 # Authorization: Bearer {{token}}

--- a/docs/requests/lanserver.http
+++ b/docs/requests/lanserver.http
@@ -8,7 +8,7 @@
 ### ----------------------------------------
 # Obtain a token
 # @name login
-POST {{lanserver}}/v1/login
+POST {{lanserver}}/api/login
 Content-Type: application/json
 
 {
@@ -19,6 +19,5 @@ Content-Type: application/json
 ### ----------------------------------------
 # get vitals by vital data element id
 
-GET {{lanserver}}/v1/encounter/{{encounterId}}/vitals/{{vitalDataElementId}}?startDate={{startDate}}&endDate={{endDate}}
+GET {{lanserver}}/api/encounter/{{encounterId}}/vitals/{{vitalDataElementId}}?startDate={{startDate}}&endDate={{endDate}}
 Authorization: Bearer {{token}}
- 

--- a/docs/requests/reference.http
+++ b/docs/requests/reference.http
@@ -3,11 +3,11 @@
 @server=https://central.main.internal.tamanu.io
 
 ### Get a list of reference data
-GET {{server}}/v1/sync/reference?since=0  HTTP/1.1
+GET {{server}}/api/sync/reference?since=0  HTTP/1.1
 Authorization: Bearer {{token}}
 
 ### Create/update some reference data items
-POST {{server}}/v1/sync/reference  HTTP/1.1
+POST {{server}}/api/sync/reference  HTTP/1.1
 Authorization: Bearer {{token}}
 Content-Type: application/json
 

--- a/packages/central-server/__tests__/admin/asset.test.js
+++ b/packages/central-server/__tests__/admin/asset.test.js
@@ -26,7 +26,7 @@ describe('Asset upload', () => {
   });
 
   it('should forbid uploading without permission', async () => {
-    const response = await baseApp.put(`/v1/admin/asset/${NAME}`).send({
+    const response = await baseApp.put(`/api/admin/asset/${NAME}`).send({
       name: NAME,
       filename: 'test.png',
       data: B64_PNG_1X1_CLEAR,
@@ -35,7 +35,7 @@ describe('Asset upload', () => {
   });
 
   it('should upload a new asset', async () => {
-    const response = await adminApp.put(`/v1/admin/asset/${NAME}`).send({
+    const response = await adminApp.put(`/api/admin/asset/${NAME}`).send({
       filename: 'test.png',
       data: B64_PNG_1X1_CLEAR,
     });
@@ -52,7 +52,7 @@ describe('Asset upload', () => {
   });
 
   it('should update an existing asset', async () => {
-    const response = await adminApp.put(`/v1/admin/asset/${OTHER_NAME}`).send({
+    const response = await adminApp.put(`/api/admin/asset/${OTHER_NAME}`).send({
       name: OTHER_NAME,
       filename: 'test.png',
       data: B64_PNG_1X1_WHITE,
@@ -60,7 +60,7 @@ describe('Asset upload', () => {
     expect(response).toHaveSucceeded();
     expect(response.body).toHaveProperty('action', 'created');
 
-    const response2 = await adminApp.put(`/v1/admin/asset/${OTHER_NAME}`).send({
+    const response2 = await adminApp.put(`/api/admin/asset/${OTHER_NAME}`).send({
       name: OTHER_NAME,
       filename: 'test.png',
       data: B64_PNG_1X1_BLACK,
@@ -75,7 +75,7 @@ describe('Asset upload', () => {
   });
 
   it('should reject an asset with an invalid name', async () => {
-    const response = await adminApp.put('/v1/admin/asset/madeupname').send({
+    const response = await adminApp.put('/api/admin/asset/madeupname').send({
       filename: 'test.png',
       data: B64_PNG_1X1_CLEAR,
     });
@@ -84,7 +84,7 @@ describe('Asset upload', () => {
   });
 
   it('should detect .svg as image/svg', async () => {
-    const response = await adminApp.put(`/v1/admin/asset/${NAME}`).send({
+    const response = await adminApp.put(`/api/admin/asset/${NAME}`).send({
       filename: 'test.svg',
       data: B64_PNG_1X1_CLEAR,
     });
@@ -97,7 +97,7 @@ describe('Asset upload', () => {
   });
 
   it('should reject an asset with an invalid mime filename', async () => {
-    const response = await adminApp.put(`/v1/admin/asset/${NAME}`).send({
+    const response = await adminApp.put(`/api/admin/asset/${NAME}`).send({
       filename: 'test.xyz',
       data: B64_PNG_1X1_CLEAR,
     });
@@ -106,7 +106,7 @@ describe('Asset upload', () => {
   });
 
   it('should reject an asset without data', async () => {
-    const response = await adminApp.put(`/v1/admin/asset/${NAME}`).send({
+    const response = await adminApp.put(`/api/admin/asset/${NAME}`).send({
       filename: 'test.png',
       data: '',
     });

--- a/packages/central-server/__tests__/admin/fhirJobStats.test.js
+++ b/packages/central-server/__tests__/admin/fhirJobStats.test.js
@@ -26,7 +26,7 @@ describe('FHIR job stats', () => {
     );
 
     // act
-    const response = await app.get('/v1/admin/fhir/jobStats?order=desc&orderBy=count');
+    const response = await app.get('/api/admin/fhir/jobStats?order=desc&orderBy=count');
 
     // assert
     expect(response.status).toBe(200);

--- a/packages/central-server/__tests__/admin/patientLetterTemplate.test.js
+++ b/packages/central-server/__tests__/admin/patientLetterTemplate.test.js
@@ -21,7 +21,7 @@ describe('Patient merge', () => {
   it('Should create a PatientLetterTemplate', async () => {
     const { PatientLetterTemplate } = models;
 
-    const result = await adminApp.post('/v1/admin/patientLetterTemplate').send({
+    const result = await adminApp.post('/api/admin/patientLetterTemplate').send({
       name: 'Sick note (1)',
     });
     expect(result).toHaveSucceeded();
@@ -37,7 +37,7 @@ describe('Patient merge', () => {
       name: 'Sick note (2)',
     });
 
-    const result = await adminApp.put(`/v1/admin/patientLetterTemplate/${patientLetterTemplate.id}`).send({
+    const result = await adminApp.put(`/api/admin/patientLetterTemplate/${patientLetterTemplate.id}`).send({
       name: 'Sick note (2)',
       body: 'Now we have some text',
     });
@@ -59,7 +59,7 @@ describe('Patient merge', () => {
       name: 'Sick note (3)',
     });
 
-    const response = await adminApp.put(`/v1/admin/patientLetterTemplate/${patientLetterTemplate.id}`).send({
+    const response = await adminApp.put(`/api/admin/patientLetterTemplate/${patientLetterTemplate.id}`).send({
       name: 'Sick note - name should conflict',
       body: 'Now we have some text',
     });
@@ -79,7 +79,7 @@ describe('Patient merge', () => {
       name: 'Sick note - name should conflict',
     });
 
-    const response = await adminApp.post('/v1/admin/patientLetterTemplate').send({
+    const response = await adminApp.post('/api/admin/patientLetterTemplate').send({
       name: 'Sick note - name should conflict',
     });
     expect(response).toHaveRequestError(422);

--- a/packages/central-server/__tests__/admin/patientMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge.test.js
@@ -743,7 +743,7 @@ describe('Patient merge', () => {
     it('Should call the function from the endpoint', async () => {
       const [keep, merge] = await makeTwoPatients();
 
-      const response = await adminApp.post('/v1/admin/mergePatient').send({
+      const response = await adminApp.post('/api/admin/mergePatient').send({
         keepPatientId: keep.id,
         unwantedPatientId: merge.id,
       });
@@ -768,7 +768,7 @@ describe('Patient merge', () => {
       const [keep, merge] = await makeTwoPatients();
       const app = await baseApp.asRole('reception');
 
-      const response = await app.post('/v1/admin/mergePatient').send({
+      const response = await app.post('/api/admin/mergePatient').send({
         keepPatientId: keep.id,
         unwantedPatientId: merge.id,
       });
@@ -779,7 +779,7 @@ describe('Patient merge', () => {
       const { Patient } = models;
       const patient = await Patient.create(fake(Patient));
 
-      const response = await adminApp.post('/v1/admin/mergePatient').send({
+      const response = await adminApp.post('/api/admin/mergePatient').send({
         keepPatientId: patient.id,
         unwantedPatientId: 'doesnt exist',
       });

--- a/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
+++ b/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
@@ -61,13 +61,13 @@ describe('reportRoutes', () => {
 
   describe('GET /reports', () => {
     it('should not return reports with no versions', async () => {
-      const res = await adminApp.get('/v1/admin/reports');
+      const res = await adminApp.get('/api/admin/reports');
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(0);
     });
     it('should return a list of reports', async () => {
       await models.ReportDefinitionVersion.create(getMockReportVersion(1));
-      const res = await adminApp.get('/v1/admin/reports');
+      const res = await adminApp.get('/api/admin/reports');
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(1);
       expect(res.body[0]).toMatchObject({
@@ -81,7 +81,7 @@ describe('reportRoutes', () => {
       const latestVersion = await withDate(new Date(Date.now() + 10000), () =>
         ReportDefinitionVersion.create(getMockReportVersion(2)),
       );
-      const res = await adminApp.get('/v1/admin/reports');
+      const res = await adminApp.get('/api/admin/reports');
       expect(res).toHaveSucceeded();
       expect(res.body[0].versionCount).toBe(2);
       expect(new Date(res.body[0].lastUpdated)).toEqual(latestVersion.updatedAt);
@@ -93,7 +93,7 @@ describe('reportRoutes', () => {
       const { ReportDefinitionVersion } = models;
       const v1 = await ReportDefinitionVersion.create(getMockReportVersion(1));
       const v2 = await ReportDefinitionVersion.create(getMockReportVersion(2));
-      const res = await adminApp.get(`/v1/admin/reports/${testReport.id}/versions`);
+      const res = await adminApp.get(`/api/admin/reports/${testReport.id}/versions`);
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(2);
       expect(res.body.map(x => x.id)).toEqual(expect.arrayContaining([v1.id, v2.id]));
@@ -101,7 +101,7 @@ describe('reportRoutes', () => {
     it('shouldnt return unnecessary metadata', async () => {
       const { ReportDefinitionVersion } = models;
       await ReportDefinitionVersion.create(getMockReportVersion(1));
-      const res = await adminApp.get(`/v1/admin/reports/${testReport.id}/versions`);
+      const res = await adminApp.get(`/api/admin/reports/${testReport.id}/versions`);
       expect(res).toHaveSucceeded();
       const allowedKeys = [
         'id',
@@ -128,7 +128,7 @@ describe('reportRoutes', () => {
         1,
         'select * from patients limit 1',
       );
-      const res = await adminApp.post('/v1/admin/reports').send({ name, dbSchema, ...definition });
+      const res = await adminApp.post('/api/admin/reports').send({ name, dbSchema, ...definition });
       expect(res).toHaveSucceeded();
       expect(res.body.query).toBe('select * from patients limit 1');
       expect(res.body.versionNumber).toBe(1);
@@ -152,7 +152,7 @@ describe('reportRoutes', () => {
         'select * from patients limit 1',
       );
       const res = await adminApp
-        .post('/v1/admin/reports')
+        .post('/api/admin/reports')
         .send({ name: 'Test Report 3', dbSchema, ...definition });
       expect(res).toHaveSucceeded();
       expect(Object.keys(res.body)).toEqual(
@@ -179,7 +179,7 @@ describe('reportRoutes', () => {
         'select * from patients limit 1',
       );
       const res = await adminApp
-        .post(`/v1/admin/reports/${testReport.id}/versions`)
+        .post(`/api/admin/reports/${testReport.id}/versions`)
         .send(newVersion);
       expect(res).toHaveSucceeded();
       expect(res.body.query).toBe('select * from patients limit 1');
@@ -198,7 +198,7 @@ describe('reportRoutes', () => {
         'select * from patients limit 1',
       );
       const res = await adminApp
-        .post(`/v1/admin/reports/${testReport.id}/versions`)
+        .post(`/api/admin/reports/${testReport.id}/versions`)
         .send(newVersion);
       expect(res).toHaveSucceeded();
       expect(Object.keys(res.body)).toEqual(
@@ -222,7 +222,7 @@ describe('reportRoutes', () => {
       const versionData = getMockReportVersion(1);
       const v1 = await ReportDefinitionVersion.create(versionData);
       const res = await adminApp.get(
-        `/v1/admin/reports/${testReport.id}/versions/${v1.id}/export/json`,
+        `/api/admin/reports/${testReport.id}/versions/${v1.id}/export/json`,
       );
       expect(res).toHaveSucceeded();
 
@@ -241,7 +241,7 @@ describe('reportRoutes', () => {
       const versionData = getMockReportVersion(1, 'select\n bark from dog');
       const v1 = await ReportDefinitionVersion.create(versionData);
       const res = await adminApp.get(
-        `/v1/admin/reports/${testReport.id}/versions/${v1.id}/export/sql`,
+        `/api/admin/reports/${testReport.id}/versions/${v1.id}/export/sql`,
       );
       expect(res).toHaveSucceeded();
       expect(res.body.filename).toBe('test-report-v1.sql');
@@ -252,7 +252,7 @@ describe('reportRoutes', () => {
 
   describe('POST /reports/import', () => {
     it('should not create a version if dry run', async () => {
-      const res = await adminApp.post(`/v1/admin/reports/import`).send({
+      const res = await adminApp.post(`/api/admin/reports/import`).send({
         file: path.join(__dirname, '/data/without-version-number.json'),
         name: 'Report Import Test Dry Run',
         dryRun: true,
@@ -274,7 +274,7 @@ describe('reportRoutes', () => {
       expect(report).toBeFalsy();
     });
     it('should import a version for new definition', async () => {
-      const res = await adminApp.post(`/v1/admin/reports/import`).send({
+      const res = await adminApp.post(`/api/admin/reports/import`).send({
         file: path.join(__dirname, '/data/without-version-number.json'),
         name: 'Report Import Test',
         deleteFileAfterImport: false,
@@ -300,7 +300,7 @@ describe('reportRoutes', () => {
     it('should create a new latest version if existing definition and no version number', async () => {
       const { ReportDefinitionVersion } = models;
       await ReportDefinitionVersion.create(getMockReportVersion(1));
-      const res = await adminApp.post(`/v1/admin/reports/import`).send({
+      const res = await adminApp.post(`/api/admin/reports/import`).send({
         file: path.join(__dirname, '/data/without-version-number.json'),
         name: testReport.name,
         deleteFileAfterImport: false,
@@ -325,7 +325,7 @@ describe('reportRoutes', () => {
     it('should fail with InvalidOperationError if version number is specified', async () => {
       const { ReportDefinitionVersion } = models;
       await ReportDefinitionVersion.create(getMockReportVersion(1));
-      const res = await adminApp.post(`/v1/admin/reports/import`).send({
+      const res = await adminApp.post(`/api/admin/reports/import`).send({
         file: path.join(__dirname, '/data/with-version-number.json'),
         name: testReport.name,
         deleteFileAfterImport: false,

--- a/packages/central-server/__tests__/attachment.test.js
+++ b/packages/central-server/__tests__/attachment.test.js
@@ -27,18 +27,18 @@ describe('Attachment (central-server)', () => {
   afterAll(async () => ctx.close());
 
   it('should send an error if attachment does not exist', async () => {
-    const result = await app.get('/v1/attachment/1');
+    const result = await app.get('/api/attachment/1');
     expect(result).toBeForbidden();
   });
 
   it('should read an attachment as a buffer', async () => {
-    const result = await app.get(`/v1/attachment/${attachment.id}`);
+    const result = await app.get(`/api/attachment/${attachment.id}`);
     expect(result).toHaveSucceeded();
     expect(Buffer.isBuffer(result.body)).toBeTruthy();
   });
 
   it('should read an attachment as a base64 string', async () => {
-    const result = await app.get(`/v1/attachment/${attachment.id}?base64=true`);
+    const result = await app.get(`/api/attachment/${attachment.id}?base64=true`);
     expect(result).toHaveSucceeded();
     const receivedStr = result.body.data;
     expect(typeof receivedStr).toBe('string');
@@ -51,7 +51,7 @@ describe('Attachment (central-server)', () => {
 
   it('should send error if there is no enough disk space', async () => {
     canUploadAttachment.mockImplementationOnce(async () => false);
-    const result = await app.post('/v1/attachment').send({
+    const result = await app.post('/api/attachment').send({
       type: 'image/jpeg',
       size: 1002,
       data: FILEDATA,
@@ -65,7 +65,7 @@ describe('Attachment (central-server)', () => {
 
   it('should create an attachment and receive its ID back', async () => {
     canUploadAttachment.mockImplementationOnce(async () => true);
-    const result = await app.post('/v1/attachment').send({
+    const result = await app.post('/api/attachment').send({
       type: 'image/jpeg',
       size: 1002,
       data: FILEDATA,

--- a/packages/central-server/__tests__/facility.test.js
+++ b/packages/central-server/__tests__/facility.test.js
@@ -31,12 +31,12 @@ describe('facility routes', () => {
   afterAll(async () => ctx.close());
 
   it('should receive the correct count of facilities', async () => {
-    const { body: result } = await app.get('/v1/facility');
+    const { body: result } = await app.get('/api/facility');
     expect(result.count).toBe(3);
   });
 
   it('should receive the correct facilities', async () => {
-    const { body: result } = await app.get('/v1/facility');
+    const { body: result } = await app.get('/api/facility');
 
     expect(result.data[0].code).toBe(facilities[0].code);
     expect(result.data[0].name).toBe(facilities[0].name);

--- a/packages/central-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/DiagnosticReport.test.js
@@ -149,7 +149,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       } = await createLabTestHierarchy(ctx.store.models, patient);
       const mat = await FhirDiagnosticReport.materialiseFromUpstream(labTest.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport/${mat.id}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -226,7 +226,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
         await FhirDiagnosticReport.materialiseFromUpstream(labTest.id);
       }
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -249,7 +249,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       await Promise.all([laboratory.destroy(), labTestMethod.destroy()]);
       const mat = await FhirDiagnosticReport.materialiseFromUpstream(labTest.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport/${mat.id}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -281,7 +281,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       const mat = await FhirDiagnosticReport.materialiseFromUpstream(labTest.id);
 
       const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport?subject%3Aidentifier=${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport?subject%3Aidentifier=${id}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -369,7 +369,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
     it('returns not found when fetching a non-existent diagnostic report', async () => {
       const id = fakeUUID();
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport/${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport/${id}`;
       const response = await app.get(path);
 
       expect(response.status).toBe(404);
@@ -395,7 +395,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       const { labTest } = await createLabTestHierarchy(ctx.store.models, patient);
       await FhirDiagnosticReport.materialiseFromUpstream(labTest.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport?_sort=id&_page=z&_count=x`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport?_sort=id&_page=z&_count=x`;
       const response = await app.get(path);
 
       expect(response).toHaveRequestError(500);
@@ -442,7 +442,7 @@ describe(`Materialised FHIR - DiagnosticReport`, () => {
       const { labTest } = await createLabTestHierarchy(ctx.store.models, patient);
       await FhirDiagnosticReport.materialiseFromUpstream(labTest.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/DiagnosticReport?whatever=something`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/DiagnosticReport?whatever=something`;
       const response = await app.get(path);
 
       expect(response).toHaveRequestError(501);

--- a/packages/central-server/__tests__/hl7fhir/materialised/Encounter.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Encounter.test.js
@@ -132,7 +132,7 @@ describe(`Materialised FHIR - Encounter`, () => {
       });
 
       // act
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Encounter/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Encounter/${mat.id}`;
       const response = await app.get(path);
 
       // assert
@@ -204,7 +204,7 @@ describe(`Materialised FHIR - Encounter`, () => {
       });
 
       // act
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Encounter/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Encounter/${mat.id}`;
       const response = await app.get(path);
 
       // assert
@@ -262,7 +262,7 @@ describe(`Materialised FHIR - Encounter`, () => {
     });
 
     it('returns a list when passed no query params', async () => {
-      const response = await app.get(`/v1/integration/${INTEGRATION_ROUTE}/Encounter`);
+      const response = await app.get(`/api/integration/${INTEGRATION_ROUTE}/Encounter`);
 
       expect(response.body.total).toBe(12);
       expect(response.body.entry).toHaveLength(12);
@@ -272,7 +272,7 @@ describe(`Materialised FHIR - Encounter`, () => {
     describe('sorts', () => {
       it('by lastUpdated ascending', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Encounter?_sort=_lastUpdated`,
+          `/api/integration/${INTEGRATION_ROUTE}/Encounter?_sort=_lastUpdated`,
         );
 
         expect(response.body.total).toBe(12);
@@ -284,7 +284,7 @@ describe(`Materialised FHIR - Encounter`, () => {
 
       it('by lastUpdated descending', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Encounter?_sort=-_lastUpdated`,
+          `/api/integration/${INTEGRATION_ROUTE}/Encounter?_sort=-_lastUpdated`,
         );
 
         expect(response.body.total).toBe(12);
@@ -296,7 +296,7 @@ describe(`Materialised FHIR - Encounter`, () => {
 
       it('by status', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Encounter?_sort=status`,
+          `/api/integration/${INTEGRATION_ROUTE}/Encounter?_sort=status`,
         );
 
         expect(response.body.total).toBe(12);
@@ -331,7 +331,7 @@ describe(`Materialised FHIR - Encounter`, () => {
         const [newEncounter, newMat] = await makeEncounter({ encounterType: 'emergency' });
         newMat.update({ lastUpdated: addDays(new Date(), 5) });
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Encounter?_lastUpdated=gt${encodeURIComponent(
+          `/api/integration/${INTEGRATION_ROUTE}/Encounter?_lastUpdated=gt${encodeURIComponent(
             formatFhirDate(addDays(new Date(), 4)),
           )}`,
         );
@@ -345,7 +345,7 @@ describe(`Materialised FHIR - Encounter`, () => {
 
       it('by status', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Encounter?status=discharged`,
+          `/api/integration/${INTEGRATION_ROUTE}/Encounter?status=discharged`,
         );
 
         expect(response.body.total).toBe(6);
@@ -356,7 +356,7 @@ describe(`Materialised FHIR - Encounter`, () => {
       });
 
       it('by class', async () => {
-        const response = await app.get(`/v1/integration/${INTEGRATION_ROUTE}/Encounter?class=|IMP`);
+        const response = await app.get(`/api/integration/${INTEGRATION_ROUTE}/Encounter?class=|IMP`);
 
         expect(response.body.total).toBe(6);
         expect(response.body.entry).toHaveLength(6);
@@ -369,7 +369,7 @@ describe(`Materialised FHIR - Encounter`, () => {
     it('returns not found when fetching a non-existent encounter', async () => {
       // arrange
       const id = fakeUUID();
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Encounter/${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Encounter/${id}`;
 
       // act
       const response = await app.get(path);
@@ -394,7 +394,7 @@ describe(`Materialised FHIR - Encounter`, () => {
 
     it('returns an error if there are any unknown search params', async () => {
       // arrange
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Encounter?whatever=something`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Encounter?whatever=something`;
 
       // act
       const response = await app.get(path);

--- a/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -64,7 +64,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
   afterAll(() => ctx.close());
 
   describe('create', () => {
-    const PATH = `/v1/integration/${INTEGRATION_ROUTE}/ImagingStudy`;
+    const PATH = `/api/integration/${INTEGRATION_ROUTE}/ImagingStudy`;
 
     let encounter;
     beforeEach(async () => {
@@ -351,7 +351,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
     describe('errors', () => {
       it('returns invalid if the resourceType does not match', async () => {
         // act
-        const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
+        const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
           resourceType: 'Patient',
         });
 
@@ -392,7 +392,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
         await FhirServiceRequest.resolveUpstreams();
 
         // act
-        const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
+        const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
           resourceType: 'ImagingStudy',
           status: 'pending',
           identifier: [
@@ -430,7 +430,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
 
       it('returns invalid structure if the service request id is missing', async () => {
         // act
-        const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
+        const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
           resourceType: 'ImagingStudy',
           status: 'final',
           identifier: [
@@ -465,7 +465,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
         const srId = fakeUUID();
 
         // act
-        const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
+        const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/ImagingStudy`).send({
           resourceType: 'ImagingStudy',
           status: 'final',
           identifier: [

--- a/packages/central-server/__tests__/hl7fhir/materialised/Immunization.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Immunization.test.js
@@ -117,7 +117,7 @@ describe(`Materialised FHIR - Immunization`, () => {
       } = await createAdministeredVaccineHierarchy(ctx.store.models);
       const mat = await FhirImmunization.materialiseFromUpstream(administeredVaccine.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization/${mat.id}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -173,7 +173,7 @@ describe(`Materialised FHIR - Immunization`, () => {
       await administeredVaccine.save();
       const mat = await FhirImmunization.materialiseFromUpstream(administeredVaccine.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization/${mat.id}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -196,7 +196,7 @@ describe(`Materialised FHIR - Immunization`, () => {
         await FhirImmunization.materialiseFromUpstream(administeredVaccine.id);
       }
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -224,7 +224,7 @@ describe(`Materialised FHIR - Immunization`, () => {
         }
       }
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization?patient=Patient/${patientId}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization?patient=Patient/${patientId}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -246,7 +246,7 @@ describe(`Materialised FHIR - Immunization`, () => {
       );
       await FhirImmunization.materialiseFromUpstream(otherAdmVx.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization?vaccine-code=${vaccineCode}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization?vaccine-code=${vaccineCode}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -258,7 +258,7 @@ describe(`Materialised FHIR - Immunization`, () => {
     it('returns not found when fetching a non-existent immunization', async () => {
       const id = fakeUUID();
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization/${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization/${id}`;
       const response = await app.get(path);
 
       expect(response.status).toBe(404);
@@ -283,7 +283,7 @@ describe(`Materialised FHIR - Immunization`, () => {
       const { administeredVaccine } = await createAdministeredVaccineHierarchy(ctx.store.models);
       await FhirImmunization.materialiseFromUpstream(administeredVaccine.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization?_sort=id&_page=z&_count=x`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization?_sort=id&_page=z&_count=x`;
       const response = await app.get(path);
 
       expect(response).toHaveRequestError(500);
@@ -329,7 +329,7 @@ describe(`Materialised FHIR - Immunization`, () => {
       const { administeredVaccine } = await createAdministeredVaccineHierarchy(ctx.store.models);
       await FhirImmunization.materialiseFromUpstream(administeredVaccine.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Immunization?whatever=something`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Immunization?whatever=something`;
       const response = await app.get(path);
 
       expect(response).toHaveRequestError(501);

--- a/packages/central-server/__tests__/hl7fhir/materialised/Patient.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Patient.test.js
@@ -39,7 +39,7 @@ describe(`Materialised FHIR - Patient`, () => {
       await patient.reload(); // saving PatientAdditionalData updates the patient too
       const mat = await FhirPatient.materialiseFromUpstream(patient.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient/${mat.id}`;
 
       // act
       const response = await app.get(path);
@@ -121,7 +121,7 @@ describe(`Materialised FHIR - Patient`, () => {
       const mat = await FhirPatient.materialiseFromUpstream(patient.id);
 
       const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-issued&_page=0&_count=2&status=final&identifier=${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-issued&_page=0&_count=2&status=final&identifier=${id}`;
 
       // act
       const response = await app.get(path);
@@ -216,7 +216,7 @@ describe(`Materialised FHIR - Patient`, () => {
         Patient.create(fake(Patient)),
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient`;
 
       // act
       const response = await app.get(path);
@@ -246,7 +246,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=birthdate`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=birthdate`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -268,7 +268,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-birthdate`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-birthdate`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -297,7 +297,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ]);
         await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=given`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=given`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -319,7 +319,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ]);
         await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-given`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-given`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -341,7 +341,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ]);
         await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=family`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=family`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -363,7 +363,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ]);
         await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-family`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-family`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -404,7 +404,7 @@ describe(`Materialised FHIR - Patient`, () => {
           ),
         );
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=address`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=address`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -447,7 +447,7 @@ describe(`Materialised FHIR - Patient`, () => {
           ),
         );
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-address`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-address`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -487,7 +487,7 @@ describe(`Materialised FHIR - Patient`, () => {
           ),
         );
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=address-city`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=address-city`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -527,7 +527,7 @@ describe(`Materialised FHIR - Patient`, () => {
           ),
         );
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-address-city`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-address-city`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -576,7 +576,7 @@ describe(`Materialised FHIR - Patient`, () => {
           ),
         );
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=telecom`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=telecom`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -626,7 +626,7 @@ describe(`Materialised FHIR - Patient`, () => {
           ),
         );
 
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=-telecom`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=-telecom`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -693,7 +693,7 @@ describe(`Materialised FHIR - Patient`, () => {
         );
 
         // Sort by firstName ascending, lastName descending, primaryContactNumber ascending
-        const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=given,-family,telecom`;
+        const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=given,-family,telecom`;
         const response = await app.get(path);
 
         expect(response).toHaveSucceeded();
@@ -731,7 +731,7 @@ describe(`Materialised FHIR - Patient`, () => {
       );
 
       const identifier = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patientOne.displayId}`);
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?identifier=${identifier}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?identifier=${identifier}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -749,7 +749,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?given=${firstName}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?given=${firstName}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -762,7 +762,7 @@ describe(`Materialised FHIR - Patient`, () => {
       const patient = await Patient.create(fake(Patient, { firstName: 'Bob' }));
       await FhirPatient.materialiseFromUpstream(patient.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?given=bob`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?given=bob`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -775,7 +775,7 @@ describe(`Materialised FHIR - Patient`, () => {
       const patient = await Patient.create(fake(Patient, { firstName: 'Bob' }));
       await FhirPatient.materialiseFromUpstream(patient.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?given:starts-with=bo`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?given:starts-with=bo`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -788,7 +788,7 @@ describe(`Materialised FHIR - Patient`, () => {
       const patient = await Patient.create(fake(Patient, { firstName: 'Bob' }));
       await FhirPatient.materialiseFromUpstream(patient.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?given:ends-with=ob`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?given:ends-with=ob`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -801,7 +801,7 @@ describe(`Materialised FHIR - Patient`, () => {
       const patient = await Patient.create(fake(Patient, { firstName: 'Bob' }));
       await FhirPatient.materialiseFromUpstream(patient.id);
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?given:contains=o`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?given:contains=o`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -819,7 +819,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?family=${lastName}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?family=${lastName}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -837,7 +837,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?gender=${sex}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?gender=${sex}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -855,7 +855,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?birthdate=${dateOfBirth}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?birthdate=${dateOfBirth}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -873,7 +873,7 @@ describe(`Materialised FHIR - Patient`, () => {
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
       // Query deceased=true
-      const pathTrue = `/v1/integration/${INTEGRATION_ROUTE}/Patient?deceased=true`;
+      const pathTrue = `/api/integration/${INTEGRATION_ROUTE}/Patient?deceased=true`;
       const responseTrue = await app.get(pathTrue);
 
       expect(responseTrue).toHaveSucceeded();
@@ -881,7 +881,7 @@ describe(`Materialised FHIR - Patient`, () => {
       expect(responseTrue.body.entry.length).toBe(1);
 
       // Query deceased=false
-      const pathFalse = `/v1/integration/${INTEGRATION_ROUTE}/Patient?deceased=false`;
+      const pathFalse = `/api/integration/${INTEGRATION_ROUTE}/Patient?deceased=false`;
       const responseFalse = await app.get(pathFalse);
 
       expect(responseFalse).toHaveSucceeded();
@@ -918,7 +918,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ),
       );
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?address-city=${cityTown}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?address-city=${cityTown}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -954,7 +954,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ),
       );
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?address=luxembourg`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?address=luxembourg`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -996,7 +996,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ),
       );
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?telecom=${phone}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?telecom=${phone}`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -1023,7 +1023,7 @@ describe(`Materialised FHIR - Patient`, () => {
       ]);
       await Promise.all(patients.map(({ id }) => FhirPatient.materialiseFromUpstream(id)));
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?active=true`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?active=true`;
       const response = await app.get(path);
 
       expect(response).toHaveSucceeded();
@@ -1041,7 +1041,7 @@ describe(`Materialised FHIR - Patient`, () => {
     it('returns not found when fetching a non-existent patient', async () => {
       // arrange
       const id = fakeUUID();
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient/${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient/${id}`;
 
       // act
       const response = await app.get(path);
@@ -1072,7 +1072,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ...fake(PatientAdditionalData),
         patientId: patient.id,
       });
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_sort=id&_page=z&_count=x`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_sort=id&_page=z&_count=x`;
 
       // act
       const response = await app.get(path);
@@ -1124,7 +1124,7 @@ describe(`Materialised FHIR - Patient`, () => {
         ...fake(PatientAdditionalData),
         patientId: patient.id,
       });
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?whatever=something`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?whatever=something`;
 
       // act
       const response = await app.get(path);

--- a/packages/central-server/__tests__/hl7fhir/materialised/PatientMerge.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/PatientMerge.test.js
@@ -73,7 +73,7 @@ describe(`Materialised FHIR - Patient Merge`, () => {
 
     // Flaky test (EPI-275)
     it.skip('links patients that were merged into the top level patient A (as fetch)', async () => {
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient/${ids.a}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient/${ids.a}`;
 
       // act
       const response = await app.get(path);
@@ -124,7 +124,7 @@ describe(`Materialised FHIR - Patient Merge`, () => {
 
     // Flaky test (EPI-275)
     it.skip('links patients that were merged into, and patients that replaced, the mid level patient B (as fetch)', async () => {
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient/${ids.b}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient/${ids.b}`;
 
       // act
       const response = await app.get(path);
@@ -174,7 +174,7 @@ describe(`Materialised FHIR - Patient Merge`, () => {
     });
 
     it('links patients that replaced the mid level patients C and D (as search)', async () => {
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_id=${ids.c},${ids.d}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_id=${ids.c},${ids.d}`;
 
       // act
       const response = await app.get(path);
@@ -294,7 +294,7 @@ describe(`Materialised FHIR - Patient Merge`, () => {
     });
 
     it('links patients that were merged into the top level patient A (as fetch)', async () => {
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient/${ids.a}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient/${ids.a}`;
 
       // act
       const response = await app.get(path);
@@ -345,7 +345,7 @@ describe(`Materialised FHIR - Patient Merge`, () => {
 
     // Flaky test (EPI-275)
     it.skip('links patients that were merged into, and patients that replaced, the mid level patient B (as fetch)', async () => {
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient/${ids.b}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient/${ids.b}`;
 
       // act
       const response = await app.get(path);
@@ -395,7 +395,7 @@ describe(`Materialised FHIR - Patient Merge`, () => {
     });
 
     it('links patients that replaced the mid level patients C and D (as search)', async () => {
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Patient?_id=${ids.c},${ids.d}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Patient?_id=${ids.c},${ids.d}`;
 
       // act
       const response = await app.get(path);

--- a/packages/central-server/__tests__/hl7fhir/materialised/Practitioner.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Practitioner.test.js
@@ -26,7 +26,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
       const [user, mat] = await makePractitioner();
 
       // act
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Practitioner/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Practitioner/${mat.id}`;
       const response = await app.get(path);
 
       // assert
@@ -78,7 +78,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
     });
 
     it('should return a list when passed no query params', async () => {
-      const response = await app.get(`/v1/integration/${INTEGRATION_ROUTE}/Practitioner`);
+      const response = await app.get(`/api/integration/${INTEGRATION_ROUTE}/Practitioner`);
 
       expect(response.body.total).toBe(6);
       expect(response.body.entry).toHaveLength(6);
@@ -88,7 +88,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
     describe('sorts', () => {
       it('should sort by lastUpdated ascending', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Practitioner?_sort=_lastUpdated`,
+          `/api/integration/${INTEGRATION_ROUTE}/Practitioner?_sort=_lastUpdated`,
         );
 
         expect(response.body.total).toBe(6);
@@ -100,7 +100,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
 
       it('should sort by lastUpdated descending', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Practitioner?_sort=-_lastUpdated`,
+          `/api/integration/${INTEGRATION_ROUTE}/Practitioner?_sort=-_lastUpdated`,
         );
 
         expect(response.body.total).toBe(6);
@@ -114,7 +114,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
     describe('filters', () => {
       it('should filter by identifier', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Practitioner?identifier=${practitioners[0][0].id}`,
+          `/api/integration/${INTEGRATION_ROUTE}/Practitioner?identifier=${practitioners[0][0].id}`,
         );
 
         expect(response.body.total).toBe(1);
@@ -126,7 +126,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
 
       it('should filter by email (telecom)', async () => {
         const response = await app.get(
-          `/v1/integration/${INTEGRATION_ROUTE}/Practitioner?telecom=${testEmail}`,
+          `/api/integration/${INTEGRATION_ROUTE}/Practitioner?telecom=${testEmail}`,
         );
 
         expect(response.body.total).toBe(1);
@@ -142,7 +142,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
     it('returns not found when fetching a non-existent practitioner', async () => {
       // arrange
       const id = fakeUUID();
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Practitioner/${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Practitioner/${id}`;
 
       // act
       const response = await app.get(path);
@@ -167,7 +167,7 @@ describe(`Materialised FHIR - Practitioner`, () => {
 
     it('returns an error if there are any unknown search params', async () => {
       // arrange
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/Practitioner?whatever=something`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/Practitioner?whatever=something`;
 
       // act
       const response = await app.get(path);

--- a/packages/central-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -102,7 +102,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
       await FhirServiceRequest.resolveUpstreams();
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest/${mat.id}`;
 
       // act
       const response = await app.get(path);
@@ -214,7 +214,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
       await FhirServiceRequest.resolveUpstreams();
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest/${mat.id}`;
 
       // act
       const response = await app.get(path);
@@ -309,7 +309,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
       await FhirServiceRequest.resolveUpstreams();
 
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest/${mat.id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest/${mat.id}`;
 
       // act
       const response = await app.get(path);
@@ -356,7 +356,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       const id = encodeURIComponent(
         `http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html|${ir.id}`,
       );
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${id}`;
 
       // act
       const response = await app.get(path);
@@ -475,7 +475,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       const id = encodeURIComponent(
         `http://data-dictionary.tamanu-fiji.org/tamanu-mrid-imagingrequest.html|${ir.displayId}`,
       );
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${id}`;
 
       // act
       const response = await app.get(path);
@@ -633,7 +633,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
     });
 
     it('returns a list when passed no query params', async () => {
-      const response = await app.get(`/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest`);
+      const response = await app.get(`/api/integration/${INTEGRATION_ROUTE}/ServiceRequest`);
 
       expect(response.body.total).toBe(2);
       expect(response).toHaveSucceeded();
@@ -641,7 +641,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('sorts by lastUpdated ascending', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=_lastUpdated`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=_lastUpdated`,
       );
 
       expect(response.body.total).toBe(2);
@@ -654,7 +654,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('sorts by lastUpdated descending', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=-_lastUpdated`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=-_lastUpdated`,
       );
 
       expect(response.body.total).toBe(2);
@@ -667,7 +667,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('sorts by status', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=status`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=status`,
       );
 
       expect(response.body.total).toBe(2);
@@ -680,7 +680,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('sorts by priority', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=priority`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?_sort=priority`,
       );
 
       expect(response.body.total).toBe(2);
@@ -693,7 +693,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by lastUpdated=gt with a date', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?_lastUpdated=gt${formatFhirDate(
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?_lastUpdated=gt${formatFhirDate(
           addDays(new Date(), 7),
           FHIR_DATETIME_PRECISION.DAYS,
         )}`,
@@ -706,7 +706,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by lastUpdated=gt with a datetime', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?_lastUpdated=gt${encodeURIComponent(
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?_lastUpdated=gt${encodeURIComponent(
           formatFhirDate(addDays(new Date(), 7)),
         )}`,
       );
@@ -718,7 +718,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by upstream ID (identifier)', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${irs[0].id}`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?identifier=${irs[0].id}`,
       );
 
       expect(response.body.total).toBe(1);
@@ -728,7 +728,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by status', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?status=active`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?status=active`,
       );
 
       expect(response.body.total).toBe(1);
@@ -738,7 +738,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by priority', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?priority=urgent`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?priority=urgent`,
       );
 
       expect(response.body.total).toBe(1);
@@ -748,7 +748,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by category (match)', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005`,
       );
 
       expect(response.body.total).toBe(2);
@@ -757,7 +757,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('filters by category (no match)', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679123`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679123`,
       );
 
       expect(response.body.total).toBe(0);
@@ -766,7 +766,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('includes subject patient', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Patient:subject`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Patient:subject`,
       );
 
       expect(response.body.total).toBe(2);
@@ -780,7 +780,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('includes subject patient with targetType (match)', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Patient:subject:Patient`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Patient:subject:Patient`,
       );
 
       expect(response.body.total).toBe(2);
@@ -794,7 +794,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('includes subject patient with targetType (no match)', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Patient:subject:Practitioner`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Patient:subject:Practitioner`,
       );
 
       expect(response.body.total).toBe(2);
@@ -805,7 +805,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('includes encounter as materialised encounter', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Encounter:encounter`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Encounter:encounter`,
       );
       expect(response.body.total).toBe(2);
       expect(response.body.entry.length).toBe(3);
@@ -817,7 +817,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('includes requester practitioner', async () => {
       const response = await app.get(
-        `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Practitioner:requester`,
+        `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?category=363679005&_include=Practitioner:requester`,
       );
       const practitionerRef = response.body.entry.find(
         ({ search: { mode } }) => mode === 'include',
@@ -836,7 +836,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
     it('returns not found when fetching a non-existent service request', async () => {
       // arrange
       const id = fakeUUID();
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest/${id}`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest/${id}`;
 
       // act
       const response = await app.get(path);
@@ -861,7 +861,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
 
     it('returns an error if there are any unknown search params', async () => {
       // arrange
-      const path = `/v1/integration/${INTEGRATION_ROUTE}/ServiceRequest?whatever=something`;
+      const path = `/api/integration/${INTEGRATION_ROUTE}/ServiceRequest?whatever=something`;
 
       // act
       const response = await app.get(path);

--- a/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -43,7 +43,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
           },
         ],
       };
-      const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
+      const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
@@ -75,7 +75,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
           },
         ],
       };
-      const response = await app.post(`/v1/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
+      const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
@@ -93,7 +93,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         at: 'the pass',
       };
       const response = await app
-        .post(`/v1/integration/${INTEGRATION_ROUTE}/HeadMeOff`)
+        .post(`/api/integration/${INTEGRATION_ROUTE}/HeadMeOff`)
         .set('X-Forwarded-For', '123.45.67.89')
         .set('Authz', 'lmao')
         .set('X-Tamanu-Field', 'it me')

--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testDiagnosticReportHandler.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testDiagnosticReportHandler.js
@@ -120,7 +120,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         } = await createLabTestHierarchy(patient);
 
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Aresult&_include=DiagnosticReport%3Aresult.device%3ADevice`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Aresult&_include=DiagnosticReport%3Aresult.device%3ADevice`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -266,13 +266,13 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         await createLabTestHierarchy(someOtherPatient);
 
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
 
         // act
         const response1 = await app.get(path).set(requestHeaders);
 
         const nextUrl = response1.body.link.find(l => l.relation === 'next')?.url;
-        const urlRegEx = new RegExp(`^.*(/v1/integration/${integrationName}/.*)$`);
+        const urlRegEx = new RegExp(`^.*(/api/integration/${integrationName}/.*)$`);
         const [, nextPath] = nextUrl.match(urlRegEx);
         const response2 = await app.get(nextPath).set(requestHeaders);
 
@@ -285,7 +285,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
             {
               relation: 'next',
               url: expect.stringContaining(
-                `/v1/integration/${integrationName}/DiagnosticReport?searchId=`,
+                `/api/integration/${integrationName}/DiagnosticReport?searchId=`,
               ),
             },
           ],
@@ -313,7 +313,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
       it("returns no error but no results when subject:identifier doesn't match a patient", async () => {
         // arrange
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|not-an-existing-id`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -349,7 +349,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         await labRequest.save();
 
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Aresult&_include=DiagnosticReport%3Aresult.device%3ADevice`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Aresult&_include=DiagnosticReport%3Aresult.device%3ADevice`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -390,7 +390,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         const { labTest, labTestMethod } = await createLabTestHierarchy(patient, { isRDT: true });
 
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Aresult&_include=DiagnosticReport%3Aresult.device%3ADevice`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Aresult&_include=DiagnosticReport%3Aresult.device%3ADevice`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -446,7 +446,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         await labRequest2.save();
 
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -471,7 +471,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         await createLabTestHierarchy(patient);
 
         const id = encodeURIComponent(`https://wrong.com/this-is-wrong|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/DiagnosticReport?_sort=deceased&_page=-1&_count=101&status=invalid-status&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Asomething-invalid`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport?_sort=deceased&_page=-1&_count=101&status=invalid-status&subject%3Aidentifier=${id}&_include=DiagnosticReport%3Asomething-invalid`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -497,7 +497,7 @@ export function testDiagnosticReportHandler(integrationName, requestHeaders = {}
         const patient = await Patient.create(fake(Patient));
         await createLabTestHierarchy(patient);
 
-        const path = `/v1/integration/${integrationName}/DiagnosticReport`;
+        const path = `/api/integration/${integrationName}/DiagnosticReport`;
 
         // act
         const response = await app.get(path).set(requestHeaders);

--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testImmunizationHandler.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testImmunizationHandler.js
@@ -112,7 +112,7 @@ export function testImmunizationHandler(integrationName, requestHeaders = {}) {
     describe('success', () => {
       it("returns no error but no results when patient reference doesn't match", async () => {
         const id = '123456789';
-        const path = `/v1/integration/${integrationName}/Immunization?_sort=-issued&_page=0&_count=2&patient=${id}`;
+        const path = `/api/integration/${integrationName}/Immunization?_sort=-issued&_page=0&_count=2&patient=${id}`;
         const response = await app.get(path).set(requestHeaders);
         expect(response).toHaveSucceeded();
         expect(response.body).toEqual({
@@ -135,7 +135,7 @@ export function testImmunizationHandler(integrationName, requestHeaders = {}) {
       });
 
       it("returns no error but no results when vaccine code doesn't match", async () => {
-        const path = `/v1/integration/${integrationName}/Immunization?_sort=-issued&_page=0&_count=2&vaccine-code=${NON_SUPPORTED_VACCINE_ID}`;
+        const path = `/api/integration/${integrationName}/Immunization?_sort=-issued&_page=0&_count=2&vaccine-code=${NON_SUPPORTED_VACCINE_ID}`;
         const response = await app.get(path).set(requestHeaders);
         expect(response).toHaveSucceeded();
         expect(response.body).toEqual({
@@ -159,7 +159,7 @@ export function testImmunizationHandler(integrationName, requestHeaders = {}) {
 
       it('returns a list of supported immunizations when passed no query params', async () => {
         const response = await app
-          .get(`/v1/integration/${integrationName}/Immunization`)
+          .get(`/api/integration/${integrationName}/Immunization`)
           .set(requestHeaders);
         expect(response).toHaveSucceeded();
         // We created 3, but only 2 types of vaccine are supported to be included
@@ -169,7 +169,7 @@ export function testImmunizationHandler(integrationName, requestHeaders = {}) {
 
     describe('failure', () => {
       it('returns a 422 error when passed the wrong query params', async () => {
-        const path = `/v1/integration/${integrationName}/Immunization?_sort=id&_page=z&_count=x&status=initial`;
+        const path = `/api/integration/${integrationName}/Immunization?_sort=id&_page=z&_count=x&status=initial`;
         const response = await app.get(path).set(requestHeaders);
         expect(response).toHaveRequestError(422);
         expect(response.body).toMatchObject({

--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testPatientHandler.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testPatientHandler.js
@@ -29,7 +29,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
         });
         await patient.reload(); // saving PatientAdditionalData updates the patient too
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -111,7 +111,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
       it("returns no error but no results when subject:identifier doesn't match a patient", async () => {
         // arrange
         const id = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|abc123-not-real`);
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-issued&_page=0&_count=2&status=final&subject%3Aidentifier=${id}`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -145,7 +145,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           ...fake(PatientAdditionalData),
           patientId: patient.id,
         });
-        const path = `/v1/integration/${integrationName}/Patient`;
+        const path = `/api/integration/${integrationName}/Patient`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -171,7 +171,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { firstName: 'Charlie' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=given`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=given`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -189,7 +189,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { firstName: 'Charlie' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-given`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-given`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -207,7 +207,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { lastName: 'Carter' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=family`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=family`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -225,7 +225,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { lastName: 'Carter' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-family`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-family`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -244,7 +244,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { dateOfBirth: '1985-03-21' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=birthdate`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=birthdate`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -264,7 +264,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { dateOfBirth: '1985-03-21' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-birthdate`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-birthdate`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -298,7 +298,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=address`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=address`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -331,7 +331,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-address`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-address`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -364,7 +364,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=address-city`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=address-city`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -397,7 +397,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-address-city`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-address-city`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -430,7 +430,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=telecom`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=telecom`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -463,7 +463,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?_sort=-telecom`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=-telecom`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -507,7 +507,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
         ]);
 
         // Sort by firstName ascending, lastName descending, primaryContactNumber ascending
-        const path = `/v1/integration/${integrationName}/Patient?_sort=given,-family,telecom`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=given,-family,telecom`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -536,7 +536,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
         ]);
 
         const identifier = encodeURIComponent(`${IDENTIFIER_NAMESPACE}|${patientOne.displayId}`);
-        const path = `/v1/integration/${integrationName}/Patient?identifier=${identifier}`;
+        const path = `/api/integration/${integrationName}/Patient?identifier=${identifier}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -552,7 +552,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { firstName: 'Bob' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?given=${firstName}`;
+        const path = `/api/integration/${integrationName}/Patient?given=${firstName}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -568,7 +568,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { lastName: 'Gray' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?family=${lastName}`;
+        const path = `/api/integration/${integrationName}/Patient?family=${lastName}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -584,7 +584,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { sex: 'female' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?gender=${sex}`;
+        const path = `/api/integration/${integrationName}/Patient?gender=${sex}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -600,7 +600,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { dateOfBirth: '1985-10-20' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?birthdate=${dateOfBirth}`;
+        const path = `/api/integration/${integrationName}/Patient?birthdate=${dateOfBirth}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -616,14 +616,14 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
         ]);
 
         // Query deceased=true
-        const pathTrue = `/v1/integration/${integrationName}/Patient?deceased=true`;
+        const pathTrue = `/api/integration/${integrationName}/Patient?deceased=true`;
         const responseTrue = await app.get(pathTrue).set(requestHeaders);
 
         expect(responseTrue).toHaveSucceeded();
         expect(responseTrue.body.total).toBe(1);
 
         // Query deceased=false
-        const pathFalse = `/v1/integration/${integrationName}/Patient?deceased=false`;
+        const pathFalse = `/api/integration/${integrationName}/Patient?deceased=false`;
         const responseFalse = await app.get(pathFalse).set(requestHeaders);
 
         expect(responseFalse).toHaveSucceeded();
@@ -654,7 +654,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?address-city=${cityTown}`;
+        const path = `/api/integration/${integrationName}/Patient?address-city=${cityTown}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -689,7 +689,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?address=${cityTown}`;
+        const path = `/api/integration/${integrationName}/Patient?address=${cityTown}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -721,7 +721,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           }),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?telecom=${primaryContactNumber}`;
+        const path = `/api/integration/${integrationName}/Patient?telecom=${primaryContactNumber}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -735,7 +735,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { visibilityStatus: 'whatever' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?active=true`;
+        const path = `/api/integration/${integrationName}/Patient?active=true`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -751,7 +751,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           Patient.create(fake(Patient, { firstName: 'Alice' })),
         ]);
 
-        const path = `/v1/integration/${integrationName}/Patient?given:contains=${firstName.slice(
+        const path = `/api/integration/${integrationName}/Patient?given:contains=${firstName.slice(
           1,
           3,
         )}`;
@@ -773,7 +773,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
         ]);
 
         const slicedName = firstName.slice(1, 3);
-        const path = `/v1/integration/${integrationName}/Patient?given:contains=${slicedName}&family=${lastName}&birthdate=${dateOfBirth}`;
+        const path = `/api/integration/${integrationName}/Patient?given:contains=${slicedName}&family=${lastName}&birthdate=${dateOfBirth}`;
         const response = await app.get(path).set(requestHeaders);
 
         expect(response).toHaveSucceeded();
@@ -791,7 +791,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           patientId: patient.id,
         });
         const id = encodeURIComponent(`not-the-right-identifier|${patient.displayId}`);
-        const path = `/v1/integration/${integrationName}/Patient?_sort=id&_page=z&_count=x&subject%3Aidentifier=${id}`;
+        const path = `/api/integration/${integrationName}/Patient?_sort=id&_page=z&_count=x&subject%3Aidentifier=${id}`;
 
         // act
         const response = await app.get(path).set(requestHeaders);
@@ -818,7 +818,7 @@ export function testPatientHandler(integrationName, requestHeaders = {}) {
           ...fake(PatientAdditionalData),
           patientId: patient.id,
         });
-        const path = `/v1/integration/${integrationName}/Patient?whatever=something`;
+        const path = `/api/integration/${integrationName}/Patient?whatever=something`;
 
         // act
         const response = await app.get(path).set(requestHeaders);

--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testSingleResourceHandler.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/testSingleResourceHandler.js
@@ -26,7 +26,7 @@ export function testSingleResourceHandler(integrationName, requestHeaders = {}) 
         });
         await patient.reload();
 
-        const path = `/v1/integration/${integrationName}/Patient/${patient.id}`;
+        const path = `/api/integration/${integrationName}/Patient/${patient.id}`;
         const response = await app.get(path).set(requestHeaders);
         expect(response).toHaveSucceeded();
         expect(response.body).toEqual({
@@ -84,7 +84,7 @@ export function testSingleResourceHandler(integrationName, requestHeaders = {}) 
 
       it('returns a 422 error when the resource does not exist', async () => {
         const nonExistingId = '1234567890';
-        const path = `/v1/integration/${integrationName}/Patient/${nonExistingId}`;
+        const path = `/api/integration/${integrationName}/Patient/${nonExistingId}`;
         const response = await app.get(path).set(requestHeaders);
         expect(response).toHaveRequestError(422);
         expect(response.body).toMatchObject({

--- a/packages/central-server/__tests__/importers/referenceDataImporter.test.js
+++ b/packages/central-server/__tests__/importers/referenceDataImporter.test.js
@@ -281,7 +281,7 @@ describe('Data definition import', () => {
     const { baseApp } = ctx;
     const nonAdminApp = await baseApp.asRole('practitioner');
 
-    const response = await nonAdminApp.post('/v1/admin/importRefData');
+    const response = await nonAdminApp.post('/api/admin/importRefData');
     expect(response).toBeForbidden();
   });
 

--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -338,7 +338,7 @@ describe('fijiAspenMediciReport', () => {
           end,
         )}`;
         const response = await app
-          .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+          .get(`/api/integration/fijiAspenMediciReport?${query}`)
           .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
         expect(response).toHaveSucceeded();
@@ -351,7 +351,7 @@ describe('fijiAspenMediciReport', () => {
         'nonexistant-id',
       ])}`;
       const response = await app
-        .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+        .get(`/api/integration/fijiAspenMediciReport?${query}`)
         .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
       expect(response).toHaveSucceeded();
@@ -364,7 +364,7 @@ describe('fijiAspenMediciReport', () => {
         'nonexistant-id',
       ])}`;
       const response = await app
-        .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+        .get(`/api/integration/fijiAspenMediciReport?${query}`)
         .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
       expect(response).toHaveSucceeded();
@@ -374,7 +374,7 @@ describe('fijiAspenMediciReport', () => {
 
   it('should produce reports without any params', async () => {
     const response = await app
-      .get('/v1/integration/fijiAspenMediciReport')
+      .get('/api/integration/fijiAspenMediciReport')
       .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
     expect(response).toHaveSucceeded();
@@ -388,7 +388,7 @@ describe('fijiAspenMediciReport', () => {
     const isoStringRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/;
     // act
     const response = await app
-      .get('/v1/integration/fijiAspenMediciReport?period.start=2022-05-09&period.end=2022-10-09')
+      .get('/api/integration/fijiAspenMediciReport?period.start=2022-05-09&period.end=2022-10-09')
       .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
     // assert

--- a/packages/central-server/__tests__/integrations/fijiVrs/hook_DELETE.test.js
+++ b/packages/central-server/__tests__/integrations/fijiVrs/hook_DELETE.test.js
@@ -27,7 +27,7 @@ describe('VRS integration - hook - DELETE', () => {
 
     // act
     const response = await app
-      .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+      .post(`/api/integration/fijiVrs/hooks/patientCreated`)
       .send({
         fetch_id: fetchId,
         operation: 'DELETE',
@@ -76,7 +76,7 @@ describe('VRS integration - hook - DELETE', () => {
 
     // act
     const response = await app
-      .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+      .post(`/api/integration/fijiVrs/hooks/patientCreated`)
       .send({
         fetch_id: fetchId,
         operation: 'DELETE',

--- a/packages/central-server/__tests__/integrations/fijiVrs/hook_INSERTandUPDATE.test.js
+++ b/packages/central-server/__tests__/integrations/fijiVrs/hook_INSERTandUPDATE.test.js
@@ -62,7 +62,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
 
         // act
         const response = await app
-          .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+          .post(`/api/integration/fijiVrs/hooks/patientCreated`)
           .send({
             fetch_id: fetchId,
             operation,
@@ -142,7 +142,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
 
       // act
       const response = await app
-        .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+        .post(`/api/integration/fijiVrs/hooks/patientCreated`)
         .send({
           fetch_id: fetchId,
           operation: 'INSERT',
@@ -181,7 +181,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
 
       // act
       const response = await app
-        .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+        .post(`/api/integration/fijiVrs/hooks/patientCreated`)
         .send({
           fetch_id: fetchId,
           operation: 'INSERT',
@@ -228,7 +228,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
 
       // act
       const response = await app
-        .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+        .post(`/api/integration/fijiVrs/hooks/patientCreated`)
         .send({
           fetch_id: fetchId,
           operation: 'INSERT',
@@ -269,7 +269,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
 
       // act
       const response = await app
-        .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+        .post(`/api/integration/fijiVrs/hooks/patientCreated`)
         .send({
           fetch_id: fetchId,
           operation: 'INSERT',
@@ -313,7 +313,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
 
       // act
       const response = await app
-        .post(`/v1/integration/fijiVrs/hooks/patientCreated`)
+        .post(`/api/integration/fijiVrs/hooks/patientCreated`)
         .send({
           fetch_id: fetchId,
           operation: 'INSERT',

--- a/packages/central-server/__tests__/integrations/fijiVrs/vrs_sandbox_hook.js
+++ b/packages/central-server/__tests__/integrations/fijiVrs/vrs_sandbox_hook.js
@@ -58,7 +58,7 @@ app.use('/api', (req, res, next) => {
 
 // step 1. - call the hook
 const callHook = async body => {
-  const url = `${tamanuHost}/v1/public/integration/fijiVrs/hooks/patientCreated`;
+  const url = `${tamanuHost}/api/public/integration/fijiVrs/hooks/patientCreated`;
   const opts = {
     method: 'POST',
     body: JSON.stringify(body),

--- a/packages/central-server/__tests__/integrations/omniLab/auth.test.js
+++ b/packages/central-server/__tests__/integrations/omniLab/auth.test.js
@@ -11,7 +11,7 @@ describe('omniLab auth', () => {
 
   it('does not allow default API keys', async () => {
     const app = await ctx.baseApp.asRole('admin');
-    const request = await app.get('/v1/public/integration/omniLab');
+    const request = await app.get('/api/public/integration/omniLab');
     expect(request).not.toHaveSucceeded();
   });
 
@@ -24,7 +24,7 @@ describe('omniLab auth', () => {
 
     // act
     const request = await app
-      .get('/v1/public/integration/omniLab')
+      .get('/api/public/integration/omniLab')
       .set('Authorization', `Bearer ${token}`);
 
     // assert

--- a/packages/central-server/__tests__/middleware/auth.test.js
+++ b/packages/central-server/__tests__/middleware/auth.test.js
@@ -66,7 +66,7 @@ describe('Auth', () => {
     disableHardcodedPermissionsForSuite();
 
     it('should include role in the data returned by a successful login', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: TEST_ROLE_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -80,7 +80,7 @@ describe('Auth', () => {
 
   describe('Logging in', () => {
     it('Should get a valid access token for correct credentials', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -102,7 +102,7 @@ describe('Auth', () => {
     });
 
     it('Should issue a refresh token and save hashed refreshId to the database', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -134,7 +134,7 @@ describe('Auth', () => {
 
     it('Should not issue a refresh token for external client', async () => {
       const response = await baseApp
-        .post('/v1/login')
+        .post('/api/login')
         .set({ 'X-Tamanu-Client': 'FHIR' })
         .send({
           email: TEST_EMAIL,
@@ -145,7 +145,7 @@ describe('Auth', () => {
     });
 
     it('Should respond with user details with correct credentials', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -161,7 +161,7 @@ describe('Auth', () => {
     });
 
     it('Should return feature flags in the login response', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -176,7 +176,7 @@ describe('Auth', () => {
     });
 
     it('Should reject an empty credential', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: '',
         deviceId: TEST_DEVICE_ID,
@@ -185,7 +185,7 @@ describe('Auth', () => {
     });
 
     it('Should reject an incorrect password', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: 'not the password',
         deviceId: TEST_DEVICE_ID,
@@ -194,7 +194,7 @@ describe('Auth', () => {
     });
 
     it('Should reject a deactivated user', async () => {
-      const response = await baseApp.post('/v1/login').send({
+      const response = await baseApp.post('/api/login').send({
         email: deactivatedUser.email,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -205,7 +205,7 @@ describe('Auth', () => {
 
   describe('Refresh token', () => {
     it('Should return a new access token with expiresAt for a valid refresh token', async () => {
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -216,7 +216,7 @@ describe('Auth', () => {
 
       // Make sure that Date used in signing new token is different from global mock date
       const refreshResponse = await withDate(new Date(Date.now() + 10000), () =>
-        baseApp.post('/v1/refresh').send({
+        baseApp.post('/api/refresh').send({
           refreshToken,
           deviceId: TEST_DEVICE_ID,
         }),
@@ -243,7 +243,7 @@ describe('Auth', () => {
       expect(newTokenContents.exp).toBeGreaterThan(oldTokenContents.exp);
     });
     it('Should return a rotated refresh token', async () => {
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -254,7 +254,7 @@ describe('Auth', () => {
 
       // Make sure that Date used in signing new token is different from global mock date
       const refreshResponse = await withDate(new Date(Date.now() + 10000), () =>
-        baseApp.post('/v1/refresh').send({
+        baseApp.post('/api/refresh').send({
           refreshToken,
           deviceId: TEST_DEVICE_ID,
         }),
@@ -290,14 +290,14 @@ describe('Auth', () => {
       ).resolves.toBe(true);
     });
     it('Should reject if external client', async () => {
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
       });
       expect(loginResponse).toHaveSucceeded();
       const refreshResponse = await baseApp
-        .post('/v1/refresh')
+        .post('/api/refresh')
         .set('X-Tamanu-Client', 'FHIR')
         .send({
           refreshToken: loginResponse.refreshToken,
@@ -306,21 +306,21 @@ describe('Auth', () => {
       expect(refreshResponse).toHaveRequestError();
     });
     it('Should reject invalid refresh token', async () => {
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
       });
       expect(loginResponse).toHaveSucceeded();
 
-      const refreshResponse = await baseApp.post('/v1/refresh').send({
+      const refreshResponse = await baseApp.post('/api/refresh').send({
         refreshToken: 'invalid-token',
         deviceId: TEST_DEVICE_ID,
       });
       expect(refreshResponse).toHaveRequestError();
     });
     it('Should fail if refresh token requested with a token with aud not of refresh', async () => {
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -329,7 +329,7 @@ describe('Auth', () => {
 
       const { token } = loginResponse.body;
 
-      const refreshResponse = await baseApp.post('/v1/refresh').send({
+      const refreshResponse = await baseApp.post('/api/refresh').send({
         // Incorrectly send token instead
         refreshToken: token,
         deviceId: TEST_DEVICE_ID,
@@ -337,7 +337,7 @@ describe('Auth', () => {
       expect(refreshResponse).toHaveRequestError();
     });
     it('Should fail if refresh token requested from different device', async () => {
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: TEST_EMAIL,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -346,7 +346,7 @@ describe('Auth', () => {
 
       const { refreshToken } = loginResponse.body;
 
-      const refreshResponse = await baseApp.post('/v1/refresh').send({
+      const refreshResponse = await baseApp.post('/api/refresh').send({
         refreshToken,
         deviceId: 'different-device',
       });
@@ -359,7 +359,7 @@ describe('Auth', () => {
           password: TEST_PASSWORD,
         }),
       );
-      const loginResponse = await baseApp.post('/v1/login').send({
+      const loginResponse = await baseApp.post('/api/login').send({
         email: freshUser.email,
         password: TEST_PASSWORD,
         deviceId: TEST_DEVICE_ID,
@@ -371,7 +371,7 @@ describe('Auth', () => {
         visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
       });
 
-      const refreshResponse = await baseApp.post('/v1/refresh').send({
+      const refreshResponse = await baseApp.post('/api/refresh').send({
         refreshToken,
         deviceId: TEST_DEVICE_ID,
       });
@@ -386,7 +386,7 @@ describe('Auth', () => {
 
   it('Should answer a whoami request correctly', async () => {
     // first, log in and get token
-    const response = await baseApp.post('/v1/login').send({
+    const response = await baseApp.post('/api/login').send({
       email: TEST_EMAIL,
       password: TEST_PASSWORD,
       deviceId: TEST_DEVICE_ID,
@@ -396,7 +396,7 @@ describe('Auth', () => {
     const { token } = response.body;
 
     // then run the whoami request
-    const whoamiResponse = await baseApp.get('/v1/whoami').set('Authorization', `Bearer ${token}`);
+    const whoamiResponse = await baseApp.get('/api/whoami').set('Authorization', `Bearer ${token}`);
     expect(whoamiResponse).toHaveSucceeded();
 
     const { body } = whoamiResponse;
@@ -406,7 +406,7 @@ describe('Auth', () => {
   });
 
   it('Should send permissions alongside login information', async () => {
-    const response = await baseApp.post('/v1/login').send({
+    const response = await baseApp.post('/api/login').send({
       email: TEST_EMAIL,
       password: TEST_PASSWORD,
       deviceId: TEST_DEVICE_ID,
@@ -419,7 +419,7 @@ describe('Auth', () => {
   describe('Change password', () => {
     describe('Creating a one-time login', () => {
       it('Should create a one-time login for a password reset request', async () => {
-        const response = await baseApp.post('/v1/resetPassword').send({
+        const response = await baseApp.post('/api/resetPassword').send({
           email: TEST_EMAIL,
         });
 
@@ -438,7 +438,7 @@ describe('Auth', () => {
       });
 
       it('Should email the user a one-time login', async () => {
-        await baseApp.post('/v1/resetPassword').send({
+        await baseApp.post('/api/resetPassword').send({
           email: TEST_EMAIL,
         });
         const email = emailService.sendEmail.mock.calls[0][0].text;
@@ -462,7 +462,7 @@ describe('Auth', () => {
 
         await store.models.OneTimeLogin.create({ userId, token, expiresAt: new Date(2077, 1, 1) });
 
-        const response = await baseApp.post('/v1/changePassword').send({
+        const response = await baseApp.post('/api/changePassword').send({
           email: TEST_EMAIL,
           newPassword,
           token,
@@ -484,7 +484,7 @@ describe('Auth', () => {
       });
 
       it('Should reject a password reset if no one-time login exists', async () => {
-        const response = await baseApp.post('/v1/changePassword').send({
+        const response = await baseApp.post('/api/changePassword').send({
           email: TEST_EMAIL,
           newPassword: crypto.randomUUID(),
           token: crypto.randomUUID(),
@@ -503,7 +503,7 @@ describe('Auth', () => {
           usedAt: new Date(2000, 1, 1),
         });
 
-        const response = await baseApp.post('/v1/changePassword').send({
+        const response = await baseApp.post('/api/changePassword').send({
           email: TEST_EMAIL,
           newPassword,
           token,
@@ -522,7 +522,7 @@ describe('Auth', () => {
           expiresAt: new Date(2000, 1, 1),
         });
 
-        const response = await baseApp.post('/v1/changePassword').send({
+        const response = await baseApp.post('/api/changePassword').send({
           email: TEST_EMAIL,
           newPassword,
           token,

--- a/packages/central-server/__tests__/permissions/permissions.test.js
+++ b/packages/central-server/__tests__/permissions/permissions.test.js
@@ -104,7 +104,7 @@ describe('Permissions', () => {
 
     it('should send the list of permissions for a user', async () => {
       const userApp = await ctx.baseApp.asRole('practitioner');
-      const response = await userApp.get('/v1/permissions');
+      const response = await userApp.get('/api/permissions');
       const { permissions } = response.body;
       expect(permissions.some(x => x.verb === 'write' && x.noun === 'EncounterDiagnosis'));
     });

--- a/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
+++ b/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
@@ -20,7 +20,7 @@ describe('SyncQueuedDevice', () => {
   };
 
   const requestSync = async (device, lastSyncedTick = 0, urgent = false) => {
-    const result = await app.post('/v1/sync').send({
+    const result = await app.post('/api/sync').send({
       deviceId: `queue-${device}`,
       facilityId: `facility${device}`,
       lastSyncedTick,

--- a/packages/central-server/app/createApp.js
+++ b/packages/central-server/app/createApp.js
@@ -2,7 +2,6 @@ import bodyParser from 'body-parser';
 import compression from 'compression';
 import config from 'config';
 import express from 'express';
-import path from 'path';
 
 import { getLoggingMiddleware } from '@tamanu/shared/services/logging';
 import { constructPermission } from '@tamanu/shared/permissions/middleware';
@@ -17,6 +16,15 @@ import { loadshedder } from './middleware/loadshedder';
 import { versionCompatibility } from './middleware/versionCompatibility';
 
 import { version } from './serverInfo';
+
+function api(ctx) {
+  const apiRoutes = express.Router();
+  apiRoutes.use('/public', publicRoutes);
+  apiRoutes.use(authModule);
+  apiRoutes.use(constructPermission);
+  apiRoutes.use(buildRoutes(ctx));
+  return apiRoutes;
+}
 
 export function createApp(ctx) {
   const { store, emailService, reportSchemaStores } = ctx;
@@ -50,7 +58,6 @@ export function createApp(ctx) {
     next();
   });
 
-  // TODO: serve index page
   app.get('/$', (req, res) => {
     res.send({
       index: true,
@@ -71,13 +78,4 @@ export function createApp(ctx) {
   app.use(defaultErrorHandler);
 
   return app;
-}
-
-function api(ctx) {
-  const apiRoutes = express.Router();
-  apiRoutes.use('/public', publicRoutes);
-  apiRoutes.use(authModule);
-  apiRoutes.use(constructPermission);
-  apiRoutes.use(buildRoutes(ctx));
-  return apiRoutes;
 }

--- a/packages/central-server/app/createApp.js
+++ b/packages/central-server/app/createApp.js
@@ -57,11 +57,11 @@ export function createApp(ctx) {
     });
   });
 
-  // API v1
-  app.use('/v1/public', publicRoutes);
-  app.use('/v1', authModule);
-  app.use('/v1', constructPermission);
-  app.use('/v1', buildRoutes(ctx));
+  // API
+  app.use('/api', api(ctx));
+
+  // Legacy API endpoint
+  app.use('/v1', api(ctx));
 
   // Dis-allow all other routes
   app.use('*', (req, res) => {
@@ -71,4 +71,13 @@ export function createApp(ctx) {
   app.use(defaultErrorHandler);
 
   return app;
+}
+
+function api(ctx) {
+  const apiRoutes = express.Router();
+  apiRoutes.use('/public', publicRoutes);
+  apiRoutes.use(authModule);
+  apiRoutes.use(constructPermission);
+  apiRoutes.use(buildRoutes(ctx));
+  return apiRoutes;
 }

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -65,7 +65,7 @@
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix
-    // (e.g. the path `/v1/sync/xxx/pull` would match the prefix `/v1/sync/`)
+    // (e.g. the path `/api/sync/xxx/pull` would match the prefix `/api/sync/`)
     //
     // if the path of a request matches a prefix it is added to that queue and
     // may be dropped under heavy load
@@ -77,7 +77,7 @@
       // (defaults to shedding requests for sync or attachments earlier than other requests)
       {
         "name": "low_priority",
-        "prefixes": ["/v1/sync", "/v1/attachment"],
+        "prefixes": ["/api/sync", "/api/attachment"],
         "maxActiveRequests": 4,
         "maxQueuedRequests": 8,
         "queueTimeout": 7500

--- a/packages/central-server/scripts/certificateCommand.js
+++ b/packages/central-server/scripts/certificateCommand.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const prompts = require('prompts');
 const program = require('commander');
 
-const API_VERSION = 'v1';
 let token = null; // Auth token, saved after login
 
 // Required args for all commands
@@ -38,7 +37,7 @@ program.parse();
 async function fetchFromSyncServer(address, endpoint, params = {}) {
   const { headers = {}, body, method = 'GET', ...otherParams } = params;
 
-  const url = `${address}/${API_VERSION}/${endpoint}`;
+  const url = `${address}/api/${endpoint}`;
 
   const response = await fetch(url, {
     method,

--- a/packages/facility-server/__tests__/apiv1/Allergy.test.js
+++ b/packages/facility-server/__tests__/apiv1/Allergy.test.js
@@ -22,7 +22,7 @@ describe('Allergy', () => {
   afterAll(() => ctx.close());
 
   it('should record an allergy', async () => {
-    const result = await app.post('/v1/allergy').send({
+    const result = await app.post('/api/allergy').send({
       allergyId: await randomReferenceId(models, 'allergy'),
       patientId: patient.id,
       practitionerId: await randomUser(models),
@@ -32,7 +32,7 @@ describe('Allergy', () => {
   });
 
   it('should require a valid allergy', async () => {
-    const result = await app.post('/v1/allergy').send({
+    const result = await app.post('/api/allergy').send({
       allergyId: 'invalid id',
       patientId: patient.id,
       practitionerId: await randomUser(models),

--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -21,7 +21,7 @@ describe('Appointments', () => {
   });
   afterAll(() => ctx.close());
   it('should create a new appointment', async () => {
-    const result = await userApp.post('/v1/appointments').send({
+    const result = await userApp.post('/api/appointments').send({
       patientId: patient.id,
       startTime: add(new Date(), { days: 1 }), // create a date in the future
       clinicianId: userApp.user.dataValues.id,
@@ -34,7 +34,7 @@ describe('Appointments', () => {
     expect(result.body.clinicianId).toEqual(userApp.user.dataValues.id);
   });
   it('should list appointments', async () => {
-    const result = await userApp.get('/v1/appointments');
+    const result = await userApp.get('/api/appointments');
     expect(result).toHaveSucceeded();
     expect(result.body.count).toEqual(1);
     // verify that the appointment returned is the one created above
@@ -50,16 +50,16 @@ describe('Appointments', () => {
         where: { id: appointment.id },
       },
     );
-    const result = await userApp.get('/v1/appointments');
+    const result = await userApp.get('/api/appointments');
     expect(result.body.data[0].locationGroup.id).toEqual(locationId);
   });
   it('should cancel an appointment', async () => {
-    const result = await userApp.put(`/v1/appointments/${appointment.id}`).send({
+    const result = await userApp.put(`/api/appointments/${appointment.id}`).send({
       status: APPOINTMENT_STATUSES.CANCELLED,
     });
     expect(result).toHaveSucceeded();
     expect(result.body.status).toEqual(APPOINTMENT_STATUSES.CANCELLED);
-    const getResult = await userApp.get('/v1/appointments');
+    const getResult = await userApp.get('/api/appointments');
     expect(getResult).toHaveSucceeded();
     expect(getResult.body.count).toEqual(1);
     expect(getResult.body.data[0].status).toEqual(APPOINTMENT_STATUSES.CANCELLED);

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -48,7 +48,7 @@ describe('Encounter', () => {
       patientId: patient.id,
     });
 
-    const result = await noPermsApp.get(`/v1/encounter/${encounter.id}`);
+    const result = await noPermsApp.get(`/api/encounter/${encounter.id}`);
     expect(result).toBeForbidden();
   });
 
@@ -59,7 +59,7 @@ describe('Encounter', () => {
       ...(await createDummyEncounter(models)),
       patientId: patient.id,
     });
-    const result = await app.get(`/v1/encounter/${v.id}`);
+    const result = await app.get(`/api/encounter/${v.id}`);
     expect(result).toHaveSucceeded();
     expect(result.body.id).toEqual(v.id);
     expect(result.body.patientId).toEqual(patient.id);
@@ -75,7 +75,7 @@ describe('Encounter', () => {
       patientId: patient.id,
     });
 
-    const result = await app.get(`/v1/patient/${patient.id}/encounters`);
+    const result = await app.get(`/api/patient/${patient.id}/encounters`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toBeGreaterThan(0);
     expect(result.body.data.some(x => x.id === v.id)).toEqual(true);
@@ -92,7 +92,7 @@ describe('Encounter', () => {
   });
 
   it('should fail to get an encounter that does not exist', async () => {
-    const result = await app.get('/v1/encounter/nonexistent');
+    const result = await app.get('/api/encounter/nonexistent');
     expect(result).toHaveRequestError();
   });
 
@@ -106,7 +106,7 @@ describe('Encounter', () => {
       dischargerId: app.user.id,
     });
 
-    const result = await app.get(`/v1/encounter/${encounter.id}/discharge`);
+    const result = await app.get(`/api/encounter/${encounter.id}/discharge`);
 
     expect(result).toHaveSucceeded();
     expect(result.body).toMatchObject({
@@ -145,7 +145,7 @@ describe('Encounter', () => {
       ),
     ]);
 
-    const result = await app.get(`/v1/encounter/${encounter.id}/notes`);
+    const result = await app.get(`/api/encounter/${encounter.id}/notes`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toEqual(3);
     expect(result.body.data.every(x => x.content.match(/^Test \d$/))).toEqual(true);
@@ -163,7 +163,7 @@ describe('Encounter', () => {
       models.Note.createForRecord(encounter.id, 'Encounter', 'admission', 'Test 6'),
     ]);
 
-    const result = await app.get(`/v1/encounter/${encounter.id}/notes?noteType=treatmentPlan`);
+    const result = await app.get(`/api/encounter/${encounter.id}/notes?noteType=treatmentPlan`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toEqual(2);
     expect(result.body.data.every(x => x.noteType === 'treatmentPlan')).toEqual(true);
@@ -216,7 +216,7 @@ describe('Encounter', () => {
       }),
     );
 
-    const result = await app.get(`/v1/encounter/${encounter.id}/notes/${rootNote.id}/changelogs`);
+    const result = await app.get(`/api/encounter/${encounter.id}/notes/${rootNote.id}/changelogs`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toEqual(4);
     expect(result.body.data[0]).toMatchObject({
@@ -270,7 +270,7 @@ describe('Encounter', () => {
         })),
       });
 
-      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests`);
+      const result = await app.get(`/api/encounter/${encounter.id}/labRequests`);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         count: 2,
@@ -323,7 +323,7 @@ describe('Encounter', () => {
         })),
       });
 
-      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests`);
+      const result = await app.get(`/api/encounter/${encounter.id}/labRequests`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(3);
       expect(result.body.data.length).toEqual(3);
@@ -362,7 +362,7 @@ describe('Encounter', () => {
         labRequestId: labRequest1.id,
       });
 
-      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests`);
+      const result = await app.get(`/api/encounter/${encounter.id}/labRequests`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(2);
       expect(result.body.data.length).toEqual(2);
@@ -390,7 +390,7 @@ describe('Encounter', () => {
       });
 
       const result = await app.get(
-        `/v1/encounter/${encounter.id}/labRequests?status=reception_pending`,
+        `/api/encounter/${encounter.id}/labRequests?status=reception_pending`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
@@ -420,7 +420,7 @@ describe('Encounter', () => {
         authorId: app.user.id,
       });
 
-      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests`);
+      const result = await app.get(`/api/encounter/${encounter.id}/labRequests`);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         count: 1,
@@ -450,7 +450,7 @@ describe('Encounter', () => {
         authorId: app.user.id,
       });
 
-      const result = await app.get(`/v1/encounter/${encounter.id}/labRequests?includeNotes=true`);
+      const result = await app.get(`/api/encounter/${encounter.id}/labRequests?includeNotes=true`);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         count: 1,
@@ -504,7 +504,7 @@ describe('Encounter', () => {
       models.DocumentMetadata.create(metadataFour),
     ]);
 
-    const result = await app.get(`/v1/encounter/${encounter.id}/documentMetadata`);
+    const result = await app.get(`/api/encounter/${encounter.id}/documentMetadata`);
     expect(result).toHaveSucceeded();
     expect(result.body).toMatchObject({
       count: 2,
@@ -532,13 +532,13 @@ describe('Encounter', () => {
 
     // Sort by name ASC/DESC (presumably sufficient to test only one field)
     const resultAsc = await app.get(
-      `/v1/encounter/${encounter.id}/documentMetadata?order=asc&orderBy=name`,
+      `/api/encounter/${encounter.id}/documentMetadata?order=asc&orderBy=name`,
     );
     expect(resultAsc).toHaveSucceeded();
     expect(resultAsc.body.data[0].id).toBe(metadataOne.id);
 
     const resultDesc = await app.get(
-      `/v1/encounter/${encounter.id}/documentMetadata?order=desc&orderBy=name`,
+      `/api/encounter/${encounter.id}/documentMetadata?order=desc&orderBy=name`,
     );
     expect(resultDesc).toHaveSucceeded();
     expect(resultDesc.body.data[0].id).toBe(metadataTwo.id);
@@ -561,7 +561,7 @@ describe('Encounter', () => {
     }
     await models.DocumentMetadata.bulkCreate(documents);
     const result = await app.get(
-      `/v1/encounter/${encounter.id}/documentMetadata?page=1&rowsPerPage=10&offset=5`,
+      `/api/encounter/${encounter.id}/documentMetadata?page=1&rowsPerPage=10&offset=5`,
     );
     expect(result).toHaveSucceeded();
     expect(result.body.data.length).toBe(7);
@@ -576,7 +576,7 @@ describe('Encounter', () => {
         reasonForEncounter: 'intact',
       });
 
-      const result = await noPermsApp.put(`/v1/encounter/${encounter.id}`).send({
+      const result = await noPermsApp.put(`/api/encounter/${encounter.id}`).send({
         reasonForEncounter: 'forbidden',
       });
       expect(result).toBeForbidden();
@@ -587,7 +587,7 @@ describe('Encounter', () => {
 
     it('should reject creating a new encounter with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
-      const result = await noPermsApp.post('/v1/encounter').send({
+      const result = await noPermsApp.post('/api/encounter').send({
         ...(await createDummyEncounter(models)),
         patientId: patient.id,
         reasonForEncounter: 'should-not-be-created',
@@ -608,7 +608,7 @@ describe('Encounter', () => {
       // triage happens in Triage.test.js
 
       it('should create a new encounter', async () => {
-        const result = await app.post('/v1/encounter').send({
+        const result = await app.post('/api/encounter').send({
           ...(await createDummyEncounter(models)),
           patientId: patient.id,
         });
@@ -627,7 +627,7 @@ describe('Encounter', () => {
           name: 'Test referral source',
         });
 
-        const result = await app.post('/v1/encounter').send({
+        const result = await app.post('/api/encounter').send({
           ...(await createDummyEncounter(models)),
           patientId: patient.id,
           referralSourceId: referralSource.id,
@@ -646,7 +646,7 @@ describe('Encounter', () => {
           reasonForEncounter: 'before',
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           reasonForEncounter: 'after',
         });
         expect(result).toHaveSucceeded();
@@ -662,7 +662,7 @@ describe('Encounter', () => {
           encounterType: 'triage',
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           encounterType: 'admission',
         });
         expect(result).toHaveSucceeded();
@@ -682,7 +682,7 @@ describe('Encounter', () => {
           encounterType: 'triage',
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           encounterType: 'not-a-real-encounter-type',
         });
         expect(result).toHaveRequestError();
@@ -700,7 +700,7 @@ describe('Encounter', () => {
           departmentId: departments[0].id,
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           departmentId: departments[1].id,
         });
         expect(result).toHaveSucceeded();
@@ -723,7 +723,7 @@ describe('Encounter', () => {
           locationId: fromLocation.id,
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           locationId: toLocation.id,
         });
         expect(result).toHaveSucceeded();
@@ -762,7 +762,7 @@ describe('Encounter', () => {
           patientId: patient.id,
           locationId: location.id,
         });
-        const result = await app.put(`/v1/encounter/${encounter.id}`).send({
+        const result = await app.put(`/api/encounter/${encounter.id}`).send({
           locationId: location2.id,
         });
 
@@ -784,7 +784,7 @@ describe('Encounter', () => {
           examinerId: fromClinician.id,
         });
 
-        const result = await app.put(`/v1/encounter/${existingEncounter.id}`).send({
+        const result = await app.put(`/api/encounter/${existingEncounter.id}`).send({
           examinerId: toClinician.id,
         });
         expect(result).toHaveSucceeded();
@@ -812,7 +812,7 @@ describe('Encounter', () => {
         });
         const endDate = getCurrentDateTimeString();
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           endDate,
           discharge: {
             encounterId: v.id,
@@ -858,7 +858,7 @@ describe('Encounter', () => {
         });
 
         // Mark only one medication for discharge
-        const result = await app.put(`/v1/encounter/${encounter.id}`).send({
+        const result = await app.put(`/api/encounter/${encounter.id}`).send({
           endDate: new Date(),
           discharge: {
             encounterId: encounter.id,
@@ -901,7 +901,7 @@ describe('Encounter', () => {
           patientId: patient.id,
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           locationId: 'invalid-location-id',
         });
 
@@ -920,7 +920,7 @@ describe('Encounter', () => {
           locationId: fromLocation.id,
         });
 
-        const result = await app.put(`/v1/encounter/${v.id}`).send({
+        const result = await app.put(`/api/encounter/${v.id}`).send({
           locationId: toLocation.id,
           encounterType: 'not-a-real-encounter-type',
         });
@@ -957,7 +957,7 @@ describe('Encounter', () => {
       });
 
       it('should record a diagnosis', async () => {
-        const result = await app.post('/v1/diagnosis').send({
+        const result = await app.post('/api/diagnosis').send({
           encounterId: diagnosisEncounter.id,
           diagnosisId: testDiagnosis.id,
         });
@@ -966,7 +966,7 @@ describe('Encounter', () => {
       });
 
       it('should get diagnoses for an encounter', async () => {
-        const result = await app.get(`/v1/encounter/${diagnosisEncounter.id}/diagnoses`);
+        const result = await app.get(`/api/encounter/${diagnosisEncounter.id}/diagnoses`);
         expect(result).toHaveSucceeded();
         const { body } = result;
         expect(body.count).toBeGreaterThan(0);
@@ -974,7 +974,7 @@ describe('Encounter', () => {
       });
 
       it('should get diagnosis reference info when listing encounters', async () => {
-        const result = await app.get(`/v1/encounter/${diagnosisEncounter.id}/diagnoses`);
+        const result = await app.get(`/api/encounter/${diagnosisEncounter.id}/diagnoses`);
         expect(result).toHaveSucceeded();
         const { body } = result;
         expect(body.count).toBeGreaterThan(0);
@@ -1002,7 +1002,7 @@ describe('Encounter', () => {
       });
 
       it('should record a medication', async () => {
-        const result = await app.post('/v1/medication').send({
+        const result = await app.post('/api/medication').send({
           encounterId: medicationEncounter.id,
           medicationId: testMedication.id,
           prescriberId: app.user.id,
@@ -1012,7 +1012,7 @@ describe('Encounter', () => {
       });
 
       it('should get medications for an encounter', async () => {
-        const result = await app.get(`/v1/encounter/${medicationEncounter.id}/medications`);
+        const result = await app.get(`/api/encounter/${medicationEncounter.id}/medications`);
         expect(result).toHaveSucceeded();
         const { body } = result;
         expect(body.count).toBeGreaterThan(0);
@@ -1020,7 +1020,7 @@ describe('Encounter', () => {
       });
 
       it('should get medication reference info when listing encounters', async () => {
-        const result = await app.get(`/v1/encounter/${medicationEncounter.id}/medications`);
+        const result = await app.get(`/api/encounter/${medicationEncounter.id}/medications`);
         expect(result).toHaveSucceeded();
         const { body } = result;
         expect(body.count).toBeGreaterThan(0);
@@ -1083,7 +1083,7 @@ describe('Encounter', () => {
         });
         it('should record a new vitals reading', async () => {
           const submissionDate = getCurrentDateTimeString();
-          const result = await app.post('/v1/surveyResponse').send({
+          const result = await app.post('/api/surveyResponse').send({
             surveyId: 'vitals-survey',
             patientId: vitalsPatient.id,
             startTime: submissionDate,
@@ -1108,14 +1108,14 @@ describe('Encounter', () => {
             'pde-PatientVitalsHeight': 456,
             'pde-PatientVitalsWeight': 789,
           };
-          await app.post('/v1/surveyResponse').send({
+          await app.post('/api/surveyResponse').send({
             surveyId: 'vitals-survey',
             patientId: vitalsPatient.id,
             startTime: submissionDate,
             endTime: submissionDate,
             answers,
           });
-          const result = await app.get(`/v1/encounter/${vitalsEncounter.id}/vitals`);
+          const result = await app.get(`/api/encounter/${vitalsEncounter.id}/vitals`);
           expect(result).toHaveSucceeded();
           const { body } = result;
           expect(body).toHaveProperty('count');
@@ -1178,7 +1178,7 @@ describe('Encounter', () => {
               'pde-PatientVitalsDate': submissionDate,
               [patientVitalSbpKey]: value,
             };
-            await app.post('/v1/surveyResponse').send({
+            await app.post('/api/surveyResponse').send({
               id: responseId,
               surveyId: 'vitals-survey',
               patientId: vitalsPatient.id,
@@ -1223,7 +1223,7 @@ describe('Encounter', () => {
           );
 
           const result = await app.get(
-            `/v1/encounter/${vitalsEncounter.id}/vitals/${patientVitalSbpKey}?startDate=${startDateString}&endDate=${endDateString}`,
+            `/api/encounter/${vitalsEncounter.id}/vitals/${patientVitalSbpKey}?startDate=${startDateString}&endDate=${endDateString}`,
           );
           expect(result).toHaveSucceeded();
           const { body } = result;
@@ -1253,7 +1253,7 @@ describe('Encounter', () => {
           const startDateString = answers[0].submissionDate;
           const endDateString = formatISO9075(new Date());
           const result = await app.get(
-            `/v1/encounter/${vitalsEncounter.id}/vitals/${patientVitalSbpKey}?startDate=${startDateString}&endDate=${endDateString}`,
+            `/api/encounter/${vitalsEncounter.id}/vitals/${patientVitalSbpKey}?startDate=${startDateString}&endDate=${endDateString}`,
           );
           expect(result).toHaveSucceeded();
           const { body } = result;
@@ -1275,7 +1275,7 @@ describe('Encounter', () => {
 
     describe('document metadata', () => {
       it('should fail creating a document metadata if the encounter ID does not exist', async () => {
-        const result = await app.post('/v1/encounter/123456789/documentMetadata').send({
+        const result = await app.post('/api/encounter/123456789/documentMetadata').send({
           name: 'test document',
           documentOwner: 'someone',
           note: 'some note',
@@ -1296,7 +1296,7 @@ describe('Encounter', () => {
           attachmentId: '123456789',
         }));
 
-        const result = await app.post(`/v1/encounter/${encounter.id}/documentMetadata`).send({
+        const result = await app.post(`/api/encounter/${encounter.id}/documentMetadata`).send({
           name: 'test document',
           type: 'application/pdf',
           source: DOCUMENT_SOURCES.PATIENT_LETTER,
@@ -1341,7 +1341,7 @@ describe('Encounter', () => {
 
         // act
         const result = await app.get(
-          `/v1/encounter/${encodeURIComponent(encounter.id)}/imagingRequests`,
+          `/api/encounter/${encodeURIComponent(encounter.id)}/imagingRequests`,
         );
 
         // assert
@@ -1389,7 +1389,7 @@ describe('Encounter', () => {
 
         // act
         const result = await app.get(
-          `/v1/encounter/${encodeURIComponent(
+          `/api/encounter/${encodeURIComponent(
             encounter.id,
           )}/imagingRequests?orderBy=requestedBy.displayName&order=asc`,
         );
@@ -1409,7 +1409,7 @@ describe('Encounter', () => {
     describe('encounter history', () => {
       describe('single change', () => {
         it('should record an encounter history when an encounter is created', async () => {
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
           });
@@ -1438,7 +1438,7 @@ describe('Encounter', () => {
         it('should record an encounter history for a location change', async () => {
           const [oldLocation, newLocation] = await models.Location.findAll({ limit: 2 });
           const submittedTime = getCurrentDateTimeString();
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
             locationId: oldLocation.id,
@@ -1447,7 +1447,7 @@ describe('Encounter', () => {
           expect(result).toHaveSucceeded();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
-          const updateResult = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult = await app.put(`/api/encounter/${encounter.id}`).send({
             locationId: newLocation.id,
             submittedTime,
           });
@@ -1486,7 +1486,7 @@ describe('Encounter', () => {
         it('should record an encounter history for a department change', async () => {
           const [oldDepartment, newDepartment] = await models.Department.findAll({ limit: 2 });
           const submittedTime = getCurrentDateTimeString();
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
             departmentId: oldDepartment.id,
@@ -1495,7 +1495,7 @@ describe('Encounter', () => {
           expect(result).toHaveSucceeded();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
-          const updateResult = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult = await app.put(`/api/encounter/${encounter.id}`).send({
             departmentId: newDepartment.id,
             submittedTime,
           });
@@ -1534,7 +1534,7 @@ describe('Encounter', () => {
           const [oldClinician, newClinician] = await models.User.findAll({ limit: 2 });
           const submittedTime = getCurrentDateTimeString();
 
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
             examinerId: oldClinician.id,
@@ -1543,7 +1543,7 @@ describe('Encounter', () => {
           expect(result).toHaveSucceeded();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
-          const updateResult = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult = await app.put(`/api/encounter/${encounter.id}`).send({
             examinerId: newClinician.id,
             submittedTime,
           });
@@ -1583,7 +1583,7 @@ describe('Encounter', () => {
           const newEncounterType = 'clinic';
           const submittedTime = getCurrentDateTimeString();
 
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
             encounterType: oldEncounterType,
@@ -1592,7 +1592,7 @@ describe('Encounter', () => {
           expect(result).toHaveSucceeded();
           const encounter = await models.Encounter.findByPk(result.body.id);
 
-          const updateResult = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult = await app.put(`/api/encounter/${encounter.id}`).send({
             encounterType: newEncounterType,
             submittedTime,
           });
@@ -1634,7 +1634,7 @@ describe('Encounter', () => {
           const [oldDepartment, newDepartment] = await models.Department.findAll({ limit: 2 });
           const [oldClinician, newClinician] = await models.User.findAll({ limit: 2 });
 
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
             examinerId: oldClinician.id,
@@ -1647,7 +1647,7 @@ describe('Encounter', () => {
 
           const locationChangeSubmittedTime = getCurrentDateTimeString();
 
-          const updateResult = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult = await app.put(`/api/encounter/${encounter.id}`).send({
             locationId: newLocation.id,
             submittedTime: locationChangeSubmittedTime,
           });
@@ -1679,7 +1679,7 @@ describe('Encounter', () => {
           });
 
           const departmentChangeSubmittedTime = getCurrentDateTimeString();
-          const updateResult2 = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult2 = await app.put(`/api/encounter/${encounter.id}`).send({
             departmentId: newDepartment.id,
             submittedTime: departmentChangeSubmittedTime,
           });
@@ -1725,7 +1725,7 @@ describe('Encounter', () => {
           });
 
           const clinicianChangeSubmittedTime = getCurrentDateTimeString();
-          const updateResult3 = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult3 = await app.put(`/api/encounter/${encounter.id}`).send({
             examinerId: newClinician.id,
             submittedTime: clinicianChangeSubmittedTime,
           });
@@ -1788,7 +1788,7 @@ describe('Encounter', () => {
           const [oldDepartment, newDepartment] = await models.Department.findAll({ limit: 2 });
           const [clinician] = await models.User.findAll({ limit: 1 });
 
-          const result = await app.post('/v1/encounter').send({
+          const result = await app.post('/api/encounter').send({
             ...(await createDummyEncounter(models)),
             patientId: patient.id,
             examinerId: clinician.id,
@@ -1800,7 +1800,7 @@ describe('Encounter', () => {
           const encounter = await models.Encounter.findByPk(result.body.id);
 
           const locationChangeSubmittedTime = getCurrentDateTimeString();
-          const updateResult = await app.put(`/v1/encounter/${encounter.id}`).send({
+          const updateResult = await app.put(`/api/encounter/${encounter.id}`).send({
             locationId: newLocation.id, // update new location
             departmentId: newDepartment.id, // update new department
             examinerId: clinician.id,
@@ -1856,7 +1856,7 @@ describe('Encounter', () => {
           locationId: location.id,
         });
 
-        const result = await app.put(`/v1/encounter/${encounter.id}`).send({
+        const result = await app.put(`/api/encounter/${encounter.id}`).send({
           plannedLocationId: plannedLocation.id,
           submittedTime,
         });
@@ -1876,7 +1876,7 @@ describe('Encounter', () => {
           submittedTime: getCurrentDateTimeString(),
         });
 
-        const result = await app.put(`/v1/encounter/${encounter.id}`).send({
+        const result = await app.put(`/api/encounter/${encounter.id}`).send({
           plannedLocationId: null,
         });
         expect(result).toHaveSucceeded();
@@ -1895,7 +1895,7 @@ describe('Encounter', () => {
           submittedTime: getCurrentDateTimeString(),
         });
 
-        const result = await app.put(`/v1/encounter/${encounter.id}`).send({
+        const result = await app.put(`/api/encounter/${encounter.id}`).send({
           locationId: plannedLocation.id,
         });
         expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/FamilyHistory.test.js
+++ b/packages/facility-server/__tests__/apiv1/FamilyHistory.test.js
@@ -23,7 +23,7 @@ describe('Family history', () => {
   afterAll(() => ctx.close());
 
   it('should record family history', async () => {
-    const result = await app.post('/v1/familyHistory').send({
+    const result = await app.post('/api/familyHistory').send({
       diagnosisId: await randomReferenceId(models, 'icd10'),
       patientId: patient.id,
       practitionerId: await randomUser(models),
@@ -34,7 +34,7 @@ describe('Family history', () => {
   });
 
   it('should require a valid diagnosis', async () => {
-    const result = await app.post('/v1/familyHistory').send({
+    const result = await app.post('/api/familyHistory').send({
       diagnosisId: 'invalid id',
       patientId: patient.id,
       practitionerId: await randomUser(models),

--- a/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
@@ -36,7 +36,7 @@ describe('Imaging requests', () => {
 
   describe('Creating an imaging request', () => {
     it('should record an imaging request', async () => {
-      const result = await app.post('/v1/imagingRequest').send({
+      const result = await app.post('/api/imagingRequest').send({
         encounterId: encounter.id,
         imagingType: IMAGING_TYPES.CT_SCAN,
         requestedById: app.user.id,
@@ -46,7 +46,7 @@ describe('Imaging requests', () => {
     });
 
     it('should require a valid status', async () => {
-      const result = await app.post('/v1/imagingRequest').send({
+      const result = await app.post('/api/imagingRequest').send({
         encounterId: encounter.id,
         status: 'invalid',
         imagingType: IMAGING_TYPES.CT_SCAN,
@@ -56,7 +56,7 @@ describe('Imaging requests', () => {
     });
 
     it('should require a valid status', async () => {
-      const result = await app.post('/v1/imagingRequest').send({
+      const result = await app.post('/api/imagingRequest').send({
         encounterId: encounter.id,
         status: 'invalid',
         imagingType: IMAGING_TYPES.CT_SCAN,
@@ -72,7 +72,7 @@ describe('Imaging requests', () => {
       imagingType: IMAGING_TYPES.CT_SCAN,
       requestedById: app.user.id,
     });
-    const result = await app.get(`/v1/encounter/${encounter.id}/imagingRequests`);
+    const result = await app.get(`/api/encounter/${encounter.id}/imagingRequests`);
     expect(result).toHaveSucceeded();
 
     const { body } = result;
@@ -107,7 +107,7 @@ describe('Imaging requests', () => {
         app.user.id,
       );
 
-      const result = await app.get(`/v1/imagingRequest/${createdImagingRequest.id}`);
+      const result = await app.get(`/api/imagingRequest/${createdImagingRequest.id}`);
 
       expect(result).toHaveSucceeded();
 
@@ -140,7 +140,7 @@ describe('Imaging requests', () => {
 
       // Act
       const result = await app.get(
-        `/v1/encounter/${encounter.id}/imagingRequests?includeNotes=true`,
+        `/api/encounter/${encounter.id}/imagingRequests?includeNotes=true`,
       );
 
       // Assert
@@ -166,7 +166,7 @@ describe('Imaging requests', () => {
         requestedById: app.user.id,
         imagingType: IMAGING_TYPES.CT_SCAN,
       });
-      const result = await app.get(`/v1/encounter/${encounter.id}/imagingRequests`);
+      const result = await app.get(`/api/encounter/${encounter.id}/imagingRequests`);
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body.count).toBeGreaterThan(0);
@@ -176,7 +176,7 @@ describe('Imaging requests', () => {
     });
 
     it('should return note content when providing note or areaNote', async () => {
-      const result = await app.post('/v1/imagingRequest').send({
+      const result = await app.post('/api/imagingRequest').send({
         encounterId: encounter.id,
         imagingType: IMAGING_TYPES.CT_SCAN,
         requestedById: app.user.id,
@@ -191,7 +191,7 @@ describe('Imaging requests', () => {
 
   describe('Area listing', () => {
     it('should return areas to be imaged', async () => {
-      const result = await app.get('/v1/imagingRequest/areas');
+      const result = await app.get('/api/imagingRequest/areas');
       expect(result).toHaveSucceeded();
       const { body } = result;
       const expectedAreas = expect.arrayContaining([
@@ -216,7 +216,7 @@ describe('Imaging requests', () => {
         }),
       );
 
-      const result = await app.get('/v1/imagingRequest/areas');
+      const result = await app.get('/api/imagingRequest/areas');
       expect(result).toHaveSucceeded();
       const { body } = result;
 
@@ -248,7 +248,7 @@ describe('Imaging requests', () => {
     });
 
     // act
-    const result = await app.get(`/v1/imagingRequest/${ir.id}`);
+    const result = await app.get(`/api/imagingRequest/${ir.id}`);
 
     // assert
     expect(result).toHaveSucceeded();
@@ -272,7 +272,7 @@ describe('Imaging requests', () => {
     });
 
     // act
-    const result = await app.put(`/v1/imagingRequest/${ir.id}`).send({
+    const result = await app.put(`/api/imagingRequest/${ir.id}`).send({
       status: 'completed',
       newResult: {
         description: 'new result description',
@@ -300,7 +300,7 @@ describe('Imaging requests', () => {
     });
 
     // act
-    const result1 = await app.put(`/v1/imagingRequest/${ir.id}`).send({
+    const result1 = await app.put(`/api/imagingRequest/${ir.id}`).send({
       status: 'completed',
       newResult: {
         description: 'new result description 1',
@@ -308,7 +308,7 @@ describe('Imaging requests', () => {
         completedById: app.user.dataValues.id,
       },
     });
-    const result2 = await app.put(`/v1/imagingRequest/${ir.id}`).send({
+    const result2 = await app.put(`/api/imagingRequest/${ir.id}`).send({
       status: 'completed',
       newResult: {
         description: 'new result description 2',
@@ -339,7 +339,7 @@ describe('Imaging requests', () => {
 
     const newResultDate = getCurrentDateTimeString();
     // act
-    const result1 = await app.put(`/v1/imagingRequest/${ir.id}`).send({
+    const result1 = await app.put(`/api/imagingRequest/${ir.id}`).send({
       status: 'completed',
       newResult: {
         completedAt: newResultDate,
@@ -383,7 +383,7 @@ describe('Imaging requests', () => {
     });
 
     // act
-    const result = await app.get(`/v1/imagingRequest/${ir.id}`);
+    const result = await app.get(`/api/imagingRequest/${ir.id}`);
 
     // reset settings
     await models.Setting.set('integrations.imaging', settings);
@@ -450,7 +450,7 @@ describe('Imaging requests', () => {
       });
 
       it('should omit external requests when allFacilities is false', async () => {
-        const result = await app.get(`/v1/imagingRequest?allFacilities=false`);
+        const result = await app.get(`/api/imagingRequest?allFacilities=false`);
         expect(result).toHaveSucceeded();
         result.body.data.forEach(ir => {
           expect(ir.encounter.location.facilityId).toBe(config.serverFacilityId);
@@ -458,7 +458,7 @@ describe('Imaging requests', () => {
       });
 
       it('should include all requests when allFacilities is true', async () => {
-        const result = await app.get(`/v1/imagingRequest?allFacilities=true`);
+        const result = await app.get(`/api/imagingRequest?allFacilities=true`);
         expect(result).toHaveSucceeded();
 
         const hasConfigFacility = result.body.data.some(
@@ -474,7 +474,7 @@ describe('Imaging requests', () => {
 
       it('Completed tab should only show completed imaging requests', async () => {
         const result = await app.get(
-          `/v1/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}`,
+          `/api/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}`,
         );
         expect(result).toHaveSucceeded();
         result.body.data.forEach(ir => {
@@ -508,7 +508,7 @@ describe('Imaging requests', () => {
 
       it('Should paginate correctly', async () => {
         const getPage = async page => {
-          const result = await app.get(`/v1/imagingRequest?page=${page}`);
+          const result = await app.get(`/api/imagingRequest?page=${page}`);
           expect(result).toHaveSucceeded();
           return result;
         };
@@ -531,7 +531,7 @@ describe('Imaging requests', () => {
       it('Should paginate correctly when sorting by completedAt', async () => {
         const getPage = async page => {
           const result = await app.get(
-            `/v1/imagingRequest?orderBy=completedAt&page=${page}&order=DESC`,
+            `/api/imagingRequest?orderBy=completedAt&page=${page}&order=DESC`,
           );
           expect(result).toHaveSucceeded();
           return result;
@@ -568,7 +568,7 @@ describe('Imaging requests', () => {
       it('Should paginate correctly when sorting by completedAt and filtering by status', async () => {
         const getPage = async page => {
           const result = await app.get(
-            `/v1/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}&orderBy=completedAt&page=${page}&order=ASC`,
+            `/api/imagingRequest?status=${IMAGING_REQUEST_STATUS_TYPES.COMPLETED}&orderBy=completedAt&page=${page}&order=ASC`,
           );
           expect(result).toHaveSucceeded();
           return result;

--- a/packages/facility-server/__tests__/apiv1/LabRequestLogs.test.js
+++ b/packages/facility-server/__tests__/apiv1/LabRequestLogs.test.js
@@ -25,7 +25,7 @@ describe('Lab request logs', () => {
       await randomLabRequest(models, { patientId }),
     );
     const status = LAB_REQUEST_STATUSES.TO_BE_VERIFIED;
-    const response = await app.put(`/v1/labRequest/${requestId}`).send({ status });
+    const response = await app.put(`/api/labRequest/${requestId}`).send({ status });
     expect(response).toHaveRequestError();
 
     // Errored request should not have updated status
@@ -34,13 +34,13 @@ describe('Lab request logs', () => {
   });
 
   it('should create a lab request log when updating a labs status', async () => {
-    const user = await app.get('/v1/user/me');
+    const user = await app.get('/api/user/me');
     const { id: requestId } = await models.LabRequest.createWithTests(
       await randomLabRequest(models, { patientId }),
     );
     const status = LAB_REQUEST_STATUSES.TO_BE_VERIFIED;
     const userId = user.body.id;
-    const response = await app.put(`/v1/labRequest/${requestId}`).send({ status, userId });
+    const response = await app.put(`/api/labRequest/${requestId}`).send({ status, userId });
     expect(response).toHaveSucceeded();
 
     const labRequest = await models.LabRequest.findByPk(requestId);
@@ -62,7 +62,7 @@ describe('Lab request logs', () => {
     const { id: requestId } = await models.LabRequest.createWithTests(
       await randomLabRequest(models, { patientId }),
     );
-    const response = await app.put(`/v1/labRequest/${requestId}`).send({ urgent: true });
+    const response = await app.put(`/api/labRequest/${requestId}`).send({ urgent: true });
     expect(response).toHaveSucceeded();
 
     const labRequestLog = await models.LabRequestLog.findAll({

--- a/packages/facility-server/__tests__/apiv1/Labs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Labs.test.js
@@ -30,7 +30,7 @@ describe('Labs', () => {
     const labRequest = await randomLabRequest(models, {
       patientId,
     });
-    const response = await app.post('/v1/labRequest').send(labRequest);
+    const response = await app.post('/api/labRequest').send(labRequest);
     expect(response).toHaveSucceeded();
 
     const createdRequest = await models.LabRequest.findByPk(response.body[0].id);
@@ -67,7 +67,7 @@ describe('Labs', () => {
       categoryId: category2,
     });
 
-    const response = await app.post('/v1/labRequest').send({
+    const response = await app.post('/api/labRequest').send({
       ...labRequest,
       labTestTypeIds: [...labRequest.labTestTypeIds, ...labRequest2.labTestTypeIds],
     });
@@ -109,7 +109,7 @@ describe('Labs', () => {
       categoryId: category1,
     });
     const labTestTypeIds = [...labRequest.labTestTypeIds, ...labRequest2.labTestTypeIds];
-    const response = await app.post('/v1/labRequest').send({
+    const response = await app.post('/api/labRequest').send({
       ...labRequest,
       labTestTypeIds,
     });
@@ -130,7 +130,7 @@ describe('Labs', () => {
     });
     const content = chance.string();
 
-    const response = await app.post('/v1/labRequest').send({
+    const response = await app.post('/api/labRequest').send({
       ...data,
       note: {
         date: chance.date(),
@@ -154,7 +154,7 @@ describe('Labs', () => {
     });
     const content = chance.string();
 
-    const response = await app.post('/v1/labRequest').send({
+    const response = await app.post('/api/labRequest').send({
       ...data,
       note: {
         date: chance.date(),
@@ -186,7 +186,7 @@ describe('Labs', () => {
     });
 
     const response = await app
-      .post('/v1/labRequest')
+      .post('/api/labRequest')
       .send({ panelIds: [labTestPanel.id], encounterId: encounter.id });
 
     expect(response).toHaveSucceeded();
@@ -226,7 +226,7 @@ describe('Labs', () => {
         sampleTime,
       },
     };
-    const response = await app.post('/v1/labRequest').send({
+    const response = await app.post('/api/labRequest').send({
       panelIds: [labTestPanel.id],
       encounterId: encounter.id,
       sampleDetails,
@@ -256,7 +256,7 @@ describe('Labs', () => {
 
   it('should not record a lab request with an invalid testTypeId', async () => {
     const labTestTypeIds = ['invalid-test-type-id', 'another-invalid-test-type-id'];
-    const response = await app.post('/v1/labRequest').send({
+    const response = await app.post('/api/labRequest').send({
       patientId,
       labTestTypeIds,
     });
@@ -273,9 +273,9 @@ describe('Labs', () => {
       await randomLabRequest(models, { patientId }),
     );
     const status = LAB_REQUEST_STATUSES.TO_BE_VERIFIED;
-    const user = await app.get('/v1/user/me');
+    const user = await app.get('/api/user/me');
     const response = await app
-      .put(`/v1/labRequest/${requestId}`)
+      .put(`/api/labRequest/${requestId}`)
       .send({ status, userId: user.body.id });
     expect(response).toHaveSucceeded();
 
@@ -288,9 +288,9 @@ describe('Labs', () => {
       await randomLabRequest(models, { patientId }),
     );
     const status = LAB_REQUEST_STATUSES.PUBLISHED;
-    const user = await app.get('/v1/user/me');
+    const user = await app.get('/api/user/me');
     const response = await app
-      .put(`/v1/labRequest/${requestId}`)
+      .put(`/api/labRequest/${requestId}`)
       .send({ status, userId: user.body.id });
     expect(response).toHaveSucceeded();
 
@@ -324,7 +324,7 @@ describe('Labs', () => {
     await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.HISTORICAL);
     await makeLabTestType(LAB_TEST_TYPE_VISIBILITY_STATUSES.HISTORICAL);
 
-    const result = await app.get('/v1/labTestType');
+    const result = await app.get('/api/labTestType');
     expect(result).toHaveSucceeded();
     const { body } = result;
     expect(body.length).toBe(3);
@@ -339,7 +339,7 @@ describe('Labs', () => {
       code: 'historical-test-panel',
       visibilityStatus: 'historical',
     });
-    const result = await app.get('/v1/labTestPanel');
+    const result = await app.get('/api/labTestPanel');
     expect(result).toHaveSucceeded();
     const { body } = result;
 
@@ -363,7 +363,7 @@ describe('Labs', () => {
         const [test1, test2] = await labRequest.getTests();
         const mockResult = 'Mock result';
         const mockVerification = 'verified';
-        const response = await app.put(`/v1/labRequest/${labRequest.id}/tests`).send({
+        const response = await app.put(`/api/labRequest/${labRequest.id}/tests`).send({
           [test1.id]: {
             result: mockResult,
             verification: mockVerification,
@@ -389,7 +389,7 @@ describe('Labs', () => {
         const mockVerification = 'verified';
         const mockResult2 = 'Mock result2';
         const mockVerification2 = 'also verified';
-        const response = await app.put(`/v1/labRequest/${labRequest.id}/tests`).send({
+        const response = await app.put(`/api/labRequest/${labRequest.id}/tests`).send({
           [test1.id]: {
             result: mockResult,
             verification: mockVerification,
@@ -413,7 +413,7 @@ describe('Labs', () => {
         const [test1] = await labRequest.getTests();
         const mockResult = 'Mock result';
         const mockVerification = 'verified';
-        const response = await app.put(`/v1/labRequest/${labRequest.id}/tests`).send({
+        const response = await app.put(`/api/labRequest/${labRequest.id}/tests`).send({
           [test1.id]: {
             result: mockResult,
             verification: mockVerification,
@@ -470,7 +470,7 @@ describe('Labs', () => {
     });
 
     it('should omit external requests when allFacilities is false', async () => {
-      const result = await app.get(`/v1/labRequest?allFacilities=false`);
+      const result = await app.get(`/api/labRequest?allFacilities=false`);
       expect(result).toHaveSucceeded();
       result.body.data.forEach(lr => {
         expect(lr.facilityId).toBe(config.serverFacilityId);
@@ -478,7 +478,7 @@ describe('Labs', () => {
     });
 
     it('should include all requests when allFacilities  is true', async () => {
-      const result = await app.get(`/v1/labRequest?allFacilities=true`);
+      const result = await app.get(`/api/labRequest?allFacilities=true`);
       expect(result).toHaveSucceeded();
 
       const hasConfigFacility = result.body.data.some(

--- a/packages/facility-server/__tests__/apiv1/LocationGroup.test.js
+++ b/packages/facility-server/__tests__/apiv1/LocationGroup.test.js
@@ -117,7 +117,7 @@ describe('Location groups', () => {
         date: getDateTimeSubtractedFromNow(1),
       });
 
-      const result = await app.get(`/v1/locationGroup/${group.id}/handoverNotes`);
+      const result = await app.get(`/api/locationGroup/${group.id}/handoverNotes`);
       expect(result).toHaveSucceeded();
       expect(result.body.data).toHaveLength(1);
       expect(result.body.data[0]).toMatchObject({
@@ -151,7 +151,7 @@ describe('Location groups', () => {
         date: getDateTimeSubtractedFromNow(1),
       });
 
-      const result = await app.get(`/v1/locationGroup/${group.id}/handoverNotes`);
+      const result = await app.get(`/api/locationGroup/${group.id}/handoverNotes`);
       expect(result).toHaveSucceeded();
       expect(result.body.data).toHaveLength(1);
       expect(result.body.data[0]).toMatchObject({

--- a/packages/facility-server/__tests__/apiv1/OngoingCondition.test.js
+++ b/packages/facility-server/__tests__/apiv1/OngoingCondition.test.js
@@ -18,7 +18,7 @@ describe('Ongoing conditions', () => {
   afterAll(() => ctx.close());
 
   it('should record an ongoing condition', async () => {
-    const result = await app.post('/v1/ongoingCondition').send({
+    const result = await app.post('/api/ongoingCondition').send({
       conditionId: await randomReferenceId(models, 'icd10'),
       patientId: patient.id,
       examinerId: await randomUser(models),
@@ -40,13 +40,13 @@ describe('Ongoing conditions', () => {
       resolutionNote: 'Resolution Note',
     };
 
-    const result = await app.post('/v1/ongoingCondition').send(dummyFormObject);
+    const result = await app.post('/api/ongoingCondition').send(dummyFormObject);
 
     expect(result.body).toMatchObject(dummyFormObject);
   });
 
   it('should require a valid diagnosis', async () => {
-    const result = await app.post('/v1/ongoingCondition').send({
+    const result = await app.post('/api/ongoingCondition').send({
       conditionId: 'invalid id',
       patientId: patient.id,
       practitionerId: await randomUser(models),

--- a/packages/facility-server/__tests__/apiv1/Patient.relations.test.js
+++ b/packages/facility-server/__tests__/apiv1/Patient.relations.test.js
@@ -86,7 +86,7 @@ describe('Patient relations', () => {
   describe('programResponses', () => {
     it('should return empty list if no programResponses', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
-      const response = await app.get(`/v1/patient/${patient.id}/programResponses`);
+      const response = await app.get(`/api/patient/${patient.id}/programResponses`);
       expect(response.body).toEqual({ count: 0, data: [] });
     });
 
@@ -94,7 +94,7 @@ describe('Patient relations', () => {
       const { patient } = await setupSurvey({
         surveyName: 'test-survey-name',
       });
-      const response = await app.get(`/v1/patient/${patient.id}/programResponses`);
+      const response = await app.get(`/api/patient/${patient.id}/programResponses`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(1);
       expect(response.body.data).toHaveLength(1);
@@ -113,7 +113,7 @@ describe('Patient relations', () => {
         endTime: '2019-01-02 00:00:00',
         patientId: patient.id,
       });
-      const response = await app.get(`/v1/patient/${patient.id}/programResponses`);
+      const response = await app.get(`/api/patient/${patient.id}/programResponses`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(3);
       expect(response.body.data).toHaveLength(3);
@@ -137,7 +137,7 @@ describe('Patient relations', () => {
         patientId: patient.id,
       });
       const response = await app.get(
-        `/v1/patient/${patient.id}/programResponses?orderBy=surveyName&order=asc`,
+        `/api/patient/${patient.id}/programResponses?orderBy=surveyName&order=asc`,
       );
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(3);
@@ -153,13 +153,13 @@ describe('Patient relations', () => {
   describe('referrals', () => {
     it('should return empty list if no referrals', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
-      const response = await app.get(`/v1/patient/${patient.id}/referrals`);
+      const response = await app.get(`/api/patient/${patient.id}/referrals`);
       expect(response.body).toEqual({ count: 0, data: [] });
     });
 
     it('should return list of referrals', async () => {
       const { patient, referral } = await setupSurvey({ withReferral: true });
-      const response = await app.get(`/v1/patient/${patient.id}/referrals`);
+      const response = await app.get(`/api/patient/${patient.id}/referrals`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(1);
       expect(response.body.data).toHaveLength(1);
@@ -171,7 +171,7 @@ describe('Patient relations', () => {
         submissionDate: '2020-01-01',
       });
 
-      const response = await app.get(`/v1/patient/${patient.id}/referrals`);
+      const response = await app.get(`/api/patient/${patient.id}/referrals`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(1);
       expect(response.body.data).toHaveLength(1);
@@ -184,7 +184,7 @@ describe('Patient relations', () => {
       const { patient, surveyResponse, referral } = await setupSurvey({
         withReferral: true,
       });
-      const response = await app.get(`/v1/patient/${patient.id}/referrals`);
+      const response = await app.get(`/api/patient/${patient.id}/referrals`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(1);
       expect(response.body.data).toHaveLength(1);
@@ -206,7 +206,7 @@ describe('Patient relations', () => {
         submissionDate: '2019-01-02',
         patientId: patient.id,
       });
-      const response = await app.get(`/v1/patient/${patient.id}/referrals`);
+      const response = await app.get(`/api/patient/${patient.id}/referrals`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(3);
       expect(response.body.data).toHaveLength(3);
@@ -232,7 +232,7 @@ describe('Patient relations', () => {
         patientId: patient.id,
       });
       const response = await app.get(
-        `/v1/patient/${patient.id}/referrals?orderBy=referralType&order=asc`,
+        `/api/patient/${patient.id}/referrals?orderBy=referralType&order=asc`,
       );
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(3);
@@ -249,7 +249,7 @@ describe('Patient relations', () => {
     it('should get an empty list of patient issues', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
 
-      const result = await app.get(`/v1/patient/${patient.id}/issues`);
+      const result = await app.get(`/api/patient/${patient.id}/issues`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(0);
     });
@@ -274,7 +274,7 @@ describe('Patient relations', () => {
         type: 'issue',
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/issues`);
+      const result = await app.get(`/api/patient/${patient.id}/issues`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(2);
       expect(result.body.data.every(x => x.note.includes('include'))).toEqual(true);
@@ -285,7 +285,7 @@ describe('Patient relations', () => {
     it('should get an empty list of patient allergies', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
 
-      const result = await app.get(`/v1/patient/${patient.id}/allergies`);
+      const result = await app.get(`/api/patient/${patient.id}/allergies`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(0);
     });
@@ -310,7 +310,7 @@ describe('Patient relations', () => {
         note: 'fail',
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/allergies`);
+      const result = await app.get(`/api/patient/${patient.id}/allergies`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(2);
       expect(result.body.data.every(x => x.note.includes('include'))).toEqual(true);
@@ -324,7 +324,7 @@ describe('Patient relations', () => {
         patientId: patient.id,
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/allergies`);
+      const result = await app.get(`/api/patient/${patient.id}/allergies`);
       expect(result).toHaveSucceeded();
       expect(result.body.data[0].allergy).toHaveProperty('name');
     });
@@ -334,7 +334,7 @@ describe('Patient relations', () => {
     it('should get an empty list of history items', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
 
-      const result = await app.get(`/v1/patient/${patient.id}/familyHistory`);
+      const result = await app.get(`/api/patient/${patient.id}/familyHistory`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(0);
     });
@@ -359,7 +359,7 @@ describe('Patient relations', () => {
         note: 'fail',
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/familyHistory`);
+      const result = await app.get(`/api/patient/${patient.id}/familyHistory`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(2);
       expect(result.body.data.every(x => x.note.includes('include'))).toEqual(true);
@@ -373,7 +373,7 @@ describe('Patient relations', () => {
         patientId: patient.id,
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/familyHistory`);
+      const result = await app.get(`/api/patient/${patient.id}/familyHistory`);
       expect(result).toHaveSucceeded();
       expect(result.body.data[0].diagnosis).toHaveProperty('name');
     });
@@ -383,7 +383,7 @@ describe('Patient relations', () => {
     it('should get an empty list of conditions', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
 
-      const result = await app.get(`/v1/patient/${patient.id}/conditions`);
+      const result = await app.get(`/api/patient/${patient.id}/conditions`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(0);
     });
@@ -408,7 +408,7 @@ describe('Patient relations', () => {
         note: 'fail',
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/conditions`);
+      const result = await app.get(`/api/patient/${patient.id}/conditions`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(2);
       expect(result.body.data.every(x => x.note.includes('include'))).toEqual(true);
@@ -422,7 +422,7 @@ describe('Patient relations', () => {
         patientId: patient.id,
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/conditions`);
+      const result = await app.get(`/api/patient/${patient.id}/conditions`);
       expect(result).toHaveSucceeded();
       expect(result.body.data[0].condition).toHaveProperty('name');
     });
@@ -432,7 +432,7 @@ describe('Patient relations', () => {
     it('should get an empty list of patient secondary IDs', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
 
-      const result = await app.get(`/v1/patient/${patient.id}/secondaryId`);
+      const result = await app.get(`/api/patient/${patient.id}/secondaryId`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(0);
     });
@@ -461,7 +461,7 @@ describe('Patient relations', () => {
         patientId: otherPatient.id,
       });
 
-      const result = await app.get(`/v1/patient/${patient.id}/secondaryId`);
+      const result = await app.get(`/api/patient/${patient.id}/secondaryId`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(2);
     });
@@ -469,7 +469,7 @@ describe('Patient relations', () => {
     it('should create a new secondary ID', async () => {
       const patient = await models.Patient.create(await createDummyPatient(models));
       const idValue = '12345678910';
-      const result = await app.post(`/v1/patient/${patient.id}/secondaryId`).send({
+      const result = await app.post(`/api/patient/${patient.id}/secondaryId`).send({
         value: idValue,
         visibilityStatus: 'current',
         typeId: await randomReferenceId(models, 'secondaryIdType'),
@@ -488,7 +488,7 @@ describe('Patient relations', () => {
         patientId: patient.id,
       });
       const newVisibilityStatus = 'historical';
-      const result = await app.put(`/v1/patient/${patient.id}/secondaryId/${secondaryId.id}`).send({
+      const result = await app.put(`/api/patient/${patient.id}/secondaryId/${secondaryId.id}`).send({
         visibilityStatus: newVisibilityStatus,
       });
       expect(result).toHaveSucceeded();
@@ -534,7 +534,7 @@ describe('Patient relations', () => {
       });
 
       // Act
-      const result = await app.get(`/v1/patient/${patient.id}/fields`);
+      const result = await app.get(`/api/patient/${patient.id}/fields`);
 
       // Assert
       expect(result).toHaveSucceeded();
@@ -564,7 +564,7 @@ describe('Patient relations', () => {
       });
 
       // Act
-      const result = await app.get(`/v1/patientFieldDefinition`);
+      const result = await app.get(`/api/patientFieldDefinition`);
 
       // Assert
       expect(result).toHaveSucceeded();
@@ -635,7 +635,7 @@ describe('Patient relations', () => {
     });
 
     it('Defaults to only fetching published lab tests', async () => {
-      const response = await app.get(`/v1/patient/${labTestsPatient.id}/labTestResults`);
+      const response = await app.get(`/api/patient/${labTestsPatient.id}/labTestResults`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(labTestTypes.length);
       response.body.data.forEach(testResults => {
@@ -647,7 +647,7 @@ describe('Patient relations', () => {
 
     it('Allows overriding the status filter', async () => {
       const response = await app.get(
-        `/v1/patient/${labTestsPatient.id}/labTestResults?status=${LAB_REQUEST_STATUSES.RECEPTION_PENDING}`,
+        `/api/patient/${labTestsPatient.id}/labTestResults?status=${LAB_REQUEST_STATUSES.RECEPTION_PENDING}`,
       );
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(labTestTypes.length);
@@ -659,7 +659,7 @@ describe('Patient relations', () => {
     });
 
     it('Fetches lab tests across multiple categories', async () => {
-      const response = await app.get(`/v1/patient/${labTestsPatient.id}/labTestResults`);
+      const response = await app.get(`/api/patient/${labTestsPatient.id}/labTestResults`);
       expect(response).toHaveSucceeded();
       expect(response.body.count).toEqual(labTestTypes.length);
       const uniqueCategories = [...new Set(response.body.data.map(x => x.testCategory))];
@@ -668,7 +668,7 @@ describe('Patient relations', () => {
 
     it('Allows filtering lab tests by category', async () => {
       const response = await app.get(
-        `/v1/patient/${labTestsPatient.id}/labTestResults?categoryId=${randomCategory.id}`,
+        `/api/patient/${labTestsPatient.id}/labTestResults?categoryId=${randomCategory.id}`,
       );
       expect(response).toHaveSucceeded();
       response.body.data.forEach(labTest => {

--- a/packages/facility-server/__tests__/apiv1/Patient.search.test.js
+++ b/packages/facility-server/__tests__/apiv1/Patient.search.test.js
@@ -155,14 +155,14 @@ describe('Patient search', () => {
   afterAll(() => ctx.close());
 
   it('should error if user has insufficient permissions', async () => {
-    const response = await baseApp.get('/v1/patient').query({
+    const response = await baseApp.get('/api/patient').query({
       displayId: 'really-shouldnt-show-up',
     });
     expect(response).toBeForbidden();
   });
 
   it('should not error if there are no results', async () => {
-    const response = await app.get('/v1/patient').query({
+    const response = await app.get('/api/patient').query({
       displayId: 'really-shouldnt-show-up',
     });
     expect(response).toHaveSucceeded();
@@ -171,7 +171,7 @@ describe('Patient search', () => {
   });
 
   it('should get a patient by displayId', async () => {
-    const response = await app.get('/v1/patient').query({
+    const response = await app.get('/api/patient').query({
       displayId: 'search-by-display-id',
     });
     expect(response).toHaveSucceeded();
@@ -183,7 +183,7 @@ describe('Patient search', () => {
 
   describe('Searching by secondary IDs', () => {
     it('should NOT get a patient by secondary ID by default', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'patient-secondary-id',
       });
       expect(response).toHaveSucceeded();
@@ -191,7 +191,7 @@ describe('Patient search', () => {
     });
 
     it('should get a patient by secondary ID if query param matchSecondaryIds is true', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'patient-secondary-id',
         matchSecondaryIds: true,
       });
@@ -203,7 +203,7 @@ describe('Patient search', () => {
     });
 
     it('should get a patient by secondary ID case-insensitively', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'Patient-Secondary-Id',
         matchSecondaryIds: true,
       });
@@ -215,7 +215,7 @@ describe('Patient search', () => {
     });
 
     it("should not get a patient by secondaryId if it's only a partial match", async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'patient-seco',
         matchSecondaryIds: true,
       });
@@ -224,7 +224,7 @@ describe('Patient search', () => {
     });
 
     it('should get a patient by displayId even if query param matchSecondaryIds is true', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'search-by-display-id',
         matchSecondaryIds: true,
       });
@@ -236,7 +236,7 @@ describe('Patient search', () => {
     });
 
     it('should not see duplicates when patient primary displayId matches a secondary ID', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'matching-2ndary-id',
       });
       expect(response).toHaveSucceeded();
@@ -244,7 +244,7 @@ describe('Patient search', () => {
     });
 
     it('should not see duplicates when patients have multiple secondary IDs', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'multiple-secondary-id',
       });
       expect(response).toHaveSucceeded();
@@ -253,7 +253,7 @@ describe('Patient search', () => {
   });
 
   it('should get a list of patients by first name', async () => {
-    const response = await app.get('/v1/patient').query({
+    const response = await app.get('/api/patient').query({
       firstName: 'search-by-name',
     });
     expect(response).toHaveSucceeded();
@@ -265,7 +265,7 @@ describe('Patient search', () => {
   });
 
   it('should get a list of patients by first name (partial match, case insensitive)', async () => {
-    const response = await app.get('/v1/patient').query({
+    const response = await app.get('/api/patient').query({
       firstName: 'SeArCh-bY-Na',
     });
     expect(response).toHaveSucceeded();
@@ -278,7 +278,7 @@ describe('Patient search', () => {
 
   describe('Age filtering', () => {
     it('should get a list of patients by maximum age', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         ageMax: 30,
         rowsPerPage: searchTestPatients.length,
       });
@@ -295,7 +295,7 @@ describe('Patient search', () => {
     });
 
     it('should get a list of patients by minimum age', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         ageMin: 20,
         rowsPerPage: searchTestPatients.length,
       });
@@ -312,7 +312,7 @@ describe('Patient search', () => {
     });
 
     it('should get a list of patients by age range', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         ageMax: 30,
         ageMin: 20,
         rowsPerPage: searchTestPatients.length,
@@ -332,7 +332,7 @@ describe('Patient search', () => {
 
   it('should get a list of patients by village', async () => {
     const { id: villageId, name: villageName } = villages[0];
-    const response = await app.get('/v1/patient').query({
+    const response = await app.get('/api/patient').query({
       villageId,
     });
     expect(response).toHaveSucceeded();
@@ -349,7 +349,7 @@ describe('Patient search', () => {
 
   describe('Joining encounter info', () => {
     it('should get a list of outpatients', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         outpatient: true,
       });
       expect(response).toHaveSucceeded();
@@ -365,7 +365,7 @@ describe('Patient search', () => {
     });
 
     it('should get a list of inpatients', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         inpatient: true,
       });
       expect(response).toHaveSucceeded();
@@ -381,7 +381,7 @@ describe('Patient search', () => {
     });
 
     it('should get a list of patients by location (not on all-patients listing)', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         locationId: locations[0].id,
         facilityId: locations[0].facilityId,
       });
@@ -394,7 +394,7 @@ describe('Patient search', () => {
     });
 
     it('should get a list of patients by location group (not on all-patients listing)', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         locationGroupId: locationGroups[0].id,
         facilityId: locationGroups[0].facilityId,
       });
@@ -407,7 +407,7 @@ describe('Patient search', () => {
     });
 
     it('should get a list of patients by department (not on all-patients listing)', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         departmentId: departments[0].id,
         facilityId: departments[0].facilityId,
       });
@@ -420,7 +420,7 @@ describe('Patient search', () => {
     });
 
     it('should return only 1 result for patients with multiple open encounters', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         firstName: 'more-than-one-open-encounter',
       });
       expect(response).toHaveSucceeded();
@@ -464,7 +464,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by surname by default', async () => {
-      const response = await app.get('/v1/patient');
+      const response = await app.get('/api/patient');
 
       expect(response).toHaveSucceeded();
 
@@ -472,7 +472,7 @@ describe('Patient search', () => {
     });
 
     it('should sort in descending order', async () => {
-      const response = await app.get('/v1/patient', {
+      const response = await app.get('/api/patient', {
         order: 'desc',
       });
 
@@ -482,7 +482,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by date of birth', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'dateOfBirth',
       });
 
@@ -492,7 +492,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by date of birth in descending order', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'dateOfBirth',
         order: 'desc',
       });
@@ -503,7 +503,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by age', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'age',
       });
 
@@ -513,7 +513,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by age in descending order', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'age',
         order: 'desc',
       });
@@ -524,7 +524,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by encounter type', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'encounterType',
       });
 
@@ -534,7 +534,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by encounter type in descending order', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'encounterType',
         order: 'desc',
       });
@@ -545,7 +545,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by location (not on all-patients listing)', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'locationName',
         facilityId: locations[0].facilityId,
       });
@@ -556,7 +556,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by department (not on all-patients listing)', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'departmentName',
         facilityId: departments[0].facilityId,
       });
@@ -567,7 +567,7 @@ describe('Patient search', () => {
     });
 
     it('should sort by village', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         orderBy: 'villageName',
       });
 
@@ -579,7 +579,7 @@ describe('Patient search', () => {
 
   describe('Pagination', () => {
     it('should retrieve first page of patients', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         firstName: 'pagination',
         orderBy: 'lastName',
         rowsPerPage: 3,
@@ -595,7 +595,7 @@ describe('Patient search', () => {
     });
 
     it('should retrieve second page of patients', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         firstName: 'pagination',
         orderBy: 'lastName',
         rowsPerPage: 3,
@@ -638,7 +638,7 @@ describe('Patient search', () => {
     });
 
     it('Display Id - Exact match on top and rest are sorted alphabetically', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'sort-test-1C',
       });
 
@@ -657,7 +657,7 @@ describe('Patient search', () => {
     });
 
     it('First Name - Exact match on top and rest are sorted according to best match', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         firstName: 'QQQQ',
       });
 
@@ -681,7 +681,7 @@ describe('Patient search', () => {
     });
 
     it('Last Name - Exact match on top and rest are sorted according to best match', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         lastName: 'UUUU',
       });
 
@@ -704,7 +704,7 @@ describe('Patient search', () => {
     // If we have a condition attended by two or more results, for instance, a exact match for display id and first time.
     // It should prioritize 1)displayId 2)lastName 3)firstName.
     it('Should prioritize 1-displayId, 2-lastName, 3-firstName', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         displayId: 'sort-test-1',
         firstName: 'QQQQ',
         lastName: 'UUUU',
@@ -725,7 +725,7 @@ describe('Patient search', () => {
     });
 
     it('Should prioritize Last name in relation to first name', async () => {
-      const response = await app.get('/v1/patient').query({
+      const response = await app.get('/api/patient').query({
         firstName: 'QQQQ',
         lastName: 'UUUU',
       });

--- a/packages/facility-server/__tests__/apiv1/Patient.test.js
+++ b/packages/facility-server/__tests__/apiv1/Patient.test.js
@@ -39,7 +39,7 @@ describe('Patient', () => {
 
   it('should reject reading a patient with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.get(`/v1/patient/${patient.id}`);
+    const result = await noPermsApp.get(`/api/patient/${patient.id}`);
     expect(result).toBeForbidden();
   });
 
@@ -49,7 +49,7 @@ describe('Patient', () => {
   test.todo('should reject listing of patients with insufficient permissions');
 
   it('should get the details of a patient', async () => {
-    const result = await app.get(`/v1/patient/${patient.id}`);
+    const result = await app.get(`/api/patient/${patient.id}`);
     expect(result).toHaveSucceeded();
     expect(result.body).toHaveProperty('displayId', patient.displayId);
     expect(result.body).toHaveProperty('firstName', patient.firstName);
@@ -69,7 +69,7 @@ describe('Patient', () => {
     });
 
     // Expect result data to be empty since there are no discharged encounters or medications
-    const result = await app.get(`/v1/patient/${patient.id}/lastDischargedEncounter/medications`);
+    const result = await app.get(`/api/patient/${patient.id}/lastDischargedEncounter/medications`);
     expect(result).toHaveSucceeded();
     expect(result.body).toMatchObject({
       count: 0,
@@ -112,7 +112,7 @@ describe('Patient', () => {
 
     // Expect encounter to be the second encounter discharged
     // and include discharged medication with reference associations
-    const result = await app.get(`/v1/patient/${patient.id}/lastDischargedEncounter/medications`);
+    const result = await app.get(`/api/patient/${patient.id}/lastDischargedEncounter/medications`);
     expect(result).toHaveSucceeded();
     expect(result.body).toMatchObject({
       count: 1,
@@ -131,7 +131,7 @@ describe('Patient', () => {
     it('should reject users with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
 
-      const result = await noPermsApp.put(`/v1/patient/${patient.id}`).send({
+      const result = await noPermsApp.put(`/api/patient/${patient.id}`).send({
         firstName: 'New',
       });
 
@@ -140,7 +140,7 @@ describe('Patient', () => {
 
     it('should create a new patient', async () => {
       const newPatient = await createDummyPatient(models);
-      const result = await app.post('/v1/patient').send(newPatient);
+      const result = await app.post('/api/patient').send(newPatient);
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveProperty('displayId', newPatient.displayId);
       expect(result.body).toHaveProperty('firstName', newPatient.firstName);
@@ -149,7 +149,7 @@ describe('Patient', () => {
 
     it('should create a new patient with additional data', async () => {
       const newPatient = await createDummyPatient(models);
-      const result = await app.post('/v1/patient').send({
+      const result = await app.post('/api/patient').send({
         ...newPatient,
         passport: 'TEST-PASSPORT',
       });
@@ -176,7 +176,7 @@ describe('Patient', () => {
       const newPatient = await createDummyPatient(models);
 
       // Act
-      const result = await app.post('/v1/patient').send({
+      const result = await app.post('/api/patient').send({
         ...newPatient,
         patientFields: {
           [definition.id]: 'Test Field Value',
@@ -198,11 +198,11 @@ describe('Patient', () => {
     it('should update patient details', async () => {
       // skip middleName, to be added in PUT request
       const newPatient = await createDummyPatient(models, { middleName: '' });
-      const result = await app.post('/v1/patient').send(newPatient);
+      const result = await app.post('/api/patient').send(newPatient);
       expect(result.body.middleName).toEqual('');
 
       const newVillage = await randomReferenceId(models, 'village');
-      const updateResult = await app.put(`/v1/patient/${result.body.id}`).send({
+      const updateResult = await app.put(`/api/patient/${result.body.id}`).send({
         villageId: newVillage,
         middleName: 'MiddleName',
         bloodType: 'AB+',
@@ -212,7 +212,7 @@ describe('Patient', () => {
       expect(updateResult.body).toHaveProperty('villageId', newVillage);
       expect(updateResult.body).toHaveProperty('middleName', 'MiddleName');
 
-      const additionalDataResult = await app.get(`/v1/patient/${result.body.id}/additionalData`);
+      const additionalDataResult = await app.get(`/api/patient/${result.body.id}/additionalData`);
 
       expect(additionalDataResult).toHaveSucceeded();
       expect(additionalDataResult.body).toHaveProperty('bloodType', 'AB+');
@@ -232,7 +232,7 @@ describe('Patient', () => {
       const newPatient = await createDummyPatient(models);
       const {
         body: { id: patientId },
-      } = await app.post('/v1/patient').send({
+      } = await app.post('/api/patient').send({
         ...newPatient,
         patientFields: {
           [definition.id]: 'Test Field Value',
@@ -240,7 +240,7 @@ describe('Patient', () => {
       });
 
       // Act
-      const result = await app.put(`/v1/patient/${patientId}`).send({
+      const result = await app.put(`/api/patient/${patientId}`).send({
         patientFields: {
           [definition.id]: 'Test Field Value 2',
         },
@@ -305,7 +305,7 @@ describe('Patient', () => {
       });
 
       const newDisplayId = '123456789';
-      const updateResult = await app.put(`/v1/patient/${newPatient.id}`).send({
+      const updateResult = await app.put(`/api/patient/${newPatient.id}`).send({
         displayId: newDisplayId,
       });
       expect(updateResult).toHaveSucceeded();
@@ -325,7 +325,7 @@ describe('Patient', () => {
       });
 
       const newDisplayId = '555666777';
-      const updateResult = await app.put(`/v1/patient/${newPatient.id}`).send({
+      const updateResult = await app.put(`/api/patient/${newPatient.id}`).send({
         displayId: newDisplayId,
       });
       expect(updateResult).toHaveSucceeded();
@@ -421,7 +421,7 @@ describe('Patient', () => {
       });
 
       const result = await app.get(
-        `/v1/patient/${patient1.id}/covidLabTests?certType=${CertificateTypes.clearance}`,
+        `/api/patient/${patient1.id}/covidLabTests?certType=${CertificateTypes.clearance}`,
       );
 
       expect(result).toHaveSucceeded();
@@ -466,7 +466,7 @@ describe('Patient', () => {
       });
 
       const result = await app.get(
-        `/v1/patient/${patient2.id}/covidLabTests?certType=${CertificateTypes.clearance}`,
+        `/api/patient/${patient2.id}/covidLabTests?certType=${CertificateTypes.clearance}`,
       );
 
       expect(result).toHaveSucceeded();
@@ -512,7 +512,7 @@ describe('Patient', () => {
       });
 
       const result = await app.get(
-        `/v1/patient/${patient1.id}/covidLabTests?certType=${CertificateTypes.clearance}`,
+        `/api/patient/${patient1.id}/covidLabTests?certType=${CertificateTypes.clearance}`,
       );
 
       expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/PatientCarePlan.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientCarePlan.test.js
@@ -18,7 +18,7 @@ describe('PatientCarePlan', () => {
 
   it('should reject creating an admissions report with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.post(`/v1/patientCarePlan`, {});
+    const result = await noPermsApp.post(`/api/patientCarePlan`, {});
     expect(result).toBeForbidden();
   });
 
@@ -33,7 +33,7 @@ describe('PatientCarePlan', () => {
     it('should create a care plan with note', async () => {
       const onBehalfOfUserId = await randomUser(models);
       const carePlanDate = getCurrentDateTimeString();
-      const result = await app.post('/v1/patientCarePlan').send({
+      const result = await app.post('/api/patientCarePlan').send({
         date: carePlanDate,
         carePlanId,
         patientId: patient.get('id'),
@@ -45,7 +45,7 @@ describe('PatientCarePlan', () => {
       expect(result.body).toHaveProperty('date', carePlanDate);
       expect(result.body.patientId).toBe(patient.get('id'));
       expect(result.body.carePlanId).toBe(carePlanId);
-      const noteResult = await app.get(`/v1/patientCarePlan/${result.body.id}/notes`);
+      const noteResult = await app.get(`/api/patientCarePlan/${result.body.id}/notes`);
       expect(noteResult).toHaveSucceeded();
       expect(noteResult.body.length).toBeGreaterThan(0);
       expect(noteResult.body[0].content).toBe('Main care plan');
@@ -53,7 +53,7 @@ describe('PatientCarePlan', () => {
     });
 
     it('should reject care plan without notes', async () => {
-      const result = await app.post('/v1/patientCarePlan').send({
+      const result = await app.post('/api/patientCarePlan').send({
         date: getCurrentDateTimeString(),
         carePlanId,
         patientId: patient.get('id'),
@@ -63,7 +63,7 @@ describe('PatientCarePlan', () => {
 
     it('should return return notes in order of creation', async () => {
       const onBehalfOfUserId = await randomUser(models);
-      const createCarePlanRequest = await app.post('/v1/patientCarePlan').send({
+      const createCarePlanRequest = await app.post('/api/patientCarePlan').send({
         date: getCurrentDateTimeString(),
         carePlanId,
         patientId: patient.get('id'),
@@ -72,7 +72,7 @@ describe('PatientCarePlan', () => {
       });
       expect(createCarePlanRequest).toHaveSucceeded();
       const additionalNoteRequest = await app
-        .post(`/v1/patientCarePlan/${createCarePlanRequest.body.id}/notes`)
+        .post(`/api/patientCarePlan/${createCarePlanRequest.body.id}/notes`)
         .send({
           date: getCurrentDateTimeString(),
           content: 'Second note',
@@ -80,7 +80,7 @@ describe('PatientCarePlan', () => {
         });
       expect(additionalNoteRequest).toHaveSucceeded();
       const noteResult = await app.get(
-        `/v1/patientCarePlan/${createCarePlanRequest.body.id}/notes`,
+        `/api/patientCarePlan/${createCarePlanRequest.body.id}/notes`,
       );
 
       expect(noteResult).toHaveSucceeded();
@@ -92,16 +92,16 @@ describe('PatientCarePlan', () => {
 
     it('should delete a note', async () => {
       const noteDate = getCurrentDateTimeString();
-      const result = await app.post('/v1/patientCarePlan').send({
+      const result = await app.post('/api/patientCarePlan').send({
         date: noteDate,
         carePlanId,
         patientId: patient.get('id'),
         content: 'Main care plan',
       });
-      const noteResult = await app.get(`/v1/patientCarePlan/${result.body.id}/notes`);
-      const deleteResult = await app.delete(`/v1/notes/${noteResult.body[0].id}`);
+      const noteResult = await app.get(`/api/patientCarePlan/${result.body.id}/notes`);
+      const deleteResult = await app.delete(`/api/notes/${noteResult.body[0].id}`);
       expect(deleteResult).toHaveSucceeded();
-      const emptyNotesResult = await app.get(`/v1/patientCarePlan/${result.body.id}/notes`);
+      const emptyNotesResult = await app.get(`/api/patientCarePlan/${result.body.id}/notes`);
       expect(emptyNotesResult.body.length).toBe(0);
     });
   });

--- a/packages/facility-server/__tests__/apiv1/PatientDeath.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientDeath.test.js
@@ -76,7 +76,7 @@ describe('PatientDeath', () => {
     const { clinicianId, facilityId, cond1Id, cond2Id, cond3Id } = commons;
 
     const dod = '2021-09-01 00:00:00';
-    const result = await app.post(`/v1/patient/${id}/death`).send({
+    const result = await app.post(`/api/patient/${id}/death`).send({
       clinicianId,
       facilityId,
       outsideHealthFacility: false,
@@ -113,7 +113,7 @@ describe('PatientDeath', () => {
     const { Patient } = models;
     const { id } = await Patient.create({ ...fake(Patient), dateOfDeath: null });
 
-    const result = await app.post(`/v1/patient/${id}/death`).send({});
+    const result = await app.post(`/api/patient/${id}/death`).send({});
     expect(result).not.toHaveSucceeded();
   });
 
@@ -121,7 +121,7 @@ describe('PatientDeath', () => {
     const { Patient } = models;
     const { id } = await Patient.create({ ...fake(Patient), dateOfDeath: null });
 
-    const result = await app.post(`/v1/patient/${id}/death`).send({
+    const result = await app.post(`/api/patient/${id}/death`).send({
       timeOfDeath: 'this is not a date',
     });
     expect(result).not.toHaveSucceeded();
@@ -140,7 +140,7 @@ describe('PatientDeath', () => {
       endDate: null,
     });
 
-    const result = await app.post(`/v1/patient/${id}/death`).send({
+    const result = await app.post(`/api/patient/${id}/death`).send({
       clinicianId,
       facilityId,
       timeOfDeath: '2021-09-01 00:00:00',
@@ -166,7 +166,7 @@ describe('PatientDeath', () => {
     const { Patient } = models;
     const { id, dateOfBirth } = await Patient.create({ ...fake(Patient), dateOfDeath: null });
 
-    const result = await app.get(`/v1/patient/${id}/death`);
+    const result = await app.get(`/api/patient/${id}/death`);
 
     expect(result).toHaveStatus(404);
     expect(result.body).toMatchObject({
@@ -182,7 +182,7 @@ describe('PatientDeath', () => {
     const { clinicianId, facilityId, cond1, cond2, cond3, cond1Id, cond2Id, cond3Id } = commons;
 
     const dod = '2021-09-01 12:30:25';
-    await app.post(`/v1/patient/${id}/death`).send({
+    await app.post(`/api/patient/${id}/death`).send({
       clinicianId,
       facilityId,
       outsideHealthFacility: false,
@@ -210,7 +210,7 @@ describe('PatientDeath', () => {
       numberOfHoursSurvivedSinceBirth: 12,
     });
 
-    const result = await app.get(`/v1/patient/${id}/death`);
+    const result = await app.get(`/api/patient/${id}/death`);
 
     expect(result).toHaveSucceeded();
     expect(result.body.dateOfDeath).toEqual(dod);
@@ -270,7 +270,7 @@ describe('PatientDeath', () => {
       const { clinicianId } = commons;
 
       const dod = '2021-09-01 00:00:00';
-      const result = await app.post(`/v1/patient/${id}/death`).send({
+      const result = await app.post(`/api/patient/${id}/death`).send({
         clinicianId,
         timeOfDeath: dod,
         isPartialWorkflow: true,
@@ -294,7 +294,7 @@ describe('PatientDeath', () => {
       });
 
       const mod = 'Accident';
-      const result = await app.post(`/v1/patient/${id}/death`).send({
+      const result = await app.post(`/api/patient/${id}/death`).send({
         clinicianId,
         facilityId,
         outsideHealthFacility: false,
@@ -340,7 +340,7 @@ describe('PatientDeath', () => {
         isFinal: false,
       });
 
-      const result = await app.post(`/v1/patient/${id}/revertDeath`).send({});
+      const result = await app.post(`/api/patient/${id}/revertDeath`).send({});
       expect(result).toHaveSucceeded();
       const deathData = await PatientDeathData.findAll({
         where: { patientId: id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
@@ -361,7 +361,7 @@ describe('PatientDeath', () => {
         isFinal: true,
       });
 
-      const result = await app.post(`/v1/patient/${id}/revertDeath`).send({});
+      const result = await app.post(`/api/patient/${id}/revertDeath`).send({});
       expect(result).not.toHaveSucceeded();
       const deathData = await PatientDeathData.findAll({
         where: { patientId: id, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
@@ -380,7 +380,7 @@ describe('PatientDeath', () => {
         isFinal: false,
       });
 
-      const result = await app.post(`/v1/patient/${id}/revertDeath`).send({});
+      const result = await app.post(`/api/patient/${id}/revertDeath`).send({});
       expect(result).toHaveSucceeded();
       const revertLog = await DeathRevertLog.findOne({ where: { patientId: id } });
       expect(revertLog).toBeTruthy();

--- a/packages/facility-server/__tests__/apiv1/PatientDocumentMetadata.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientDocumentMetadata.test.js
@@ -64,7 +64,7 @@ describe('PatientDocumentMetadata', () => {
       models.DocumentMetadata.create(metadataFive),
     ]);
 
-    const result = await app.get(`/v1/patient/${patient.id}/documentMetadata`);
+    const result = await app.get(`/api/patient/${patient.id}/documentMetadata`);
     expect(result).toHaveSucceeded();
     expect(result.body).toMatchObject({
       count: 4,
@@ -96,13 +96,13 @@ describe('PatientDocumentMetadata', () => {
 
     // Sort by name ASC/DESC (presumably sufficient to test only one field)
     const resultAsc = await app.get(
-      `/v1/patient/${patient.id}/documentMetadata?order=asc&orderBy=name`,
+      `/api/patient/${patient.id}/documentMetadata?order=asc&orderBy=name`,
     );
     expect(resultAsc).toHaveSucceeded();
     expect(resultAsc.body.data[0].id).toBe(metadataOne.id);
 
     const resultDesc = await app.get(
-      `/v1/patient/${patient.id}/documentMetadata?order=desc&orderBy=name`,
+      `/api/patient/${patient.id}/documentMetadata?order=desc&orderBy=name`,
     );
     expect(resultDesc).toHaveSucceeded();
     expect(resultDesc.body.count).toBe(2);
@@ -122,7 +122,7 @@ describe('PatientDocumentMetadata', () => {
     }
     await models.DocumentMetadata.bulkCreate(documents);
     const result = await app.get(
-      `/v1/patient/${patient.id}/documentMetadata?page=1&rowsPerPage=10&offset=5`,
+      `/api/patient/${patient.id}/documentMetadata?page=1&rowsPerPage=10&offset=5`,
     );
     expect(result).toHaveSucceeded();
     expect(result.body.count).toBe(12);
@@ -138,7 +138,7 @@ describe('PatientDocumentMetadata', () => {
       { name: 'C', type: 'image/jpeg', attachmentId: 'fake-id-3', patientId: patient.id },
     ]);
 
-    const result = await app.get(`/v1/patient/${patient.id}/documentMetadata?type=pdf`);
+    const result = await app.get(`/api/patient/${patient.id}/documentMetadata?type=pdf`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toBe(2);
   });
@@ -173,7 +173,7 @@ describe('PatientDocumentMetadata', () => {
       },
     ]);
 
-    const result = await app.get(`/v1/patient/${patient.id}/documentMetadata?documentOwner=ownerA`);
+    const result = await app.get(`/api/patient/${patient.id}/documentMetadata?documentOwner=ownerA`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toBe(2);
   });
@@ -207,7 +207,7 @@ describe('PatientDocumentMetadata', () => {
     ]);
 
     const result = await app.get(
-      `/v1/patient/${patient.id}/documentMetadata?departmentName=${slicedDepartmentName}`,
+      `/api/patient/${patient.id}/documentMetadata?departmentName=${slicedDepartmentName}`,
     );
     expect(result).toHaveSucceeded();
     expect(result.body.count).toBe(2);
@@ -252,14 +252,14 @@ describe('PatientDocumentMetadata', () => {
     ]);
 
     const result = await app.get(
-      `/v1/patient/${patient.id}/documentMetadata?departmentName=${slicedDepartmentName}&type=pdf&documentOwner=ownerB`,
+      `/api/patient/${patient.id}/documentMetadata?departmentName=${slicedDepartmentName}&type=pdf&documentOwner=ownerB`,
     );
     expect(result).toHaveSucceeded();
     expect(result.body.count).toBe(1);
   });
 
   it('should fail creating a document metadata if the patient ID does not exist', async () => {
-    const result = await app.post('/v1/patient/123456789/documentMetadata').send({
+    const result = await app.post('/api/patient/123456789/documentMetadata').send({
       name: 'test document',
       documentOwner: 'someone',
       note: 'some note',
@@ -277,7 +277,7 @@ describe('PatientDocumentMetadata', () => {
       attachmentId: '123456789',
     }));
 
-    const result = await app.post(`/v1/patient/${patient.id}/documentMetadata`).send({
+    const result = await app.post(`/api/patient/${patient.id}/documentMetadata`).send({
       name: 'test document',
       type: 'application/pdf',
       documentOwner: 'someone',

--- a/packages/facility-server/__tests__/apiv1/PatientIssue.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientIssue.test.js
@@ -18,7 +18,7 @@ describe('PatientIssue', () => {
   afterAll(() => ctx.close());
 
   it('should record an issue', async () => {
-    const result = await app.post('/v1/patientIssue').send({
+    const result = await app.post('/api/patientIssue').send({
       patientId: patient.id,
       note: 'A patient issue',
     });
@@ -27,7 +27,7 @@ describe('PatientIssue', () => {
   });
 
   it('should require a valid patient', async () => {
-    const result = await app.post('/v1/patientIssue').send({
+    const result = await app.post('/api/patientIssue').send({
       patientId: 'not a patient',
       note: 'A patient issue',
     });

--- a/packages/facility-server/__tests__/apiv1/PatientLocations.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientLocations.test.js
@@ -65,7 +65,7 @@ describe('PatientLocations', () => {
       endDate: null,
     });
 
-    const oneReservedTwoOccupiedStatsResponse = await app.get('/v1/patient/locations/stats');
+    const oneReservedTwoOccupiedStatsResponse = await app.get('/api/patient/locations/stats');
     expect(oneReservedTwoOccupiedStatsResponse).toHaveSucceeded();
 
     const {
@@ -82,7 +82,7 @@ describe('PatientLocations', () => {
       endDate: new Date(),
     });
 
-    const oneOccupiedStatsResponse = await app.get('/v1/patient/locations/stats');
+    const oneOccupiedStatsResponse = await app.get('/api/patient/locations/stats');
     expect(oneOccupiedStatsResponse).toHaveSucceeded();
 
     const {
@@ -101,7 +101,7 @@ describe('PatientLocations', () => {
   });
 
   it('should return accurate occupancy', async () => {
-    const oneInpatientEncounterOccupancyResponse = await app.get('/v1/patient/locations/occupancy');
+    const oneInpatientEncounterOccupancyResponse = await app.get('/api/patient/locations/occupancy');
 
     expect(oneInpatientEncounterOccupancyResponse).toHaveSucceeded();
     expect(oneInpatientEncounterOccupancyResponse.body.data).toBeGreaterThanOrEqual(
@@ -123,7 +123,7 @@ describe('PatientLocations', () => {
     });
 
     const oneOutpatientOneInpatientOccupancyResponse = await app.get(
-      '/v1/patient/locations/occupancy',
+      '/api/patient/locations/occupancy',
     );
 
     expect(oneOutpatientOneInpatientOccupancyResponse).toHaveSucceeded();
@@ -136,7 +136,7 @@ describe('PatientLocations', () => {
   });
 
   it('should return accurate readmissions', async () => {
-    const oneEncounterReadmissionsResponse = await app.get('/v1/patient/locations/readmissions');
+    const oneEncounterReadmissionsResponse = await app.get('/api/patient/locations/readmissions');
     expect(oneEncounterReadmissionsResponse).toHaveSucceeded();
     expect(oneEncounterReadmissionsResponse.body.data).toEqual(0);
 
@@ -154,7 +154,7 @@ describe('PatientLocations', () => {
     });
 
     const oneReadmittedPatientnReadmissionsResponse = await app.get(
-      '/v1/patient/locations/readmissions',
+      '/api/patient/locations/readmissions',
     );
     expect(oneReadmittedPatientnReadmissionsResponse).toHaveSucceeded();
     expect(oneReadmittedPatientnReadmissionsResponse.body.data).toEqual(1);
@@ -175,7 +175,7 @@ describe('PatientLocations', () => {
       endDate: new Date(),
     });
 
-    const oneEncounterAlosResponse = await app.get('/v1/patient/locations/alos');
+    const oneEncounterAlosResponse = await app.get('/api/patient/locations/alos');
     expect(oneEncounterAlosResponse).toHaveSucceeded();
     expect(oneEncounterAlosResponse.body.data).toEqual(2);
 
@@ -193,18 +193,18 @@ describe('PatientLocations', () => {
       endDate: new Date(),
     });
 
-    const twoEncountersAlosResponse = await app.get('/v1/patient/locations/alos');
+    const twoEncountersAlosResponse = await app.get('/api/patient/locations/alos');
     expect(twoEncountersAlosResponse).toHaveSucceeded();
     expect(twoEncountersAlosResponse.body.data).toEqual((4 + 2) / 2);
   });
 
   it('should return correct bed management table values', async () => {
-    const oneEncounterBedManagementResponse = await app.get('/v1/patient/locations/bedManagement');
+    const oneEncounterBedManagementResponse = await app.get('/api/patient/locations/bedManagement');
     expect(oneEncounterBedManagementResponse).toHaveSucceeded();
     expect(oneEncounterBedManagementResponse.body.count).toEqual(locations.length);
 
     const oneEncounterLocationBedManagementResponse = await app.get(
-      `/v1/patient/locations/bedManagement?location=${maxOneOccupancyLocations[0].id}`,
+      `/api/patient/locations/bedManagement?location=${maxOneOccupancyLocations[0].id}`,
     );
     expect(oneEncounterLocationBedManagementResponse).toHaveSucceeded();
     expect(oneEncounterLocationBedManagementResponse.body.data).toHaveLength(1);
@@ -234,7 +234,7 @@ describe('PatientLocations', () => {
     });
 
     const twoEncountersLocationBedManagementResponse = await app.get(
-      `/v1/patient/locations/bedManagement?location=${maxOneOccupancyLocations[0].id}`,
+      `/api/patient/locations/bedManagement?location=${maxOneOccupancyLocations[0].id}`,
     );
     expect(twoEncountersLocationBedManagementResponse).toHaveSucceeded();
     expect(twoEncountersLocationBedManagementResponse.body.data).toHaveLength(1);
@@ -264,13 +264,13 @@ describe('PatientLocations', () => {
     });
 
     const threeEncountersBedManagementResponse = await app.get(
-      '/v1/patient/locations/bedManagement',
+      '/api/patient/locations/bedManagement',
     );
     expect(threeEncountersBedManagementResponse).toHaveSucceeded();
     expect(threeEncountersBedManagementResponse.body.count).toEqual(locations.length + 1);
 
     const threeEncountersLocationBedManagementResponse = await app.get(
-      `/v1/patient/locations/bedManagement?location=${maxOneOccupancyLocations[1].id}`,
+      `/api/patient/locations/bedManagement?location=${maxOneOccupancyLocations[1].id}`,
     );
     expect(threeEncountersLocationBedManagementResponse).toHaveSucceeded();
     expect(threeEncountersLocationBedManagementResponse.body.data).toHaveLength(1);
@@ -299,7 +299,7 @@ describe('PatientLocations', () => {
     const locationIds = createdLocations.map(l => l.id);
 
     // Act
-    const response = await app.get('/v1/patient/locations/bedManagement');
+    const response = await app.get('/api/patient/locations/bedManagement');
 
     // Assert
     expect(response).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/PatientProfilePicture.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProfilePicture.test.js
@@ -62,7 +62,7 @@ describe('Patient profile picture', () => {
     const patient = await models.Patient.create(await createDummyPatient(models));
     await uploadDummyProfilePicture(models, patient.id);
 
-    const result = await app.get(`/v1/patient/${patient.id}/profilePicture`);
+    const result = await app.get(`/api/patient/${patient.id}/profilePicture`);
     expect(result).toHaveSucceeded();
 
     expect(result.body).toHaveProperty('data');
@@ -72,7 +72,7 @@ describe('Patient profile picture', () => {
   it('should send a placeholder picture when no real one is available', async () => {
     const otherPatient = await models.Patient.create(await createDummyPatient(models));
 
-    const result = await app.get(`/v1/patient/${otherPatient.id}/profilePicture`);
+    const result = await app.get(`/api/patient/${otherPatient.id}/profilePicture`);
     expect(result).toHaveRequestError();
   });
 });

--- a/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -108,7 +108,7 @@ describe('PatientProgramRegistration', () => {
         }),
       );
 
-      const result = await app.get(`/v1/patient/${patient.id}/programRegistration`);
+      const result = await app.get(`/api/patient/${patient.id}/programRegistration`);
 
       expect(result).toHaveSucceeded();
       expect(result.body.data).toMatchObject([
@@ -147,7 +147,7 @@ describe('PatientProgramRegistration', () => {
       const programRegistryCondition = await models.ProgramRegistryCondition.create(
         fake(models.ProgramRegistryCondition, { programRegistryId: programRegistry1.id }),
       );
-      const result = await app.post(`/v1/patient/${patient.id}/programRegistration`).send({
+      const result = await app.post(`/api/patient/${patient.id}/programRegistration`).send({
         programRegistryId: programRegistry1.id,
         clinicianId: clinician.id,
         patientId: patient.id,
@@ -198,7 +198,7 @@ describe('PatientProgramRegistration', () => {
       // Add a small delay so the registrations are definitely created at distinctly different times.
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      const result = await app.post(`/v1/patient/${patient.id}/programRegistration`).send({
+      const result = await app.post(`/api/patient/${patient.id}/programRegistration`).send({
         // clinicianId: Should come from existing registration
         patientId: patient.id,
         programRegistryId: programRegistry1.id,
@@ -284,7 +284,7 @@ describe('PatientProgramRegistration', () => {
       ];
 
       for (const r of records) {
-        await app.post(`/v1/patient/${patient.id}/programRegistration`).send(r);
+        await app.post(`/api/patient/${patient.id}/programRegistration`).send(r);
         // await sleepAsync(1000);
       }
 
@@ -295,7 +295,7 @@ describe('PatientProgramRegistration', () => {
       const { patient, registry, records } = await populate();
 
       const result = await app.get(
-        `/v1/patient/${patient.id}/programRegistration/${registry.id}/history`,
+        `/api/patient/${patient.id}/programRegistration/${registry.id}/history`,
       );
       expect(result).toHaveSucceeded();
 
@@ -322,7 +322,7 @@ describe('PatientProgramRegistration', () => {
     it('fetches the full detail of the latest registration', async () => {
       const { patient, registry, records } = await populate();
 
-      const result = await app.get(`/v1/patient/${patient.id}/programRegistration/${registry.id}`);
+      const result = await app.get(`/api/patient/${patient.id}/programRegistration/${registry.id}`);
       expect(result).toHaveSucceeded();
 
       const record = result.body;
@@ -346,7 +346,7 @@ describe('PatientProgramRegistration', () => {
 
         // real patient, real registry, but not registered
         const result = await app.get(
-          `/v1/patient/${patient.id}/programRegistration/${registry.id}`,
+          `/api/patient/${patient.id}/programRegistration/${registry.id}`,
         );
         expect(result).toHaveStatus(404);
       });
@@ -356,7 +356,7 @@ describe('PatientProgramRegistration', () => {
 
         const newApp = await baseApp.asRole('base');
         const result = await newApp.get(
-          `/v1/patient/${patient.id}/programRegistration/${registry.id}`,
+          `/api/patient/${patient.id}/programRegistration/${registry.id}`,
         );
         expect(result).toBeForbidden();
       });
@@ -390,7 +390,7 @@ describe('PatientProgramRegistration', () => {
 
       it('creates a new condition', async () => {
         const result = await app
-          .post(`/v1/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
+          .post(`/api/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
           .send({
             programRegistryConditionId: programRegistryCondition.id,
             date: '2023-09-02 08:00:00',
@@ -421,7 +421,7 @@ describe('PatientProgramRegistration', () => {
           }),
         );
         const result = await app
-          .post(`/v1/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
+          .post(`/api/patient/${patient.id}/programRegistration/${programRegistry.id}/condition`)
           .send({
             programRegistryConditionId: programRegistryCondition.id,
             date: '2023-09-02 08:00:00',
@@ -453,7 +453,7 @@ describe('PatientProgramRegistration', () => {
         );
         const result = await app
           .delete(
-            `/v1/patient/${patient.id}/programRegistration/${programRegistry1.id}/condition/${createdCondition.id}`,
+            `/api/patient/${patient.id}/programRegistration/${programRegistry1.id}/condition/${createdCondition.id}`,
           )
           .send({
             programRegistryConditionId: programRegistryCondition.id,

--- a/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
@@ -166,20 +166,20 @@ describe('PatientVaccine', () => {
 
   it('should reject with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.get(`/v1/patient/${patient.id}/scheduledVaccines`, {});
+    const result = await noPermsApp.get(`/api/patient/${patient.id}/scheduledVaccines`, {});
     expect(result).toBeForbidden();
   });
 
   describe('Scheduled vaccines', () => {
     it('should only return vaccines with some that have not been administered', async () => {
-      const result = await app.get(`/v1/patient/${patient.id}/scheduledVaccines`);
+      const result = await app.get(`/api/patient/${patient.id}/scheduledVaccines`);
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveLength(3);
     });
 
     it('should get a list of scheduled vaccines based on category', async () => {
       const result = await app.get(
-        `/v1/patient/${patient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.CAMPAIGN}`,
+        `/api/patient/${patient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.CAMPAIGN}`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveLength(1);
@@ -190,7 +190,7 @@ describe('PatientVaccine', () => {
       // add an administered vaccine for patient1, of schedule 2
 
       const result = await app.get(
-        `/v1/patient/${patient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.ROUTINE}`,
+        `/api/patient/${patient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.ROUTINE}`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveLength(1);
@@ -204,7 +204,7 @@ describe('PatientVaccine', () => {
       // just create a new patient with no vaccinations
       const freshPatient = await models.Patient.create(await createDummyPatient(models));
       const result = await app.get(
-        `/v1/patient/${freshPatient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.ROUTINE}`,
+        `/api/patient/${freshPatient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.ROUTINE}`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveLength(1);
@@ -217,7 +217,7 @@ describe('PatientVaccine', () => {
     it('should only return vaccines with some that have not been administered for a category', async () => {
       // just create a new patient with no vaccinations
       const result = await app.get(
-        `/v1/patient/${patient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.CATCHUP}`,
+        `/api/patient/${patient.id}/scheduledVaccines?category=${VACCINE_CATEGORIES.CATCHUP}`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveLength(1);
@@ -253,7 +253,7 @@ describe('PatientVaccine', () => {
     });
 
     it('Should get administered vaccines', async () => {
-      const result = await app.get(`/v1/patient/${patient.id}/administeredVaccines`);
+      const result = await app.get(`/api/patient/${patient.id}/administeredVaccines`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(5); // there are 5 recorded given vaccines in beforeAll
     });
@@ -266,7 +266,7 @@ describe('PatientVaccine', () => {
       });
 
       const result = await app.get(
-        `/v1/patient/${freshPatient.id}/administeredVaccines?includeNotGiven=true`,
+        `/api/patient/${freshPatient.id}/administeredVaccines?includeNotGiven=true`,
       );
 
       expect(result).toHaveSucceeded();
@@ -276,10 +276,10 @@ describe('PatientVaccine', () => {
     });
 
     it('Should mark an administered vaccine as recorded in error', async () => {
-      const result = await app.get(`/v1/patient/${patient.id}/administeredVaccines`);
+      const result = await app.get(`/api/patient/${patient.id}/administeredVaccines`);
 
       const markedAsRecordedInError = await app
-        .put(`/v1/patient/${patient.id}/administeredVaccine/${result.body.data[0].id}`)
+        .put(`/api/patient/${patient.id}/administeredVaccine/${result.body.data[0].id}`)
         .send({ status: 'RECORDED_IN_ERROR' });
       expect(markedAsRecordedInError).toHaveSucceeded();
       expect(markedAsRecordedInError.body.status).toEqual('RECORDED_IN_ERROR');
@@ -292,7 +292,7 @@ describe('PatientVaccine', () => {
         code: 'Australia',
       });
 
-      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_RECORDING_TYPES.GIVEN,
         scheduledVaccineId: scheduled1.id,
         recorderId: clinician.id,
@@ -319,7 +319,7 @@ describe('PatientVaccine', () => {
         await createScheduledVaccine(models, { category: VACCINE_CATEGORIES.OTHER }),
       );
 
-      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_RECORDING_TYPES.GIVEN,
         category: VACCINE_CATEGORIES.OTHER,
         locationId: location.id,
@@ -354,7 +354,7 @@ describe('PatientVaccine', () => {
         facility.id,
       );
 
-      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_RECORDING_TYPES.GIVEN,
         scheduledVaccineId: scheduled1.id,
         recorderId: clinician.id,
@@ -379,7 +379,7 @@ describe('PatientVaccine', () => {
         status: VACCINE_STATUS.NOT_GIVEN,
       });
 
-      const result = await app.post(`/v1/patient/${freshPatient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${freshPatient.id}/administeredVaccine`).send({
         status: VACCINE_STATUS.GIVEN,
         scheduledVaccineId: scheduled1.id,
         recorderId: clinician.id,
@@ -397,7 +397,7 @@ describe('PatientVaccine', () => {
     });
 
     it('Should assign current date to vaccine date when no date is provided', async () => {
-      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_STATUS.GIVEN,
         scheduledVaccineId: scheduled1.id,
         recorderId: clinician.id,
@@ -414,7 +414,7 @@ describe('PatientVaccine', () => {
     });
 
     it('Should not have current date as default', async () => {
-      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_STATUS.GIVEN,
         scheduledVaccineId: scheduled1.id,
         recorderId: clinician.id,
@@ -429,7 +429,7 @@ describe('PatientVaccine', () => {
     });
 
     it('Should create a vaccine encounter with the correct description', async () => {
-      const result = await app.post(`/v1/patient/${patient.id}/administeredVaccine`).send({
+      const result = await app.post(`/api/patient/${patient.id}/administeredVaccine`).send({
         status: VACCINE_STATUS.GIVEN,
         scheduledVaccineId: scheduled1.id,
         recorderId: clinician.id,
@@ -448,13 +448,13 @@ describe('PatientVaccine', () => {
     });
 
     it('Should update reason for encounter with correct description when vaccine is recorded in error', async () => {
-      const result = await app.get(`/v1/patient/${patient.id}/administeredVaccines`);
+      const result = await app.get(`/api/patient/${patient.id}/administeredVaccines`);
       const vaccineId = result.body.data[0].id;
       const vaccine = await models.AdministeredVaccine.findByPk(vaccineId);
       const encounter = await vaccine.getEncounter();
 
       const markedAsRecordedInError = await app
-        .put(`/v1/patient/${patient.id}/administeredVaccine/${vaccineId}`)
+        .put(`/api/patient/${patient.id}/administeredVaccine/${vaccineId}`)
         .send({ status: VACCINE_STATUS.RECORDED_IN_ERROR });
 
       expect(markedAsRecordedInError).toHaveSucceeded();
@@ -490,14 +490,14 @@ describe('PatientVaccine', () => {
     });
 
     it('Should return the vaccines for a patient', async () => {
-      const result = await app.get(`/v1/patient/${readPatient.id}/administeredVaccines`);
+      const result = await app.get(`/api/patient/${readPatient.id}/administeredVaccines`);
       expect(result).toHaveSucceeded();
       expect(result.body.data).toHaveLength(3);
     });
 
     it('Should sort null dates as though they are old', async () => {
       const result = await app.get(
-        `/v1/patient/${readPatient.id}/administeredVaccines?orderBy=date`,
+        `/api/patient/${readPatient.id}/administeredVaccines?orderBy=date`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body.data).toHaveLength(3);
@@ -510,7 +510,7 @@ describe('PatientVaccine', () => {
 
     it('Should sort null dates as though they are old (descending)', async () => {
       const result = await app.get(
-        `/v1/patient/${readPatient.id}/administeredVaccines?orderBy=date&order=desc`,
+        `/api/patient/${readPatient.id}/administeredVaccines?orderBy=date&order=desc`,
       );
       expect(result).toHaveSucceeded();
       expect(result.body.data).toHaveLength(3);

--- a/packages/facility-server/__tests__/apiv1/Procedures.test.js
+++ b/packages/facility-server/__tests__/apiv1/Procedures.test.js
@@ -33,7 +33,7 @@ describe('Procedures', () => {
   afterAll(() => ctx.close());
 
   it('should record a procedure', async () => {
-    const result = await app.post('/v1/procedure').send({
+    const result = await app.post('/api/procedure').send({
       encounterId: encounter.id,
       note: 'test',
       date: new Date(),
@@ -51,7 +51,7 @@ describe('Procedures', () => {
       encounterId: encounter.id,
     });
 
-    const result = await app.put(`/v1/procedure/${record.id}`).send({
+    const result = await app.put(`/api/procedure/${record.id}`).send({
       note: 'after',
     });
     expect(result).toHaveSucceeded();
@@ -67,7 +67,7 @@ describe('Procedures', () => {
     });
     expect(record.endTime).toBeFalsy();
 
-    const result = await app.put(`/v1/procedure/${record.id}`).send({
+    const result = await app.put(`/api/procedure/${record.id}`).send({
       endTime: new Date(),
     });
     expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/facility-server/__tests__/apiv1/ProgramRegistry.test.js
@@ -22,7 +22,7 @@ describe('ProgramRegistry', () => {
     await models.Patient.truncate({ cascade: true });
   });
 
-  describe('Getting (GET /v1/programRegistry/:id)', () => {
+  describe('Getting (GET /api/programRegistry/:id)', () => {
     it('should fetch a survey', async () => {
       const { id } = await models.ProgramRegistry.create(
         fake(models.ProgramRegistry, {
@@ -31,14 +31,14 @@ describe('ProgramRegistry', () => {
         }),
       );
 
-      const result = await app.get(`/v1/programRegistry/${id}`);
+      const result = await app.get(`/api/programRegistry/${id}`);
       expect(result).toHaveSucceeded();
 
       expect(result.body).toHaveProperty('name', 'Hepatitis Registry');
     });
   });
 
-  describe('Listing (GET /v1/programRegistry)', () => {
+  describe('Listing (GET /api/programRegistry)', () => {
     it('should list available program registries', async () => {
       await models.ProgramRegistry.create(
         fake(models.ProgramRegistry, { programId: testProgram.id }),
@@ -53,7 +53,7 @@ describe('ProgramRegistry', () => {
         fake(models.ProgramRegistry, { programId: testProgram.id }),
       );
 
-      const result = await app.get('/v1/programRegistry');
+      const result = await app.get('/api/programRegistry');
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -133,7 +133,7 @@ describe('ProgramRegistry', () => {
       );
 
       const result = await app
-        .get('/v1/programRegistry')
+        .get('/api/programRegistry')
         .query({ excludePatientId: testPatient.id });
       expect(result).toHaveSucceeded();
       expect(result.body.data.length).toBe(3);
@@ -148,14 +148,14 @@ describe('ProgramRegistry', () => {
 
     it('should escape the excludePatientId parameter', async () => {
       const result = await app
-        .get('/v1/programRegistry')
+        .get('/api/programRegistry')
         .query({ excludePatientId: "'bobby tables/\\'&;" });
       expect(result).toHaveSucceeded();
       expect(result.body.data.length).toBe(0);
     });
   });
 
-  describe('Listing conditions (GET /v1/programRegistry/:id/conditions)', () => {
+  describe('Listing conditions (GET /api/programRegistry/:id/conditions)', () => {
     it('should list available conditions', async () => {
       const { id: programRegistryId } = await models.ProgramRegistry.create(
         fake(models.ProgramRegistry, { programId: testProgram.id }),
@@ -167,7 +167,7 @@ describe('ProgramRegistry', () => {
         fake(models.ProgramRegistryCondition, { programRegistryId }),
       );
 
-      const result = await app.get(`/v1/programRegistry/${programRegistryId}/conditions`);
+      const result = await app.get(`/api/programRegistry/${programRegistryId}/conditions`);
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -176,7 +176,7 @@ describe('ProgramRegistry', () => {
     });
   });
 
-  describe('Listing registrations (GET /v1/programRegistry/:id/registrations)', () => {
+  describe('Listing registrations (GET /api/programRegistry/:id/registrations)', () => {
     it('should list registrations', async () => {
       const { id: programRegistryId } = await models.ProgramRegistry.create(
         fake(models.ProgramRegistry, { programId: testProgram.id }),
@@ -227,7 +227,7 @@ describe('ProgramRegistry', () => {
         }),
       );
 
-      const result = await app.get(`/v1/programRegistry/${programRegistryId}/registrations`).query({
+      const result = await app.get(`/api/programRegistry/${programRegistryId}/registrations`).query({
         sortBy: 'clinicalStatus',
       });
       expect(result).toHaveSucceeded();
@@ -332,7 +332,7 @@ describe('ProgramRegistry', () => {
         }),
       );
 
-      const result = await app.get(`/v1/programRegistry/${programRegistryId}/registrations`).query({
+      const result = await app.get(`/api/programRegistry/${programRegistryId}/registrations`).query({
         programRegistryCondition: relevantCondition.id,
       });
       expect(result).toHaveSucceeded();
@@ -382,7 +382,7 @@ describe('ProgramRegistry', () => {
       it.each(patientFilters)(
         'Should only include records matching patient filter ($filter: $value)',
         async ({ filter, value }) => {
-          const result = await app.get(`/v1/programRegistry/${registryId}/registrations`).query({
+          const result = await app.get(`/api/programRegistry/${registryId}/registrations`).query({
             rowsPerPage: 100,
             [filter]: value,
           });

--- a/packages/facility-server/__tests__/apiv1/Programs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Programs.test.js
@@ -122,7 +122,7 @@ describe('Programs', () => {
 
   describe('Listing', () => {
     it('should list available programs', async () => {
-      const result = await app.get(`/v1/program`);
+      const result = await app.get(`/api/program`);
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -132,7 +132,7 @@ describe('Programs', () => {
     });
 
     it('should list surveys within a program', async () => {
-      const result = await app.get(`/v1/program/${testProgram.id}/surveys`);
+      const result = await app.get(`/api/program/${testProgram.id}/surveys`);
       expect(result).toHaveSucceeded();
 
       expect(result.body.count).toEqual(4);
@@ -149,7 +149,7 @@ describe('Programs', () => {
         { programId: testProgram.id, surveyType: SURVEY_TYPES.PROGRAM, name: 'relevant' },
       ]);
 
-      const result = await app.get('/v1/suggestions/survey');
+      const result = await app.get('/api/suggestions/survey');
       expect(result).toHaveSucceeded();
       const resultIds = result.body.map(x => x.id);
       expect(resultIds.includes(obsolete.id)).toEqual(false);
@@ -159,7 +159,7 @@ describe('Programs', () => {
   });
 
   it('should fetch a survey', async () => {
-    const result = await app.get(`/v1/survey/${testSurvey.id}`);
+    const result = await app.get(`/api/survey/${testSurvey.id}`);
     expect(result).toHaveSucceeded();
 
     const { body } = result;
@@ -174,7 +174,7 @@ describe('Programs', () => {
   describe('Survey responses', () => {
     it('should submit a survey response against an encounter', async () => {
       const responseData = createDummySurveyResponse(testSurvey);
-      const result = await app.post(`/v1/surveyResponse`).send({
+      const result = await app.post(`/api/surveyResponse`).send({
         ...responseData,
         encounterId: testEncounter.id,
         surveyId: testSurvey.id,
@@ -218,7 +218,7 @@ describe('Programs', () => {
       );
 
       const programResponses = await app.get(
-        `/v1/encounter/${encounter.id}/programResponses?rowsPerPage=100`,
+        `/api/encounter/${encounter.id}/programResponses?rowsPerPage=100`,
       );
       expect(programResponses).toHaveSucceeded();
 
@@ -260,7 +260,7 @@ describe('Programs', () => {
         5,
       );
 
-      const result = await app.get(`/v1/patient/${patient.id}/programResponses?rowsPerPage=10`);
+      const result = await app.get(`/api/patient/${patient.id}/programResponses?rowsPerPage=10`);
       expect(result).toHaveSucceeded();
 
       // check pagination is coming through ok
@@ -281,7 +281,7 @@ describe('Programs', () => {
 
       // check page 2
       const result2 = await app.get(
-        `/v1/patient/${patient.id}/programResponses?rowsPerPage=10&page=1`,
+        `/api/patient/${patient.id}/programResponses?rowsPerPage=10&page=1`,
       );
       expect(result2).toHaveSucceeded();
       expect(result2.body.data.length).toEqual(5);
@@ -298,7 +298,7 @@ describe('Programs', () => {
       expect(patient).toBeTruthy();
       expect(existingEncounter).toHaveProperty('patientId', patient.id);
 
-      const result = await app.post(`/v1/surveyResponse`).send({
+      const result = await app.post(`/api/surveyResponse`).send({
         ...createDummySurveyResponse(testSurvey),
         patientId: patient.id,
       });
@@ -315,7 +315,7 @@ describe('Programs', () => {
     it('should automatically create an encounter if none exists', async () => {
       const { examinerId, departmentId, locationId } = await createDummyEncounter(models);
 
-      const result = await app.post(`/v1/surveyResponse`).send({
+      const result = await app.post(`/api/surveyResponse`).send({
         ...createDummySurveyResponse(testSurvey),
         patientId: testPatient.id,
         userId: examinerId,
@@ -355,7 +355,7 @@ describe('Programs', () => {
 
       it('should NOT list survey responses of type referral when fetching programResponses', async () => {
         const programResponses = await app.get(
-          `/v1/patient/${patientId}/programResponses?rowsPerPage=100`,
+          `/api/patient/${patientId}/programResponses?rowsPerPage=100`,
         );
 
         expect(programResponses).toHaveSucceeded();
@@ -364,7 +364,7 @@ describe('Programs', () => {
 
       it('should NOT list survey responses of type referral when fetching programResponses', async () => {
         const programResponses = await app.get(
-          `/v1/patient/${patientId}/programResponses?surveyId=${testSurvey2.id}`,
+          `/api/patient/${patientId}/programResponses?surveyId=${testSurvey2.id}`,
         );
 
         expect(programResponses).toHaveSucceeded();
@@ -407,7 +407,7 @@ describe('Programs', () => {
         });
         expect(beforeIssue).toBeFalsy();
 
-        const result = await app.post(`/v1/surveyResponse`).send({
+        const result = await app.post(`/api/surveyResponse`).send({
           answers: { [pdeId]: true },
           surveyId,
           encounterId: testEncounter.id,
@@ -433,7 +433,7 @@ describe('Programs', () => {
         const TEST_EMAIL = 'updated-email@tamanu.io';
         expect(testPatient.email).not.toEqual(TEST_EMAIL);
 
-        const result = await app.post(`/v1/surveyResponse`).send({
+        const result = await app.post(`/api/surveyResponse`).send({
           answers: { [pdeId]: TEST_EMAIL },
           surveyId,
           encounterId: testEncounter.id,
@@ -458,7 +458,7 @@ describe('Programs', () => {
         const padRecord = await models.PatientAdditionalData.getOrCreateForPatient(testPatient.id);
         expect(padRecord.passport).not.toEqual(TEST_PASSPORT);
 
-        const result = await app.post(`/v1/surveyResponse`).send({
+        const result = await app.post(`/api/surveyResponse`).send({
           answers: { [pdeId]: TEST_PASSPORT },
           surveyId,
           encounterId: testEncounter.id,
@@ -485,7 +485,7 @@ describe('Programs', () => {
         const noPadRecord = await models.PatientAdditionalData.getForPatient(freshPatient.id);
         expect(noPadRecord).toBeFalsy();
 
-        const result = await app.post(`/v1/surveyResponse`).send({
+        const result = await app.post(`/api/surveyResponse`).send({
           answers: { [pdeId]: TEST_PASSPORT },
           surveyId,
           patientId: freshPatient.id,
@@ -504,7 +504,7 @@ describe('Programs', () => {
       // get some valid ids
       const { examinerId, locationId } = await createDummyEncounter(models);
 
-      const result = await app.post(`/v1/surveyResponse`).send({
+      const result = await app.post(`/api/surveyResponse`).send({
         ...createDummySurveyResponse(testSurvey),
         patientId: testPatient.id,
         userId: examinerId,
@@ -519,7 +519,7 @@ describe('Programs', () => {
       // get some valid ids
       const { examinerId, locationId } = await createDummyEncounter(models);
 
-      const result = await app.post(`/v1/surveyResponse`).send({
+      const result = await app.post(`/api/surveyResponse`).send({
         ...createDummySurveyResponse(testSurvey),
         patientId: testPatient.id,
         userId: examinerId,

--- a/packages/facility-server/__tests__/apiv1/ReferenceData.test.js
+++ b/packages/facility-server/__tests__/apiv1/ReferenceData.test.js
@@ -17,7 +17,7 @@ describe('Reference data', () => {
   afterAll(() => ctx.close());
 
   it('should not allow a regular user to create a new reference item', async () => {
-    const result = await userApp.post('/v1/referenceData').send({
+    const result = await userApp.post('/api/referenceData').send({
       type: 'icd10',
       name: 'fail',
       code: 'fail',
@@ -31,14 +31,14 @@ describe('Reference data', () => {
       name: 'no-user-change',
       code: 'no-user-change',
     });
-    const result = await userApp.put(`/v1/referenceData/${existing.id}`).send({
+    const result = await userApp.put(`/api/referenceData/${existing.id}`).send({
       name: 'fail',
     });
     expect(result).toBeForbidden();
   });
 
   it('should allow an admin create a new reference data item', async () => {
-    const result = await adminApp.post('/v1/referenceData').send({
+    const result = await adminApp.post('/api/referenceData').send({
       type: 'icd10',
       code: 'succeed',
       name: 'succeed',
@@ -52,7 +52,7 @@ describe('Reference data', () => {
       name: 'change-label',
       code: 'change-label',
     });
-    const result = await adminApp.put(`/v1/referenceData/${existing.id}`).send({
+    const result = await adminApp.put(`/api/referenceData/${existing.id}`).send({
       name: 'succeed',
     });
     expect(result).toHaveSucceeded();
@@ -64,14 +64,14 @@ describe('Reference data', () => {
       name: 'no-change-type',
       code: 'no-change-type',
     });
-    const result = await adminApp.put(`/v1/referenceData/${existing.id}`).send({
+    const result = await adminApp.put(`/api/referenceData/${existing.id}`).send({
       type: 'drug',
     });
     expect(result).toHaveRequestError();
   });
 
   it('should not allow creating a reference data with an invalid type', async () => {
-    const result = await adminApp.post('/v1/referenceData').send({
+    const result = await adminApp.post('/api/referenceData').send({
       type: 'fail',
       name: 'test',
     });

--- a/packages/facility-server/__tests__/apiv1/Referrals.test.js
+++ b/packages/facility-server/__tests__/apiv1/Referrals.test.js
@@ -90,7 +90,7 @@ describe('Referrals', () => {
 
   it('should record a referral request', async () => {
     const { departmentId, locationId } = encounter;
-    const result = await app.post('/v1/referral').send({
+    const result = await app.post('/api/referral').send({
       answers,
       startTime: Date.now(),
       endTime: Date.now(),
@@ -105,7 +105,7 @@ describe('Referrals', () => {
   it('should get all referrals for a patient', async () => {
     const { departmentId, locationId } = encounter;
     // create a second referral
-    await app.post('/v1/referral').send({
+    await app.post('/api/referral').send({
       answers,
       startTime: Date.now(),
       endTime: Date.now(),
@@ -115,7 +115,7 @@ describe('Referrals', () => {
       locationId,
     });
 
-    const result = await app.get(`/v1/patient/${patient.id}/referrals`);
+    const result = await app.get(`/api/patient/${patient.id}/referrals`);
     expect(result).toHaveSucceeded();
     expect(result.body.count).toEqual(2);
   });
@@ -125,7 +125,7 @@ describe('Referrals', () => {
     const department = await findOneOrCreate(ctx.models, ctx.models.Department, { code: departmentCode });
 
     const { locationId } = encounter;
-    const result = await app.post('/v1/referral').send({
+    const result = await app.post('/api/referral').send({
       answers,
       startTime: Date.now(),
       endTime: Date.now(),
@@ -146,7 +146,7 @@ describe('Referrals', () => {
     const location = await findOneOrCreate(ctx.models, ctx.models.Location, { code: locationCode });
 
     const { departmentId } = encounter;
-    const result = await app.post('/v1/referral').send({
+    const result = await app.post('/api/referral').send({
       answers,
       startTime: Date.now(),
       endTime: Date.now(),

--- a/packages/facility-server/__tests__/apiv1/ReportRequest.test.js
+++ b/packages/facility-server/__tests__/apiv1/ReportRequest.test.js
@@ -13,7 +13,7 @@ describe('ReportRequest', () => {
 
   it('should reject reading a patient with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.post('/v1/reportRequest/').send({
+    const result = await noPermsApp.post('/api/reportRequest/').send({
       reportId: 'incomplete-referrals',
     });
     expect(result).toBeForbidden();
@@ -22,7 +22,7 @@ describe('ReportRequest', () => {
   describe('permissions', () => {
     testReportPermissions(
       () => ctx,
-      (reportApp, reportId) => reportApp.post('/v1/reportRequest').send({ reportId }),
+      (reportApp, reportId) => reportApp.post('/api/reportRequest').send({ reportId }),
     );
   });
 
@@ -33,7 +33,7 @@ describe('ReportRequest', () => {
     });
 
     it('should fail with 404 and message if report module is not found', async () => {
-      const res = await app.post('/v1/reportRequest').send({
+      const res = await app.post('/api/reportRequest').send({
         reportId: 'invalid-report',
         emailList: [],
       });
@@ -42,7 +42,7 @@ describe('ReportRequest', () => {
     });
 
     it('should create a new report request', async () => {
-      const result = await app.post('/v1/reportRequest').send({
+      const result = await app.post('/api/reportRequest').send({
         reportId: 'incomplete-referrals',
         emailList: ['example@gmail.com', 'other@gmail.com'],
       });

--- a/packages/facility-server/__tests__/apiv1/ReportSchemaRoles.test.js
+++ b/packages/facility-server/__tests__/apiv1/ReportSchemaRoles.test.js
@@ -115,7 +115,7 @@ describe('ReportSchemaRoles', () => {
         versionNumber: 1,
         userId: user.id,
       });
-      const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`);
+      const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`);
       expect(response).toHaveSucceeded();
       expect(response.body).toEqual([
         ['id', 'name'],
@@ -132,7 +132,7 @@ describe('ReportSchemaRoles', () => {
         versionNumber: 1,
         userId: user.id,
       });
-      const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`);
+      const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`);
       expect(response).toHaveRequestError();
       expect(response.body.error.message).toEqual('permission denied for table raw_test_table');
     });
@@ -147,7 +147,7 @@ describe('ReportSchemaRoles', () => {
         versionNumber: 1,
         userId: user.id,
       });
-      const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`);
+      const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`);
       expect(response).toHaveSucceeded();
       expect(response.body).toEqual([
         ['id', 'name'],
@@ -164,7 +164,7 @@ describe('ReportSchemaRoles', () => {
         versionNumber: 1,
         userId: user.id,
       });
-      const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`);
+      const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`);
       expect(response).toHaveSucceeded();
       expect(response.body).toEqual([
         ['id', 'name'],
@@ -184,7 +184,7 @@ describe('ReportSchemaRoles', () => {
       versionNumber: 1,
       userId: user.id,
     });
-    const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`);
+    const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`);
     expect(response).toHaveRequestError();
     expect(response.body.error.message).toEqual('permission denied for table reporting_test_table');
   });

--- a/packages/facility-server/__tests__/apiv1/Reports.test.js
+++ b/packages/facility-server/__tests__/apiv1/Reports.test.js
@@ -51,14 +51,14 @@ describe('Reports', () => {
     });
 
     it('should run a simple database defined report', async () => {
-      const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`);
+      const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`);
       expect(response).toHaveSucceeded();
       // There will be more than one user because of the app context
       expect(response.body.length).toBeGreaterThan(1);
     });
 
     it('should apply filters on a database defined report', async () => {
-      const response = await adminApp.post(`/v1/reports/${reportDefinitionVersion.id}`).send({
+      const response = await adminApp.post(`/api/reports/${reportDefinitionVersion.id}`).send({
         parameters: {
           email: user.email,
         },
@@ -96,7 +96,7 @@ describe('Reports', () => {
       const { app, permittedReports } = await setupReportPermissionsTest(baseApp, ctx.models);
 
       // Act
-      const res = await app.get('/v1/reports');
+      const res = await app.get('/api/reports');
 
       // Assert
       expect(res).toHaveSucceeded();
@@ -110,7 +110,7 @@ describe('Reports', () => {
   describe('post permissions', () => {
     testReportPermissions(
       () => ctx,
-      (reportApp, reportId) => reportApp.post(`/v1/reports/${reportId}`),
+      (reportApp, reportId) => reportApp.post(`/api/reports/${reportId}`),
     );
   });
 
@@ -118,21 +118,21 @@ describe('Reports', () => {
     disableHardcodedPermissionsForSuite();
     it('should reject reading a report with insufficient permissions', async () => {
       const app = await baseApp.asRole('base');
-      const result = await app.post('/v1/reports/incomplete-referrals', {});
+      const result = await app.post('/api/reports/incomplete-referrals', {});
       expect(result).toBeForbidden();
     });
 
     it('should fail with 404 and message if report module is not found', async () => {
       jest.spyOn(reportsUtils, 'getReportModule').mockResolvedValue(null);
       const app = await baseApp.asRole('practitioner');
-      const res = await app.post('/v1/reports/invalid-report', {});
+      const res = await app.post('/api/reports/invalid-report', {});
       expect(res).toHaveStatus(404);
       expect(res.body).toMatchObject({ error: { message: 'Report module not found' } });
     });
 
     it('should fail with 400 and error message if dataGenerator encounters error', async () => {
       const app = await baseApp.asNewRole([['run', 'StaticReport', 'incomplete-referrals']]);
-      const res = await app.post('/v1/reports/incomplete-referrals').send({
+      const res = await app.post('/api/reports/incomplete-referrals').send({
         parameters: {
           fromDate: '2020-01-01',
           toDate: 'invalid-date',

--- a/packages/facility-server/__tests__/apiv1/ScheduledVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/ScheduledVaccine.test.js
@@ -39,19 +39,19 @@ describe('Scheduled Vaccine', () => {
 
   it('should reject with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.get(`/v1/scheduledVaccine`);
+    const result = await noPermsApp.get(`/api/scheduledVaccine`);
     expect(result).toBeForbidden();
   });
 
   it('should only return vaccines with visibilityStatus = current', async () => {
-    const result = await app.get(`/v1/scheduledVaccine`, {});
+    const result = await app.get(`/api/scheduledVaccine`, {});
     expect(result).toHaveSucceeded();
     expect(result.body.length).toBe(2);
   });
 
   describe('returns data based on query parameters', () => {
     it('should return data for vaccines of the right category', async () => {
-      const result = await app.get('/v1/scheduledVaccine?category=Category1');
+      const result = await app.get('/api/scheduledVaccine?category=Category1');
       const { body } = result;
 
       expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -45,7 +45,7 @@ describe('Suggestions', () => {
     });
 
     it('should get a patient by first name', async () => {
-      const result = await userApp.get('/v1/suggestions/patient').query({ q: 'Test' });
+      const result = await userApp.get('/api/suggestions/patient').query({ q: 'Test' });
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -54,7 +54,7 @@ describe('Suggestions', () => {
     });
 
     it('should get a patient by last name', async () => {
-      const result = await userApp.get('/v1/suggestions/patient').query({ q: 'Appear' });
+      const result = await userApp.get('/api/suggestions/patient').query({ q: 'Appear' });
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -63,7 +63,7 @@ describe('Suggestions', () => {
     });
 
     it('should get a patient by combined first and last name', async () => {
-      const result = await userApp.get('/v1/suggestions/patient').query({ q: 'Test Appear' });
+      const result = await userApp.get('/api/suggestions/patient').query({ q: 'Test Appear' });
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -72,7 +72,7 @@ describe('Suggestions', () => {
     });
 
     it('should get a patient by displayId', async () => {
-      const result = await userApp.get('/v1/suggestions/patient').query({ q: 'abcabc123123' });
+      const result = await userApp.get('/api/suggestions/patient').query({ q: 'abcabc123123' });
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -81,7 +81,7 @@ describe('Suggestions', () => {
     });
 
     it('should not get patients without permission', async () => {
-      const result = await baseApp.get('/v1/suggestions/patient').query({ q: 'anything' });
+      const result = await baseApp.get('/api/suggestions/patient').query({ q: 'anything' });
       expect(result).toBeForbidden();
     });
   });
@@ -134,7 +134,7 @@ describe('Suggestions', () => {
     });
 
     it('should calculate location availability and return it with suggestion list', async () => {
-      const result = await userApp.get('/v1/suggestions/location');
+      const result = await userApp.get('/api/suggestions/location');
       expect(result).toHaveSucceeded();
 
       const { body } = result;
@@ -180,12 +180,12 @@ describe('Suggestions', () => {
         name: 'Bed 3',
         visibilityStatus: 'current',
       });
-      const result = await userApp.get('/v1/suggestions/location');
+      const result = await userApp.get('/api/suggestions/location');
       expect(result).toHaveSucceeded();
       expect(result?.body?.length).toEqual(3);
 
       const filteredResult = await userApp.get(
-        '/v1/suggestions/location?locationGroupId=test-area',
+        '/api/suggestions/location?locationGroupId=test-area',
       );
       expect(filteredResult).toHaveSucceeded();
       expect(filteredResult?.body?.length).toEqual(2);
@@ -208,7 +208,7 @@ describe('Suggestions', () => {
         visibilityStatus: 'current',
         facilityId: facility.id,
       });
-      const result = await userApp.get('/v1/suggestions/location');
+      const result = await userApp.get('/api/suggestions/location');
       expect(result).toHaveSucceeded();
       expect(result?.body?.length).toEqual(1);
       expect(result.body[0].facilityId).toEqual(facility.id);
@@ -219,7 +219,7 @@ describe('Suggestions', () => {
     const limit = 25;
 
     it('should get a default list of suggestions with an empty query', async () => {
-      const result = await userApp.get('/v1/suggestions/icd10');
+      const result = await userApp.get('/api/suggestions/icd10');
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body).toBeInstanceOf(Array);
@@ -227,7 +227,7 @@ describe('Suggestions', () => {
     });
 
     it('should get a full list of diagnoses with a general query', async () => {
-      const result = await userApp.get('/v1/suggestions/icd10?q=A');
+      const result = await userApp.get('/api/suggestions/icd10?q=A');
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body).toBeInstanceOf(Array);
@@ -237,7 +237,7 @@ describe('Suggestions', () => {
     it('should get a partial list of diagnoses with a specific query', async () => {
       const count = testDiagnoses.filter(td => td.name.toLowerCase().includes('bacterial')).length;
       expect(count).toBeLessThan(limit); // ensure we're actually testing filtering!
-      const result = await userApp.get('/v1/suggestions/icd10?q=bacterial');
+      const result = await userApp.get('/api/suggestions/icd10?q=bacterial');
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body).toBeInstanceOf(Array);
@@ -245,7 +245,7 @@ describe('Suggestions', () => {
     });
 
     it('should not be case sensitive', async () => {
-      const result = await userApp.get('/v1/suggestions/icd10?q=pNeUmOnIa');
+      const result = await userApp.get('/api/suggestions/icd10?q=pNeUmOnIa');
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body).toBeInstanceOf(Array);
@@ -254,7 +254,7 @@ describe('Suggestions', () => {
 
     it('should look up a specific suggestion', async () => {
       const record = await models.ReferenceData.findOne();
-      const result = await userApp.get(`/v1/suggestions/icd10/${record.id}`);
+      const result = await userApp.get(`/api/suggestions/icd10/${record.id}`);
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body).toHaveProperty('name', record.name);
@@ -264,7 +264,7 @@ describe('Suggestions', () => {
 
   describe('Other suggesters', () => {
     it('should get suggestions for a medication', async () => {
-      const result = await userApp.get('/v1/suggestions/drug?q=a');
+      const result = await userApp.get('/api/suggestions/drug?q=a');
       expect(result).toHaveSucceeded();
       const { body } = result;
       expect(body).toBeInstanceOf(Array);
@@ -314,7 +314,7 @@ describe('Suggestions', () => {
       ]);
 
       const result = await userApp
-        .get('/v1/suggestions/survey')
+        .get('/api/suggestions/survey')
         .query({ q: 'X', programId: 'all-survey-program-id' });
       expect(result).toHaveSucceeded();
       const { body } = result;
@@ -342,7 +342,7 @@ describe('Suggestions', () => {
 
       await models.ReferenceData.bulkCreate(testData);
 
-      const result = await userApp.get('/v1/suggestions/icd10?q=cons');
+      const result = await userApp.get('/api/suggestions/icd10?q=cons');
       expect(result).toHaveSucceeded();
       const { body } = result;
       const firstResult = body[0];
@@ -371,7 +371,7 @@ describe('Suggestions', () => {
 
       await models.ReferenceData.bulkCreate(testData);
 
-      const result = await userApp.get('/v1/suggestions/icd10?q=acute');
+      const result = await userApp.get('/api/suggestions/icd10?q=acute');
       expect(result).toHaveSucceeded();
       const { body } = result;
 
@@ -393,7 +393,7 @@ describe('Suggestions', () => {
       visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
     });
 
-    const result = await userApp.get('/v1/suggestions/allergy?q=visibility');
+    const result = await userApp.get('/api/suggestions/allergy?q=visibility');
     expect(result).toHaveSucceeded();
     const { body } = result;
 
@@ -412,7 +412,7 @@ describe('Suggestions', () => {
     }));
 
     await models.ReferenceData.bulkCreate(dummyRecords);
-    const result = await userApp.get('/v1/suggestions/icd10/all');
+    const result = await userApp.get('/api/suggestions/icd10/all');
     expect(result).toHaveSucceeded();
     expect(result.body).toHaveLength(30);
   });

--- a/packages/facility-server/__tests__/apiv1/Survey.test.js
+++ b/packages/facility-server/__tests__/apiv1/Survey.test.js
@@ -41,7 +41,7 @@ describe('Survey', () => {
       });
     });
     it('should return the vitals survey', async () => {
-      const result = await app.get(`/v1/survey/vitals`);
+      const result = await app.get(`/api/survey/vitals`);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         id: 'vitals-survey',

--- a/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
@@ -93,7 +93,7 @@ describe('SurveyResponse', () => {
       );
 
       // act
-      const result = await app.get(`/v1/surveyResponse/${response.id}`);
+      const result = await app.get(`/api/surveyResponse/${response.id}`);
 
       // assert
       expect(result).toHaveSucceeded();
@@ -119,7 +119,7 @@ describe('SurveyResponse', () => {
       const { response } = await setupAutocompleteSurvey('{}', facility.id);
 
       // act
-      const result = await app.get(`/v1/surveyResponse/${response.id}`);
+      const result = await app.get(`/api/surveyResponse/${response.id}`);
 
       // assert
       expect(result).not.toHaveSucceeded();
@@ -140,7 +140,7 @@ describe('SurveyResponse', () => {
       );
 
       // act
-      const result = await app.get(`/v1/surveyResponse/${response.id}`);
+      const result = await app.get(`/api/surveyResponse/${response.id}`);
 
       // assert
       expect(result).not.toHaveSucceeded();
@@ -161,7 +161,7 @@ describe('SurveyResponse', () => {
       );
 
       // act
-      const result = await app.get(`/v1/surveyResponse/${response.id}`);
+      const result = await app.get(`/api/surveyResponse/${response.id}`);
 
       // assert
       expect(result).not.toHaveSucceeded();
@@ -182,7 +182,7 @@ describe('SurveyResponse', () => {
       );
 
       // act
-      const result = await app.get(`/v1/surveyResponse/${response.id}`);
+      const result = await app.get(`/api/surveyResponse/${response.id}`);
 
       // assert
       expect(result).not.toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/SurveyResponseAnswer.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponseAnswer.test.js
@@ -161,7 +161,7 @@ describe('SurveyResponseAnswer', () => {
         const answers = await response.getAnswers();
         const singleAnswer = answers.find(answer => answer.dataElementId === dataElements[0].id);
         const newValue = parseInt(singleAnswer.body, 10) + 1;
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
           reasonForChange: 'test',
           newValue,
           date: getCurrentDateTimeString(),
@@ -178,7 +178,7 @@ describe('SurveyResponseAnswer', () => {
         const previousValue = singleAnswer.body;
         const newValue = parseInt(previousValue, 10) + 1;
         const reasonForChange = 'test2';
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
           reasonForChange,
           newValue,
           date: getCurrentDateTimeString(),
@@ -208,7 +208,7 @@ describe('SurveyResponseAnswer', () => {
         const newCalculatedValue = (newValue + 1).toFixed(1);
         const reasonForChange = 'test3';
 
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/${usedAnswer.id}`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/${usedAnswer.id}`).send({
           reasonForChange,
           newValue,
           date: getCurrentDateTimeString(),
@@ -264,7 +264,7 @@ describe('SurveyResponseAnswer', () => {
         );
         const answers = await response.getAnswers();
         const singleAnswer = answers.find(answer => answer.dataElementId === pde.id);
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
           reasonForChange: 'test4',
           newValue: chance.string(),
           date: getCurrentDateTimeString(),
@@ -280,7 +280,7 @@ describe('SurveyResponseAnswer', () => {
           answer => answer.dataElementId === dataElements[2].id,
         );
 
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/${calculatedAnswer.id}`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/${calculatedAnswer.id}`).send({
           reasonForChange: 'test5',
           newValue: chance.integer({ min: 0, max: 100 }),
           date: getCurrentDateTimeString(),
@@ -294,7 +294,7 @@ describe('SurveyResponseAnswer', () => {
         const answers = await response.getAnswers();
         const singleAnswer = answers.find(answer => answer.dataElementId === dataElements[0].id);
         const newValue = singleAnswer.body;
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/${singleAnswer.id}`).send({
           reasonForChange: 'test6',
           newValue,
         });
@@ -312,7 +312,7 @@ describe('SurveyResponseAnswer', () => {
           localisation: JSON.stringify({ features: { enableVitalEdit: false } }),
         });
 
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/nonImportantID`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/nonImportantID`).send({
           reasonForChange: 'test7',
           newValue: chance.integer({ min: 0, max: 100 }),
         });
@@ -323,7 +323,7 @@ describe('SurveyResponseAnswer', () => {
       it('should return error if feature flag does not exist', async () => {
         await models.UserLocalisationCache.truncate({ cascade: true });
 
-        const result = await app.put(`/v1/surveyResponseAnswer/vital/nonImportantID`).send({
+        const result = await app.put(`/api/surveyResponseAnswer/vital/nonImportantID`).send({
           reasonForChange: 'test8',
           newValue: chance.integer({ min: 0, max: 100 }),
         });
@@ -365,7 +365,7 @@ describe('SurveyResponseAnswer', () => {
         const answers = await response.getAnswers();
         const dateAnswer = answers.find(answer => answer.dataElementId === dataElements[3].id);
         const newValue = chance.integer({ min: 0, max: 100 });
-        const result = await app.post('/v1/surveyResponseAnswer/vital').send({
+        const result = await app.post('/api/surveyResponseAnswer/vital').send({
           reasonForChange: 'another-test',
           newValue,
           date: getCurrentDateTimeString(),
@@ -387,7 +387,7 @@ describe('SurveyResponseAnswer', () => {
         const newValue = chance.integer({ min: 0, max: 100 });
         const reasonForChange = 'another-test2';
         const date = getCurrentDateTimeString();
-        const result = await app.post('/v1/surveyResponseAnswer/vital').send({
+        const result = await app.post('/api/surveyResponseAnswer/vital').send({
           reasonForChange,
           newValue,
           date,
@@ -414,7 +414,7 @@ describe('SurveyResponseAnswer', () => {
           localisation: JSON.stringify({ features: { enableVitalEdit: false } }),
         });
 
-        const result = await app.post('/v1/surveyResponseAnswer/vital').send({
+        const result = await app.post('/api/surveyResponseAnswer/vital').send({
           reasonForChange: 'another-test3',
           newValue: chance.integer({ min: 0, max: 100 }),
         });
@@ -425,7 +425,7 @@ describe('SurveyResponseAnswer', () => {
       it('should return error if feature flag does not exist', async () => {
         await models.UserLocalisationCache.truncate({ cascade: true, force: true });
 
-        const result = await app.post('/v1/surveyResponseAnswer/vital').send({
+        const result = await app.post('/api/surveyResponseAnswer/vital').send({
           reasonForChange: 'another-test4',
           newValue: chance.integer({ min: 0, max: 100 }),
         });

--- a/packages/facility-server/__tests__/apiv1/Template.test.js
+++ b/packages/facility-server/__tests__/apiv1/Template.test.js
@@ -30,7 +30,7 @@ describe('Template', () => {
       const facility = await models.Facility.create(fake(models.Facility));
       await Setting.set(TEST_KEY, TEST_VALUE, facility.id);
 
-      const result = await app.get(`/v1/template/${TEST_KEY}?facilityId=${facility.id}`).send({});
+      const result = await app.get(`/api/template/${TEST_KEY}?facilityId=${facility.id}`).send({});
 
       expect(result).toHaveSucceeded();
       expect(result.body.data).toEqual(TEST_VALUE);
@@ -41,7 +41,7 @@ describe('Template', () => {
       const facility2 = await models.Facility.create(fake(models.Facility));
       await Setting.set(TEST_KEY, TEST_VALUE, facility1.id);
 
-      const result = await app.get(`/v1/template/${TEST_KEY}?facilityId=${facility2.id}`).send({});
+      const result = await app.get(`/api/template/${TEST_KEY}?facilityId=${facility2.id}`).send({});
 
       expect(result).toHaveSucceeded();
       expect(result.body.data).toEqual(null);

--- a/packages/facility-server/__tests__/apiv1/Triage.test.js
+++ b/packages/facility-server/__tests__/apiv1/Triage.test.js
@@ -41,7 +41,7 @@ describe('Triage', () => {
 
   it('should admit a patient to triage', async () => {
     const encounterPatient = await models.Patient.create(await createDummyPatient(models));
-    const response = await app.post('/v1/triage').send(
+    const response = await app.post('/api/triage').send(
       await createDummyTriage(models, {
         patientId: encounterPatient.id,
         departmentId: await randomRecordId(models, 'Department'),
@@ -63,7 +63,7 @@ describe('Triage', () => {
       name: 'Test arrival mode',
     });
     const encounterPatient = await models.Patient.create(await createDummyPatient(models));
-    const response = await app.post('/v1/triage').send(
+    const response = await app.post('/api/triage').send(
       await createDummyTriage(models, {
         patientId: encounterPatient.id,
         departmentId: await randomRecordId(models, 'Department'),
@@ -91,7 +91,7 @@ describe('Triage', () => {
 
     expect(encounter.endDate).toBeFalsy();
 
-    const response = await app.post('/v1/triage').send(
+    const response = await app.post('/api/triage').send(
       await createDummyTriage(models, {
         patientId: encounterPatient.id,
         departmentId: await randomRecordId(models, 'Department'),
@@ -111,7 +111,7 @@ describe('Triage', () => {
 
     expect(encounter.endDate).toBeTruthy();
 
-    const response = await app.post('/v1/triage').send(
+    const response = await app.post('/api/triage').send(
       await createDummyTriage(models, {
         patientId: encounterPatient.id,
         departmentId: await randomRecordId(models, 'Department'),
@@ -131,7 +131,7 @@ describe('Triage', () => {
     const createdEncounter = await models.Encounter.findByPk(createdTriage.encounterId);
     expect(createdEncounter).toBeTruthy();
 
-    const progressResponse = await app.put(`/v1/encounter/${createdEncounter.id}`).send({
+    const progressResponse = await app.put(`/api/encounter/${createdEncounter.id}`).send({
       encounterType: ENCOUNTER_TYPES.EMERGENCY,
       submittedTime: getCurrentDateTimeString(),
     });
@@ -151,7 +151,7 @@ describe('Triage', () => {
     const createdEncounter = await models.Encounter.findByPk(createdTriage.encounterId);
     expect(createdEncounter).toBeTruthy();
 
-    const progressResponse = await app.put(`/v1/encounter/${createdEncounter.id}`).send({
+    const progressResponse = await app.put(`/api/encounter/${createdEncounter.id}`).send({
       endDate: Date.now(),
     });
     expect(progressResponse).toHaveSucceeded();
@@ -174,7 +174,7 @@ describe('Triage', () => {
     const DATE_2 = '2023-01-01 10:30:00';
 
     // progress encounter once (which should update the triage)
-    const progressResponse = await app.put(`/v1/encounter/${createdEncounter.id}`).send({
+    const progressResponse = await app.put(`/api/encounter/${createdEncounter.id}`).send({
       encounterType: ENCOUNTER_TYPES.EMERGENCY,
       submittedTime: DATE_1,
     });
@@ -183,7 +183,7 @@ describe('Triage', () => {
     expect(updatedTriage.closedTime).toEqual(DATE_1);
 
     // and again (which should NOT update the triage)
-    const progressResponse2 = await app.put(`/v1/encounter/${createdEncounter.id}`).send({
+    const progressResponse2 = await app.put(`/api/encounter/${createdEncounter.id}`).send({
       encounterType: ENCOUNTER_TYPES.ADMISSION,
       submittedTime: DATE_2,
     });
@@ -313,7 +313,7 @@ describe('Triage', () => {
     });
 
     it('should get a list of triages ordered by score and arrival time', async () => {
-      const response = await app.get('/v1/triage');
+      const response = await app.get('/api/triage');
       const results = response.body;
       expect(results.count).toEqual(5);
       // Test Score
@@ -334,7 +334,7 @@ describe('Triage', () => {
         reasonForEncounter: 'Test include short stay',
         encounterType: ENCOUNTER_TYPES.EMERGENCY,
       });
-      const response = await app.get('/v1/triage');
+      const response = await app.get('/api/triage');
 
       expect(response.body.data.some(b => b.encounterId === createdEncounter.id)).toEqual(true);
     });

--- a/packages/facility-server/__tests__/apiv1/User.test.js
+++ b/packages/facility-server/__tests__/apiv1/User.test.js
@@ -56,7 +56,7 @@ describe('User', () => {
     });
 
     it('should include role in the data returned by a successful login', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: authUser.email,
         password: rawPassword,
       });
@@ -83,7 +83,7 @@ describe('User', () => {
     });
 
     it('should obtain a valid login token', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: authUser.email,
         password: rawPassword,
       });
@@ -96,33 +96,33 @@ describe('User', () => {
 
     it('should get the user based on the current token', async () => {
       const userAgent = await baseApp.asUser(authUser);
-      const result = await userAgent.get('/v1/user/me');
+      const result = await userAgent.get('/api/user/me');
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveProperty('id', authUser.id);
     });
 
     it('should fail to get the user with a null token', async () => {
-      const result = await baseApp.get('/v1/user/me');
+      const result = await baseApp.get('/api/user/me');
       expect(result).toHaveRequestError();
     });
 
     it('should fail to get the user with an expired token', async () => {
       const expiredToken = await getToken(authUser, '-1s');
       const result = await baseApp
-        .get('/v1/user/me')
+        .get('/api/user/me')
         .set('authorization', `Bearer ${expiredToken}`);
       expect(result).toHaveRequestError();
     });
 
     it('should fail to get the user with an invalid token', async () => {
       const result = await baseApp
-        .get('/v1/user/me')
+        .get('/api/user/me')
         .set('authorization', 'Bearer ABC_not_a_valid_token');
       expect(result).toHaveRequestError();
     });
 
     it('should fail to obtain a token for a wrong password', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: authUser.email,
         password: 'PASSWARD',
       });
@@ -130,7 +130,7 @@ describe('User', () => {
     });
 
     it('should fail to obtain a token for a wrong email', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: 'test@toast.com',
         password: rawPassword,
       });
@@ -138,7 +138,7 @@ describe('User', () => {
     });
 
     it('should return cached feature flags in the login request', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: authUser.email,
         password: rawPassword,
       });
@@ -166,7 +166,7 @@ describe('User', () => {
     });
 
     it('should include permissions in the data returned by a successful login', async () => {
-      const result = await baseApp.post('/v1/login').send({
+      const result = await baseApp.post('/api/login').send({
         email: authUser.email,
         password: rawPassword,
       });
@@ -177,41 +177,41 @@ describe('User', () => {
     describe('Rejected tokens', () => {
       it('should get the user based on the current token', async () => {
         const userAgent = await baseApp.asUser(authUser);
-        const result = await userAgent.get('/v1/user/me');
+        const result = await userAgent.get('/api/user/me');
         expect(result).toHaveSucceeded();
         expect(result.body).toHaveProperty('id', authUser.id);
       });
 
       it('should fail to get the user with a null token', async () => {
-        const result = await baseApp.get('/v1/user/me');
+        const result = await baseApp.get('/api/user/me');
         expect(result).toHaveRequestError();
       });
 
       it('should fail to get the user with an expired token', async () => {
         const expiredToken = await getToken(authUser, '-1s');
         const result = await baseApp
-          .get('/v1/user/me')
+          .get('/api/user/me')
           .set('authorization', `Bearer ${expiredToken}`);
         expect(result).toHaveRequestError();
       });
 
       it('should fail to get the user with an invalid token', async () => {
         const result = await baseApp
-          .get('/v1/user/me')
+          .get('/api/user/me')
           .set('authorization', 'Bearer ABC_not_a_valid_token');
         expect(result).toHaveRequestError();
       });
 
       it('should fail to get a deactivated user with a valid token', async () => {
         const userAgent = await baseApp.asUser(deactivatedUser);
-        const result = await userAgent.get('/v1/user/me');
+        const result = await userAgent.get('/api/user/me');
         expect(result).toHaveRequestError();
       });
     });
 
     describe('Rejected logins', () => {
       it('should fail to obtain a token for a wrong password', async () => {
-        const result = await baseApp.post('/v1/login').send({
+        const result = await baseApp.post('/api/login').send({
           email: authUser.email,
           password: 'PASSWARD',
         });
@@ -219,7 +219,7 @@ describe('User', () => {
       });
 
       it('should fail to obtain a token for a wrong email', async () => {
-        const result = await baseApp.post('/v1/login').send({
+        const result = await baseApp.post('/api/login').send({
           email: 'test@toast.com',
           password: rawPassword,
         });
@@ -227,7 +227,7 @@ describe('User', () => {
       });
 
       it('should fail to obtain a token for a deactivated user', async () => {
-        const result = await baseApp.post('/v1/login').send({
+        const result = await baseApp.post('/api/login').send({
           email: deactivatedUser.email,
           password: rawPassword,
         });
@@ -242,7 +242,7 @@ describe('User', () => {
     let patients = [];
 
     const viewPatient = async patient => {
-      const result = await app.post(`/v1/user/recently-viewed-patients/${patient.id}`);
+      const result = await app.post(`/api/user/recently-viewed-patients/${patient.id}`);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         userId: user.id,
@@ -278,7 +278,7 @@ describe('User', () => {
 
       await viewPatient(firstPatient);
 
-      const getResult = await app.get('/v1/user/recently-viewed-patients');
+      const getResult = await app.get('/api/user/recently-viewed-patients');
       expect(getResult).toHaveSucceeded();
       expect(getResult.body.data).toHaveLength(1);
       expect(getResult.body.count).toBe(1);
@@ -294,7 +294,7 @@ describe('User', () => {
       const result2Date = new Date(result2.body.updatedAt);
       expect(result2Date.getTime()).toBeGreaterThan(resultDate.getTime());
 
-      const getResult = await app.get('/v1/user/recently-viewed-patients');
+      const getResult = await app.get('/api/user/recently-viewed-patients');
       expect(getResult).toHaveSucceeded();
       expect(getResult.body.data).toHaveLength(1);
       expect(getResult.body.count).toBe(1);
@@ -311,7 +311,7 @@ describe('User', () => {
         await viewPatient(p);
       }
 
-      const result = await app.get('/v1/user/recently-viewed-patients');
+      const result = await app.get('/api/user/recently-viewed-patients');
       expect(result).toHaveSucceeded();
       expect(result.body.count).toBe(12);
       expect(result.body.data).toHaveLength(12);
@@ -350,7 +350,7 @@ describe('User', () => {
         await viewPatient(p);
       }
 
-      const result = await app.get('/v1/user/recently-viewed-patients?encounterType=admission');
+      const result = await app.get('/api/user/recently-viewed-patients?encounterType=admission');
       expect(result).toHaveSucceeded();
       // orders should match
       const resultIds = result.body.data.map(x => x.id);
@@ -386,7 +386,7 @@ describe('User', () => {
         await viewPatient(p);
       }
 
-      const result = await app.get('/v1/user/recently-viewed-patients?encounterType=admission');
+      const result = await app.get('/api/user/recently-viewed-patients?encounterType=admission');
       expect(result).toHaveSucceeded();
 
       // orders should match
@@ -405,7 +405,7 @@ describe('User', () => {
       'data-element-3',
     ].join(',');
     const updateUserPreference = async userPreference => {
-      const result = await app.post('/v1/user/userPreferences').send(userPreference);
+      const result = await app.post('/api/user/userPreferences').send(userPreference);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         id: user.id,
@@ -429,7 +429,7 @@ describe('User', () => {
     });
 
     it('should fetch current user existing user preference', async () => {
-      const result = await app.get('/v1/user/userPreferences');
+      const result = await app.get('/api/user/userPreferences');
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
         selectedGraphedVitalsOnFilter: defaultSelectedGraphedVitalsOnFilter,
@@ -438,7 +438,7 @@ describe('User', () => {
 
     it('should update current user preference and updatedAt for selected graphed vitals on filter', async () => {
       const newSelectedGraphedVitalsOnFilter = ['data-element-1', 'data-element-2'].join(',');
-      const result1 = await app.get('/v1/user/userPreferences');
+      const result1 = await app.get('/api/user/userPreferences');
       const result2 = await updateUserPreference({
         selectedGraphedVitalsOnFilter: newSelectedGraphedVitalsOnFilter,
       });

--- a/packages/facility-server/__tests__/apiv1/VaccinationSettings.test.js
+++ b/packages/facility-server/__tests__/apiv1/VaccinationSettings.test.js
@@ -37,7 +37,7 @@ describe('Vaccination Settings', () => {
 
       await Setting.set(TEST_KEY, TEST_VALUE, config.serverFacilityId);
 
-      const result = await app.get(`/v1/vaccinationSettings/${TEST_KEY}`).send({});
+      const result = await app.get(`/api/vaccinationSettings/${TEST_KEY}`).send({});
 
       expect(result).toHaveSucceeded();
       expect(result.body.data).toEqual(TEST_VALUE);
@@ -51,7 +51,7 @@ describe('Vaccination Settings', () => {
 
       await Setting.set(TEST_KEY, TEST_VALUE, anotherFacility.id);
 
-      const result = await app.get(`/v1/vaccinationSettings/${TEST_KEY}`).send({});
+      const result = await app.get(`/api/vaccinationSettings/${TEST_KEY}`).send({});
 
       expect(result).toHaveSucceeded();
       expect(result.body.data).toEqual(null);

--- a/packages/facility-server/__tests__/apiv1/reports/AEFI.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/AEFI.test.js
@@ -66,7 +66,7 @@ describe('AEFI report', () => {
       await createDummyEncounter(models, { patientId: wrongVillagePatient.id, current: true }),
     );
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: 'program-aefi/survey-aefi_immunisation',
       startTime: '2021-03-17T21:50:28.133Z',
       patientId: expectedPatient.id,
@@ -74,7 +74,7 @@ describe('AEFI report', () => {
       answers: createDummyAefiSurveyAnswers(),
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: 'program-aefi/survey-aefi_immunisation',
       startTime: '2021-03-17T21:50:28.133Z',
       patientId: wrongVillagePatient.id,
@@ -115,13 +115,13 @@ describe('AEFI report', () => {
 
   it('should reject creating an aefi report with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.post(`/v1/reports/aefi`, {});
+    const result = await noPermsApp.post(`/api/reports/aefi`, {});
     expect(result).toBeForbidden();
   });
 
   describe('returns data based on parameters', () => {
     it('should return data for patients of the right village', async () => {
-      const result = await app.post('/v1/reports/aefi').send({
+      const result = await app.post('/api/reports/aefi').send({
         parameters: { village: village, fromDate: '2021-03-15' },
       });
 

--- a/packages/facility-server/__tests__/apiv1/reports/Admissions.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/Admissions.test.js
@@ -89,7 +89,7 @@ describe('Admissions report', () => {
 
   it('should reject creating an admissions report with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.post(`/v1/reports/admissions`, {});
+    const result = await noPermsApp.post(`/api/reports/admissions`, {});
     expect(result).toBeForbidden();
   });
 
@@ -207,7 +207,7 @@ describe('Admissions report', () => {
         date: '2021-02-20 12:10:00',
       });
 
-      const result = await app.post('/v1/reports/admissions').send({
+      const result = await app.post('/api/reports/admissions').send({
         parameters: {
           fromDate: '2021-02-01 00:00:00',
           locationGroup: expectedLocationGroup.id,

--- a/packages/facility-server/__tests__/apiv1/reports/IncompleteReferrals.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/IncompleteReferrals.test.js
@@ -68,7 +68,7 @@ describe('Incomplete Referrals report', () => {
 
   it('should reject creating a diagnoses report with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.post(`/v1/reports/incomplete-referrals`, {});
+    const result = await noPermsApp.post(`/api/reports/incomplete-referrals`, {});
     expect(result).toBeForbidden();
   });
 
@@ -81,7 +81,7 @@ describe('Incomplete Referrals report', () => {
       });
     });
     it('should return only requested village', async () => {
-      const result = await app.post('/v1/reports/incomplete-referrals').send({
+      const result = await app.post('/api/reports/incomplete-referrals').send({
         parameters: { village: village1 },
       });
 
@@ -92,7 +92,7 @@ describe('Incomplete Referrals report', () => {
     });
 
     it('should return multiple diagnoses', async () => {
-      const result = await app.post('/v1/reports/incomplete-referrals').send({
+      const result = await app.post('/api/reports/incomplete-referrals').send({
         parameters: { village: village1 },
       });
 

--- a/packages/facility-server/__tests__/apiv1/reports/RecentDiagnoses.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/RecentDiagnoses.test.js
@@ -36,7 +36,7 @@ describe('Recent Diagnoses report', () => {
 
   it('should reject creating a diagnoses report with insufficient permissions', async () => {
     const noPermsApp = await baseApp.asRole('base');
-    const result = await noPermsApp.post(`/v1/reports/recent-diagnoses`, {});
+    const result = await noPermsApp.post(`/api/reports/recent-diagnoses`, {});
     expect(result).toBeForbidden();
   });
 
@@ -74,7 +74,7 @@ describe('Recent Diagnoses report', () => {
         }),
       );
 
-      const result = await app.post('/v1/reports/recent-diagnoses').send({
+      const result = await app.post('/api/reports/recent-diagnoses').send({
         parameters: { diagnosis: expectedDiagnosis },
       });
       expect(result).toHaveSucceeded();
@@ -114,7 +114,7 @@ describe('Recent Diagnoses report', () => {
         }),
       );
 
-      const result = await app.post('/v1/reports/recent-diagnoses').send({
+      const result = await app.post('/api/reports/recent-diagnoses').send({
         parameters: { diagnosis: firstDiagnosis.id, diagnosis2: secondDiagnosis.id },
       });
       expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/reports/base-assistive-technology-device-line-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/base-assistive-technology-device-line-list.test.js
@@ -80,7 +80,7 @@ describe('Assistive technology device line list', () => {
     ]);
 
     // ----Submit answers for patient 1----
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: REGISTRATION_FORM_SURVEY_ID,
       startTime: '2021-03-12 10:50:28',
       patientId: expectedPatient1.id,
@@ -90,7 +90,7 @@ describe('Assistive technology device line list', () => {
       },
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: REGISTRATION_FORM_SURVEY_ID,
       startTime: '2021-03-15 10:50:28',
       patientId: expectedPatient1.id,
@@ -100,7 +100,7 @@ describe('Assistive technology device line list', () => {
       },
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: MOBILITY_SURVEY_ID,
       startTime: '2021-03-17 10:50:28',
       patientId: expectedPatient1.id,
@@ -112,7 +112,7 @@ describe('Assistive technology device line list', () => {
       },
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: MOBILITY_SURVEY_ID,
       startTime: '2021-03-17 11:50:28',
       patientId: expectedPatient1.id,
@@ -124,7 +124,7 @@ describe('Assistive technology device line list', () => {
       },
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: MOBILITY_SURVEY_ID,
       startTime: '2021-03-20 10:50:28',
       patientId: expectedPatient1.id,
@@ -136,7 +136,7 @@ describe('Assistive technology device line list', () => {
       },
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: MOBILITY_SURVEY_ID,
       startTime: '2021-03-20 11:50:28',
       patientId: expectedPatient1.id,
@@ -149,7 +149,7 @@ describe('Assistive technology device line list', () => {
     });
 
     // ----Submit answers for patient 2----
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: REGISTRATION_FORM_SURVEY_ID,
       startTime: '2021-03-12 10:50:28',
       patientId: expectedPatient2.id,
@@ -159,7 +159,7 @@ describe('Assistive technology device line list', () => {
       },
     });
 
-    await app.post('/v1/surveyResponse').send({
+    await app.post('/api/surveyResponse').send({
       surveyId: MOBILITY_SURVEY_ID,
       startTime: '2021-03-17 10:50:28',
       patientId: expectedPatient2.id,
@@ -177,7 +177,7 @@ describe('Assistive technology device line list', () => {
     it('should reject creating an assistive technology device line list report with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
       const result = await noPermsApp.post(
-        `/v1/reports/iraq-assistive-technology-device-line-list`,
+        `/api/reports/iraq-assistive-technology-device-line-list`,
         {},
       );
       expect(result).toBeForbidden();
@@ -187,7 +187,7 @@ describe('Assistive technology device line list', () => {
   describe('returns the correct data', () => {
     it('should return latest data per patient and latest data per patient per date', async () => {
       const result = await app
-        .post('/v1/reports/iraq-assistive-technology-device-line-list')
+        .post('/api/reports/iraq-assistive-technology-device-line-list')
         .send({});
 
       expect(result).toHaveSucceeded();
@@ -307,7 +307,7 @@ describe('Assistive technology device line list', () => {
 
     it('should return data within date range', async () => {
       const result = await app
-        .post('/v1/reports/iraq-assistive-technology-device-line-list')
+        .post('/api/reports/iraq-assistive-technology-device-line-list')
         .send({ parameters: { fromDate: '2021-03-18', toDate: '2021-03-21' } });
 
       expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/reports/covid-module/covid-swab-lab-test-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/covid-module/covid-swab-lab-test-list.test.js
@@ -291,7 +291,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
   );
 
   // ----Submit answers for patient 1----
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-11 10:50:28',
     patientId: expectedPatient1.id,
@@ -305,7 +305,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
       'pde-FijCOVSamp11': 'pde-FijCOVSamp11-on-2021-03-13 10:53:15-Patient1',
     },
   });
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-14 10:50:28',
     patientId: expectedPatient1.id,
@@ -319,7 +319,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
       'pde-FijCOVSamp11': 'pde-FijCOVSamp11-on-2021-03-14 10:53:15-Patient1',
     },
   });
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-16 10:50:28',
     patientId: expectedPatient1.id,
@@ -333,7 +333,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
       'pde-FijCOVSamp11': 'pde-FijCOVSamp11-on-2021-03-16 10:53:15-Patient1',
     },
   });
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-18 10:50:28',
     patientId: expectedPatient1.id,
@@ -349,7 +349,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
   });
 
   // ----Submit answers for patient 2----
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-18 10:50:28',
     patientId: expectedPatient2.id,
@@ -363,7 +363,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
       'pde-FijCOVSamp11': 'pde-FijCOVSamp11-on-2021-03-18 10:53:15-Patient2',
     },
   });
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-19 10:50:28',
     patientId: expectedPatient2.id,
@@ -377,7 +377,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
       'pde-FijCOVSamp11': 'pde-FijCOVSamp11-on-2021-03-19 10:53:15-Patient2',
     },
   });
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-21 10:50:28',
     patientId: expectedPatient2.id,
@@ -391,7 +391,7 @@ const createSurveys = async (models, app, expectedPatient1, expectedPatient2) =>
       'pde-FijCOVSamp11': 'pde-FijCOVSamp11-on-2021-03-21 10:53:15-Patient2',
     },
   });
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: FIJI_SAMP_SURVEY_ID,
     startTime: '2021-03-23 10:50:28',
     patientId: expectedPatient2.id,
@@ -448,7 +448,7 @@ describe('Covid swab lab test list', () => {
   describe('checks permissions', () => {
     it('should reject creating a report with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
-      const result = await noPermsApp.post(`/v1/reports/fiji-covid-swab-lab-test-list`, {});
+      const result = await noPermsApp.post(`/api/reports/fiji-covid-swab-lab-test-list`, {});
       expect(result).toBeForbidden();
     });
   });
@@ -456,7 +456,7 @@ describe('Covid swab lab test list', () => {
   describe('returns the correct data', () => {
     it('with a village parameter', async () => {
       const PATIENT_ID_COLUMN = 4;
-      const result = await app.post('/v1/reports/fiji-covid-swab-lab-test-list').send({
+      const result = await app.post('/api/reports/fiji-covid-swab-lab-test-list').send({
         parameters: {
           village: village1,
           fromDate: '2021-03-01',
@@ -471,7 +471,7 @@ describe('Covid swab lab test list', () => {
       ]);
     });
     it('should return latest data per patient and latest data per patient per date', async () => {
-      const result = await app.post('/v1/reports/fiji-covid-swab-lab-test-list').send({
+      const result = await app.post('/api/reports/fiji-covid-swab-lab-test-list').send({
         parameters: {
           fromDate: '2021-03-01',
         },

--- a/packages/facility-server/__tests__/apiv1/reports/covid-module/fiji-traveller-covid-lab-test-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/covid-module/fiji-traveller-covid-lab-test-list.test.js
@@ -8,7 +8,7 @@ import {
   createPatient,
 } from './covid-swab-lab-test-report-utils';
 
-const REPORT_URL = '/v1/reports/fiji-traveller-covid-lab-test-list';
+const REPORT_URL = '/api/reports/fiji-traveller-covid-lab-test-list';
 const PROGRAM_ID = 'program-fijicovidtourism';
 const SURVEY_ID = 'program-fijicovidtourism-fijicovidtravform';
 
@@ -209,7 +209,7 @@ async function createFormAnswerForPatient(app, models, patient, formData) {
     await createDummyEncounter(models, { patientId: patient.id }),
   );
 
-  return app.post('/v1/surveyResponse').send({
+  return app.post('/api/surveyResponse').send({
     surveyId: SURVEY_ID,
     startTime: formData.formDate,
     patientId: patient.id,

--- a/packages/facility-server/__tests__/apiv1/reports/covid-module/nauru-covid-swab-lab-test-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/covid-module/nauru-covid-swab-lab-test-list.test.js
@@ -14,7 +14,7 @@ import {
   LAB_METHOD_NAME,
 } from './covid-swab-lab-test-report-utils';
 
-const REPORT_URL = '/v1/reports/nauru-covid-swab-lab-test-list';
+const REPORT_URL = '/api/reports/nauru-covid-swab-lab-test-list';
 const PROGRAM_ID = 'program-naurucovid19';
 const SURVEY_ID = 'program-naurucovid19-naurucovidtestregistration';
 
@@ -57,7 +57,7 @@ async function submitInitialFormForPatient(app, models, patient, date, answers) 
   const encounter = await models.Encounter.create(
     await createDummyEncounter(models, { patientId: patient.id }),
   );
-  return app.post('/v1/surveyResponse').send({
+  return app.post('/api/surveyResponse').send({
     surveyId: SURVEY_ID,
     startTime: date,
     patientId: patient.id,

--- a/packages/facility-server/__tests__/apiv1/reports/covid-module/palau-covid-case-report-line-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/covid-module/palau-covid-case-report-line-list.test.js
@@ -3,7 +3,7 @@ import { createTestContext } from '../../../utilities';
 import { MATCH_ANY } from '../../../toMatchTabularReport';
 import { createPatient } from './covid-swab-lab-test-report-utils';
 
-const REPORT_URL = '/v1/reports/palau-covid-case-report-line-list';
+const REPORT_URL = '/api/reports/palau-covid-case-report-line-list';
 const PROGRAM_ID = 'program-palaucovid19';
 const INITIAL_SURVEY_ID = 'program-palaucovid19-palaucovidinitialcasereportform';
 const FOLLOW_UP_SURVEY_ID = 'program-palaucovid19-palaucovidfollowupcasereport';
@@ -108,7 +108,7 @@ async function submitInitialFormForPatient(app, models, patient, formData) {
   const encounter = await models.Encounter.create(
     await createDummyEncounter(models, { patientId: patient.id }),
   );
-  return await app.post('/v1/surveyResponse').send({
+  return await app.post('/api/surveyResponse').send({
     surveyId: INITIAL_SURVEY_ID,
     startTime: formData.interviewDate,
     patientId: patient.id,
@@ -133,7 +133,7 @@ async function submitFollowUpFormForPatient(app, models, patient, formData) {
   const encounter = await models.Encounter.create(
     await createDummyEncounter(models, { patientId: patient.id }),
   );
-  return await app.post('/v1/surveyResponse').send({
+  return await app.post('/api/surveyResponse').send({
     surveyId: FOLLOW_UP_SURVEY_ID,
     startTime: formData.sampleDate,
     patientId: patient.id,

--- a/packages/facility-server/__tests__/apiv1/reports/covid-module/samoa-covid-swab-lab-test-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/covid-module/samoa-covid-swab-lab-test-list.test.js
@@ -8,7 +8,7 @@ import {
   createPatient,
 } from './covid-swab-lab-test-report-utils';
 
-const REPORT_URL = '/v1/reports/samoa-covid-swab-lab-test-list';
+const REPORT_URL = '/api/reports/samoa-covid-swab-lab-test-list';
 const PROGRAM_ID = 'program-samoacovid19';
 const SURVEY_ID = 'program-samoacovid19-samcovidsampcollectionv2';
 
@@ -85,7 +85,7 @@ async function createFormAnswerForPatient(app, models, patient, formData) {
   const encounter = await models.Encounter.create(
     await createDummyEncounter(models, { patientId: patient.id }),
   );
-  return app.post('/v1/surveyResponse').send({
+  return app.post('/api/surveyResponse').send({
     surveyId: SURVEY_ID,
     startTime: formData.formDate,
     patientId: patient.id,

--- a/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/fiji-ncd-primary-screening-line-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/fiji-ncd-primary-screening-line-list.test.js
@@ -163,14 +163,14 @@ describe('Fiji NCD Primary Screening line list', () => {
   describe('checks permissions', () => {
     it('should reject creating a report request with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
-      const result = await noPermsApp.post(`/v1/reports/fiji-ncd-primary-screening-line-list`, {});
+      const result = await noPermsApp.post(`/api/reports/fiji-ncd-primary-screening-line-list`, {});
       expect(result).toBeForbidden();
     });
   });
 
   describe('returns the correct data', () => {
     it('should generate a row for each form submission and pull referral details if it was created on the same date', async () => {
-      const result = await app.post('/v1/reports/fiji-ncd-primary-screening-line-list').send({});
+      const result = await app.post('/api/reports/fiji-ncd-primary-screening-line-list').send({});
 
       expect(result).toHaveSucceeded();
       expect(result.body).toHaveLength(4);

--- a/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/fiji-ncd-primary-screening-pending-referrals-line-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/fiji-ncd-primary-screening-pending-referrals-line-list.test.js
@@ -148,7 +148,7 @@ describe('Fiji NCD Primary Screening Pending Referrals line list', () => {
     it('should reject creating a report request with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
       const result = await noPermsApp.post(
-        `/v1/reports/fiji-ncd-primary-screening-pending-referrals-line-list`,
+        `/api/reports/fiji-ncd-primary-screening-pending-referrals-line-list`,
         {},
       );
       expect(result).toBeForbidden();
@@ -158,7 +158,7 @@ describe('Fiji NCD Primary Screening Pending Referrals line list', () => {
   describe('returns the correct data', () => {
     it('should generate a row for latest pending referrals per date', async () => {
       const result = await app
-        .post('/v1/reports/fiji-ncd-primary-screening-pending-referrals-line-list')
+        .post('/api/reports/fiji-ncd-primary-screening-pending-referrals-line-list')
         .send({});
 
       expect(result).toHaveSucceeded();

--- a/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/fiji-ncd-primary-screening-summary.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/fiji-ncd-primary-screening-summary.test.js
@@ -159,14 +159,14 @@ describe('Fiji NCD Primary Screening Summary', () => {
   describe('checks permissions', () => {
     it('should reject creating a report request with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
-      const result = await noPermsApp.post(`/v1/reports/fiji-ncd-primary-screening-summary`, {});
+      const result = await noPermsApp.post(`/api/reports/fiji-ncd-primary-screening-summary`, {});
       expect(result).toBeForbidden();
     });
   });
 
   describe('returns the correct data', () => {
     it('should populate correct data', async () => {
-      const result = await app.post('/v1/reports/fiji-ncd-primary-screening-summary').send({});
+      const result = await app.post('/api/reports/fiji-ncd-primary-screening-summary').send({});
 
       expect(result).toHaveSucceeded();
       // 1 for the header plus 2 content rows

--- a/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/utils.js
+++ b/packages/facility-server/__tests__/apiv1/reports/fiji-ncd-primary-screening/utils.js
@@ -10,7 +10,7 @@ const SNAP_FORM_SURVEY_ID = 'program-fijincdprimaryscreening-fijisnapassessform'
 
 export const createCVDFormSurveyResponse = async (app, patient, surveyDate, overrides = {}) => {
   const { answerOverrides = {} } = overrides;
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: CVD_PRIMARY_FORM_SURVEY_ID,
     startTime: surveyDate,
     patientId: patient.id,
@@ -28,7 +28,7 @@ export const createCVDFormSurveyResponse = async (app, patient, surveyDate, over
 };
 
 export const createCVDReferral = async (app, patient, referralDate) => {
-  await app.post('/v1/referral').send({
+  await app.post('/api/referral').send({
     surveyId: CVD_PRIMARY_REFERRAL_SURVEY_ID,
     startTime: referralDate,
     patientId: patient.id,
@@ -50,7 +50,7 @@ export const createBreastCancerFormSurveyResponse = async (
   overrides = {},
 ) => {
   const { answerOverrides = {}, ...otherOverrides } = overrides;
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: BREAST_CANCER_FORM_SURVEY_ID,
     startTime: surveyDate,
     patientId: patient.id,
@@ -69,7 +69,7 @@ export const createBreastCancerFormSurveyResponse = async (
 };
 
 export const createBreastCancerReferral = async (app, patient, referralDate) => {
-  await app.post('/v1/referral').send({
+  await app.post('/api/referral').send({
     surveyId: BREAST_CANCER_REFERRAL_SURVEY_ID,
     startTime: referralDate,
     patientId: patient.id,
@@ -86,7 +86,7 @@ export const createBreastCancerReferral = async (app, patient, referralDate) => 
 
 export const createSNAPFormSurveyResponse = async (app, patient, surveyDate, overrides = {}) => {
   const { answerOverrides = {}, ...otherOverrides } = overrides;
-  await app.post('/v1/surveyResponse').send({
+  await app.post('/api/surveyResponse').send({
     surveyId: SNAP_FORM_SURVEY_ID,
     startTime: surveyDate,
     patientId: patient.id,

--- a/packages/facility-server/__tests__/apiv1/reports/fiji-statistical-report-for-phis-summary.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/fiji-statistical-report-for-phis-summary.test.js
@@ -341,7 +341,7 @@ describe('Fiji statistical report for phis summary', () => {
   describe('checks permissions', () => {
     it('should reject creating a report with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
-      const result = await noPermsApp.post(`/v1/reports/fiji-statistical-report-for-phis-summary`, {
+      const result = await noPermsApp.post(`/api/reports/fiji-statistical-report-for-phis-summary`, {
         parameters: {
           fromDate: '1960-01-01',
         },
@@ -352,7 +352,7 @@ describe('Fiji statistical report for phis summary', () => {
 
   describe('returns the correct data', () => {
     it('should sort the dates from oldest to most recent', async () => {
-      const result = await app.post('/v1/reports/fiji-statistical-report-for-phis-summary').send({
+      const result = await app.post('/api/reports/fiji-statistical-report-for-phis-summary').send({
         parameters: {
           fromDate: '1960-01-01',
         },
@@ -363,7 +363,7 @@ describe('Fiji statistical report for phis summary', () => {
     });
 
     it('should return latest data per patient and latest data per patient per date', async () => {
-      const result = await app.post('/v1/reports/fiji-statistical-report-for-phis-summary').send({
+      const result = await app.post('/api/reports/fiji-statistical-report-for-phis-summary').send({
         parameters: {
           fromDate: '1960-01-01',
         },
@@ -483,7 +483,7 @@ describe('Fiji statistical report for phis summary', () => {
     });
 
     it('should return correct data after filtering', async () => {
-      const result = await app.post('/v1/reports/fiji-statistical-report-for-phis-summary').send({
+      const result = await app.post('/api/reports/fiji-statistical-report-for-phis-summary').send({
         parameters: {
           fromDate: '1960-01-01',
           medicalArea: medicalArea.id,

--- a/packages/facility-server/__tests__/apiv1/reports/vaccine-list.test.js
+++ b/packages/facility-server/__tests__/apiv1/reports/vaccine-list.test.js
@@ -72,14 +72,14 @@ describe('Vaccine list report', () => {
   describe('permission check', () => {
     it('should reject creating an vaccine line list report with insufficient permissions', async () => {
       const noPermsApp = await baseApp.asRole('base');
-      const result = await noPermsApp.post(`/v1/reports/vaccine-list`, {});
+      const result = await noPermsApp.post(`/api/reports/vaccine-list`, {});
       expect(result).toBeForbidden();
     });
   });
 
   describe('returns data based on parameters', () => {
     it('should return data for patients of the right village', async () => {
-      const result = await app.post('/v1/reports/vaccine-list').send({
+      const result = await app.post('/api/reports/vaccine-list').send({
         parameters: { village, fromDate: '2021-03-15' },
       });
 
@@ -96,7 +96,7 @@ describe('Vaccine list report', () => {
     });
 
     it('should return no data for patients with random village', async () => {
-      const result = await app.post('/v1/reports/vaccine-list').send({
+      const result = await app.post('/api/reports/vaccine-list').send({
         parameters: { village: 'RANDOM_VILLAGE', fromDate: '2021-03-15' },
       });
 
@@ -105,7 +105,7 @@ describe('Vaccine list report', () => {
     });
 
     it('should return data for patients with the right vaccine category and vaccine type', async () => {
-      const result = await app.post('/v1/reports/vaccine-list').send({
+      const result = await app.post('/api/reports/vaccine-list').send({
         parameters: { category: 'Campaign', vaccine: 'COVID-19', fromDate: '2021-03-01' },
       });
 
@@ -122,7 +122,7 @@ describe('Vaccine list report', () => {
     });
 
     it('should return no data for patients with random vaccine type', async () => {
-      const result = await app.post('/v1/reports/vaccine-list').send({
+      const result = await app.post('/api/reports/vaccine-list').send({
         parameters: { category: 'Campaign', vaccine: 'RANDOM_VACCINE', fromDate: '2021-03-01' },
       });
 

--- a/packages/facility-server/__tests__/apiv1/sync.test.js
+++ b/packages/facility-server/__tests__/apiv1/sync.test.js
@@ -19,7 +19,7 @@ describe('sync', () => {
       ['Sync completed', { enabled: true, ran: true, queued: false }],
     ])('triggers a sync and returns %s', async (message, info) => {
       ctx.syncManager.triggerSync = jest.fn().mockResolvedValueOnce(info);
-      const result = await app.post('/v1/sync/run');
+      const result = await app.post('/api/sync/run');
       expect(result).toHaveProperty('body.message', message);
     });
   });

--- a/packages/facility-server/__tests__/audit.test.js
+++ b/packages/facility-server/__tests__/audit.test.js
@@ -35,7 +35,7 @@ describe('Audit log', () => {
   });
 
   it('should leave an access record', async () => {
-    const result = await app.post('/v1/allergy').send(fake(models.PatientAllergy));
+    const result = await app.post('/api/allergy').send(fake(models.PatientAllergy));
     expect(result).toHaveSucceeded();
     expect(result.body.recordedDate).toBeTruthy();
 
@@ -49,7 +49,7 @@ describe('Audit log', () => {
   });
 
   it('should leave an access record with permission failure details', async () => {
-    const result = await baseApp.post('/v1/allergy').send(fake(models.PatientAllergy));
+    const result = await baseApp.post('/api/allergy').send(fake(models.PatientAllergy));
     expect(result).toBeForbidden();
 
     const [log] = getRecentEntries();
@@ -67,7 +67,7 @@ describe('Audit log', () => {
   it('should track multiple permission checks in a single request', async () => {
     const patient = await models.Patient.create(await createDummyPatient());
 
-    const result = await app.put(`/v1/patient/${patient.id}`).send({
+    const result = await app.put(`/api/patient/${patient.id}`).send({
       firstName: 'test',
     });
     expect(result).toHaveSucceeded();
@@ -88,7 +88,7 @@ describe('Audit log', () => {
   it('should discard an audit log when appropriate', async () => {
     // we don't care about the result of this, we just need any endpoint that doesn't
     // perform any permission checks - login is one of these
-    await app.post('/v1/login').send({});
+    await app.post('/api/login').send({});
 
     const logs = getRecentEntries();
     expect(logs).toHaveLength(0);

--- a/packages/facility-server/app/routes/index.js
+++ b/packages/facility-server/app/routes/index.js
@@ -5,6 +5,11 @@ import { apiv1 } from './apiv1';
 const router = express.Router();
 
 router.use(ensurePermissionCheck);
+
+// API
+router.use('/api', apiv1);
+
+// Legacy API endpoint
 router.use('/v1', apiv1);
 
 export default router;

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -16,8 +16,6 @@ import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
 import { version } from '../serverInfo';
 import { callWithBackoff } from './callWithBackoff';
 
-const API_VERSION = 'v1';
-
 const getVersionIncompatibleMessage = (error, response) => {
   if (error.message === VERSION_COMPATIBILITY_ERRORS.LOW) {
     const minVersion = response.headers.get('X-Min-Client-Version');
@@ -78,7 +76,7 @@ export class CentralServerConnection {
       }
     }
 
-    const url = `${this.host}/${API_VERSION}/${endpoint}`;
+    const url = `${this.host}/api/${endpoint}`;
     log.debug(`[sync] ${method} ${url}`);
 
     return callWithBackoff(async () => {

--- a/packages/facility-server/app/tasks/SenaitePoller.js
+++ b/packages/facility-server/app/tasks/SenaitePoller.js
@@ -50,7 +50,7 @@ export class SenaitePoller extends ScheduledTask {
   }
 
   async apiRequest(endpoint) {
-    const url = `${BASE_URL}/@@API/senaite/v1/${endpoint}`;
+    const url = `${BASE_URL}/@@API/senaite/api/${endpoint}`;
     return this.request(url);
   }
 

--- a/packages/mobile/request-examples.http
+++ b/packages/mobile/request-examples.http
@@ -3,7 +3,7 @@
 
 ### Login
 # @name login
-POST {{server}}/v1/login
+POST {{server}}/api/login
 Content-Type: application/json
 
 {
@@ -13,12 +13,12 @@ Content-Type: application/json
 }
 
 ### Retrieve first 100 patient records for sync
-GET {{server}}/v1/sync/patient?since=0&limit=100
+GET {{server}}/api/sync/patient?since=0&limit=100
 Authorization: Bearer {{token}}
 Accept: application/json
 
 ### Get all surveys
-GET {{server}}/v1/sync/survey?since=1614690000000;aaa   HTTP/1.1
+GET {{server}}/api/sync/survey?since=1614690000000;aaa   HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
@@ -27,7 +27,7 @@ Authorization: Bearer {{token}}
 ###
 
 # update an existing survey screen component
-POST {{server}}/v1/sync/survey HTTP/1.1
+POST {{server}}/api/sync/survey HTTP/1.1
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -59,7 +59,7 @@ Content-Type: application/json
 
 # See: https://github.com/beyondessential/tamanu/blob/dev/docs/Surveys.md for more info.
 # requires tamanu facility server to be running locally.
-POST http://localhost:4000/v1/admin/importSurvey
+POST http://localhost:4000/api/admin/importSurvey
 X-Client-Version: 1.0.0
 Content-Type: application/json
 
@@ -77,7 +77,7 @@ Content-Type: application/json
 
 # See: https://github.com/beyondessential/tamanu/blob/dev/docs/Surveys.md for more info.
 # requires tamanu facility server to be running locally.
-POST http://localhost:4000/v1/admin/importSurvey
+POST http://localhost:4000/api/admin/importSurvey
 X-Client-Version: 1.0.0
 Content-Type: application/json
 
@@ -95,7 +95,7 @@ Content-Type: application/json
 
 # See: https://github.com/beyondessential/tamanu/blob/dev/docs/Surveys.md for more info.
 # requires tamanu facility server to be running locally.
-POST http://localhost:4000/v1/admin/importSurvey
+POST http://localhost:4000/api/admin/importSurvey
 X-Client-Version: 1.0.0
 Content-Type: application/json
 

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -55,11 +55,8 @@ export default defineConfig({
         // you can also specify other servers to use as backend, e.g.
         // target: 'https://central.main.internal.tamanu.io',
         // target: 'https://facility-1.main.internal.tamanu.io',
-        //
-        // when using a hosted server, remove the rewrite: line.
-        // that rewrite is already done by routing in test/prod deployments
+
         changeOrigin: true,
-        rewrite: path => path.replace(/^\/api/, '/v1/'),
       },
     },
   },


### PR DESCRIPTION
### Changes

- Change all references of /v1/ to /api/
- Remove the rewriting in vite
- Add a route to central and facility duplicating the /v1/ route to the /api/ route

This immediately makes the vite rewrite and confusion therein obsolete, and should also make the switching for mobile unneeded.

The reason for a duplication rather than straight replace is to leave some time for other components (notably the tester envs, which need a config change to switch to _not_ rename the /api path when routing to backends) to flexibly move, rather than coordinate a synchronous change.

A larger question is should we do the final "delete /v1" _tomorrow_, once the tester deploys have moved, or should we leave that duplication in place for the medium term, so that integrations that call our API can move at their own pace rather than break when we deploy 2.x.

### Checklist

- [x] Code is finished
- [x] Tests pass

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps