### PR TITLE
Fix: Program registries query bug

### DIFF
--- a/packages/facility-server/__tests__/apiv1/ProgramRegistry.test.js
+++ b/packages/facility-server/__tests__/apiv1/ProgramRegistry.test.js
@@ -305,6 +305,7 @@ describe('ProgramRegistry', () => {
           patientId: patient1.id,
           programRegistryId,
           programRegistryConditionId: decoyCondition.id,
+          deletionStatus: null
         }),
       );
       await models.PatientProgramRegistrationCondition.create(
@@ -312,6 +313,7 @@ describe('ProgramRegistry', () => {
           patientId: patient1.id,
           programRegistryId,
           programRegistryConditionId: relevantCondition.id,
+          deletionStatus: null
         }),
       );
 
@@ -329,6 +331,7 @@ describe('ProgramRegistry', () => {
           patientId: patient2.id,
           programRegistryId,
           programRegistryConditionId: decoyCondition.id,
+          deletionStatus: null
         }),
       );
 

--- a/packages/facility-server/app/routes/apiv1/programRegistry.js
+++ b/packages/facility-server/app/routes/apiv1/programRegistry.js
@@ -181,7 +181,7 @@ programRegistry.get(
           FROM patient_program_registration_conditions pprc
             JOIN program_registry_conditions prc
               ON pprc.program_registry_condition_id = prc.id
-          WHERE pprc.program_registry_id = :programRegistryId
+          WHERE pprc.program_registry_id = :programRegistryId AND pprc.deletion_status IS NULL
           GROUP BY patient_id
         )
     `;

--- a/packages/web/app/api/queries/useProgramRegistryConditions.js
+++ b/packages/web/app/api/queries/useProgramRegistryConditions.js
@@ -3,7 +3,7 @@ import { useApi } from '../useApi';
 
 export const useProgramRegistryConditions = (programRegistryId, fetchOptions) => {
   const api = useApi();
-  return useQuery(['ProgramRegistryConditions', programRegistryId], () =>
+  return useQuery(['programRegistry', programRegistryId, 'conditions'], () =>
     api.get(`programRegistry/${encodeURIComponent(programRegistryId)}/conditions`, {
       orderBy: 'name',
       order: 'ASC',

--- a/packages/web/app/api/queries/useProgramRegistryConditions.js
+++ b/packages/web/app/api/queries/useProgramRegistryConditions.js
@@ -3,7 +3,7 @@ import { useApi } from '../useApi';
 
 export const useProgramRegistryConditions = (programRegistryId, fetchOptions) => {
   const api = useApi();
-  return useQuery(['PatientProgramRegistryConditions', programRegistryId], () =>
+  return useQuery(['ProgramRegistryConditions', programRegistryId], () =>
     api.get(`programRegistry/${encodeURIComponent(programRegistryId)}/conditions`, {
       orderBy: 'name',
       order: 'ASC',

--- a/packages/web/app/views/programRegistry/ActivatePatientProgramRegistry.jsx
+++ b/packages/web/app/views/programRegistry/ActivatePatientProgramRegistry.jsx
@@ -33,11 +33,14 @@ export const ActivatePatientProgramRegistry = ({ onClose, patientProgramRegistra
   const programRegistryStatusSuggester = useSuggester('programRegistryClinicalStatus', {
     baseQueryParameters: { programRegistryId: patientProgramRegistration.programRegistryId },
   });
-  const { data: registrationConditions } = usePatientProgramRegistryConditionsQuery(
+  const {
+    data: registrationConditions,
+    isLoading: isPatientConditionsLoading,
+  } = usePatientProgramRegistryConditionsQuery(
     patientProgramRegistration.patientId,
     patientProgramRegistration.programRegistryId,
   );
-  const { data: conditions } = useProgramRegistryConditionsQuery(
+  const { data: conditions, isLoading: isConditionsLoading } = useProgramRegistryConditionsQuery(
     patientProgramRegistration.programRegistryId,
   );
 
@@ -88,6 +91,8 @@ export const ActivatePatientProgramRegistry = ({ onClose, patientProgramRegistra
     queryClient.invalidateQueries([`infoPaneListItem-${PROGRAM_REGISTRY}`]);
     onClose();
   };
+
+  if (isPatientConditionsLoading || isConditionsLoading) return null;
 
   return (
     <Modal


### PR DESCRIPTION
### Changes

We were having some weird behaviour around changing "related conditions" for program registries. I had to make a few tweaks to get this working as expected:
- Change name of duplicate useQuery key - this was the main problem
- Await for loading to finish before rendering
- Filter table statuses to ensure they arent returning deleted conditions

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
