### PR TITLE
feat(server): EPI-700: Order PatientCommunication processing by retryCount

### DIFF
--- a/packages/central-server/app/services/EmailService.js
+++ b/packages/central-server/app/services/EmailService.js
@@ -83,7 +83,7 @@ export class EmailService {
       });
       return { status: COMMUNICATION_STATUSES.SENT, result: emailResult };
     } catch (e) {
-      return { status: COMMUNICATION_STATUSES.ERROR, error: e.message };
+      return { status: COMMUNICATION_STATUSES.ERROR, error: e.message, shouldRetry: true };
     }
   }
 }

--- a/packages/central-server/app/services/TelegramBotService.js
+++ b/packages/central-server/app/services/TelegramBotService.js
@@ -51,7 +51,7 @@ export class TelegramBotService {
       const message = await TelegramBotService.#bot.sendMessage(chatId, text);
       return { status: COMMUNICATION_STATUSES.SENT, result: message };
     } catch (e) {
-      return { status: COMMUNICATION_STATUSES.ERROR, error: e.message };
+      return { status: COMMUNICATION_STATUSES.ERROR, error: e.message, shouldRetry: true };
     }
   }
 }

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -1239,6 +1239,9 @@
   "allowMismatchedTimeZones": false,
   "telegramBot": {
     apiToken: "",
-    secretToken: ""
+    secretToken: "",
+  },
+  "patientCommunication": {
+    "retryThreshold": 20
   }
 }

--- a/packages/shared/src/models/PatientCommunication.js
+++ b/packages/shared/src/models/PatientCommunication.js
@@ -41,7 +41,7 @@ export class PatientCommunication extends Model {
   }
 
   static getBaseQueryPendingMessage(channel) {
-    const threshold = config.patientCommunication?.retryThreshold || 20;
+    const threshold = config.patientCommunication?.retryThreshold;
 
     return {
       where: {

--- a/packages/shared/src/models/PatientCommunication.js
+++ b/packages/shared/src/models/PatientCommunication.js
@@ -8,6 +8,7 @@ import {
 } from '@tamanu/constants';
 
 import { Model } from './Model';
+import config from 'config';
 
 export class PatientCommunication extends Model {
   static init({ primaryKey, ...options }) {
@@ -37,5 +38,36 @@ export class PatientCommunication extends Model {
       foreignKey: 'patientId',
       as: 'patient',
     });
+  }
+
+  static getBaseQueryPendingMessage(channel) {
+    const threshold = config.patientCommunication?.retryThreshold || 20;
+
+    return {
+      where: {
+        status: COMMUNICATION_STATUSES.QUEUED,
+        channel,
+        [Sequelize.Op.or]: [
+          { retryCount: { [Sequelize.Op.lte]: threshold } },
+          { retryCount: null },
+        ],
+      },
+    };
+  }
+
+  static getPendingMessages(channel, queryOptions) {
+    return this.findAll({
+      ...this.getBaseQueryPendingMessage(channel),
+      order: [
+        [this.sequelize.literal('retry_count IS NULL'), 'DESC'],
+        ['retryCount', 'ASC'],
+        ['createdAt', 'ASC'],
+      ],
+      ...queryOptions,
+    });
+  }
+
+  static countPendingMessages(channel) {
+    return this.count(this.getBaseQueryPendingMessage(channel));
   }
 }


### PR DESCRIPTION
### Changes

- Add some methods to PatientCommunication model for getting and counting pending messages
- Update PatientEmailCommunicationProcessor and PatientTelegramCommunicationProcessor to increase retryCount whenever it failed to send message or email
- Add new environment retryThreshold

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
