### PR TITLE
fix(mediciReport): SAV-579: Only send latest note and include note Ids (Hotfix 1.36)

### DIFF
--- a/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
+++ b/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
@@ -150,21 +150,35 @@ imaging_info as (
   group by encounter_id
 ),
 
+encounter_notes AS (
+  SELECT 
+    *,
+    CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END edit_chain
+  FROM notes n
+  WHERE record_type = 'Encounter'
+),
+
 -- Note this will include non-encounter notes - but they won't join anywhere because we use uuids
-encounter_notes_info as (
+latest_encounter_notes_info as (
   select
     record_id encounter_id,
     json_agg(
       json_build_object(
+        'revisedById', edit_chain,
         'noteType', note_type,
         'content', "content",
         'noteDate', "date"::timestamp at time zone $timezone_string
       ) order by n.date desc
     ) "Notes"
-  from notes n
+  from (
+    SELECT DISTINCT ON (edit_chain)
+    *
+    FROM encounter_notes n
+    ORDER BY edit_chain, date DESC
+  ) n
   where note_type != 'system'
   and record_id = $encounter_id
-  group by record_id
+  group by n.record_id
 ),
 
 department_info as (
@@ -318,7 +332,7 @@ left join diagnosis_info di on e.id = di.encounter_id
 left join procedure_info pi on e.id = pi.encounter_id
 left join lab_request_info lri on lri.encounter_id = e.id
 left join imaging_info ii on ii.encounter_id = e.id
-left join encounter_notes_info ni on ni.encounter_id = e.id
+left join latest_encounter_notes_info ni on ni.encounter_id = e.id
 left join triages t on t.encounter_id = e.id
 left join triage_info ti on ti.encounter_id = e.id
 left join location_info li on li.encounter_id = e.id

--- a/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
+++ b/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
@@ -9,6 +9,7 @@ notes_info as (
     record_id,
     json_agg(
       json_build_object(
+        'revisedById', id,
         'noteType', note_type,
         'content', "content",
         'noteDate', "date"::timestamp at time zone $timezone_string

--- a/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
+++ b/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
@@ -150,15 +150,15 @@ imaging_info as (
   group by encounter_id
 ),
 
+-- select encounter notes and also the provide the edit chain of the notes
 encounter_notes AS (
   SELECT 
     *,
-    CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END edit_chain
+    CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END edit_chain -- assign edit_chain with the id of itself if it is the root note
   FROM notes n
   WHERE record_type = 'Encounter'
 ),
 
--- Note this will include non-encounter notes - but they won't join anywhere because we use uuids
 latest_encounter_notes_info as (
   select
     record_id encounter_id,

--- a/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
+++ b/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
@@ -156,7 +156,7 @@ encounter_notes AS (
     *,
     CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END edit_chain -- assign edit_chain with the id of itself if it is the root note
   FROM notes n
-  WHERE record_type = 'Encounter'
+  WHERE record_id = $encounter_id
 ),
 
 latest_encounter_notes_info as (

--- a/packages/sync-server/__tests__/hl7fhir/materialised/MediciReport.test.js
+++ b/packages/sync-server/__tests__/hl7fhir/materialised/MediciReport.test.js
@@ -1,6 +1,12 @@
+import { sub } from 'date-fns';
 import { fake } from '@tamanu/shared/test-helpers';
 import { chance } from '@tamanu/shared/test-helpers';
-import { IMAGING_REQUEST_STATUS_TYPES, REFERENCE_TYPES } from '@tamanu/constants';
+import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
+import {
+  IMAGING_REQUEST_STATUS_TYPES,
+  REFERENCE_TYPES,
+  NOTE_RECORD_TYPES,
+} from '@tamanu/constants';
 
 import { createTestContext } from '../../utilities';
 
@@ -64,7 +70,7 @@ describe(`Materialised - MediciReport`, () => {
       Procedure,
       EncounterDiagnosis,
       EncounterMedication,
-      AdministeredVaccine,
+      Note,
     } = ctx.store.models;
 
     const startDate = '2023-11-11 00:00:00';
@@ -108,7 +114,7 @@ describe(`Materialised - MediciReport`, () => {
       type: 'labTestMethod',
       code: 'RDT',
     });
-    const labTest = await LabTest.create({
+    await LabTest.create({
       ...fake(LabTest),
       labTestTypeId: labTestType.id,
       labRequestId: labRequest.id,
@@ -126,11 +132,15 @@ describe(`Materialised - MediciReport`, () => {
         status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
         priority: 'routine',
         requestedDate: '2022-03-04 15:30:00',
+        imagingType: 'vascularStudy',
       }),
     );
 
     const procedureType = await ReferenceData.create(
-      fake(ReferenceData, { type: REFERENCE_TYPES.PROCEDURE_TYPE, name: 'Glucose (hypertonic) 5%' }),
+      fake(ReferenceData, {
+        type: REFERENCE_TYPES.PROCEDURE_TYPE,
+        name: 'Glucose (hypertonic) 5%',
+      }),
     );
     const procedure = await Procedure.create({
       ...fake(Procedure),
@@ -146,6 +156,7 @@ describe(`Materialised - MediciReport`, () => {
     });
     const encounterDiagnosis = await EncounterDiagnosis.create({
       ...fake(EncounterDiagnosis),
+      isPrimary: false,
       encounterId: encounter.id,
       diagnosisId: diagnosis.id,
     });
@@ -157,13 +168,36 @@ describe(`Materialised - MediciReport`, () => {
       ...fake(EncounterMedication),
       encounterId: encounter.id,
       medicationId,
+      discontinued: false,
     });
 
-    return { encounter, encounterDiagnosis, encounterMedication, procedure, procedureType };
+    const rootNote = await Note.create(
+      fake(Note, {
+        recordId: encounter.id,
+        recordType: NOTE_RECORD_TYPES.ENCOUNTER,
+        content: 'Root note',
+        authorId: resources.practitioner.id,
+        date: toDateTimeString(sub(new Date(), { days: 8 })),
+      }),
+    );
+
+    return {
+      encounter,
+      encounterDiagnosis,
+      encounterMedication,
+      procedure,
+      procedureType,
+      rootNote,
+    };
   }
 
   it('materialise a Medici report', async () => {
-    const { encounter, encounterDiagnosis, encounterMedication, procedureType } = await makeEncounter({
+    const {
+      encounter,
+      encounterDiagnosis,
+      encounterMedication,
+      procedureType,
+    } = await makeEncounter({
       encounterType: 'emergency',
     });
 
@@ -238,6 +272,72 @@ describe(`Materialised - MediciReport`, () => {
           ],
         },
       ],
+    });
+  });
+
+  describe('materialise Notes in Medici Report', () => {
+    it('returns root encounter note if it has not been edited', async () => {
+      const {
+        encounter,
+        rootNote,
+      } = await makeEncounter({
+        encounterType: 'emergency',
+      });
+
+      const { MediciReport } = ctx.store.models;
+
+      await MediciReport.materialiseFromUpstream(encounter.id);
+      await MediciReport.resolveUpstreams();
+
+      const mediciReport = await MediciReport.findAll();
+
+      expect(mediciReport[0].dataValues).toMatchObject({
+        notes: [
+          {
+            content: rootNote.content,
+            noteType: rootNote.noteType,
+            revisedById: rootNote.id,
+          },
+        ],
+      });
+    });
+
+    it('returns latest encounter note if it has been edited', async () => {
+      const { Note } = ctx.store.models;
+      const {
+        encounter,
+        rootNote,
+      } = await makeEncounter({
+        encounterType: 'emergency',
+      });
+
+      const changelog1 = await Note.create(
+        fake(Note, {
+          recordId: encounter.id,
+          recordType: NOTE_RECORD_TYPES.ENCOUNTER,
+          content: 'Changelog1',
+          authorId: resources.practitioner.id,
+          date: toDateTimeString(sub(new Date(), { days: 6 })),
+          revisedById: rootNote.id,
+        }),
+      );
+
+      const { MediciReport } = ctx.store.models;
+
+      await MediciReport.materialiseFromUpstream(encounter.id);
+      await MediciReport.resolveUpstreams();
+
+      const mediciReport = await MediciReport.findAll();
+
+      expect(mediciReport[0].dataValues).toMatchObject({
+        notes: [
+          {
+            content: changelog1.content,
+            noteType: changelog1.noteType,
+            revisedById: changelog1.revisedById,
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -252,7 +252,7 @@ const fakeAllData = async (models, ctx) => {
       areaId: rightImagingAreaId,
     }),
   );
-  await models.Note.create(
+  const imagingRequestNote = await models.Note.create(
     fake(models.Note, {
       recordId: imagingRequestId,
       noteType: NOTE_TYPES.OTHER,
@@ -266,7 +266,7 @@ const fakeAllData = async (models, ctx) => {
     fake(models.LabRequest, { encounterId }),
   );
   await models.LabTest.create(fake(models.LabTest, { labRequestId, labTestTypeId }));
-  await models.Note.create(
+  const labRequestNote = await models.Note.create(
     fake(models.Note, {
       recordId: labRequestId,
       noteType: NOTE_TYPES.OTHER,
@@ -325,7 +325,7 @@ const fakeAllData = async (models, ctx) => {
     lastUpdated: new Date(Date.UTC(2022, 6 - 1, 12, 0, 2, 54, 225)),
   });
 
-  return { patient, encounterId, encounterNote };
+  return { patient, encounterId, encounterNote, imagingRequestNote, labRequestNote };
 };
 
 describe('fijiAspenMediciReport', () => {
@@ -538,6 +538,7 @@ describe('fijiAspenMediciReport', () => {
                 noteType: NOTE_TYPES.OTHER,
                 content: 'Please perform this lab test very carefully',
                 noteDate: '2022-06-09T02:04:54+00:00',
+                revisedById: fakedata.labRequestNote.id,
               },
             ],
           },
@@ -551,6 +552,7 @@ describe('fijiAspenMediciReport', () => {
                 noteType: 'other',
                 content: 'Check for fractured knees please',
                 noteDate: '2022-06-10T06:04:54+00:00',
+                revisedById: fakedata.imagingRequestNote.id,
               },
             ],
           },

--- a/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/sync-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -284,7 +284,7 @@ const fakeAllData = async (models, ctx) => {
     }),
   );
 
-  await models.Note.create(
+  const encounterNote = await models.Note.create(
     fake(models.Note, {
       recordId: encounterId,
       noteType: NOTE_TYPES.NURSING,
@@ -325,7 +325,7 @@ const fakeAllData = async (models, ctx) => {
     lastUpdated: new Date(Date.UTC(2022, 6 - 1, 12, 0, 2, 54, 225)),
   });
 
-  return { patient, encounterId };
+  return { patient, encounterId, encounterNote };
 };
 
 describe('fijiAspenMediciReport', () => {
@@ -560,6 +560,7 @@ describe('fijiAspenMediciReport', () => {
             noteType: NOTE_TYPES.NURSING,
             content: 'A\nB\nC\nD\nE\nF\nG\n',
             noteDate: '2022-06-10T03:39:57+00:00',
+            revisedById: fakedata.encounterNote.id,
           },
         ],
       },


### PR DESCRIPTION
### Changes
- Only send latest note and include note Ids

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
