### PR TITLE
ci(packaging): Fix missing permission and improve for manual runs

### DIFF
--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -156,25 +156,17 @@ jobs:
           tar -cf '${{ env.OUTPUT_NAME }}.tar' '${{ env.BUILD_NAME }}'
           zstd --rm --adapt -T0 -10 '${{ env.OUTPUT_NAME }}.tar' -o '${{ env.OUTPUT_NAME }}.tar.zst'
 
-      - uses: cargo-bins/cargo-binstall@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Sign build
         shell: bash
         env:
-          MINISIGN_KEY: ${{ secrets.SIGNING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
-          set -e
-          echo "$MINISIGN_KEY" > minisign.key
-          set -x
-          cargo binstall -y --only-signed rsign2
-          rsign sign -W \
-            -s minisign.key \
-            -x '${{ env.OUTPUT_NAME }}.tar.zst.sig' \
-            -t "ts=$(date +%s) repo=${{ github.repository }} commit=${{ needs.info.outputs.actual_ref }} gharun=${{ github.run_id }}" \
+          curl -Lo bestool https://tools.ops.tamanu.io/bestool/gha/${{ runner.os }}-${{ runner.arch }}
+          chmod +x bestool
+          ./bestool crypto sign --key-env SIGNING_KEY \
+            --comment 'ts={timestamp} repo=${{ github.repository }} commit=${{ needs.info.outputs.actual_ref }} gharun=${{ github.run_id }}' \
             '${{ env.OUTPUT_NAME }}.tar.zst'
-          rm minisign.*
+
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: read
   id-token: write # OIDC token for AWS
 
 jobs:

--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -49,6 +49,8 @@ jobs:
     env:
       BUILD_NAME: "release-v${{ needs.info.outputs.version }}"
       ARTIFACT_NAME: "${{ matrix.package }}-${{ needs.info.outputs.version }}"
+      OUTPUT_NAME: "${{ matrix.package }}-${{ needs.info.outputs.version }}-linux-amd64"
+      S3_PATH: s3://bes-tamanu-release-servers/${{ needs.info.outputs.version }}
 
     steps:
       - name: Configure AWS Credentials
@@ -94,14 +96,52 @@ jobs:
             packages/${{ matrix.package }}-server/pm2.config.js > ${{ env.BUILD_NAME }}/pm2.config.js
 
       - name: Prepare artifact output
-        run: zip -r '${{ env.BUILD_NAME }}.zip' '${{ env.BUILD_NAME }}'
+        run: |
+          zip -r '${{ env.BUILD_NAME }}.zip' '${{ env.BUILD_NAME }}'
+          tar -cf '${{ env.OUTPUT_NAME }}.tar' '${{ env.BUILD_NAME }}'
+          zstd --rm --adapt -T0 -10 '${{ env.OUTPUT_NAME }}.tar' -o '${{ env.OUTPUT_NAME }}.tar.zst'
 
-      - name: Upload artifact
+      - name: Sign build
+        shell: bash
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        run: |
+          curl -Lo bestool https://tools.ops.tamanu.io/bestool/gha/${{ runner.os }}-${{ runner.arch }}
+          chmod +x bestool
+          ./bestool crypto sign --key-env SIGNING_KEY  \
+            --comment 'ts={timestamp} repo=${{ github.repository }} commit=${{ needs.info.outputs.actual_ref }} gharun=${{ github.run_id }}' \
+            '${{ env.OUTPUT_NAME }}.tar.zst'
+
+      - name: Upload artifact for next step
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: '${{ env.BUILD_NAME }}.zip'
           retention-days: 1
+
+      - name: Upload final output
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            ${{ env.OUTPUT_NAME }}.tar.zst
+            ${{ env.OUTPUT_NAME }}.tar.zst.sig
+          retention-days: 15
+
+      - name: Configure AWS Credentials
+        if: github.event_name != 'workflow_dispatch'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::143295493206:role/gha-server-s3
+          role-session-name: GHA@Tamanu=ServerPackage
+
+      - name: Push to S3
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          aws s3 cp '${{ env.OUTPUT_NAME }}.tar.zst' '${{ env.S3_PATH }}/${{ env.OUTPUT_NAME }}.tar.zst' --no-progress
+          aws s3 cp '${{ env.OUTPUT_NAME }}.tar.zst.sig' '${{ env.S3_PATH }}/${{ env.OUTPUT_NAME }}.tar.zst.sig' --no-progress
 
   windows-zip:
     needs:
@@ -167,8 +207,18 @@ jobs:
             --comment 'ts={timestamp} repo=${{ github.repository }} commit=${{ needs.info.outputs.actual_ref }} gharun=${{ github.run_id }}' \
             '${{ env.OUTPUT_NAME }}.tar.zst'
 
+      - name: Upload final build
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.OUTPUT_NAME }}
+          path: |
+            ${{ env.OUTPUT_NAME }}.tar.zst
+            ${{ env.OUTPUT_NAME }}.tar.zst.sig
+          retention-days: 15
 
       - name: Configure AWS Credentials
+        if: github.event_name != 'workflow_dispatch'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ap-southeast-2
@@ -176,6 +226,7 @@ jobs:
           role-session-name: GHA@Tamanu=ServerPackage
 
       - name: Push to S3
+        if: github.event_name != 'workflow_dispatch'
         run: |
           aws s3 cp '${{ env.OUTPUT_NAME }}.tar.zst' '${{ env.S3_PATH }}/${{ env.OUTPUT_NAME }}.tar.zst' --no-progress
           aws s3 cp '${{ env.OUTPUT_NAME }}.tar.zst.sig' '${{ env.S3_PATH }}/${{ env.OUTPUT_NAME }}.tar.zst.sig' --no-progress

--- a/.github/workflows/cd-web-package.yml
+++ b/.github/workflows/cd-web-package.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write # OIDC token for AWS
   contents: read
+  id-token: write # OIDC token for AWS
 
 jobs:
   build:
@@ -42,35 +42,28 @@ jobs:
           mv resources dist/resources
           mv dist tamanu-web-$ver
           zip -r -0 tamanu-web-$ver.zip tamanu-web-$ver
+          tar -cf web-$ver.tar tamanu-web-$ver
+          zstd --rm --adapt -T0 -10 web-$ver.tar -o web-$ver.tar.zst
 
-      - uses: cargo-bins/cargo-binstall@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Sign build
-        shell: bash
         working-directory: packages/web
         env:
-          MINISIGN_KEY: ${{ secrets.SIGNING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
-          set -e
-          echo "$MINISIGN_KEY" > minisign.key
-          set -x
-          ver=$(jq -r .version package.json)
-          cargo binstall -y --only-signed rsign2
-          rsign sign -W \
-            -s minisign.key \
-            -x "tamanu-web-$ver.zip.sig" \
-            -t "ts=$(date +%s) repo=${{ github.repository }} commit=${{ github.sha }} gharun=${{ github.run_id }}" \
-            "tamanu-web-$ver.zip"
-          rm minisign.*
+          curl -Lo bestool https://tools.ops.tamanu.io/bestool/gha/${{ runner.os }}-${{ runner.arch }}
+          chmod +x bestool
+          ./bestool crypto sign --key-env SIGNING_KEY  \
+            --comment 'ts={timestamp} repo=${{ github.repository }} commit=${{ github.sha }} gharun=${{ github.run_id }}' \
+            web-*.tar.zst
 
       - name: Upload to artifact
         uses: actions/upload-artifact@v4
         with:
           name: web-package
-          path: packages/web/tamanu-web*.zip*
-          retention-days: 14
+          path: |
+            packages/web/tamanu-web*.zip
+            packages/web/web*.tar.zst*
+          retention-days: 15
           if-no-files-found: error
 
       - name: Set S3 destination
@@ -83,7 +76,7 @@ jobs:
             if (context.ref == 'refs/heads/main') {
               return `${base}/main/${(new Date).toISOString().replaceAll(':','-').split('.')[0]}.${context.sha.slice(0, 10)}`;
             } else if (context.ref.startsWith('refs/tags/v')) {
-              return `${base}/${context.ref.replace('refs/tags/', '')}`;
+              return `${base}/${context.ref.replace('refs/tags/v', '')}`;
             } else if (context.ref.startsWith('refs/heads/release/')) {
               return `${base}/${context.ref.replace('refs/tags/', '')}-rc`;
             } else {
@@ -105,6 +98,6 @@ jobs:
           target: ${{ steps.destination.outputs.result }}
         run: |
           set -exu
-          for file in *.zip*; do
+          for file in *.tar.zst*; do
             aws s3 cp $file $target/$file --no-progress
           done


### PR DESCRIPTION
### Changes

- There was a missing `contents: read` permission which prevented the workflow from running
- As we can't upload to AWS with `workflow_dispatch`, switch in this case to upload it as an artifact (kept for 15 days aka enough for the release cycle)
- Use the bestool to sign the file instead of the previous complicated minisign/rsign setup

### Checklist

- [x] Code is finished