### PR TITLE
repo: add `merge:` conventional type

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -25,7 +25,7 @@ jobs:
       if: always()
       shell: bash
       run: |
-        if ! grep -qP '^(ci|config|db|deps|doc|feat|fix|fmt|refactor|release|repo|revert|style|test|tweak)(\(\w+\))?:\s' <<< "$PR_TITLE"; then
+        if ! grep -qP '^(ci|config|db|deps|doc|feat|fix|fmt|merge|refactor|release|repo|revert|style|test|tweak)(\(\w+\))?:\s' <<< "$PR_TITLE"; then
           echo "::warning::PR title Conventional Type is not on the list; refer to CONTRIBUTING.md"
           exit 1
         fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,7 @@ The following types are conventional:
 - `feat` for new features
 - `fix` for bug fixes
 - `fmt` for automatic formatting changes (ignored in changelogs)
+- `merge` for merging between branches (generally between `main` and `release/*`)
 - `refactor` for code refactoring
 - `release` for changes that are part of the release process (generally automated commits, not manual use)
 - `repo` for changes to the repository structure, or for config/dotfiles (e.g. `.gitignore`, `.editorconfig`, etc)


### PR DESCRIPTION
### Changes

Adds the `merge:` conventional type for merging between branches.

### Checklist

- [x] Code is finished