### PR TITLE
fix(web): error on clearing survey field

### DIFF
--- a/packages/web/app/contexts/ProgramRegistry.jsx
+++ b/packages/web/app/contexts/ProgramRegistry.jsx
@@ -13,6 +13,10 @@ export const ProgramRegistryProvider = ({ children }) => {
   const [programRegistryId, setProgramRegistryId] = useState(null);
   const api = useApi();
   const setProgramRegistryIdByProgramId = async programId => {
+    if (!programId) {
+      setProgramRegistryId(null);
+      return;
+    }
     const { programRegistries } = await api.get(`program/${programId}`);
     if (programRegistries.length > 0) {
       setProgramRegistryId(programRegistries[0].id);


### PR DESCRIPTION
### Changes

The new ProgramRegistry context is sending requests for the programRegistries for a program even if the field has been cleared to empty. this throws an error for hitting the request with an "undefined" value. Ideally I would reorganise this logic to be a useQuery that listens to a programId set and wont fire if falsy, but it seems like it would require a decent bit of logic shuffling around (more than i am comfortable doing as i am unfamiliar with program registries and we are right at the end of regression).

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
