### PR TITLE
Fix main: Restore checkServerAlive method

### DIFF
--- a/packages/web/app/api/TamanuApi.js
+++ b/packages/web/app/api/TamanuApi.js
@@ -125,4 +125,8 @@ export class TamanuApi extends ApiClient {
   async get(endpoint, query, { showUnknownErrorToast = true, ...options } = {}) {
     return this.fetch(endpoint, query, { method: 'GET', showUnknownErrorToast, ...options });
   }
+  
+  async checkServerAlive() {
+    return this.get('public/ping', null, { showUnknownErrorToast: false });
+  }
 }

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -55,11 +55,7 @@ export default defineConfig({
         // you can also specify other servers to use as backend, e.g.
         // target: 'https://central.main.internal.tamanu.io',
         // target: 'https://facility-1.main.internal.tamanu.io',
-        //
-        // when using a hosted server, remove the rewrite: line.
-        // that rewrite is already done by routing in test/prod deployments
         changeOrigin: true,
-        rewrite: path => path.replace(/^\/api/, '/v1/'),
       },
     },
   },


### PR DESCRIPTION
### Changes

The `checkServerAlive` method went missing in the API client PR.

### Checklist

- [x] Code is finished