### PR TITLE
fix: NASS-1173: Double clicking on the imaging record in the imaging side bar table throws an error

### DIFF
--- a/packages/web/app/components/ImagingRequestsTable.jsx
+++ b/packages/web/app/components/ImagingRequestsTable.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { push } from 'connected-react-router';
@@ -40,6 +40,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, memoryKey, status
   const imagingTypes = getLocalisation('imagingTypes') || {};
   const { searchParameters } = useImagingRequests(memoryKey);
   const isCompletedTable = memoryKey === IMAGING_TABLE_VERSIONS.COMPLETED.memoryKey;
+  const [isRowsDisabled, setIsRowsDisabled] = useState(false);
 
   const statusFilter = statuses.length > 0 ? { status: statuses } : {};
 
@@ -83,6 +84,8 @@ export const ImagingRequestsTable = React.memo(({ encounterId, memoryKey, status
 
   const selectImagingRequest = useCallback(
     async imagingRequest => {
+      if (isRowsDisabled) return;
+      setIsRowsDisabled(true);
       const { encounter } = imagingRequest;
       const patientId = params.patientId || encounter.patient.id;
       if (encounter) {
@@ -97,8 +100,9 @@ export const ImagingRequestsTable = React.memo(({ encounterId, memoryKey, status
             encounter.id}/imaging-request/${imagingRequest.id}`,
         ),
       );
+      setIsRowsDisabled(false);
     },
-    [loadEncounter, dispatch, params.patientId, params.category, encounterId],
+    [loadEncounter, dispatch, params.patientId, params.category, encounterId, isRowsDisabled],
   );
 
   const globalImagingRequestsFetchOptions = { ...statusFilter, ...searchParameters };
@@ -116,6 +120,7 @@ export const ImagingRequestsTable = React.memo(({ encounterId, memoryKey, status
         order: 'desc',
         orderBy: isCompletedTable ? 'completedAt' : 'requestedDate',
       }}
+      isRowsDisabled={isRowsDisabled}
     />
   );
 });

--- a/packages/web/app/components/Table/DataFetchingTable.jsx
+++ b/packages/web/app/components/Table/DataFetchingTable.jsx
@@ -301,7 +301,12 @@ export const DataFetchingTable = memo(
           orderBy={orderBy}
           rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
           refreshTable={refreshTable}
-          rowStyle={row => (row.highlighted ? 'background-color: #F0FFF0;' : '')}
+          rowStyle={row => {
+            const rowStyle = [];
+            if (row.highlighted) rowStyle.push("background-color: #F0FFF0;");
+            if (props.isRowsDisabled) rowStyle.push("cursor: not-allowed;");
+            return rowStyle.join("");
+          }}
           lazyLoading={lazyLoading}
           ref={tableRef}
           {...props}

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -183,12 +183,12 @@ const ImagingResultRow = ({ result }) => {
 };
 
 const ImagingResultsSection = ({ results }) => {
-  if (results.length === 0) return null;
+  if (results?.length === 0) return null;
 
   return (
     <>
       <h3>Results</h3>
-      {results.map(result => (
+      {results?.map(result => (
         <ImagingResultRow key={result.id} result={result} />
       ))}
     </>
@@ -231,7 +231,7 @@ const ImagingRequestInfoPane = React.memo(({ imagingRequest, onSubmit }) => {
           <>
             <ImagingRequestSection currentStatus={values.status} imagingRequest={imagingRequest} />
             <ImagingResultsSection results={imagingRequest.results} />
-            <h4>{imagingRequest.results.length > 0 ? 'Add additional result' : 'Add result'}</h4>
+            <h4>{imagingRequest.results?.length > 0 ? 'Add additional result' : 'Add result'}</h4>
             <NewResultSection disabled={!canAddResult} />
             <ButtonRow style={{ marginTop: 20 }}>
               {!isCancelled && <FormSubmitButton text="Save" />}

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -263,7 +263,7 @@ export const ImagingRequestView = () => {
     IMAGING_REQUEST_STATUS_TYPES.COMPLETED,
   ].includes(imagingRequest.status);
 
-  if (patient.loading) return <LoadingIndicator />;
+  if (patient.loading || imagingRequest.loading) return <LoadingIndicator />;
 
   return (
     <>


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
