### PR TITLE
2.1 fix: watermark causing vaccine certificate to crash

### DIFF
--- a/packages/shared/src/utils/patientCertificates/Layout.jsx
+++ b/packages/shared/src/utils/patientCertificates/Layout.jsx
@@ -51,6 +51,8 @@ export const styles = StyleSheet.create({
     bottom: 0,
     minWidth: '100%',
     minHeight: '100%',
+    maxHeight: '100vw',
+    maxWidth: '100vw',
     backgroundColor: '#aaaaaa',
     opacity: 0.05,
     flexDirection: 'row',

--- a/packages/shared/src/utils/patientCertificates/Layout.jsx
+++ b/packages/shared/src/utils/patientCertificates/Layout.jsx
@@ -51,7 +51,7 @@ export const styles = StyleSheet.create({
     bottom: 0,
     minWidth: '100%',
     minHeight: '100%',
-    maxHeight: '100vw',
+    maxHeight: '100vh',
     maxWidth: '100vw',
     backgroundColor: '#aaaaaa',
     opacity: 0.05,


### PR DESCRIPTION
### Changes
In certain cases the watermark exceeded view width and height values could cause the  vaccine certificate to never load.
I debugged this by creating a pdf worker to take the pdf render off the main thread - and noticed that while it did not outright crash the app - it still never loaded.

After reading around it seems there can be some oddities with images exceeded the content window causing a full crash. [Similar issue report](https://github.com/diegomura/react-pdf/issues/2242)
Doing this fix of limiting the size of the fullbleed watermark to view size resolved the issue.

Here is the draft pr for worker
[WIP: PDF rendered in worker](https://github.com/beyondessential/tamanu/pull/5300) - although it needs much more work than is appropriate for 2.1 regression 🙏 

I checked for visual regressions here and there is no change from before except it doesn't crash in the case identified by testers

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
