### PR TITLE
ci(determinism): separate the "Tests pass" for non determinism

### DIFF
--- a/.github/workflows/ci-fake-db-dump.yml
+++ b/.github/workflows/ci-fake-db-dump.yml
@@ -3,9 +3,6 @@ name: Fake DB Dump
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-      - release/*
 
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
@@ -17,6 +14,15 @@ env:
 
 jobs:
   generate-fake:
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'push' && (
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') ||
+          contains(github.event.commits.*.message, '[generate-fake-db]')
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +38,33 @@ jobs:
       ARTIFACT_NAME: fake-pg${{ matrix.postgres }}
     steps:
       - uses: actions/checkout@v4
+        id: autocheckout
+        if: >-
+          github.event_name == 'workflow_dispatch' || (
+            github.event_name == 'push' && (
+              github.ref == 'refs/heads/main' ||
+              startsWith(github.ref, 'refs/heads/release/') ||
+              startsWith(github.ref, 'refs/tags/')
+            )
+          )
+
+      - uses: actions/github-script@v7
+        if: steps.autocheckout.conclusion == 'skipped'
+        id: commit
+        with:
+          result-encoding: string
+          script: |
+            for (const { message, id } of context.payload.commits) {
+              console.log(id, message);
+              if (message.includes('[generate-fake-db]')) {
+                return id;
+              }
+            }
+      - uses: actions/checkout@v4
+        if: steps.commit.conclusion == 'success'
+        with:
+          ref: ${{ steps.commit.outputs.result }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-
+    branches:
+      - main
+      - release/*
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
   NODE_ENV: test

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - main
-      - release/*
 
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
@@ -73,7 +70,7 @@ jobs:
   # Dummy job to have a stable name for PR requirements
   tests-pass:
     if: always() # always run even if dependencies fail
-    name: Tests pass
+    name: Non-determinism pass
     needs: [test-for-non-determinism]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Changes

- Separate the "Tests pass" for non determinism, so that we can enable/disable that separately from the general CI. Emilio caught it earlier actually but I thought github worked differently.
- Make it possible to generate a db dump for any commit (e.g. in PRs) by including `[generate-fake-db]` anywhere in the commit message (subject or body).


### Checklist

- [x] Code is finished