### PR TITLE
fix(programRegistries): TAN-2423: Display name not id of ref data

### DIFF
--- a/packages/mobile/App/constants/surveys.ts
+++ b/packages/mobile/App/constants/surveys.ts
@@ -5,12 +5,12 @@ const makeLookupFields = (model: string, fields: string[]) =>
 // Please keep in sync with:
 // - @tamanu/constants/surveys.js
 export const PATIENT_DATA_FIELD_LOCATIONS = {
-  registrationClinicalStatus: ['PatientProgramRegistration', 'clinicalStatusId'],
-  programRegistrationStatus: ['PatientProgramRegistration', 'registrationStatus'],
-  registrationClinician: ['PatientProgramRegistration', 'clinicianId'],
-  registeringFacility: ['PatientProgramRegistration', 'registeringFacilityId'],
-  registrationCurrentlyAtVillage: ['PatientProgramRegistration', 'villageId'],
-  registrationCurrentlyAtFacility: ['PatientProgramRegistration', 'facilityId'],
+  registrationClinicalStatus: ['PatientProgramRegistration', 'clinicalStatusName'],
+  programRegistrationStatus: ['PatientProgramRegistration', 'registrationStatusName'],
+  registrationClinician: ['PatientProgramRegistration', 'clinicianName'],
+  registeringFacility: ['PatientProgramRegistration', 'registeringFacilityName'],
+  registrationCurrentlyAtVillage: ['PatientProgramRegistration', 'villageName'],
+  registrationCurrentlyAtFacility: ['PatientProgramRegistration', 'facilityName'],
   ...makeLookupFields('Patient', [
     'firstName',
     'middleName',

--- a/packages/mobile/App/models/PatientProgramRegistration.ts
+++ b/packages/mobile/App/models/PatientProgramRegistration.ts
@@ -123,20 +123,30 @@ export class PatientProgramRegistration extends BaseModel implements IPatientPro
     return mostRecentRegistrations;
   }
 
-  static async getFullPprById(id: string) {
+  static async getRegistrationForDisplay(id: string) {
     const registrationRepository = this.getRepository(PatientProgramRegistration);
-    const fullPpr = await registrationRepository
+    const registrationForDisplay = await registrationRepository
       .createQueryBuilder('registration')
       .where('registration.id = :id', { id })
-      .leftJoinAndSelect('registration.programRegistry', 'programRegistry')
-      .leftJoinAndSelect('registration.patient', 'patient')
-      .leftJoinAndSelect('registration.clinicalStatus', 'clinicalStatus')
-      .leftJoinAndSelect('registration.village', 'village')
-      .leftJoinAndSelect('registration.facility', 'facility')
-      .leftJoinAndSelect('registration.registeringFacility', 'registeringFacility')
-      .leftJoinAndSelect('registration.clinician', 'clinician')
-      .getOne();
-    return fullPpr;
+      .leftJoin('registration.programRegistry', 'programRegistry')
+      .leftJoin('registration.patient', 'patient')
+      .leftJoin('registration.clinicalStatus', 'clinicalStatus')
+      .leftJoin('registration.village', 'village')
+      .leftJoin('registration.facility', 'facility')
+      .leftJoin('registration.registeringFacility', 'registeringFacility')
+      .leftJoin('registration.clinician', 'clinician')
+      .select([
+        'registration.*',
+        'programRegistry.name as programRegistryName',
+        "patient.firstName || ' ' || patient.lastName as patientName",
+        'clinicalStatus.name as clinicalStatusName',
+        'village.name as villageName',
+        'facility.name as facilityName',
+        'registeringFacility.name as registeringFacilityName',
+        'clinician.displayName as clinicianName',
+      ])
+      .getRawOne();
+    return registrationForDisplay;
   }
 
   static async appendRegistration(

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistrationDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistrationDetails.tsx
@@ -73,12 +73,12 @@ export const PatientProgramRegistrationDetails = ({ route }) => {
         label="Date of registration"
         value={formatStringDate(patientProgramRegistration.date, DateFormats.DDMMYY)}
       />
-      <DataRow label="Registered by" value={patientProgramRegistration?.clinician?.displayName} />
+      <DataRow label="Registered by" value={patientProgramRegistration?.clinicianName} />
       <DataRow
         label="Registration facility"
-        value={patientProgramRegistration.registeringFacility?.name}
+        value={patientProgramRegistration.registeringFacilityName}
       />
-      <DataRow label="Status" value={patientProgramRegistration?.clinicalStatus?.name || '-'} />
+      <DataRow label="Status" value={patientProgramRegistration?.clinicalStatusName || '-'} />
       <DataRow
         label="Conditions"
         value={

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -14,7 +14,7 @@ import { ViewPhotoLink } from '../../../../components/ViewPhotoLink';
 import { LoadingScreen } from '../../../../components/LoadingScreen';
 import { useBackendEffect } from '../../../../hooks';
 
-const AutocompleteAnswer = ({ question, answer }): ReactElement => {
+const AnswerFromBackend = ({ question, answer }): ReactElement => {
   const config = JSON.parse(question.config);
   const [refData, error] = useBackendEffect(
     ({ models }) => models[config.source].getRepository().findOne(answer),
@@ -74,15 +74,9 @@ const renderAnswer = (question, answer): ReactElement => {
     case FieldTypes.PHOTO:
       return <ViewPhotoLink imageId={answer} />;
     case FieldTypes.AUTOCOMPLETE:
-      return <AutocompleteAnswer question={question} answer={answer} />;
+    case FieldTypes.PATIENT_DATA:
+      return <AnswerFromBackend question={question} answer={answer} />;
     default:
-      if (question.config) {
-        const config = JSON.parse(question.config);
-        const { source, writeToPatient } = config;
-        if (source && writeToPatient?.fieldType === FieldTypes.AUTOCOMPLETE) {
-          return <AutocompleteAnswer question={question} answer={answer} />;
-        }
-      }
       return (
         <StyledText textAlign="right" color={theme.colors.TEXT_DARK}>
           {getAnswerText(question, answer)}

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -78,11 +78,8 @@ const renderAnswer = (question, answer): ReactElement => {
     default:
       if (question.config) {
         const config = JSON.parse(question.config);
-        const {
-          source,
-          writeToPatient: { fieldType },
-        } = config;
-        if (source && fieldType === FieldTypes.AUTOCOMPLETE) {
+        const { source, writeToPatient } = config;
+        if (source && writeToPatient?.fieldType === FieldTypes.AUTOCOMPLETE) {
           return <AutocompleteAnswer question={question} answer={answer} />;
         }
       }

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseScreen.tsx
@@ -59,9 +59,21 @@ export const SurveyResponseScreen = ({ route }: SurveyResponseScreenProps): Reac
   );
 
   const [patientProgramRegistration, pprError, isPprLoading] = useBackendEffect(
-    ({ models }) => {
-      if (canReadRegistration === false) return null;
-      return models.PatientProgramRegistration.getRecentOne(survey?.programId, selectedPatient.id);
+    async ({ models }) => {
+      if (canReadRegistration === false) {
+        return null;
+      }
+
+      const registration = await models.PatientProgramRegistration.getRecentOne(
+        survey?.programId,
+        selectedPatient.id,
+      );
+
+      if (!registration) {
+        return null;
+      }
+
+      return models.PatientProgramRegistration.getRegistrationForDisplay(registration.id);
     },
     [survey],
   );

--- a/packages/mobile/App/ui/navigation/stacks/PatientProgramRegistrationDetailsStack.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/PatientProgramRegistrationDetailsStack.tsx
@@ -16,7 +16,9 @@ export const PatientProgramRegistrationDetailsStack = ({ navigation, route }: Ba
   const { patientProgramRegistration } = route.params;
   const [registration, registrationError, isRegistrationLoading] = useBackendEffect(
     async ({ models }) =>
-      await models.PatientProgramRegistration.getFullPprById(patientProgramRegistration.id),
+      await models.PatientProgramRegistration.getRegistrationForDisplay(
+        patientProgramRegistration.id,
+      ),
     [patientProgramRegistration.id],
   );
 
@@ -26,7 +28,7 @@ export const PatientProgramRegistrationDetailsStack = ({ navigation, route }: Ba
     <ErrorBoundary>
       <FullView>
         <EmptyStackHeader
-          title={registration?.programRegistry?.name}
+          title={registration?.programRegistryName}
           onGoBack={() => navigation.navigate(Routes.HomeStack.PatientSummaryStack.Index)}
           status={
             <PatientProgramRegistryRegistrationStatus


### PR DESCRIPTION
### Changes

Changes `getFullPprById` to `getRegistrationForDisplay`, and instead of returning nested objects representing clinician, village, etc., it just adds fields like `clinicianName`, `villageName`, etc.

This makes it work seamlessly when trying to show the name of the relevant reference data

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
