### PR TITLE
db(migrations): KAM-36: Allow disabling sync trigger

### DIFF
--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -3,6 +3,7 @@ import { isSyncTriggerDisabled } from '@tamanu/shared/dataMigrations';
 import { EmailService } from './services/EmailService';
 import { closeDatabase, initDatabase, initReporting } from './database';
 import { initIntegrations } from './integrations';
+import { log } from '@tamanu/shared/services/logging';
 
 export class ApplicationContext {
   store = null;

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -1,4 +1,5 @@
 import config from 'config';
+import { isSyncTriggerDisabled } from '@tamanu/shared/dataMigrations';
 import { EmailService } from './services/EmailService';
 import { closeDatabase, initDatabase, initReporting } from './database';
 import { initIntegrations } from './integrations';
@@ -19,6 +20,11 @@ export class ApplicationContext {
     this.store = await initDatabase({ testMode });
     if (config.db.reportSchemas?.enabled) {
       this.reportSchemaStores = await initReporting();
+    }
+
+    if (await isSyncTriggerDisabled(this.store.sequelize)) {
+      log.warn("Sync Trigger is disabled in the database.");
+      return null;
     }
 
     this.closePromise = new Promise(resolve => {

--- a/packages/facility-server/app/database/integrity.js
+++ b/packages/facility-server/app/database/integrity.js
@@ -1,8 +1,13 @@
 import config from 'config';
 import { log } from '@tamanu/shared/services/logging';
+import { isSyncTriggerDisabled } from '@tamanu/shared/dataMigrations';
 import { CentralServerConnection } from '../sync';
 
 export async function performDatabaseIntegrityChecks(context) {
+  if (await isSyncTriggerDisabled(context.sequelize)) {
+    throw Error("Sync Trigger is disabled in the database.");
+  }
+
   // run in a transaction so any errors roll back all changes
   await context.sequelize.transaction(async () => {
     await ensureHostMatches(context);

--- a/packages/shared/__tests__/sync/migrations.test.js
+++ b/packages/shared/__tests__/sync/migrations.test.js
@@ -32,8 +32,8 @@ describe('migrations', () => {
             const tickAtStart = await report_definition.updatedAtSyncTick;
 
             // act
-            await models.LocalSystemFact.set('currentSyncTick', 2);
             await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
+            await models.LocalSystemFact.set('currentSyncTick', 2);
             await umzug.up({ step: 1 });
             await report_definition.reload();
             const tickAfterMigration = await report_definition.updatedAtSyncTick;
@@ -47,8 +47,8 @@ describe('migrations', () => {
             const tickAtStart = await report_definition.updatedAtSyncTick;
 
             // act
-            await models.LocalSystemFact.set('currentSyncTick', 2);
             await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
+            await models.LocalSystemFact.set('currentSyncTick', 2);
             await umzug.up({ step: 1 });
 
             // make sure running migration doesn't affect normal sync tick update

--- a/packages/shared/__tests__/sync/migrations.test.js
+++ b/packages/shared/__tests__/sync/migrations.test.js
@@ -30,6 +30,7 @@ describe('migrations', () => {
 
         it('should not trigger the sync tick update while migrating', async () => {
             const tickAtStart = await report_definition.updatedAtSyncTick;
+
             // act
             await models.LocalSystemFact.set('currentSyncTick', 2);
             await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
@@ -44,6 +45,7 @@ describe('migrations', () => {
 
         it('ensure sync tick update still work', async () => {
             const tickAtStart = await report_definition.updatedAtSyncTick;
+
             // act
             await models.LocalSystemFact.set('currentSyncTick', 2);
             await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
@@ -53,6 +55,7 @@ describe('migrations', () => {
             await report_definition.update({ name: "lorem ipsum" });
             await report_definition.reload();
             const tickAfterUpdate = await report_definition.updatedAtSyncTick;
+
             // assertions
             expect(tickAtStart).toBe('1');
             expect(tickAfterUpdate).toBe('2');

--- a/packages/shared/__tests__/sync/migrations.test.js
+++ b/packages/shared/__tests__/sync/migrations.test.js
@@ -1,0 +1,61 @@
+import { closeDatabase, initDatabase } from './utilities';
+import { runPostMigration } from '../../dist/cjs/services/migrations/runPostMigration';
+import { createMigrationInterface } from '../../dist/cjs/services/migrations/migrations';
+import { fake } from '../../dist/cjs/test-helpers/fake';
+import { log } from '../../dist/cjs/services/logging/log';
+
+describe('migrations', () => {
+
+    describe('Disabling sync trigger', () => {
+        let database, umzug, models, report_definition;
+        beforeEach(async () => {
+            database = await initDatabase();
+            models = database.models;
+            umzug = createMigrationInterface(log, database.sequelize);
+            await umzug.up();
+            await runPostMigration(log, database.sequelize);
+            await models.LocalSystemFact.set('currentSyncTick', 1);
+            // setup test data
+            const { ReportDefinition } = models;
+            report_definition = await ReportDefinition.create(
+                fake(ReportDefinition, {
+                    dbSchema: 'raw'
+                })
+            );
+        });
+
+        afterEach(async () => {
+            await closeDatabase();
+        });
+
+        it('should not trigger the sync tick update while migrating', async () => {
+            const tickAtStart = await report_definition.updatedAtSyncTick;
+            // act
+            await models.LocalSystemFact.set('currentSyncTick', 2);
+            await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
+            await umzug.up({ step: 1 });
+            await report_definition.reload();
+            const tickAfterMigration = await report_definition.updatedAtSyncTick;
+
+            // assertions
+            expect(tickAtStart).toBe('1');
+            expect(tickAfterMigration).toBe('1');
+        });
+
+        it('ensure sync tick update still work', async () => {
+            const tickAtStart = await report_definition.updatedAtSyncTick;
+            // act
+            await models.LocalSystemFact.set('currentSyncTick', 2);
+            await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
+            await umzug.up({ step: 1 });
+
+            // make sure running migration doesn't affect normal sync tick update
+            await report_definition.update({ name: "lorem ipsum" });
+            await report_definition.reload();
+            const tickAfterUpdate = await report_definition.updatedAtSyncTick;
+            // assertions
+            expect(tickAtStart).toBe('1');
+            expect(tickAfterUpdate).toBe('2');
+        });
+    });
+});

--- a/packages/shared/__tests__/sync/utilities.js
+++ b/packages/shared/__tests__/sync/utilities.js
@@ -11,7 +11,7 @@ const getOrCreateConnection = async (configOverrides, key = 'main') => {
   });
 };
 
-async function initDatabase() {
+export async function initDatabase() {
   const testMode = process.env.NODE_ENV === 'test';
   return getOrCreateConnection({
     primaryKeyDefault: testMode ? fakeUUID : undefined,

--- a/packages/shared/src/dataMigrations/CursorDataMigration.js
+++ b/packages/shared/src/dataMigrations/CursorDataMigration.js
@@ -26,17 +26,11 @@ export class CursorDataMigration extends DataMigration {
     } = this;
     this.started = true;
     log.debug('CursorDataMigration batch started', { lastMaxId });
-    const [[{ maxId }], { rowCount }] = await sequelize.transaction(async () => {
-      const { LocalSystemFact } = sequelize.models;
-      await LocalSystemFact.set('syncTrigger', 'disabled');
-      const res = await sequelize.query(await this.getQuery(), {
-        bind: {
-          fromId: lastMaxId,
-          limit,
-        },
-      });
-      await LocalSystemFact.set('syncTrigger', 'enabled');
-      return res;
+    const [[{ maxId }], { rowCount }] = await sequelize.query(await this.getQuery(), {
+      bind: {
+        fromId: lastMaxId,
+        limit,
+      },
     });
     log.debug('CursorDataMigration batch done', { lastMaxId, maxId });
     this.lastMaxId = maxId;

--- a/packages/shared/src/dataMigrations/index.js
+++ b/packages/shared/src/dataMigrations/index.js
@@ -12,3 +12,8 @@ export const disableSyncTrigger = async (sequelize, callback) => {
     await callback();
     await LocalSystemFact.set('syncTrigger', 'enabled');
 };
+
+export const isSyncTriggerDisabled = async sequelize => {
+    const state = await sequelize.models.LocalSystemFact.get('syncTrigger');
+    return state === 'disabled';
+};

--- a/packages/shared/src/dataMigrations/index.js
+++ b/packages/shared/src/dataMigrations/index.js
@@ -1,2 +1,14 @@
 export { DataMigration } from './DataMigration';
 export { CursorDataMigration } from './CursorDataMigration';
+
+/*
+ * No query done in `callback` trigger the sync tick update.
+ * It's recommended to wrap this in a transaction.
+ * Otherwise, the trigger kept disabled when the callback throws an error.
+ */
+export const disableSyncTrigger = async (sequelize, callback) => {
+    const { LocalSystemFact } = sequelize.models;
+    await LocalSystemFact.set('syncTrigger', 'disabled');
+    await callback();
+    await LocalSystemFact.set('syncTrigger', 'enabled');
+};

--- a/packages/shared/src/migrations/1692710205000-allowDisablingSyncTrigger.js
+++ b/packages/shared/src/migrations/1692710205000-allowDisablingSyncTrigger.js
@@ -6,7 +6,7 @@ export async function up(query) {
       LANGUAGE plpgsql AS
       $func$
       BEGIN
-        IF (SELECT current_setting('tamanu.sync') = 'disabled') THEN
+        IF ((SELECT value FROM local_system_facts WHERE key = 'syncTrigger') = 'disabled') THEN
             RETURN NEW;
         END IF;
         -- If setting to "-1" representing "not marked as updated on this client", we actually use

--- a/packages/shared/src/migrations/1692710205000-allowDisablingSyncTrigger.js
+++ b/packages/shared/src/migrations/1692710205000-allowDisablingSyncTrigger.js
@@ -1,0 +1,59 @@
+// copied from 1669675313161-renameTriggerFunctionForUpdatedAtSyncTick with a guard to skip syncing
+export async function up(query) {
+    await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION set_updated_at_sync_tick()
+      RETURNS trigger
+      LANGUAGE plpgsql AS
+      $func$
+      BEGIN
+        IF (SELECT current_setting('tamanu.sync') = 'disabled') THEN
+            RETURN NEW;
+        END IF;
+        -- If setting to "-1" representing "not marked as updated on this client", we actually use
+        -- a different number, "-999", to represent that in the db, so that we can identify the
+        -- difference between explicitly setting it to not marked as updated (when NEW contains -1),
+        -- and having other fields updated without the updated_at_sync_tick being altered (in which
+        -- case NEW will contain -999, easily distinguished from -1)
+        IF NEW.updated_at_sync_tick = -1 THEN
+          NEW.updated_at_sync_tick := -999;
+        ELSE
+          SELECT value FROM local_system_facts WHERE key = 'currentSyncTick' INTO NEW.updated_at_sync_tick;
+
+          -- take an advisory lock on the current sync tick (if one doesn't already exist), to
+          -- record that an active transaction is using this sync tick
+          -- see waitForPendingEditsUsingSyncTick for more details
+          PERFORM pg_try_advisory_xact_lock_shared(NEW.updated_at_sync_tick);
+        END IF;
+        RETURN NEW;
+      END
+      $func$;
+  `);
+}
+
+export async function down(query) {
+    await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION set_updated_at_sync_tick()
+      RETURNS trigger
+      LANGUAGE plpgsql AS
+      $func$
+      BEGIN
+        -- If setting to "-1" representing "not marked as updated on this client", we actually use
+        -- a different number, "-999", to represent that in the db, so that we can identify the
+        -- difference between explicitly setting it to not marked as updated (when NEW contains -1),
+        -- and having other fields updated without the updated_at_sync_tick being altered (in which
+        -- case NEW will contain -999, easily distinguished from -1)
+        IF NEW.updated_at_sync_tick = -1 THEN
+          NEW.updated_at_sync_tick := -999;
+        ELSE
+          SELECT value FROM local_system_facts WHERE key = 'currentSyncTick' INTO NEW.updated_at_sync_tick;
+
+          -- take an advisory lock on the current sync tick (if one doesn't already exist), to
+          -- record that an active transaction is using this sync tick
+          -- see waitForPendingEditsUsingSyncTick for more details
+          PERFORM pg_try_advisory_xact_lock_shared(NEW.updated_at_sync_tick);
+        END IF;
+        RETURN NEW;
+      END
+      $func$;
+  `);
+}

--- a/packages/shared/src/services/migrations/migrations.js
+++ b/packages/shared/src/services/migrations/migrations.js
@@ -2,9 +2,11 @@ import Umzug from 'umzug';
 import { readdirSync } from 'fs';
 import path from 'path';
 import { runPostMigration } from './runPostMigration';
+import { wrap, chain } from 'lodash';
 
 // before this, we just cut our losses and accept irreversible migrations
 const LAST_REVERSIBLE_MIGRATION = '048_changeNoteRecordTypeColumn.js';
+const NO_SYNC_MIGRATION_TIMESTAMP = '1692710205000';
 
 export function createMigrationInterface(log, sequelize) {
   // ie, shared/src/migrations
@@ -24,7 +26,24 @@ export function createMigrationInterface(log, sequelize) {
     migrations: {
       path: migrationsDir,
       params: [sequelize.getQueryInterface()],
-      wrap: updown => (...args) => sequelize.transaction(() => updown(...args)),
+      // wrap: updown => (...args) => sequelize.transaction(() => updown(...args)),
+      customResolver: sqlPath => {
+        const migration = require(sqlPath);
+        const transaction = (updown, ...args) => sequelize.transaction(() => updown(...args));
+        const disableSyncTrigger = async (updown, query, ...args) => {
+          await query.sequelize.query("SET LOCAL tamanu.sync TO 'disabled';");
+          await updown(query, ...args);
+        };
+
+        const timestamp = path.basename(sqlPath).split(/[-_]/, 1);
+        const is_no_sync = !migration.NON_DETERMINISTIC && timestamp > NO_SYNC_MIGRATION_TIMESTAMP;
+        // const is_no_sync = false;
+        return chain(migration)
+          .pick(['up', 'down'])
+          .mapValues(updown => is_no_sync ? wrap(updown, disableSyncTrigger) : updown)
+          .mapValues(updown => wrap(updown, transaction))
+          .value();
+      }
     },
     storage: 'sequelize',
     storageOptions: {

--- a/packages/shared/src/services/migrations/migrations.js
+++ b/packages/shared/src/services/migrations/migrations.js
@@ -30,8 +30,10 @@ export function createMigrationInterface(log, sequelize) {
         const migration = require(sqlPath);
         const transaction = (updown, ...args) => sequelize.transaction(() => updown(...args));
         const disableSyncTrigger = async (updown, query, ...args) => {
-          await query.sequelize.query("SET LOCAL tamanu.sync TO 'disabled';");
+          const { LocalSystemFact } = query.sequelize.models;
+          await LocalSystemFact.set('syncTrigger', 'disabled');
           await updown(query, ...args);
+          await LocalSystemFact.set('syncTrigger', 'enabled');
         };
 
         const timestamp = path.basename(sqlPath).split(/[-_]/, 1);

--- a/packages/shared/src/services/migrations/migrations.js
+++ b/packages/shared/src/services/migrations/migrations.js
@@ -26,7 +26,6 @@ export function createMigrationInterface(log, sequelize) {
     migrations: {
       path: migrationsDir,
       params: [sequelize.getQueryInterface()],
-      // wrap: updown => (...args) => sequelize.transaction(() => updown(...args)),
       customResolver: sqlPath => {
         const migration = require(sqlPath);
         const transaction = (updown, ...args) => sequelize.transaction(() => updown(...args));
@@ -37,7 +36,7 @@ export function createMigrationInterface(log, sequelize) {
 
         const timestamp = path.basename(sqlPath).split(/[-_]/, 1);
         const is_no_sync = !migration.NON_DETERMINISTIC && timestamp > NO_SYNC_MIGRATION_TIMESTAMP;
-        // const is_no_sync = false;
+
         return chain(migration)
           .pick(['up', 'down'])
           .mapValues(updown => is_no_sync ? wrap(updown, disableSyncTrigger) : updown)


### PR DESCRIPTION
The implementation feels a bit questionable. This uses [Customized Options](https://www.postgresql.org/docs/16/runtime-config-custom.html), which is made for extension modules rather than local variables. I'm using for now because I found that many people (on Stackoverflow for example) (ab)use it for temporary variables. I'm open to change it to something like `LocalSystemFact`. Also, this inserts the new migration in the middle. This is necessary for testing. The latest migration I could find that fires the sync trigger (i.e. does update or insert) was `addDbUserToReportDefinitions`, so this was the easiest way to test this.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Checklist

- [x] Code is finished
- [x] Tests are written

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
