### PR TITLE
fix(mobile): Missing responsive field font sizes

### DIFF
--- a/packages/mobile/App/ui/components/AutocompleteModal/AutocompleteModalField.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/AutocompleteModalField.tsx
@@ -41,10 +41,11 @@ export const AutocompleteModalField = ({
     setLabel(selectedItem.label);
   };
 
-  const openModal = (): void => navigation.navigate(modalRoute, {
-    callback: onPress,
-    suggester,
-  });
+  const openModal = (): void =>
+    navigation.navigate(modalRoute, {
+      callback: onPress,
+      suggester,
+    });
 
   useEffect(() => {
     if (!suggester) return;
@@ -62,7 +63,7 @@ export const AutocompleteModalField = ({
     <StyledView marginBottom={screenPercentageToDP('2.24', Orientation.Height)} width="100%">
       {!!fieldLabel && (
         <StyledText
-          fontSize={14}
+          fontSize={screenPercentageToDP(2.1, Orientation.Height)}
           fontWeight={600}
           marginBottom={2}
           color={theme.colors.TEXT_SUPER_DARK}
@@ -83,7 +84,7 @@ export const AutocompleteModalField = ({
         borderColor={error ? theme.colors.ERROR : '#EBEBEB'}
         borderWidth={1}
         fontWeight={400}
-        fontSize={15}
+        fontSize={screenPercentageToDP(2.1, Orientation.Height)}
         padding={10}
         onPress={openModal}
         disabled={disabled}

--- a/packages/mobile/App/ui/components/AutocompleteModal/AutocompleteModalField.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/AutocompleteModalField.tsx
@@ -59,11 +59,13 @@ export const AutocompleteModalField = ({
     })();
   }, [value]);
 
+  const fontSize = screenPercentageToDP(2.1, Orientation.Height)
+
   return (
     <StyledView marginBottom={screenPercentageToDP('2.24', Orientation.Height)} width="100%">
       {!!fieldLabel && (
         <StyledText
-          fontSize={screenPercentageToDP(2.1, Orientation.Height)}
+          fontSize={fontSize}
           fontWeight={600}
           marginBottom={2}
           color={theme.colors.TEXT_SUPER_DARK}
@@ -84,7 +86,7 @@ export const AutocompleteModalField = ({
         borderColor={error ? theme.colors.ERROR : '#EBEBEB'}
         borderWidth={1}
         fontWeight={400}
-        fontSize={screenPercentageToDP(2.1, Orientation.Height)}
+        fontSize={fontSize}
         padding={10}
         onPress={openModal}
         disabled={disabled}

--- a/packages/mobile/App/ui/components/DateField/DateField.tsx
+++ b/packages/mobile/App/ui/components/DateField/DateField.tsx
@@ -108,7 +108,7 @@ export const DateField = React.memo(
       <StyledView marginBottom={screenPercentageToDP(2.24, Orientation.Height)} width="100%">
         {!!label && (
           <StyledText
-            fontSize={14}
+            fontSize={screenPercentageToDP(2.1, Orientation.Height)}
             fontWeight={600}
             marginBottom={2}
             color={theme.colors.TEXT_SUPER_DARK}

--- a/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
@@ -71,8 +71,8 @@ if (UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
-const checkIconSize = screenPercentageToDP(2.1, Orientation.Height);
-const chevronIconSize = screenPercentageToDP(3, Orientation.Height);
+const regularFontSize = screenPercentageToDP(2.1, Orientation.Height);
+const largeFontSize = screenPercentageToDP(3, Orientation.Height);
 
 const defaultSearchIcon = () => null;
 export class MultiSelect extends Component {
@@ -257,7 +257,7 @@ export class MultiSelect extends Component {
               {
                 flex: 1,
                 color: tagTextColor,
-                fontSize: 15,
+                fontSize: regularFontSize,
               },
               styleTextTag && styleTextTag,
               fontFamily ? { fontFamily } : {},
@@ -275,7 +275,7 @@ export class MultiSelect extends Component {
               name="close-circle"
               style={{
                 color: tagRemoveIconColor,
-                fontSize: 22,
+                fontSize: largeFontSize,
                 marginLeft: 10,
               }}
             />
@@ -428,7 +428,7 @@ export class MultiSelect extends Component {
               <Icon
                 name="check"
                 style={{
-                  fontSize: checkIconSize,
+                  fontSize: regularFontSize,
                   marginRight: -5,
                   color: selectedItemIconColor,
                 }}
@@ -635,7 +635,7 @@ export class MultiSelect extends Component {
                     style={[
                       styles.indicator,
                       { paddingLeft: 15, paddingRight: 15 },
-                      { fontSize: chevronIconSize },
+                      { fontSize: largeFontSize },
                       styleIndicator && styleIndicator,
                     ]}
                   />
@@ -650,7 +650,7 @@ export class MultiSelect extends Component {
                   style={[
                     { marginRight: 10 },
                     styles.indicator,
-                    { fontSize: chevronIconSize },
+                    { fontSize: largeFontSize },
                     styleIndicator && styleIndicator,
                   ]}
                 />
@@ -728,7 +728,7 @@ export class MultiSelect extends Component {
                           name={hideSubmitButton ? 'menu-right' : 'close'}
                           style={[
                             styles.removeIndicator,
-                            { fontSize: checkIconSize },
+                            { fontSize: regularFontSize },
                             styleIndicator && styleIndicator,
                           ]}
                         />
@@ -740,7 +740,7 @@ export class MultiSelect extends Component {
                       style={[
                         { marginRight: -7 },
                         styles.indicator,
-                        { fontSize: chevronIconSize },
+                        { fontSize: largeFontSize },
                         styleIndicator && styleIndicator,
                       ]}
                     />

--- a/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
@@ -71,6 +71,9 @@ if (UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
+const checkIconSize = screenPercentageToDP(2.1, Orientation.Height);
+const chevronIconSize = screenPercentageToDP(3, Orientation.Height);
+
 const defaultSearchIcon = () => null;
 export class MultiSelect extends Component {
   static propTypes = {
@@ -425,7 +428,7 @@ export class MultiSelect extends Component {
               <Icon
                 name="check"
                 style={{
-                  fontSize: screenPercentageToDP(2.1, Orientation.Height),
+                  fontSize: checkIconSize,
                   marginRight: -5,
                   color: selectedItemIconColor,
                 }}
@@ -632,8 +635,8 @@ export class MultiSelect extends Component {
                     style={[
                       styles.indicator,
                       { paddingLeft: 15, paddingRight: 15 },
+                      { fontSize: chevronIconSize },
                       styleIndicator && styleIndicator,
-                      { fontSize: screenPercentageToDP(3, Orientation.Height) },
                     ]}
                   />
                 </TouchableOpacity>
@@ -647,8 +650,8 @@ export class MultiSelect extends Component {
                   style={[
                     { marginRight: 10 },
                     styles.indicator,
+                    { fontSize: chevronIconSize },
                     styleIndicator && styleIndicator,
-                    { fontSize: screenPercentageToDP(3, Orientation.Height) },
                   ]}
                 />
               )}
@@ -725,7 +728,7 @@ export class MultiSelect extends Component {
                           name={hideSubmitButton ? 'menu-right' : 'close'}
                           style={[
                             styles.removeIndicator,
-                            { fontSize: screenPercentageToDP(2.1, Orientation.Height) },
+                            { fontSize: checkIconSize },
                             styleIndicator && styleIndicator,
                           ]}
                         />
@@ -737,7 +740,7 @@ export class MultiSelect extends Component {
                       style={[
                         { marginRight: -7 },
                         styles.indicator,
-                        { fontSize: screenPercentageToDP(3, Orientation.Height) },
+                        { fontSize: chevronIconSize },
                         styleIndicator && styleIndicator,
                       ]}
                     />

--- a/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
@@ -19,6 +19,7 @@ import find from 'lodash/find';
 import get from 'lodash/get';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import styles, { colorPack } from './styles';
+import { screenPercentageToDP, Orientation } from '../../../helpers/screen';
 
 const ViewPropTypes = {
   style: PropTypes.any,
@@ -630,6 +631,7 @@ export class MultiSelect extends Component {
                     name="chevron-down"
                     style={[
                       styles.indicator,
+                      { fontSize: screenPercentageToDP(2.1, Orientation.Height) },
                       { paddingLeft: 15, paddingRight: 15 },
                       styleIndicator && styleIndicator,
                     ]}
@@ -716,7 +718,11 @@ export class MultiSelect extends Component {
                       <TouchableWithoutFeedback onPress={this._removeAllItems}>
                         <Icon
                           name={hideSubmitButton ? 'menu-right' : 'close'}
-                          style={[styles.removeIndicator, styleIndicator && styleIndicator]}
+                          style={[
+                            styles.removeIndicator,
+                            { fontSize: screenPercentageToDP(2.1, Orientation.Height) },
+                            styleIndicator && styleIndicator,
+                          ]}
                         />
                       </TouchableWithoutFeedback>
                     ) : null}

--- a/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
@@ -425,7 +425,7 @@ export class MultiSelect extends Component {
               <Icon
                 name="check"
                 style={{
-                  fontSize: 20,
+                  fontSize: screenPercentageToDP(2.1, Orientation.Height),
                   marginRight: -5,
                   color: selectedItemIconColor,
                 }}
@@ -631,9 +631,9 @@ export class MultiSelect extends Component {
                     name="chevron-down"
                     style={[
                       styles.indicator,
-                      { fontSize: screenPercentageToDP(2.1, Orientation.Height) },
                       { paddingLeft: 15, paddingRight: 15 },
                       styleIndicator && styleIndicator,
+                      { fontSize: screenPercentageToDP(3, Orientation.Height) },
                     ]}
                   />
                 </TouchableOpacity>
@@ -644,7 +644,12 @@ export class MultiSelect extends Component {
                   size={20}
                   onPress={this._clearSelectorCallback}
                   color={colorPack.placeholderTextColor}
-                  style={[{ marginRight: 10 }, styles.indicator, styleIndicator && styleIndicator]}
+                  style={[
+                    { marginRight: 10 },
+                    styles.indicator,
+                    styleIndicator && styleIndicator,
+                    { fontSize: screenPercentageToDP(3, Orientation.Height) },
+                  ]}
                 />
               )}
             </View>
@@ -732,6 +737,7 @@ export class MultiSelect extends Component {
                       style={[
                         { marginRight: -7 },
                         styles.indicator,
+                        { fontSize: screenPercentageToDP(3, Orientation.Height) },
                         styleIndicator && styleIndicator,
                       ]}
                     />

--- a/packages/mobile/App/ui/components/Dropdown/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/index.tsx
@@ -136,10 +136,7 @@ export const Dropdown = React.memo(
           selectedItemIconColor={theme.colors.PRIMARY_MAIN}
           itemTextColor={theme.colors.TEXT_SUPER_DARK}
           itemFontSize={fontSize}
-          searchInputStyle={{
-            color: theme.colors.PRIMARY_MAIN,
-            fontSize: screenPercentageToDP(2.1, Orientation.Height),
-          }}
+          searchInputStyle={{ color: theme.colors.PRIMARY_MAIN }}
           submitButtonColor={theme.colors.SAFE}
           submitButtonText="Confirm selection"
           styleMainWrapper={{ zIndex: 999 }}
@@ -173,7 +170,7 @@ export const Dropdown = React.memo(
           textInputProps={filterable ? {} : { editable: false, autoFocus: false }}
           searchIcon={filterable ? undefined : null}
           disabled={disabled}
-          fontSize={screenPercentageToDP(2.1, Orientation.Height)}
+          fontSize={fontSize}
           {...getStyleProps(error, disabled)}
         />
         {error && <TextFieldErrorMessage>{error}</TextFieldErrorMessage>}

--- a/packages/mobile/App/ui/components/Dropdown/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/index.tsx
@@ -103,11 +103,12 @@ export const Dropdown = React.memo(
       [selectedItems],
     );
     const filterable = options.length >= MIN_COUNT_FILTERABLE_BY_DEFAULT;
+    const fontSize = screenPercentageToDP(2.1, Orientation.Height);
     return (
       <StyledView width="100%" marginBottom={screenPercentageToDP(2.24, Orientation.Height)}>
         {!!label && (
           <StyledText
-            fontSize={14}
+            fontSize={fontSize}
             fontWeight={600}
             marginBottom={2}
             color={labelColor || theme.colors.TEXT_SUPER_DARK}
@@ -134,8 +135,11 @@ export const Dropdown = React.memo(
           selectedItemTextColor={theme.colors.PRIMARY_MAIN}
           selectedItemIconColor={theme.colors.PRIMARY_MAIN}
           itemTextColor={theme.colors.TEXT_SUPER_DARK}
-          itemFontSize={14}
-          searchInputStyle={{ color: theme.colors.PRIMARY_MAIN }}
+          itemFontSize={fontSize}
+          searchInputStyle={{
+            color: theme.colors.PRIMARY_MAIN,
+            fontSize: screenPercentageToDP(2.1, Orientation.Height),
+          }}
           submitButtonColor={theme.colors.SAFE}
           submitButtonText="Confirm selection"
           styleMainWrapper={{ zIndex: 999 }}
@@ -169,6 +173,7 @@ export const Dropdown = React.memo(
           textInputProps={filterable ? {} : { editable: false, autoFocus: false }}
           searchIcon={filterable ? undefined : null}
           disabled={disabled}
+          fontSize={screenPercentageToDP(2.1, Orientation.Height)}
           {...getStyleProps(error, disabled)}
         />
         {error && <TextFieldErrorMessage>{error}</TextFieldErrorMessage>}

--- a/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
+++ b/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
@@ -29,7 +29,7 @@ const Label = styled(StyledText)`
   color: ${theme.colors.TEXT_SUPER_DARK};
   font-size: ${screenPercentageToDP(2.1, Orientation.Height)};
   font-weight: 600;
-  padding-left: ${screenPercentageToDP(1, Orientation.Width)};
+  // padding-left: ${screenPercentageToDP(1, Orientation.Width)};
   margin-bottom: ${screenPercentageToDP(0.5, Orientation.Width)};
 `;
 

--- a/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
+++ b/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
@@ -29,7 +29,7 @@ const Label = styled(StyledText)`
   color: ${theme.colors.TEXT_SUPER_DARK};
   font-size: ${screenPercentageToDP(2.1, Orientation.Height)};
   font-weight: 600;
-  // padding-left: ${screenPercentageToDP(1, Orientation.Width)};
+  padding-left: ${screenPercentageToDP(1, Orientation.Width)};
   margin-bottom: ${screenPercentageToDP(0.5, Orientation.Width)};
 `;
 

--- a/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
+++ b/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
@@ -52,7 +52,7 @@ export const RadioButtonGroup = ({
           {required && <RequiredIndicator />}
         </Label>
       )}
-      <RowView>
+      <RowView marginBottom={10}>
         {options.map((option, index) => (
           <RadioComponent
             key={option.label}


### PR DESCRIPTION
### Changes

We discovered during regression testing that some mobile fields are responsive and some aren't on the register patient details page. I have just added the responsiveness used on the text fields to the other types that were looking weird when the user was on a very large or very small screen (autocomplete, select, date)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
