### PR TITLE
feat(mobile): NASS-1035: Translate mobile 'sync' page

### DIFF
--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -32,7 +32,7 @@ const replaceStringVariables = (
     // Even indexes are the unchanged parts of the string
     if (index % 2 === 0) return part;
 
-    return replacements[part.slice(1)] || part;
+    return replacements[part.slice(1)] ?? part;
   });
 
   return uppercase

--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/SyncDataScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/SyncDataScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '../../../../components/Button';
 import { SyncErrorDisplay } from '../../../../components/SyncErrorDisplay';
 import { ErrorIcon, GreenTickIcon } from '../../../../components/Icons';
+import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
 
 export const SyncDataScreen = ({ navigation }): ReactElement => {
   const backend = useContext(BackendContext);
@@ -150,7 +151,7 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
             fontSize={screenPercentageToDP(2.55, Orientation.Height)}
             textAlign="center"
           >
-            Sync failed
+            <TranslatedText stringId="sync.error.syncFailed" fallback="Sync failed" />
           </StyledText>
         ) : null}
         {isSyncing || syncFinishedSuccessfully ? (
@@ -172,7 +173,7 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
             outline
             textColor={theme.colors.SECONDARY_MAIN}
             borderColor={theme.colors.SECONDARY_MAIN}
-            buttonText="Manual sync"
+            buttonText={<TranslatedText stringId="sync.action.manualSync" fallback="Manual sync" />}
             marginTop={20}
           />
         )}
@@ -183,7 +184,13 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
             fontWeight={500}
             color={theme.colors.WHITE}
           >
-            {`${syncStage} of ${SYNC_STAGES_TOTAL} syncing`}
+            {
+              <TranslatedText
+                stringId="sync.message.syncStatus"
+                fallback=":currentSyncStage of :totalSyncStages syncing"
+                replacements={{ currentSyncStage: syncStage, totalSyncStages: SYNC_STAGES_TOTAL }}
+              />
+            }
           </StyledText>
         ) : null}
         {isSyncing ? (
@@ -203,7 +210,10 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
               fontWeight={500}
               color={theme.colors.WHITE}
             >
-              Last successful sync
+              <TranslatedText
+                stringId="sync.subHeading.lastSuccessfulSync"
+                fallback="Last successful sync"
+              />
             </StyledText>
             <StyledText
               fontSize={screenPercentageToDP(1.7, Orientation.Height)}
@@ -218,11 +228,16 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
                 fontSize={screenPercentageToDP(1.7, Orientation.Height)}
                 color={theme.colors.WHITE}
               >
-                {`pulled ${lastSyncPulledRecordsCount} change${
-                  lastSyncPulledRecordsCount === 1 ? '' : 's'
-                }, pushed ${lastSyncPushedRecordsCount} change${
-                  lastSyncPushedRecordsCount === 1 ? '' : 's'
-                }`}
+                <TranslatedText
+                  stringId="sync.message.syncSummary"
+                  fallback="pulled :pulledCount change:pulledPlural, pushed :pushCount change:pushedPlural"
+                  replacements={{
+                    pulledCount: lastSyncPulledRecordsCount,
+                    pulledPlural: lastSyncPulledRecordsCount === 1 ? '' : 's',
+                    pushCount: lastSyncPushedRecordsCount,
+                    pushedPlural: lastSyncPushedRecordsCount === 1 ? '' : 's',
+                  }}
+                />
               </StyledText>
             ) : null}
           </>

--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/SyncDataScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/SyncDataScreen.tsx
@@ -118,6 +118,9 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
 
   const syncFinishedSuccessfully = syncStarted && !isSyncing && !isQueuing && !hasError;
 
+  const changeTranslation = <TranslatedText stringId='sync.message.syncSummary.change' fallback='change' />
+  const changePluralTranslation = <TranslatedText stringId='sync.message.syncSummary.changePlural' fallback='changes' />
+
   return (
     <CenterView background={theme.colors.MAIN_SUPER_DARK} flex={1}>
       <StyledView alignItems="center">
@@ -230,12 +233,12 @@ export const SyncDataScreen = ({ navigation }): ReactElement => {
               >
                 <TranslatedText
                   stringId="sync.message.syncSummary"
-                  fallback="pulled :pulledCount change:pulledPlural, pushed :pushCount change:pushedPlural"
+                  fallback="pulled :pullCount :pullChange, pushed :pushCount :pushChange"
                   replacements={{
-                    pulledCount: lastSyncPulledRecordsCount,
-                    pulledPlural: lastSyncPulledRecordsCount === 1 ? '' : 's',
+                    pullCount: lastSyncPulledRecordsCount,
+                    pullChange: lastSyncPulledRecordsCount === 1 ? changeTranslation : changePluralTranslation,
                     pushCount: lastSyncPushedRecordsCount,
-                    pushedPlural: lastSyncPushedRecordsCount === 1 ? '' : 's',
+                    pushChange: lastSyncPushedRecordsCount === 1 ? changeTranslation : changePluralTranslation,
                   }}
                 />
               </StyledText>


### PR DESCRIPTION
### Changes

Translated mobile 'sync' page
**Note**: some (2) translation messages, i.e. 'Pausing at 33%...' originate from `MobileSyncManager.ts` - so no obvious way to use translation hook

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
