### PR TITLE
fix(mobile): Remove emitting at this point

### DIFF
--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -74,7 +74,6 @@ export class MobileSyncManager {
   setProgress(progress: number, progressMessage: string): void {
     this.progress = progress;
     this.progressMessage = progressMessage;
-    this.emitter.emit(SYNC_EVENT_ACTIONS.SYNC_STATE_CHANGED);
   }
 
   /**


### PR DESCRIPTION
### Changes

I noticed this while debugging other stuff. We are emitting this a lot of times on a sync and it seems too unnecessary, nothing is listening for it, plus it seems wrong because it's not a sync state change?