### PR TITLE
fix(web): disabled select field issues

### DIFF
--- a/packages/web/app/components/Field/SelectField.jsx
+++ b/packages/web/app/components/Field/SelectField.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Select, { components } from 'react-select';
@@ -173,12 +173,15 @@ export const SelectInput = ({
 
   const isReadonly = (readonly && !disabled) || (value && !onChange);
   if (disabled || isReadonly || !options || options.length === 0) {
-    const valueText = ((options || []).find(o => o.value === value) || {}).label || '';
+    const selectedOptionLabel = ((options || []).find(o => o.value === value) || {}).label || '';
+    const valueText =
+      isValidElement(selectedOptionLabel) && selectedOptionLabel.type.name === 'TranslatedText'
+        ? selectedOptionLabel.props.fallback // temporary workaround to stop [object Object] from being displayed
+        : selectedOptionLabel;
     return (
       <OuterLabelFieldWrapper label={label} {...props}>
         <StyledTextField
           value={valueText}
-          styles={defaultStyles}
           variant="outlined"
           classes={classes}
           disabled={disabled}

--- a/packages/web/app/components/Field/SelectField.jsx
+++ b/packages/web/app/components/Field/SelectField.jsx
@@ -182,6 +182,7 @@ export const SelectInput = ({
       <OuterLabelFieldWrapper label={label} {...props}>
         <StyledTextField
           value={valueText}
+          styles={defaultStyles}
           variant="outlined"
           classes={classes}
           disabled={disabled}

--- a/packages/web/app/components/Translation/getTranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/getTranslatedOptions.jsx
@@ -5,12 +5,11 @@ import React from 'react';
 export const getTranslatedOptions = (options, prefix) => {
   if (!options) return [];
   return options.map(option => {
-    const { label, value, isDisabled } = option;
+    const { label, ...rest } = option;
     return typeof label === 'string'
       ? {
-          value,
           label: <TranslatedText stringId={`${prefix}.${camelCase(label)}`} fallback={label} />,
-          isDisabled,
+          ...rest,
         }
       : option;
   });

--- a/packages/web/app/components/Translation/getTranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/getTranslatedOptions.jsx
@@ -5,11 +5,12 @@ import React from 'react';
 export const getTranslatedOptions = (options, prefix) => {
   if (!options) return [];
   return options.map(option => {
-    const { label, value } = option;
+    const { label, value, isDisabled } = option;
     return typeof label === 'string'
       ? {
           value,
           label: <TranslatedText stringId={`${prefix}.${camelCase(label)}`} fallback={label} />,
+          isDisabled,
         }
       : option;
   });


### PR DESCRIPTION
We discovered some broken behaviour with the select field during regression testing when disabling individual options or entire fields

- Disabled select fields with a value will show as `[object Object]`
- `isDisabled` tag for options was not passed through in `getTranslatedOptions`


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
