### PR TITLE
Fix: Version number not displaying

### DIFF
--- a/packages/web/app/components/Sidebar/Sidebar.jsx
+++ b/packages/web/app/components/Sidebar/Sidebar.jsx
@@ -181,7 +181,7 @@ const isHighlighted = (currentPath, menuItemPath, sectionIsOpen, isRetracted) =>
 export const Sidebar = React.memo(({ items }) => {
   const [selectedParentItem, setSelectedParentItem] = useState('');
   const [isRetracted, setIsRetracted] = useState(false);
-  const { appVersion } = useApi();
+  const { agentVersion } = useApi();
   const { facility, centralHost, currentUser, onLogout, currentRole } = useAuth();
   const currentPath = useSelector(getCurrentRoute);
   const dispatch = useDispatch();
@@ -320,7 +320,7 @@ export const Sidebar = React.memo(({ items }) => {
                 Support centre
                 <Launch style={{ marginLeft: '5px', fontSize: '12px' }} />
               </SupportDesktopLink>
-              <Version>Version {appVersion}</Version>
+              <Version>Version {agentVersion}</Version>
             </StyledMetadataBox>
           </>
         )}

--- a/packages/web/app/views/LoginView.jsx
+++ b/packages/web/app/views/LoginView.jsx
@@ -108,7 +108,7 @@ export const LoginView = () => {
   const resetPasswordEmail = useSelector(state => state.auth.resetPassword.lastEmailUsed);
   const changePasswordError = useSelector(state => state.auth.changePassword.error);
   const changePasswordSuccess = useSelector(state => state.auth.changePassword.success);
-  const { appVersion } = api;
+  const { agentVersion } = api;
 
   const rememberEmail = localStorage.getItem(REMEMBER_EMAIL);
 
@@ -199,7 +199,7 @@ export const LoginView = () => {
             <Launch style={{ marginLeft: '3px', fontSize: '12px' }} />
           </SupportDesktopLink>
         )}
-        <DesktopVersionText>Version {appVersion}</DesktopVersionText>
+        <DesktopVersionText>Version {agentVersion}</DesktopVersionText>
       </LoginContainer>
       <LoginSplashImage />
     </Container>


### PR DESCRIPTION
### Changes

With the api upgrade we changed the name of the api property that stores the tamanu version. It is now called agentVersion instead of appVersion.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
