### PR TITLE
TAN-2318: 2.1 Fix: Survey forms using writeToPatient attempt to write all un-entered values to database

### DIFF
--- a/packages/web/app/utils/survey.jsx
+++ b/packages/web/app/utils/survey.jsx
@@ -273,7 +273,7 @@ export function getFormInitialValues(
 
       // explicitly check against undefined and null rather than just !patientValue
       if (isNullOrUndefined(patientValue)) {
-        initialValues[component.dataElement.id] = '';
+        initialValues[component.dataElement.id] = undefined;
       } else {
         initialValues[component.dataElement.id] = patientValue;
       }

--- a/packages/web/app/utils/survey.jsx
+++ b/packages/web/app/utils/survey.jsx
@@ -271,10 +271,7 @@ export function getFormInitialValues(
         patientValue = transformPatientProgramRegistrationData(patientProgramRegistration, config);
       }
 
-      // explicitly check against undefined and null rather than just !patientValue
-      if (!isNullOrUndefined(patientValue)) {
-        initialValues[component.dataElement.id] = patientValue;
-      }
+      initialValues[component.dataElement.id] = patientValue;
     }
   }
   return initialValues;

--- a/packages/web/app/utils/survey.jsx
+++ b/packages/web/app/utils/survey.jsx
@@ -272,9 +272,7 @@ export function getFormInitialValues(
       }
 
       // explicitly check against undefined and null rather than just !patientValue
-      if (isNullOrUndefined(patientValue)) {
-        initialValues[component.dataElement.id] = undefined;
-      } else {
+      if (!isNullOrUndefined(patientValue)) {
         initialValues[component.dataElement.id] = patientValue;
       }
     }

--- a/packages/web/app/views/programs/ProgramsView.jsx
+++ b/packages/web/app/views/programs/ProgramsView.jsx
@@ -20,7 +20,6 @@ import { useEncounter } from '../../contexts/Encounter';
 import { PATIENT_TABS } from '../../constants/patientPaths';
 import { ENCOUNTER_TAB_NAMES } from '../../constants/encounterTabNames';
 import { useApi } from '../../api';
-import _ from 'lodash';
 
 const SurveyFlow = ({ patient, currentUser }) => {
   const api = useApi();
@@ -88,20 +87,13 @@ const SurveyFlow = ({ patient, currentUser }) => {
     [api, selectedProgramId, clearProgram],
   );
 
-  const submitSurveyResponse = async (data, { initialValues }) => {
-    // exclude answers where value = '' and initial value = ''
-    const answers = Object.fromEntries(
-      Object.entries(data).map(([key, value]) =>
-        value === '' && initialValues[key] === '' ? [key, undefined] : [key, value],
-      ),
-    );
-
+  const submitSurveyResponse = async data => {
     await api.post('surveyResponse', {
       surveyId: survey.id,
       startTime,
       patientId: patient.id,
       endTime: getCurrentDateTimeString(),
-      answers: getAnswersFromData(answers, survey),
+      answers: getAnswersFromData(data, survey),
     });
     if (params?.encounterId && encounter && !encounter.endDate) {
       navigateToEncounter(params.encounterId, { tab: ENCOUNTER_TAB_NAMES.FORMS });

--- a/packages/web/app/views/programs/ProgramsView.jsx
+++ b/packages/web/app/views/programs/ProgramsView.jsx
@@ -20,6 +20,7 @@ import { useEncounter } from '../../contexts/Encounter';
 import { PATIENT_TABS } from '../../constants/patientPaths';
 import { ENCOUNTER_TAB_NAMES } from '../../constants/encounterTabNames';
 import { useApi } from '../../api';
+import _ from 'lodash';
 
 const SurveyFlow = ({ patient, currentUser }) => {
   const api = useApi();
@@ -87,13 +88,20 @@ const SurveyFlow = ({ patient, currentUser }) => {
     [api, selectedProgramId, clearProgram],
   );
 
-  const submitSurveyResponse = async data => {
+  const submitSurveyResponse = async (data, { initialValues }) => {
+    // exclude answers where value = '' and initial value = ''
+    const answers = Object.fromEntries(
+      Object.entries(data).map(([key, value]) =>
+        value === '' && initialValues[key] === '' ? [key, undefined] : [key, value],
+      ),
+    );
+
     await api.post('surveyResponse', {
       surveyId: survey.id,
       startTime,
       patientId: patient.id,
       endTime: getCurrentDateTimeString(),
-      answers: getAnswersFromData(data, survey),
+      answers: getAnswersFromData(answers, survey),
     });
     if (params?.encounterId && encounter && !encounter.endDate) {
       navigateToEncounter(params.encounterId, { tab: ENCOUNTER_TAB_NAMES.FORMS });


### PR DESCRIPTION
### Changes
Previously:
attempting to write patient fields as `""` which breaks if foreign key or date etc

In testing it seems that just defaulting it to its value weither null or undefined is enough to solve the issue wihtout breaking any other aspect of the flow. And is the closest to behavior pre-regression.
The other idea was to filter answers on front end if intial value = '' and submit value. = '' but this had the consiquence of filtering things like middleName set to "". Which does not match previous behavior

this is because during generation of initial values any existant values will be prepopulated and any that are null or undefined will be set as such not breaking patient schema or additional data on write to patient fields.

Ideally I feel that these values would be excluded all together in the step of writeToPatientField
But this would require further refactors to compare existing value vs attempted write.

This solution behaves the same as pre program registry logic - where all the undefined patient fields where sent as undefined on submit.

[See thread: ](https://beyondessential.slack.com/archives/C03KJSEPV9A/p1706658761748349)

Really keen to discuss better solutions here.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
