### PR TITLE
fix(web): EPI-767: Change the word 'Prescription' to 'Instructions' in the medication table in an encounter

### DIFF
--- a/packages/web/app/components/MedicationTable.jsx
+++ b/packages/web/app/components/MedicationTable.jsx
@@ -26,7 +26,7 @@ const MEDICATION_COLUMNS = [
     sortable: false,
   },
   {
-    key: 'instructions',
+    key: 'prescription',
     title: (
       <TranslatedText stringId="medication.table.column.instructions" fallback="Instructions" />
     ),

--- a/packages/web/app/components/MedicationTable.jsx
+++ b/packages/web/app/components/MedicationTable.jsx
@@ -26,9 +26,9 @@ const MEDICATION_COLUMNS = [
     sortable: false,
   },
   {
-    key: 'prescription',
+    key: 'instructions',
     title: (
-      <TranslatedText stringId="medication.table.column.prescription" fallback="Prescription" />
+      <TranslatedText stringId="medication.table.column.instructions" fallback="Instructions" />
     ),
   },
   {


### PR DESCRIPTION

### Changes

- Change the word 'Prescription' to 'Instructions' in the medication table in an encounter

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
