### PR TITLE
ci: Make check-pr-title.yml run on all PRs

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -5,12 +5,11 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 jobs:
-  merge-to-main:
-    name: When merging to main
+  check:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'dev'
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:


### PR DESCRIPTION
### Changes

If the workflow isn't set to run on `synchronize` on all PRs, it can't be used for required PR status checks, as on some PRs it will be marked as "skipped".

This incurs a small additional cost where it will run more often than strictly necessary.

Additionally this enforces good PR titles (ie commit messages) for merging to epics, which is a somewhat positive side effect.

### Checklist

- [x] Code is finished