### PR TITLE
fix(web): useLabTest throwing error when undefined

### DIFF
--- a/packages/web/app/api/queries/useLabTest.js
+++ b/packages/web/app/api/queries/useLabTest.js
@@ -3,6 +3,7 @@ import { useApi } from '../useApi';
 
 export const useLabTest = labTestId => {
   const api = useApi();
+  
   return useQuery(
     ['labTest', labTestId],
     () => api.get(`labTest/${encodeURIComponent(labTestId)}`),

--- a/packages/web/app/api/queries/useLabTest.js
+++ b/packages/web/app/api/queries/useLabTest.js
@@ -3,8 +3,9 @@ import { useApi } from '../useApi';
 
 export const useLabTest = labTestId => {
   const api = useApi();
-
-  return useQuery(['labTest', labTestId], () =>
-    api.get(`labTest/${encodeURIComponent(labTestId)}`),
+  return useQuery(
+    ['labTest', labTestId],
+    () => api.get(`labTest/${encodeURIComponent(labTestId)}`),
+    { enabled: !!labTestId },
   );
 };


### PR DESCRIPTION
This has been around since 2.2 actually and not exactly sure what the cause was. The problem was it was trying to hit a query with an undefined id. I have just set up `enabled` on the query to listen for the id. Also checked the intended functionality and seems to be working as expected

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
