### PR TITLE
fix(programRegistries): TAN-2424: Use logic from web for PatientData fields

### DIFF
--- a/packages/mobile/App/ui/components/AutocompleteModal/AutocompleteModalField.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/AutocompleteModalField.tsx
@@ -9,6 +9,7 @@ import { Routes } from '~/ui/helpers/routes';
 import { TextFieldErrorMessage } from '/components/TextField/TextFieldErrorMessage';
 import { RequiredIndicator } from '../RequiredIndicator';
 import { SearchIcon } from '../Icons';
+import { ReadOnlyField } from '../ReadOnlyField/index';
 
 interface AutocompleteModalFieldProps {
   value?: string;
@@ -21,6 +22,7 @@ interface AutocompleteModalFieldProps {
   label?: string;
   required?: boolean;
   disabled?: boolean;
+  readOnly?: boolean;
 }
 
 export const AutocompleteModalField = ({
@@ -34,6 +36,7 @@ export const AutocompleteModalField = ({
   required,
   marginTop = 0,
   disabled = false,
+  readOnly = false,
 }: AutocompleteModalFieldProps): ReactElement => {
   const navigation = useNavigation();
   const [label, setLabel] = useState(null);
@@ -55,12 +58,16 @@ export const AutocompleteModalField = ({
       if (data) {
         setLabel(data.label);
       } else {
-        setLabel(placeholder);
+        setLabel(null);
       }
     })();
   }, [value]);
 
   const fontSize = screenPercentageToDP(2.1, Orientation.Height);
+
+  if (readOnly) {
+    return <ReadOnlyField value={label} />;
+  }
 
   return (
     <StyledView marginBottom={screenPercentageToDP('2.24', Orientation.Height)} width="100%">

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -13,12 +13,20 @@ interface SurveyQuestionProps {
   zIndex: number;
 }
 
-function getField(type: string, { writeToPatient: { fieldType = '' } = {} } = {}): Element {
+function getField(type: string, { writeToPatient: { fieldType = '' } = {}, source } = {}): Element {
   let field = FieldByType[type];
 
-  if (type === FieldTypes.PATIENT_DATA && fieldType) {
-    // PatientData specifically can overwrite field type if we are writing back to patient records
-    field = FieldByType[fieldType];
+  // see getComponentForQuestionType in web/app/utils/survey.jsx for source of the following logic
+  if (type === FieldTypes.PATIENT_DATA) {
+    if (fieldType) {
+      // PatientData specifically can overwrite field type if we are writing back to patient record
+      field = FieldByType[fieldType];
+    } else if (source) {
+      // we're displaying a relation, so use a disabled Autocomplete
+      // (using a standard field will just display the bare id)
+      const Autocomplete = FieldByType[FieldTypes.AUTOCOMPLETE];
+      field = props => <Autocomplete {...props} disabled />;
+    }
   }
   if (field || field === null) return field;
   return (): Element => <StyledText>{`No field type ${type}`}</StyledText>;

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { StyledText, StyledView } from '/styled/common';
-import { IPatient, ISurveyScreenComponent } from '~/types';
+import { IPatient, ISurveyScreenComponent, SurveyScreenConfig } from '~/types';
 import { Field } from '../FormField';
 import { FieldTypes } from '~/ui/helpers/fields';
 import { FieldByType } from '~/ui/helpers/fieldComponents';
@@ -13,7 +13,10 @@ interface SurveyQuestionProps {
   zIndex: number;
 }
 
-function getField(type: string, { writeToPatient: { fieldType = '' } = {}, source } = {}): Element {
+function getField(
+  type: string,
+  { writeToPatient: { fieldType = '' } = {}, source }: SurveyScreenConfig = {},
+): Element {
   let field = FieldByType[type];
 
   // see getComponentForQuestionType in web/app/utils/survey.jsx for source of the following logic
@@ -25,7 +28,7 @@ function getField(type: string, { writeToPatient: { fieldType = '' } = {}, sourc
       // we're displaying a relation, so use a disabled Autocomplete
       // (using a standard field will just display the bare id)
       const Autocomplete = FieldByType[FieldTypes.AUTOCOMPLETE];
-      field = props => <Autocomplete {...props} disabled />;
+      field = props => <Autocomplete {...props} readOnly />;
     }
   }
   if (field || field === null) return field;

--- a/packages/mobile/App/ui/components/ReadOnlyField/index.tsx
+++ b/packages/mobile/App/ui/components/ReadOnlyField/index.tsx
@@ -3,16 +3,16 @@ import { Orientation, screenPercentageToDP } from '~/ui/helpers/screen';
 import { StyledText } from '~/ui/styled/common';
 
 const getValueToDisplay = value => {
-  if(typeof value === "number") return value.toFixed(1);
-  if(!value) return 'N/A';
+  if (typeof value === 'number') return value.toFixed(1);
+  if (!value) return 'N/A';
   return value;
-}
+};
 
-export const ReadOnlyField = ({ name, value }: { name: string, value: any }) => {
+export const ReadOnlyField = ({ value }: { value: any }) => {
   const styleProps = {
     color: value ? '#000' : '#aaa',
     fontSize: screenPercentageToDP('2.2', Orientation.Height),
-  }
+  };
 
   return <StyledText {...styleProps}>{getValueToDisplay(value)}</StyledText>;
 };

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -67,8 +67,7 @@ function getAnswerText(question, answer): string | number {
   }
 }
 
-// Same discriminant logic used in getAutocompleteComponentMap
-// inside file packages/shared/src/reports/utilities/transformAnswers.js
+// Logic duplicated in packages/shared/src/reports/utilities/transformAnswers.js
 const isAutocomplete = ({ config, dataElement }) => dataElement.type === 'Autocomplete' ||
  (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete');
 

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -67,6 +67,8 @@ function getAnswerText(question, answer): string | number {
   }
 }
 
+// Same discriminant logic used in getAutocompleteComponentMap
+// inside file packages/shared/src/reports/utilities/transformAnswers.js
 const isAutocomplete = ({ config, dataElement }) => dataElement.type === 'Autocomplete' ||
  (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete');
 

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -67,7 +67,7 @@ function getAnswerText(question, answer): string | number {
   }
 }
 
-const isFromBackend = ({ config, dataElement }) => {
+const isFromBackend = ({ config, dataElement }): Boolean => {
   // all autocompletes have answers connected to the backend
   if (dataElement.type === FieldTypes.AUTOCOMPLETE) {
     return true;
@@ -89,6 +89,8 @@ const isFromBackend = ({ config, dataElement }) => {
       return true;
     }
   }
+
+  return false;
 };
 
 const renderAnswer = (question, answer): ReactElement => {

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -67,15 +67,17 @@ function getAnswerText(question, answer): string | number {
   }
 }
 
+const isAutocomplete = ({ config, dataElement }) => dataElement.type === 'Autocomplete' ||
+ (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete');
+
 const renderAnswer = (question, answer): ReactElement => {
+  if (isAutocomplete(question)) return <AnswerFromBackend question={question} answer={answer} />;
+
   switch (question.dataElement.type) {
     case FieldTypes.RESULT:
       return <SurveyResultBadge resultText={answer} />;
     case FieldTypes.PHOTO:
       return <ViewPhotoLink imageId={answer} />;
-    case FieldTypes.AUTOCOMPLETE:
-    case FieldTypes.PATIENT_DATA:
-      return <AnswerFromBackend question={question} answer={answer} />;
     default:
       return (
         <StyledText textAlign="right" color={theme.colors.TEXT_DARK}>

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -14,7 +14,7 @@ import { ViewPhotoLink } from '../../../../components/ViewPhotoLink';
 import { LoadingScreen } from '../../../../components/LoadingScreen';
 import { useBackendEffect } from '../../../../hooks';
 
-const AnswerFromBackend = ({ question, answer }): ReactElement => {
+const AutocompleteAnswer = ({ question, answer }): ReactElement => {
   const config = JSON.parse(question.config);
   const [refData, error] = useBackendEffect(
     ({ models }) => models[config.source].getRepository().findOne(answer),
@@ -72,7 +72,7 @@ const isAutocomplete = ({ config, dataElement }) => dataElement.type === 'Autoco
  (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete');
 
 const renderAnswer = (question, answer): ReactElement => {
-  if (isAutocomplete(question)) return <AnswerFromBackend question={question} answer={answer} />;
+  if (isAutocomplete(question)) return <AutocompleteAnswer question={question} answer={answer} />;
 
   switch (question.dataElement.type) {
     case FieldTypes.RESULT:

--- a/packages/shared/src/reports/utilities/transformAnswers.js
+++ b/packages/shared/src/reports/utilities/transformAnswers.js
@@ -58,16 +58,13 @@ export const getAnswerBody = async (models, componentConfig, type, answer, trans
   }
 };
 
+// Logic duplicated in packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+const isAutocomplete = ({ config, dataElement }) => dataElement.type === 'Autocomplete' ||
+ (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete');
+
 export const getAutocompleteComponentMap = surveyComponents => {
-  // There's a couple of components that use the "source" config option
-  // to specify foreign data for the question answers to link to,
-  // but we only want to transform the Autocomplete ones here (for now)
   const autocompleteComponents = surveyComponents
-    .filter(
-      ({ config, dataElement }) =>
-        dataElement.type === 'Autocomplete' ||
-        (config && JSON.parse(config).writeToPatient?.fieldType === 'Autocomplete'),
-    )
+    .filter(isAutocomplete)
     .map(({ dataElementId, config: componentConfig }) => [
       dataElementId,
       componentConfig ? JSON.parse(componentConfig) : {},


### PR DESCRIPTION
@NavarroEmilioLuis this copies the logic from desktop, and works almost perfectly

The display when you're filling out the survey is not so nice, as the disabled autocomplete on mobile is barely legible. We could create a different component instead - but gotta go catch a ferry!

<img width="284" alt="image" src="https://github.com/beyondessential/tamanu/assets/1274422/8e42755d-f845-4a56-9b83-4bcd3a5d852f">
