### PR TITLE
fix(fhir) SAV-541: Fix cherry pick conflict (2.1)

### DIFF
--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -14,7 +14,7 @@ import { fake } from '@tamanu/shared/test-helpers/fake';
 import { log } from '@tamanu/shared/services/logging';
 
 import { createTestContext } from '@tamanu/central-server/__tests__/utilities';
-import { allFromUpstream } from '../../../app/tasks/fhir/refresh/allFromUpstream';
+import { allFromUpstream } from '../../../dist/tasks/fhir/refresh/allFromUpstream';
 
 const COUNTRY_TIMEZONE = config?.countryTimeZone;
 

--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -363,7 +363,7 @@ describe('fijiAspenMediciReport', () => {
           end,
         )}`;
         const response = await app
-          .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+          .get(`/api/integration/fijiAspenMediciReport?${query}`)
           .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
         expect(response).toHaveSucceeded();
@@ -376,7 +376,7 @@ describe('fijiAspenMediciReport', () => {
         'nonexistant-id',
       ])}`;
       const response = await app
-        .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+        .get(`/api/integration/fijiAspenMediciReport?${query}`)
         .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
       expect(response).toHaveSucceeded();
@@ -389,7 +389,7 @@ describe('fijiAspenMediciReport', () => {
         'nonexistant-id',
       ])}`;
       const response = await app
-        .get(`/v1/integration/fijiAspenMediciReport?${query}`)
+        .get(`/api/integration/fijiAspenMediciReport?${query}`)
         .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
       expect(response).toHaveSucceeded();
@@ -399,7 +399,7 @@ describe('fijiAspenMediciReport', () => {
 
   it('should produce reports without any params', async () => {
     const response = await app
-      .get('/v1/integration/fijiAspenMediciReport')
+      .get('/api/integration/fijiAspenMediciReport')
       .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
     expect(response).toHaveSucceeded();
@@ -413,7 +413,7 @@ describe('fijiAspenMediciReport', () => {
     const isoStringRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/;
     // act
     const response = await app
-      .get('/v1/integration/fijiAspenMediciReport?period.start=2022-05-09&period.end=2022-10-09')
+      .get('/api/integration/fijiAspenMediciReport?period.start=2022-05-09&period.end=2022-10-09')
       .set({ 'X-Tamanu-Client': 'medici', 'X-Version': '0.0.1' });
 
     // assert

--- a/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
+++ b/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
@@ -8,7 +8,7 @@ import {
   fakeResourcesOfFhirServiceRequest,
   fakeResourcesOfFhirServiceRequestWithImagingRequest,
 } from '../fake/fhir';
-import { allFromUpstream } from '../../app/tasks/fhir/refresh/allFromUpstream';
+import { allFromUpstream } from '../../dist/tasks/fhir/refresh/allFromUpstream';
 
 describe('FHIR refresh handler', () => {
   let ctx;

--- a/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -98,7 +98,7 @@ routes.get(
       offset = 0,
     } = req.query;
     if (!COUNTRY_TIMEZONE) {
-      throw new Error('A countryTimeZone must be configured in local.json for this report to run');
+      throw new Error('A countryTimeZone must be configured in local.json5 for this report to run');
     }
 
     const data = await sequelize.query(reportQuery, {


### PR DESCRIPTION
When cherry picking SAV-541 from 1.36 to 2.1, there were a lot of restructured files so I made a few minor mistakes picking the wrong changes... This PR is to fix that conflicts. 

Don't think it actually affects anything as tests were still passing and the mistakes were only in test files, but still want to correct them to be on the safe side.