### PR TITLE
fix(web): NASS-1211: Add browser & platform restrictions to version 2.1

### DIFF
--- a/packages/web/app/App.jsx
+++ b/packages/web/app/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
+import Bowser from 'bowser';
 import 'typeface-roboto';
 import { Colors } from './constants';
 import { checkIsLoggedIn } from './store/auth';
@@ -9,8 +10,15 @@ import { LoginView } from './views';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PromiseErrorBoundary } from './components/PromiseErrorBoundary';
 import { ForbiddenErrorModal } from './components/ForbiddenErrorModal';
-import { LoadingStatusPage, UnavailableStatusPage } from './components/StatusPage';
+import {
+  LoadingStatusPage,
+  UnavailableStatusPage,
+  UnsupportedBrowserStatusPage,
+  MobileStatusPage,
+  SingleTabStatusPage,
+} from './components/StatusPage';
 import { useCheckServerAliveQuery } from './api/queries/useCheckServerAliveQuery';
+import { useSingleTab } from './utils/singleTab';
 
 const AppContainer = styled.div`
   display: flex;
@@ -28,7 +36,23 @@ export function App({ sidebar, children }) {
   const { data: isServerAlive, isLoading } = useCheckServerAliveQuery();
   const isUserLoggedIn = useSelector(checkIsLoggedIn);
   const currentRoute = useSelector(getCurrentRoute);
+  const isPrimaryTab = useSingleTab();
+  const disableSingleTab = localStorage.getItem('DISABLE_SINGLE_TAB');
 
+  const browser = Bowser.getParser(window.navigator.userAgent);
+  const isChrome = browser.satisfies({
+    chrome: '>=88.0.4324.109', // Early 2021 release of chrome. Arbitrarily chosen as recentish.
+  });
+  const platformType = browser.getPlatformType();
+  const isDesktop = platformType === 'desktop';
+  const isDebugMode = localStorage.getItem('DEBUG_PROD');
+
+  if (!isDebugMode) {
+    // Skip browser/platform check in debug mode
+    if (!isDesktop) return <MobileStatusPage platformType={platformType} />;
+    if (!isChrome) return <UnsupportedBrowserStatusPage />;
+  }
+  if (!isPrimaryTab && !disableSingleTab) return <SingleTabStatusPage />;
   if (isLoading) return <LoadingStatusPage />;
   if (!isServerAlive) return <UnavailableStatusPage />;
   if (!isUserLoggedIn) return <LoginView />;

--- a/packages/web/app/components/StatusPage.jsx
+++ b/packages/web/app/components/StatusPage.jsx
@@ -5,34 +5,65 @@ import { Colors } from '../constants';
 import { TamanuLogoLeftIconBlue } from './TamanuLogo';
 import { Typography } from '@material-ui/core';
 
+import HeroImg from '../assets/images/splashscreens/screen_4.png';
+
+const FlexContainer = styled.div`
+  display: flex;
+`;
+
 const Container = styled.div`
   padding: 25px 35px;
   height: 100vh;
   background: ${Colors.white};
+  flex: 1;
 `;
 
 const Content = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 50px;
+  margin: 50px auto;
 `;
 
-const ErrorMessage = styled(Typography)`
+const ErrorMessage = styled(Typography).attrs({
+  variant: 'h1',
+})`
   font-weight: 500;
   font-size: 38px;
-  line-height: 32px;
 `;
 
 const ErrorDescription = styled(LargeBodyText)`
   margin-top: 20px;
   max-width: 450px;
-  text-align: center;
+  text-align: ${props => (props.$heroImage ? 'left' : 'center')};
 `;
 
 const Logo = styled(TamanuLogoLeftIconBlue)`
   cursor: pointer;
 `;
+
+const handleRefreshPage = () => {
+  window.location.reload();
+};
+
+export const StatusPage = ({ message, description }) => {
+  return (
+    <Container>
+      <Logo onClick={handleRefreshPage} />
+      <Content>
+        <ErrorMessage>{message}</ErrorMessage>
+        <ErrorDescription color="textTertiary">{description}</ErrorDescription>
+      </Content>
+    </Container>
+  );
+};
+
+export const UnavailableStatusPage = () => (
+  <StatusPage
+    message="Tamanu is currently unavailable"
+    description="Tamanu is currently unavailable. Please try again later or contact your system administrator for further information."
+  />
+);
 
 const ellipsis = keyframes`
   from {
@@ -55,21 +86,6 @@ const AnimateEllipsis = styled.span`
   }
 `;
 
-export const StatusPage = ({ message, description }) => {
-  const handleRefreshPage = () => {
-    window.location.reload();
-  };
-  return (
-    <Container>
-      <Logo onClick={handleRefreshPage} />
-      <Content>
-        <ErrorMessage>{message}</ErrorMessage>
-        <ErrorDescription color="textTertiary">{description}</ErrorDescription>
-      </Content>
-    </Container>
-  );
-};
-
 export const LoadingStatusPage = () => (
   <StatusPage
     message={<AnimateEllipsis>Tamanu is loading</AnimateEllipsis>}
@@ -77,9 +93,83 @@ export const LoadingStatusPage = () => (
   />
 );
 
-export const UnavailableStatusPage = () => (
-  <StatusPage
-    message="Tamanu is currently unavailable"
-    description="Tamanu is currently unavailable. Please try again later or contact your system administrator for further information."
+const HeroImage = styled.div`
+  background-image: url(${HeroImg});
+  background-size: cover;
+  height: 100vh;
+  width: 50vw;
+`;
+
+const HeroContent = styled(Content)`
+  align-items: flex-start;
+  margin: 200px auto;
+  max-width: 467px;
+`;
+
+const HeroErrorDescription = styled(ErrorDescription)`
+  text-align: left;
+`;
+
+export const StatusPageWithHeroImage = ({ message, description }) => {
+  return (
+    <FlexContainer>
+      <Container>
+        <Logo onClick={handleRefreshPage} size="140px" />
+        <HeroContent>
+          <ErrorMessage>{message}</ErrorMessage>
+          <HeroErrorDescription color="textTertiary">{description}</HeroErrorDescription>
+        </HeroContent>
+      </Container>
+      <HeroImage />
+    </FlexContainer>
+  );
+};
+
+export const UnsupportedBrowserStatusPage = () => (
+  <StatusPageWithHeroImage
+    message="Tamanu is only available on Chrome"
+    description="Please contact your system administrator for further information on how to access Tamanu using a Chrome browser."
   />
 );
+
+const MobileContainer = styled(Container)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  img {
+    display: block;
+    margin: 0 auto;
+    width: ${props => (props.$platformType === 'tablet' ? '371px' : '194px')}};
+  }
+  div {
+    font-size: ${props => (props.$platformType === 'tablet' ? '18px' : '14px')}};
+  }
+`;
+
+export const MobileStatusPage = ({ platformType }) => (
+  <MobileContainer $platformType={platformType}>
+    <Logo onClick={handleRefreshPage} />
+    <ErrorDescription color="textTertiary">
+      Tamanu Desktop is not currently supported by mobile or tablet devices. Please access Tamanu
+      via a desktop computer or laptop.
+    </ErrorDescription>
+  </MobileContainer>
+);
+
+const SingleTabErrorMessage = styled(ErrorMessage)`
+  text-align: center;
+`;
+
+export const SingleTabStatusPage = () => {
+  return (
+    <StatusPage
+      message={
+        <SingleTabErrorMessage>
+          Tamanu can not be opened across <br /> multiple tabs.
+        </SingleTabErrorMessage>
+      }
+      description="Please continue working in the existing tab."
+    />
+  );
+};

--- a/packages/web/app/utils/singleTab.js
+++ b/packages/web/app/utils/singleTab.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+const tabStart = Date.now();
+const channel = new BroadcastChannel('tamanuSingleTab');
+
+export const useSingleTab = () => {
+  const [isPrimaryTab, setIsPrimaryTab] = useState(true);
+
+  useEffect(() => {
+    const listener = event => {
+      const otherTabStart = event.data;
+
+      if (otherTabStart < tabStart) {
+        // Another tab is older than this one
+        setIsPrimaryTab(false);
+        channel.removeEventListener('message', listener);
+      } else if (isPrimaryTab) {
+        // another tab is checking if it's the primary - current tab is primary
+        channel.postMessage(tabStart);
+      }
+    };
+
+    channel.addEventListener('message', listener);
+    channel.postMessage(tabStart);
+
+    return () => {
+      channel.removeEventListener('message', listener);
+    };
+  }, []);
+
+  return isPrimaryTab;
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -51,6 +51,7 @@
     "@tanstack/react-query-devtools": "^4.0.10",
     "@types/react-autosuggest": "^9.3.7",
     "@vitejs/plugin-react-swc": "^3.5.0",
+    "bowser": "^2.11.0",
     "bulma": "^0.7.1",
     "chance": "^1.1.8",
     "cheerio": "^1.0.0-rc.10",


### PR DESCRIPTION
### Changes
- Update version 2.1 with the browser checks from version 2.2. All code is just copy pasted from version 2.2.
  - Prevent multiple tabs being open
  - Prevent use in a mobile browser
  - Prevent use in browsers other than chrome

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
