### PR TITLE
fix(mobileTranslations): Add back TranslatedTextElement

### DIFF
--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -40,6 +40,8 @@ const replaceStringVariables = (
     : jsxElements;
 };
 
+export type TranslatedTextElement = ReactElement<TranslatedTextProps> | string;
+
 export const TranslatedText = ({
   stringId,
   fallback,


### PR DESCRIPTION
### Changes

`TranslatedTextElement` was removed during a merge - this adds it back

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
