### PR TITLE
fix: NASS-1197: Remove Nationality and Passport from Vaccination certificate pdf

### DIFF
--- a/packages/shared/src/utils/patientCertificates/PatientDetailsSection.jsx
+++ b/packages/shared/src/utils/patientCertificates/PatientDetailsSection.jsx
@@ -4,7 +4,7 @@ import { H3, P } from './Typography';
 import {
   getDOB,
   getSex,
-  getVillageName
+  getVillageName,
 } from '../patientAccessors';
 
 const PATIENT_FIELDS = [
@@ -17,7 +17,7 @@ const PATIENT_FIELDS = [
     label: 'DOB',
     accessor: getDOB,
   },
-  { key: 'villageName', label: 'Village', accessor: getVillageName }
+  { key: 'villageName', label: 'Village', accessor: getVillageName },
 ];
 
 export const PatientDetailsSection = ({ patient, getLocalisation, extraFields = [] }) => {

--- a/packages/shared/src/utils/patientCertificates/PatientDetailsSection.jsx
+++ b/packages/shared/src/utils/patientCertificates/PatientDetailsSection.jsx
@@ -4,9 +4,7 @@ import { H3, P } from './Typography';
 import {
   getDOB,
   getSex,
-  getVillageName,
-  getNationality,
-  getPassportNumber,
+  getVillageName
 } from '../patientAccessors';
 
 const PATIENT_FIELDS = [
@@ -19,9 +17,7 @@ const PATIENT_FIELDS = [
     label: 'DOB',
     accessor: getDOB,
   },
-  { key: 'villageName', label: 'Village', accessor: getVillageName },
-  { key: 'passport', label: 'Passport Number', accessor: getPassportNumber },
-  { key: 'nationality', label: 'Nationality', accessor: getNationality },
+  { key: 'villageName', label: 'Village', accessor: getVillageName }
 ];
 
 export const PatientDetailsSection = ({ patient, getLocalisation, extraFields = [] }) => {


### PR DESCRIPTION

### Changes

- Remove Nationality and Passport fields from Vaccination certificate pdf

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
