### PR TITLE
fix(web): Allow populating of patient sidebar edit form from existing record

### DIFF
--- a/packages/web/app/components/CarePlanNoteDisplay.jsx
+++ b/packages/web/app/components/CarePlanNoteDisplay.jsx
@@ -94,13 +94,17 @@ export const CarePlanNoteDisplay = ({ note, isMainCarePlan, onEditClicked, onNot
                   onEditClicked();
                 },
               },
-              ...(!isMainCarePlan && {
-                label: <TranslatedText stringId="general.action.delete" fallback="Delete" />,
-                action: async () => {
-                  await deleteNote(note.id);
-                  onNoteDeleted();
-                },
-              }),
+              ...(isMainCarePlan
+                ? []
+                : [
+                    {
+                      label: <TranslatedText stringId="general.action.delete" fallback="Delete" />,
+                      action: async () => {
+                        await deleteNote(note.id);
+                        onNoteDeleted();
+                      },
+                    },
+                  ]),
             ]}
           />
         </VerticalCenter>

--- a/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
+++ b/packages/web/app/components/PatientInfoPane/InfoPaneList.jsx
@@ -76,7 +76,7 @@ const getItems = (isIssuesPane, response) => {
 };
 
 export const InfoPaneList = ({
-  id,
+  id: paneId,
   patient,
   readonly,
   title,
@@ -94,11 +94,11 @@ export const InfoPaneList = ({
   const [addEditState, setAddEditState] = useState({ adding: false, editKey: null });
   const { adding, editKey } = addEditState;
   const api = useApi();
-  const { data, error } = useQuery([`infoPaneListItem-${id}`, patient.id], () =>
+  const { data, error } = useQuery([`infoPaneListItem-${paneId}`, patient.id], () =>
     api.get(getEndpoint),
   );
 
-  const isIssuesPane = id === PANE_SECTION_IDS.ISSUES;
+  const isIssuesPane = paneId === PANE_SECTION_IDS.ISSUES;
   const { items, warnings } = getItems(isIssuesPane, data);
 
   const handleAddButtonClick = useCallback(
@@ -128,7 +128,7 @@ export const InfoPaneList = ({
         Form={Form}
         endpoint={endpoint}
         onClose={handleCloseForm}
-        id={id}
+        id={paneId}
         items={items}
       />
     </Wrapper>
@@ -176,7 +176,7 @@ export const InfoPaneList = ({
                       endpoint={endpoint}
                       item={item}
                       onClose={handleCloseForm}
-                      title={title}
+                      id={paneId}
                       items={items}
                     />
                   </Collapse>


### PR DESCRIPTION
### Changes

There was a tweak to the patient sidebar logic that altered a bunch comparisons to use ids instead of their title string. There was a missed prop supplied to the edit form in this change so this is just updating that form to include the id prop.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
