### PR TITLE
tweak: Tests and endpoint update

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -45,6 +45,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
+      await sleepAsync(1);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
@@ -104,6 +105,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/fhir+json; fhirVersion=4.0')
         .send(body);
+      await sleepAsync(1);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({

--- a/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -1,5 +1,6 @@
 import { Op } from 'sequelize';
 
+import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
 import { showError } from '@tamanu/shared/test-helpers';
 
 import { createTestContext } from '../../utilities';
@@ -76,6 +77,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
+      await sleepAsync(1);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -1077,7 +1077,8 @@ describe('Encounter', () => {
       });
 
       describe('basic vital features', () => {
-        afterEach(async () => {
+        beforeEach(async () => {
+          await models.VitalLog.truncate({});
           await models.SurveyResponseAnswer.truncate({});
           await models.SurveyResponse.truncate({});
         });

--- a/packages/facility-server/__tests__/apiv1/Triage.test.js
+++ b/packages/facility-server/__tests__/apiv1/Triage.test.js
@@ -264,6 +264,8 @@ describe('Triage', () => {
 
     beforeAll(async () => {
       await models.Triage.truncate({ cascade: true });
+      await models.Encounter.truncate({ cascade: true });
+      await models.Patient.truncate({ cascade: true });
 
       // create a few test triages
       const { id: locationId } = await models.Location.create({

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -92,9 +92,9 @@ triage.get(
       `
         SELECT
           triages.*,
-          encounters.*,
+          encounters.encounter_type,
           encounters.id as encounter_id,
-          patients.*,
+          patients.id as patient_id,
           location.name AS location_name,
           location_group.name AS location_group_name,
           complaint.name AS chief_complaint,


### PR DESCRIPTION
### Changes

Was definitely a weird one. Unfortunately it is very hard to trigger these, so I'm just assuming that having 0 errors after these changes are proof enough.

Also had to modify the triage endpoint, its only being used in one place and doesn't really read that much info. Still, I don't want to touch it much, but just made the smallest change I thought could happen that will result in a "correct" response. Previously, the `id` returned by the endpoint did not match triages, but patient IDs, which seems whack.

Errors:
https://github.com/beyondessential/tamanu/actions/runs/8516684545/job/23326101712
https://github.com/beyondessential/tamanu/actions/runs/8526521781/job/23356005042
https://github.com/beyondessential/tamanu/actions/runs/8528077197/job/23361016994