### PR TITLE
fix(vaccines): NASS-1164: immunisation certificate displays logged in facility

### DIFF
--- a/packages/central-server/__tests__/patientCertificate.test.js
+++ b/packages/central-server/__tests__/patientCertificate.test.js
@@ -191,6 +191,7 @@ describe('Certificate', () => {
       patientRecord,
       printedBy,
       printedAt,
+      'test facility',
       models,
       'TEST UVCI',
       [{ foo: 'bar' }],

--- a/packages/central-server/app/subCommands/generateVaccineCertificate.js
+++ b/packages/central-server/app/subCommands/generateVaccineCertificate.js
@@ -10,7 +10,7 @@ export const generateCertificate = async ({ patientId }) => {
   try {
     const patient = await Patient.findByPk(patientId);
     log.info(`Generating vaccine certificate for patient id "${patientId}"`);
-    const pdf = await makeVaccineCertificate(patient, 'Admin', store.models, 'uvci123');
+    const pdf = await makeVaccineCertificate(patient, 'Admin', null, store.models);
     log.info(`Certificate output: `, pdf);
   } catch (error) {
     process.stderr.write(`Report failed: ${error.stack}\n`);

--- a/packages/central-server/app/tasks/CertificateNotificationProcessor/index.js
+++ b/packages/central-server/app/tasks/CertificateNotificationProcessor/index.js
@@ -74,6 +74,7 @@ export class CertificateNotificationProcessor extends ScheduledTask {
         const type = notification.get('type');
         const printedBy = notification.get('createdBy');
         const printedDate = notification.get('printedDate');
+        const facilityName = notification.get('facilityName');
 
         const { country } = await getLocalisation();
         const countryCode = country['alpha-2'];
@@ -188,7 +189,13 @@ export class CertificateNotificationProcessor extends ScheduledTask {
 
           case VACCINATION_CERTIFICATE:
             template = 'vaccineCertificateEmail';
-            pdf = await makeVaccineCertificate(patient, printedBy, printedDate, models);
+            pdf = await makeVaccineCertificate(
+              patient,
+              printedBy,
+              printedDate,
+              facilityName,
+              models,
+            );
             break;
 
           default:

--- a/packages/central-server/app/utils/makePatientCertificate.jsx
+++ b/packages/central-server/app/utils/makePatientCertificate.jsx
@@ -101,7 +101,13 @@ export const makeCovidVaccineCertificate = async (
   );
 };
 
-export const makeVaccineCertificate = async (patient, printedBy, printedDate, models) => {
+export const makeVaccineCertificate = async (
+  patient,
+  printedBy,
+  printedDate,
+  facilityName,
+  models,
+) => {
   const localisation = await getLocalisation();
   const getLocalisationData = key => get(localisation, key);
 
@@ -118,6 +124,7 @@ export const makeVaccineCertificate = async (patient, printedBy, printedDate, mo
       printedBy={printedBy}
       printedDate={printedDate}
       vaccinations={vaccines}
+      facilityName={facilityName}
       signingSrc={signingImage}
       watermarkSrc={watermark}
       logoSrc={logo}

--- a/packages/shared/src/migrations/1708567454083-addFacilityNameToCertificateNotifications.js
+++ b/packages/shared/src/migrations/1708567454083-addFacilityNameToCertificateNotifications.js
@@ -1,0 +1,12 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('certificate_notifications', 'facility_name', {
+    type: DataTypes.STRING,
+    allowNull: true,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('certificate_notifications', 'facility_name');
+}

--- a/packages/shared/src/models/CertificateNotification.js
+++ b/packages/shared/src/models/CertificateNotification.js
@@ -11,6 +11,7 @@ export class CertificateNotification extends Model {
         id: primaryKey,
         createdBy: Sequelize.STRING,
         type: Sequelize.STRING,
+        facilityName: Sequelize.STRING,
         forwardAddress: Sequelize.STRING,
         requireSigning: Sequelize.BOOLEAN,
         status: Sequelize.STRING,

--- a/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
+++ b/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
@@ -85,6 +85,7 @@ export const VaccineCertificate = ({
   patient,
   printedBy,
   printedDate,
+  facilityName,
   vaccinations,
   certificateId,
   watermarkSrc,
@@ -116,7 +117,7 @@ export const VaccineCertificate = ({
         <Text style={vaccineCertificateStyles.labelText}>Print date: </Text>
         <Text style={vaccineCertificateStyles.valueText}>{getDisplayDate(printedDate)} | </Text>
         <Text style={vaccineCertificateStyles.labelText}>Printing facility: </Text>
-        <Text style={vaccineCertificateStyles.valueText}>{healthFacility} | </Text>
+        <Text style={vaccineCertificateStyles.valueText}>{facilityName || healthFacility} | </Text>
         <Text style={vaccineCertificateStyles.labelText}>Printed by: </Text>
         <Text style={vaccineCertificateStyles.valueText}>{printedBy}</Text>
       </View>

--- a/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
@@ -16,9 +16,11 @@ import {
 } from '../../../api/queries';
 
 import { PDFViewer, printPDF } from '../PDFViewer';
+import { useAuth } from '../../../contexts/Auth';
 
 export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) => {
   const api = useApi();
+  const { facility } = useAuth();
   const { getLocalisation } = useLocalisation();
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER,
@@ -45,10 +47,11 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
         requireSigning: false,
         patientId: patient.id,
         forwardAddress: data.email,
+        facilityName: facility.name,
         createdBy: printedBy,
         createdAt: getCurrentDateString(),
       }),
-    [api, patient.id, printedBy],
+    [api, patient.id, printedBy, facility.name],
   );
 
   const village = useReferenceData(patient.villageId).data;
@@ -73,6 +76,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
           vaccinations={vaccinations}
           watermarkSrc={watermark}
           logoSrc={logo}
+          facilityName={facility.name}
           signingSrc={footerImg}
           printedBy={printedBy}
           printedDate={getCurrentDateString()}


### PR DESCRIPTION
### Changes
Previously it displayed 'templates.vaccineCertificate.healthFacility'. I have left this as fallback in the case of generating using central server subcommand which doesn't have access to any facility id in config.
I had to add an extra column to certificate notification in the case of email certificates

cert now displays:
<img width="331" alt="Screenshot 2024-02-22 at 2 51 57 PM" src="https://github.com/beyondessential/tamanu/assets/38335330/2884177a-ee12-4ac9-913a-08095bb1bef9">

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
