### PR TITLE
ci: build containers for arm64

### DIFF
--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -1,0 +1,86 @@
+name: CD Containers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+
+concurrency:
+  # only one build or destroy at a time, per PR/branch, but don't cancel existing runs
+  group: cd-${{ github.ref }}
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write # OIDC token for AWS
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: linux/amd64
+            runs-on: ubuntu-latest
+          - arch: linux/arm64
+            runs-on: macos-14
+        package:
+          - name: central
+            path: central-server
+            target: server
+          - name: facility
+            path: facility-server
+            target: server
+          - name: frontend
+            path: web
+            target: frontend
+          - name: meta
+            path: meta-server
+            target: server
+
+    name: Make ${{ matrix.platform.arch }} image for ${{ matrix.package.name }}
+    runs-on: ${{ matrix.platform.runs-on }}
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::143295493206:role/gha-image-push
+          role-session-name: GHA@Tamanu=BuildImage
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - uses: actions/checkout@v4
+
+      - if: matrix.platform.runs-on == 'macos-14-arm64'
+        uses: crazy-max/ghaction-setup-docker@v3
+        env:
+          LIMA_START_ARGS: --arch arm64
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: ${{ matrix.platform.arch }}
+          cache-from: type=gha,scope=${{ github.ref }}:${{ matrix.package.name }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref }}:${{ matrix.package.name }}
+          build-args: PACKAGE_PATH=${{ matrix.package.path }}
+          target: ${{ matrix.package.target }}
+          push: true
+          labels: |
+            org.opencontainers.image.vendor=BES
+            org.opencontainers.image.title=Tamanu ${{ matrix.package.name }}
+            org.opencontainers.image.url=https://www.bes.au/products/tamanu/
+            org.opencontainers.image.source=https://github.com/beyondessential/tamanu/
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.pull_request.merged_at || github.event.head_commit.timestamp }}
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package.name }}:sha-${{ github.sha }}
+    outputs:
+      tag: "sha-${{ github.sha }}"

--- a/.github/workflows/cd-containers.yml
+++ b/.github/workflows/cd-containers.yml
@@ -51,17 +51,17 @@ jobs:
           role-to-assume: arn:aws:iam::143295493206:role/gha-image-push
           role-session-name: GHA@Tamanu=BuildImage
 
+      - uses: actions/checkout@v4
+
+      - if: startsWith(matrix.platform.runs-on, 'macos')
+        run: |
+          brew install colima docker
+          colima start --arch arm64
+      - uses: docker/setup-buildx-action@v2
+
       - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-
-      - uses: actions/checkout@v4
-
-      - if: matrix.platform.runs-on == 'macos-14-arm64'
-        uses: crazy-max/ghaction-setup-docker@v3
-        env:
-          LIMA_START_ARGS: --arch arm64
-      - uses: docker/setup-buildx-action@v2
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/cd-server-package.yml
+++ b/.github/workflows/cd-server-package.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   info:
+    if: false
     name: Branch info
     uses: ./.github/workflows/branch-info.yml
 

--- a/.github/workflows/cd-web-package.yml
+++ b/.github/workflows/cd-web-package.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     name: Build web package
     steps:

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   test-for-non-determinism:
+    if: false
     permissions:
       id-token: write # allow accessing OIDC token for AWS
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   node_modules_cache:
+    if: false
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Changes

- Separate workflow just for building containers
- Use macos-14-arm64 runners to build Linux ARM64 images quickly
- Build the meta server too
- [ ] Rewrite Packaging and Up jobs to wait for the image becoming available and then using it

### Checklist

- [x] Code is finished