### PR TITLE
fix(web): reformat-program-registry-actions

### DIFF
--- a/packages/web/app/views/programRegistry/DisplayPatientRegDetails.jsx
+++ b/packages/web/app/views/programRegistry/DisplayPatientRegDetails.jsx
@@ -14,6 +14,7 @@ import { RemoveProgramRegistryFormModal } from './RemoveProgramRegistryFormModal
 import { OutlinedButton } from '../../components';
 import { ClinicalStatusDisplay } from './ClinicalStatusDisplay';
 import { ConditionalTooltip } from '../../components/Tooltip';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 const DisplayContainer = styled.div`
   display: flex;
@@ -88,22 +89,40 @@ export const DisplayPatientRegDetails = ({ patientProgramRegistration }) => {
   const isDeleted =
     patientProgramRegistration.registrationStatus === REGISTRATION_STATUSES.RECORDED_IN_ERROR;
 
-  let actions = {
-    Remove: () => setOpenRemoveProgramRegistryFormModal(true),
-    Delete: () => setOpenDeleteProgramRegistryFormModal(true),
-  };
+  let actions = [
+    {
+      label: <TranslatedText stringId="general.action.remove" fallback="Remove" />,
+      action: () => setOpenRemoveProgramRegistryFormModal(true),
+    },
+    {
+      label: <TranslatedText stringId="general.action.delete" fallback="Delete" />,
+      action: () => setOpenDeleteProgramRegistryFormModal(true),
+    },
+  ];
 
   if (isRemoved)
-    actions = {
-      Activate: () => setOpenActivateProgramRegistryFormModal(true),
-      Delete: () => setOpenDeleteProgramRegistryFormModal(true),
-    };
+    actions = [
+      {
+        label: <TranslatedText stringId="general.action.activate" fallback="Activate" />,
+        action: () => setOpenActivateProgramRegistryFormModal(true),
+      },
+      {
+        label: <TranslatedText stringId="general.action.delete" fallback="Delete" />,
+        action: () => setOpenDeleteProgramRegistryFormModal(true),
+      },
+    ];
 
   if (isDeleted)
-    actions = {
-      Activate: () => setOpenActivateProgramRegistryFormModal(true),
-      Remove: () => setOpenRemoveProgramRegistryFormModal(true),
-    };
+    actions = [
+      {
+        label: <TranslatedText stringId="general.action.activate" fallback="Activate" />,
+        action: () => setOpenActivateProgramRegistryFormModal(true),
+      },
+      {
+        label: <TranslatedText stringId="general.action.remove" fallback="Remove" />,
+        action: () => setOpenRemoveProgramRegistryFormModal(true),
+      },
+    ];
 
   return (
     <DisplayContainer>

--- a/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
@@ -14,6 +14,7 @@ import { RegistrationStatusIndicator } from './RegistrationStatusIndicator';
 import { ClinicalStatusDisplay } from './ClinicalStatusDisplay';
 import { useRefreshCount } from '../../hooks/useRefreshCount';
 import { ActivatePatientProgramRegistry } from './ActivatePatientProgramRegistry';
+import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 export const ProgramRegistryTable = ({ searchParameters }) => {
   const params = useParams();
@@ -99,23 +100,46 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
           const isRemoved = row.registrationStatus === REGISTRATION_STATUSES.INACTIVE;
           const isDeleted = row.registrationStatus === REGISTRATION_STATUSES.RECORDED_IN_ERROR;
 
-          let actions = {
-            'Change status': () => setOpenModal({ action: 'ChangeStatus', data: row }),
-            Remove: () => setOpenModal({ action: 'Remove', data: row }),
-            Delete: () => setOpenModal({ action: 'Delete', data: row }),
-          };
+          let actions = [
+            {
+              label: (
+                <TranslatedText stringId="general.action.changeStatus" fallback="Change status" />
+              ),
+              action: () => setOpenModal({ action: 'ChangeStatus', data: row }),
+            },
+            {
+              label: <TranslatedText stringId="general.action.remove" fallback="Remove" />,
+              action: () => setOpenModal({ action: 'Remove', data: row }),
+            },
+            {
+              label: <TranslatedText stringId="general.action.delete" fallback="Delete" />,
+              action: () => setOpenModal({ action: 'Delete', data: row }),
+            },
+          ];
 
           if (isRemoved)
-            actions = {
-              Activate: () => setOpenModal({ action: 'Activate', data: row }),
-              Delete: () => setOpenModal({ action: 'Delete', data: row }),
-            };
+            actions = [
+              {
+                label: <TranslatedText stringId="general.action.activate" fallback="Activate" />,
+                action: () => setOpenModal({ action: 'Activate', data: row }),
+              },
+              {
+                label: <TranslatedText stringId="general.action.delete" fallback="Delete" />,
+                action: () => setOpenModal({ action: 'Delete', data: row }),
+              },
+            ];
 
           if (isDeleted)
-            actions = {
-              Activate: () => setOpenModal({ action: 'Activate', data: row }),
-              Remove: () => setOpenModal({ action: 'Remove', data: row }),
-            };
+            actions = [
+              {
+                label: <TranslatedText stringId="general.action.activate" fallback="Activate" />,
+                action: () => setOpenModal({ action: 'Activate', data: row }),
+              },
+              {
+                label: <TranslatedText stringId="general.action.remove" fallback="Remove" />,
+                action: () => setOpenModal({ action: 'Remove', data: row }),
+              },
+            ];
           return <MenuButton onClick={() => {}} actions={actions} />;
         },
         sortable: false,


### PR DESCRIPTION
Result of merge between program registries/translations. 

In doing translations work we changed the format of the actions supplied to MenuButton.jsx to an array rather than an object with the key being its label. It didnt work with our new translated text component and was also quite a different way of handling options to the rest of the app so we adjusted to match that

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
