### PR TITLE
feat(provisioner): KAM-175: load data from URL

### DIFF
--- a/docs/provisioning/example.json5
+++ b/docs/provisioning/example.json5
@@ -14,22 +14,23 @@
       user: 'facility-a@tamanu.io',
       password: 'facility-a',
     },
-
-    'facility-b': {
-      name: 'Facility B',
-      code: 'b',
-      user: 'facility-b@tamanu.io',
-      password: 'facility-b',
-    },
   },
 
   referenceData: [
-    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/referencedata/default.xlsx' }
+    {
+      url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/referencedata/default.xlsx',
+    },
   ],
 
   programs: [
-    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/vitals.xlsx' },
-    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/ncd-primary-screening.xlsx' },
-    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/immunisation.xlsx' },
+    {
+      url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/vitals.xlsx',
+    },
+    {
+      url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/ncd-primary-screening.xlsx',
+    },
+    {
+      url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/immunisation.xlsx',
+    },
   ],
 }

--- a/docs/provisioning/example.json5
+++ b/docs/provisioning/example.json5
@@ -23,6 +23,13 @@
     },
   },
 
-  referenceData: [{ file: '2023-07-03-demo-like.xlsx' }],
-  programs: [{ file: 'vitals.xlsx' }],
+  referenceData: [
+    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/referencedata/default.xlsx' }
+  ],
+
+  programs: [
+    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/vitals.xlsx' },
+    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/ncd-primary-screening.xlsx' },
+    { url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/programs/immunisation.xlsx' },
+  ],
 }

--- a/packages/central-server/app/admin/programImporter/programImporter.js
+++ b/packages/central-server/app/admin/programImporter/programImporter.js
@@ -1,5 +1,5 @@
 import { log } from '@tamanu/shared/services/logging';
-import { readFile } from 'xlsx';
+import { read, readFile } from 'xlsx';
 
 import { importRows } from '../importRows';
 
@@ -9,7 +9,7 @@ import { importProgramRegistry } from './importProgramRegistry';
 
 export const PERMISSIONS = ['Program', 'Survey'];
 
-export async function programImporter({ errors, models, stats, file, whitelist = [] }) {
+export async function programImporter({ errors, models, stats, file, data = null, whitelist = [] }) {
   const createContext = sheetName => ({
     errors,
     log: log.child({
@@ -21,8 +21,8 @@ export async function programImporter({ errors, models, stats, file, whitelist =
 
   log.info('Importing surveys from file', { file });
 
-  const workbook = readFile(file);
-  const { programRecord, surveyMetadata } = await readMetadata(workbook.Sheets.Metadata);
+  const workbook = data ? read(data, { type: 'buffer' }) : readFile(file);
+  const { programRecord, surveyMetadata } = readMetadata(workbook.Sheets.Metadata);
 
   // actually import the program to the database
   stats.push(

--- a/packages/central-server/app/admin/referenceDataImporter/referenceDataImporter.js
+++ b/packages/central-server/app/admin/referenceDataImporter/referenceDataImporter.js
@@ -23,7 +23,7 @@ export async function referenceDataImporter({
   log.info('Importing data definitions from file', { file });
 
   log.debug('Parse XLSX workbook');
-  const workbook = data ? read(data) : readFile(file);
+  const workbook = data ? read(data, { type: 'buffer' }) : readFile(file);
 
   log.debug('Normalise all sheet names for lookup');
   const sheets = new Map();

--- a/packages/central-server/app/admin/referenceDataImporter/referenceDataImporter.js
+++ b/packages/central-server/app/admin/referenceDataImporter/referenceDataImporter.js
@@ -1,5 +1,5 @@
 import { upperFirst } from 'lodash';
-import { readFile } from 'xlsx';
+import { read, readFile } from 'xlsx';
 
 import { log } from '@tamanu/shared/services/logging';
 import { REFERENCE_TYPE_VALUES } from '@tamanu/constants';
@@ -17,12 +17,13 @@ export async function referenceDataImporter({
   models,
   stats,
   file,
+  data = null,
   includedDataTypes = [],
 }) {
   log.info('Importing data definitions from file', { file });
 
   log.debug('Parse XLSX workbook');
-  const workbook = readFile(file);
+  const workbook = data ? read(data) : readFile(file);
 
   log.debug('Normalise all sheet names for lookup');
   const sheets = new Map();

--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -44,20 +44,41 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
 
   const errors = [];
   const stats = [];
-  for (const { file: referenceDataFile, ...rest } of referenceData ?? []) {
-    if (!referenceDataFile) {
+
+  const importerOptions = {
+    errors,
+    models: store.models,
+    stats,
+    includedDataTypes: [...GENERAL_IMPORTABLE_DATA_TYPES, ...PERMISSION_IMPORTABLE_DATA_TYPES],
+  };
+
+  for (const {
+    file: referenceDataFile = null,
+    url: referenceDataUrl = null,
+    ...rest
+  } of referenceData ?? []) {
+    if (!referenceDataFile || !referenceDataUrl) {
       throw new Error(`Unknown reference data import with keys ${Object.keys(rest).join(', ')}`);
     }
 
-    const realpath = resolve(provisioningFile, referenceDataFile);
-    log.info('Importing reference data file', { file: realpath });
-    await referenceDataImporter({
-      errors,
-      models: store.models,
-      stats,
-      file: realpath,
-      includedDataTypes: [...GENERAL_IMPORTABLE_DATA_TYPES, ...PERMISSION_IMPORTABLE_DATA_TYPES],
-    });
+    if (referenceDataFile) {
+      const realpath = resolve(provisioningFile, referenceDataFile);
+      log.info('Importing reference data file', { file: realpath });
+      await referenceDataImporter({
+        file: realpath,
+        ...importerOptions,
+      });
+    } else if (referenceDataUrl) {
+      log.info('Downloading reference data file', { url: referenceDataUrl });
+      const file = await fetch(referenceDataUrl);
+      const data = await file.blob();
+      log.info('Importing reference data', { size: data.size });
+      await referenceDataImporter({
+        data,
+        file: referenceDataUrl,
+        ...importerOptions,
+      });
+    }
   }
 
   if (errors.length) {
@@ -157,19 +178,31 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
   /// ////////
   /// PROGRAMS
 
-  for (const { file: programFile, ...rest } of programs) {
-    if (!programFile) {
+  const programOptions = { errors, models: store.models, stats };
+
+  for (const { file: programFile = null, url: programUrl = null, ...rest } of programs) {
+    if (!programFile || !programUrl) {
       throw new Error(`Unknown program import with keys ${Object.keys(rest).join(', ')}`);
     }
 
-    const realpath = resolve(provisioningFile, programFile);
-    log.info('Importing program from file', { file: realpath });
-    await programImporter({
-      errors,
-      models: store.models,
-      stats,
-      file: realpath,
-    });
+    if (programFile) {
+      const realpath = resolve(provisioningFile, programFile);
+      log.info('Importing program file', { file: realpath });
+      await programImporter({
+        file: realpath,
+        ...programOptions,
+      });
+    } else if (programUrl) {
+      log.info('Downloading program file', { url: programUrl });
+      const file = await fetch(programUrl);
+      const data = await file.blob();
+      log.info('Importing program', { size: data.size });
+      await programImporter({
+        data,
+        file: programUrl,
+        ...programOptions,
+      });
+    }
   }
 
   if (errors.length) {

--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -57,7 +57,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
     url: referenceDataUrl = null,
     ...rest
   } of referenceData ?? []) {
-    if (!referenceDataFile || !referenceDataUrl) {
+    if (!referenceDataFile && !referenceDataUrl) {
       throw new Error(`Unknown reference data import with keys ${Object.keys(rest).join(', ')}`);
     }
 
@@ -71,8 +71,8 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
     } else if (referenceDataUrl) {
       log.info('Downloading reference data file', { url: referenceDataUrl });
       const file = await fetch(referenceDataUrl);
-      const data = await file.blob();
-      log.info('Importing reference data', { size: data.size });
+      const data = Buffer.from(await (await file.blob()).arrayBuffer());
+      log.info('Importing reference data', { size: data.byteLength });
       await referenceDataImporter({
         data,
         file: referenceDataUrl,
@@ -181,7 +181,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
   const programOptions = { errors, models: store.models, stats };
 
   for (const { file: programFile = null, url: programUrl = null, ...rest } of programs) {
-    if (!programFile || !programUrl) {
+    if (!programFile && !programUrl) {
       throw new Error(`Unknown program import with keys ${Object.keys(rest).join(', ')}`);
     }
 
@@ -195,8 +195,8 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
     } else if (programUrl) {
       log.info('Downloading program file', { url: programUrl });
       const file = await fetch(programUrl);
-      const data = await file.blob();
-      log.info('Importing program', { size: data.size });
+      const data = Buffer.from(await (await file.blob()).arrayBuffer());
+      log.info('Importing program', { size: data.byteLength });
       await programImporter({
         data,
         file: programUrl,


### PR DESCRIPTION
### Changes

This is both a requirement for K8S for data size reasons and also a nice quality-of-life improvement for e.g. onboarding, reducing provisioning in dev to this single call:

```console
$ yarn workspace @tamanu/central-server start provision $PWD/docs/provisioning/example.json5
```

### Checklist

- [x] Code is finished

_Upon merging:_

- [x] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
- [x] Update the [relevant runbook](https://beyond-essential.slab.com/posts/tamanu-monorepo-setup-63tub6pv#hte5m-populating-servers)
