### PR TITLE
style(mobile): Fix linting stuff

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,7 +77,14 @@ export default [
     files: [`packages/mobile/**/*.${TS_EXTS}`],
     rules: {
       'no-unused-vars': 'off',
-      "@typescript-eslint/no-unused-vars": 'error',
+      "@typescript-eslint/no-unused-vars": [
+        'error',
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_",
+        },
+      ],
       'no-constructor-return': 'warn',
       'no-promise-executor-return': 'warn',
       'require-atomic-updates': 'warn',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,7 +77,7 @@ export default [
     files: [`packages/mobile/**/*.${TS_EXTS}`],
     rules: {
       'no-unused-vars': 'off',
-      "@typescript-eslint/no-unused-vars": 'warn',
+      "@typescript-eslint/no-unused-vars": 'error',
       'no-constructor-return': 'warn',
       'no-promise-executor-return': 'warn',
       'require-atomic-updates': 'warn',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,7 +76,8 @@ export default [
     // mobile rule exclusions (as warnings, until we fix them)
     files: [`packages/mobile/**/*.${TS_EXTS}`],
     rules: {
-      'no-unused-vars': 'warn',
+      'no-unused-vars': 'off',
+      "@typescript-eslint/no-unused-vars": 'warn',
       'no-constructor-return': 'warn',
       'no-promise-executor-return': 'warn',
       'require-atomic-updates': 'warn',

--- a/packages/mobile/App/migrations/1661160427226-databaseSetup.ts
+++ b/packages/mobile/App/migrations/1661160427226-databaseSetup.ts
@@ -22,6 +22,7 @@ export class databaseSetup1661160427226 implements MigrationInterface {
     }
   }
 
-  async down(queryRunner: QueryRunner): Promise<void> {
+  async down(): Promise<void> {
+    // No down migration as this is the initial setup
   }
 }

--- a/packages/mobile/App/migrations/1675907161000-wipeAllDataAndResync.ts
+++ b/packages/mobile/App/migrations/1675907161000-wipeAllDataAndResync.ts
@@ -103,7 +103,7 @@ export class wipeAllDataAndResync1675907161000 implements MigrationInterface {
     }
   }
 
-  async down(queryRunner: QueryRunner): Promise<void> {
+  async down(): Promise<void> {
     // Unable to revert this migration
   }
 }

--- a/packages/mobile/App/migrations/1682923186000-addConsentGivenByToAdministeredVaccine.ts
+++ b/packages/mobile/App/migrations/1682923186000-addConsentGivenByToAdministeredVaccine.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 import { getTable } from './utils/queryRunner';
 
 const tableName = 'administered_vaccine';

--- a/packages/mobile/App/migrations/1688950151000-migrateNotePagesToNotes.ts
+++ b/packages/mobile/App/migrations/1688950151000-migrateNotePagesToNotes.ts
@@ -3,9 +3,6 @@ import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey, T
 const ISO9075_DATE_FORMAT = 'YYYY-MM-DD';
 const ISO9075_DATE_FORMAT_LENGTH = ISO9075_DATE_FORMAT.length;
 
-const ISO9075_FORMAT = 'YYYY-MM-DD HH:mm:ss';
-const ISO9075_FORMAT_LENGTH = ISO9075_FORMAT.length;
-
 const baseIndex = new TableIndex({
   columnNames: ['updatedAtSyncTick'],
 });

--- a/packages/mobile/App/migrations/1694090332843-addPatientCustomFieldsTables.ts
+++ b/packages/mobile/App/migrations/1694090332843-addPatientCustomFieldsTables.ts
@@ -1,11 +1,5 @@
 import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
 
-const ISO9075_DATE_FORMAT = 'YYYY-MM-DD';
-const ISO9075_DATE_FORMAT_LENGTH = ISO9075_DATE_FORMAT.length;
-
-const ISO9075_FORMAT = 'YYYY-MM-DD HH:mm:ss';
-const ISO9075_FORMAT_LENGTH = ISO9075_FORMAT.length;
-
 const baseIndex = new TableIndex({
   columnNames: ['updatedAtSyncTick'],
 });

--- a/packages/mobile/App/migrations/utils/dateTime.ts
+++ b/packages/mobile/App/migrations/utils/dateTime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // This file is the typeORM equivalent to the same utility in shared-src/migrations
 //
 // THESE FUNCTIONS ARE TEMPLATES, COPY PASTE THEM TO YOUR MIGRATION

--- a/packages/mobile/App/models/AdministeredVaccine.ts
+++ b/packages/mobile/App/models/AdministeredVaccine.ts
@@ -1,4 +1,4 @@
-import { BeforeInsert, BeforeUpdate, Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
+import { Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
 import { BaseModel, IdRelation } from './BaseModel';
 import { IAdministeredVaccine, InjectionSiteType } from '~/types';
 import { SYNC_DIRECTIONS } from './types';

--- a/packages/mobile/App/models/BaseModel.ts
+++ b/packages/mobile/App/models/BaseModel.ts
@@ -5,9 +5,6 @@ export type ModelPojo = {
   id: string;
 };
 
-// https://stackoverflow.com/questions/54281631/is-it-possible-to-get-instancetypet-to-work-on-an-abstract-class
-type AbstractInstanceType<T> = T extends { prototype: infer U } ? U : never;
-
 // This is used instead of @RelationId provided by typeorm, because
 // typeorm's @RelationId causes a O(n^2) operation for every query to that model.
 export const IdRelation = (options = {}): any => Column({ nullable: true, ...options });

--- a/packages/mobile/App/models/Encounter.spec.ts
+++ b/packages/mobile/App/models/Encounter.spec.ts
@@ -1,5 +1,5 @@
 import { Database } from '~/infra/db';
-import { createWithRelations, fake, fakeEncounter, fakePatient, fakeUser } from '/root/tests/helpers/fake';
+import { fakeEncounter, fakePatient, fakeUser } from '/root/tests/helpers/fake';
 
 beforeAll(async () => {
   await Database.connect();
@@ -20,8 +20,8 @@ describe('Encounter', () => {
       await Database.models.Encounter.insert(encounter);
 
       const result = await Database.models.Encounter.getForPatient(patient.id);
-      const { examiner, ...expectedResult } = encounter; // examiner is not eager-loaded from db
-      expect(result[0]).toMatchObject(expectedResult);
+      delete encounter.examiner;
+      expect(result[0]).toMatchObject(encounter);
     });
   });
 });

--- a/packages/mobile/App/models/Encounter.spec.ts
+++ b/packages/mobile/App/models/Encounter.spec.ts
@@ -20,7 +20,7 @@ describe('Encounter', () => {
       await Database.models.Encounter.insert(encounter);
 
       const result = await Database.models.Encounter.getForPatient(patient.id);
-      delete encounter.examiner;
+      delete encounter.examiner; // examiner is not eager-loaded from db
       expect(result[0]).toMatchObject(encounter);
     });
   });

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, OneToMany, getManager } from 'typeorm/browser';
+import { Column, Entity, Index, OneToMany } from 'typeorm/browser';
 import { getUniqueId } from 'react-native-device-info';
 import { addHours, parseISO, startOfDay, subYears } from 'date-fns';
 import { groupBy } from 'lodash';

--- a/packages/mobile/App/models/PatientAdditionalData.ts
+++ b/packages/mobile/App/models/PatientAdditionalData.ts
@@ -1,5 +1,4 @@
 import {
-  AfterLoad,
   BeforeInsert,
   BeforeUpdate,
   Column,
@@ -8,7 +7,7 @@ import {
   PrimaryColumn,
   RelationId,
 } from 'typeorm/browser';
-import { isEmpty, isEqual, snakeCase } from 'lodash';
+import { isEmpty, snakeCase } from 'lodash';
 import { BaseModel, IdRelation } from './BaseModel';
 import { IPatientAdditionalData } from '~/types';
 import { ReferenceData, ReferenceDataRelation } from './ReferenceData';

--- a/packages/mobile/App/models/PatientFieldDefinition.ts
+++ b/packages/mobile/App/models/PatientFieldDefinition.ts
@@ -1,8 +1,7 @@
-import { Column, Entity, ManyToOne, OneToMany, RelationId } from 'typeorm/browser';
+import { Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
 
 import { IPatientFieldDefinition } from '~/types';
 import { BaseModel } from './BaseModel';
-import { ReferenceDataRelation } from './ReferenceData';
 import { PatientFieldDefinitionCategory } from './PatientFieldDefinitionCategory';
 import { SYNC_DIRECTIONS } from './types';
 

--- a/packages/mobile/App/models/PatientFieldDefinitionCategory.ts
+++ b/packages/mobile/App/models/PatientFieldDefinitionCategory.ts
@@ -1,10 +1,8 @@
-import { Column, Entity, OneToMany } from 'typeorm/browser';
+import { Column, Entity } from 'typeorm/browser';
 
 import { IPatientFieldDefinitionCategory } from '~/types';
 import { BaseModel } from './BaseModel';
-import { ReferenceDataRelation } from './ReferenceData';
 import { SYNC_DIRECTIONS } from './types';
-
 
 @Entity('patient_field_definition_category')
 export class PatientFieldDefinitionCategory extends BaseModel implements IPatientFieldDefinitionCategory {

--- a/packages/mobile/App/models/PatientIssue.ts
+++ b/packages/mobile/App/models/PatientIssue.ts
@@ -1,4 +1,4 @@
-import { BeforeInsert, BeforeUpdate, Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
+import { BeforeInsert, Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
 import { BaseModel } from './BaseModel';
 import { Patient } from './Patient';
 import { IPatientIssue, PatientIssueType } from '~/types';

--- a/packages/mobile/App/models/PatientSecondaryId.ts
+++ b/packages/mobile/App/models/PatientSecondaryId.ts
@@ -1,4 +1,4 @@
-import { BeforeInsert, BeforeUpdate, Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
+import { BeforeInsert, Column, Entity, ManyToOne, RelationId } from 'typeorm/browser';
 import { BaseModel, IdRelation } from './BaseModel';
 import { Patient } from './Patient';
 import { ReferenceData, ReferenceDataRelation } from './ReferenceData';

--- a/packages/mobile/App/models/Setting.ts
+++ b/packages/mobile/App/models/Setting.ts
@@ -1,4 +1,4 @@
-import { Brackets, Column, Like, RelationId } from 'typeorm';
+import { Brackets, Column, RelationId } from 'typeorm';
 import { Entity, ManyToOne } from 'typeorm/browser';
 import { get as getAtPath, set as setAtPath } from 'lodash';
 

--- a/packages/mobile/App/models/Survey.ts
+++ b/packages/mobile/App/models/Survey.ts
@@ -6,7 +6,6 @@ import { Database } from '~/infra/db';
 import { VitalsDataElements } from '/helpers/constants';
 import { ISurvey, ISurveyScreenComponent, IVitalsSurvey, SurveyTypes } from '~/types';
 import { SYNC_DIRECTIONS } from './types';
-import { VisibilityStatus } from '~/visibilityStatuses';
 
 @Entity('survey')
 export class Survey extends BaseModel implements ISurvey {

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -6,7 +6,6 @@ import {
   FieldTypes,
   getResultValue,
   getStringValue,
-  isCalculated,
   getPatientDataDbLocation,
 } from '~/ui/helpers/fields';
 

--- a/packages/mobile/App/models/relationIds.spec.ts
+++ b/packages/mobile/App/models/relationIds.spec.ts
@@ -1,6 +1,6 @@
 import { Database } from '~/infra/db';
 import { BaseModel } from '~/models/BaseModel';
-import { MODELS_ARRAY, MODELS_MAP } from '~/models/modelsMap';
+import { MODELS_ARRAY } from '~/models/modelsMap';
 
 const verifyModelHasIdsForRelations = (model: typeof BaseModel): string[] => {
   const { relationIds, columns, manyToOneRelations, oneToOneRelations } = model.getRepository().metadata;

--- a/packages/mobile/App/services/localData.ts
+++ b/packages/mobile/App/services/localData.ts
@@ -5,7 +5,7 @@ import { readConfig, writeConfig } from './config';
  * Service to store data received from AuthService on "remoteSignIn"
  * event locally
  */
-export class LocalDataService {
+export abstract class LocalDataService {
   static CONFIG_KEY: string;
 
   auth: AuthService;
@@ -22,9 +22,7 @@ export class LocalDataService {
     });
   }
 
-  extractDataFromPayload(_payload: any): any {
-    throw new Error('Child of LocalDataService needs to implement its own extractDataFromPayload method');
-  }
+  abstract extractDataFromPayload(payload: any): any;
 
   onDataLoaded(): void {
     // do nothing on the parent class

--- a/packages/mobile/App/services/sync/utils/executeCrud.ts
+++ b/packages/mobile/App/services/sync/utils/executeCrud.ts
@@ -1,8 +1,14 @@
-import { chunk } from 'lodash';
+import { chunk, cloneDeep } from 'lodash';
 
 import { DataToPersist } from '../types';
 import { chunkRows, SQLITE_MAX_PARAMETERS } from '../../../infra/db/helpers';
 import { BaseModel } from '../../../models/BaseModel';
+
+function strippedIsDeleted(row) {
+  const newRow = cloneDeep(row);
+  delete newRow.isDeleted;
+  return newRow;
+}
 
 export const executeInserts = async (
   model: typeof BaseModel,
@@ -13,12 +19,12 @@ export const executeInserts = async (
   // because it has a lab request attached
   const deduplicated = [];
   const idsAdded = new Set();
-  const softDeleted = rows.filter(row => row.isDeleted).map(({ isDeleted, ...row }) => row);
+  const softDeleted = rows.filter(row => row.isDeleted).map(strippedIsDeleted);
 
   for (const row of rows) {
-    const { id, isDeleted, ...data } = row;
+    const { id } = row;
     if (!idsAdded.has(id)) {
-      deduplicated.push({ ...data, id });
+      deduplicated.push({ ...strippedIsDeleted(row), id });
       idsAdded.add(id);
     }
   }

--- a/packages/mobile/App/types/IPatientProgramRegistrationCondition.ts
+++ b/packages/mobile/App/types/IPatientProgramRegistrationCondition.ts
@@ -1,6 +1,6 @@
 import { ID } from './ID';
 import { DateTimeString } from './DateString';
-import { IFacility, IPatient, IReferenceData, IUser } from '.';
+import { IPatient, IUser } from '.';
 import { IProgramRegistry } from './IProgramRegistry';
 import { IProgramRegistryCondition } from './IProgramRegistryCondition';
 

--- a/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import {
   FlatList,
-  ScrollView,
   Text,
   TextInput,
   TouchableOpacity,

--- a/packages/mobile/App/ui/components/ErrorBoundary.tsx
+++ b/packages/mobile/App/ui/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { View } from 'react-native';
 import { theme } from '~/ui/styled/theme';
 import { Popup } from 'popup-ui';
 import { useNavigation } from '@react-navigation/native';

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/FormGroup.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/FormGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useMemo } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { StyledView } from '/styled/common';
 import { SectionHeader } from '../../SectionHeader';
 import { Orientation, screenPercentageToDP } from '/helpers/screen';

--- a/packages/mobile/App/ui/components/Forms/RegisterAccountForms/RegisterAccountStep01.tsx
+++ b/packages/mobile/App/ui/components/Forms/RegisterAccountForms/RegisterAccountStep01.tsx
@@ -29,11 +29,7 @@ export const RegisterAccountStep01: FunctionComponent<any> = (props: {
   </FullView>
 );
 
-interface FormProps {
-  navigation: NavigationProp<any>;
-}
-
-const Form: FunctionComponent<any> = ({ navigation }: FormProps) => (
+const Form: FunctionComponent<any> = () => (
   <Formik
     initialValues={{
       firstName: '',

--- a/packages/mobile/App/ui/components/Forms/ResetPasswordForm/ResetPasswordFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/ResetPasswordForm/ResetPasswordFields.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { StyledText, StyledView } from '/styled/common';
 import { theme } from '/styled/theme';
 import { Field } from '../FormField';

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -66,7 +66,6 @@ interface FormFieldsProps {
   components: ISurveyScreenComponent[];
   patient: IPatient;
   isSubmitting: boolean;
-  note: string;
   onCancel?: () => Promise<void>;
   onGoBack?: () => void;
   currentScreenIndex: number;
@@ -78,7 +77,6 @@ export const FormFields = ({
   currentScreenIndex,
   setCurrentScreenIndex,
   isSubmitting,
-  note,
   patient,
   onCancel,
   onGoBack,

--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -10,7 +10,6 @@ import { LocationField } from '../../LocationField';
 import { INJECTION_SITE_OPTIONS, ReferenceDataType } from '~/types';
 import { AutocompleteModalField } from '../../AutocompleteModal/AutocompleteModalField';
 import { Dropdown, SuggesterDropdown } from '../../Dropdown';
-import { Routes } from '~/ui/helpers/routes';
 import { Suggester } from '~/ui/helpers/suggester';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';

--- a/packages/mobile/App/ui/components/Forms/VitalsForm.tsx
+++ b/packages/mobile/App/ui/components/Forms/VitalsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { ReduxStoreProps } from '/interfaces/ReduxStoreProps';
 import { PatientStateProps } from '/store/ducks/patient';

--- a/packages/mobile/App/ui/components/Forms/VitalsForm.tsx
+++ b/packages/mobile/App/ui/components/Forms/VitalsForm.tsx
@@ -30,7 +30,6 @@ interface VitalsFormProps {
 export const VitalsForm: React.FC<VitalsFormProps> = ({ onAfterSubmit }) => {
   const { models } = useBackend();
   const user = useSelector(authUserSelector);
-  const [note, setNote] = useState('');
   const { currentScreenIndex, setCurrentScreenIndex } = useCurrentScreen();
 
   const { selectedPatient } = useSelector(
@@ -79,7 +78,6 @@ export const VitalsForm: React.FC<VitalsFormProps> = ({ onAfterSubmit }) => {
         encounterReason: `Form response for ${name}`,
       },
       { ...values, [dateComponent.dataElement.code]: getCurrentDateTimeString() },
-      setNote,
     );
 
     if (responseRecord) {

--- a/packages/mobile/App/ui/components/LocationField.tsx
+++ b/packages/mobile/App/ui/components/LocationField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useFormikContext } from 'formik';
 import { NavigationProp } from '@react-navigation/native';
 
@@ -8,7 +8,6 @@ import { AutocompleteModalField } from './AutocompleteModal/AutocompleteModalFie
 import { Suggester } from '~/ui/helpers/suggester';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
-import { Routes } from '~/ui/helpers/routes';
 
 interface LocationFieldProps {
   navigation: NavigationProp<any>;

--- a/packages/mobile/App/ui/components/PatientHistoryAccordion/Header.tsx
+++ b/packages/mobile/App/ui/components/PatientHistoryAccordion/Header.tsx
@@ -6,7 +6,7 @@ import { formatStringDate } from '/helpers/date';
 import { DateFormats, EncounterTypeNames, HeaderIcons } from '/helpers/constants';
 import * as Icons from '../Icons';
 import { Separator } from '../Separator';
-import { EncounterType, IEncounter, ILocation, IUser } from '~/types';
+import { EncounterType, IEncounter, ILocation } from '~/types';
 
 interface IconProps {
   IconComponent: FunctionComponent<SvgProps>;

--- a/packages/mobile/App/ui/components/PatientHistoryAccordion/fixtures.tsx
+++ b/packages/mobile/App/ui/components/PatientHistoryAccordion/fixtures.tsx
@@ -1,5 +1,3 @@
-import * as Icons from '../Icons';
-
 export const data = [
   {
     id: '0',

--- a/packages/mobile/App/ui/components/PatientMenuButton/index.spec.tsx
+++ b/packages/mobile/App/ui/components/PatientMenuButton/index.spec.tsx
@@ -10,8 +10,6 @@ describe('<PatientMenuButton />', () => {
     Icon: DeceasedIcon,
   };
 
-  const { getByText } = render(<PatientMenuButton {...props} />);
-  const buttonTitle = getByText(props.title);
   it('should render PatientMenuButton', () => {
     const { getByText } = render(<PatientMenuButton {...props} />);
     const buttonTitle = getByText(props.title);

--- a/packages/mobile/App/ui/components/PatientSectionList/fixture.tsx
+++ b/packages/mobile/App/ui/components/PatientSectionList/fixture.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { groupEntriesByLetter } from '/helpers/list';
 import { StyledView } from '/styled/common';
 import { PatientSectionList } from './index';
 import { IPatient } from '~/types';

--- a/packages/mobile/App/ui/components/PatientSectionList/index.spec.tsx
+++ b/packages/mobile/App/ui/components/PatientSectionList/index.spec.tsx
@@ -1,7 +1,9 @@
+/*
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { groupEntriesByLetter } from '/helpers/list';
 import { BaseStory, data } from './fixture';
+*/
 
 describe.skip('<PatientSectionList', () => {
   it('should pass', () => expect(true).toEqual(true));

--- a/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
+++ b/packages/mobile/App/ui/components/RadioButtonGroup/index.tsx
@@ -18,12 +18,6 @@ export interface RadioButtonGroupProps {
   CustomComponent?: FC<any>;
 }
 
-const getTitleColor = (value?: string, error?: boolean): string => {
-  if (value) return theme.colors.TEXT_MID;
-  if (error) return theme.colors.ALERT;
-  return theme.colors.TEXT_SOFT;
-};
-
 const Label = styled(StyledText)`
   color: ${theme.colors.TEXT_SUPER_DARK};
   font-size: ${screenPercentageToDP(2.1, Orientation.Height)};

--- a/packages/mobile/App/ui/components/ReadOnlyField/index.tsx
+++ b/packages/mobile/App/ui/components/ReadOnlyField/index.tsx
@@ -9,7 +9,7 @@ const getValueToDisplay = value => {
   return value;
 };
 
-export const ReadOnlyField = ({ name, value }: { name: string; value: any }) => {
+export const ReadOnlyField = ({ value }: { value: any }) => {
   const styleProps = {
     color: value ? '#000' : '#aaa',
     fontSize: screenPercentageToDP('2.2', Orientation.Height),

--- a/packages/mobile/App/ui/components/ReferenceDataField/index.tsx
+++ b/packages/mobile/App/ui/components/ReferenceDataField/index.tsx
@@ -14,11 +14,7 @@ interface ReferenceDataFieldProps extends BaseInputProps {
 export const ReferenceDataField = React.memo(({
   value,
   onChange,
-  label,
-  error,
   referenceDataType,
-  disabled = false,
-  required = false,
 }: ReferenceDataFieldProps): JSX.Element => {
   const { models } = useBackend();
   const [dropdownItems, setDropdownItems] = useState([]);

--- a/packages/mobile/App/ui/components/ReferenceDataField/index.tsx
+++ b/packages/mobile/App/ui/components/ReferenceDataField/index.tsx
@@ -1,10 +1,7 @@
-import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
-import { Platform, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import React, { useEffect, useState } from 'react';
 import { ReferenceDataType } from '~/types';
 import { useBackend } from '~/ui/hooks';
 import { BaseInputProps } from '~/ui/interfaces/BaseInputProps';
-import { StyledText, StyledView } from '~/ui/styled/common';
-import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
 
 interface ReferenceDataFieldProps extends BaseInputProps {

--- a/packages/mobile/App/ui/components/VaccineCard/ModalField.tsx
+++ b/packages/mobile/App/ui/components/VaccineCard/ModalField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement } from 'react';
+import React, { FC } from 'react';
 import { RowView, StyledText, StyledView } from '/styled/common';
 import { theme } from '/styled/theme';
 import { Orientation, screenPercentageToDP } from '/helpers/screen';

--- a/packages/mobile/App/ui/components/VaccineCard/index.stories.tsx
+++ b/packages/mobile/App/ui/components/VaccineCard/index.stories.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from 'styled-components/native';
 import {
   CenterView,
   FullView,
-  StyledSafeAreaView,
   themeSystem,
 } from '/styled/common';
 import { theme } from '/styled/theme';

--- a/packages/mobile/App/ui/contexts/AuthContext.tsx
+++ b/packages/mobile/App/ui/contexts/AuthContext.tsx
@@ -77,7 +77,8 @@ const Provider = ({
   const signInAs = (authenticatedUser): void => {
     // Destructure the local password out of the user object - it only needs to be in
     // the database, we don't need or want to store it in app state as well.
-    const { localPassword, ...userData } = authenticatedUser;
+    const userData = { ...authenticatedUser };
+    delete userData.localPassword;
     setUser(userData);
     setContextUserAndAbility(userData);
     setSignedInStatus(true);
@@ -179,7 +180,7 @@ const Provider = ({
   // Sign user out if an auth error was thrown
   // except if user is trying to reconnect with password from modal interface
   useEffect(() => {
-    const errHandler = (err: Error): void => {
+    const errHandler = (): void => {
       if (preventSignOutOnFailure) {
         // reset flag to prevent sign out being
         // skipped on subsequent failed authentications

--- a/packages/mobile/App/ui/contexts/FacilityContext.tsx
+++ b/packages/mobile/App/ui/contexts/FacilityContext.tsx
@@ -15,10 +15,10 @@ interface FacilityContextData {
   assignFacility: (id: string, name: string) => Promise<void>;
 }
 
-const FacilityContext = createContext({
+const FacilityContext = createContext<FacilityContextData>({
   facilityId: null,
   facilityName: "Unmounted context",
-  assignFacility: (id: string, name: string) => Promise.resolve(null),
+  assignFacility: () => Promise.resolve(null),
 });
 
 export const useFacility = () => useContext(FacilityContext);

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/Container.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/Container.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useMemo } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import { Screen } from './Screen';
 import { Routes } from '/helpers/routes';
 import { BaseAppProps } from '/interfaces/BaseAppProps';

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/RecentViewed.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/RecentViewed.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
 import { Platform } from 'react-native';
 import { compose } from 'redux';
-import { NavigationProp } from '@react-navigation/native';
 import { FlatList, TouchableOpacity } from 'react-native-gesture-handler';
 // Containers
 import { withPatient } from '/containers/Patient';

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/RecentViewed.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/RecentViewed.tsx
@@ -21,12 +21,6 @@ import { navigateAfterTimeout } from '~/ui/helpers/navigators';
 import { theme } from '~/ui/styled/theme';
 import { PatientFromRoute } from '~/ui/helpers/constants';
 
-interface PatientListProps {
-  list: any[];
-  setSelectedPatient: Function;
-  navigation: NavigationProp<any>;
-}
-
 const NoPatientsCard = (): ReactElement => (
   <StyledText
     color={theme.colors.TEXT_SUPER_DARK}

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -51,7 +51,7 @@ export const AdditionalInfo = ({ patient, onEdit }: AdditionalInfoProps): ReactE
     return { title, fields: mappedFields, onEditCallback };
   });
 
-  const customSections = customPatientSections.map(([categoryId, fields]) => {
+  const customSections = customPatientSections.map(([_categoryId, fields]) => {
     const title = fields[0].category.name;
     const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues);
     const mappedFields = fields.map(field => ([field.name, customPatientFieldValues[field.id]?.[0]?.value]));

--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/MoreScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/MoreScreen.tsx
@@ -15,7 +15,6 @@ import { CameraOutlineIcon, LaunchIcon } from '/components/Icons';
 import { version as AppVersion } from '/root/package.json';
 import { useAuth } from '~/ui/contexts/AuthContext';
 import { useFacility } from '~/ui/contexts/FacilityContext';
-import { BaseAppProps } from '~/ui/interfaces/BaseAppProps';
 import { authUserSelector } from '/helpers/selectors';
 import { useLocalisation } from '~/ui/contexts/LocalisationContext';
 
@@ -91,7 +90,7 @@ const Footer = ({ version, deviceId }: FooterProps): ReactElement => (
   </StyledText>
 );
 
-export const MoreScreen = ({ navigation }: BaseAppProps): ReactElement => {
+export const MoreScreen = (): ReactElement => {
   const { getLocalisation } = useLocalisation();
   const supportDeskUrl = getLocalisation('supportDeskUrl');
   const authCtx = useAuth();

--- a/packages/mobile/App/ui/navigation/screens/labRequests/tabs/ViewHistoryScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/labRequests/tabs/ViewHistoryScreen.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { compose } from 'redux';
 import { Routes } from '/helpers/routes';

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
@@ -105,7 +105,7 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
         })}
         onSubmit={submitPatientProgramRegistration}
       >
-        {({ errors, handleSubmit, values }): ReactElement => {
+        {({ handleSubmit, values }): ReactElement => {
           return (
             <>
               <StyledView marginTop={20} marginLeft={20} marginRight={20}>

--- a/packages/mobile/App/ui/navigation/screens/signup/RegisterAccountScreenStep2/Container.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/RegisterAccountScreenStep2/Container.tsx
@@ -1,13 +1,12 @@
 import React, { FC, useCallback, useContext, useMemo, useState } from 'react';
 import { Value } from 'react-native-reanimated';
-import { Keyboard, Platform } from 'react-native';
+import { Keyboard } from 'react-native';
 //Protocols
 import { RegisterAccountScreenProps } from '../../../../interfaces/screens/SignUpStack/RegisterAccountStep1Props';
 // contexts
 import {
   RegisterAccountContext,
   RegisterAccountFormStep2FormValues,
-  RegisterAccountFormStep2Props,
 } from '../../../../contexts/RegisterAccountContext';
 //helpers
 import {

--- a/packages/mobile/App/ui/navigation/screens/signup/RegisterAccountScreenStep2/Screen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/RegisterAccountScreenStep2/Screen.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { KeyboardAvoidingView } from 'react-native';
 import Animated, { Value } from 'react-native-reanimated';
 //Components

--- a/packages/mobile/App/ui/navigation/screens/signup/SelectFacilityScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SelectFacilityScreen.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, ReactElement, useCallback, useEffect, useState } from 'react';
 import * as Yup from 'yup';
-import { KeyboardAvoidingView, StatusBar } from 'react-native';
+import { StatusBar } from 'react-native';
 import {
   FullView,
   StyledSafeAreaView,

--- a/packages/mobile/App/ui/navigation/screens/signup/SelectFacilityScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SelectFacilityScreen.tsx
@@ -57,7 +57,7 @@ export const SelectFacilityForm = ({ onSubmitForm }) => {
   }, []);
 
   const onSubmit = useCallback(
-    async ({ facilityId, ...extras }) => {
+    async ({ facilityId }) => {
       const selected = facilityOptions.find(x => x.value === facilityId);
       if (selected) {
         onSubmitForm({ facilityId, facilityName: selected.label });

--- a/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
+++ b/packages/mobile/App/ui/navigation/screens/signup/SignIn.tsx
@@ -9,7 +9,7 @@ import {
   StyledTouchableOpacity,
   StyledView,
 } from '/styled/common';
-import { CrossIcon, HomeBottomLogoIcon, LaunchIcon } from '/components/Icons';
+import { CrossIcon, HomeBottomLogoIcon } from '/components/Icons';
 import { Orientation, screenPercentageToDP } from '/helpers/screen';
 import { theme } from '/styled/theme';
 import { SignInForm } from '/components/Forms/SignInForm';
@@ -20,9 +20,7 @@ import { authSelector } from '/helpers/selectors';
 import { OutdatedVersionError } from '~/services/error';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useLocalisation } from '~/ui/contexts/LocalisationContext';
-import { marginTop } from 'styled-system';
 import { SupportCentreButton } from './SupportCentreButton';
-import { Orient } from 'react-native-svg';
 
 interface ModalContent {
   message: string;

--- a/packages/mobile/App/ui/navigation/screens/vaccine/tableTabs/VaccineHistoryTab.tsx
+++ b/packages/mobile/App/ui/navigation/screens/vaccine/tableTabs/VaccineHistoryTab.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import { StatusBar } from 'react-native';
 import { NavigationProp } from '@react-navigation/native';
 import { FullView, StyledSafeAreaView } from '/styled/common';

--- a/packages/mobile/App/ui/navigation/stacks/LabRequestTabs.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/LabRequestTabs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useMemo } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import { compose } from 'redux';
 import { NavigationProp } from '@react-navigation/native';
 import { Routes } from '/helpers/routes';

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -27,7 +27,8 @@
       "/infra/*": ["App/infra/*"],
       "/presentation/*": ["App/presentation/*"],
       "/migrations/*": ["App/migrations/*"]
-    },    
+    },
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "jsx": "react",
     "lib": ["es2019"],


### PR DESCRIPTION
### Changes

3 type of changes:
- Lots of enums were having this error, when they are clearly being used (outside their file). See https://github.com/typescript-eslint/typescript-eslint/issues/2619
- A couple of actual errors on the migration files, which should be okay because it doesn't affect the file itself.
- Getting rid of the import errors `Cannot find module '<module>'.` which happens quite often, this does not seem to affect the way we package stuff so we're good (the app builds fine in development)
