### PR TITLE
db(migration): Use default value 0 instead of false

### DIFF
--- a/packages/mobile/App/migrations/1705264433000-addHideFromCertificateToScheduledVaccines.ts
+++ b/packages/mobile/App/migrations/1705264433000-addHideFromCertificateToScheduledVaccines.ts
@@ -11,7 +11,7 @@ export class addHideFromCertificateToScheduledVaccines1705264433000 implements M
         name: 'hideFromCertificate',
         isNullable: false,
         type: 'boolean',
-        default: false,
+        default: 0,
       }),
     );
   }


### PR DESCRIPTION
### Changes

This is needed for backward compatibility

https://www.sqlite.org/datatype3.html
2.1. Boolean Datatype
SQLite does not have a separate Boolean storage class. Instead, Boolean values are stored as integers 0 (false) and 1 (true).
SQLite recognizes the keywords "TRUE" and "FALSE", as of version 3.23.0 (2018-04-02) but those keywords are really just alternative spellings for the integer literals 1 and 0 respectively.