### PR TITLE
fix(mobile): Mobile patient details edit button fix

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/PatientSection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/PatientSection.tsx
@@ -25,7 +25,7 @@ export const PatientSection = ({
   };
 
   const overlappedButton = onEdit ? (
-    <StyledView alignItems="flex-end">
+    <StyledView zIndex={1} alignItems="flex-end">
       <StyledView position="absolute" paddingTop={10} paddingRight={20}>
         <EditButton sectionTitle={title} onPress={onEdit} />
       </StyledView>


### PR DESCRIPTION
The pencil edit icon on mobile seems to no longer be working. Not sure why but possibly related to node upgrade somehow? Anyways i am just adding a zIndex to an absolutely positioned edit button to make sure it is pressable

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
