### PR TITLE
fix(regression): restore missing triage endpoint fields

### DIFF
--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -95,6 +95,11 @@ triage.get(
           encounters.encounter_type,
           encounters.id as encounter_id,
           patients.id as patient_id,
+          patients.first_name as first_name,
+          patients.last_name as last_name,
+          patients.sex as sex,
+          patients.display_id as display_id,
+          patients.date_of_birth as date_of_birth,
           location.name AS location_name,
           location_group.name AS location_group_name,
           complaint.name AS chief_complaint,
@@ -119,7 +124,7 @@ triage.get(
           AND encounters.end_date IS NULL
           AND location.facility_id = :facility
           AND encounters.encounter_type IN (:triageEncounterTypes)
-        ORDER BY encounter_type IN (:seenEncounterTypes) ASC, ${sortKey} ${sortDirection} NULLS LAST, Coalesce(arrival_time,triage_time) ASC 
+        ORDER BY encounter_type IN (:seenEncounterTypes) ASC, ${sortKey} ${sortDirection} NULLS LAST, Coalesce(arrival_time,triage_time) ASC
       `,
       {
         model: Triage,


### PR DESCRIPTION
### Changes

Some of the fields in the triage endpoint were recently removed by accident (here). This PR puts them back. Note that before the endpoint was returning all the patient data using patients.* but here I've just selected the required data so that it's more transparent.

ps. This issue was raised in the release regression testing

![image (23)](https://github.com/beyondessential/tamanu/assets/12807916/c2b66e30-3aaa-4518-b84a-dd6af2bcda90)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed
