### PR TITLE
Fix: fix api errors showing

### DIFF
--- a/packages/central-server/__tests__/integrations/fijiVrs/hook_INSERTandUPDATE.test.js
+++ b/packages/central-server/__tests__/integrations/fijiVrs/hook_INSERTandUPDATE.test.js
@@ -326,6 +326,7 @@ describe('VRS integration hook: INSERT and UPDATE operations', () => {
       expect(response.body).toEqual({
         response: false,
         error: {
+          status: 502,
           message: expect.stringContaining('500'),
           name: 'RemoteCallFailedError',
         },

--- a/packages/shared/src/errors.js
+++ b/packages/shared/src/errors.js
@@ -2,6 +2,7 @@ class BaseError extends Error {
   constructor(message) {
     super(message);
     this.name = this.constructor.name;
+    this.status = getCodeForErrorName(this.name);
   }
 }
 

--- a/packages/web/app/api/TamanuApi.js
+++ b/packages/web/app/api/TamanuApi.js
@@ -1,7 +1,4 @@
-import {
-  TamanuApi as ApiClient,
-  AuthExpiredError,
-} from '@tamanu/api-client';
+import { TamanuApi as ApiClient, AuthExpiredError } from '@tamanu/api-client';
 import { SERVER_TYPES } from '@tamanu/constants';
 import { buildAbilityForUser } from '@tamanu/shared/permissions/buildAbility';
 
@@ -44,20 +41,18 @@ function clearLocalStorage() {
   localStorage.removeItem(ROLE);
 }
 
-export function isErrorUnknownDefault(error, response) {
-  void(error); // error is required for this function signature, but we don't use it
-
-  if (!response || typeof response.status !== 'number') {
+export function isErrorUnknownDefault(error) {
+  if (!error || typeof error.status !== 'number') {
     return true;
   }
-  return response.status >= 400;
+  return error.status >= 400;
 }
 
-export function isErrorUnknownAllow404s(error, response) {
-  if (response?.status === 404) {
+export function isErrorUnknownAllow404s(error) {
+  if (error?.status === 404) {
     return false;
   }
-  return isErrorUnknownDefault(error, response);
+  return isErrorUnknownDefault(error);
 }
 
 export class TamanuApi extends ApiClient {
@@ -67,12 +62,12 @@ export class TamanuApi extends ApiClient {
     host.search = '';
     host.hash = '';
     host.pathname = '/api';
-    
+
     super({
       endpoint: host.toString(),
       agentName: SERVER_TYPES.WEBAPP,
       agentVersion: appVersion,
-      deviceId: getDeviceId()
+      deviceId: getDeviceId(),
     });
   }
 
@@ -106,11 +101,11 @@ export class TamanuApi extends ApiClient {
     try {
       return await super.fetch(endpoint, query, otherConfig);
     } catch (err) {
-      const message = err?.message || err?.response?.status;
+      const message = err?.message || err?.status;
 
       if (err instanceof AuthExpiredError) {
         clearLocalStorage();
-      } else if (showUnknownErrorToast && isErrorUnknown(err, err.response)) {
+      } else if (showUnknownErrorToast && isErrorUnknown(err)) {
         notifyError([
           'Network request failed',
           `Path: ${err.path ?? endpoint}`,
@@ -125,7 +120,7 @@ export class TamanuApi extends ApiClient {
   async get(endpoint, query, { showUnknownErrorToast = true, ...options } = {}) {
     return this.fetch(endpoint, query, { method: 'GET', showUnknownErrorToast, ...options });
   }
-  
+
   async checkServerAlive() {
     return this.get('public/ping', null, { showUnknownErrorToast: false });
   }


### PR DESCRIPTION
### Changes

The TamanuApi class was recently refactored and split out into a new TamanuApi package. In the new extractError method the way that errors are parsed and thrown means that the custom errors that are passed back to the client version of Tamanu Api are different to what they used to be and one of the key changes is that they didn't have the error status included. This change adds the status to all custom errors using the existing mapping of errors and statuses and then updates the client version of the api class to read those statuses.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
