### PR TITLE
2.1 Fix: Ensure that certificate assets are finished fetching before rendering pdf

### DIFF
--- a/packages/shared/src/utils/patientCertificates/Layout.jsx
+++ b/packages/shared/src/utils/patientCertificates/Layout.jsx
@@ -51,8 +51,6 @@ export const styles = StyleSheet.create({
     bottom: 0,
     minWidth: '100%',
     minHeight: '100%',
-    maxHeight: '100vh',
-    maxWidth: '100vw',
     backgroundColor: '#aaaaaa',
     opacity: 0.05,
     flexDirection: 'row',

--- a/packages/web/app/components/BedManagement/HandoverNotesModal.jsx
+++ b/packages/web/app/components/BedManagement/HandoverNotesModal.jsx
@@ -11,14 +11,15 @@ import { PDFViewer, printPDF } from '../PatientPrinting/PDFViewer';
 export const HandoverNotesModal = React.memo(({ area: areaId, ...props }) => {
   const { getLocalisation } = useLocalisation();
   const api = useApi();
-  const { title, subTitle, logo } = useCertificate();
+  const { data: certificateData, isFetching: isFetchingCertificate } = useCertificate();
+  const { logo, title, subTitle } = certificateData;
   const letterheadConfig = { title, subTitle };
   const modalTitle = `Handover notes ${getDisplayDate(new Date(), 'dd/MM/yy')}`;
 
   const {
     data: { data: handoverNotes = [], locationGroup = {} } = {},
     refetch: refetchHandoverNotes,
-    isFetching,
+    isFetching: isFetchingHandoverNotes,
   } = useQuery(
     ['locationGroupHandoverNotes'],
     () => areaId && api.get(`locationGroup/${areaId}/handoverNotes`),
@@ -30,7 +31,7 @@ export const HandoverNotesModal = React.memo(({ area: areaId, ...props }) => {
     }
   }, [refetchHandoverNotes, areaId]);
 
-  if (isFetching) return null;
+  if (isFetchingCertificate || isFetchingHandoverNotes) return null;
 
   return (
     <Modal {...props} title={modalTitle} onPrint={() => printPDF('handover-notes')}>

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -13,7 +13,7 @@ import { BirthNotificationCertificate } from '@tamanu/shared/utils/patientCertif
 import { PDFViewer, printPDF } from '../PDFViewer';
 
 const useParent = (api, enabled, parentId) => {
-  const { data: parentData, isLoading: isParentDataIsLoading } = useQuery(
+  const { data: parentData, isLoading: isParentDataLoading } = useQuery(
     ['parentData', parentId],
     async () => (parentId ? api.get(`patient/${encodeURIComponent(parentId)}`) : null),
     { enabled },
@@ -81,7 +81,7 @@ const useParent = (api, enabled, parentId) => {
       father: grandFather,
     },
     isLoading:
-      isParentDataIsLoading ||
+      isParentDataLoading ||
       isAdditionalDataLoading ||
       isGrandMotherLoading ||
       isGrandFatherLoading ||

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -31,7 +31,7 @@ const useParent = (api, enabled, parentId) => {
       parentData?.villageId
         ? api.get(`referenceData/${encodeURIComponent(parentData.villageId)}`)
         : null,
-    { enabled: !parentDataIsLoading },
+    { enabled: !isParentDataLoading },
   );
 
   const { data: occupation, isLoading: isOccupationLoading } = useQuery(
@@ -40,7 +40,7 @@ const useParent = (api, enabled, parentId) => {
       additionalData?.occupationId
         ? api.get(`referenceData/${encodeURIComponent(additionalData.occupationId)}`)
         : null,
-    { enabled: !additionalDataLoading },
+    { enabled: !isAdditionalDataLoading },
   );
 
   const { data: ethnicity, isLoading: isEthnicityLoading } = useQuery(
@@ -49,7 +49,7 @@ const useParent = (api, enabled, parentId) => {
       additionalData?.ethnicityId
         ? api.get(`referenceData/${encodeURIComponent(additionalData.ethnicityId)}`)
         : null,
-    { enabled: !additionalDataLoading },
+    { enabled: !isAdditionalDataLoading },
   );
 
   const { data: grandMother, isLoading: isGrandMotherLoading } = useQuery(
@@ -58,7 +58,7 @@ const useParent = (api, enabled, parentId) => {
       additionalData?.motherId
         ? api.get(`patient/${encodeURIComponent(additionalData?.motherId)}`)
         : null,
-    { enabled: !additionalDataLoading },
+    { enabled: !isAdditionalDataLoading },
   );
 
   const { data: grandFather, isLoading: isGrandFatherLoading } = useQuery(
@@ -67,7 +67,7 @@ const useParent = (api, enabled, parentId) => {
       additionalData?.fatherId
         ? api.get(`patient/${encodeURIComponent(additionalData?.fatherId)}`)
         : null,
-    { enabled: !additionalDataLoading },
+    { enabled: !isAdditionalDataLoading },
   );
 
   return {

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -96,7 +96,7 @@ export const BirthNotificationCertificateModal = React.memo(({ patient }) => {
   const api = useApi();
   const { facility } = useAuth();
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
   const { data: additionalData, isLoading: additionalDataLoading } = usePatientAdditionalDataQuery(
     patient.id,
   );
@@ -137,7 +137,8 @@ export const BirthNotificationCertificateModal = React.memo(({ patient }) => {
     fatherDataLoading ||
     birthDataLoading ||
     ethnicityLoading ||
-    deathDataLoading;
+    deathDataLoading ||
+    isCertificateFetching;
 
   return (
     <Modal

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -13,19 +13,19 @@ import { BirthNotificationCertificate } from '@tamanu/shared/utils/patientCertif
 import { PDFViewer, printPDF } from '../PDFViewer';
 
 const useParent = (api, enabled, parentId) => {
-  const { data: parentData, isLoading: parentDataIsLoading } = useQuery(
+  const { data: parentData, isLoading: isParentDataIsLoading } = useQuery(
     ['parentData', parentId],
     async () => (parentId ? api.get(`patient/${encodeURIComponent(parentId)}`) : null),
     { enabled },
   );
 
-  const { data: additionalData, isLoading: additionalDataLoading } = useQuery(
+  const { data: additionalData, isLoading: isAdditionalDataLoading } = useQuery(
     ['additionalData', parentId],
     () => api.get(`patient/${encodeURIComponent(parentId)}/additionalData`),
     { enabled },
   );
 
-  const { data: village, isLoading: villageLoading } = useQuery(
+  const { data: village, isLoading: isVillageLoading } = useQuery(
     ['village', parentData?.villageId],
     () =>
       parentData?.villageId
@@ -34,7 +34,7 @@ const useParent = (api, enabled, parentId) => {
     { enabled: !parentDataIsLoading },
   );
 
-  const { data: occupation, isLoading: occupationLoading } = useQuery(
+  const { data: occupation, isLoading: isOccupationLoading } = useQuery(
     ['occupation', additionalData?.occupationId],
     () =>
       additionalData?.occupationId
@@ -43,7 +43,7 @@ const useParent = (api, enabled, parentId) => {
     { enabled: !additionalDataLoading },
   );
 
-  const { data: ethnicity, isLoading: ethnicityLoading } = useQuery(
+  const { data: ethnicity, isLoading: isEthnicityLoading } = useQuery(
     ['ethnicity', additionalData?.ethnicityId],
     () =>
       additionalData?.ethnicityId
@@ -52,7 +52,7 @@ const useParent = (api, enabled, parentId) => {
     { enabled: !additionalDataLoading },
   );
 
-  const { data: grandMother, isLoading: grandMotherLoading } = useQuery(
+  const { data: grandMother, isLoading: isGrandMotherLoading } = useQuery(
     ['mothersName', additionalData?.motherId],
     () =>
       additionalData?.motherId
@@ -61,7 +61,7 @@ const useParent = (api, enabled, parentId) => {
     { enabled: !additionalDataLoading },
   );
 
-  const { data: grandFather, isLoading: grandFatherLoading } = useQuery(
+  const { data: grandFather, isLoading: isGrandFatherLoading } = useQuery(
     ['fathersName', additionalData?.fatherId],
     () =>
       additionalData?.fatherId
@@ -81,13 +81,13 @@ const useParent = (api, enabled, parentId) => {
       father: grandFather,
     },
     isLoading:
-      parentDataIsLoading ||
-      additionalDataLoading ||
-      grandMotherLoading ||
-      grandFatherLoading ||
-      villageLoading ||
-      occupationLoading ||
-      ethnicityLoading,
+      isParentDataIsLoading ||
+      isAdditionalDataLoading ||
+      isGrandMotherLoading ||
+      isGrandFatherLoading ||
+      isVillageLoading ||
+      isOccupationLoading ||
+      isEthnicityLoading,
   };
 };
 
@@ -97,47 +97,51 @@ export const BirthNotificationCertificateModal = React.memo(({ patient }) => {
   const { facility } = useAuth();
   const { getLocalisation } = useLocalisation();
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
-  const { data: additionalData, isLoading: additionalDataLoading } = usePatientAdditionalDataQuery(
-    patient.id,
-  );
-  const { data: motherData, isLoading: motherDataLoading } = useParent(
+  const {
+    data: additionalData,
+    isLoading: isAdditionalDataLoading,
+  } = usePatientAdditionalDataQuery(patient.id);
+  const { data: motherData, isLoading: isMotherDataLoading } = useParent(
     api,
     !!additionalData,
     additionalData?.motherId,
   );
-  const { data: fatherData, isLoading: fatherDataLoading } = useParent(
+  const { data: fatherData, isLoading: isFatherDataLoading } = useParent(
     api,
     !!additionalData,
     additionalData?.fatherId,
   );
 
-  const { data: birthData, isLoading: birthDataLoading } = useQuery(['birthData', patient.id], () =>
-    api.get(`patient/${encodeURIComponent(patient.id)}/birthData`),
+  const { data: birthData, isLoading: isBirthDataLoading } = useQuery(
+    ['birthData', patient.id],
+    () => api.get(`patient/${encodeURIComponent(patient.id)}/birthData`),
   );
 
-  const { data: deathData, isLoading: deathDataLoading } = useQuery(['deathData', patient.id], () =>
-    api.get(
-      `patient/${encodeURIComponent(patient.id)}/death`,
-      {},
-      { isErrorUnknown: isErrorUnknownAllow404s },
-    ),
+  const { data: deathData, isLoading: isDeathDataLoading } = useQuery(
+    ['deathData', patient.id],
+    () =>
+      api.get(
+        `patient/${encodeURIComponent(patient.id)}/death`,
+        {},
+        { isErrorUnknown: isErrorUnknownAllow404s },
+      ),
   );
 
-  const { data: ethnicity, isLoading: ethnicityLoading } = useQuery(
+  const { data: ethnicity, isLoading: isEthnicityLoading } = useQuery(
     ['ethnicity', additionalData?.ethnicityId],
     () =>
       additionalData?.ethnicityId
         ? api.get(`referenceData/${encodeURIComponent(additionalData.ethnicityId)}`)
         : null,
-    { enabled: !additionalDataLoading },
+    { enabled: !isAdditionalDataLoading },
   );
 
-  const loading =
-    motherDataLoading ||
-    fatherDataLoading ||
-    birthDataLoading ||
-    ethnicityLoading ||
-    deathDataLoading ||
+  const isLoading =
+    isMotherDataLoading ||
+    isFatherDataLoading ||
+    isBirthDataLoading ||
+    isEthnicityLoading ||
+    isDeathDataLoading ||
     isCertificateFetching;
 
   return (
@@ -149,7 +153,7 @@ export const BirthNotificationCertificateModal = React.memo(({ patient }) => {
       keepMounted
       onPrint={() => printPDF('birth-notification')}
     >
-      {loading ? (
+      {isLoading ? (
         <LoadingIndicator />
       ) : (
         <PDFViewer id="birth-notification">

--- a/packages/web/app/components/PatientPrinting/modals/CovidClearanceCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidClearanceCertificateModal.jsx
@@ -21,6 +21,7 @@ export const CovidClearanceCertificateModal = React.memo(({ patient }) => {
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_CLEARANCE_CERTIFICATE_FOOTER,
   });
+  const { watermark, logo, footerImg, printedBy } = certificateData;
   const {
     data: additionalData,
     isLoading: isAdditionalDataLoading,
@@ -29,8 +30,6 @@ export const CovidClearanceCertificateModal = React.memo(({ patient }) => {
     patient.id,
     CertificateTypes.clearance,
   );
-
-  const { watermark, logo, footerImg, printedBy } = certificateData;
 
   const isLoading = isLabTestsLoading || isAdditionalDataLoading || isCertificateFetching;
 

--- a/packages/web/app/components/PatientPrinting/modals/CovidClearanceCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidClearanceCertificateModal.jsx
@@ -18,7 +18,7 @@ export const CovidClearanceCertificateModal = React.memo(({ patient }) => {
   const [open, setOpen] = useState(true);
   const { getLocalisation } = useLocalisation();
   const api = useApi();
-  const { watermark, logo, footerImg, printedBy } = useCertificate({
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_CLEARANCE_CERTIFICATE_FOOTER,
   });
   const {
@@ -30,7 +30,9 @@ export const CovidClearanceCertificateModal = React.memo(({ patient }) => {
     CertificateTypes.clearance,
   );
 
-  const isLoading = isLabTestsLoading || isAdditionalDataLoading;
+  const { watermark, logo, footerImg, printedBy } = certificateData;
+
+  const isLoading = isLabTestsLoading || isAdditionalDataLoading || isCertificateFetching;
 
   const createCovidTestCertNotification = useCallback(
     data =>

--- a/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
@@ -17,15 +17,15 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
   const [open, setOpen] = useState(true);
   const { getLocalisation } = useLocalisation();
   const api = useApi();
+
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER,
   });
-
+  const { watermark, logo, footerImg, printedBy } = certificateData;
   const { data: labTestsResponse, isLoading: isLabTestsLoading } = useCovidLabTestQuery(
     patient.id,
     CertificateTypes.test,
   );
-  const { watermark, logo, footerImg, printedBy } = certificateData;
   const {
     data: additionalData,
     isLoading: isAdditionalDataLoading,

--- a/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidTestCertificateModal.jsx
@@ -17,7 +17,7 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
   const [open, setOpen] = useState(true);
   const { getLocalisation } = useLocalisation();
   const api = useApi();
-  const { watermark, logo, footerImg, printedBy } = useCertificate({
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER,
   });
 
@@ -25,12 +25,13 @@ export const CovidTestCertificateModal = React.memo(({ patient }) => {
     patient.id,
     CertificateTypes.test,
   );
+  const { watermark, logo, footerImg, printedBy } = certificateData;
   const {
     data: additionalData,
     isLoading: isAdditionalDataLoading,
   } = usePatientAdditionalDataQuery(patient.id);
 
-  const isLoading = isLabTestsLoading || isAdditionalDataLoading;
+  const isLoading = isLabTestsLoading || isAdditionalDataLoading || isCertificateFetching;
 
   const createCovidTestCertNotification = useCallback(
     data =>

--- a/packages/web/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/CovidVaccineCertificateModal.jsx
@@ -16,12 +16,13 @@ import { PDFViewer, printPDF } from '../PDFViewer';
 export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient }) => {
   const api = useApi();
   const { getLocalisation } = useLocalisation();
-  const { watermark, logo, footerImg, printedBy } = useCertificate({
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.COVID_VACCINATION_CERTIFICATE_FOOTER,
   });
+  const { watermark, logo, footerImg, printedBy } = certificateData;
   const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
 
-  const { data: vaccineData, isFetching } = useAdministeredVaccines(patient.id, {
+  const { data: vaccineData, isFetching: isVaccineFetching } = useAdministeredVaccines(patient.id, {
     orderBy: 'date',
     order: 'ASC',
     invertNullDateOrdering: true,
@@ -44,7 +45,7 @@ export const CovidVaccineCertificateModal = React.memo(({ open, onClose, patient
 
   const patientData = { ...patient, additionalData };
 
-  if (isFetching) return null;
+  if (isVaccineFetching || isCertificateFetching) return null;
 
   return (
     <Modal

--- a/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
@@ -10,9 +10,9 @@ export const DeathCertificateModal = ({ patient, deathData }) => {
   const [isOpen, setIsOpen] = useState();
   const patientData = { ...patient, ...deathData };
   const { getLocalisation } = useLocalisation();
-  const { data: certificateData, isFetching } = useCertificate();
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
 
-  if (isFetching) return null;
+  if (isCertificateFetching) return null;
 
   return (
     <>

--- a/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
@@ -10,7 +10,9 @@ export const DeathCertificateModal = ({ patient, deathData }) => {
   const [isOpen, setIsOpen] = useState();
   const patientData = { ...patient, ...deathData };
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const { data: certificateData, isFetching } = useCertificate();
+
+  if (isFetching) return null;
 
   return (
     <>

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -143,7 +143,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
     dischargeQuery,
     villageQuery,
     notesQuery,
-    isFetching,
+    certificateQuery,
   ]);
 
   const modalProps = {

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -102,7 +102,8 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
   const clinicianText = useLocalisedText({ path: 'fields.clinician.shortLabel' });
 
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const certificateQuery = useCertificate();
+  const { data: certificateData } = certificateQuery;
 
   const patientQuery = usePatientData(encounter.patientId);
   const patient = patientQuery.data;
@@ -142,6 +143,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
     dischargeQuery,
     villageQuery,
     notesQuery,
+    isFetching,
   ]);
 
   const modalProps = {

--- a/packages/web/app/components/PatientPrinting/modals/MultipleImagingRequestsPrintoutModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/MultipleImagingRequestsPrintoutModal.jsx
@@ -11,13 +11,14 @@ import { Modal } from '../../Modal';
 
 export const MultipleImagingRequestsWrapper = ({ encounter, imagingRequests }) => {
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
   const { data: patient, isLoading: isPatientLoading } = usePatientData(encounter.patientId);
   const isVillageEnabled = patient?.villageId;
   const { data: village, isLoading: isVillageLoading } = useReferenceData(patient?.villageId);
-  const isLoading = isPatientLoading || (isVillageEnabled && isVillageLoading);
+  const isLoading =
+    isPatientLoading || (isVillageEnabled && isVillageLoading) || isCertificateFetching;
 
-  if (isLoading || !certificateData.logo) {
+  if (isLoading) {
     return <LoadingIndicator />;
   }
 

--- a/packages/web/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.jsx
@@ -14,7 +14,7 @@ import { MultipleLabRequestsPrintout } from '@tamanu/shared/utils/patientCertifi
 
 export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open, onClose }) => {
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
   const api = useApi();
 
   const { data: patient, isLoading: patientLoading } = useQuery(
@@ -47,7 +47,7 @@ export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open,
       printable
       onPrint={() => printPDF('lab-request-printout')}
     >
-      {patientLoading || additionalDataLoading || villageLoading ? (
+      {patientLoading || additionalDataLoading || villageLoading || isCertificateFetching ? (
         <LoadingIndicator />
       ) : (
         <PDFViewer id="lab-request-printout">

--- a/packages/web/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.jsx
@@ -20,16 +20,16 @@ export const MultiplePrescriptionPrintoutModal = ({
   onClose,
 }) => {
   const { getLocalisation } = useLocalisation();
-  const { data: certificateData, isFetching: isFetchingCertificate } = useCertificate();
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
   const api = useApi();
   const { facility } = useAuth();
 
-  const { data: patient, isLoading: isLoadingPatient } = useQuery(
+  const { data: patient, isLoading: isPatientLoading } = useQuery(
     ['patient', encounter.patientId],
     () => api.get(`patient/${encounter.patientId}`),
   );
 
-  const { data: prescriber, isLoading: isLoadingPrescriber } = useQuery(
+  const { data: prescriber, isLoading: isPrescriberLoading } = useQuery(
     ['prescriber', prescriberId],
     () => api.get(`user/${prescriberId}`),
     {
@@ -37,12 +37,12 @@ export const MultiplePrescriptionPrintoutModal = ({
     },
   );
 
-  const { data: additionalData, isLoading: isLoadingAdditionalData } = useQuery(
+  const { data: additionalData, isLoading: isAdditionalDataLoading } = useQuery(
     ['additionalData', encounter.patientId],
     () => api.get(`patient/${encounter.patientId}/additionalData`),
   );
 
-  const { data: village = {}, isLoading: isLoadingVillage } = useQuery(
+  const { data: village = {}, isLoading: isVillageLoading } = useQuery(
     ['village', encounter.patientId],
     () => api.get(`referenceData/${encodeURIComponent(patient.villageId)}`),
     {
@@ -50,13 +50,12 @@ export const MultiplePrescriptionPrintoutModal = ({
     },
   );
 
-  const isVillageLoading = isLoadingVillage && !!patient?.villageId;
   const isLoading =
-    isLoadingPatient ||
-    isLoadingAdditionalData ||
-    isVillageLoading ||
-    isFetchingCertificate ||
-    isLoadingPrescriber;
+    isPatientLoading ||
+    isAdditionalDataLoading ||
+    isPrescriberLoading ||
+    (isVillageLoading && !!patient?.villageId) ||
+    isCertificateFetching;
 
   return (
     <Modal

--- a/packages/web/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/MultiplePrescriptionPrintoutModal.jsx
@@ -20,16 +20,16 @@ export const MultiplePrescriptionPrintoutModal = ({
   onClose,
 }) => {
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const { data: certificateData, isFetching: isFetchingCertificate } = useCertificate();
   const api = useApi();
   const { facility } = useAuth();
 
-  const { data: patient, isLoading: patientLoading } = useQuery(
+  const { data: patient, isLoading: isLoadingPatient } = useQuery(
     ['patient', encounter.patientId],
     () => api.get(`patient/${encounter.patientId}`),
   );
 
-  const { data: prescriber, isLoading: prescriberLoading } = useQuery(
+  const { data: prescriber, isLoading: isLoadingPrescriber } = useQuery(
     ['prescriber', prescriberId],
     () => api.get(`user/${prescriberId}`),
     {
@@ -37,12 +37,12 @@ export const MultiplePrescriptionPrintoutModal = ({
     },
   );
 
-  const { data: additionalData, isLoading: additionalDataLoading } = useQuery(
+  const { data: additionalData, isLoading: isLoadingAdditionalData } = useQuery(
     ['additionalData', encounter.patientId],
     () => api.get(`patient/${encounter.patientId}/additionalData`),
   );
 
-  const { data: village = {}, isLoading: villageQueryLoading } = useQuery(
+  const { data: village = {}, isLoading: isLoadingVillage } = useQuery(
     ['village', encounter.patientId],
     () => api.get(`referenceData/${encodeURIComponent(patient.villageId)}`),
     {
@@ -50,7 +50,13 @@ export const MultiplePrescriptionPrintoutModal = ({
     },
   );
 
-  const villageLoading = villageQueryLoading && !!patient?.villageId;
+  const isVillageLoading = isLoadingVillage && !!patient?.villageId;
+  const isLoading =
+    isLoadingPatient ||
+    isLoadingAdditionalData ||
+    isVillageLoading ||
+    isFetchingCertificate ||
+    isLoadingPrescriber;
 
   return (
     <Modal
@@ -62,7 +68,7 @@ export const MultiplePrescriptionPrintoutModal = ({
       printable
       onPrint={() => printPDF('prescription-printout')}
     >
-      {patientLoading || additionalDataLoading || villageLoading || prescriberLoading ? (
+      {isLoading ? (
         <LoadingIndicator />
       ) : (
         <PDFViewer id="prescription-printout">

--- a/packages/web/app/components/PatientPrinting/modals/PrintPrescriptionModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintPrescriptionModal.jsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../../contexts/Auth';
 
 export const PrintPrescriptionModal = ({ medication, open, onClose }) => {
   const { getLocalisation } = useLocalisation();
-  const certificateData = useCertificate();
+  const { data: certificateData, isFetching: isFetchingCertificate } = useCertificate();
   const api = useApi();
   const [encounter, setEncounter] = useState({});
   const [patient, setPatient] = useState({});
@@ -81,6 +81,14 @@ export const PrintPrescriptionModal = ({ medication, open, onClose }) => {
     })();
   }, [api, medication.prescriberId]);
 
+  const isLoading =
+    encounterLoading ||
+    patientLoading ||
+    additionalDataLoading ||
+    villageLoading ||
+    prescriberLoading ||
+    isFetchingCertificate;
+
   return (
     <>
       <Modal
@@ -91,11 +99,7 @@ export const PrintPrescriptionModal = ({ medication, open, onClose }) => {
         printable
         onPrint={() => printPDF('prescription-printout')}
       >
-        {encounterLoading ||
-        patientLoading ||
-        additionalDataLoading ||
-        villageLoading ||
-        prescriberLoading ? (
+        {isLoading ? (
           <LoadingIndicator />
         ) : (
           <PDFViewer id="prescription-printout">

--- a/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
@@ -20,13 +20,7 @@ import { PDFViewer, printPDF } from '../PDFViewer';
 export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) => {
   const api = useApi();
   const { getLocalisation } = useLocalisation();
-  const {
-    watermark,
-    logo,
-    footerImg,
-    printedBy,
-    isFetching: isCertificateFetching,
-  } = useCertificate({
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER,
   });
   const {
@@ -57,6 +51,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
 
   const village = useReferenceData(patient.villageId).data;
   const patientData = { ...patient, village, additionalData };
+  const { logo, watermark, footerImg, printedBy } = certificateData;
 
   if (isAdditionalDataFetching || isVaccineFetching || isCertificateFetching) return null;
 

--- a/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
@@ -20,12 +20,21 @@ import { PDFViewer, printPDF } from '../PDFViewer';
 export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) => {
   const api = useApi();
   const { getLocalisation } = useLocalisation();
-  const { watermark, logo, footerImg, printedBy } = useCertificate({
+  const {
+    watermark,
+    logo,
+    footerImg,
+    printedBy,
+    isFetching: isCertificateFetching,
+  } = useCertificate({
     footerAssetName: ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER,
   });
-  const { data: additionalData } = usePatientAdditionalDataQuery(patient.id);
+  const {
+    data: additionalData,
+    isFetching: isAdditionalDataFetching,
+  } = usePatientAdditionalDataQuery(patient.id);
 
-  const { data: vaccineData, isFetching } = useAdministeredVaccines(patient.id, {
+  const { data: vaccineData, isFetching: isVaccineFetching } = useAdministeredVaccines(patient.id, {
     orderBy: 'date',
     order: 'ASC',
     invertNullDateOrdering: true,
@@ -49,9 +58,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
   const village = useReferenceData(patient.villageId).data;
   const patientData = { ...patient, village, additionalData };
 
-  if (isFetching) return null;
-
-  if (isFetching) return null;
+  if (isAdditionalDataFetching || isVaccineFetching || isCertificateFetching) return null;
 
   return (
     <Modal

--- a/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
@@ -23,6 +23,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER,
   });
+  const { logo, watermark, footerImg, printedBy } = certificateData;
   const {
     data: additionalData,
     isFetching: isAdditionalDataFetching,
@@ -51,7 +52,6 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
 
   const village = useReferenceData(patient.villageId).data;
   const patientData = { ...patient, village, additionalData };
-  const { logo, watermark, footerImg, printedBy } = certificateData;
 
   if (isAdditionalDataFetching || isVaccineFetching || isCertificateFetching) return null;
 

--- a/packages/web/app/utils/useAsset.js
+++ b/packages/web/app/utils/useAsset.js
@@ -10,7 +10,7 @@ export const useAsset = assetName => {
 
   const fallbackAssetName = ASSET_FALLBACK_NAMES[assetName];
 
-  const { data: queryData, isFetched: assetFetched, isFetching: isAssetFetching } = useQuery({
+  const { data: queryData, isFetching: isAssetFetching, isFetched: assetFetched } = useQuery({
     queryKey: ['asset', assetName],
     queryFn: () => api.get(`asset/${assetName}`),
     enabled: !!assetName,

--- a/packages/web/app/utils/useAsset.js
+++ b/packages/web/app/utils/useAsset.js
@@ -10,13 +10,13 @@ export const useAsset = assetName => {
 
   const fallbackAssetName = ASSET_FALLBACK_NAMES[assetName];
 
-  const { data: queryData, isFetched: assetFetched } = useQuery({
+  const { data: queryData, isFetched: assetFetched, isFetching: isAssetFetching } = useQuery({
     queryKey: ['asset', assetName],
     queryFn: () => api.get(`asset/${assetName}`),
     enabled: !!assetName,
   });
 
-  const { data: fallbackQueryData } = useQuery({
+  const { data: fallbackQueryData, isFetching: isFallbackFetching } = useQuery({
     queryKey: ['asset', fallbackAssetName],
     queryFn: () => api.get(`asset/${fallbackAssetName}`),
     enabled: !!fallbackAssetName && assetFetched && !queryData,
@@ -39,9 +39,8 @@ export const useAsset = assetName => {
     }
   }, [queryData, fallbackQueryData]);
 
-  if (!assetData) {
-    return null;
-  }
-
-  return `data:${assetDataType};base64,${assetData}`;
+  return {
+    data: `data:${assetDataType};base64,${assetData}`,
+    isFetching: isAssetFetching || isFallbackFetching,
+  };
 };

--- a/packages/web/app/utils/useCertificate.js
+++ b/packages/web/app/utils/useCertificate.js
@@ -43,7 +43,7 @@ export const useCertificate = ({ footerAssetName } = {}) => {
   };
 
   return {
-    data
+    data,
     isFetching,
   };
 };

--- a/packages/web/app/utils/useCertificate.js
+++ b/packages/web/app/utils/useCertificate.js
@@ -32,7 +32,7 @@ export const useCertificate = ({ footerAssetName } = {}) => {
 
   const currentUser = useSelector(getCurrentUser);
 
-  return {
+  const data = {
     title,
     subTitle,
     logo,
@@ -40,6 +40,10 @@ export const useCertificate = ({ footerAssetName } = {}) => {
     footerImg,
     deathCertFooterImg,
     printedBy: currentUser?.displayName,
+  };
+
+  return {
+    data
     isFetching,
   };
 };

--- a/packages/web/app/utils/useCertificate.js
+++ b/packages/web/app/utils/useCertificate.js
@@ -7,13 +7,28 @@ import { getCurrentUser } from '../store';
 
 export const useCertificate = ({ footerAssetName } = {}) => {
   const { getLocalisation } = useLocalisation();
-  const logo = useAsset(ASSET_NAMES.LETTERHEAD_LOGO);
-  const watermark = useAsset(ASSET_NAMES.VACCINE_CERTIFICATE_WATERMARK);
-  const footerImg = useAsset(footerAssetName || ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG);
-  const deathCertFooterImg = useAsset(ASSET_NAMES.DEATH_CERTIFICATE_BOTTOM_HALF_IMG);
-  const letterhead = useTemplate('templates.letterhead')?.data;
+  const { data: logo, isFetching: isLogoFetching } = useAsset(ASSET_NAMES.LETTERHEAD_LOGO);
+  const { data: watermark, isFetching: isWatermarkFetching } = useAsset(
+    ASSET_NAMES.VACCINE_CERTIFICATE_WATERMARK,
+  );
+  const { data: footerImg, isFetching: isFooterImgFetching } = useAsset(
+    footerAssetName || ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG,
+  );
+  const { data: deathCertFooterImg, isFetching: isDeathCertFooterImgFetching } = useAsset(
+    ASSET_NAMES.DEATH_CERTIFICATE_BOTTOM_HALF_IMG,
+  );
+  const { data: letterhead, isFetching: isLetterheadFetching } = useTemplate(
+    'templates.letterhead',
+  );
   const title = letterhead?.data?.title || getLocalisation('templates.letterhead.title');
   const subTitle = letterhead?.data?.subTitle || getLocalisation('templates.letterhead.subTitle');
+
+  const isFetching =
+    isLogoFetching ||
+    isWatermarkFetching ||
+    isFooterImgFetching ||
+    isLetterheadFetching ||
+    isDeathCertFooterImgFetching;
 
   const currentUser = useSelector(getCurrentUser);
 
@@ -25,5 +40,6 @@ export const useCertificate = ({ footerAssetName } = {}) => {
     footerImg,
     deathCertFooterImg,
     printedBy: currentUser?.displayName,
+    isFetching,
   };
 };

--- a/packages/web/app/views/patients/DischargeSummaryView.jsx
+++ b/packages/web/app/views/patients/DischargeSummaryView.jsx
@@ -32,7 +32,7 @@ const NavContainer = styled.div`
 `;
 
 export const DischargeSummaryView = React.memo(() => {
-  const certiciateData = useCertificate();
+  const { data: certiciateData, isFetching: isCertificateFetching } = useCertificate();
   const { getLocalisation } = useLocalisation();
   const { encounter } = useEncounter();
   const patient = useSelector(state => state.patient);
@@ -50,7 +50,8 @@ export const DischargeSummaryView = React.memo(() => {
     return <Redirect to="/patients/all" />;
   }
 
-  if (isPADLoading || isDischargeLoading || isLoadingPatientConditions) return <LoadingIndicator />;
+  if (isPADLoading || isDischargeLoading || isLoadingPatientConditions || isCertificateFetching)
+    return <LoadingIndicator />;
 
   return (
     <Container>

--- a/packages/web/app/views/patients/components/LabRequestPrintModal.jsx
+++ b/packages/web/app/views/patients/components/LabRequestPrintModal.jsx
@@ -48,8 +48,8 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
     areTestsLoading ||
     areNotesLoading ||
     isAdditionalDataLoading ||
-    isCertificateFetching ||
-    (isVillageEnabled && isVillageLoading);
+    (isVillageEnabled && isVillageLoading) ||
+    isCertificateFetching;
 
   return (
     <Modal

--- a/packages/web/app/views/patients/components/LabRequestPrintModal.jsx
+++ b/packages/web/app/views/patients/components/LabRequestPrintModal.jsx
@@ -18,7 +18,7 @@ import { MultipleLabRequestsPrintout } from '@tamanu/shared/utils/patientCertifi
 export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onClose }) => {
   const { getLocalisation } = useLocalisation();
   const api = useApi();
-  const certificate = useCertificate();
+  const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
 
   const { data: encounter, isLoading: isEncounterLoading } = useEncounterData(
     labRequest.encounterId,
@@ -48,6 +48,7 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
     areTestsLoading ||
     areNotesLoading ||
     isAdditionalDataLoading ||
+    isCertificateFetching ||
     (isVillageEnabled && isVillageLoading);
 
   return (
@@ -68,7 +69,7 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
             labRequests={[{ ...labRequest, tests: testsData.data, notes: notes?.data || [] }]}
             patientData={{ ...patient, additionalData, village }}
             encounter={encounter}
-            certificateData={certificate}
+            certificateData={certificateData}
             getLocalisation={getLocalisation}
           />
         </PDFViewer>


### PR DESCRIPTION
### Changes
Effected all printouts as asset load queries where not incorporated into loading state. isFetching is used due to optional nature of queries.

Bug is reproducible consistently by doing this
- Refresh on a printout page (to be safe that query hasn't loaded already)
- Open a printout 
- Initial load of prinout can be missing assets as there was no component refresh of pdf in time to populate

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
