### PR TITLE
fix(web): Table exports after translations merge

### DIFF
--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -19,7 +19,7 @@ function getHeaderValue(column) {
   if (typeof column.title === 'object') {
     if (isValidElement(column.title)) {
       const { props, type } = column.title;
-      if (type.name === 'TranslatedText') return props.fallback;
+      if (type.name === 'TranslatedText') return props.fallback; // Temporary until we implement translated export tables
       return cheerio.load(ReactDOMServer.renderToString(column.title)).text();
     }
   }

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -12,17 +12,16 @@ import { TranslatedText } from '../Translation/TranslatedText';
 // This is a temporary implementation to basically keep TranslatedText components from breaking export
 // by supplying the fallback string in place of the component. proper translation export implmentation coming in NASS-1201
 const normaliseTranslatedText = element => {
-  if (element.type.name === 'TranslatedText') return element.props.fallback;
+  if (element.type?.name === 'TranslatedText') return element.props.fallback;
+  if (!Array.isArray(element.props?.children)) return element;
 
-  const normalisedElement = Array.isArray(element.props.children)
-    ? React.cloneElement(element, {
-        children: element.props.children.map(child => {
-          return child.type?.name === 'TranslatedText' ? child.props.fallback : child;
-        }),
-      })
-    : element;
-
-  return normalisedElement;
+  return React.cloneElement(element, {
+    children: element.props.children.map(child => {
+      return child.type?.name === 'TranslatedText'
+        ? child.props.fallback
+        : normaliseTranslatedText(child);
+    }),
+  });
 };
 
 function getHeaderValue(column) {

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -50,10 +50,12 @@ export function DownloadDataButton({ exportName, columns, data }) {
 
             if (c.accessor) {
               const value = c.accessor(d);
-              // render react element and get the text value with cheerio
               if (typeof value === 'object') {
                 if (isValidElement(value)) {
-                  dx[headerValue] = cheerio.load(ReactDOMServer.renderToString(value)).text();
+                  dx[headerValue] =
+                    value.type.name === 'TranslatedText'
+                      ? value.props.fallback // Temporary until we implement translated export tables
+                      : cheerio.load(ReactDOMServer.renderToString(value)).text(); // render react element and get the text value with cheerio
                 } else {
                   dx[headerValue] = d[c.key];
                 }


### PR DESCRIPTION
### Changes

Discovered during regression testing that translatedText components don't really work with our table export functionality as they contain a hook that cant be accessed during the `ReactDOMServer.renderToString` usage. 

As this is supposed to be a "silent" merge where we want everything to act as it did before (translations not being used yet) i have implemented a workaround that just supplies the fallback string in place of the component to be rendered. Card created for actual implementation here  NASS-1201


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
