### PR TITLE
ci(cd): fix for namespace length restriction

### DIFF
--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -12,6 +12,7 @@ export function stackName(head_ref, ref_name = null) {
     .replace(/^refs\/(heads|tags)\//, '')
     .replace(/[^a-z0-9-]/g, '-')
     .replace(/-+/g, '-')
+    .slice(0, 63 - 'tamanu-'.length) // max length of namespace, excl prefix
     .replace(/^-|-$/g, '');
 }
 

--- a/packages/scripts/tests/gha-cd-helpers.test.mjs
+++ b/packages/scripts/tests/gha-cd-helpers.test.mjs
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { parseDeployConfig } from '../src/gha-cd-helpers.mjs';
+import { parseDeployConfig, stackName } from '../src/gha-cd-helpers.mjs';
 
 function withoutOptions({ ...deploy }) {
   delete deploy.options;
@@ -27,20 +27,23 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 - [ ] **Deploy (Sima)** <!-- #deploy=sima %facilities=3 -->
 `;
 
-  const parsed = parseDeployConfig({ body, ref: 'refs/heads/ci/k8s-deploy' });
+  const parsed = parseDeployConfig({ body, ref: 'refs/heads/ci/k8s-deploy', control: 'pr=1' });
   t.equal(parsed.length, 3);
   t.deepEqual(parsed.map(withoutOptions), [
     {
       enabled: true,
       name: 'ci-k8s-deploy',
+      control: 'pr=1',
     },
     {
       enabled: false,
       name: 'ci-k8s-deploy-klaus',
+      control: 'pr=1',
     },
     {
       enabled: false,
       name: 'ci-k8s-deploy-sima',
+      control: 'pr=1',
     },
   ]);
   t.equal(parsed.find(d => d.name === 'ci-k8s-deploy-klaus').options.facilities, 0);
@@ -53,13 +56,38 @@ test('parse a short ref name', t => {
   t.plan(3);
 
   const body = '- [x] **Deploy to Tamanu Internal** <!-- #deploy -->';
-  const parsed = parseDeployConfig({ body, ref: 'main' });
+  const parsed = parseDeployConfig({ body, ref: 'main', control: 'issue=2' });
   t.equal(parsed.length, 1);
   t.deepEqual(parsed.map(withoutOptions), [
     {
       enabled: true,
       name: 'main',
+      control: 'issue=2',
     },
   ]);
   t.equal(parsed.find(d => d.name === 'main').options.facilities, 2, 'option should default');
+});
+
+test('normalise a branch name', t => {
+  t.plan(1);
+  t.equal(
+    stackName('refs/heads/feat/ticket-123-invent-microwaves'),
+    'feat-ticket-123-invent-microwaves',
+  );
+});
+
+test('normalise a long branch name', t => {
+  t.plan(1);
+  t.equal(
+    stackName('refs/heads/refactor/ticket-456-make-it-possible-for-microwaves-to-operate-without-a-rotating-base-plate'),
+    'refactor-ticket-456-make-it-possible-for-microwaves-to-o',
+  );
+});
+
+test('normalise a complex branch name', t => {
+  t.plan(1);
+  t.equal(
+    stackName('refs/heads/fix/refs/heads/§ING interpretèd 🌌'),
+    'fix-refs-heads-ing-interpret-d',
+  );
 });


### PR DESCRIPTION
### Changes

Whoops! Branch names longer than 56 chars fail to deploy because of length restrictions.

### Checklist

- [x] Code is finished
- [x] Tests are written