### PR TITLE
fix(mobile): NOTAM-300: show missing items on dark mode

### DIFF
--- a/packages/mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/mobile/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:datePickerDialogTheme">@style/Dialog.Theme</item>
     </style>

--- a/packages/mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/mobile/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
+    <!-- Use light theme to avoid Android changing the style when using dark mode -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:datePickerDialogTheme">@style/Dialog.Theme</item>


### PR DESCRIPTION
### Changes

We do not support dark mode yet, so this is just explicitly setting that so there are no surprises with the display