### PR TITLE
test: Resolve intermittent failures

### DIFF
--- a/packages/central-server/__tests__/admin/patientMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge.test.js
@@ -158,19 +158,19 @@ describe('Patient merge', () => {
   it('Should throw if the keep patient and merge patient are the same', async () => {
     const { Patient } = models;
     const keep = await Patient.create(fake(Patient));
-    expect(() => mergePatient(models, keep.id, keep.id)).rejects.toThrow(InvalidParameterError);
+    await expect(() => mergePatient(models, keep.id, keep.id)).rejects.toThrow(InvalidParameterError);
   });
 
   it("Should throw if the keep patient doesn't exist", async () => {
     const { Patient } = models;
     const keep = await Patient.create(fake(Patient));
-    expect(() => mergePatient(models, keep.id, 'not real')).rejects.toThrow(InvalidParameterError);
+    await expect(() => mergePatient(models, keep.id, 'not real')).rejects.toThrow(InvalidParameterError);
   });
 
   it("Should throw if the merge patient doesn't exist", async () => {
     const { Patient } = models;
     const merge = await Patient.create(fake(Patient));
-    expect(() => mergePatient(models, 'not real', merge.id)).rejects.toThrow(InvalidParameterError);
+    await expect(() => mergePatient(models, 'not real', merge.id)).rejects.toThrow(InvalidParameterError);
   });
 
   it('Should merge a page of notes across', async () => {

--- a/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
+++ b/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
@@ -394,20 +394,20 @@ describe('reportRoutes', () => {
         });
       });
       it('should throw error if file does not exist', async () => {
-        expect(readJSON(path.join(__dirname, '/data/non-existent.json'))).rejects.toThrow();
+        await expect(readJSON(path.join(__dirname, '/data/non-existent.json'))).rejects.toThrow();
       });
       it('should throw error if file is not valid json', async () => {
-        expect(readJSON(path.join(__dirname, '/data/invalid.json'))).rejects.toThrow();
+        await expect(readJSON(path.join(__dirname, '/data/invalid.json'))).rejects.toThrow();
       });
     });
     describe('verifyQuery', () => {
       it('should return true if query is valid', async () => {
         const query = 'select * from patients limit 1';
-        expect(verifyQuery(query, { parameters: [] }, { store: ctx.store })).resolves.not.toThrow();
+        await expect(verifyQuery(query, { parameters: [] }, { store: ctx.store })).resolves.not.toThrow();
       });
       it('should return true if query is valid with paramDefinition', async () => {
         const query = 'select * from patients where id = :test limit 1';
-        expect(
+        await expect(
           verifyQuery(
             query,
             {
@@ -423,7 +423,7 @@ describe('reportRoutes', () => {
       });
       it('should return false if query is invalid', async () => {
         const query = 'some random non sql query';
-        expect(verifyQuery(query, [], ctx.store)).rejects.toThrow();
+        await expect(verifyQuery(query, [], ctx.store)).rejects.toThrow();
       });
     });
   });

--- a/packages/central-server/__tests__/integrations/VdsNc/Translation.test.js
+++ b/packages/central-server/__tests__/integrations/VdsNc/Translation.test.js
@@ -417,7 +417,7 @@ describe('VDS: Proof of Test', () => {
     });
     await patient.reload();
 
-    const facility = await await Facility.create({
+    const facility = await Facility.create({
       ...fake(Facility),
       name: 'Utopia GP',
       streetAddress: 'Utopia pastoral lease No. 637',

--- a/packages/central-server/__tests__/middleware/auth.test.js
+++ b/packages/central-server/__tests__/middleware/auth.test.js
@@ -129,7 +129,7 @@ describe('Auth', () => {
       });
       expect(refreshTokenRecord).not.toBeNull();
       expect(refreshTokenRecord).toHaveProperty('refreshId');
-      expect(bcrypt.compare(contents.refreshId, refreshTokenRecord.refreshId)).resolves.toBe(true);
+      await expect(bcrypt.compare(contents.refreshId, refreshTokenRecord.refreshId)).resolves.toBe(true);
     });
 
     it('Should not issue a refresh token for external client', async () => {
@@ -285,7 +285,7 @@ describe('Auth', () => {
       });
       expect(refreshTokenRecord).not.toBeNull();
       expect(refreshTokenRecord).toHaveProperty('refreshId');
-      expect(
+      await expect(
         bcrypt.compare(newRefreshTokenContents.refreshId, refreshTokenRecord.refreshId),
       ).resolves.toBe(true);
     });

--- a/packages/central-server/__tests__/models/SurveyResponse.test.js
+++ b/packages/central-server/__tests__/models/SurveyResponse.test.js
@@ -63,7 +63,7 @@ describe('SurveyResponse.createWithAnswers', () => {
       type: PROGRAM_DATA_ELEMENT_TYPES.NUMBER,
     });
 
-    expect(() =>
+    await expect(() =>
       models.SurveyResponse.createWithAnswers({
         patientId,
         encounterId,

--- a/packages/central-server/__tests__/subCommands/importReport/actions.test.js
+++ b/packages/central-server/__tests__/subCommands/importReport/actions.test.js
@@ -148,7 +148,7 @@ describe('importReport actions', () => {
         ...baseVersionData,
         versionNumber: 3,
       };
-      expect(
+      await expect(
         createVersion(data, mockDefinition, [{ versionNumber: 1 }], mockStore),
       ).rejects.toThrow(getVersionError({ versionNumber: 3 }));
     });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -131,7 +131,7 @@ describe('CentralSyncManager', () => {
         'Snapshot processing incomplete, likely because the central server restarted during the snapshot';
       await session.save();
 
-      expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow(
+      await expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow(
         `Sync session '${sessionId}' encountered an error: Snapshot processing incomplete, likely because the central server restarted during the snapshot`,
       );
     });

--- a/packages/facility-server/__tests__/apiv1/LocationGroup.test.js
+++ b/packages/facility-server/__tests__/apiv1/LocationGroup.test.js
@@ -37,7 +37,7 @@ describe('Location groups', () => {
     const facility = await findOneOrCreate(models, models.Facility, {
       name: 'Test Facility',
     });
-    expect(
+    await expect(
       models.LocationGroup.create({
         name: 'Test, Location Group',
         code: 'test-location-group',

--- a/packages/facility-server/__tests__/sync/CentralServerConnection.test.js
+++ b/packages/facility-server/__tests__/sync/CentralServerConnection.test.js
@@ -139,7 +139,7 @@ describe('CentralServerConnection', () => {
       fetch.mockImplementationOnce(fakeTimeout('fake timeout'));
       const connectPromise = centralServer.connect();
       jest.runAllTimers();
-      await await expect(connectPromise).rejects.toThrow('fake timeout');
+      await expect(connectPromise).rejects.toThrow('fake timeout');
     });
   });
 });

--- a/packages/mobile/App/services/sync/CentralServerConnection.test.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.test.ts
@@ -167,7 +167,7 @@ describe('CentralServerConnection', () => {
       const mockEmail = 'test@testemail.com';
       const mockPassword = 'test-password';
 
-      expect(centralServerConnection.login(mockEmail, mockPassword)).rejects.toThrowError(
+      await expect(centralServerConnection.login(mockEmail, mockPassword)).rejects.toThrowError(
         new AuthenticationError(generalErrorMessage),
       );
     });
@@ -213,7 +213,7 @@ describe('CentralServerConnection', () => {
         refreshToken: mockRefreshToken,
       });
 
-      expect(centralServerConnection.refresh()).rejects.toThrowError(
+      await expect(centralServerConnection.refresh()).rejects.toThrowError(
         new AuthenticationError(generalErrorMessage),
       );
     });
@@ -337,7 +337,7 @@ describe('CentralServerConnection', () => {
         status: 401,
       });
       const refreshSpy = jest.spyOn(centralServerConnection, 'refresh');
-      expect(
+      await expect(
         centralServerConnection.fetch('test-path', {}, { skipAttemptRefresh: true }),
       ).rejects.toThrowError(new AuthenticationError(invalidTokenMessage));
       expect(refreshSpy).not.toHaveBeenCalled();
@@ -353,7 +353,7 @@ describe('CentralServerConnection', () => {
           },
         }),
       });
-      expect(centralServerConnection.fetch('test-path', {}, {})).rejects.toThrowError(
+      await expect(centralServerConnection.fetch('test-path', {}, {})).rejects.toThrowError(
         new OutdatedVersionError(mockUpdateUrl),
       );
     });


### PR DESCRIPTION
### Changes

This type of error: https://github.com/beyondessential/tamanu/actions/runs/8516684545/job/23326101467?pr=5632 was common, after some investigation, it seems we weren't properly awaiting for the promises. See https://jestjs.io/docs/asynchronous#asyncawait (specially the caution bit).