### PR TITLE
feat(server): SAV-621: standardize service request priorities

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ServiceRequest.test.js
@@ -290,7 +290,7 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
       expect(response.body.subject).not.toHaveProperty('identifier');
     });
 
-    it('materialises the default priority if the source data has a null priority', async () => {
+    it('does not have a default priority if the source data has a null priority', async () => {
       // arrange
       const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
       const ir = await ImagingRequest.create(
@@ -329,8 +329,8 @@ describe(`Materialised FHIR - ServiceRequest`, () => {
             value: ir.displayId,
           },
         ],
-        priority: 'routine',
       });
+      expect(Object.keys(response.body).includes('priority')).toBe(false);
       expect(response).toHaveSucceeded();
     });
 

--- a/packages/shared/src/models/fhir/ServiceRequest/getQueryOptions.js
+++ b/packages/shared/src/models/fhir/ServiceRequest/getQueryOptions.js
@@ -80,6 +80,10 @@ export function getQueryOptions(models) {
         as: 'requestedBy',
       },
       {
+        model: ReferenceData,
+        as: 'priority',
+      },
+      {
         model: Encounter,
         as: 'encounter',
         include: [

--- a/packages/shared/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared/src/models/fhir/ServiceRequest/getValues.js
@@ -129,7 +129,7 @@ async function getValuesFromLabRequest(upstream) {
         ],
       }),
     ],
-    priority: validatePriority(upstream.priority, upstream.urgent),
+    priority: validatePriority(upstream.priority?.name),
     code: labCode(upstream),
     orderDetail: labOrderDetails(upstream),
     subject: new FhirReference({
@@ -163,15 +163,13 @@ function imagingCode(upstream) {
   });
 }
 
-function validatePriority(priority, urgent) {
-  if (urgent === true) {
-    return FHIR_REQUEST_PRIORITY.STAT;
-  }
-  console.log({ priority, urgent })
+// Match the priority to a FHIR ServiceRequest priority where possible
+// otherwise return null
+// See: https://hl7.org/fhir/R4B/valueset-request-priority.html#expansion
+function validatePriority(priority) {
   if (!Object.values(FHIR_REQUEST_PRIORITY).includes(priority)) {
     return null;
   }
-  console.log({ returning:priority })
   return priority;
 }
 

--- a/packages/shared/src/models/fhir/ServiceRequest/getValues.js
+++ b/packages/shared/src/models/fhir/ServiceRequest/getValues.js
@@ -129,7 +129,7 @@ async function getValuesFromLabRequest(upstream) {
         ],
       }),
     ],
-    priority: validatePriority(upstream.priority),
+    priority: validatePriority(upstream.priority, upstream.urgent),
     code: labCode(upstream),
     orderDetail: labOrderDetails(upstream),
     subject: new FhirReference({
@@ -163,16 +163,15 @@ function imagingCode(upstream) {
   });
 }
 
-function validatePriority(priority) {
-  if (!priority) {
-    // default to routine when we don't have a priority in Tamanu
-    return FHIR_REQUEST_PRIORITY.ROUTINE;
+function validatePriority(priority, urgent) {
+  if (urgent === true) {
+    return FHIR_REQUEST_PRIORITY.STAT;
   }
-
+  console.log({ priority, urgent })
   if (!Object.values(FHIR_REQUEST_PRIORITY).includes(priority)) {
-    throw new Exception(`Invalid priority: ${priority}`);
+    return null;
   }
-
+  console.log({ returning:priority })
   return priority;
 }
 


### PR DESCRIPTION
### Changes

This is a PR will not be merged but still needs oversight of other devs. It will be merged into uat-release for SENAITE phase 2. 
ServiceRequest.priorities were not being handled correctly and we needed to unify them. The real challenge was that LabRequests use reference data while ImagingRequests simply use strings. 

For more details see card [SAV-621](https://linear.app/bes/issue/SAV-621/fix-servicerequest-priorities) here.
### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
