### PR TITLE
fix(web): use ids for logic rather than titles in sidebar

### DIFF
--- a/packages/web/app/api/queries/usePatientProgramRegistration.js
+++ b/packages/web/app/api/queries/usePatientProgramRegistration.js
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
-import { PROGRAM_REGISTRY } from '../../components/PatientInfoPane/paneTitles';
+import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 
 export const usePatientProgramRegistration = (patientId, programRegistryId, fetchOptions) => {
   const api = useApi();
-  return useQuery([`infoPaneListItem-${PROGRAM_REGISTRY}`, patientId, programRegistryId], () =>
+  return useQuery([`infoPaneListItem-${PANE_SECTION_IDS.PROGRAM_REGISTRY}`, patientId, programRegistryId], () =>
     api.get(
       `patient/${encodeURIComponent(patientId)}/programRegistration/${encodeURIComponent(
         programRegistryId,

--- a/packages/web/app/components/PatientInfoPane/InfoPaneAddEditForm.jsx
+++ b/packages/web/app/components/PatientInfoPane/InfoPaneAddEditForm.jsx
@@ -4,29 +4,23 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useApi } from '../../api';
 import { Suggester } from '../../utils/suggester';
-import {
-  ALLERGIES_TITLE,
-  CARE_PLANS_TITLE,
-  CONDITIONS_TITLE,
-  FAMILY_HISTORY_TITLE,
-  ISSUES_TITLE,
-} from './paneTitles';
+import { PANE_SECTION_IDS } from './paneSections';
 
 const FormContainer = styled.div`
   margin: 1rem 0;
 `;
 
-const getSuggesters = (title, items) => {
-  switch (title) {
-    case CONDITIONS_TITLE:
+const getSuggesters = (id, items) => {
+  switch (id) {
+    case PANE_SECTION_IDS.CONDITIONS:
       return { practitioner: {}, icd10: {} };
-    case ALLERGIES_TITLE:
+    case PANE_SECTION_IDS.ALLERGIES:
       return { practitioner: {}, allergy: {} };
-    case FAMILY_HISTORY_TITLE:
+    case PANE_SECTION_IDS.FAMILY_HISTORY:
       return { practitioner: {}, icd10: {} };
-    case ISSUES_TITLE:
+    case PANE_SECTION_IDS.ISSUES:
       return {};
-    case CARE_PLANS_TITLE:
+    case PANE_SECTION_IDS.CARE_PLANS:
       return {
         practitioner: {},
         carePlan: {
@@ -38,7 +32,7 @@ const getSuggesters = (title, items) => {
   }
 };
 
-export const InfoPaneAddEditForm = memo(({ endpoint, onClose, Form, item, title, items }) => {
+export const InfoPaneAddEditForm = memo(({ endpoint, onClose, Form, item, id, items }) => {
   const api = useApi();
   const queryClient = useQueryClient();
   const patient = useSelector(state => state.patient);
@@ -51,21 +45,21 @@ export const InfoPaneAddEditForm = memo(({ endpoint, onClose, Form, item, title,
         await api.post(endpoint, { ...data, patientId: patient.id });
       }
 
-      queryClient.invalidateQueries([`infoPaneListItem-${title}`, patient.id]);
+      queryClient.invalidateQueries([`infoPaneListItem-${id}`, patient.id]);
       onClose();
     },
-    [api, endpoint, onClose, patient.id, title, queryClient],
+    [api, endpoint, onClose, patient.id, id, queryClient],
   );
 
   const suggesters = useMemo(
     () =>
       Object.fromEntries(
-        Object.entries(getSuggesters(title, items)).map(([key, options = {}]) => [
+        Object.entries(getSuggesters(id, items)).map(([key, options = {}]) => [
           `${key}Suggester`,
           new Suggester(api, key, options),
         ]),
       ),
-    [api, title, items],
+    [api, id, items],
   );
 
   return (

--- a/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
+++ b/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
@@ -9,7 +9,7 @@ import { Colors } from '../../constants';
 import { FormModal } from '../FormModal';
 import { PatientAlert } from '../PatientAlert';
 import { InfoPaneAddEditForm } from './InfoPaneAddEditForm';
-import { ISSUES_TITLE } from './paneTitles';
+import { PANE_SECTION_IDS } from './paneSections';
 import { useApi } from '../../api';
 
 const TitleContainer = styled.div`
@@ -97,7 +97,8 @@ export const InfoPaneList = ({
   const { data, error } = useQuery([`infoPaneListItem-${id}`, patient.id], () =>
     api.get(getEndpoint),
   );
-  const isIssuesPane = title === ISSUES_TITLE;
+
+  const isIssuesPane = id === PANE_SECTION_IDS.ISSUES;
   const { items, warnings } = getItems(isIssuesPane, data);
 
   const handleAddButtonClick = useCallback(
@@ -127,7 +128,7 @@ export const InfoPaneList = ({
         Form={Form}
         endpoint={endpoint}
         onClose={handleCloseForm}
-        title={title}
+        id={id}
         items={items}
       />
     </Wrapper>

--- a/packages/web/app/components/PatientInfoPane/paneSections.jsx
+++ b/packages/web/app/components/PatientInfoPane/paneSections.jsx
@@ -7,7 +7,7 @@ export const PANE_SECTION_IDS = {
   FAMILY_HISTORY: 'familyHistory',
   ISSUES: 'issues',
   CARE_PLANS: 'carePlans',
-  PROGRAM_REGISTRY: 'programRegistries',
+  PROGRAM_REGISTRY: 'programRegistry',
 };
 
 export const PANE_SECTION_TITLES = {
@@ -38,7 +38,7 @@ export const PANE_SECTION_TITLES = {
   [PANE_SECTION_IDS.PROGRAM_REGISTRY]: (
     <TranslatedText
       stringId="patient.detailsSidebar.subheading.programRegistries"
-      fallback="Program registries"
+      fallback="Program registry"
     />
   ),
 };

--- a/packages/web/app/components/PatientInfoPane/paneSections.jsx
+++ b/packages/web/app/components/PatientInfoPane/paneSections.jsx
@@ -7,6 +7,7 @@ export const PANE_SECTION_IDS = {
   FAMILY_HISTORY: 'familyHistory',
   ISSUES: 'issues',
   CARE_PLANS: 'carePlans',
+  PROGRAM_REGISTRY: 'programRegistries',
 };
 
 export const PANE_SECTION_TITLES = {
@@ -33,5 +34,11 @@ export const PANE_SECTION_TITLES = {
   ),
   [PANE_SECTION_IDS.CARE_PLANS]: (
     <TranslatedText stringId="patient.detailsSidebar.subheading.carePlans" fallback="Care plans" />
+  ),
+  [PANE_SECTION_IDS.PROGRAM_REGISTRY]: (
+    <TranslatedText
+      stringId="patient.detailsSidebar.subheading.programRegistries"
+      fallback="Program registries"
+    />
   ),
 };

--- a/packages/web/app/components/PatientInfoPane/paneTitles.js
+++ b/packages/web/app/components/PatientInfoPane/paneTitles.js
@@ -1,6 +1,0 @@
-export const CONDITIONS_TITLE = 'Ongoing conditions';
-export const ALLERGIES_TITLE = 'Allergies';
-export const FAMILY_HISTORY_TITLE = 'Family history';
-export const ISSUES_TITLE = 'Other patient issues';
-export const CARE_PLANS_TITLE = 'Care plans';
-export const PROGRAM_REGISTRY = 'Program registry';

--- a/packages/web/app/views/programRegistry/ActivatePatientProgramRegistry.jsx
+++ b/packages/web/app/views/programRegistry/ActivatePatientProgramRegistry.jsx
@@ -20,7 +20,7 @@ import { useSuggester } from '../../api';
 import { useAuth } from '../../contexts/Auth';
 import { Modal } from '../../components/Modal';
 import { useApi } from '../../api/useApi';
-import { PROGRAM_REGISTRY } from '../../components/PatientInfoPane/paneTitles';
+import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 import {
   usePatientProgramRegistryConditionsQuery,
   useProgramRegistryConditionsQuery,
@@ -94,7 +94,7 @@ export const ActivatePatientProgramRegistry = ({ onClose, patientProgramRegistra
     );
 
     // Invalidate queries and close modal
-    queryClient.invalidateQueries([`infoPaneListItem-${PROGRAM_REGISTRY}`]);
+    queryClient.invalidateQueries([`infoPaneListItem-${PANE_SECTION_IDS.PROGRAM_REGISTRY}`]);
     onClose();
   };
 

--- a/packages/web/app/views/programRegistry/ChangeStatusFormModal.jsx
+++ b/packages/web/app/views/programRegistry/ChangeStatusFormModal.jsx
@@ -15,7 +15,7 @@ import {
 } from '../../components';
 import { useApi, useSuggester } from '../../api';
 import { optionalForeignKey } from '../../utils/validation';
-import { PROGRAM_REGISTRY } from '../../components/PatientInfoPane/paneTitles';
+import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 import { FORM_TYPES } from '../../constants';
 
 const StyledFormGrid = styled(FormGrid)`
@@ -46,7 +46,7 @@ export const ChangeStatusFormModal = ({ patientProgramRegistration, onClose, ope
       { ...rest, ...changedStatus, date: getCurrentDateTimeString(), },
     );
 
-    queryClient.invalidateQueries([`infoPaneListItem-${PROGRAM_REGISTRY}`]);
+    queryClient.invalidateQueries([`infoPaneListItem-${PANE_SECTION_IDS.PROGRAM_REGISTRY}`]);
     onClose();
   };
 

--- a/packages/web/app/views/programRegistry/DeleteProgramRegistryFormModal.jsx
+++ b/packages/web/app/views/programRegistry/DeleteProgramRegistryFormModal.jsx
@@ -6,7 +6,7 @@ import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { ConfirmCancelRow, FormSeparatorLine, Modal } from '../../components';
 import { useApi } from '../../api';
 import { Colors } from '../../constants';
-import { PROGRAM_REGISTRY } from '../../components/PatientInfoPane/paneTitles';
+import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 
 const Text = styled.div`
   display: flex;
@@ -45,7 +45,7 @@ export const DeleteProgramRegistryFormModal = ({ patientProgramRegistration, onC
       },
     );
 
-    queryClient.invalidateQueries([`infoPaneListItem-${PROGRAM_REGISTRY}`]);
+    queryClient.invalidateQueries([`infoPaneListItem-${PANE_SECTION_IDS.PROGRAM_REGISTRY}`]);
     onClose({ success: true });
   };
 

--- a/packages/web/app/views/programRegistry/RemoveProgramRegistryFormModal.jsx
+++ b/packages/web/app/views/programRegistry/RemoveProgramRegistryFormModal.jsx
@@ -6,7 +6,7 @@ import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { ConfirmCancelRow, DateDisplay, FormSeparatorLine, Modal } from '../../components';
 import { Colors } from '../../constants';
 import { useApi } from '../../api';
-import { PROGRAM_REGISTRY } from '../../components/PatientInfoPane/paneTitles';
+import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 
 const WarningDiv = styled.div`
   display: flex;
@@ -77,7 +77,7 @@ export const RemoveProgramRegistryFormModal = ({ patientProgramRegistration, onC
       },
     );
 
-    queryClient.invalidateQueries([`infoPaneListItem-${PROGRAM_REGISTRY}`]);
+    queryClient.invalidateQueries([`infoPaneListItem-${PANE_SECTION_IDS.PROGRAM_REGISTRY}`]);
     onClose();
   };
 

--- a/packages/web/stories/programRegistry.stories.jsx
+++ b/packages/web/stories/programRegistry.stories.jsx
@@ -7,7 +7,7 @@ import { REGISTRATION_STATUSES } from '@tamanu/constants';
 import { ChangeStatusFormModal } from '../app/views/programRegistry/ChangeStatusFormModal';
 import { ApiContext } from '../app/api';
 import { Modal } from '../app/components/Modal';
-import { PROGRAM_REGISTRY } from '../app/components/PatientInfoPane/paneTitles';
+import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 import { InfoPaneList } from '../app/components/PatientInfoPane/InfoPaneList';
 import { PatientProgramRegistryForm } from '../app/views/programRegistry/PatientProgramRegistryForm';
 import { ProgramRegistryListItem } from '../app/views/programRegistry/ProgramRegistryListItem';
@@ -30,6 +30,7 @@ import { RemoveConditionFormModal } from '../app/views/programRegistry/RemoveCon
 import { PatientProgramRegistrationSelectSurvey } from '../app/views/programRegistry/PatientProgramRegistrationSelectSurvey';
 import { ProgramRegistrySurveyView } from '../app/views/programRegistry/ProgramRegistrySurveyView';
 import { ProgramRegistryView } from '../app/views/programRegistry/ProgramRegistryView';
+import { PANE_SECTION_TITLES } from '../app/components/PatientInfoPane/paneSections';
 
 //#region InfoPaneList
 storiesOf('Program Registry', module).add('ProgramRegistry Info Panlist', () => {
@@ -39,7 +40,8 @@ storiesOf('Program Registry', module).add('ProgramRegistry Info Panlist', () => 
         <InfoPaneList
           patient={patient}
           readonly={false}
-          title={PROGRAM_REGISTRY}
+          id={PANE_SECTION_IDS.PROGRAM_REGISTRY}
+          title={PANE_SECTION_TITLES[PANE_SECTION_IDS.PROGRAM_REGISTRY]}
           endpoint="programRegistry"
           getEndpoint={`patient/${patient.id}/programRegistration`}
           Form={PatientProgramRegistryForm}

--- a/packages/web/stories/programRegistry.stories.jsx
+++ b/packages/web/stories/programRegistry.stories.jsx
@@ -7,7 +7,6 @@ import { REGISTRATION_STATUSES } from '@tamanu/constants';
 import { ChangeStatusFormModal } from '../app/views/programRegistry/ChangeStatusFormModal';
 import { ApiContext } from '../app/api';
 import { Modal } from '../app/components/Modal';
-import { PANE_SECTION_IDS } from '../../components/PatientInfoPane/paneSections';
 import { InfoPaneList } from '../app/components/PatientInfoPane/InfoPaneList';
 import { PatientProgramRegistryForm } from '../app/views/programRegistry/PatientProgramRegistryForm';
 import { ProgramRegistryListItem } from '../app/views/programRegistry/ProgramRegistryListItem';
@@ -30,7 +29,7 @@ import { RemoveConditionFormModal } from '../app/views/programRegistry/RemoveCon
 import { PatientProgramRegistrationSelectSurvey } from '../app/views/programRegistry/PatientProgramRegistrationSelectSurvey';
 import { ProgramRegistrySurveyView } from '../app/views/programRegistry/ProgramRegistrySurveyView';
 import { ProgramRegistryView } from '../app/views/programRegistry/ProgramRegistryView';
-import { PANE_SECTION_TITLES } from '../app/components/PatientInfoPane/paneSections';
+import { PANE_SECTION_TITLES, PANE_SECTION_IDS } from '../app/components/PatientInfoPane/paneSections';
 
 //#region InfoPaneList
 storiesOf('Program Registry', module).add('ProgramRegistry Info Panlist', () => {


### PR DESCRIPTION
In the translations work removed the string comparison used for the patient sidebar panes. This kind of broke a bunch of stuff on merge so this is just standardising all the new program registry work to use ids for comparisons/query invalidation rather than the title string used previously. This seems more in line with our general pattern for this kind of logic anyway

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
