### PR TITLE
fix(programRegistries): TAN-2424: Bug displaying program forms

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -14,7 +14,7 @@ import { ViewPhotoLink } from '../../../../components/ViewPhotoLink';
 import { LoadingScreen } from '../../../../components/LoadingScreen';
 import { useBackendEffect } from '../../../../hooks';
 
-const AutocompleteAnswer = ({ question, answer }): ReactElement => {
+const AnswerFromBackend = ({ question, answer }): ReactElement => {
   const config = JSON.parse(question.config);
   const [refData, error] = useBackendEffect(
     ({ models }) => models[config.source].getRepository().findOne(answer),
@@ -74,15 +74,9 @@ const renderAnswer = (question, answer): ReactElement => {
     case FieldTypes.PHOTO:
       return <ViewPhotoLink imageId={answer} />;
     case FieldTypes.AUTOCOMPLETE:
-      return <AutocompleteAnswer question={question} answer={answer} />;
+    case FieldTypes.PATIENT_DATA:
+      return <AnswerFromBackend question={question} answer={answer} />;
     default:
-      if (question.config) {
-        const config = JSON.parse(question.config);
-        const { source, writeToPatient } = config;
-        if (source && writeToPatient?.fieldType === FieldTypes.AUTOCOMPLETE) {
-          return <AutocompleteAnswer question={question} answer={answer} />;
-        }
-      }
       return (
         <StyledText textAlign="right" color={theme.colors.TEXT_DARK}>
           {getAnswerText(question, answer)}

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -78,11 +78,8 @@ const renderAnswer = (question, answer): ReactElement => {
     default:
       if (question.config) {
         const config = JSON.parse(question.config);
-        const {
-          source,
-          writeToPatient: { fieldType },
-        } = config;
-        if (source && fieldType === FieldTypes.AUTOCOMPLETE) {
+        const { source, writeToPatient } = config;
+        if (source && writeToPatient?.fieldType === FieldTypes.AUTOCOMPLETE) {
           return <AutocompleteAnswer question={question} answer={answer} />;
         }
       }


### PR DESCRIPTION
### Changes

New rendering rules for filled-out forms assumed the presence of `writeToPatient`, where it may not exist, causing a crash.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
