### PR TITLE
feat(mobile): EPI-760: Reminder messages: Show/Hide Reminder Contacts UI based on config settings

### DIFF
--- a/packages/mobile/App/constants/settings.ts
+++ b/packages/mobile/App/constants/settings.ts
@@ -1,3 +1,4 @@
 export const SETTING_KEYS = {
   VACCINATION_DEFAULTS: 'vaccinations.defaults',
+  FEATURES_REMINDER_CONTACT_ENABLED: 'features.reminderContactModule.enabled',
 };

--- a/packages/mobile/App/models/Setting.ts
+++ b/packages/mobile/App/models/Setting.ts
@@ -84,4 +84,8 @@ export class Setting extends BaseModel {
       return sanitizedRow;
     });
   }
+
+  static getTableNameForSync(): string {
+    return 'settings';
+  }
 }

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/Screen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/Screen.tsx
@@ -30,10 +30,22 @@ import { Button } from '~/ui/components/Button';
 import { ReminderBellIcon } from '~/ui/components/Icons/ReminderBellIcon';
 import { useAuth } from '~/ui/contexts/AuthContext';
 import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
+import { useBackendEffect } from '~/ui/hooks';
+import { SETTING_KEYS } from '~/constants';
+import { readConfig } from '~/services/config';
 
 const Screen = ({ navigation, selectedPatient }: BaseAppProps): ReactElement => {
   const { ability } = useAuth();
   const canReadReminderContacts = ability.can('read', 'Patient');
+
+  const [isReminderContactEnabled] = useBackendEffect(
+    async ({ models }) => {
+      const facilityId = await readConfig('facilityId', '');
+      const isReminderContactEnabled = await models.Setting.get(SETTING_KEYS.FEATURES_REMINDER_CONTACT_ENABLED, facilityId);
+      return isReminderContactEnabled;
+    },
+    [],
+  );
 
   const onNavigateBack = useCallback(() => {
     navigation.goBack();
@@ -113,8 +125,7 @@ const Screen = ({ navigation, selectedPatient }: BaseAppProps): ReactElement => 
               {`${getDisplayAge(selectedPatient.dateOfBirth, ageDisplayFormat)} old`}
             </StyledText>
           </StyledView>
-          {/* TODO: Enable show/hide based on config on mobile */}
-          {canReadReminderContacts && (
+          {canReadReminderContacts && isReminderContactEnabled && (
             <StyledView alignSelf="flex-end" alignItems="flex-end" marginRight={15}>
               <Button
                 marginTop={screenPercentageToDP(1.21, Orientation.Height)}


### PR DESCRIPTION
### Changes

Show reminder contacts based on the settings table on mobile

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
