### PR TITLE
fix(reports): parameter select field options showing empty

### DIFF
--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -339,7 +339,6 @@ export const ReportGeneratorForm = () => {
               <Spacer />
               <FormGrid columns={3}>
                 {parameters.map(({ parameterField, required, name, label, ...restOfProps }) => {
-                  delete restOfProps.options;
                   return (
                     <ParameterField
                       key={name || parameterField}


### PR DESCRIPTION
Not sure why this keep being added back in unless Im missing something. This is the third time i have deleted this line of code im pretty sure 🤔 Basically the parameter select fields for report generation aren't getting their options as they are getting explicitly deleted here

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
