### PR TITLE
fix(translation): no-issue: search being treated as translation in admin panel

### DIFF
--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -42,6 +42,7 @@ const ReservedText = styled.p`
 `;
 
 const validationSchema = yup.lazy(values => {
+  delete values.search;
   const newEntrySchema = {
     stringId: yup
       .string()
@@ -206,8 +207,7 @@ export const FormContents = ({
   if (data.length === 0)
     return (
       <Alert severity="info">
-        Please load in translations using the reference data importer to activate this
-        tab
+        Please load in translations using the reference data importer to activate this tab
       </Alert>
     );
 
@@ -246,6 +246,7 @@ export const TranslationForm = () => {
 
   const handleSubmit = async payload => {
     // Swap temporary id out for stringId
+    delete payload.search;
     const submitData = Object.fromEntries(
       Object.entries(payload).map(([key, { stringId, ...rest }]) => [stringId || key, rest]),
     );


### PR DESCRIPTION
### Changes
Small fix to strip search values before treating everything as translation.

### Checklist

- [x] Code is finished
- [x] Tests are written
- [x] UI Screenshots added to the Linear issue
- [x] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
