### PR TITLE
fix(web): NASS-1189: Pad data query invalidation bug

### DIFF
--- a/packages/web/app/views/patients/PatientView.jsx
+++ b/packages/web/app/views/patients/PatientView.jsx
@@ -26,6 +26,7 @@ import { useUrlSearchParams } from '../../utils/useUrlSearchParams';
 import { PatientSearchParametersProvider } from '../../contexts/PatientViewSearchParameters';
 import { invalidatePatientDataQueries } from '../../utils';
 import { usePatientNavigation } from '../../utils/usePatientNavigation';
+import { useSyncState } from '../../contexts/SyncState';
 
 const StyledDisplayTabs = styled(TabDisplay)`
   overflow: initial;
@@ -119,6 +120,8 @@ export const PatientView = () => {
   const [currentTab, setCurrentTab] = useState(queryTab || PATIENT_TABS.HISTORY);
   const disabled = !!patient.death;
   const api = useApi();
+  const syncState = useSyncState();
+  const isSyncing = syncState.isPatientSyncing(patient.id);
   const { data: additionalData, isLoading: isLoadingAdditionalData } = useQuery(
     ['additionalData', patient.id],
     () => api.get(`patient/${patient.id}/additionalData`),
@@ -144,14 +147,14 @@ export const PatientView = () => {
   }, [api, patient.id]);
 
   useEffect(() => {
-    if (!patient.syncing) {
+    if (!isSyncing) {
       // invalidate the cache of patient data queries to reload the patient data
       invalidatePatientDataQueries(queryClient, patient.id);
     }
 
     // invalidate queries only when syncing is done (changed from true to false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [patient.syncing]);
+  }, [isSyncing]);
 
   const visibleTabs = usePatientTabs();
 


### PR DESCRIPTION
### Changes

We added a new context for getting the sync state for the patient and this bit of query invalidation logic just needed to be updated to use it

### Checklist

- [x] Code is finished
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
