### PR TITLE
fix(web): allow for TranslatedText in pop up error logic

### DIFF
--- a/packages/web/app/components/Field/Form.jsx
+++ b/packages/web/app/components/Field/Form.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { isValidElement, useEffect } from 'react';
 import { Formik, useFormikContext } from 'formik';
 import PropTypes from 'prop-types';
 import { ValidationError } from 'yup';
@@ -13,7 +13,10 @@ import { useFormSubmission } from '../../contexts/FormSubmission';
 import { IS_DEVELOPMENT } from '../../utils/env';
 import { TranslatedText } from '../Translation/TranslatedText';
 
-const ErrorMessage = ({ error }) => `${JSON.stringify(error)}`;
+const ErrorMessage = ({ error }) => {
+  if (isValidElement(error)) return error
+  return `${JSON.stringify(error)}`;
+};
 
 const FormErrors = ({ errors }) => {
   const allErrors = flattenObject(errors);

--- a/packages/web/app/utils/flattenObject.js
+++ b/packages/web/app/utils/flattenObject.js
@@ -1,4 +1,5 @@
 import { isArray, isObject } from 'lodash';
+import { isValidElement } from 'react';
 
 /*
 This helper function will return a flat object containing
@@ -31,7 +32,8 @@ export const flattenObject = (obj, prefix = '') => {
     const newKey = isObjArray ? `[${key}]` : key;
     const separator = isObjArray ? '' : '.';
     const prefixedKey = prefix ? `${prefix}${separator}${newKey}` : newKey;
-    if (isObject(value)) Object.assign(flattened, flattenObject(value, prefixedKey));
+    if (isObject(value) && !isValidElement(value)) // stop it from trying to flatten react elements
+      Object.assign(flattened, flattenObject(value, prefixedKey));
     else flattened[prefixedKey] = value;
   });
   return flattened;


### PR DESCRIPTION
In testing the report generator form we discovered that the validation errors were going through a couple of functions that didnt like TranslatedText being used as the error text
- `flattenObject`: was trying to flatten any react objects supplied which would lead to a max call stack error
- `json.stringify`: being applied to the error even if it was a TranslatedText component

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
