### PR TITLE
fix(scripts): Stop hasty watch

### DIFF
--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -21,7 +21,7 @@
     "setup-dev": "node dist setup",
     "shell": "yarn build && node dist shell",
     "start-dev": "concurrently npm:build-watch npm:start-watch",
-    "start-watch": "nodemon \"dist/**/*.js\"",
+    "start-watch": "sleep 1 && nodemon --delay 1 \"dist/**/*.js\"",
     "start": "node dist",
     "test": "yarn test-build && NODE_ENV=test jest",
     "test-build": "swc --delete-dir-on-start --out-dir __disttests__ --copy-files --source-maps true __tests__",

--- a/packages/facility-server/package.json
+++ b/packages/facility-server/package.json
@@ -16,7 +16,7 @@
     "shell": "yarn build && node dist shell",
     "start": "node dist",
     "start-dev": "concurrently npm:build-watch npm:start-watch",
-    "start-watch": "nodemon \"dist/**/*.js\"",
+    "start-watch": "sleep 1 && nodemon --delay 1 \"dist/**/*.js\"",
     "test": "yarn test-build && NODE_ENV=test jest",
     "test-build": "swc --delete-dir-on-start --out-dir __disttests__ --copy-files --source-maps true __tests__",
     "test-watch": "yarn test --watch"

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -15,7 +15,7 @@
     "test": "NODE_ENV=test jest",
     "setup-dev": "node dist setup",
     "shell": "yarn build && node dist shell",
-    "start-watch": "nodemon \"dist/**/*.js\"",
+    "start-watch": "sleep 1 && nodemon --delay 1 \"dist/**/*.js\"",
     "test-watch": "yarn test --watch",
     "build-watch": "yarn run build --watch",
     "start-dev": "concurrently npm:build-watch npm:start-watch"

--- a/scripts/watch-shared-and.js
+++ b/scripts/watch-shared-and.js
@@ -7,7 +7,7 @@ concurrently(
     // running build-shared in raw:true mode will cause its output to interfere with
     // the way the second process handles stdin (eg it will break jest-watch hotkeys)
     { command: 'yarn workspace @tamanu/shared run build-watch', raw: false },
-    { command: `yarn workspace ${workspace} run ${command}`, raw: true },
+    { command: `sleep 2 && yarn workspace ${workspace} run ${command}`, raw: true },
   ], 
   {
     defaultInputTarget: 1,


### PR DESCRIPTION
### Changes

Given we launch two watch processes concurrently and ultimately read from the `dist` files, nodemon ends up restarting the server a lot of times and I think this sometimes trips up starts and restarts. Adding an intended delay seems to take care of this - at least on my local machine, it's likely it will depend on the speed of the builds from each machine - however this should still help it and seemed easier than trying to come up with some obscure way of a muxer or semaphore between the concurrent process, if even possible.

Main motivation was this: https://github.com/beyondessential/tamanu/actions/runs/8514441298/job/23322324429?pr=5566 had to repeat one test 5 times to get it right, and I suspected it had to do with the facility server not being ready when the curl was made. Unfortunately this effort doesn't get rid of that error completely 😭 but it does seem to improve it? Maybe not even that, but this might still be worth it.

I also realized this could help us bring back the main scripts and seemed to work