### PR TITLE
fix(forms): TAN-2497: Properly save form data

### DIFF
--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -221,7 +221,9 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
 
         const body = getStringValue(dataElement.type, value);
         // Don't create null answers
-        if (body === null) continue;
+        if (body === null) {
+          continue;
+        }
 
         setNote(`Attaching answer for ${dataElement.id}...`);
         const answerRecord = await SurveyResponseAnswer.createAndSaveOne({

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -219,13 +219,8 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
         }
         const { dataElement } = component;
 
-        if (isCalculated(dataElement.type) && value !== 0 && !value) {
-          // calculated values will always be in the answer object - but we
-          // shouldn't save null answers
-          continue;
-        }
-
         const body = getStringValue(dataElement.type, value);
+        // Don't create null answers
         if (body === null) continue;
 
         setNote(`Attaching answer for ${dataElement.id}...`);

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -226,6 +226,7 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
         }
 
         const body = getStringValue(dataElement.type, value);
+        if (body === null) continue;
 
         setNote(`Attaching answer for ${dataElement.id}...`);
         const answerRecord = await SurveyResponseAnswer.createAndSaveOne({

--- a/packages/mobile/App/ui/helpers/fields.ts
+++ b/packages/mobile/App/ui/helpers/fields.ts
@@ -45,6 +45,8 @@ export const getPatientDataDbLocation = fieldName => {
 };
 
 export const getStringValue = (type: string, value: any): string => {
+  if (value === null) return null;
+
   switch (type) {
     case FieldTypes.TEXT:
     case FieldTypes.MULTILINE:

--- a/packages/shared/src/migrations/1709161471775-updateSurveyResponseAnswersInvalidBody.js
+++ b/packages/shared/src/migrations/1709161471775-updateSurveyResponseAnswersInvalidBody.js
@@ -1,0 +1,12 @@
+export async function up(query) {
+  await query.sequelize.query(`
+    UPDATE survey_response_answers
+    SET body = ''
+    WHERE body = 'null'
+  `);
+}
+
+export async function down() {
+  // No down as is a data correction
+  return null;
+}

--- a/packages/shared/src/models/SurveyResponse.js
+++ b/packages/shared/src/models/SurveyResponse.js
@@ -294,9 +294,8 @@ export class SurveyResponse extends Model {
       }
       const body = getStringValue(dataElement.type, value);
       // Don't create null answers
-      if (body === null) {
-        continue;
-      }
+      if (body === null) continue;
+
       const answer = await models.SurveyResponseAnswer.create({
         dataElementId: dataElement.id,
         body,

--- a/packages/shared/src/models/SurveyResponse.js
+++ b/packages/shared/src/models/SurveyResponse.js
@@ -294,7 +294,9 @@ export class SurveyResponse extends Model {
       }
       const body = getStringValue(dataElement.type, value);
       // Don't create null answers
-      if (body === null) continue;
+      if (body === null) {
+        continue;
+      }
 
       const answer = await models.SurveyResponseAnswer.create({
         dataElementId: dataElement.id,


### PR DESCRIPTION
### Changes

Somehow this went undetected for a long time - we were creating a very weird survey response answer in mobile versions. With this change, we avoid creating answers with a `null` body (same logic than server), changed the code a bit so both look more similar and also migrates the bad data.

The last part I think should be fine because we shouldn't have that many anyway!