### PR TITLE
feat(dataDeletion): SAV-558: Use generic hook

### DIFF
--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -14,7 +14,6 @@ import { dateTimeType } from './dateTimeTypes';
 import { Model } from './Model';
 import { onSaveMarkPatientForSync } from './onSaveMarkPatientForSync';
 import { dischargeOutpatientEncounters } from '../utils/dischargeOutpatientEncounters';
-import { beforeDestroyEncounter, beforeBulkDestroyEncounter } from '../utils/beforeDestroyHooks';
 
 export class Encounter extends Model {
   static init({ primaryKey, hackToSkipEncounterValidation, ...options }) {
@@ -64,10 +63,6 @@ export class Encounter extends Model {
         ...options,
         validate,
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
-        hooks: {
-          beforeDestroy: beforeDestroyEncounter,
-          beforeBulkDestroy: beforeBulkDestroyEncounter,
-        },
       },
     );
     onSaveMarkPatientForSync(this);

--- a/packages/shared/src/models/Model.js
+++ b/packages/shared/src/models/Model.js
@@ -1,5 +1,6 @@
 import * as sequelize from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { genericBeforeDestroy, genericBeforeBulkDestroy } from '../utils/beforeDestroyHooks';
 
 const { Op, Utils, Sequelize } = sequelize;
 
@@ -22,6 +23,10 @@ export class Model extends sequelize.Model {
       timestamps,
       schema,
       ...options,
+      hooks: {
+        beforeDestroy: genericBeforeDestroy,
+        beforeBulkDestroy: genericBeforeBulkDestroy,
+      },
     });
     this.defaultIdValue = attributes.id.defaultValue;
     if (!syncDirection) {

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -3,8 +3,6 @@ import { Op } from 'sequelize';
 async function getIds(options) {
   let ids = options.where?.id?.[Op.in];
 
-  // options.where.attribute.val.col
-  // .logic[Op.LIKE]
   if (ids) {
     return ids;
   }

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -13,7 +13,7 @@ async function getIds(options) {
 
 function getDependantAssociations(model) {
   return Object.values(model.associations).filter(
-    ({ associationType }) => associationType === 'HasMany' || associationType === 'HasOne',
+    ({ associationType }) => ['HasMany', 'HasOne'].includes(associationType),
   );
 }
 

--- a/packages/shared/src/utils/beforeDestroyHooks.js
+++ b/packages/shared/src/utils/beforeDestroyHooks.js
@@ -1,60 +1,6 @@
 import { Op } from 'sequelize';
 
-export async function beforeDestroyEncounter(encounter) {
-  // Sequelize is going to work on cascade for paranoid table in the future.
-  // There is an open issue for this: https://github.com/sequelize/sequelize/issues/2586
-  // TODO: update this list as its incomplete
-  const [
-    vitals,
-    notes,
-    procedures,
-    labRequests,
-    imagingRequests,
-    medications,
-    surveyResponses,
-    documents,
-    invoices,
-    initiatedReferrals,
-    completedReferrals,
-    encounterHistories,
-  ] = await Promise.all([
-    encounter.getVitals(),
-    encounter.getNotes(),
-    encounter.getProcedures(),
-    encounter.getLabRequests(),
-    encounter.getImagingRequests(),
-    encounter.getMedications(),
-    encounter.getSurveyResponses(),
-    encounter.getDocuments(),
-    encounter.getInvoice(),
-    encounter.getInitiatedReferrals(),
-    encounter.getCompletedReferrals(),
-    encounter.getEncounterHistories(),
-  ]);
-
-  await Promise.all(
-    [
-      vitals,
-      notes,
-      procedures,
-      labRequests,
-      imagingRequests,
-      medications,
-      surveyResponses,
-      documents,
-      invoices,
-      initiatedReferrals,
-      completedReferrals,
-      encounterHistories,
-    ].map(async records => {
-      if (records && Array.isArray(records)) {
-        await Promise.all(records.map(record => record.destroy()));
-      }
-    }),
-  );
-}
-
-async function getEncounterIds(options) {
+async function getIds(options) {
   let ids = options.where?.id?.[Op.in];
 
   // options.where.attribute.val.col
@@ -67,43 +13,27 @@ async function getEncounterIds(options) {
   return encounters.map(x => x.id);
 }
 
-export async function beforeBulkDestroyEncounter(options) {
-  const ids = await getEncounterIds(options);
-  // Bulk delete all other models - Should we actually apply this to individual delete, too?
-  const {
-    Discharge,
-    Invoice,
-    SurveyResponse,
-    Referral,
-    AdministeredVaccine,
-    EncounterDiagnosis,
-    EncounterMedication,
-    LabRequest,
-    ImagingRequest,
-    Procedure,
-    Vitals,
-    Triage,
-    LabTestPanelRequest,
-    DocumentMetadata,
-    EncounterHistory,
-    Note,
-  } = options.model.sequelize.models;
+function getDependantAssociations(model) {
+  return Object.values(model.associations).filter(
+    ({ associationType }) => associationType === 'HasMany' || associationType === 'HasOne',
+  );
+}
 
-  await Discharge.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Invoice.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await SurveyResponse.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Referral.destroy({ where: { initiatingEncounterId: { [Op.in]: ids } } });
-  await Referral.destroy({ where: { completingEncounterId: { [Op.in]: ids } } });
-  await AdministeredVaccine.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await EncounterDiagnosis.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await EncounterMedication.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await LabRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await ImagingRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Procedure.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Vitals.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Triage.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await LabTestPanelRequest.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await DocumentMetadata.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await EncounterHistory.destroy({ where: { encounterId: { [Op.in]: ids } } });
-  await Note.destroy({ where: { recordType: options.model.name, recordId: { [Op.in]: ids } } });
+export async function genericBeforeDestroy(instance) {
+  const dependantAssociations = getDependantAssociations(instance.constructor);
+
+  for (const association of dependantAssociations) {
+    const { target, foreignKey } = association;
+    await target.destroy({ where: { [foreignKey]: instance.id } });
+  }
+}
+
+export async function genericBeforeBulkDestroy(options) {
+  const ids = await getIds(options);
+  const dependantAssociations = getDependantAssociations(options.model);
+
+  for (const association of dependantAssociations) {
+    const { target, foreignKey } = association;
+    await target.destroy({ where: { [foreignKey]: { [Op.in]: ids } } });
+  }
 }


### PR DESCRIPTION
### Changes

Given that we are aiming to mark all children (and their children) records to be deleted with the parent, I thought a generic approach was more sensible, rather than explicitly declaring all models that use the functionality.