### PR TITLE
Fix: Add back signing section to vax cert

### DIFF
--- a/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
+++ b/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
@@ -15,6 +15,7 @@ import { PatientDetailsSection } from './PatientDetailsSection';
 import { H3 } from './Typography';
 import { LetterheadSection } from './LetterheadSection';
 import { getDisplayDate } from './getDisplayDate';
+import { SigningSection } from './SigningSection';
 
 const columns = [
   {
@@ -87,6 +88,7 @@ export const VaccineCertificate = ({
   vaccinations,
   certificateId,
   watermarkSrc,
+  signingSrc,
   logoSrc,
   getLocalisation,
   extraPatientFields,
@@ -157,6 +159,7 @@ export const VaccineCertificate = ({
             columnStyle={{ padding: '10px 5px' }}
           />
         </Box>
+        <SigningSection signingSrc={signingSrc} />
         <FixedFooter>
           <VaccineCertificateFooter />
         </FixedFooter>


### PR DESCRIPTION
### Changes

In the vaccine cert updates we accidentally removed the custom signing section image. Here i just add it back :)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
