### PR TITLE
fix: NASS-1216: suggestByFacility in immunisation search bar

### DIFF
--- a/packages/web/app/views/patients/ImmunisationsView.jsx
+++ b/packages/web/app/views/patients/ImmunisationsView.jsx
@@ -43,7 +43,7 @@ export const ImmunisationsView = () => {
             fallback="Patient immunisation search"
           />
         </SearchTableTitle>
-        <PatientSearchBar onSearch={setSearchParameters} suggestByFacility={false} />
+        <PatientSearchBar onSearch={setSearchParameters} />
         <SearchTable
           endpoint="patient"
           columns={COLUMNS}


### PR DESCRIPTION
### Changes
This was requested to be removed on immunisation table as part of cambodia testing.
it passes filterByFacility to department and area (locationGroup) suggestion

There are discussions as to the original requirements for this being false 🤔 

Do not merge as discussion ongoing

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
