### PR TITLE
fix(web): add missing prop to patient details section

### DIFF
--- a/packages/web/app/forms/PatientDetailsForm/layouts/generic/GenericLayout.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/layouts/generic/GenericLayout.jsx
@@ -198,7 +198,7 @@ export const GenericSecondaryDetailsLayout = ({
       />
     </PatientDetailsHeading>
     <SecondaryDetailsFormGrid>
-      <GenericPersonalFields filterByMandatory={false} />
+      <GenericPersonalFields patientRegistryType={patientRegistryType} filterByMandatory={false} />
     </SecondaryDetailsFormGrid>
 
     <PatientDetailsHeading>

--- a/packages/web/app/forms/PatientDetailsForm/layouts/generic/GenericLayout.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/layouts/generic/GenericLayout.jsx
@@ -213,6 +213,6 @@ export const GenericSecondaryDetailsLayout = ({
   </SecondaryDetailsGroup>
 );
 
-export const GenericPatientFieldLayout = ({ fieldDefinition, fieldValues }) => (
-  <PatientFieldsGroup fieldDefinitions={fieldDefinition} fieldValues={fieldValues} />
+export const GenericPatientFieldLayout = ({ fieldDefinitions, fieldValues }) => (
+  <PatientFieldsGroup fieldDefinitions={fieldDefinitions} fieldValues={fieldValues} />
 );


### PR DESCRIPTION
There was a refractor of the patient details form and a prop that was used in some conditionals wasnt added to a component. This mean that certain fields were never showing. added this prop for the intended functionality

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
