### PR TITLE
fix(web): add sorting to upcoming vaccines table

### DIFF
--- a/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
@@ -113,8 +113,8 @@ patientVaccineRoutes.get(
       date: 'due_date',
     };
 
-    const { orderBy, order = 'ASC', rowsPerPage = 10, page = 0 } = req.query;
-    let sortKey = orderBy ? sortKeys[orderBy] : sortKeys.dueDate;
+    const { orderBy = 'due_date', order = 'ASC', rowsPerPage = 10, page = 0 } = req.query;
+    let sortKey = sortKeys[orderBy];
     const sortDirection = order.toLowerCase() === 'asc' ? 'ASC' : 'DESC';
 
     const fromUpcomingVaccinations = `FROM upcoming_vaccinations uv

--- a/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
@@ -113,14 +113,14 @@ patientVaccineRoutes.get(
       date: 'due_date',
     };
 
-    const { orderBy = 'due_date', order = 'ASC', rowsPerPage = 10, page = 0 } = req.query;
+    const { orderBy = 'dueDate', order = 'ASC', rowsPerPage = 10, page = 0 } = req.query;
     let sortKey = sortKeys[orderBy];
     const sortDirection = order.toLowerCase() === 'asc' ? 'ASC' : 'DESC';
 
     const fromUpcomingVaccinations = `FROM upcoming_vaccinations uv
     JOIN scheduled_vaccines sv ON sv.id = uv.scheduled_vaccine_id
     WHERE uv.patient_id = :patientId
-    AND uv.status <> 'MISSED'`;
+    AND uv.status <> ${VACCINE_STATUS.MISSED}`;
 
     const results = await req.db.query(
       `SELECT

--- a/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientVaccine.js
@@ -102,10 +102,20 @@ patientVaccineRoutes.get(
   }),
 );
 
+const UPCOMING_VACC_SORT_KEYS = {
+  vaccine: 'label',
+  dueDate: 'due_date',
+  date: 'due_date',
+};
+
 patientVaccineRoutes.get(
   '/:id/upcomingVaccination',
   asyncHandler(async (req, res) => {
     req.checkPermission('list', 'PatientVaccine');
+
+    const { orderBy, order = 'ASC' } = req.query;
+    let sortKey = orderBy ? UPCOMING_VACC_SORT_KEYS[orderBy] : UPCOMING_VACC_SORT_KEYS.dueDate;
+    const sortDirection = order.toLowerCase() === 'asc' ? 'ASC' : 'DESC';
 
     const results = await req.db.query(
       `
@@ -121,7 +131,7 @@ patientVaccineRoutes.get(
     JOIN scheduled_vaccines sv ON sv.id = uv.scheduled_vaccine_id
     WHERE uv.patient_id = :patientId
     AND uv.status <> 'MISSED'
-    ORDER BY uv.due_date, sv.label;
+    ORDER BY ${sortKey} ${sortDirection}, sv.label;
     `,
       {
         replacements: {

--- a/packages/web/app/components/Table/DataFetchingTable.jsx
+++ b/packages/web/app/components/Table/DataFetchingTable.jsx
@@ -73,6 +73,7 @@ export const DataFetchingTable = memo(
         const isDesc = orderBy === columnKey && order === 'desc';
         const newSorting = { order: isDesc ? 'asc' : 'desc', orderBy: columnKey };
         setSorting(newSorting);
+        setPage(0);
       },
       [sorting],
     );
@@ -149,9 +150,8 @@ export const DataFetchingTable = memo(
 
     const transformData = (data, count) => {
       const transformedData = transformRow ? data.map(transformRow) : data;
-      const hasSearchChanged =
-        !isEqual(fetchOptions, fetchState?.fetchOptions) ||
-        !isEqual(fetchOptions, fetchState?.sorting);
+      const hasSearchChanged = !isEqual(fetchOptions, fetchState?.fetchOptions);
+      const hasSortingChanged = !isEqual(sorting, fetchState?.sorting);
 
       if (lazyLoading && hasSearchChanged) {
         // eslint-disable-next-line no-unused-expressions
@@ -160,7 +160,7 @@ export const DataFetchingTable = memo(
 
       // When fetch option is no longer the same (eg: filter changed), it should reload the entire table
       // instead of keep adding data for lazy loading
-      if (lazyLoading && !hasSearchChanged) {
+      if (lazyLoading && !hasSearchChanged && !hasSortingChanged) {
         return [...(fetchState.data || []), ...(transformedData || [])];
       }
 
@@ -174,7 +174,6 @@ export const DataFetchingTable = memo(
       if (count > fetchState.count) setIsNotificationMuted(false);
 
       const isInitialSort = isEqual(sorting, initialSort);
-      const hasSortingChanged = !isEqual(sorting, fetchState?.sorting);
 
       const getShouldResetRowHighlighting = () => {
         if (fetchState.count === 0) return true; // first fetch never needs a highlight
@@ -213,6 +212,7 @@ export const DataFetchingTable = memo(
 
     useEffect(() => {
       const shouldLoadMoreData = fetchState.data?.length > 0 && lazyLoading;
+
       if (shouldLoadMoreData) setIsLoadingMoreData(true);
       const loadingDelay = !shouldLoadMoreData && loadingIndicatorDelay();
 

--- a/packages/web/app/components/Table/DataFetchingTable.jsx
+++ b/packages/web/app/components/Table/DataFetchingTable.jsx
@@ -149,7 +149,9 @@ export const DataFetchingTable = memo(
 
     const transformData = (data, count) => {
       const transformedData = transformRow ? data.map(transformRow) : data;
-      const hasSearchChanged = !isEqual(fetchOptions, fetchState?.fetchOptions);
+      const hasSearchChanged =
+        !isEqual(fetchOptions, fetchState?.fetchOptions) ||
+        !isEqual(fetchOptions, fetchState?.sorting);
 
       if (lazyLoading && hasSearchChanged) {
         // eslint-disable-next-line no-unused-expressions
@@ -271,6 +273,7 @@ export const DataFetchingTable = memo(
     const notificationMessage = `${newRowCount} new record${
       newRowCount > 1 ? 's' : ''
     } available to view`;
+
     return (
       <>
         {!isNotificationMuted && showNotification && (
@@ -303,9 +306,9 @@ export const DataFetchingTable = memo(
           refreshTable={refreshTable}
           rowStyle={row => {
             const rowStyle = [];
-            if (row.highlighted) rowStyle.push("background-color: #F0FFF0;");
-            if (props.isRowsDisabled) rowStyle.push("cursor: not-allowed;");
-            return rowStyle.join("");
+            if (row.highlighted) rowStyle.push('background-color: #F0FFF0;');
+            if (props.isRowsDisabled) rowStyle.push('cursor: not-allowed;');
+            return rowStyle.join('');
           }}
           lazyLoading={lazyLoading}
           ref={tableRef}

--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -288,6 +288,7 @@ class TableComponent extends React.Component {
         LAZY_LOADING_BOTTOM_SENSITIVITY <=
       event.target.clientHeight;
     const isNotLastPage = page + 1 < Math.ceil(count / rowsPerPage);
+    console.log('isNotLastPage', isNotLastPage);
     if (bottom && isNotLastPage) onChangePage(page + 1);
   };
 

--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -288,7 +288,6 @@ class TableComponent extends React.Component {
         LAZY_LOADING_BOTTOM_SENSITIVITY <=
       event.target.clientHeight;
     const isNotLastPage = page + 1 < Math.ceil(count / rowsPerPage);
-    console.log('isNotLastPage', isNotLastPage);
     if (bottom && isNotLastPage) onChangePage(page + 1);
   };
 

--- a/packages/web/app/features/ImmunisationsTable/ImmunisationScheduleTable.jsx
+++ b/packages/web/app/features/ImmunisationsTable/ImmunisationScheduleTable.jsx
@@ -32,10 +32,9 @@ export const ImmunisationScheduleTable = React.memo(({ patient, onItemEdit }) =>
   const COLUMNS = useMemo(
     () => [
       {
-        key: 'vaccineDisplayName',
+        key: 'vaccine',
         title: <TranslatedText stringId="vaccine.table.column.vaccine" fallback="Vaccine" />,
         accessor: getVaccineName,
-        sortable: false,
       },
       {
         key: 'schedule',
@@ -47,7 +46,6 @@ export const ImmunisationScheduleTable = React.memo(({ patient, onItemEdit }) =>
         key: 'dueDate',
         title: <TranslatedText stringId="vaccine.table.column.dueDate" fallback="Due date" />,
         accessor: getDueDate,
-        sortable: false,
       },
       {
         key: 'status',


### PR DESCRIPTION
### Changes

- add sorting of upcoming vaccines based on due date and vaccine label
Note that tests are being added for this api endpoint in NASS-1179 so I haven't added a test here

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
