### PR TITLE
ci: Add alls-green job to non-determinism test so it can be added to requirements

### DIFF
--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -71,3 +71,14 @@ jobs:
       - run: aws s3 cp s3://bes-tamanu-test-data-snapshots/${{ steps.commit-finder.outputs.commit }}/fake-pg${{ matrix.postgres }}.dump ./ --no-progress
 
       - run: yarn workspace scripts run test-determinism --dump-path $(realpath fake-pg${{ matrix.postgres }}.dump)
+
+  # Dummy job to have a stable name for PR requirements
+  tests-pass:
+    if: always() # always run even if dependencies fail
+    name: Tests pass
+    needs: [test-for-non-determinism]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### Changes

Otherwise we have one job per postgres version, and would need to change requirements when adding/removing versions.

### Checklist

- [x] Code is finished