### PR TITLE
ci(migrations): No ticket: Avoid hitting rate limits with GH API due to KAM-37

### DIFF
--- a/.github/scripts/find-dumped.py
+++ b/.github/scripts/find-dumped.py
@@ -14,6 +14,7 @@ commits_bytes = subprocess.run(
     ["/usr/bin/git", "log", "--pretty=format:%H"], check=True, capture_output=True
 ).stdout.splitlines()
 commits = map(lambda c: str(c, encoding="ascii"), commits_bytes)
+commits = commits[1:]  # Skip the latest commit as we want an old db dump.
 
 dumped = next(dumped_iter)
 commits_iter = iter(commits)

--- a/.github/scripts/find-dumped.py
+++ b/.github/scripts/find-dumped.py
@@ -13,7 +13,7 @@ dumped_iter = iter(
 commits_bytes = subprocess.run(
     ["/usr/bin/git", "log", "--pretty=format:%H"], check=True, capture_output=True
 ).stdout.splitlines()
-commits = map(lambda c: str(c, encoding="ascii"), commits_bytes)
+commits = list(map(lambda c: str(c, encoding="ascii"), commits_bytes))
 commits = commits[1:]  # Skip the latest commit as we want an old db dump.
 
 dumped = next(dumped_iter)

--- a/.github/scripts/find-dumped.py
+++ b/.github/scripts/find-dumped.py
@@ -1,14 +1,7 @@
 #!/usr/bin/env python3
 
-import argparse
-from gql import gql, Client
-from gql.transport.httpx import HTTPXTransport
+import subprocess
 import boto3
-
-parser = argparse.ArgumentParser()
-parser.add_argument("--github-token", required=True)
-parser.add_argument("--branch", required=True)
-args = parser.parse_args()
 
 aws_client = boto3.client("s3")
 dumped_iter = iter(
@@ -17,62 +10,27 @@ dumped_iter = iter(
     )
 )
 
-transport = HTTPXTransport(
-    url="https://api.github.com/graphql",
-    headers={"authorization": f"Bearer {args.github_token}"},
-)
-gql_client = Client(transport=transport, fetch_schema_from_transport=True)
-query_string = """
-query($endCursor: String) {
-  repository(owner: "beyondessential", name: "tamanu") {
-    ref(qualifiedName: "{{branch}}") {
-      target {
-        ...on Commit {
-          history(after: $endCursor) {
-            nodes { oid }
-              pageInfo {
-                  hasNextPage
-                  endCursor
-              }
-          }
-        }
-      }
-    }
-  }
-}
-""".replace(
-    "{{branch}}", args.branch
-)
-gh_query = gql(query_string)
+commits_bytes = subprocess.run(
+    ["/usr/bin/git", "log", "--pretty=format:%H"], check=True, capture_output=True
+).stdout.splitlines()
+commits = map(lambda c: str(c, encoding="ascii"), commits_bytes)
 
 dumped = next(dumped_iter)
-commits = gql_client.execute(gh_query)["repository"]["ref"]["target"]["history"]
-
-commits["nodes"] = commits["nodes"][1:] # Skip the latest commit as we want an old db dump.
-commits_iter = iter(commits["nodes"])
+commits_iter = iter(commits)
 while True:
     try:
         # Return if this commit hash is in the dumped list.
-        commit = next(commits_iter)["oid"]
+        commit = next(commits_iter)
         hashes = map(lambda d: d["Prefix"][:-1], dumped["CommonPrefixes"])
         if any([hash == commit for hash in hashes]):
             print(commit)
             exit(0)
     except StopIteration:
-        # Fetch more commits if any.
-        if commits["pageInfo"]["hasNextPage"]:
-            new_commits = gql_client.execute(
-                gh_query, {"endCursor": commits["pageInfo"]["endCursor"]}
-            )["repository"]["ref"]["target"]["history"]
-            commits["nodes"].extend(new_commits["nodes"])
-            commits = {"nodes": commits["nodes"], "pageInfo": new_commits["pageInfo"]}
-            commits_iter = iter(new_commits["nodes"])
-            continue
-        # With all commits fetched, retry with the next page of the dumped list until the end.
+        # Retry with the next page of the dumped list until the end.
         # Fetching the commits first ensures we check the latest commit from the branch.
-        commits_iter = iter(commits["nodes"])
+        commits_iter = iter(commits)
         try:
             dumped = next(dumped_iter)
         except StopIteration:
-            print(f"No commit found from {args.branch} in the bucket")
+            print(f"No commit found in the bucket")
             exit(1)

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -41,6 +41,8 @@ jobs:
           role-to-assume: arn:aws:iam::143295493206:role/gha-tamanu-test-data-snapshots-s3
           role-session-name: GHA@fake=generate
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 4000
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
@@ -58,11 +60,11 @@ jobs:
           source .github/scripts/install-postgres-ubuntu.sh ${{ matrix.postgres }}
           .github/scripts/setup-postgres-for-one-package.sh fake
 
-      - run: python3 -m pip install gql boto3 httpx
+      - run: python3 -m pip install gql
 
       - id: commit-finder
         run: |
-          commit=$(.github/scripts/find-dumped.py --github-token ${{ github.token }} --branch ${{ github.head_ref || github.ref_name }})
+          commit=$(.github/scripts/find-dumped.py)
           (( $? == 0 )) || exit 1
           echo "commit=$commit" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -60,7 +60,7 @@ jobs:
           source .github/scripts/install-postgres-ubuntu.sh ${{ matrix.postgres }}
           .github/scripts/setup-postgres-for-one-package.sh fake
 
-      - run: python3 -m pip install gql
+      - run: python3 -m pip install boto3
 
       - id: commit-finder
         run: |


### PR DESCRIPTION
### Changes

This uses `git log` over GitHub API by fetching more with `actions/checkout`. The depth of 4000 is enough to cover one to two year of commits. (Fetching everything is possible, but I think it's overkill.) It's still not clear to me if fetching more is more efficient, but it seems to be true that GH imposes much more relaxed rate limits on cloning than the API.

### Checklist

- [x] Code is finished