### PR TITLE
fix(sync): SAV-601: Turn assertIfPulledRecordsUpdatedAfterPushSnapshot off by default (v2.4)

### DIFF
--- a/packages/facility-server/__tests__/sync/FacilitySyncManager-edgecases.test.js
+++ b/packages/facility-server/__tests__/sync/FacilitySyncManager-edgecases.test.js
@@ -235,7 +235,10 @@ describe('FacilitySyncManager edge cases', () => {
         }),
       }));
 
-      const encounter = await initializeSyncManager();
+      const configToOverride = {
+        sync: { enabled: true, assertIfPulledRecordsUpdatedAfterPushSnapshot: true },
+      };
+      const encounter = await initializeSyncManager(configToOverride);
 
       // start the sync
       const syncPromise = syncManager.runSync();

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -24,7 +24,7 @@
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,
     "pauseBetweenCacheBatchInMilliseconds": 50,
     "persistUpdateWorkerPoolSize": 5,
-    "assertIfPulledRecordsUpdatedAfterPushSnapshot": true,
+    "assertIfPulledRecordsUpdatedAfterPushSnapshot": false,
     "enabled": true,
     "jitterTime": "1s",
     "backoff": {


### PR DESCRIPTION
### Changes
- Turn assertIfPulledRecordsUpdatedAfterPushSnapshot off by default (v2.4)

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
