### PR TITLE
fix(web): misaligned lab request category header

### DIFF
--- a/packages/web/app/views/labRequest/SampleDetailsField.jsx
+++ b/packages/web/app/views/labRequest/SampleDetailsField.jsx
@@ -14,11 +14,7 @@ const Container = styled.div`
   display: grid;
   grid-template-columns: ${props => (props.hasPanels ? 'repeat(6, 1fr)' : ' 230px repeat(4, 1fr)')};
   padding-bottom: 10px;
-
-  > div:first-child {
-    padding-left: 32px;
-  }
-
+  
   > div:nth-last-child(-n + ${props => (props.hasPanels ? '6' : '5')}) {
     border-bottom: none;
   }
@@ -29,6 +25,9 @@ const HeaderCell = styled(Heading4)`
   padding: 15px 16px 15px 0px;
   border-bottom: 1px solid ${Colors.outline};
   color: ${Colors.midText};
+  &:first-of-type {
+    padding-left: 32px;
+  }
 `;
 
 const Cell = styled.div`


### PR DESCRIPTION
This css rule broke after we updated our header components to be the correct html semantically. Previously our reusable header component was actually a div and we updated it to an `h4` to allow from correct font styling. This however breaks css rules that depended on the headers being a div like here.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
