### PR TITLE
fix(programRegistries): TAN-2498: Properly go back after submitting form in mobile

### DIFF
--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -68,7 +68,7 @@ const getFieldsToWrite = (questions, answers): RecordValuesByModel => {
  * DUPLICATED IN shared/models/SurveyResponse.js
  * Please keep in sync
  */
-async function writeToPatientFields(questions, answers, patientId, surveyId, submittedTime) {
+async function writeToPatientFields(questions, answers, patientId, surveyId, userId, submittedTime) {
   const valuesByModel = getFieldsToWrite(questions, answers);
 
   if (valuesByModel.Patient) {
@@ -90,7 +90,11 @@ async function writeToPatientFields(questions, answers, patientId, surveyId, sub
     await PatientProgramRegistration.appendRegistration(
       patientId,
       programRegistryId,
-      { date: submittedTime, ...valuesByModel.PatientProgramRegistration },
+      {
+        date: submittedTime,
+        ...valuesByModel.PatientProgramRegistration,
+        clinicianId: valuesByModel.PatientProgramRegistration.clinicianId || userId,
+      },
     );
   }
 }
@@ -248,6 +252,7 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
         finalValues,
         patientId,
         surveyId,
+        userId,
         responseRecord.endTime,
       );
 

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -82,7 +82,7 @@ async function writeToPatientFields(questions, answers, patientId, surveyId, sub
   if (valuesByModel.PatientProgramRegistration) {
     const { programId } = await Survey.findOne({ id: surveyId });
     const { id: programRegistryId } = await ProgramRegistry.findOne({
-      where: { programId, visibilityStatus: VisibilityStatus.Current },
+      where: { program: { id: programId }, visibilityStatus: VisibilityStatus.Current },
     });
     if (!programRegistryId) {
       throw new Error('No program registry configured for the current form');


### PR DESCRIPTION
### Changes

Okay so this problem only happened for program registry related forms - the reason being that the code was getting blocked when trying to create a patient program registration.

This happened because:
- Wrong TypeORM synxtax
- Clinician ID is non nullable