### PR TITLE
feat(web): EPI-749: Ability to edit the 'Reason for encounter' after saved

### DIFF
--- a/packages/web/app/components/ChangeReasonModal.jsx
+++ b/packages/web/app/components/ChangeReasonModal.jsx
@@ -1,0 +1,44 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { useEncounter } from '../contexts/Encounter';
+import { usePatientNavigation } from '../utils/usePatientNavigation';
+
+import { FormModal } from './FormModal';
+import { TranslatedText } from './Translation/TranslatedText';
+import { ChangeReasonForm } from '../forms/ChangeReasonForm';
+
+export const ChangeReasonModal = React.memo(({ open, onClose }) => {
+  const { navigateToEncounter } = usePatientNavigation();
+  const { encounter, writeAndViewEncounter } = useEncounter();
+  const onSubmit = useCallback(
+    async data => {
+      await writeAndViewEncounter(encounter.id, data);
+      navigateToEncounter(encounter.id);
+    },
+    [encounter, writeAndViewEncounter, navigateToEncounter],
+  );
+
+  return (
+    <FormModal
+      title={
+        <TranslatedText
+          stringId="encounter.modal.changeReason.title"
+          fallback="Change reason for encounter"
+        />
+      }
+      open={open}
+      onClose={onClose}
+    >
+      <ChangeReasonForm
+        onSubmit={onSubmit}
+        onCancel={onClose}
+        reasonForEncounter={encounter.reasonForEncounter}
+      />
+    </FormModal>
+  );
+});
+
+ChangeReasonModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/packages/web/app/forms/ChangeReasonForm.jsx
+++ b/packages/web/app/forms/ChangeReasonForm.jsx
@@ -14,6 +14,8 @@ export const ChangeReasonForm = ({ onCancel, onSubmit, reasonForEncounter }) => 
         name="reasonForEncounter"
         label={<TranslatedText stringId="general.localisedField.reasonForEncounter.label" fallback="Reason for encounter" />}
         component={TextField}
+        multiline
+        rows={3}
       />
       <ModalActionRow confirmText="Confirm" onConfirm={submitForm} onCancel={onCancel} />
     </FormGrid>

--- a/packages/web/app/forms/ChangeReasonForm.jsx
+++ b/packages/web/app/forms/ChangeReasonForm.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
+import { FORM_TYPES } from '../constants';
+import { Field, Form, TextField } from '../components/Field';
+import { FormGrid } from '../components/FormGrid';
+import { TranslatedText } from '../components/Translation/TranslatedText';
+import { ModalActionRow } from '../components';
+
+export const ChangeReasonForm = ({ onCancel, onSubmit, reasonForEncounter }) => {
+  const renderForm = ({ submitForm }) => (
+    <FormGrid columns={1}>
+      <Field
+        name="reasonForEncounter"
+        label={<TranslatedText stringId="general.localisedField.reasonForEncounter.label" fallback="Reason for encounter" />}
+        component={TextField}
+      />
+      <ModalActionRow confirmText="Confirm" onConfirm={submitForm} onCancel={onCancel} />
+    </FormGrid>
+  );
+
+  return (
+    <Form
+      initialValues={{
+        // Used in creation of associated notes
+        submittedTime: getCurrentDateTimeString(),
+        reasonForEncounter,
+      }}
+      formType={FORM_TYPES.EDIT_FORM}
+      render={renderForm}
+      onSubmit={onSubmit}
+    />
+  );
+};
+
+ChangeReasonForm.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};

--- a/packages/web/app/forms/ChangeReasonForm.jsx
+++ b/packages/web/app/forms/ChangeReasonForm.jsx
@@ -36,4 +36,5 @@ export const ChangeReasonForm = ({ onCancel, onSubmit, reasonForEncounter }) => 
 ChangeReasonForm.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  reasonForEncounter: PropTypes.string.isRequired,
 };

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -17,6 +17,7 @@ import { MoveModal } from './MoveModal';
 import { EncounterRecordModal } from '../../../components/PatientPrinting/modals/EncounterRecordModal';
 import { Colors } from '../../../constants';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
+import { ChangeReasonModal } from '../../../components/ChangeReasonModal';
 
 const TypographyLink = styled(Typography)`
   color: ${Colors.primary};
@@ -41,6 +42,7 @@ const ENCOUNTER_MODALS = {
   CHANGE_DEPARTMENT: 'changeDepartment',
   CHANGE_LOCATION: 'changeLocation',
   CHANGE_TYPE: 'changeType',
+  CHANGE_REASON: 'changeReason',
 
   DISCHARGE: 'discharge',
 
@@ -68,6 +70,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
   const onChangeLocation = () => setOpenModal(ENCOUNTER_MODALS.CHANGE_LOCATION);
   const onViewSummary = () => navigateToSummary();
   const onViewEncounterRecord = () => setOpenModal(ENCOUNTER_MODALS.ENCOUNTER_RECORD);
+  const onChangeReason = () => setOpenModal(ENCOUNTER_MODALS.CHANGE_REASON);
 
   if (encounter.endDate) {
     return (
@@ -223,6 +226,15 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
       condition: () => !enablePatientMoveActions && !encounter.plannedLocation,
       onClick: onChangeLocation,
     },
+    {
+      label: (
+        <TranslatedText
+          stringId="patient.encounter.action.changeReason"
+          fallback="Change reason"
+        />
+      ),
+      onClick: onChangeReason,
+    },
   ].filter(action => !action.condition || action.condition());
 
   return <DropdownButton actions={actions} />;
@@ -282,6 +294,11 @@ export const EncounterActions = React.memo(({ encounter }) => {
       <EncounterRecordModal
         encounter={encounter}
         open={openModal === ENCOUNTER_MODALS.ENCOUNTER_RECORD}
+        onClose={onClose}
+      />
+      <ChangeReasonModal
+        encounter={encounter}
+        open={openModal === ENCOUNTER_MODALS.CHANGE_REASON}
         onClose={onClose}
       />
     </>


### PR DESCRIPTION
### Changes

- Create a Modal for editing 'Reason for encounter'

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
