### PR TITLE
feat(db): allow connection via unix socket

### DIFF
--- a/packages/shared/src/services/database.js
+++ b/packages/shared/src/services/database.js
@@ -96,17 +96,16 @@ async function connectToDatabase(dbOptions) {
     logging = null;
   }
 
-  const options = {
-    dialect: 'postgres',
-    dialectOptions: { application_name: serviceName(serviceContext()) ?? 'tamanu' },
-  };
-
   const sequelize = new Sequelize(name, username, password, {
-    ...options,
     host,
     port,
     logging,
     pool,
+    dialect: 'postgres',
+    dialectOptions: {
+      application_name: serviceName(serviceContext()) ?? 'tamanu',
+      ...dbOptions.pgOptions ?? {},
+    },
   });
   setupQuote(sequelize);
   await sequelize.authenticate();

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -99,7 +99,7 @@ export function DownloadDataButton({ exportName, columns, data }) {
     await saveFile({
       defaultFileName: `${exportName}-${getCurrentDateString()}`,
       data: xlsxDataArray,
-      extensions: ['xlsx'],
+      extension: 'xlsx',
     });
   };
 

--- a/packages/web/app/utils/fileSystemAccess.js
+++ b/packages/web/app/utils/fileSystemAccess.js
@@ -1,40 +1,50 @@
 const sanitizeFileName = fileName => {
   return fileName
+    .trim() // prevent leading or trailing whitespace
     .replace(/CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9]/g, 'download') // replace windows reserved filenames
     .replace(/[-<>:"/\\|?*\s]+/g, '-') // replace any consecutive windows reserved characters
     .trim('-'); // prevent leading or trailing hyphen
 };
 
 const FILE_TYPES = {
+  DEFAULT: { description: 'File', accept: { 'application/binary': ['.bin', ''] } },
+  csv: { description: 'CSV Files', accept: { 'text/csv': ['.csv'] } },
+  jpeg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
+  jpg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
+  json: { description: 'JSON Files', accept: { 'application/json': ['.json'] } },
   pdf: { description: 'PDF Files', accept: { 'application/pdf': ['.pdf'] } },
-  jpeg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg'] } },
+  png: { description: 'PNG Images', accept: { 'image/png': ['.png'] } },
+  sql: { description: 'SQL Files', accept: { 'text/sql': ['.sql'] } },
   xlsx: {
     description: 'Excel Workbook',
     accept: { 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'] },
   },
-  csv: { description: 'CSV Files', accept: { 'text/csv': ['.csv'] } },
-  json: { description: 'JSON Files', accept: { 'application/json': ['.json'] } },
-  sql: { description: 'SQL Files', accept: { 'text/sql': ['.sql'] } },
 };
 
-const buildTypesArray = extensions => extensions.map(ext => FILE_TYPES[ext]).filter(Boolean);
-
-export const createFileSystemHandle = async ({ defaultFileName, extensions }) => {
-  const types = buildTypesArray(extensions);
-  const fileHandle = await window.showSaveFilePicker({
+const createFileSystemHandle = async ({ defaultFileName, filetype }) =>
+  window.showSaveFilePicker({
     suggestedName: sanitizeFileName(`${defaultFileName}`),
-    types,
+    types: [filetype],
   });
-  return fileHandle;
-};
 
 export const saveFile = async ({
   defaultFileName,
   data, // The file data to write, in the form of an ArrayBuffer, TypedArray, DataView, Blob, or string.
-  extensions, // An array of possible extensions. If only one is in the array it will default to this extension.
+  extension, // The file extension.
 }) => {
-  const fileHandle = await createFileSystemHandle({ defaultFileName, extensions });
-  const writable = await fileHandle.createWritable();
-  await writable.write(data);
-  await writable.close();
+  const filetype = FILE_TYPES[(extension ?? '').toLowerCase()] ?? FILE_TYPES.DEFAULT;
+
+  try {
+    const fileHandle = await createFileSystemHandle({ defaultFileName, filetype });
+    const writable = await fileHandle.createWritable();
+    await writable.write(data);
+    await writable.close();
+  } catch (_) {
+    // fallback to non-file-picker download if it's not available
+    // or if the Transient User Activation window has closed
+    const blob = new Blob([data], {
+      type: Object.keys(filetype.accept)?.[0] ?? 'application/binary',
+    });
+    open(URL.createObjectURL(blob), '_blank');
+  }
 };

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -21,6 +21,6 @@ export async function saveExcelFile({ data, metadata, defaultFileName = '', book
   await saveFile({
     defaultFileName,
     data: xlsxDataArray,
-    extensions: [bookType],
+    extension: bookType,
   });
 }

--- a/packages/web/app/views/administration/components/ExporterView.jsx
+++ b/packages/web/app/views/administration/components/ExporterView.jsx
@@ -39,7 +39,7 @@ export const ExporterView = memo(({ title, endpoint, dataTypes, dataTypesSelecta
       await saveFile({
         defaultFileName: `${title} export ${getCurrentDateTimeString()}`,
         data: blob,
-        extensions: ['xlsx'],
+        extension: 'xlsx',
       });
     },
     [api, title, endpoint],

--- a/packages/web/app/views/administration/reports/ExportReportView.jsx
+++ b/packages/web/app/views/administration/reports/ExportReportView.jsx
@@ -39,7 +39,7 @@ export const ExportReportView = () => {
       await saveFile({
         defaultFileName: filename,
         data,
-        extensions: [format],
+        extension: format,
       });
     } catch (err) {
       toast.error(`Failed to export: ${err.message}`);

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -80,7 +80,7 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
         await saveFile({
           defaultFileName: document.name,
           data: base64ToUint8Array(data),
-          extensions: [fileExtension],
+          extensions: fileExtension,
         });
 
         notifySuccess('Successfully downloaded file');


### PR DESCRIPTION
### Changes

For Tamanu Iti: allow database connection to use a unix socket, via allowing arbitrary dialect options from config.

This PR folds in the saveFilePicker workaround into 2.4, because that got missed I guess.

### Checklist

- [x] Code is finished