### PR TITLE
fix(mobile): Clear selected patient state on search

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/HomeScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/HomeScreen/index.tsx
@@ -5,6 +5,7 @@ import { RecentlyViewedPatientTiles } from './RecentlyViewedPatientTiles';
 import { LogoV2Icon, SearchIcon } from '/components/Icons';
 import { UserAvatar } from '/components/UserAvatar';
 import { withAuth } from '/containers/Auth';
+import { withPatient } from '~/ui/containers/Patient';
 import { useAuth } from '~/ui/contexts/AuthContext';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { disableAndroidBackButton } from '/helpers/android';
@@ -45,7 +46,7 @@ const SearchPatientsButton = ({ onPress }: { onPress: () => void }): ReactElemen
   </StyledTouchableOpacity>
 );
 
-const BaseHomeScreen = ({ navigation, user }: BaseAppProps): ReactElement => {
+const BaseHomeScreen = ({ navigation, user, setSelectedPatient }: BaseAppProps): ReactElement => {
   disableAndroidBackButton();
   const { checkFirstSession, setUserFirstSignIn } = useAuth();
   const { facilityName } = useFacility();
@@ -57,6 +58,7 @@ const BaseHomeScreen = ({ navigation, user }: BaseAppProps): ReactElement => {
   }, []);
 
   const onNavigateToSearchPatient = useCallback(() => {
+    setSelectedPatient(null)
     navigation.navigate(Routes.HomeStack.SearchPatientStack.Index);
   }, []);
 
@@ -69,63 +71,63 @@ const BaseHomeScreen = ({ navigation, user }: BaseAppProps): ReactElement => {
   }
 
   return (
-      <StyledSafeAreaView flex={1} background={theme.colors.PRIMARY_MAIN}>
-        <FullView>
-          <StatusBar barStyle="light-content" />
-          <StyledView
-            height="31.59%"
-            width="100%"
-            paddingRight={screenPercentageToDP(6.08, Orientation.Width)}
-            paddingLeft={screenPercentageToDP(6.08, Orientation.Width)}
-          >
-            <StyledView width="100%">
-              <RowView
-                alignItems="center"
-                marginTop={screenPercentageToDP(1.21, Orientation.Height)}
-                width="100%"
-                justifyContent="space-between"
-              >
-                <LogoV2Icon height={23} width={95} fill={theme.colors.WHITE} />
-                <UserAvatar
-                  size={screenPercentageToDP(5.46, Orientation.Height)}
-                  displayName={user.displayName}
-                  sex={user.gender}
-                />
-              </RowView>
-              <StyledText
-                marginTop={screenPercentageToDP(3.07, Orientation.Height)}
-                fontSize={screenPercentageToDP(4.86, Orientation.Height)}
-                fontWeight="bold"
-                color={theme.colors.WHITE}
-              >
-                Hi {user.displayName}
-              </StyledText>
-              <StyledText
-                fontSize={screenPercentageToDP(2.18, Orientation.Height)}
-                color={theme.colors.WHITE}
-              >
-                {facilityName}
-              </StyledText>
-            </StyledView>
+    <StyledSafeAreaView flex={1} background={theme.colors.PRIMARY_MAIN}>
+      <FullView>
+        <StatusBar barStyle="light-content" />
+        <StyledView
+          height="31.59%"
+          width="100%"
+          paddingRight={screenPercentageToDP(6.08, Orientation.Width)}
+          paddingLeft={screenPercentageToDP(6.08, Orientation.Width)}
+        >
+          <StyledView width="100%">
+            <RowView
+              alignItems="center"
+              marginTop={screenPercentageToDP(1.21, Orientation.Height)}
+              width="100%"
+              justifyContent="space-between"
+            >
+              <LogoV2Icon height={23} width={95} fill={theme.colors.WHITE} />
+              <UserAvatar
+                size={screenPercentageToDP(5.46, Orientation.Height)}
+                displayName={user.displayName}
+                sex={user.gender}
+              />
+            </RowView>
+            <StyledText
+              marginTop={screenPercentageToDP(3.07, Orientation.Height)}
+              fontSize={screenPercentageToDP(4.86, Orientation.Height)}
+              fontWeight="bold"
+              color={theme.colors.WHITE}
+            >
+              Hi {user.displayName}
+            </StyledText>
+            <StyledText
+              fontSize={screenPercentageToDP(2.18, Orientation.Height)}
+              color={theme.colors.WHITE}
+            >
+              {facilityName}
+            </StyledText>
           </StyledView>
-          <StyledView
-            zIndex={2}
-            position="absolute"
-            paddingLeft={screenPercentageToDP(4.86, Orientation.Width)}
-            paddingRight={screenPercentageToDP(4.86, Orientation.Width)}
-            top="28%"
-            width="100%"
-          >
-            <SearchPatientsButton onPress={onNavigateToSearchPatient} />
-          </StyledView>
-          <ConditionalRegisterPatientButton />
-          <RecentlyViewedPatientTiles />
-          <StyledView background={theme.colors.BACKGROUND_GREY}>
-            <SyncInactiveAlert />
-          </StyledView>
-        </FullView>
-      </StyledSafeAreaView>
+        </StyledView>
+        <StyledView
+          zIndex={2}
+          position="absolute"
+          paddingLeft={screenPercentageToDP(4.86, Orientation.Width)}
+          paddingRight={screenPercentageToDP(4.86, Orientation.Width)}
+          top="28%"
+          width="100%"
+        >
+          <SearchPatientsButton onPress={onNavigateToSearchPatient} />
+        </StyledView>
+        <ConditionalRegisterPatientButton />
+        <RecentlyViewedPatientTiles />
+        <StyledView background={theme.colors.BACKGROUND_GREY}>
+          <SyncInactiveAlert />
+        </StyledView>
+      </FullView>
+    </StyledSafeAreaView>
   );
 };
 
-export const HomeScreen = compose(withAuth)(BaseHomeScreen);
+export const HomeScreen = compose(withPatient(compose(withAuth)(BaseHomeScreen)));


### PR DESCRIPTION
### Changes

There were some changes to the backend navigation logic that caused some weird behaviour with the patient state. The patient search now sits in the patients tab which will conditionally render either a patient record or a search based on if a selected patient is present in state. This means that if you click "Search for patients" when a patient is in state, it will just navigate to that patient record and confuse the user. To get around this we now clear the state when the user presses that search button

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
