### PR TITLE
fix(mobile): nass-1121: Update camera/photo picker logic for PhotoID

### DIFF
--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
 import { useBackend } from '~/ui/hooks';
-import { StyledImage, StyledView, ColumnView, StyledText } from '/styled/common';
+import { StyledImage, StyledView, StyledText } from '/styled/common';
 import {
   getImageFromPhotoLibrary,
   getImageFromCamera,

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
+import { Popup } from 'popup-ui';
 import { useBackend } from '~/ui/hooks';
 import { StyledImage, StyledView, StyledText } from '/styled/common';
 import {

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
-import { Popup } from 'popup-ui';
 import { useBackend } from '~/ui/hooks';
-import { StyledImage, StyledView } from '/styled/common';
+import { StyledImage, StyledView, ColumnView, StyledText } from '/styled/common';
 import {
   getImageFromPhotoLibrary,
   getImageFromCamera,
@@ -13,6 +12,7 @@ import {
 import { deleteFileInDocuments } from '/helpers/file';
 import { BaseInputProps } from '../../interfaces/BaseInputProps';
 import { Button } from '~/ui/components/Button';
+import { theme } from '~/ui/styled/theme';
 
 const IMAGE_RESIZE_OPTIONS = {
   maxWidth: 1920,
@@ -45,8 +45,18 @@ interface UploadPhotoComponentProps {
 
 const IMAGE_WIDTH = Dimensions.get('window').width * 0.6;
 
-const ImageActionButton = ({ onPress, label, marginTop }) => (
-  <Button buttonText={label} onPress={onPress} margin={5} marginTop={marginTop} />
+const ImageActionButton = ({ onPress, label, marginTop = 5, border = true }) => (
+  <Button
+    buttonText={label}
+    onPress={onPress}
+    textColor={theme.colors.PRIMARY_MAIN}
+    borderColor={theme.colors.PRIMARY_MAIN}
+    backgroundColor="transparent"
+    margin={5}
+    marginTop={marginTop}
+    marginBottom={0}
+    borderWidth={border ? 1 : 0}
+  />
 );
 
 const UploadedImage = ({ imageData }: UploadedImageProps) => (
@@ -78,15 +88,19 @@ const UploadPhotoComponent = ({
     {loading && <LoadingPlaceholder />}
     {imageData && <UploadedImage imageData={imageData} />}
     {!imageData && errorMessage && <Text>{`Error loading image: ${errorMessage}`}</Text>}
+    <StyledText fontWeight="500" color={theme.colors.TEXT_SUPER_DARK} marginTop={10}>
+      {imageData ? 'Change photo' : 'Upload photo'}
+    </StyledText>
     <StyledView justifyContent="space-between" marginLeft={-10}>
-      <ImageActionButton
-        onPress={onPressChoosePhoto}
-        label="Choose photo from library"
-        marginTop={5}
-      />
-      <ImageActionButton onPress={onPressTakePhoto} label="Take photo with camera" marginTop={-3} />
+      <ImageActionButton onPress={onPressChoosePhoto} label="Choose photo from library" />
+      <ImageActionButton onPress={onPressTakePhoto} label="Take photo with camera" />
       {imageData && (
-        <ImageActionButton onPress={onPressRemovePhoto} label="Remove photo" marginTop={0} />
+        <ImageActionButton
+          onPress={onPressRemovePhoto}
+          label="Remove photo"
+          border={false}
+          marginTop={-3}
+        />
       )}
     </StyledView>
   </StyledView>

--- a/packages/mobile/App/ui/helpers/image.ts
+++ b/packages/mobile/App/ui/helpers/image.ts
@@ -1,6 +1,5 @@
-import ImagePicker, { ImagePickerResponse } from 'react-native-image-picker';
+import { launchCamera, launchImageLibrary } from 'react-native-image-picker';
 import ImageResizer from 'react-native-image-resizer';
-import { check, PERMISSIONS, request } from 'react-native-permissions';
 
 /**
  * @see https://github.com/bamlab/react-native-image-resizer#api
@@ -17,57 +16,34 @@ interface ResizeOptions {
   onlyScaleDown?: boolean;
 }
 
-export const launchImagePicker = (): Promise<ImagePickerResponse | null> =>
-  new Promise((resolve, reject) => {
-    ImagePicker.showImagePicker(
-      {
-        title: 'Select Photo',
-        // work around for image-picker bug when taking photo:
-        //https://github.com/react-native-image-picker/react-native-image-picker/issues/655
-        rotation: 360
-      },
-      imagePickerResponse => {
-        if (imagePickerResponse.error) {
-          // Add log later
-          reject(new Error(imagePickerResponse.error));
-        } else if (imagePickerResponse.didCancel) {
-          resolve(null);
-        } else {
-          resolve(imagePickerResponse);
-        }
-      }
-    );
-  });
+const getImageDataFromResponse = image => {
+  if (image.errorCode) throw new Error(image.errorMessage);
+  if (image.didCancel) return null;
+  return image.assets[0];
+};
 
-export const getImageFromPhotoLibrary = async () => {
-  let image : ImagePickerResponse = null;
-
+export const getImageFromCamera = async () => {
   try {
-    const photoLibraryPermissionAndroid = await check(
-      PERMISSIONS.ANDROID.WRITE_EXTERNAL_STORAGE
-    );
-    if (photoLibraryPermissionAndroid !== 'granted') {
-      const photoLibraryPermissionRequest = await request(
-        PERMISSIONS.ANDROID.WRITE_EXTERNAL_STORAGE
-      );
-      if (photoLibraryPermissionRequest === 'granted') {
-        image = await launchImagePicker();
-        console.log('loaded');
-        return image;
-      }
-    } else {
-      image = await launchImagePicker();
-      return image;
-    }
+    const cameraResponse = await launchCamera({ mediaType: 'photo', includeBase64: true });
+    return getImageDataFromResponse(cameraResponse);
   } catch (error) {
     throw new Error(error);
   }
-
-  return image;
 };
 
-export const imageToBase64URI = (image: string): string =>
-  `data:image/jpeg;base64, ${image}`;
+export const getImageFromPhotoLibrary = async () => {
+  try {
+    const photoLibraryResponse = await launchImageLibrary({
+      mediaType: 'photo',
+      includeBase64: true,
+    });
+    return getImageDataFromResponse(photoLibraryResponse);
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const imageToBase64URI = (image: string): string => `data:image/jpeg;base64, ${image}`;
 
 export const resizeImage = (path: string, options: ResizeOptions) => {
   const {
@@ -79,7 +55,7 @@ export const resizeImage = (path: string, options: ResizeOptions) => {
     outputPath,
     keepMeta,
     mode,
-    onlyScaleDown = true
+    onlyScaleDown = true,
   } = options;
 
   return ImageResizer.createResizedImage(
@@ -91,6 +67,6 @@ export const resizeImage = (path: string, options: ResizeOptions) => {
     rotation,
     outputPath,
     keepMeta,
-    { mode, onlyScaleDown }
+    { mode, onlyScaleDown },
   );
 };

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.CAMERA" />
 
     <queries>
         <intent>

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -66,7 +66,7 @@
     "react-native-fs": "^2.17.0",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-get-random-values": "^1.10.0",
-    "react-native-image-picker": "^2.3.1",
+    "react-native-image-picker": "^7.1.2",
     "react-native-image-resizer": "^1.4.4",
     "react-native-keyboard-aware-scroll-view": "^0.9.1",
     "react-native-masked-text": "^1.13.0",

--- a/packages/mobile/yarn.lock
+++ b/packages/mobile/yarn.lock
@@ -11305,10 +11305,10 @@ react-native-gradle-plugin@^0.71.19:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.19.tgz#3379e28341fcd189bc1f4691cefc84c1a4d7d232"
   integrity sha512-1dVk9NwhoyKHCSxcrM6vY6cxmojeATsBobDicX0ZKr7DgUF2cBQRTKsimQFvzH8XhOVXyH8p4HyDSZNIFI8OlQ==
 
-react-native-image-picker@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-2.4.0.tgz#33231ac6d7794193d595b4e13ca6167fc4d523ef"
-  integrity sha512-vve5vcrFlV0lzU4bzY40CsOAEPMr036KlyIH181DN14y+T7i3hsl+PZ6vip4/fJdjLnedv5alLN2ddb46kHhkA==
+react-native-image-picker@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-7.1.2.tgz#383849d1953caf4578874a1f5e5dd11c737bd5cd"
+  integrity sha512-b5y5nP60RIPxlAXlptn2QwlIuZWCUDWa/YPUVjgHc0Ih60mRiOg1PSzf0IjHSLeOZShCpirpvSPGnDExIpTRUg==
 
 react-native-image-resizer@^1.4.4:
   version "1.4.5"


### PR DESCRIPTION
### Changes

Seemingly after the node upgrade we are having some issues with the photo picker for the photoid upload stopping it from working completely. On playing around it seems that the best solution is to update the very old photo-picker library and use its new functions to simulate the current functionality.

With the updated library there is no longer a built in "photo picker" menu that lets you choose between camera and library as the photo source. We now have to make this choice within our own ui. I got in touch with felicity and she created a design with 2 buttons for the two options that would previously show in popup and i have implemented them. This change is completely isolated to the photo upload component used in the photo ID survey

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
