### PR TITLE
NASS-1037: Increase status page message line height

### DIFF
--- a/packages/web/app/components/StatusPage.jsx
+++ b/packages/web/app/components/StatusPage.jsx
@@ -30,7 +30,6 @@ const ErrorMessage = styled(Typography).attrs({
 })`
   font-weight: 500;
   font-size: 38px;
-  line-height: 32px;
 `;
 
 const ErrorDescription = styled(LargeBodyText)`


### PR DESCRIPTION
### Changes

The line height was a bit short and was making the status messages look cramped. Remove line height constraint per felicity's request

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
