### PR TITLE
ci: make deploy cleanup stop complaining

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -84,7 +84,7 @@ jobs:
             kubectl delete namespace tamanu-${{ inputs.deploy-name }}
           fi
       - # run pulumi destroy again to clean up any resources that might have been left behind
-        if: steps.hard-delete.outcome == 'success'
+        if: always() && steps.hard-delete.outcome == 'success'
         name: Down again!
         uses: pulumi/actions@v5
         with:

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -59,16 +59,23 @@ jobs:
             exit 1
           fi
 
+      - name: Get full stack name
+        id: stack
+        working-directory: ops/pulumi/stacks/${{ fromJson(inputs.options).opsstack }}
+        run: |
+          project=$(ruby -e 'require "yaml"; puts YAML.load(open "Pulumi.yaml")["name"]')
+          echo "stackname=bes/$project/${{ inputs.deploy-name }}" >> $GITHUB_OUTPUT
+
       - # outcome is from before continue-on-error, so will skip if check fails
         if: steps.check.outcome == 'success'
         id: down
         name: Down!
         uses: pulumi/actions@v5
         with:
-          work-dir: ops/pulumi/stacks/${{ inputs.options.opsstack }}
+          work-dir: ops/pulumi/stacks/${{ fromJson(inputs.options).opsstack }}
           command: destroy
           remove: true
-          stack-name: bes/${{ inputs.deploy-name }}
+          stack-name: ${{ steps.stack.outputs.stackname }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: true
         env:
@@ -88,10 +95,10 @@ jobs:
         name: Down again!
         uses: pulumi/actions@v5
         with:
-          work-dir: ops/pulumi/stacks/${{ inputs.options.opsstack }}
+          work-dir: ops/pulumi/stacks/${{ fromJson(inputs.options).opsstack }}
           command: destroy
           remove: true
-          stack-name: bes/${{ inputs.deploy-name }}
+          stack-name: ${{ steps.stack.outputs.stackname }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: true
         env:

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -77,12 +77,19 @@ jobs:
             const { configMap } = await import(`${cwd}/packages/scripts/src/gha-cd-helpers.mjs`);
             core.setOutput('pulumi', configMap('${{ inputs.deploy-name }}', '${{ inputs.image-tag }}', ${{ inputs.options }}));
 
+      - name: Get full stack name
+        id: stack
+        working-directory: ops/pulumi/stacks/${{ fromJson(inputs.options).opsstack }}
+        run: |
+          project=$(ruby -e 'require "yaml"; puts YAML.load(open "Pulumi.yaml")["name"]')
+          echo "stackname=bes/$project/${{ inputs.deploy-name }}" >> $GITHUB_OUTPUT
+
       - name: Up!
         uses: pulumi/actions@v5
         with:
           work-dir: ops/pulumi/stacks/${{ fromJson(inputs.options).opsstack }}
           command: up
-          stack-name: bes/${{ inputs.deploy-name }}
+          stack-name: ${{ steps.stack.outputs.stackname }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: true
           upsert: true


### PR DESCRIPTION
### Changes

The auto-deploy cleanup routine _works_, but it [reports errors](https://github.com/beyondessential/tamanu/actions/runs/8673340406/attempts/2). It has some redundancy built-in so that doesn't stop it working, but it's annoying.

This PR stops pulumi from complaining about shorthand stack names so it won't error anymore.

### Checklist

- [x] Code is finished