### PR TITLE
fix(web): Template query appending question mark (2.4) 

### DIFF
--- a/packages/web/app/utils/useTemplate.js
+++ b/packages/web/app/utils/useTemplate.js
@@ -8,6 +8,6 @@ export const useTemplate = key => {
   const { facility } = useAuth();
 
   return useQuery(['template', key, facility.id], () =>
-    api.get(`template/${key}?facilityId=${facility.id}`),
+    api.get(`template/${key}?facilityId=${facility.id}`, null),
   );
 };

--- a/packages/web/app/utils/useTemplate.js
+++ b/packages/web/app/utils/useTemplate.js
@@ -8,6 +8,6 @@ export const useTemplate = key => {
   const { facility } = useAuth();
 
   return useQuery(['template', key, facility.id], () =>
-    api.get(`template/${key}?facilityId=${facility.id}`, null),
+    api.get(`template/${key}`, { facilityId: facility.id }),
   );
 };


### PR DESCRIPTION
### Changes

Api client changes means that if null not specified explicitly in useTemplate get request template/${key}?facilityId=${facility.id} will hit endpoint with a facility id of ref/facility/a? with an appended question mark and will not receive the template.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
