### PR TITLE
fix(web): Report editor parameter fields not working for editing

### DIFF
--- a/packages/web/app/views/administration/reports/ReportEditor.jsx
+++ b/packages/web/app/views/administration/reports/ReportEditor.jsx
@@ -111,7 +111,8 @@ const ReportEditorForm = ({ isSubmitting, values, setValues, dirty, isEdit }) =>
   const { ability } = useAuth();
   const api = useApi();
   const setQuery = query => setValues({ ...values, query });
-  const params = values.parameters || [];
+  const params =
+    values.parameters.map(param => ({ ...generateDefaultParameter(), ...param })) || [];
   const setParams = newParams => setValues({ ...values, parameters: newParams });
   const onParamsAdd = () => setParams([...params, generateDefaultParameter()]);
   const onParamsChange = (paramId, field, newValue) => {


### PR DESCRIPTION
### Changes

Surprised this hasnt popped up sooner honestly. The logic for editing/deleting parameter fields is all based on an id property of a parameter field. The issue is that this id is only generated when the user adds a new one. When the user visits an existing report full of param fields, they wont be able to edit or delete properly as none of them will have ids generated for the logic to use

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
