### PR TITLE
fix(docker): KAM-126: Serve web on all interfaces

### DIFF
--- a/packages/web/Caddyfile.docker
+++ b/packages/web/Caddyfile.docker
@@ -2,8 +2,8 @@
 	root * /app
 	encode zstd gzip
 	log {
-    output stderr
-  }
+		output stderr
+	}
 
 	file_server {
 		precompressed zstd br gzip

--- a/packages/web/Caddyfile.docker
+++ b/packages/web/Caddyfile.docker
@@ -1,7 +1,9 @@
-http://localhost:3000 {
+:3000 {
 	root * /app
 	encode zstd gzip
-	log
+	log {
+    output stderr
+  }
 
 	file_server {
 		precompressed zstd br gzip


### PR DESCRIPTION
### Changes

Fixes a misconfiguration of the web container. No idea how it works in ECS, it shouldn't... but anyway, this fix is required for K8S.
