### PR TITLE
fix(translations): NASS-1195: Program registry options error

### DIFF
--- a/packages/web/app/components/Translation/getTranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/getTranslatedOptions.jsx
@@ -2,17 +2,12 @@ import { TranslatedText } from './TranslatedText';
 import { camelCase } from 'lodash';
 import React from 'react';
 
-export const getTranslatedOptions = (options, prefix) =>
-  options.map(option => ({
+export const getTranslatedOptions = (options, prefix) => {
+  if (!options) return [];
+  return options.map(option => ({
     value: option.value,
     label: (
-      <TranslatedText
-        stringId={
-          option.label.type === TranslatedText
-            ? option.label.props.stringId
-            : `${prefix}.${camelCase(option.label)}`
-        }
-        fallback={option.label.type === TranslatedText ? option.label.props.fallback : option.label}
-      />
+      <TranslatedText stringId={`${prefix}.${camelCase(option.label)}`} fallback={option.label} />
     ),
   }));
+};


### PR DESCRIPTION
In program registries there is a piece of logic where we supply undefined as options to a multiselect field instead of an empty array. After the merge with translations this was breaking in the getTranslationsOptions function. I also removed some old logic for handling a situation that doesn't happen anymore after changing the handling of constants translations.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
