### PR TITLE
ci: KAM-100: deploy ECS with ARM64

### DIFF
--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -103,6 +103,7 @@ jobs:
           upsert: true
           config-map: >
             {
+            tamanu-internal:arm64: {value: true, secret: false},
             tamanu-internal:imageTag: {value: 'sha-${{ github.sha }}', secret: false},
             tamanu-internal:salt: {value: '${{ steps.salt.outputs.salt }}', secret: true},
             postgresql:host: {value: '${{ vars.INTERNAL_DB_HOST }}', secret: false},


### PR DESCRIPTION
This gives us **20% savings** on the ECS cost, which is pretty good for a one line change!
