### PR TITLE
Fix: Revert api auth bearer change

### DIFF
--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -105,7 +105,7 @@ export class TamanuApi {
   }
 
   setToken(token) {
-    this.#authHeader = token ? { authorization: `Bearer ${token}` } : {};
+    this.#authHeader = { authorization: `Bearer ${token}` };
   }
 
   async fetch(endpoint, query = {}, config = {}) {


### PR DESCRIPTION
### Changes

There was a recent change to omit the Authorization header on api requests when there is no Api Token available. The original change was aimed at avoiding sending a `Bearer null` auth header. Unfortunately that creates a bunch of new auth headers so this PR is to roll back the change.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
