### PR TITLE
fix(web): Fix broken placeholder translation

### DIFF
--- a/packages/web/app/components/Field/SearchField.jsx
+++ b/packages/web/app/components/Field/SearchField.jsx
@@ -39,7 +39,6 @@ export const SearchField = props => {
     field: { value, name },
     form: { setFieldValue } = {},
     label,
-    keepLetterCase,
   } = props;
   const [searchValue, setSearchValue] = useState(value);
 
@@ -68,13 +67,7 @@ export const SearchField = props => {
           </StyledIconButton>
         ),
       }}
-      placeholder={
-        label
-          ? getTranslation('general.placeholder.searchWithLabel', 'Search :label', {
-              label: keepLetterCase ? label : label.toLowerCase(),
-            })
-          : ''
-      }
+      placeholder={label ? getTranslation('general.placeholder.search', 'Search') : ''}
       {...props}
       value={searchValue}
     />


### PR DESCRIPTION
### Changes

fix(web): Fix broken placeholder translation. As far as I can tell it is not possible to keep the label as part of the translation because the label is a jsx component (TranslatedString) and we are trying to pass the label into the replacements.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
