### PR TITLE
fix(patientPrinting): Fix discharge summary text

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
@@ -208,6 +208,7 @@ export const DischargeSummaryPrintout = ({
   getLocalisation,
 }) => {
   const { logo } = certificateData;
+  const clinicianText = getLocalisation('fields.clinician.shortLabel');
   const { diagnoses, procedures, medications } = encounter;
   const visibleDiagnoses = diagnoses.filter(
     ({ certainty }) => !DIAGNOSIS_CERTAINTIES_TO_HIDE.includes(certainty),
@@ -231,7 +232,11 @@ export const DischargeSummaryPrintout = ({
           <PatientDetailsWithAddress patient={patientData} getLocalisation={getLocalisation} />
         </SectionContainer>
         <SectionContainer>
-          <EncounterDetailsExtended encounter={encounter} discharge={discharge} />
+          <EncounterDetailsExtended
+            encounter={encounter}
+            discharge={discharge}
+            clinicianText={clinicianText}
+          />
         </SectionContainer>
         <SectionContainer>
           {patientConditions.length > 0 && (


### PR DESCRIPTION
### Changes

Fix/discharge summary text. Clinician text was not passed into to display component for patient discharge summary. A regression from last release when printouts were changed over to PDFs.

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
