### PR TITLE
tweak(web): use .env to specify vite proxy target

### DIFF
--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,62 +1,67 @@
 import { readFile } from 'node:fs/promises';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import { json5Plugin } from 'vite-plugin-json5';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  esbuild: {
-    loader: 'jsx',
-  },
-  plugins: [
-    react(),
-    json5Plugin(),
-    nodePolyfills({
-      globals: {
-        Buffer: true,
-      },
-    }),
-  ],
+export default async ({ mode }) => {
+  Object.assign(process.env, loadEnv(mode, process.cwd(), 'TAMANU_'));
 
-  define: {
-    __VERSION__: JSON.stringify(
-      await readFile('package.json')
-        .then(JSON.parse)
-        .then(({ version }) => version),
-    ),
-    NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-    process: JSON.stringify({
-      env: {
-        NODE_ENV: process.env.NODE_ENV,
-      },
-      arch: 'wasm',
-      platform: 'web',
-    }),
-  },
-  worker: {
-    format: 'es',
-  },
-  preview: {
-    https: true,
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        generatedCode: 'es2015',
+  return defineConfig({
+    esbuild: {
+      loader: 'jsx',
+    },
+    plugins: [
+      react(),
+      json5Plugin(),
+      nodePolyfills({
+        globals: {
+          Buffer: true,
+        },
+      }),
+    ],
+
+    define: {
+      __VERSION__: JSON.stringify(
+        await readFile('package.json')
+          .then(JSON.parse)
+          .then(({ version }) => version),
+      ),
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+      process: JSON.stringify({
+        env: {
+          NODE_ENV: process.env.NODE_ENV,
+        },
+        arch: 'wasm',
+        platform: 'web',
+      }),
+    },
+    worker: {
+      format: 'es',
+    },
+    preview: {
+      https: true,
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          generatedCode: 'es2015',
+        },
       },
     },
-  },
-  server: {
-    host: 'localhost',
-    proxy: {
-      '/api': {
-        target: 'http://localhost:4000',
-        // you can also specify other servers to use as backend, e.g.
-        // target: 'https://central.main.internal.tamanu.io',
-        // target: 'https://facility-1.main.internal.tamanu.io',
-        changeOrigin: true,
+    server: {
+      host: 'localhost',
+      proxy: {
+        '/api': {
+          target: process.env.TAMANU_VITE_TARGET ?? 'https://facility-1.main.internal.tamanu.io',
+          // specify other servers to use as backend by setting the variable in a .env file, e.g.
+          // TAMANU_VITE_TARGET=http://localhost:3000
+          // TAMANU_VITE_TARGET=http://localhost:4000
+          // TAMANU_VITE_TARGET=https://central.main.internal.tamanu.io
+          changeOrigin: true,
+        },
       },
     },
-  },
-});
+  });
+};


### PR DESCRIPTION
### Changes

Lets you create a .env file containing e.g.

```env
TAMANU_VITE_TARGET=http://localhost:4000
```

to specify the backend target instead of changing the vite config itself.

### Checklist

- [x] Code is finished