### PR TITLE
Fix: Add back configurable footer to death certificate

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DeathCertificatePrintout.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import { getName, getTimeOfDeath, getDateOfDeath, getSex } from '../patientAccessors';
-import { CertificateHeader, Col, Row, styles } from './Layout';
+import { CertificateHeader, Col, Row, styles, SigningImage } from './Layout';
 import { LetterheadSection } from './LetterheadSection';
 import { Footer } from './printComponents/Footer';
 import { MultiPageHeader } from './printComponents/MultiPageHeader';
@@ -191,7 +191,7 @@ const SectionContainer = props => <View style={generalStyles.sectionContainer} {
 
 export const DeathCertificatePrintout = React.memo(
   ({ patientData, certificateData, getLocalisation }) => {
-    const { logo } = certificateData;
+    const { logo, deathCertFooterImg } = certificateData;
 
     const { causes } = patientData;
     const causeOfDeath = getCauseName(causes?.primary);
@@ -199,7 +199,7 @@ export const DeathCertificatePrintout = React.memo(
     const antecedentCause2 = getCauseName(causes?.antecedent2);
     return (
       <Document>
-        <Page size="A4" style={styles.page}>
+        <Page size="A4" style={{...styles.page, paddingBottom: 25}}>
           <MultiPageHeader
             documentName="Cause of death certificate"
             patientName={getName(patientData)}
@@ -302,7 +302,7 @@ export const DeathCertificatePrintout = React.memo(
               means the disease, injury, or complication that caused death.
             </Text>
           </View>
-          <AuthorisedAndSignSection />
+          {deathCertFooterImg ? <SigningImage src={deathCertFooterImg} /> : <AuthorisedAndSignSection />}
           <Footer />
         </Page>
       </Document>


### PR DESCRIPTION
### Changes

In converting the death certificate to reactPDF, we accidentally removed the logic for the configurable death footer. I have added this back in and also added a bit of padding to the page as I noticed it was overlapping the header if the configured image was too large.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
