### PR TITLE
fix(web): clinician text breaking encounter record

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -25,7 +25,6 @@ import { ForbiddenErrorModalContents } from '../../ForbiddenErrorModal';
 import { ModalActionRow } from '../../ModalActionRow';
 import { printPDF } from '../PDFViewer.jsx';
 import { TranslatedText } from '../../Translation/TranslatedText';
-import { LowerCase } from '../../Typography';
 import { useTranslation } from '../../../contexts/Translation';
 
 // These below functions are used to extract the history of changes made to the encounter that are stored in notes.

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -26,6 +26,7 @@ import { ModalActionRow } from '../../ModalActionRow';
 import { printPDF } from '../PDFViewer.jsx';
 import { TranslatedText } from '../../Translation/TranslatedText';
 import { LowerCase } from '../../Typography';
+import { useTranslation } from '../../../contexts/Translation';
 
 // These below functions are used to extract the history of changes made to the encounter that are stored in notes.
 // obviously a better solution needs to be to properly implemented for storing and accessing this data, but this is an ok workaround for now.
@@ -100,14 +101,11 @@ const extractLocationHistory = (notes, encounterData) => {
 };
 
 export const EncounterRecordModal = ({ encounter, open, onClose }) => {
-  const clinicianText = (
-    <LowerCase>
-      <TranslatedText
-        stringId="general.localisedField.clinician.label.short"
-        fallback="Clinician"
-      />
-    </LowerCase>
-  );
+  const { getTranslation } = useTranslation();
+  const clinicianText = getTranslation(
+    'general.localisedField.clinician.label.short',
+    'Clinician',
+  ).toLowerCase();
 
   const { getLocalisation } = useLocalisation();
   const certificateQuery = useCertificate();


### PR DESCRIPTION
When the pdf epic and translation epics merge merged together in main. it created this situation where it tries to supply a component to a certificate in shared which doesnt work properly. As useLocalisedText is now removed from the codebase i am using the getTranslation hook directly to get the clinician text

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
