### PR TITLE
fix(mobile): Update reference data type on add reminder contact screen

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/AddReminderContact/Screen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/AddReminderContact/Screen.tsx
@@ -130,7 +130,7 @@ const Screen = ({ navigation, selectedPatient }: BaseAppProps) => {
                     <LocalisedField
                       name="reminderContactRelationship"
                       component={SuggesterDropdown}
-                      referenceDataType="relationship"
+                      referenceDataType="contactRelationship"
                       selectPlaceholderText={getTranslation({
                         stringId: 'patient.details.addReminderContacts.placeholder.select',
                         fallback: 'Select',


### PR DESCRIPTION
### Changes

- On add contact screen, update reference data type from `relationship`  to `contactRelationship`

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
