### PR TITLE
Fix: Remove .form from translation ids

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentForm.jsx
+++ b/packages/web/app/components/Appointments/AppointmentForm.jsx
@@ -81,7 +81,7 @@ export const AppointmentForm = props => {
             <Field
               label={
                 <TranslatedText
-                  stringId="scheduling.newAppointment.form.type.label"
+                  stringId="scheduling.newAppointment.type.label"
                   fallback="Appointment type"
                 />
               }

--- a/packages/web/app/components/CancelModal.jsx
+++ b/packages/web/app/components/CancelModal.jsx
@@ -39,7 +39,7 @@ export const CancelModal = React.memo(
                 component={SelectField}
                 label={
                   <TranslatedText
-                    stringId="imaging.modal.cancel.form.reason.label"
+                    stringId="imaging.modal.cancel.reason.label"
                     fallback="Reason for cancellation"
                   />
                 }

--- a/packages/web/app/components/CarePlanNoteDisplay.jsx
+++ b/packages/web/app/components/CarePlanNoteDisplay.jsx
@@ -66,7 +66,7 @@ export const CarePlanNoteDisplay = ({ note, isMainCarePlan, onEditClicked, onNot
             <NoteOnBehalfOf>
               &nbsp;&nbsp;|&nbsp;&nbsp;
               <TranslatedText
-                stringId="carePlan.form.noteOnBehalfOf.label"
+                stringId="carePlan.noteOnBehalfOf.label"
                 fallback="On behalf of"
               />{' '}
               {note.onBehalfOf.displayName}

--- a/packages/web/app/components/CarePlanNoteForm.jsx
+++ b/packages/web/app/components/CarePlanNoteForm.jsx
@@ -57,7 +57,7 @@ export function CarePlanNoteForm({
               name="onBehalfOfId"
               label={
                 <TranslatedText
-                  stringId="carePlan.form.noteOnBehalfOf.label"
+                  stringId="carePlan.noteOnBehalfOf.label"
                   fallback="On behalf of"
                 />
               }
@@ -68,7 +68,7 @@ export function CarePlanNoteForm({
               name="date"
               label={
                 <TranslatedText
-                  stringId="carePlan.form.noteDateRecorded.label"
+                  stringId="carePlan.noteDateRecorded.label"
                   fallback="Date Recorded"
                 />
               }

--- a/packages/web/app/components/Field/DOBFields.jsx
+++ b/packages/web/app/components/Field/DOBFields.jsx
@@ -35,14 +35,14 @@ export const DOBFields = ({ showExactBirth = true }) => (
       name="dateOfBirthFrom"
       component={DateField}
       saveDateAsString
-      label={<TranslatedText stringId="general.form.dateOfBirthFrom.label" fallback="DOB from" />}
+      label={<TranslatedText stringId="general.dateOfBirthFrom.label" fallback="DOB from" />}
       max={getCurrentDateString()}
     />
     <Field
       name="dateOfBirthTo"
       component={DateField}
       saveDateAsString
-      label={<TranslatedText stringId="general.form.dateOfBirthTo.label" fallback="DOB to" />}
+      label={<TranslatedText stringId="general.dateOfBirthTo.label" fallback="DOB to" />}
       max={getCurrentDateString()}
     />
   </>

--- a/packages/web/app/components/Field/IdField.jsx
+++ b/packages/web/app/components/Field/IdField.jsx
@@ -45,7 +45,7 @@ export const IdInput = ({ value, name, onChange, regenerateId }) => (
     <RegenerateId onClick={() => onChange({ target: { value: regenerateId(), name } })}>
       <Autorenew />
       <Text>
-        <TranslatedText stringId="patient.form.id.regenerate" fallback="Regenerate" />
+        <TranslatedText stringId="patient.id.regenerate" fallback="Regenerate" />
       </Text>
     </RegenerateId>
   </IdControl>

--- a/packages/web/app/components/Field/ImagingPriorityField.jsx
+++ b/packages/web/app/components/Field/ImagingPriorityField.jsx
@@ -12,7 +12,7 @@ export const ImagingPriorityField = ({ name = 'priority', required }) => {
   return (
     <Field
       name={name}
-      label={<TranslatedText stringId="imaging.form.priority.label" fallback="Priority" />}
+      label={<TranslatedText stringId="imaging.priority.label" fallback="Priority" />}
       component={SelectField}
       options={imagingPriorities}
       required={required}

--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -163,8 +163,8 @@ export const LocationField = React.memo(({ field, ...props }) => {
 
 export const LocalisedLocationField = React.memo(
   ({
-    defaultGroupLabel = <TranslatedText stringId="general.form.area.label" fallback="Area" />,
-    defaultLabel = <TranslatedText stringId="general.form.location.label" fallback="Location" />,
+    defaultGroupLabel = <TranslatedText stringId="general.area.label" fallback="Area" />,
+    defaultLabel = <TranslatedText stringId="general.location.label" fallback="Location" />,
     ...props
   }) => {
     const { getLocalisation } = useLocalisation();

--- a/packages/web/app/components/InvoiceLineItemModal.jsx
+++ b/packages/web/app/components/InvoiceLineItemModal.jsx
@@ -59,7 +59,7 @@ export const InvoiceLineItemModal = ({
           <FormGrid>
             <Field
               name="dateGenerated"
-              label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
+              label={<TranslatedText stringId="general.date.label" fallback="Date" />}
               required
               component={DateField}
               saveDateAsString
@@ -68,7 +68,7 @@ export const InvoiceLineItemModal = ({
               name="invoiceLineTypeId"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.addInvoice.form.details.label"
+                  stringId="invoice.modal.addInvoice.details.label"
                   fallback="Details"
                 />
               }
@@ -80,7 +80,7 @@ export const InvoiceLineItemModal = ({
               name="orderedById"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.addInvoice.form.orderedBy.label"
+                  stringId="invoice.modal.addInvoice.orderedBy.label"
                   fallback="Ordered by"
                 />
               }
@@ -92,7 +92,7 @@ export const InvoiceLineItemModal = ({
               name="price"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.addInvoice.form.price.label"
+                  stringId="invoice.modal.addInvoice.price.label"
                   fallback="Price ($)"
                 />
               }
@@ -104,7 +104,7 @@ export const InvoiceLineItemModal = ({
               name="percentageChange"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.addInvoice.form.percentageChange.label"
+                  stringId="invoice.modal.addInvoice.percentageChange.label"
                   fallback="Discount/markup % (-/+)"
                 />
               }

--- a/packages/web/app/components/NoteChangeLogs.jsx
+++ b/packages/web/app/components/NoteChangeLogs.jsx
@@ -36,7 +36,7 @@ export const NoteChangeLogs = ({ note = {} }) => {
 
   return (
     <OuterLabelFieldWrapper
-      label={<TranslatedText stringId="note.form.changeLog.label" fallback="Change log" />}
+      label={<TranslatedText stringId="note.changeLog.label" fallback="Change log" />}
     >
       <StyledBox
         sx={{ width: '100%', maxHeight: 300, overflowY: 'auto', bgcolor: 'background.paper' }}

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -80,7 +80,7 @@ const renderOptionLabel = ({ value, label }, noteTypeCountByType) => {
 };
 export const WrittenByField = ({
   label = (
-    <TranslatedText stringId="note.form.writtenBy.label" fallback="Written by (or on behalf of)" />
+    <TranslatedText stringId="note.writtenBy.label" fallback="Written by (or on behalf of)" />
   ),
   required,
   disabled,
@@ -105,7 +105,7 @@ export const NoteDateTimeField = ({ required, disabled }) => {
   return (
     <Field
       name="date"
-      label={<TranslatedText stringId="note.form.dateTime.label" fallback="Date & time" />}
+      label={<TranslatedText stringId="note.dateTime.label" fallback="Date & time" />}
       component={DateTimeField}
       required={required}
       disabled={!getLocalisation('features.enableNoteBackdating') || disabled}
@@ -115,7 +115,7 @@ export const NoteDateTimeField = ({ required, disabled }) => {
 };
 
 export const NoteContentField = ({
-  label = <TranslatedText stringId="note.form.edit.label" fallback="Edit note" />,
+  label = <TranslatedText stringId="note.edit.label" fallback="Edit note" />,
   onChange,
 }) => (
   <Field
@@ -146,7 +146,7 @@ export const NoteInfoSection = ({
     <InfoCardItem
       numberOfColumns={numberOfColumns}
       fontSize={14}
-      label={<TranslatedText stringId="note.form.noteType.label" fallback="Note type" />}
+      label={<TranslatedText stringId="note.noteType.label" fallback="Note type" />}
       value={noteType}
       borderHeight={50}
     />
@@ -172,7 +172,7 @@ export const NoteInfoSection = ({
 export const NoteTypeField = ({ required, noteTypeCountByType }) => (
   <Field
     name="noteType"
-    label={<TranslatedText stringId="note.form.type.label" fallback="Type" />}
+    label={<TranslatedText stringId="note.type.label" fallback="Type" />}
     required={required}
     component={SelectField}
     options={getSelectableNoteTypes(noteTypeCountByType)}

--- a/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
@@ -155,7 +155,7 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
           name="prescriberId"
           label={
             <TranslatedText
-              stringId="medication.modal.printMultiple.form.prescriber.label"
+              stringId="medication.modal.printMultiple.prescriber.label"
               fallback="Prescriber"
             />
           }

--- a/packages/web/app/components/PatientPrinting/printouts/EncounterRecord.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/EncounterRecord.jsx
@@ -327,7 +327,7 @@ export const EncounterRecord = React.memo(
             <DisplayValue
               name={
                 <TranslatedText
-                  stringId="general.form.supervisingClinician.label"
+                  stringId="general.supervisingClinician.label"
                   fallback="Supervising :clinician"
                   replacements={{
                     clinician: (
@@ -348,7 +348,7 @@ export const EncounterRecord = React.memo(
             <DisplayValue
               name={
                 <TranslatedText
-                  stringId="general.form.dischargingClinician.label"
+                  stringId="general.dischargingClinician.label"
                   fallback="Discharging :clinician"
                   replacements={{
                     clinician: (

--- a/packages/web/app/components/RecentlyViewedPatientsList.jsx
+++ b/packages/web/app/components/RecentlyViewedPatientsList.jsx
@@ -148,7 +148,7 @@ const Card = ({ patient, handleClick }) => {
           <SexDisplay sex={patient.sex} />
         </CapitalizedCardText>
         <CardText>
-          <TranslatedText stringId="general.form.dateOfBirth.label" fallback="DOB" />
+          <TranslatedText stringId="general.dateOfBirth.label" fallback="DOB" />
           : <DateDisplay date={patient.dateOfBirth} shortYear />
         </CardText>
       </CardComponentContent>

--- a/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
@@ -116,7 +116,7 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
         name="dateOfBirthExact"
         component={DateField}
         saveDateAsString
-        label={<TranslatedText stringId="general.form.dateOfBirth.label" fallback="DOB" />}
+        label={<TranslatedText stringId="general.dateOfBirth.label" fallback="DOB" />}
         max={getCurrentDateString()}
       />
     </CustomisableSearchBar>

--- a/packages/web/app/components/TopBar.jsx
+++ b/packages/web/app/components/TopBar.jsx
@@ -147,7 +147,7 @@ export const EncounterTopBar = ({ title, subTitle, encounter, children }) => (
         <Cell>
           <Label>
             <TranslatedText
-              stringId="general.form.supervisingClinician.label"
+              stringId="general.supervisingClinician.label"
               fallback="Supervising :clinician"
               replacements={{
                 clinician: (

--- a/packages/web/app/components/VaccineCommonFields.jsx
+++ b/packages/web/app/components/VaccineCommonFields.jsx
@@ -41,19 +41,19 @@ export const VerticalDivider = styled(Divider)`
 const VACCINE_FIELD_CATEGORY_OPTIONS = [
   {
     value: VACCINE_CATEGORIES.ROUTINE,
-    label: <TranslatedText stringId="vaccine.form.category.option.routine" fallback="Routine" />,
+    label: <TranslatedText stringId="vaccine.category.option.routine" fallback="Routine" />,
   },
   {
     value: VACCINE_CATEGORIES.CATCHUP,
-    label: <TranslatedText stringId="vaccine.form.category.option.catchUp" fallback="Catch-up" />,
+    label: <TranslatedText stringId="vaccine.category.option.catchUp" fallback="Catch-up" />,
   },
   {
     value: VACCINE_CATEGORIES.CAMPAIGN,
-    label: <TranslatedText stringId="vaccine.form.category.option.campaign" fallback="Campaign" />,
+    label: <TranslatedText stringId="vaccine.category.option.campaign" fallback="Campaign" />,
   },
   {
     value: VACCINE_CATEGORIES.OTHER,
-    label: <TranslatedText stringId="vaccine.form.category.option.other" fallback="Other" />,
+    label: <TranslatedText stringId="vaccine.category.option.other" fallback="Other" />,
     leftOptionalElement: <VerticalDivider orientation="vertical" />,
     style: { marginLeft: '15px' },
   },
@@ -96,7 +96,7 @@ export const CategoryField = ({ setCategory, setVaccineLabel, resetForm }) => (
   <FullWidthCol>
     <Field
       name="category"
-      label={<TranslatedText stringId="vaccine.form.category.label" fallback="Category" />}
+      label={<TranslatedText stringId="vaccine.category.label" fallback="Category" />}
       component={RadioField}
       options={VACCINE_FIELD_CATEGORY_OPTIONS}
       onChange={e => {
@@ -112,7 +112,7 @@ export const CategoryField = ({ setCategory, setVaccineLabel, resetForm }) => (
 export const VaccineLabelField = ({ vaccineOptions, setVaccineLabel }) => (
   <Field
     name="vaccineLabel"
-    label={<TranslatedText stringId="vaccine.form.vaccine.label" fallback="Vaccine" />}
+    label={<TranslatedText stringId="vaccine.vaccine.label" fallback="Vaccine" />}
     component={SelectField}
     options={vaccineOptions}
     onChange={e => setVaccineLabel(e.target.value)}
@@ -123,7 +123,7 @@ export const VaccineLabelField = ({ vaccineOptions, setVaccineLabel }) => (
 export const BatchField = () => (
   <Field
     name="batch"
-    label={<TranslatedText stringId="vaccine.form.batch.label" fallback="Batch" />}
+    label={<TranslatedText stringId="vaccine.batch.label" fallback="Batch" />}
     component={TextField}
   />
 );
@@ -135,7 +135,7 @@ export const VaccineDateField = ({ label, required = true }) => (
 export const InjectionSiteField = () => (
   <Field
     name="injectionSite"
-    label={<TranslatedText stringId="vaccine.form.injectionSite.label" fallback="Injection site" />}
+    label={<TranslatedText stringId="vaccine.injectionSite.label" fallback="Injection site" />}
     component={SelectField}
     options={VACCINE_FIELD_INJECTION_SITE_OPTIONS}
   />
@@ -157,7 +157,7 @@ export const DepartmentField = () => {
   return (
     <Field
       name="departmentId"
-      label={<TranslatedText stringId="general.form.department.label" fallback="Department" />}
+      label={<TranslatedText stringId="general.department.label" fallback="Department" />}
       required
       component={AutocompleteField}
       suggester={departmentSuggester}
@@ -166,7 +166,7 @@ export const DepartmentField = () => {
 };
 
 export const GivenByField = ({
-  label = <TranslatedText stringId="vaccine.form.givenBy.label" fallback="Given by" />,
+  label = <TranslatedText stringId="vaccine.givenBy.label" fallback="Given by" />,
 }) => <Field name="givenBy" label={label} component={TextField} />;
 
 export const GivenByCountryField = () => {
@@ -175,7 +175,7 @@ export const GivenByCountryField = () => {
   return (
     <Field
       name="givenBy"
-      label={<TranslatedText stringId="vaccine.form.country.label" fallback="Country" />}
+      label={<TranslatedText stringId="vaccine.country.label" fallback="Country" />}
       component={AutocompleteField}
       suggester={countrySuggester}
       required
@@ -191,7 +191,7 @@ export const RecordedByField = () => {
     <Field
       disabled
       name="recorderId"
-      label={<TranslatedText stringId="vaccine.form.recordedBy.label" fallback="Recorded by" />}
+      label={<TranslatedText stringId="vaccine.recordedBy.label" fallback="Recorded by" />}
       component={SelectField}
       options={[
         {
@@ -207,7 +207,7 @@ export const RecordedByField = () => {
 export const ConsentField = ({ label }) => (
   <FullWidthCol>
     <OuterLabelFieldWrapper
-      label={<TranslatedText stringId="vaccine.form.consent.label" fallback="Consent" />}
+      label={<TranslatedText stringId="vaccine.consent.label" fallback="Consent" />}
       style={{ marginBottom: '5px' }}
       required
     />
@@ -219,7 +219,7 @@ export const ConsentGivenByField = () => (
   <Field
     name="consentGivenBy"
     label={
-      <TranslatedText stringId="vaccine.form.consentGivenBy.label" fallback="Consent given by" />
+      <TranslatedText stringId="vaccine.consentGivenBy.label" fallback="Consent given by" />
     }
     component={TextField}
   />
@@ -243,7 +243,7 @@ export const AdministeredVaccineScheduleField = ({ schedules }) => {
       <FullWidthCol>
         <Field
           name="scheduledVaccineId"
-          label={<TranslatedText stringId="vaccine.form.schedule.label" fallback="Schedule" />}
+          label={<TranslatedText stringId="vaccine.schedule.label" fallback="Schedule" />}
           component={RadioField}
           options={scheduleOptions}
           required
@@ -257,7 +257,7 @@ export const AdministeredVaccineScheduleField = ({ schedules }) => {
 export const VaccineNameField = () => (
   <Field
     name="vaccineName"
-    label={<TranslatedText stringId="vaccine.form.vaccineName.label" fallback="Vaccine name" />}
+    label={<TranslatedText stringId="vaccine.vaccineName.label" fallback="Vaccine name" />}
     component={TextField}
     required
   />
@@ -266,7 +266,7 @@ export const VaccineNameField = () => (
 export const VaccineBrandField = () => (
   <Field
     name="vaccineBrand"
-    label={<TranslatedText stringId="vaccine.form.vaccineBrand.label" fallback="Vaccine brand" />}
+    label={<TranslatedText stringId="vaccine.vaccineBrand.label" fallback="Vaccine brand" />}
     component={TextField}
   />
 );
@@ -274,7 +274,7 @@ export const VaccineBrandField = () => (
 export const DiseaseField = () => (
   <Field
     name="disease"
-    label={<TranslatedText stringId="vaccine.form.disease.label" fallback="Disease" />}
+    label={<TranslatedText stringId="vaccine.disease.label" fallback="Disease" />}
     component={TextField}
   />
 );

--- a/packages/web/app/components/ViewAdministeredVaccineModal.jsx
+++ b/packages/web/app/components/ViewAdministeredVaccineModal.jsx
@@ -127,55 +127,55 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
 
   const fieldObjects = {
     vaccine: {
-      label: <TranslatedText stringId="vaccine.form.vaccine.label" fallback="Vaccine" />,
+      label: <TranslatedText stringId="vaccine.vaccine.label" fallback="Vaccine" />,
       value: vaccineLabel || '-',
     },
     batch: {
-      label: <TranslatedText stringId="vaccine.form.batch.label" fallback="Batch" />,
+      label: <TranslatedText stringId="vaccine.batch.label" fallback="Batch" />,
       value: batch || '-',
     },
     schedule: {
-      label: <TranslatedText stringId="vaccine.form.schedule.label" fallback="Schedule" />,
+      label: <TranslatedText stringId="vaccine.schedule.label" fallback="Schedule" />,
       value: schedule || '-',
     },
     dateRecorded: {
-      label: <TranslatedText stringId="vaccine.form.dateRecorded.label" fallback="Date recorded" />,
+      label: <TranslatedText stringId="vaccine.dateRecorded.label" fallback="Date recorded" />,
       value: <DateDisplay date={date} />,
     },
     dateGiven: {
-      label: <TranslatedText stringId="vaccine.form.dateGiven.label" fallback="Date given" />,
+      label: <TranslatedText stringId="vaccine.dateGiven.label" fallback="Date given" />,
       value: <DateDisplay date={date} />,
     },
     injectionSite: {
       label: (
-        <TranslatedText stringId="vaccine.form.injectionSite.label" fallback="Injection site" />
+        <TranslatedText stringId="vaccine.injectionSite.label" fallback="Injection site" />
       ),
       value: injectionSite || '-',
     },
     area: {
-      label: <TranslatedText stringId="general.form.area.label" fallback="Area" />,
+      label: <TranslatedText stringId="general.area.label" fallback="Area" />,
       value: location?.locationGroup?.name || '-',
     },
     location: {
-      label: <TranslatedText stringId="general.form.location.label" fallback="Location" />,
+      label: <TranslatedText stringId="general.location.label" fallback="Location" />,
       value: location?.name || '-',
     },
     department: {
-      label: <TranslatedText stringId="general.form.department.label" fallback="Department" />,
+      label: <TranslatedText stringId="general.department.label" fallback="Department" />,
       value: department?.name || '-',
     },
     facility: {
-      label: <TranslatedText stringId="general.form.facility.label" fallback="Facility" />,
+      label: <TranslatedText stringId="general.facility.label" fallback="Facility" />,
       value: location?.facility.name || encounter.location.facility.name || '-',
     },
     givenBy: {
-      label: <TranslatedText stringId="vaccine.form.givenBy.label" fallback="Given by" />,
+      label: <TranslatedText stringId="vaccine.givenBy.label" fallback="Given by" />,
       value: givenBy || '-',
     },
     supervisingClinician: {
       label: (
         <TranslatedText
-          stringId="general.form.supervisingClinician.label"
+          stringId="general.supervisingClinician.label"
           fallback="Supervising :clinician"
           replacements={{
             clinician: (
@@ -192,35 +192,35 @@ export const ViewAdministeredVaccineContent = ({ vaccineRecord, editMode }) => {
       value: givenBy || '-',
     },
     recordedBy: {
-      label: <TranslatedText stringId="vaccine.form.recordedBy.label" fallback="Recorded by" />,
+      label: <TranslatedText stringId="vaccine.recordedBy.label" fallback="Recorded by" />,
       value: recorder?.displayName || '-',
     },
     vaccineName: {
-      label: <TranslatedText stringId="vaccine.form.vaccineName.label" fallback="Vaccine name" />,
+      label: <TranslatedText stringId="vaccine.vaccineName.label" fallback="Vaccine name" />,
       value: vaccineName || '-',
     },
     vaccineBrand: {
-      label: <TranslatedText stringId="vaccine.form.vaccineBrand.label" fallback="Vaccine brand" />,
+      label: <TranslatedText stringId="vaccine.vaccineBrand.label" fallback="Vaccine brand" />,
       value: vaccineBrand || '-',
     },
     disease: {
-      label: <TranslatedText stringId="vaccine.form.disease.label" fallback="Disease" />,
+      label: <TranslatedText stringId="vaccine.disease.label" fallback="Disease" />,
       value: disease || '-',
     },
     status: {
-      label: <TranslatedText stringId="vaccine.form.status.label" fallback="Status" />,
+      label: <TranslatedText stringId="vaccine.status.label" fallback="Status" />,
       value: givenElsewhere ? 'Given elsewhere' : VACCINE_STATUS_LABELS[status] || '-',
     },
     country: {
-      label: <TranslatedText stringId="vaccine.form.country.label" fallback="Country" />,
+      label: <TranslatedText stringId="vaccine.country.label" fallback="Country" />,
       value: givenBy || '-',
     },
     reason: {
-      label: <TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />,
+      label: <TranslatedText stringId="vaccine.reason.label" fallback="Reason" />,
       value: notGivenReason?.name || '-',
     },
     circumstance: {
-      label: <TranslatedText stringId="vaccine.form.circumstance.label" fallback="Circumstance" />,
+      label: <TranslatedText stringId="vaccine.circumstance.label" fallback="Circumstance" />,
       value:
         vaccineCircumstances?.length > 0
           ? vaccineCircumstances?.map(circumstance => circumstance?.name)?.join(', ')

--- a/packages/web/app/forms/AllergyForm.jsx
+++ b/packages/web/app/forms/AllergyForm.jsx
@@ -23,7 +23,7 @@ export const AllergyForm = ({
         <Field
           name="allergyId"
           label={
-            <TranslatedText stringId="allergies.form.allergyName.label" fallback="Allergy name" />
+            <TranslatedText stringId="allergies.allergyName.label" fallback="Allergy name" />
           }
           component={AutocompleteField}
           suggester={allergySuggester}
@@ -32,7 +32,7 @@ export const AllergyForm = ({
         <Field
           name="recordedDate"
           label={
-            <TranslatedText stringId="general.form.recordedDate.label" fallback="Date recorded" />
+            <TranslatedText stringId="general.recordedDate.label" fallback="Date recorded" />
           }
           component={DateField}
           saveDateAsString
@@ -51,7 +51,7 @@ export const AllergyForm = ({
         />
         <Field
           name="note"
-          label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+          label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
           component={TextField}
         />
         <FormSubmitCancelRow

--- a/packages/web/app/forms/ChangeClinicianForm.jsx
+++ b/packages/web/app/forms/ChangeClinicianForm.jsx
@@ -18,7 +18,7 @@ export const ChangeClinicianForm = ({ clinicianSuggester, onCancel, onSubmit }) 
         component={AutocompleteField}
         label={
           <TranslatedText
-            stringId="patient.form.changeClinician.examinerId.label"
+            stringId="patient.changeClinician.examinerId.label"
             fallback="Search new :clinician"
             replacements={{
               clinician: (

--- a/packages/web/app/forms/DeathForm.jsx
+++ b/packages/web/app/forms/DeathForm.jsx
@@ -113,7 +113,7 @@ export const DeathForm = React.memo(
             name="clinicianId"
             label={
               <TranslatedText
-                stringId="general.form.attendingClinician.label"
+                stringId="general.attendingClinician.label"
                 fallback="Attending :clinician"
                 replacements={{
                   clinician: (

--- a/packages/web/app/forms/DiagnosisForm.jsx
+++ b/packages/web/app/forms/DiagnosisForm.jsx
@@ -67,14 +67,14 @@ export const DiagnosisForm = React.memo(
               style={{ gridColumn: '1 / -1' }}
               name="isPrimary"
               label={
-                <TranslatedText stringId="diagnosis.form.isPrimary.label" fallback="Is primary" />
+                <TranslatedText stringId="diagnosis.isPrimary.label" fallback="Is primary" />
               }
               component={CheckField}
             />
             <Field
               name="certainty"
               label={
-                <TranslatedText stringId="diagnosis.form.certainty.label" fallback="Certainty" />
+                <TranslatedText stringId="diagnosis.certainty.label" fallback="Certainty" />
               }
               component={SelectField}
               options={certaintyOptions}
@@ -82,7 +82,7 @@ export const DiagnosisForm = React.memo(
             />
             <Field
               name="date"
-              label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
+              label={<TranslatedText stringId="general.date.label" fallback="Date" />}
               component={DateField}
               required
               saveDateAsString

--- a/packages/web/app/forms/DischargeForm.jsx
+++ b/packages/web/app/forms/DischargeForm.jsx
@@ -218,7 +218,7 @@ const EncounterOverview = ({
     <>
       <DateTimeInput
         label={<TranslatedText
-          stringId="discharge.form.admissionDate.label"
+          stringId="discharge.admissionDate.label"
           fallback="Admission date"
         />}
         value={startDate}
@@ -227,7 +227,7 @@ const EncounterOverview = ({
       <TextInput
         label={
           <TranslatedText
-            stringId="general.form.supervisingClinician.label"
+            stringId="general.supervisingClinician.label"
             fallback="Supervising :clinician"
             replacements={{
               clinician: (
@@ -246,7 +246,7 @@ const EncounterOverview = ({
       />
       <TextInput
         label={<TranslatedText
-          stringId="discharge.form.encounterReason.label"
+          stringId="discharge.encounterReason.label"
           fallback="Reason for encounter"
         />}
         value={reasonForEncounter}
@@ -254,13 +254,13 @@ const EncounterOverview = ({
         style={{ gridColumn: '1 / -1' }}
       />
       <OuterLabelFieldWrapper
-        label={<TranslatedText stringId="discharge.form.diagnoses.label" fallback="Diagnoses" />}
+        label={<TranslatedText stringId="discharge.diagnoses.label" fallback="Diagnoses" />}
         style={{ gridColumn: '1 / -1' }}
       >
         <DiagnosisList diagnoses={currentDiagnoses} />
       </OuterLabelFieldWrapper>
       <OuterLabelFieldWrapper
-        label={<TranslatedText stringId="discharge.form.procedures.label" fallback="Procedures" />}
+        label={<TranslatedText stringId="discharge.procedures.label" fallback="Procedures" />}
         style={{ gridColumn: '1 / -1' }}
       >
         <ProcedureList procedures={procedures} />
@@ -385,7 +385,7 @@ export const DischargeForm = ({
           name="endDate"
           label={
             <TranslatedText
-              stringId="discharge.form.dischargeDate.label"
+              stringId="discharge.dischargeDate.label"
               fallback="Discharge date"
             />
           }
@@ -398,7 +398,7 @@ export const DischargeForm = ({
           name="discharge.dischargerId"
           label={
             <TranslatedText
-              stringId="general.form.dischargingClinician.label"
+              stringId="general.dischargingClinician.label"
               fallback="Discharging :clinician"
               replacements={{
                 clinician: (
@@ -429,7 +429,7 @@ export const DischargeForm = ({
         <OuterLabelFieldWrapper
           label={
             <TranslatedText
-              stringId="discharge.form.dischargeMedications.label"
+              stringId="discharge.dischargeMedications.label"
               fallback="Discharge medications"
             />
           }
@@ -441,14 +441,14 @@ export const DischargeForm = ({
           name="sendToPharmacy"
           label={
             <TranslatedText
-              stringId="discharge.form.sendToPharmacy.label"
+              stringId="discharge.sendToPharmacy.label"
               fallback="Send prescription to pharmacy"
             />
           }
           component={CheckField}
           helperText={
             <TranslatedText
-              stringId="discharge.form.sendToPharmacy.helperText"
+              stringId="discharge.sendToPharmacy.helperText"
               fallback="Requires mSupply"
             />
           }
@@ -459,7 +459,7 @@ export const DischargeForm = ({
           name="discharge.note"
           label={
             <TranslatedText
-              stringId="discharge.form.notes.label"
+              stringId="discharge.notes.label"
               fallback="Discharge treatment plan and follow-up notes"
             />
           }

--- a/packages/web/app/forms/DocumentForm.jsx
+++ b/packages/web/app/forms/DocumentForm.jsx
@@ -68,14 +68,14 @@ const DocumentFormContents = ({ submitForm, departmentSuggester, onCancel }) => 
       <Field
         component={FileChooserField}
         filters={FILE_FILTERS}
-        label={<TranslatedText stringId="general.form.selectFile.label" fallback="Select file" />}
+        label={<TranslatedText stringId="general.selectFile.label" fallback="Select file" />}
         name="file"
         required
         style={{ gridColumn: '1 / -1' }}
       />
       <Field
         name="name"
-        label={<TranslatedText stringId="general.form.fileName.label" fallback="File name" />}
+        label={<TranslatedText stringId="general.fileName.label" fallback="File name" />}
         required
         component={TextField}
         style={{ gridColumn: '1 / -1' }}
@@ -83,19 +83,19 @@ const DocumentFormContents = ({ submitForm, departmentSuggester, onCancel }) => 
       <Field
         name="documentOwner"
         label={
-          <TranslatedText stringId="document.form.documentOwner.label" fallback="Document owner" />
+          <TranslatedText stringId="document.documentOwner.label" fallback="Document owner" />
         }
         component={TextField}
       />
       <Field
         name="departmentId"
-        label={<TranslatedText stringId="general.form.department.label" fallback="Department" />}
+        label={<TranslatedText stringId="general.department.label" fallback="Department" />}
         component={AutocompleteField}
         suggester={departmentSuggester}
       />
       <Field
         name="note"
-        label={<TranslatedText stringId="general.form.note.label" fallback="Note" />}
+        label={<TranslatedText stringId="general.note.label" fallback="Note" />}
         component={TextField}
         style={{ gridColumn: '1 / -1' }}
       />

--- a/packages/web/app/forms/EditNoteForm.jsx
+++ b/packages/web/app/forms/EditNoteForm.jsx
@@ -29,11 +29,11 @@ export const EditNoteForm = ({ note, onNoteContentChange, onSubmit, onCancel }) 
         noteType={NOTE_TYPE_LABELS[note.noteType]}
         date={note.revisedBy ? note.revisedBy.date : note.date}
         writtenByLabel={<TranslatedText
-          stringId="note.form.writtenBy.label"
+          stringId="note.writtenBy.label"
           fallback="Written by (or on behalf of)"
         />}
         writtenBy={writtenBy}
-        dateLabel={<TranslatedText stringId="note.form.dateTime.label" fallback="Date & time" />}
+        dateLabel={<TranslatedText stringId="note.dateTime.label" fallback="Date & time" />}
       />
       <br />
       <NoteContentField onChange={onNoteContentChange} />

--- a/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
+++ b/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
@@ -34,12 +34,12 @@ export const EditTreatmentPlanNoteForm = ({ note, onNoteContentChange, onSubmit,
         numberOfColumns={3}
         noteType={NOTE_TYPE_LABELS[note.noteType]}
         writtenByLabel={<TranslatedText
-          stringId="treatmentPlan.note.form.lastUpdatedBy.label"
+          stringId="treatmentPlan.note.lastUpdatedBy.label"
           fallback="Last updated by (or on behalf of)"
         />}
         writtenBy={writtenBy}
         dateLabel={<TranslatedText
-          stringId="treatmentPlan.note.form.lastUpdatedAt.label"
+          stringId="treatmentPlan.note.lastUpdatedAt.label"
           fallback="Last updated at date & time"
         />}
         date={note.date}
@@ -47,7 +47,7 @@ export const EditTreatmentPlanNoteForm = ({ note, onNoteContentChange, onSubmit,
       <StyledFormGrid columns={2}>
         <WrittenByField
           label={<TranslatedText
-            stringId="treatmentPlan.note.form.updatedBy.label"
+            stringId="treatmentPlan.note.updatedBy.label"
             fallback="Updated by (or on behalf of)"
           />}
           required
@@ -57,7 +57,7 @@ export const EditTreatmentPlanNoteForm = ({ note, onNoteContentChange, onSubmit,
 
       <NoteContentField
         label={<TranslatedText
-          stringId="treatmentPlan.note.form.updateTreatmentPlan.label"
+          stringId="treatmentPlan.note.updateTreatmentPlan.label"
           fallback="Update treatment plan"
         />}
         onChange={onNoteContentChange}

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -77,7 +77,7 @@ const HistoryLog = ({ logData, vitalLabel, vitalEditReasons }) => {
       {reasonForChange && (
         <LogText>
           <TranslatedText
-            stringId="encounter.vitals.form.editReason.label"
+            stringId="encounter.vitals.editReason.label"
             fallback="Reason for change to record"
           />
           : {reasonForChangeLabel}
@@ -164,7 +164,7 @@ export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose }) => {
             component={SelectField}
             label={
               <TranslatedText
-                stringId="encounter.vitals.form.editReason.label"
+                stringId="encounter.vitals.editReason.label"
                 fallback="Reason for change to record"
               />
             }
@@ -175,7 +175,7 @@ export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose }) => {
           <FormSeparatorLine />
           <OuterLabelFieldWrapper
             label={
-              <TranslatedText stringId="encounter.vitals.form.history.label" fallback="History" />
+              <TranslatedText stringId="encounter.vitals.history.label" fallback="History" />
             }
             style={{ gridColumn: '1 / -1' }}
           >

--- a/packages/web/app/forms/EncounterForm.jsx
+++ b/packages/web/app/forms/EncounterForm.jsx
@@ -45,7 +45,7 @@ export const EncounterForm = React.memo(
             name="encounterType"
             label={
               <TranslatedText
-                stringId="patient.modal.checkIn.form.encounterType.label"
+                stringId="patient.modal.checkIn.encounterType.label"
                 fallback="Encounter type"
               />
             }
@@ -57,7 +57,7 @@ export const EncounterForm = React.memo(
             name="startDate"
             label={
               <TranslatedText
-                stringId="patient.modal.checkIn.form.checkInDate.label"
+                stringId="patient.modal.checkIn.checkInDate.label"
                 fallback="Check-in date"
               />
             }
@@ -69,7 +69,7 @@ export const EncounterForm = React.memo(
           <Field
             name="departmentId"
             label={
-              <TranslatedText stringId="general.form.department.label" fallback="Department" />
+              <TranslatedText stringId="general.department.label" fallback="Department" />
             }
             required
             component={AutocompleteField}
@@ -117,7 +117,7 @@ export const EncounterForm = React.memo(
             name="reasonForEncounter"
             label={
               <TranslatedText
-                stringId="modal.checkIn.form.reasonForEncounter.label"
+                stringId="modal.checkIn.reasonForEncounter.label"
                 fallback="Reason for encounter"
               />
             }

--- a/packages/web/app/forms/FamilyHistoryForm.jsx
+++ b/packages/web/app/forms/FamilyHistoryForm.jsx
@@ -22,7 +22,7 @@ export const FamilyHistoryForm = ({
       <FormGrid columns={1}>
         <Field
           name="diagnosisId"
-          label={<TranslatedText stringId="general.form.diagnosis.label" fallback="Diagnosis" />}
+          label={<TranslatedText stringId="general.diagnosis.label" fallback="Diagnosis" />}
           required
           component={AutocompleteField}
           suggester={icd10Suggester}
@@ -30,7 +30,7 @@ export const FamilyHistoryForm = ({
         <Field
           name="recordedDate"
           label={
-            <TranslatedText stringId="general.form.recordedDate.label" fallback="Date recorded" />
+            <TranslatedText stringId="general.recordedDate.label" fallback="Date recorded" />
           }
           required
           component={DateField}
@@ -40,7 +40,7 @@ export const FamilyHistoryForm = ({
           name="relationship"
           label={
             <TranslatedText
-              stringId="familyHistory.form.relationship.label"
+              stringId="familyHistory.relationship.label"
               fallback="Relationship to patient"
             />
           }
@@ -59,7 +59,7 @@ export const FamilyHistoryForm = ({
         />
         <Field
           name="note"
-          label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+          label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
           component={TextField}
           multiline
           rows={2}

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -125,7 +125,7 @@ export const ImagingRequestForm = React.memo(
                 name="displayId"
                 label={
                   <TranslatedText
-                    stringId="imaging.form.requestCode.label"
+                    stringId="imaging.requestCode.label"
                     fallback="Imaging request code"
                   />
                 }
@@ -136,7 +136,7 @@ export const ImagingRequestForm = React.memo(
                 name="requestedDate"
                 label={
                   <TranslatedText
-                    stringId="imaging.form.requestedDate.label"
+                    stringId="imaging.requestedDate.label"
                     fallback="Order date and time"
                   />
                 }
@@ -147,7 +147,7 @@ export const ImagingRequestForm = React.memo(
               <TextInput
                 label={
                   <TranslatedText
-                    stringId="general.form.supervisingClinician.label"
+                    stringId="general.supervisingClinician.label"
                     fallback="Supervising :clinician"
                     replacements={{
                       clinician: (
@@ -168,7 +168,7 @@ export const ImagingRequestForm = React.memo(
                 name="requestedById"
                 label={
                   <TranslatedText
-                    stringId="general.form.requestingClinician.label"
+                    stringId="general.requestingClinician.label"
                     fallback="Requesting :clinician"
                     replacements={{
                       clinician: (
@@ -192,7 +192,7 @@ export const ImagingRequestForm = React.memo(
               <FormSeparatorLine />
               <TextInput
                 label={
-                  <TranslatedText stringId="imaging.form.encounter.label" fallback="Encounter" />
+                  <TranslatedText stringId="imaging.encounter.label" fallback="Encounter" />
                 }
                 disabled
                 value={encounterLabel}
@@ -201,7 +201,7 @@ export const ImagingRequestForm = React.memo(
                 name="imagingType"
                 label={
                   <TranslatedText
-                    stringId="imaging.form.imagingType.label"
+                    stringId="imaging.imagingType.label"
                     fallback="Imaging request type"
                   />
                 }
@@ -218,7 +218,7 @@ export const ImagingRequestForm = React.memo(
                   name="areas"
                   label={
                     <TranslatedText
-                      stringId="imaging.form.areas.label"
+                      stringId="imaging.areas.label"
                       fallback="Areas to be imaged"
                     />
                   }
@@ -229,7 +229,7 @@ export const ImagingRequestForm = React.memo(
                   name="areaNote"
                   label={
                     <TranslatedText
-                      stringId="imaging.form.imagingNote.label"
+                      stringId="imaging.imagingNote.label"
                       fallback="Areas to be imaged"
                     />
                   }
@@ -241,7 +241,7 @@ export const ImagingRequestForm = React.memo(
               )}
               <Field
                 name="note"
-                label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+                label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
                 component={TextField}
                 multiline
                 style={{ gridColumn: '1 / -1' }}

--- a/packages/web/app/forms/InvoiceDetailForm.jsx
+++ b/packages/web/app/forms/InvoiceDetailForm.jsx
@@ -148,7 +148,7 @@ export const InvoiceDetailForm = ({
               name="paymentStatus"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.view.form.paymentStatus.label"
+                  stringId="invoice.modal.view.paymentStatus.label"
                   fallback="Payment status"
                 />
               }
@@ -160,7 +160,7 @@ export const InvoiceDetailForm = ({
               name="total"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.view.form.total.label"
+                  stringId="invoice.modal.view.total.label"
                   fallback="Total ($)"
                 />
               }
@@ -170,7 +170,7 @@ export const InvoiceDetailForm = ({
             />
             <Field
               name="date"
-              label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
+              label={<TranslatedText stringId="general.date.label" fallback="Date" />}
               disabled
               required
               component={DateField}
@@ -180,7 +180,7 @@ export const InvoiceDetailForm = ({
               name="admissionType"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.view.form.admissionType.label"
+                  stringId="invoice.modal.view.admissionType.label"
                   fallback="Admission type"
                 />
               }
@@ -191,7 +191,7 @@ export const InvoiceDetailForm = ({
               name="receiptNumber"
               label={
                 <TranslatedText
-                  stringId="invoice.modal.view.form.receiptNumber.label"
+                  stringId="invoice.modal.view.receiptNumber.label"
                   fallback="Receipt number"
                 />
               }

--- a/packages/web/app/forms/InvoicePriceChangeItemForm.jsx
+++ b/packages/web/app/forms/InvoicePriceChangeItemForm.jsx
@@ -31,7 +31,7 @@ export const InvoicePriceChangeItemForm = ({
         <FormGrid>
           <Field
             name="date"
-            label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
+            label={<TranslatedText stringId="general.date.label" fallback="Date" />}
             required
             component={DateField}
             saveDateAsString
@@ -40,7 +40,7 @@ export const InvoicePriceChangeItemForm = ({
             name="description"
             label={
               <TranslatedText
-                stringId="invoice.modal.priceChange.form.description.label"
+                stringId="invoice.modal.priceChange.description.label"
                 fallback="Details"
               />
             }
@@ -51,7 +51,7 @@ export const InvoicePriceChangeItemForm = ({
             name="orderedById"
             label={
               <TranslatedText
-                stringId="invoice.modal.priceChange.form.orderedBy.label"
+                stringId="invoice.modal.priceChange.orderedBy.label"
                 fallback="Ordered by"
               />
             }
@@ -63,7 +63,7 @@ export const InvoicePriceChangeItemForm = ({
             name="percentageChange"
             label={
               <TranslatedText
-                stringId="invoice.modal.priceChange.form.percentageChange.label"
+                stringId="invoice.modal.priceChange.percentageChange.label"
                 fallback="Discount/markup % (-/+)"
               />
             }

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen1.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen1.jsx
@@ -21,11 +21,11 @@ export const LabRequestFormScreen1 = ({
     <>
       <div style={{ gridColumn: '1 / -1' }}>
         <Heading3 mb="12px">
-          <TranslatedText stringId="lab.form.create.header" fallback="Creating a new lab request" />
+          <TranslatedText stringId="lab.create.header" fallback="Creating a new lab request" />
         </Heading3>
         <BodyText mb="28px" color="textTertiary">
           <TranslatedText
-            stringId="lab.form.create.instruction"
+            stringId="lab.create.instruction"
             fallback="Please complete the details below and select the lab request type"
           />
         </BodyText>
@@ -34,7 +34,7 @@ export const LabRequestFormScreen1 = ({
         name="requestedById"
         label={
           <TranslatedText
-            stringId="lab.form.requestingClinician.label"
+            stringId="lab.requestingClinician.label"
             fallback="Requesting :clinician"
             replacements={{ clinician: (
               <LowerCase>
@@ -53,7 +53,7 @@ export const LabRequestFormScreen1 = ({
       <Field
         name="requestedDate"
         label={<TranslatedText
-          stringId="lab.form.requestDateTime.label"
+          stringId="lab.requestDateTime.label"
           fallback="Request date & time"
         />}
         required
@@ -62,13 +62,13 @@ export const LabRequestFormScreen1 = ({
       />
       <Field
         name="departmentId"
-        label={<TranslatedText stringId="general.form.department.label" fallback="Department" />}
+        label={<TranslatedText stringId="general.department.label" fallback="Department" />}
         component={AutocompleteField}
         suggester={departmentSuggester}
       />
       <Field
         name="labTestPriorityId"
-        label={<TranslatedText stringId="lab.form.priority.label" fallback="Priority" />}
+        label={<TranslatedText stringId="lab.priority.label" fallback="Priority" />}
         component={SuggesterSelectField}
         endpoint="labTestPriority"
       />

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
@@ -25,7 +25,7 @@ export const screen2ValidationSchema = yup.object().shape({
         .min(
           1,
           <TranslatedText
-            stringId="lab.form.testSelect.individual.testTypes.validation"
+            stringId="lab.testSelect.individual.testTypes.validation"
             fallback="Please select at least one test type"
           />,
         ),
@@ -41,7 +41,7 @@ export const screen2ValidationSchema = yup.object().shape({
         .min(
           1,
           <TranslatedText
-            stringId="lab.form.testSelect.panel.testTypes.validation"
+            stringId="lab.testSelect.panel.testTypes.validation"
             fallback="Please select at least one panel"
           />,
         ),
@@ -53,19 +53,19 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.INDIVIDUAL]: {
     subheading: (
       <TranslatedText
-        stringId="lab.form.testSelect.individual.subheading"
+        stringId="lab.testSelect.individual.subheading"
         fallback="Select tests"
       />
     ),
     instructions: (
       <>
         <TranslatedText
-          stringId="lab.form.testSelect.individual.instructionLine1"
+          stringId="lab.testSelect.individual.instructionLine1"
           fallback="Please select the test or tests you would like to request below and add any relevant notes."
         />
         {'\n'}
         <TranslatedText
-          stringId="lab.form.testSelect.individual.instructionLine2"
+          stringId="lab.testSelect.individual.instructionLine2"
           fallback="You can filter test by category using the field below."
         />
       </>
@@ -75,17 +75,17 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
   },
   [LAB_REQUEST_FORM_TYPES.PANEL]: {
     subheading: (
-      <TranslatedText stringId="lab.form.testSelect.panel.subheading" fallback="Select panel" />
+      <TranslatedText stringId="lab.testSelect.panel.subheading" fallback="Select panel" />
     ),
     instructions: (
       <TranslatedText
-        stringId="lab.form.testSelect.panel.instruction"
+        stringId="lab.testSelect.panel.instruction"
         fallback="Please select the panel or panels you would like to request below and add any relevant notes."
       />
     ),
     label: (
       <TranslatedText
-        stringId="lab.form.testSelect.panel.label"
+        stringId="lab.testSelect.panel.label"
         fallback="Select the test panel or panels"
       />
     ),
@@ -96,19 +96,19 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
   [LAB_REQUEST_FORM_TYPES.SUPERSET]: {
     subheading: (
       <TranslatedText
-        stringId="lab.form.testSelect.superSet.subheading"
+        stringId="lab.testSelect.superSet.subheading"
         fallback="Select superset"
       />
     ),
     instructions: (
       <>
         <TranslatedText
-          stringId="lab.form.testSelect.superset.instructionLine1"
+          stringId="lab.testSelect.superset.instructionLine1"
           fallback="Please select the superset you would like to request below and add any relevant notes."
         />
         ,{'\n'}
         <TranslatedText
-          stringId="lab.form.testSelect.superset.instructionLine2"
+          stringId="lab.testSelect.superset.instructionLine2"
           fallback="You can also remove or add additional panels to your request."
         />
       </>
@@ -155,7 +155,7 @@ export const LabRequestFormScreen2 = props => {
       <div style={{ gridColumn: '1 / -1' }}>
         <Field
           name="notes"
-          label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+          label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
           component={TextField}
           multiline
           rows={3}

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen3.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen3.jsx
@@ -44,11 +44,11 @@ export const LabRequestFormScreen3 = props => {
   return (
     <div style={{ gridColumn: '1 / -1' }}>
       <Heading3 mb="12px">
-        <TranslatedText stringId="lab.form.sampleDetails.heading" fallback="Sample details" />
+        <TranslatedText stringId="lab.sampleDetails.heading" fallback="Sample details" />
       </Heading3>
       <StyledBodyText mb="28px" color="textTertiary">
         <TranslatedText
-          stringId="lab.form.sampleDetails.instruction"
+          stringId="lab.sampleDetails.instruction"
           fallback="Please record details for the samples that have been collected. Otherwise leave blank and
         click ‘Finalise’."
         />

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormTypeRadioField.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormTypeRadioField.jsx
@@ -12,21 +12,21 @@ import { TranslatedText } from '../../components/Translation/TranslatedText';
 const OPTIONS = {
   INDIVIDUAL: {
     label: (
-      <TranslatedText stringId="lab.form.formType.option.individual.label" fallback="Individual" />
+      <TranslatedText stringId="lab.formType.option.individual.label" fallback="Individual" />
     ),
     description: (
       <TranslatedText
-        stringId="lab.form.formType.option.individual.description"
+        stringId="lab.formType.option.individual.description"
         fallback="Select an individual or multiple individual tests"
       />
     ),
     value: LAB_REQUEST_FORM_TYPES.INDIVIDUAL,
   },
   PANEL: {
-    label: <TranslatedText stringId="lab.form.formType.option.panel.label" fallback="Panel" />,
+    label: <TranslatedText stringId="lab.formType.option.panel.label" fallback="Panel" />,
     description: (
       <TranslatedText
-        stringId="lab.form.formType.option.panel.description"
+        stringId="lab.formType.option.panel.description"
         fallback="Select from a list of test panels"
       />
     ),
@@ -34,11 +34,11 @@ const OPTIONS = {
   },
   SUPERSET: {
     label: (
-      <TranslatedText stringId="lab.form.formType.option.superset.label" fallback="Superset" />
+      <TranslatedText stringId="lab.formType.option.superset.label" fallback="Superset" />
     ),
     description: (
       <TranslatedText
-        stringId="lab.form.formType.option.superset.description"
+        stringId="lab.formType.option.superset.description"
         fallback="Select from a list of supersets"
       />
     ),
@@ -106,7 +106,7 @@ export const LabRequestFormTypeRadioField = ({ value, setFieldValue }) => {
     <div style={{ gridColumn: '1 / -1' }}>
       <OuterLabelFieldWrapper
         label={
-          <TranslatedText stringId="lab.form.formType.label" fallback="Select your request type" />
+          <TranslatedText stringId="lab.formType.label" fallback="Select your request type" />
         }
         required
       >

--- a/packages/web/app/forms/LabRequestForm/LabRequestMultiStepForm.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestMultiStepForm.jsx
@@ -32,7 +32,7 @@ export const LabRequestMultiStepForm = ({
   const screen1ValidationSchema = yup.object().shape({
     requestedById: foreignKey(
       <TranslatedText
-        stringId="lab.form.requestedBy.validation"
+        stringId="lab.requestedBy.validation"
         fallback="Requesting :clinicianText is required"
         replacements={{
           clinician: (
@@ -50,7 +50,7 @@ export const LabRequestMultiStepForm = ({
       .date()
       .required(
         <TranslatedText
-          stringId="lab.form.requestedDate.validation"
+          stringId="lab.requestedDate.validation"
           fallback="Request date is required"
         />,
       ),
@@ -59,7 +59,7 @@ export const LabRequestMultiStepForm = ({
       .oneOf(Object.values(LAB_REQUEST_FORM_TYPES))
       .required(
         <TranslatedText
-          stringId="lab.form.requestFormType.validation"
+          stringId="lab.requestFormType.validation"
           fallback="Request type must be selected"
         />,
       ),

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -162,7 +162,7 @@ export const MedicationForm = React.memo(
                   name="medicationId"
                   label={
                     <TranslatedText
-                      stringId="medication.form.medication.label"
+                      stringId="medication.medication.label"
                       fallback="Medication"
                     />
                   }
@@ -176,7 +176,7 @@ export const MedicationForm = React.memo(
                 name="prescription"
                 label={
                   <TranslatedText
-                    stringId="medication.form.instructions.label"
+                    stringId="medication.instructions.label"
                     fallback="Instructions"
                   />
                 }
@@ -188,7 +188,7 @@ export const MedicationForm = React.memo(
                 name="route"
                 label={
                   <TranslatedText
-                    stringId="medication.form.route.label"
+                    stringId="medication.route.label"
                     fallback="Route of admission"
                   />
                 }
@@ -201,7 +201,7 @@ export const MedicationForm = React.memo(
                 name="date"
                 label={
                   <TranslatedText
-                    stringId="medication.form.date.label"
+                    stringId="medication.date.label"
                     fallback="Prescription date"
                   />
                 }
@@ -213,7 +213,7 @@ export const MedicationForm = React.memo(
               <Field
                 name="endDate"
                 label={
-                  <TranslatedText stringId="medication.form.endDate.label" fallback="End date" />
+                  <TranslatedText stringId="medication.endDate.label" fallback="End date" />
                 }
                 saveDateAsString
                 component={DateField}
@@ -224,7 +224,7 @@ export const MedicationForm = React.memo(
                 name="prescriberId"
                 label={
                   <TranslatedText
-                    stringId="medication.form.prescriber.label"
+                    stringId="medication.prescriber.label"
                     fallback="Prescriber"
                   />
                 }
@@ -235,7 +235,7 @@ export const MedicationForm = React.memo(
               />
               <Field
                 name="note"
-                label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+                label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
                 component={TextField}
                 style={{ gridColumn: '1/-1' }}
                 disabled={readOnly}
@@ -246,7 +246,7 @@ export const MedicationForm = React.memo(
                   name="qtyMorning"
                   label={
                     <TranslatedText
-                      stringId="medication.form.quantityMorning.label"
+                      stringId="medication.quantityMorning.label"
                       fallback="morning"
                     />
                   }
@@ -260,7 +260,7 @@ export const MedicationForm = React.memo(
                   min={0}
                   label={
                     <TranslatedText
-                      stringId="medication.form.quantityLunch.label"
+                      stringId="medication.quantityLunch.label"
                       fallback="Lunch"
                     />
                   }
@@ -272,7 +272,7 @@ export const MedicationForm = React.memo(
                   name="qtyEvening"
                   label={
                     <TranslatedText
-                      stringId="medication.form.quantityEvening.label"
+                      stringId="medication.quantityEvening.label"
                       fallback="Evening"
                     />
                   }
@@ -285,7 +285,7 @@ export const MedicationForm = React.memo(
                   name="qtyNight"
                   label={
                     <TranslatedText
-                      stringId="medication.form.quantityNight.label"
+                      stringId="medication.quantityNight.label"
                       fallback="Night"
                     />
                   }
@@ -299,7 +299,7 @@ export const MedicationForm = React.memo(
                 name="indication"
                 label={
                   <TranslatedText
-                    stringId="medication.form.indication.label"
+                    stringId="medication.indication.label"
                     fallback="Indication"
                   />
                 }
@@ -310,7 +310,7 @@ export const MedicationForm = React.memo(
                 name="quantity"
                 label={
                   <TranslatedText
-                    stringId="medication.form.dischargeQuantity.label"
+                    stringId="medication.dischargeQuantity.label"
                     fallback="Discharge quantity"
                   />
                 }
@@ -353,7 +353,7 @@ export const MedicationForm = React.memo(
                       name="discontinuingClinicianId"
                       label={
                         <TranslatedText
-                          stringId="medication.form.discontinuedBy.label"
+                          stringId="medication.discontinuedBy.label"
                           fallback="Discontinued by"
                         />
                       }
@@ -365,7 +365,7 @@ export const MedicationForm = React.memo(
                       name="discontinuingReason"
                       label={
                         <TranslatedText
-                          stringId="medication.form.discontinuedReason.label"
+                          stringId="medication.discontinuedReason.label"
                           fallback="Discontinued reason"
                         />
                       }

--- a/packages/web/app/forms/NewPatientForm.jsx
+++ b/packages/web/app/forms/NewPatientForm.jsx
@@ -122,7 +122,7 @@ export const NewPatientForm = memo(({ editedObject, onSubmit, onCancel, generate
               value: PATIENT_REGISTRY_TYPES.NEW_PATIENT,
               label: (
                 <TranslatedText
-                  stringId="patient.form.newPatientAction.option.newPatient"
+                  stringId="patient.newPatientAction.option.newPatient"
                   fallback="Create new patient"
                 />
               ),
@@ -131,7 +131,7 @@ export const NewPatientForm = memo(({ editedObject, onSubmit, onCancel, generate
               value: PATIENT_REGISTRY_TYPES.BIRTH_REGISTRY,
               label: (
                 <TranslatedText
-                  stringId="patient.form.newPatientAction.option.birthRegistry"
+                  stringId="patient.newPatientAction.option.birthRegistry"
                   fallback="Register birth"
                 />
               ),
@@ -152,13 +152,13 @@ export const NewPatientForm = memo(({ editedObject, onSubmit, onCancel, generate
               </StyledImageButton>
             )}
             <TranslatedText
-              stringId="patient.form.additionalInformation.label"
+              stringId="patient.additionalInformation.label"
               fallback="Add additional information"
             />
             <span>
               {' '}
               <TranslatedText
-                stringId="patient.form.additionalInformation.exampleText"
+                stringId="patient.additionalInformation.exampleText"
                 fallback="(religion, occupation, blood type...)"
               />
             </span>

--- a/packages/web/app/forms/NoteChangelogForm.jsx
+++ b/packages/web/app/forms/NoteChangelogForm.jsx
@@ -28,10 +28,10 @@ export const NoteChangelogForm = ({ note, onCancel }) => {
         numberOfColumns={3}
         noteType={NOTE_TYPE_LABELS[note.noteType]}
         date={note.revisedBy?.date || note.date}
-        dateLabel={<TranslatedText stringId="note.form.dateTime.label" fallback="Date & time" />}
+        dateLabel={<TranslatedText stringId="note.dateTime.label" fallback="Date & time" />}
         writtenByLabel={
           <TranslatedText
-            stringId="note.form.writtenBy.label"
+            stringId="note.writtenBy.label"
             fallback="Written by (or on behalf of)"
           />
         }

--- a/packages/web/app/forms/OngoingConditionForm.jsx
+++ b/packages/web/app/forms/OngoingConditionForm.jsx
@@ -36,7 +36,7 @@ export const OngoingConditionForm = ({
           name="conditionId"
           label={
             <TranslatedText
-              stringId="conditions.form.conditionName.label"
+              stringId="conditions.conditionName.label"
               fallback="Condition name"
             />
           }
@@ -48,7 +48,7 @@ export const OngoingConditionForm = ({
         <Field
           name="recordedDate"
           label={
-            <TranslatedText stringId="general.form.recordedDate.label" fallback="Date recorded" />
+            <TranslatedText stringId="general.recordedDate.label" fallback="Date recorded" />
           }
           saveDateAsString
           component={DateField}
@@ -68,13 +68,13 @@ export const OngoingConditionForm = ({
         />
         <Field
           name="note"
-          label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+          label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
           component={TextField}
           disabled={resolving}
         />
         <Field
           name="resolved"
-          label={<TranslatedText stringId="conditions.form.resolved.label" fallback="Resolved" />}
+          label={<TranslatedText stringId="conditions.resolved.label" fallback="Resolved" />}
           component={CheckField}
         />
         <Collapse in={resolving}>
@@ -84,7 +84,7 @@ export const OngoingConditionForm = ({
               saveDateAsString
               label={
                 <TranslatedText
-                  stringId="conditions.form.resolutionDate.label"
+                  stringId="conditions.resolutionDate.label"
                   fallback="Date resolved"
                 />
               }
@@ -94,7 +94,7 @@ export const OngoingConditionForm = ({
               name="resolutionPractitionerId"
               label={
                 <TranslatedText
-                  stringId="patient.form.ongoingCondition.resolutionPractitionerId.label"
+                  stringId="patient.ongoingCondition.resolutionPractitionerId.label"
                   fallback=":clinician confirming resolution"
                   replacements={{
                     clinician: (
@@ -113,7 +113,7 @@ export const OngoingConditionForm = ({
               name="resolutionNote"
               label={
                 <TranslatedText
-                  stringId="conditions.form.resolutionNote.label"
+                  stringId="conditions.resolutionNote.label"
                   fallback="Notes on resolution"
                 />
               }

--- a/packages/web/app/forms/PatientCarePlanForm.jsx
+++ b/packages/web/app/forms/PatientCarePlanForm.jsx
@@ -22,7 +22,7 @@ export const PatientCarePlanForm = ({
       <FormGrid columns={1}>
         <Field
           name="carePlanId"
-          label={<TranslatedText stringId="carePlan.form.plan.label" fallback="Care plan" />}
+          label={<TranslatedText stringId="carePlan.plan.label" fallback="Care plan" />}
           component={AutocompleteField}
           suggester={carePlanSuggester}
           required
@@ -31,7 +31,7 @@ export const PatientCarePlanForm = ({
           <Field
             name="date"
             label={
-              <TranslatedText stringId="general.form.recordedDate.label" fallback="Date recorded" />
+              <TranslatedText stringId="general.recordedDate.label" fallback="Date recorded" />
             }
             component={DateTimeField}
             saveDateAsString
@@ -51,7 +51,7 @@ export const PatientCarePlanForm = ({
         <Field
           name="content"
           label={
-            <TranslatedText stringId="carePlan.form.content.label" fallback="Main care plan" />
+            <TranslatedText stringId="carePlan.content.label" fallback="Main care plan" />
           }
           required
           component={TextField}

--- a/packages/web/app/forms/PatientIssueForm.jsx
+++ b/packages/web/app/forms/PatientIssueForm.jsx
@@ -10,11 +10,11 @@ import { FormSubmitCancelRow } from '../components/ButtonRow';
 const ISSUE_TYPES = [
   {
     value: PATIENT_ISSUE_TYPES.ISSUE,
-    label: <TranslatedText stringId="issues.form.option.issue" fallback="Issue" />,
+    label: <TranslatedText stringId="issues.option.issue" fallback="Issue" />,
   },
   {
     value: PATIENT_ISSUE_TYPES.WARNING,
-    label: <TranslatedText stringId="issues.form.option.warning" fallback="Warning" />,
+    label: <TranslatedText stringId="issues.option.warning" fallback="Warning" />,
   },
 ];
 
@@ -25,14 +25,14 @@ export const PatientIssueForm = ({ onSubmit, editedObject, onCancel }) => (
       <FormGrid columns={1}>
         <Field
           name="type"
-          label={<TranslatedText stringId="general.form.type.label" fallback="Type" />}
+          label={<TranslatedText stringId="general.type.label" fallback="Type" />}
           component={SelectField}
           options={ISSUE_TYPES}
           required
         />
         <Field
           name="note"
-          label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+          label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
           component={TextField}
           multiline
           rows={2}
@@ -40,7 +40,7 @@ export const PatientIssueForm = ({ onSubmit, editedObject, onCancel }) => (
         <Field
           name="recordedDate"
           label={
-            <TranslatedText stringId="general.form.recordedDate.label" fallback="Date recorded" />
+            <TranslatedText stringId="general.recordedDate.label" fallback="Date recorded" />
           }
           component={DateField}
           saveDateAsString

--- a/packages/web/app/forms/PatientLetterForm.jsx
+++ b/packages/web/app/forms/PatientLetterForm.jsx
@@ -67,14 +67,14 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
       <FormGrid columns={2} nested>
         <Field
           name="clinicianId"
-          label={<TranslatedText stringId="general.form.clinican.label" fallback="Clinician" />}
+          label={<TranslatedText stringId="general.clinican.label" fallback="Clinician" />}
           required
           component={AutocompleteField}
           suggester={practitionerSuggester}
         />
         <Field
           name="date"
-          label={<TranslatedText stringId="general.form.date.label" fallback="Date" />}
+          label={<TranslatedText stringId="general.date.label" fallback="Date" />}
           required
           component={DateField}
           saveDateAsString
@@ -84,7 +84,7 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
         <Field
           name="templateId"
           label={
-            <TranslatedText stringId="patientLetter.form.template.label" fallback="Template" />
+            <TranslatedText stringId="patientLetter.template.label" fallback="Template" />
           }
           suggester={patientLetterTemplateSuggester}
           component={AutocompleteField}
@@ -93,7 +93,7 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
         <Field
           name="title"
           label={
-            <TranslatedText stringId="patientLetter.form.title.label" fallback="Letter title" />
+            <TranslatedText stringId="patientLetter.title.label" fallback="Letter title" />
           }
           required
           component={TextField}
@@ -101,7 +101,7 @@ const PatientLetterFormContents = ({ submitForm, onCancel, setValues }) => {
         />
         <Field
           name="body"
-          label={<TranslatedText stringId="general.form.note.label" fallback="Note" />}
+          label={<TranslatedText stringId="general.note.label" fallback="Note" />}
           required
           component={TallMultilineTextField}
           disabled={templateLoading}

--- a/packages/web/app/forms/TreatmentPlanNoteChangelogForm.jsx
+++ b/packages/web/app/forms/TreatmentPlanNoteChangelogForm.jsx
@@ -25,11 +25,11 @@ export const TreatmentPlanNoteChangelogForm = ({ note, onCancel }) => {
         noteType={NOTE_TYPE_LABELS[note.noteType]}
         date={note.date}
         dateLabel={<TranslatedText
-          stringId="note.form.lastUpdatedAt.label"
+          stringId="note.lastUpdatedAt.label"
           fallback="Last updated at date & time"
         />}
         writtenByLabel={<TranslatedText
-          stringId="note.form.lastUpdatedBy.label"
+          stringId="note.lastUpdatedBy.label"
           fallback="Last updated by (or on behalf of)"
         />}
         writtenBy={writtenBy}

--- a/packages/web/app/forms/TriageForm.jsx
+++ b/packages/web/app/forms/TriageForm.jsx
@@ -31,7 +31,7 @@ const InfoPopupLabel = React.memo(() => (
   <span>
     <span>
       <TranslatedText
-        stringId="patient.modal.triage.form.triageScore.label"
+        stringId="patient.modal.triage.triageScore.label"
         fallback="Triage score"
       />
     </span>
@@ -61,7 +61,7 @@ export const TriageForm = ({
           name="arrivalTime"
           label={
             <TranslatedText
-              stringId="patient.modal.triage.form.arrivalTime.label"
+              stringId="patient.modal.triage.arrivalTime.label"
               fallback="Arrival date & time"
             />
           }
@@ -74,7 +74,7 @@ export const TriageForm = ({
           name="triageTime"
           label={
             <TranslatedText
-              stringId="patient.modal.triage.form.triageDateTime.label"
+              stringId="patient.modal.triage.triageDateTime.label"
               fallback="Triage date & time"
             />
           }
@@ -117,7 +117,7 @@ export const TriageForm = ({
             name="chiefComplaintId"
             label={
               <TranslatedText
-                stringId="patient.modal.triage.form.chiefComplaint.label"
+                stringId="patient.modal.triage.chiefComplaint.label"
                 fallback="Chief complaint"
               />
             }
@@ -129,7 +129,7 @@ export const TriageForm = ({
             name="secondaryComplaintId"
             label={
               <TranslatedText
-                stringId="patient.modal.triage.form.secondaryComplaint.label"
+                stringId="patient.modal.triage.secondaryComplaint.label"
                 fallback="Secondary complaint"
               />
             }
@@ -149,7 +149,7 @@ export const TriageForm = ({
           name="practitionerId"
           label={
             <TranslatedText
-              stringId="triage.form.practitionerId.label"
+              stringId="triage.practitionerId.label"
               fallback="Triage :clinician"
               replacements={{
                 clinician: (

--- a/packages/web/app/forms/VaccineForm.jsx
+++ b/packages/web/app/forms/VaccineForm.jsx
@@ -123,7 +123,7 @@ export const VaccineForm = ({
     return (
       <ErrorMessage
         title={
-          <TranslatedText stringId="vaccine.form.loadError" fallback="Cannot load vaccine form" />
+          <TranslatedText stringId="vaccine.loadError" fallback="Cannot load vaccine form" />
         }
         errorMessage={currentEncounterError?.message || vaccinationDefaultsError?.message}
       />

--- a/packages/web/app/forms/VaccineGivenForm.jsx
+++ b/packages/web/app/forms/VaccineGivenForm.jsx
@@ -81,7 +81,7 @@ export const VaccineGivenForm = ({
               name="givenElsewhere"
               label={
                 <TranslatedText
-                  stringId="vaccine.form.givenElsewhereCheckbox.label"
+                  stringId="vaccine.givenElsewhereCheckbox.label"
                   fallback="Given elsewhere (e.g overseas)"
                 />
               }
@@ -109,7 +109,7 @@ export const VaccineGivenForm = ({
               name="circumstanceIds"
               label={
                 <TranslatedText
-                  stringId="vaccine.form.circumstances.label"
+                  stringId="vaccine.circumstances.label"
                   fallback="Circumstances"
                 />
               }
@@ -147,7 +147,7 @@ export const VaccineGivenForm = ({
       ) : null}
 
       <VaccineDateField
-        label={<TranslatedText stringId="vaccine.form.dateGiven.label" fallback="Date given" />}
+        label={<TranslatedText stringId="vaccine.dateGiven.label" fallback="Date given" />}
         required={!values.givenElsewhere}
       />
 
@@ -176,12 +176,12 @@ export const VaccineGivenForm = ({
         label={
           values.givenElsewhere ? (
             <TranslatedText
-              stringId="vaccine.form.consentGivenElsewhere.label"
+              stringId="vaccine.consentGivenElsewhere.label"
               fallback="Do you have consent to record in Tamanu?"
             />
           ) : (
             <TranslatedText
-              stringId="vaccine.form.consent.label"
+              stringId="vaccine.consent.label"
               fallback="Do you have consent from the recipient/parent/guardian to give this vaccine and record in Tamanu?"
             />
           )

--- a/packages/web/app/forms/VaccineNotGivenForm.jsx
+++ b/packages/web/app/forms/VaccineNotGivenForm.jsx
@@ -68,13 +68,13 @@ export const VaccineNotGivenForm = ({
 
     <Field
       name="notGivenReasonId"
-      label={<TranslatedText stringId="vaccine.form.notGivenReason.label" fallback="Reason" />}
+      label={<TranslatedText stringId="vaccine.notGivenReason.label" fallback="Reason" />}
       component={SuggesterSelectField}
       endpoint="vaccineNotGivenReason"
     />
 
     <VaccineDateField
-      label={<TranslatedText stringId="vaccine.form.dateRecorded.label" fallback="Date recorded" />}
+      label={<TranslatedText stringId="vaccine.dateRecorded.label" fallback="Date recorded" />}
     />
 
     <StyledDivider />
@@ -87,7 +87,7 @@ export const VaccineNotGivenForm = ({
     <GivenByField
       label={
         <TranslatedText
-          stringId="general.form.supervisingClinician.label"
+          stringId="general.supervisingClinician.label"
           fallback="Supervising :clinician"
           replacements={{
             clinician: (

--- a/packages/web/app/views/labRequest/TestSelector.jsx
+++ b/packages/web/app/views/labRequest/TestSelector.jsx
@@ -220,7 +220,7 @@ export const TestSelectorInput = ({
                 ]}
                 label={
                   <TranslatedText
-                    stringId="lab.form.testSelect.testCategory.label"
+                    stringId="lab.testSelect.testCategory.label"
                     fallback="Test category"
                   />
                 }

--- a/packages/web/app/views/patients/components/LabRequestCard.jsx
+++ b/packages/web/app/views/patients/components/LabRequestCard.jsx
@@ -75,7 +75,7 @@ export const LabRequestCard = ({ labRequest, actions }) => {
         </CardItem>
         <BorderSection>
           <CardLabel><TranslatedText
-            stringId="general.form.requestingClinician.label"
+            stringId="general.requestingClinician.label"
             fallback="Requesting :clinician"
             replacements={{
               clinician: (

--- a/packages/web/app/views/patients/components/LabRequestSummaryPane.jsx
+++ b/packages/web/app/views/patients/components/LabRequestSummaryPane.jsx
@@ -130,11 +130,11 @@ export const LabRequestSummaryPane = React.memo(
     return (
       <Container>
         <Heading3 mb="12px">
-          <TranslatedText stringId="lab.form.requestSummary.heading" fallback="Request finalised" />
+          <TranslatedText stringId="lab.requestSummary.heading" fallback="Request finalised" />
         </Heading3>
         <BodyText mb="28px" color="textTertiary">
           <TranslatedText
-            stringId="lab.form.requestSummary.instruction"
+            stringId="lab.requestSummary.instruction"
             fallback="Your lab request has been finalised. Please select items from the list below to print
           requests or sample labels."
           />
@@ -144,7 +144,7 @@ export const LabRequestSummaryPane = React.memo(
             <InfoCardItem
               label={
                 <TranslatedText
-                  stringId="general.form.requestingClinician.label"
+                  stringId="general.requestingClinician.label"
                   fallback="Requesting :clinician"
                   replacements={{
                     clinician: (
@@ -163,7 +163,7 @@ export const LabRequestSummaryPane = React.memo(
             <InfoCardItem
               label={
                 <TranslatedText
-                  stringId="general.form.requestDateTime.label"
+                  stringId="general.requestDateTime.label"
                   fallback="Request date & time"
                 />
               }
@@ -171,12 +171,12 @@ export const LabRequestSummaryPane = React.memo(
             />
             <InfoCardItem
               label={
-                <TranslatedText stringId="general.form.department.label" fallback="Department" />
+                <TranslatedText stringId="general.department.label" fallback="Department" />
               }
               value={department?.name}
             />
             <InfoCardItem
-              label={<TranslatedText stringId="lab.form.priority.label" fallback="Priority" />}
+              label={<TranslatedText stringId="lab.priority.label" fallback="Priority" />}
               value={priority ? priority.name : '-'}
             />
           </StyledInfoCard>

--- a/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
+++ b/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
@@ -222,7 +222,7 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckin })
     <Container patientStatus={patientStatus}>
       <Header patientStatus={patientStatus}>
         <BoldTitle variant="h3">
-          <TranslatedText stringId="general.form.type.label" fallback="Type" />:
+          <TranslatedText stringId="general.type.label" fallback="Type" />:
         </BoldTitle>
         <Title variant="h3">
           {ENCOUNTER_OPTIONS_BY_VALUE[encounterType].label}
@@ -250,7 +250,7 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckin })
         <ContentItem>
           <ContentLabel>
             <TranslatedText
-              stringId="general.form.supervisingClinician.label"
+              stringId="general.supervisingClinician.label"
               fallback="Supervising :clinician"
               replacements={{
                 clinician: (

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -60,22 +60,22 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
     <FormGrid columns={3}>
       <TextInput
         value={imagingRequest.displayId}
-        label={<TranslatedText stringId="imaging.form.requestId.label" fallback="Request ID" />}
+        label={<TranslatedText stringId="imaging.requestId.label" fallback="Request ID" />}
         disabled
       />
       <TextInput
         value={imagingTypes[imagingRequest.imagingType]?.label || 'Unknown'}
-        label={<TranslatedText stringId="imaging.form.imagingType.label" fallback="Request type" />}
+        label={<TranslatedText stringId="imaging.imagingType.label" fallback="Request type" />}
         disabled
       />
       <TextInput
         value={imagingPriorities.find(p => p.value === imagingRequest.priority)?.label || ''}
-        label={<TranslatedText stringId="imaging.form.priority.label" fallback="Priority" />}
+        label={<TranslatedText stringId="imaging.priority.label" fallback="Priority" />}
         disabled
       />
       <Field
         name="status"
-        label={<TranslatedText stringId="imaging.form.status.label" fallback="Status" />}
+        label={<TranslatedText stringId="imaging.status.label" fallback="Status" />}
         component={SelectField}
         options={isCancelled ? cancelledOption : IMAGING_REQUEST_STATUS_OPTIONS}
         disabled={isCancelled}
@@ -86,7 +86,7 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
         value={imagingRequest.requestedDate}
         label={
           <TranslatedText
-            stringId="imaging.form.requestedDate.label"
+            stringId="imaging.requestedDate.label"
             fallback="Request date and time"
           />
         }
@@ -95,7 +95,7 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
       {allowLocationChange && (
         <Field
           label={
-            <TranslatedText stringId="imaging.form.facilityArea.label" fallback="Facility area" />
+            <TranslatedText stringId="imaging.facilityArea.label" fallback="Facility area" />
           }
           name="locationGroupId"
           component={AutocompleteField}
@@ -110,14 +110,14 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
             ? imagingRequest.areas.map(area => area.name).join(', ')
             : imagingRequest.areaNote
         }
-        label={<TranslatedText stringId="imaging.form.areas.label" fallback="Areas to be imaged" />}
+        label={<TranslatedText stringId="imaging.areas.label" fallback="Areas to be imaged" />}
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled
       />
       <TextInput
         multiline
         value={imagingRequest.note}
-        label={<TranslatedText stringId="general.form.notes.label" fallback="Notes" />}
+        label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled
       />
@@ -139,7 +139,7 @@ const NewResultSection = ({ disabled = false }) => {
   return (
     <FormGrid columns={2}>
       <Field
-        label={<TranslatedText stringId="imaging.form.completedBy.label" fallback="Completed by" />}
+        label={<TranslatedText stringId="imaging.completedBy.label" fallback="Completed by" />}
         name="newResult.completedById"
         placeholder="Search"
         component={AutocompleteField}
@@ -147,7 +147,7 @@ const NewResultSection = ({ disabled = false }) => {
         disabled={disabled}
       />
       <Field
-        label={<TranslatedText stringId="imaging.form.completedDate.label" fallback="Completed" />}
+        label={<TranslatedText stringId="imaging.completedDate.label" fallback="Completed" />}
         name="newResult.completedAt"
         saveDateAsString
         component={DateTimeField}
@@ -155,7 +155,7 @@ const NewResultSection = ({ disabled = false }) => {
       />
       <Field
         label={
-          <TranslatedText stringId="imaging.form.description.label" fallback="Result description" />
+          <TranslatedText stringId="imaging.description.label" fallback="Result description" />
         }
         name="newResult.description"
         placeholder="Result description..."

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -33,7 +33,7 @@ export const EncounterInfoPane = React.memo(
       }
     >
       <InfoCardItem
-        label={<TranslatedText stringId="general.form.deparment.label" fallback="Department" />}
+        label={<TranslatedText stringId="general.department.label" fallback="Department" />}
         value={getDepartmentName(encounter)}
       />
       <InfoCardItem
@@ -43,7 +43,7 @@ export const EncounterInfoPane = React.memo(
         value={patientBillingType}
       />
       <InfoCardItem
-        label={<TranslatedText stringId="general.form.location.label" fallback="Location" />}
+        label={<TranslatedText stringId="general.location.label" fallback="Location" />}
         value={getFullLocationName(encounter?.location)}
       />
       {!getLocalisation(`${referralSourcePath}.hidden`) && (

--- a/packages/web/app/views/programs/ProgramsView.jsx
+++ b/packages/web/app/views/programs/ProgramsView.jsx
@@ -137,7 +137,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
             onChange={selectProgram}
             label={
               <TranslatedText
-                stringId="program.modal.selectSurvey.form.selectProgram.label"
+                stringId="program.modal.selectSurvey.selectProgram.label"
                 fallback="Select program"
               />
             }


### PR DESCRIPTION
### Changes

Remove the .form category from our string ids as seems unnecessary
### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
