### PR TITLE
fix(web): Update label localisation in certificates

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
@@ -206,9 +206,10 @@ export const DischargeSummaryPrintout = ({
   patientConditions,
   certificateData,
   getLocalisation,
+  getTranslation,
 }) => {
   const { logo } = certificateData;
-  const clinicianText = getLocalisation('fields.clinician.shortLabel');
+  const clinicianText = getTranslation('general.localisedField.clinician.label.short', 'Clinician');
   const { diagnoses, procedures, medications } = encounter;
   const visibleDiagnoses = diagnoses.filter(
     ({ certainty }) => !DIAGNOSIS_CERTAINTIES_TO_HIDE.includes(certainty),

--- a/packages/shared/src/utils/patientCertificates/MultipleLabRequestsPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/MultipleLabRequestsPrintout.jsx
@@ -58,7 +58,7 @@ const generalStyles = StyleSheet.create({
 
 const SectionContainer = props => <View style={generalStyles.container} {...props} />;
 
-const LabRequestSigningSection = () => {
+const LabRequestSigningSection = ({ getTranslation }) => {
   const BaseSigningSection = ({ title }) => (
     <View style={{ flexDirection: 'column' }}>
       <P bold style={signingSectionStyles.underlinedText} fontSize={9}>
@@ -75,7 +75,9 @@ const LabRequestSigningSection = () => {
     <View>
       <Row>
         <Col>
-          <BaseSigningSection title="Clinician" />
+          <BaseSigningSection
+            title={getTranslation('general.localisedField.clinician.label', 'Clinician')}
+          />
         </Col>
         <Col>
           <BaseSigningSection title="Patient" />
@@ -157,13 +159,7 @@ const LabRequestDetailsView = ({ labRequests }) => {
 };
 
 export const MultipleLabRequestsPrintout = React.memo(
-  ({
-    patientData,
-    labRequests,
-    encounter,
-    certificateData,
-    getLocalisation,
-  }) => {
+  ({ patientData, labRequests, encounter, certificateData, getLocalisation, getTranslation }) => {
     const { logo } = certificateData;
 
     return (
@@ -188,7 +184,7 @@ export const MultipleLabRequestsPrintout = React.memo(
               <LabRequestDetailsView labRequests={labRequests} />
             </SectionContainer>
             <SectionContainer>
-              <LabRequestSigningSection labRequests={labRequests} />
+              <LabRequestSigningSection getTranslation={getTranslation} labRequests={labRequests} />
             </SectionContainer>
           </CertificateContent>
         </Page>

--- a/packages/shared/src/utils/patientCertificates/printComponents/EncounterDetailsExtended.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/EncounterDetailsExtended.jsx
@@ -4,8 +4,7 @@ import { DataItem } from './DataItem';
 import React from 'react';
 import { getDisplayDate } from '../getDisplayDate';
 
-export const EncounterDetailsExtended = ({ encounter, discharge, clinicianText = 'clinician' }) => {
-  // const clinicianText = useLocalisedText({ path: 'fields.clinician.shortLabel' });
+export const EncounterDetailsExtended = ({ encounter, discharge, clinicianText }) => {
   const { location, examiner, department, startDate, endDate, reasonForEncounter } = encounter;
 
   return (

--- a/packages/web/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/MultipleLabRequestsPrintoutModal.jsx
@@ -10,11 +10,13 @@ import { Colors } from '../../../constants';
 
 import { PDFViewer, printPDF } from '../PDFViewer';
 import { useLocalisation } from '../../../contexts/Localisation';
+import { useTranslation } from '../../../contexts/Translation';
 import { MultipleLabRequestsPrintout } from '@tamanu/shared/utils/patientCertificates';
 import { TranslatedText } from '../../Translation/TranslatedText';
 
 export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open, onClose }) => {
   const { getLocalisation } = useLocalisation();
+  const { getTranslation } = useTranslation();
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
   const api = useApi();
 
@@ -60,6 +62,7 @@ export const MultipleLabRequestsPrintoutModal = ({ encounter, labRequests, open,
             encounter={encounter}
             labRequests={labRequests}
             getLocalisation={getLocalisation}
+            getTranslation={getTranslation}
           />
         </PDFViewer>
       )}

--- a/packages/web/app/views/patients/DischargeSummaryView.jsx
+++ b/packages/web/app/views/patients/DischargeSummaryView.jsx
@@ -8,6 +8,7 @@ import { useEncounter } from '../../contexts/Encounter';
 import { Colors } from '../../constants';
 import { useCertificate } from '../../utils/useCertificate';
 import { useLocalisation } from '../../contexts/Localisation';
+import { useTranslation } from '../../contexts/Translation';
 import {
   usePatientAdditionalDataQuery,
   useReferenceData,
@@ -34,6 +35,7 @@ const NavContainer = styled.div`
 export const DischargeSummaryView = React.memo(() => {
   const { data: certiciateData, isFetching: isCertificateFetching } = useCertificate();
   const { getLocalisation } = useLocalisation();
+  const { getTranslation } = useTranslation();
   const { encounter } = useEncounter();
   const patient = useSelector(state => state.patient);
   const { data: additionalData, isFetching: isPADLoading } = usePatientAdditionalDataQuery(
@@ -74,6 +76,7 @@ export const DischargeSummaryView = React.memo(() => {
           patientConditions={patientConditions}
           certificateData={certiciateData}
           getLocalisation={getLocalisation}
+          getTranslation={getTranslation}
         />
       </PDFViewer>
     </Container>

--- a/packages/web/app/views/patients/components/LabRequestPrintModal.jsx
+++ b/packages/web/app/views/patients/components/LabRequestPrintModal.jsx
@@ -13,10 +13,12 @@ import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { Colors } from '../../../constants';
 import { PDFViewer, printPDF } from '../../../components/PatientPrinting/PDFViewer';
 import { useLocalisation } from '../../../contexts/Localisation';
+import { useTranslation } from '../../../contexts/Translation';
 import { MultipleLabRequestsPrintout } from '@tamanu/shared/utils/patientCertificates';
 
 export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onClose }) => {
   const { getLocalisation } = useLocalisation();
+  const { getTranslation } = useTranslation();
   const api = useApi();
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
 
@@ -71,6 +73,7 @@ export const LabRequestPrintModal = React.memo(({ labRequest, patient, open, onC
             encounter={encounter}
             certificateData={certificateData}
             getLocalisation={getLocalisation}
+            getTranslation={getTranslation}
           />
         </PDFViewer>
       )}


### PR DESCRIPTION
With the translations merge we have updated all localised labels to be done through the translation context rather than getLocalisation as done previously. This pr covers the two missed spots where we localise labels in certificates (lab signing section, discharge summary).

I just swap out the usage of `getLocalisation` with `getTranslation` 

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
