### PR TITLE
test(fakeHelpers): Prefer default values before random

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
@@ -187,6 +187,7 @@ describe(`Materialised - MediciReport`, () => {
       procedure,
       procedureType,
       rootNote,
+      labTestType,
     };
   }
 
@@ -196,6 +197,7 @@ describe(`Materialised - MediciReport`, () => {
       encounterDiagnosis,
       encounterMedication,
       procedureType,
+      labTestType,
     } = await makeEncounter({
       encounterType: 'emergency',
     });
@@ -266,7 +268,7 @@ describe(`Materialised - MediciReport`, () => {
         {
           tests: [
             {
-              name: 'AgRDT Negative, no further testing needed',
+              name: labTestType.name,
             },
           ],
         },

--- a/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
@@ -205,9 +205,9 @@ describe(`Materialised - MediciReport`, () => {
     await MediciReport.materialiseFromUpstream(encounter.id);
     await MediciReport.resolveUpstreams();
 
-    const mediciReport = await MediciReport.findAll();
+    const mediciReport = await MediciReport.findOne();
 
-    expect(mediciReport[0].dataValues).toMatchObject({
+    expect(mediciReport.dataValues).toMatchObject({
       patientId: resources.patient.displayId,
       firstName: resources.patient.firstName,
       lastName: resources.patient.lastName,
@@ -285,9 +285,9 @@ describe(`Materialised - MediciReport`, () => {
       await MediciReport.materialiseFromUpstream(encounter.id);
       await MediciReport.resolveUpstreams();
 
-      const mediciReport = await MediciReport.findAll();
+      const mediciReport = await MediciReport.findOne();
 
-      expect(mediciReport[0].dataValues).toMatchObject({
+      expect(mediciReport.dataValues).toMatchObject({
         notes: [
           {
             content: rootNote.content,
@@ -320,9 +320,9 @@ describe(`Materialised - MediciReport`, () => {
       await MediciReport.materialiseFromUpstream(encounter.id);
       await MediciReport.resolveUpstreams();
 
-      const mediciReport = await MediciReport.findAll();
+      const mediciReport = await MediciReport.findOne();
 
-      expect(mediciReport[0].dataValues).toMatchObject({
+      expect(mediciReport.dataValues).toMatchObject({
         notes: [
           {
             content: changelog1.content,

--- a/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
+++ b/packages/facility-server/__tests__/apiv1/ImagingRequests.test.js
@@ -10,6 +10,7 @@ import {
 import { createDummyEncounter, createDummyPatient } from '@tamanu/shared/demoData/patients';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 import { fake } from '@tamanu/shared/test-helpers/fake';
+import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
 
 import { createTestContext } from '../utilities';
 
@@ -494,6 +495,11 @@ describe('Imaging requests', () => {
         await models.ImagingRequest.truncate({ cascade: true });
 
         for (let i = 0; i < completedCount; ++i) {
+          // Some tests expect that the imaging results completedAt field
+          // is not duplicated, otherwise we cannot guarantee ordering.
+          // Given this field is a date time string, the precision is up to seconds
+          // which means we need to wait for one whole second between requests
+          await sleepAsync(1000);
           const resultCount = i % 4; // get a few different result counts in, including 0
           await makeRequestAtFacility(
             config.serverFacilityId,

--- a/packages/shared/src/test-helpers/fake.js
+++ b/packages/shared/src/test-helpers/fake.js
@@ -1,6 +1,6 @@
 import { isFunction, snakeCase } from 'lodash';
 import Chance from 'chance';
-import { DataTypes } from 'sequelize';
+import Sequelize, { DataTypes } from 'sequelize';
 import { inspect } from 'util';
 import { formatISO9075 } from 'date-fns';
 
@@ -527,7 +527,12 @@ export const fake = (model, passedOverrides = {}) => {
         .map(() => fakeField(name, { ...attribute, type: type.type }));
     }
 
-    if (defaultValue) return isFunction(defaultValue) ? defaultValue() : defaultValue;
+    if (defaultValue) {
+      if (defaultValue instanceof Sequelize.NOW || defaultValue instanceof Sequelize.UUIDV4) {
+        return undefined;
+      }
+      return isFunction(defaultValue) ? defaultValue() : defaultValue;
+    }
 
     if (FIELD_HANDLERS[type]) {
       return FIELD_HANDLERS[type](model, attribute, id);

--- a/packages/shared/src/test-helpers/fake.js
+++ b/packages/shared/src/test-helpers/fake.js
@@ -1,4 +1,4 @@
-import { snakeCase } from 'lodash';
+import { isFunction, snakeCase } from 'lodash';
 import Chance from 'chance';
 import { DataTypes } from 'sequelize';
 import { inspect } from 'util';
@@ -497,7 +497,7 @@ export const fake = (model, passedOverrides = {}) => {
   const overrideFields = Object.keys(overrides);
 
   function fakeField(name, attribute) {
-    const { type, fieldName } = attribute;
+    const { type, fieldName, defaultValue } = attribute;
 
     if (overrideFields.includes(fieldName)) {
       return overrides[fieldName];
@@ -526,6 +526,8 @@ export const fake = (model, passedOverrides = {}) => {
         .fill(0)
         .map(() => fakeField(name, { ...attribute, type: type.type }));
     }
+
+    if (defaultValue) return isFunction(defaultValue) ? defaultValue() : defaultValue;
 
     if (FIELD_HANDLERS[type]) {
       return FIELD_HANDLERS[type](model, attribute, id);

--- a/packages/web/.storybook/__mocks__/sequelize.js
+++ b/packages/web/.storybook/__mocks__/sequelize.js
@@ -5,3 +5,10 @@ export const DataTypes = {
 };
 
 export const QueryTypes = {};
+
+const Sequelize = {
+  NOW: {},
+  UUIDV4: {},
+};
+
+export default Sequelize;


### PR DESCRIPTION
### Changes

There are a couple of tests that break from time to time. These tests seem to be breaking because they are using random values, and these values are sometimes invalid for a specific set of business rules. I've seen a couple scenarios where we actually rely on the field default value instead of explicitly setting it on the API call. Other scenarios happen when the default is null and that is perfectly fine and we wouldn't want to overwrite it just because.