### PR TITLE
fix(web): patient listing export bug

### DIFF
--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -12,15 +12,12 @@ import { TranslatedText } from '../Translation/TranslatedText';
 // This is a temporary implementation to basically keep TranslatedText components from breaking export
 // by supplying the fallback string in place of the component. proper translation export implmentation coming in NASS-1201
 const normaliseTranslatedText = element => {
+  if (!isValidElement(element)) return element;
   if (element.type?.name === 'TranslatedText') return element.props.fallback;
   if (!Array.isArray(element.props?.children)) return element;
 
   return React.cloneElement(element, {
-    children: element.props.children.map(child => {
-      return child.type?.name === 'TranslatedText'
-        ? child.props.fallback
-        : normaliseTranslatedText(child);
-    }),
+    children: element.props.children.map(normaliseTranslatedText),
   });
 };
 


### PR DESCRIPTION
### Changes

I created a recursive function that replaced translated text components with their relevant fallback value during table exports. This function will likely be helpful in actually translating it but for now it just returns the fallback so we can keep the current behaviour for users trying to export tables.

The first implementation worked for most cases except for the patient listing views. I have just added in some more protection to ensure it is only running its logic on translated text components and also removed a duplicate comparison.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
