### PR TITLE
doc: KAM-138: Introduce conventional commit style for PRs

### DIFF
--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -16,7 +16,7 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref }}
       shell: bash
       run: |
-        if ! grep -qP '^(feature|fix|epic|merge|release)/' <<< "$BRANCH_NAME"; then
+        if ! grep -qP '^(dependabot|epic|feature|fix|merge|release)/' <<< "$BRANCH_NAME"; then
           echo "::warning::Branch name should be prefixed with one of: feature/ fix/ epic/ merge/ release/"
           exit 1
         fi

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -11,14 +11,31 @@ jobs:
     name: When merging to main
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'dev'
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
-    - name: Warn if feature PR title is not prefixed with ticket number
-      if: startsWith(github.head_ref, 'feature/')
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
+    - name: Check for Conventional Commit format
       shell: bash
       run: |
-        if ! grep -qP '^[A-Z]+-[0-9]+(:\s+\w+)?' <<< "$PR_TITLE"; then
-          echo "::warning::PR title should start with ticket number, e.g. 'ABC-123: ...'"
+        if ! grep -qP '^\w+(\(\w+\))?:\s' <<< "$PR_TITLE"; then
+          echo "::warning::PR title should be in Conventional Commit style, e.g. 'feat: ...'"
+          exit 1
+        fi
+
+    - name: Check for conventional type allow-list
+      if: always()
+      shell: bash
+      run: |
+        if ! grep -qP '^(ci|config|db|deps|doc|feat|fix|fmt|refactor|release|repo|revert|style|test|tweak)(\(\w+\))?:\s' <<< "$PR_TITLE"; then
+          echo "::warning::PR title Conventional Type is not on the list; refer to CONTRIBUTING.md"
+          exit 1
+        fi
+
+    - name: Check for Linear card number for feature/ branches
+      if: always() && startsWith(github.head_ref, 'feature/')
+      shell: bash
+      run: |
+        if ! grep -qP '^\w+(\(\w+\))?:\s[A-Z]+-[0-9]+(:\s+\w+)?' <<< "$PR_TITLE"; then
+          echo "::warning::PR title should start with ticket number, e.g. 'feat(scope): ABC-123: ...'"
           exit 1
         fi

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         set -ex
         git switch --create "$NEW_BRANCH_NAME"
-        git commit --allow-empty -m "Cut-off for $NEW_BRANCH_NAME"
+        git commit --allow-empty -m "release: Cut-off for $NEW_BRANCH_NAME"
         git push origin "$NEW_BRANCH_NAME"
         git switch main
 
@@ -77,5 +77,5 @@ jobs:
       run: |
         set -ex
         version=$(jq -r .version package.json)
-        git commit -am "Bump version to $version"
+        git commit -am "release: Bump version to $version"
         git push

--- a/.github/workflows/lint-fix-in-pr.yml
+++ b/.github/workflows/lint-fix-in-pr.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git commit -am "lint (auto fix)"
+        git commit -am "fmt: automatic lint-fix"
         git push
 
     - name: Signal we're done

--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -35,9 +35,9 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
         version=$(jq -r .version package.json)
-        git commit --allow-empty -am "Release v$version"
+        git commit --allow-empty -am "release: v$version"
         echo "current_version=$version" >> $GITHUB_OUTPUT
-        git tag -a "v$version" -m "Release $version"
+        git tag -a "v$version" -m "release: v$version"
         git push --follow-tags
 
     - name: Bump version on branch
@@ -48,7 +48,7 @@ jobs:
       run: |
         set -euxo pipefail
         version=$(jq -r .version package.json)
-        git commit -am "Bump version to $version"
+        git commit -am "release: Bump version to $version"
         echo "next_version=$version" >> $GITHUB_OUTPUT
         git push
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,24 @@ For open-source contribution branches, the naming convention is:
 
 For example, `fix/1736-pdf-export-crash`
 
+The following prefixes are conventional:
+
+- `epic/` for large features or changes that span multiple issues
+- `feature/` for new features and improvements
+- `fix/` for bug fixes
+- `merge/` for branches that merge other branches (resolving conflicts or doing complex merges)
+
+Additionally, `feature/` branches should be named after the Linear card they are associated with:
+
+```plain
+feature/team-123-my-feature
+```
+
+The following prefixes are reserved and must not be created manually:
+
+- `dependabot/` for branches created by Dependabot
+- `release/` for release branches
+
 #### Branching Strategy
 
 1. When creating a branch for your contribution, branch off the latest `main`.
@@ -107,8 +125,46 @@ your changes and provide feedback. If your pull request has been approved by a r
 will then go through a round of internal testing. Once your changes have passed testing, they
 can be merged into main and be included in an upcoming Tamanu release.
 
-_(potentially space for more information on the process of merging contributions into main (such 
-as updating changelog and info about the pr template and also the auto deploy tests))_
+#### Pull Request Title
+
+The title of pull requests must be in [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/)
+format. This is used to generate changelogs, and to provide a consistent format for commits landing
+in the main branch, as pull requests are merged in "squash" mode.
+
+```plain
+type: <description>
+type(scope): <description>
+```
+
+When a Linear card is applicable, the Linear card number should be included:
+
+```plain
+type: TEAM-123: <description>
+type(scope): TEAM-123: <description>
+```
+
+The following types are conventional:
+
+- `ci` for changes to the CI/CD workflows
+- `config` for changes to the Tamanu configuration files
+- `db` for changes to the database schema, migrations, etc
+- `deps` for changes to dependencies or dependency upgrades
+- `doc` for documentation changes
+- `feat` for new features
+- `fix` for bug fixes
+- `fmt` for automatic formatting changes (ignored in changelogs)
+- `refactor` for code refactoring
+- `release` for changes that are part of the release process (generally automated commits, not manual use)
+- `repo` for changes to the repository structure, or for config/dotfiles (e.g. `.gitignore`, `.editorconfig`, etc)
+- `revert` for reverting a previous commit
+- `style` for stylistic changes that do not affect the meaning of the code
+- `test` for adding missing tests or correcting existing tests
+- `tweak` for minor changes that do not fit into any other category
+
+When merging, additional change lines may be added to the squashed commit message to provide further
+context to be pulled into changelogs.
+
+Using Conventional Commit format for actual commit messages within pull requests is not required.
 
 ## Note on Forking
 


### PR DESCRIPTION
### Changes

- Adds a section to CONTRIBUTING.md describing the PR title style
- Lists out [an initial set of conventional types](https://github.com/beyondessential/tamanu/blob/feature/kam-138-conventional-commits/CONTRIBUTING.md#pull-request-title) to use
- Also lists prefixes for the branch naming convention
- Changes the CI checks to look for conventional commit style for PR titles

### Checklist

- [x] Code is finished