### PR TITLE
feat(dataDeletion): SAV-558: Handle bad scenarios

### DIFF
--- a/packages/central-server/__tests__/models/Encounter.test.js
+++ b/packages/central-server/__tests__/models/Encounter.test.js
@@ -1,0 +1,162 @@
+import { Op } from 'sequelize';
+import { fake } from '@tamanu/shared/test-helpers/fake';
+import { NOTE_RECORD_TYPES } from '@tamanu/constants';
+import { createTestContext } from '../utilities';
+
+async function makeEncounterWithAssociations(models) {
+  const {
+    User,
+    Facility,
+    Department,
+    Location,
+    Patient,
+    Encounter,
+    EncounterHistory,
+    Note,
+    LabRequest,
+    LabTestType,
+    LabTest,
+    ReferenceData,
+  } = models;
+
+  const examiner = await User.create(fake(User));
+  const facility = await Facility.create({ ...fake(Facility) });
+  const department = await Department.create({ ...fake(Department), facilityId: facility.id });
+  const location = await Location.create({ ...fake(Location), facilityId: facility.id });
+  const patient = await Patient.create(fake(Patient));
+
+  const encounter = await Encounter.create({
+    ...fake(Encounter),
+    patientId: patient.id,
+    examinerId: examiner.id,
+    departmentId: department.id,
+    locationId: location.id,
+  });
+
+  const history = await EncounterHistory.findOne({ where: { encounterId: encounter.id }});
+
+  const note = await Note.create(
+    fake(Note, {
+      recordType: NOTE_RECORD_TYPES.ENCOUNTER,
+      recordId: encounter.id,
+      authorId: examiner.id,
+    }),
+  );
+
+  const labTestCategory = await ReferenceData.create({
+    ...fake(ReferenceData),
+    type: 'labTestCategory',
+  });
+  const labRequest = await LabRequest.create({
+    ...fake(LabRequest),
+    requestedById: examiner.id,
+    encounterId: encounter.id,
+    labTestCategoryId: labTestCategory.id,
+  });
+  const labTestType = await LabTestType.create({
+    ...fake(LabTestType),
+    labTestCategoryId: labTestCategory.id,
+  });
+  const labTest = await LabTest.create({
+    ...fake(LabTest),
+    labTestTypeId: labTestType.id,
+    labRequestId: labRequest.id,
+  });
+
+  return { encounter, history, note, labRequest, labTest };
+}
+
+describe('Encounter', () => {
+  let ctx;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+  });
+  beforeEach(async () => {
+    await models.Encounter.truncate({ cascade: true });
+  });
+  afterAll(() => ctx.close());
+
+  describe('beforeDestroy', () => {
+    it('should destroy all associated records', async () => {
+      const { encounter, history, note } = await makeEncounterWithAssociations(models);
+
+      await encounter.destroy();
+      await encounter.reload({ paranoid: false });
+      await history.reload({ paranoid: false });
+      await note.reload({ paranoid: false });
+
+      expect(encounter.deletedAt).toBeTruthy();
+      expect(history.deletedAt).toBeTruthy();
+      expect(note.deletedAt).toBeTruthy();
+    });
+
+    it('should destroy associations of associations', async () => {
+      const { encounter, labRequest, labTest } = await makeEncounterWithAssociations(models);
+
+      await encounter.destroy();
+      await encounter.reload({ paranoid: false });
+      await labRequest.reload({ paranoid: false });
+      await labTest.reload({ paranoid: false });
+
+      expect(encounter.deletedAt).toBeTruthy();
+      expect(labRequest.deletedAt).toBeTruthy();
+      expect(labTest.deletedAt).toBeTruthy();
+    });
+  });
+
+  describe('beforeBulkDestroy', () => {
+    it('should destroy all associated records', async () => {
+      const { Encounter, EncounterHistory } = models;
+      const encounterIds = [];
+      for (let i = 0; i < 3; i++) {
+        const { encounter } = await makeEncounterWithAssociations(models);
+
+        if (i !== 0) {
+          encounterIds.push(encounter.id);
+        }
+      }
+
+      await Encounter.destroy({ where: { id: { [Op.in]: encounterIds } } });
+
+      const count = await EncounterHistory.count();
+      expect(count).toBe(1);
+    });
+
+    it('should work without specifying IDs', async () => {
+      const { Encounter, EncounterHistory } = models;
+      const reasonForEncounter = 'A very adequate reason';
+      for (let i = 0; i < 3; i++) {
+        const { encounter } = await makeEncounterWithAssociations(models);
+
+        if (i !== 0) {
+          await encounter.update({ reasonForEncounter });
+        }
+      }
+
+      await Encounter.destroy({ where: { reasonForEncounter } });
+
+      const count = await EncounterHistory.count();
+      expect(count).toBe(1);
+    });
+
+    it('should destroy associations of associations', async () => {
+      const { Encounter, LabTest } = models;
+      const encounterIds = [];
+      for (let i = 0; i < 3; i++) {
+        const { encounter } = await makeEncounterWithAssociations(models);
+
+        if (i !== 0) {
+          encounterIds.push(encounter.id);
+        }
+      }
+
+      await Encounter.destroy({ where: { id: { [Op.in]: encounterIds } } });
+
+      const count = await LabTest.count();
+      expect(count).toBe(1);
+    });
+  });
+});

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -14,6 +14,7 @@ import { dateTimeType } from './dateTimeTypes';
 import { Model } from './Model';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 import { dischargeOutpatientEncounters } from '../utils/dischargeOutpatientEncounters';
+import { beforeDestroyEncounter } from '../utils/beforeDestroyHooks';
 
 export class Encounter extends Model {
   static init({ primaryKey, hackToSkipEncounterValidation, ...options }) {
@@ -64,58 +65,7 @@ export class Encounter extends Model {
         validate,
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
         hooks: {
-          async beforeDestroy(encounter) {
-            // Sequelize is going to work on cascade for paranoid table in the future.
-            // There is an open issue for this: https://github.com/sequelize/sequelize/issues/2586
-            const [
-              vitals,
-              notes,
-              procedures,
-              labRequests,
-              imagingRequests,
-              medications,
-              surveyResponses,
-              documents,
-              invoices,
-              initiatedReferrals,
-              completedReferrals,
-              encounterHistories,
-            ] = await Promise.all([
-              encounter.getVitals(),
-              encounter.getNotes(),
-              encounter.getProcedures(),
-              encounter.getLabRequests(),
-              encounter.getImagingRequests(),
-              encounter.getMedications(),
-              encounter.getSurveyResponses(),
-              encounter.getDocuments(),
-              encounter.getInvoice(),
-              encounter.getInitiatedReferrals(),
-              encounter.getCompletedReferrals(),
-              encounter.getEncounterHistories(),
-            ]);
-
-            await Promise.all(
-              [
-                vitals,
-                notes,
-                procedures,
-                labRequests,
-                imagingRequests,
-                medications,
-                surveyResponses,
-                documents,
-                invoices,
-                initiatedReferrals,
-                completedReferrals,
-                encounterHistories,
-              ].map(async records => {
-                if (records && Array.isArray(records)) {
-                  await Promise.all(records.map(record => record.destroy()));
-                }
-              }),
-            );
-          },
+          beforeDestroy: beforeDestroyEncounter,
         },
       },
     );

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -14,7 +14,7 @@ import { dateTimeType } from './dateTimeTypes';
 import { Model } from './Model';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 import { dischargeOutpatientEncounters } from '../utils/dischargeOutpatientEncounters';
-import { beforeDestroyEncounter } from '../utils/beforeDestroyHooks';
+import { beforeDestroyEncounter, beforeBulkDestroyEncounter } from '../utils/beforeDestroyHooks';
 
 export class Encounter extends Model {
   static init({ primaryKey, hackToSkipEncounterValidation, ...options }) {
@@ -66,6 +66,7 @@ export class Encounter extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
         hooks: {
           beforeDestroy: beforeDestroyEncounter,
+          beforeBulkDestroy: beforeBulkDestroyEncounter,
         },
       },
     );

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -14,7 +14,6 @@ import { dateTimeType } from './dateTimeTypes';
 import { Model } from './Model';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 import { dischargeOutpatientEncounters } from '../utils/dischargeOutpatientEncounters';
-import { beforeDestroyEncounter, beforeBulkDestroyEncounter } from '../utils/beforeDestroyHooks';
 
 export class Encounter extends Model {
   static init({ primaryKey, hackToSkipEncounterValidation, ...options }) {
@@ -64,10 +63,6 @@ export class Encounter extends Model {
         ...options,
         validate,
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
-        hooks: {
-          beforeDestroy: beforeDestroyEncounter,
-          beforeBulkDestroy: beforeBulkDestroyEncounter,
-        },
       },
     );
     onSaveMarkPatientForSync(this);

--- a/packages/shared/src/models/Model.js
+++ b/packages/shared/src/models/Model.js
@@ -1,5 +1,6 @@
 import * as sequelize from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { genericBeforeDestroy, genericBeforeBulkDestroy } from '../utils/beforeDestroyHooks';
 
 const { Op, Utils, Sequelize } = sequelize;
 
@@ -22,6 +23,10 @@ export class Model extends sequelize.Model {
       timestamps,
       schema,
       ...options,
+      hooks: {
+        beforeDestroy: genericBeforeDestroy,
+        beforeBulkDestroy: genericBeforeBulkDestroy,
+      },
     });
     this.defaultIdValue = attributes.id.defaultValue;
     if (!syncDirection) {

--- a/packages/shared/src/sync/saveIncomingChanges.js
+++ b/packages/shared/src/sync/saveIncomingChanges.js
@@ -38,7 +38,8 @@ export const saveChangesForModel = async (model, changes, isCentralServer) => {
     const incoming = idToIncomingRecord[existing.id];
     idsForUpdate.add(existing.id);
 
-    if (existing.deletedAt && !incoming.isDeleted) {
+    // Restores only originate from central server
+    if (isCentralServer === false && existing.deletedAt && !incoming.isDeleted) {
       idsForRestore.add(existing.id);
     }
     if (!existing.deletedAt && incoming.isDeleted) {

--- a/packages/shared/src/sync/saveIncomingChanges.js
+++ b/packages/shared/src/sync/saveIncomingChanges.js
@@ -38,12 +38,14 @@ export const saveChangesForModel = async (model, changes, isCentralServer) => {
     const incoming = idToIncomingRecord[existing.id];
     idsForUpdate.add(existing.id);
 
-    // don't do anything if incoming record is deleted and existing record is already deleted
     if (existing.deletedAt && !incoming.isDeleted) {
       idsForRestore.add(existing.id);
     }
     if (!existing.deletedAt && incoming.isDeleted) {
       idsForDelete.add(existing.id);
+    }
+    if (existing.deletedAt && incoming.isDeleted) {
+      // don't do anything if incoming record is deleted and existing record is already deleted
     }
   });
   const recordsForCreate = changes

--- a/packages/shared/src/sync/saveIncomingChanges.js
+++ b/packages/shared/src/sync/saveIncomingChanges.js
@@ -46,7 +46,8 @@ export const saveChangesForModel = async (model, changes, isCentralServer) => {
       idsForDelete.add(existing.id);
     }
     if (existing.deletedAt && incoming.isDeleted) {
-      // don't do anything if incoming record is deleted and existing record is already deleted
+      // don't do anything related to deletion if incoming record
+      // is deleted and existing record is already deleted
     }
   });
   const recordsForCreate = changes

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -55,7 +55,7 @@ export async function beforeDestroyEncounter(encounter) {
 }
 
 async function getEncounterIds(options) {
-  let ids = options.where?.id?.[Op.in];
+  const ids = options.where?.id?.[Op.in];
 
   // options.where.attribute.val.col
   // .logic[Op.LIKE]

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -1,64 +1,8 @@
 import { Op } from 'sequelize';
 
-export async function beforeDestroyEncounter(encounter) {
-  // Sequelize is going to work on cascade for paranoid table in the future.
-  // There is an open issue for this: https://github.com/sequelize/sequelize/issues/2586
-  // TODO: update this list as its incomplete
-  const [
-    vitals,
-    notes,
-    procedures,
-    labRequests,
-    imagingRequests,
-    medications,
-    surveyResponses,
-    documents,
-    invoices,
-    initiatedReferrals,
-    completedReferrals,
-    encounterHistories,
-  ] = await Promise.all([
-    encounter.getVitals(),
-    encounter.getNotes(),
-    encounter.getProcedures(),
-    encounter.getLabRequests(),
-    encounter.getImagingRequests(),
-    encounter.getMedications(),
-    encounter.getSurveyResponses(),
-    encounter.getDocuments(),
-    encounter.getInvoice(),
-    encounter.getInitiatedReferrals(),
-    encounter.getCompletedReferrals(),
-    encounter.getEncounterHistories(),
-  ]);
+async function getIds(options) {
+  let ids = options.where?.id?.[Op.in];
 
-  await Promise.all(
-    [
-      vitals,
-      notes,
-      procedures,
-      labRequests,
-      imagingRequests,
-      medications,
-      surveyResponses,
-      documents,
-      invoices,
-      initiatedReferrals,
-      completedReferrals,
-      encounterHistories,
-    ].map(async records => {
-      if (records && Array.isArray(records)) {
-        await Promise.all(records.map(record => record.destroy()));
-      }
-    }),
-  );
-}
-
-async function getEncounterIds(options) {
-  const ids = options.where?.id?.[Op.in];
-
-  // options.where.attribute.val.col
-  // .logic[Op.LIKE]
   if (ids) {
     return ids;
   }
@@ -67,43 +11,27 @@ async function getEncounterIds(options) {
   return encounters.map(x => x.id);
 }
 
-export async function beforeBulkDestroyEncounter(options) {
-  const ids = await getEncounterIds(options);
-  // Bulk delete all other models - Should we actually apply this to individual delete, too?
-  const {
-    Discharge,
-    Invoice,
-    SurveyResponse,
-    Referral,
-    AdministeredVaccine,
-    EncounterDiagnosis,
-    EncounterMedication,
-    LabRequest,
-    ImagingRequest,
-    Procedure,
-    Vitals,
-    Triage,
-    LabTestPanelRequest,
-    DocumentMetadata,
-    EncounterHistory,
-    Note,
-  } = options.model.sequelize.models;
+function getDependantAssociations(model) {
+  return Object.values(model.associations).filter(
+    ({ associationType }) => ['HasMany', 'HasOne'].includes(associationType),
+  );
+}
 
-  await Discharge.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Invoice.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await SurveyResponse.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Referral.destroy({ where: { initiatingEncounterId: { [Op.in]: ids } } });
-  await Referral.destroy({ where: { completingEncounterId: { [Op.in]: ids } } });
-  await AdministeredVaccine.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await EncounterDiagnosis.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await EncounterMedication.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await LabRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await ImagingRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Procedure.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Vitals.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Triage.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await LabTestPanelRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await DocumentMetadata.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await EncounterHistory.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Note.destroy({ where: { recordType: options.model.name, recordId: { [Op.in]: ids } } });
+export async function genericBeforeDestroy(instance) {
+  const dependantAssociations = getDependantAssociations(instance.constructor);
+
+  for (const association of dependantAssociations) {
+    const { target, foreignKey } = association;
+    await target.destroy({ where: { [foreignKey]: instance.id } });
+  }
+}
+
+export async function genericBeforeBulkDestroy(options) {
+  const ids = await getIds(options);
+  const dependantAssociations = getDependantAssociations(options.model);
+
+  for (const association of dependantAssociations) {
+    const { target, foreignKey } = association;
+    await target.destroy({ where: { [foreignKey]: { [Op.in]: ids } } });
+  }
 }

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -1,0 +1,52 @@
+export async function beforeDestroyEncounter(encounter) {
+  // Sequelize is going to work on cascade for paranoid table in the future.
+  // There is an open issue for this: https://github.com/sequelize/sequelize/issues/2586
+  const [
+    vitals,
+    notes,
+    procedures,
+    labRequests,
+    imagingRequests,
+    medications,
+    surveyResponses,
+    documents,
+    invoices,
+    initiatedReferrals,
+    completedReferrals,
+    encounterHistories,
+  ] = await Promise.all([
+    encounter.getVitals(),
+    encounter.getNotes(),
+    encounter.getProcedures(),
+    encounter.getLabRequests(),
+    encounter.getImagingRequests(),
+    encounter.getMedications(),
+    encounter.getSurveyResponses(),
+    encounter.getDocuments(),
+    encounter.getInvoice(),
+    encounter.getInitiatedReferrals(),
+    encounter.getCompletedReferrals(),
+    encounter.getEncounterHistories(),
+  ]);
+
+  await Promise.all(
+    [
+      vitals,
+      notes,
+      procedures,
+      labRequests,
+      imagingRequests,
+      medications,
+      surveyResponses,
+      documents,
+      invoices,
+      initiatedReferrals,
+      completedReferrals,
+      encounterHistories,
+    ].map(async records => {
+      if (records && Array.isArray(records)) {
+        await Promise.all(records.map(record => record.destroy()));
+      }
+    }),
+  );
+}

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -54,8 +54,21 @@ export async function beforeDestroyEncounter(encounter) {
   );
 }
 
+async function getEncounterIds(options) {
+  let ids = options.where?.id?.[Op.in];
+
+  // options.where.attribute.val.col
+  // .logic[Op.LIKE]
+  if (ids) {
+    return ids;
+  }
+
+  const encounters = await options.model.findAll(options);
+  return encounters.map(x => x.id);
+}
+
 export async function beforeBulkDestroyEncounter(options) {
-  const ids = options.where.id[Op.in];
+  const ids = await getEncounterIds(options);
   // Bulk delete all other models - Should we actually apply this to individual delete, too?
   const {
     Discharge,
@@ -74,7 +87,7 @@ export async function beforeBulkDestroyEncounter(options) {
     DocumentMetadata,
     EncounterHistory,
     Note,
-  } = options.model.models;
+  } = options.model.sequelize.models;
 
   await Discharge.destroy({ where: { encounterId: { [Op.in]: ids } } });
   await Invoice.destroy({ where: { encounterId: { [Op.in]: ids } } });

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -1,6 +1,9 @@
+import { Op } from 'sequelize';
+
 export async function beforeDestroyEncounter(encounter) {
   // Sequelize is going to work on cascade for paranoid table in the future.
   // There is an open issue for this: https://github.com/sequelize/sequelize/issues/2586
+  // TODO: update this list as its incomplete
   const [
     vitals,
     notes,
@@ -49,4 +52,45 @@ export async function beforeDestroyEncounter(encounter) {
       }
     }),
   );
+}
+
+export async function beforeBulkDestroyEncounter(options) {
+  const ids = options.where.id[Op.in];
+  // Bulk delete all other models - Should we actually apply this to individual delete, too?
+  const {
+    Discharge,
+    Invoice,
+    SurveyResponse,
+    Referral,
+    AdministeredVaccine,
+    EncounterDiagnosis,
+    EncounterMedication,
+    LabRequest,
+    ImagingRequest,
+    Procedure,
+    Vitals,
+    Triage,
+    LabTestPanelRequest,
+    DocumentMetadata,
+    EncounterHistory,
+    Note,
+  } = options.model.models;
+
+  await Discharge.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await Invoice.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await SurveyResponse.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await Referral.destroy({ where: { initiatingEncounterId: { [Op.in]: ids } } });
+  await Referral.destroy({ where: { completingEncounterId: { [Op.in]: ids } } });
+  await AdministeredVaccine.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await EncounterDiagnosis.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await EncounterMedication.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await LabRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await ImagingRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await Procedure.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await Vitals.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await Triage.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await LabTestPanelRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await DocumentMetadata.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await EncounterHistory.destroy({ where: { encounterId: { [Op.in]: ids } } });
+  await Note.destroy({ where: { recordType: options.model.name, recordId: { [Op.in]: ids } } });
 }

--- a/packages/shared/src/utils/crudHelpers.js
+++ b/packages/shared/src/utils/crudHelpers.js
@@ -85,6 +85,7 @@ export const simplePut = modelName =>
     const object = await models[modelName].findByPk(params.id);
     if (!object) throw new NotFoundError();
     if (object.deletedAt)
+      // TODO SAV-558: Kinda weird message if we are not going to allow restores
       throw new InvalidOperationError(
         `Cannot update deleted object with id (${params.id}), you need to restore it first`,
       );
@@ -104,10 +105,7 @@ export const simplePost = modelName =>
     object = await models[modelName].findByPk(req.body.id, {
       paranoid: false,
     });
-    if (object && object.deletedAt) {
-      await object.restore();
-      await object.update(req.body);
-    } else if (object && !object.deletedAt) {
+    if (object) {
       throw new InvalidOperationError(
         `Cannot create object with id (${req.body.id}), it already exists`,
       );

--- a/packages/shared/src/utils/crudHelpers.js
+++ b/packages/shared/src/utils/crudHelpers.js
@@ -85,7 +85,6 @@ export const simplePut = modelName =>
     const object = await models[modelName].findByPk(params.id);
     if (!object) throw new NotFoundError();
     if (object.deletedAt)
-      // TODO SAV-558: Kinda weird message if we are not going to allow restores
       throw new InvalidOperationError(
         `Cannot update deleted object with id (${params.id}), you need to restore it first`,
       );


### PR DESCRIPTION
### Changes

- Avoid restoring on facility server
- Deleted record should never be restored by central reconciliation
- "children" records should all be deleted when parent is deleted
  - This one is still pending to implement, but I just want to check whether the approach is good first
  - Instead of redoing a different handler for each model, I thought about doing all: https://github.com/beyondessential/tamanu/pull/5695
