### PR TITLE
fix(web): allow generic translations in select fields

### DIFF
--- a/packages/web/app/components/Translation/getTranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/getTranslatedOptions.jsx
@@ -5,12 +5,12 @@ import React from 'react';
 export const getTranslatedOptions = (options, prefix) => {
   if (!options) return [];
   return options.map(option => {
-    if (typeof option.label !== 'string') return option;
-    return {
-      value: option.value,
-      label: (
-        <TranslatedText stringId={`${prefix}.${camelCase(option.label)}`} fallback={option.label} />
-      ),
-    };
+    const { label, value } = option;
+    return typeof label === 'string'
+      ? {
+          value,
+          label: <TranslatedText stringId={`${prefix}.${camelCase(label)}`} fallback={label} />,
+        }
+      : option;
   });
 };

--- a/packages/web/app/components/Translation/getTranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/getTranslatedOptions.jsx
@@ -4,10 +4,13 @@ import React from 'react';
 
 export const getTranslatedOptions = (options, prefix) => {
   if (!options) return [];
-  return options.map(option => ({
-    value: option.value,
-    label: (
-      <TranslatedText stringId={`${prefix}.${camelCase(option.label)}`} fallback={option.label} />
-    ),
-  }));
+  return options.map(option => {
+    if (typeof option.label !== 'string') return option;
+    return {
+      value: option.value,
+      label: (
+        <TranslatedText stringId={`${prefix}.${camelCase(option.label)}`} fallback={option.label} />
+      ),
+    };
+  });
 };

--- a/packages/web/app/views/patients/panes/NotesPane.jsx
+++ b/packages/web/app/views/patients/panes/NotesPane.jsx
@@ -41,7 +41,7 @@ export const NotesPane = React.memo(({ encounter, readonly }) => {
           options={[
             {
               value: null,
-              label: 'All',
+              label: <TranslatedText stringId="general.select.all" fallback="All" />,
             },
             ...noteTypes,
           ]}

--- a/packages/web/app/views/patients/panes/NotesPane.jsx
+++ b/packages/web/app/views/patients/panes/NotesPane.jsx
@@ -41,7 +41,7 @@ export const NotesPane = React.memo(({ encounter, readonly }) => {
           options={[
             {
               value: null,
-              label: <TranslatedText stringId="note.property.type.all" fallback="All" />,
+              label: 'All',
             },
             ...noteTypes,
           ]}


### PR DESCRIPTION
`TranslatableSelectField` was not designed to take `TranslatedText` components in their options as labels (they were meant to just take option formatted constants). This bug popped up that made it clear that it would actually be useful to allow us to supply our own TranslatedText components (particularly for the general/default options)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
