### PR TITLE
2.1 fix: Don't error on dataElement type of Autocomplete but no writeToPatient config

### DIFF
--- a/packages/shared/src/reports/utilities/transformAnswers.js
+++ b/packages/shared/src/reports/utilities/transformAnswers.js
@@ -66,7 +66,7 @@ export const getAutocompleteComponentMap = surveyComponents => {
     .filter(
       ({ config, dataElement }) =>
         dataElement.type === 'Autocomplete' ||
-        (config && JSON.parse(config).writeToPatient.fieldType === 'Autocomplete'),
+        (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete'),
     )
     .map(({ dataElementId, config: componentConfig }) => [
       dataElementId,


### PR DESCRIPTION
### Changes
This is a recent change and simple fix
It did not account for a dataElement with type Autocomplete that did not have a writeToPatient definition associated.

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
