### PR TITLE
fix(web): Select parameter field bug

### DIFF
--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -290,22 +290,17 @@ export const ReportGeneratorForm = () => {
             <>
               <Spacer />
               <FormGrid columns={3}>
-                {parameters.map(
-                  ({ parameterField, required, name, label, ...restOfProps }) => {
-                    delete restOfProps.options;
-                    return (
-                      <ParameterField
-                        key={name || parameterField}
-                        required={required}
-                        name={name}
-                        label={label}
-                        parameterValues={values}
-                        parameterField={parameterField}
-                        {...restOfProps}
-                      />
-                    );
-                  },
-                )}
+                {parameters.map(({ parameterField, required, name, label, ...restOfProps }) => (
+                  <ParameterField
+                    key={name || parameterField}
+                    required={required}
+                    name={name}
+                    label={label}
+                    parameterValues={values}
+                    parameterField={parameterField}
+                    {...restOfProps}
+                  />
+                ))}
               </FormGrid>
             </>
           ) : null}


### PR DESCRIPTION
### Changes

This was quite interesting. At some point between 1.38 and 2.1, we decided to destructure options and not supply it to the parameter field. I believe this means that no options for report parameter fields should have worked since this change. Felix came through and altered the format for linting purposes but in reality it should just never be destructured.


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
