### PR TITLE
feat(reports): mdev-226: add vitals surveys to generic line list report

### DIFF
--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -217,11 +217,11 @@ createNameSuggester('facilityLocationGroup', 'LocationGroup', (search, query) =>
   filterByFacilityWhereBuilder(search, { ...query, filterByFacility: true }),
 );
 
-createNameSuggester('survey', 'Survey', (search, { programId }) => ({
+createNameSuggester('survey', 'Survey', (search, { programId, surveyTypes }) => ({
   name: { [Op.iLike]: search },
   ...(programId ? { programId } : programId),
   surveyType: {
-    [Op.notIn]: [SURVEY_TYPES.OBSOLETE, SURVEY_TYPES.VITALS],
+    [Op.in]: surveyTypes ? surveyTypes : [SURVEY_TYPES.PROGRAMS, SURVEY_TYPES.REFERRAL],
   },
 }));
 

--- a/packages/shared/src/reports/reportDefinitions.js
+++ b/packages/shared/src/reports/reportDefinitions.js
@@ -7,6 +7,7 @@ import {
   REPORT_DATA_SOURCES,
   REPORT_DATE_RANGE_LABELS,
   REPORT_DEFAULT_DATE_RANGES,
+  SURVEY_TYPES,
 } from '@tamanu/constants';
 
 const LAST_30_DAYS_DATE_LABEL = REPORT_DATE_RANGE_LABELS[REPORT_DEFAULT_DATE_RANGES.THIRTY_DAYS];
@@ -359,6 +360,11 @@ export const REPORT_DEFINITIONS = [
         name: 'surveyId',
         suggesterEndpoint: 'survey',
         required: true,
+        suggesterOptions: {
+          baseQueryParameters: {
+            surveyTypes: [SURVEY_TYPES.PROGRAMS, SURVEY_TYPES.REFERRAL, SURVEY_TYPES.VITALS],
+          },
+        },
       },
     ],
   },


### PR DESCRIPTION
### Changes

feat(reports): mdev-226: add vitals surveys to generic line list report

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
