### PR TITLE
fix(mobile): Fix server selector un-scrollable for release 2.5

### DIFF
--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -55,8 +55,6 @@ export const ServerSelector = ({ onChange, label, value, error }): ReactElement 
 
   return (
     <StyledView
-      marginBottom={screenPercentageToDP(7, Orientation.Height)}
-      height={screenPercentageToDP(5.46, Orientation.Height)}
       style={{ zIndex: 9999 }}
     >
       <Dropdown

--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -4,7 +4,6 @@ import { useNetInfo } from '@react-native-community/netinfo';
 import { Dropdown, SelectOption } from '../Dropdown';
 import { StyledText, StyledView } from '../../styled/common';
 import { theme } from '../../styled/theme';
-import { Orientation, screenPercentageToDP } from '../../helpers/screen';
 import * as overrides from '/root/serverOverrides.json';
 
 type Server = {


### PR DESCRIPTION
### Changes

Removed view margin & height around server selector dropdown

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
