### PR TITLE
NASS-1122: Fix - survey response regression

### DIFF
--- a/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
@@ -108,11 +108,11 @@ describe('SurveyResponse', () => {
       });
     });
 
-    // This test currently fails because some survey utils filter the missing-source config out before 
-    // it reaches the logic that would throw the "misconfigured" error. A question with a missing 
+    // This test currently fails because some survey utils filter the missing-source config out before
+    // it reaches the logic that would throw the "misconfigured" error. A question with a missing
     // source will be obviously broken anyway, so while this should be fixed eventually it doesn't
     // represent a risk to data or user experience, just a chance of inconveniencing a PM.
-    it.skip('should error if the config has no source', async () => {
+    it('should error if the config has no source', async () => {
       // arrange
       const { Facility } = models;
       const facility = await Facility.create(fake(Facility));
@@ -170,6 +170,23 @@ describe('SurveyResponse', () => {
           message: `Selected answer Facility[this-facility-id-does-not-exist] not found`,
         },
       });
+    });
+
+    it.only('should skip error if the answer body is an empty string', async () => {
+      // arrange
+      const { Facility } = models;
+      await Facility.create(fake(Facility));
+      const { response } = await setupAutocompleteSurvey(
+        JSON.stringify({ source: 'Facility' }),
+        '',
+      );
+
+      // act
+      const result = await app.get(`/api/surveyResponse/${response.id}`);
+
+      // assert
+      expect(result).toHaveSucceeded();
+      expect(result.body.answers[0].body).toBe('');
     });
 
     it('should error and hint if users might have legacy ReferenceData sources', async () => {

--- a/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
@@ -172,7 +172,7 @@ describe('SurveyResponse', () => {
       });
     });
 
-    it.only('should skip error if the answer body is an empty string', async () => {
+    it('should skip error if the answer body is an empty string', async () => {
       // arrange
       const { Facility } = models;
       await Facility.create(fake(Facility));

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -54,11 +54,17 @@ surveyResponse.get(
 
         const result = await model.findByPk(answer.dataValues.body);
         if (!result) {
+          // If the answer is empty, return it as is rather than throwing an error
+          if (answer.dataValues.body === '') {
+            return answer;
+          }
+
           if (componentConfig.source === 'ReferenceData') {
             throw new Error(
               `Selected answer ${componentConfig.source}[${answer.dataValues.body}] not found (check that the surveyquestion's source isn't ReferenceData for a Location, Facility, or Department)`,
             );
           }
+
           throw new Error(
             `Selected answer ${componentConfig.source}[${answer.dataValues.body}] not found`,
           );

--- a/packages/web/app/utils/survey.jsx
+++ b/packages/web/app/utils/survey.jsx
@@ -251,13 +251,8 @@ export function getFormInitialValues(
         config,
       );
 
-      // explicitly check against undefined and null rather than just !patientValue
-      if (isNullOrUndefined(patientValue)) {
-        // Set the initial value to null rather than an empty string so that it doesn't save an empty answer record.
-        initialValues[component.dataElement.id] = null;
-      } else {
-        initialValues[component.dataElement.id] = patientValue;
-      }
+      // Let the initial value be null of undefined rather than an empty string so that it doesn't save an empty answer record.
+      initialValues[component.dataElement.id] = patientValue;
     }
   }
   return initialValues;

--- a/packages/web/app/utils/survey.jsx
+++ b/packages/web/app/utils/survey.jsx
@@ -205,7 +205,7 @@ function transformPatientData(patient, additionalData, patientProgramRegistratio
         case 'PatientAdditionalData':
           return additionalData ? additionalData[fieldName] : undefined;
         case 'PatientProgramRegistration':
-          return patientProgramRegistration ? patientProgramRegistration[fieldName]: undefined
+          return patientProgramRegistration ? patientProgramRegistration[fieldName] : undefined;
         default:
           return undefined;
       }
@@ -244,11 +244,17 @@ export function getFormInitialValues(
     }
     // patient data
     if (component.dataElement.type === 'PatientData') {
-      let patientValue = transformPatientData(patient, additionalData, patientProgramRegistration, config);
+      let patientValue = transformPatientData(
+        patient,
+        additionalData,
+        patientProgramRegistration,
+        config,
+      );
 
       // explicitly check against undefined and null rather than just !patientValue
       if (isNullOrUndefined(patientValue)) {
-        initialValues[component.dataElement.id] = '';
+        // Set the initial value to null rather than an empty string so that it doesn't save an empty answer record.
+        initialValues[component.dataElement.id] = null;
       } else {
         initialValues[component.dataElement.id] = patientValue;
       }


### PR DESCRIPTION
### Changes

The bug was on Surveys that were submitted with PatientData questions that were configured Autocomplete components. They were set with empty strings as initial values and this causes an error when trying to view that answer because the survey response endpoint tries to look up the submitted answer but it doesn't exist. This fix is both on the form submission side to change the default value to null and on the submission view side to not error if an autocomplete answer has an empty string submitted.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
