### PR TITLE
Fix: Program registry search bar

### DIFF
--- a/packages/web/app/views/programRegistry/ProgramRegistrySearchBar.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistrySearchBar.jsx
@@ -107,7 +107,7 @@ export const ProgramRegistrySearchBar = ({ searchParameters, setSearchParameters
         name="currentlyIn"
         component={AutocompleteField}
         suggester={
-          programRegistry && programRegistry.currentlyAt === 'village'
+          programRegistry && programRegistry.currentlyAtType === 'village'
             ? villageSuggester
             : facilitySuggester
         }


### PR DESCRIPTION
### Changes

There is a typo in the search form logic and it’s always showing facilities when it should show either village or facility depending on the program_registries.currently_at_type  in the database for each program registry. 

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
