### PR TITLE
feat(downloads): SAV-639: implement two-step downloads for reports

### DIFF
--- a/packages/web/app/components/DocumentsSearchBar.jsx
+++ b/packages/web/app/components/DocumentsSearchBar.jsx
@@ -49,7 +49,7 @@ const SubmitButton = styled(FormSubmitButton)`
 `;
 
 export const DocumentsSearchBar = ({ setSearchParameters }) => {
-  const handleSubmit = values => {
+  const handleSubmit = async values => {
     setSearchParameters(values);
   };
 

--- a/packages/web/app/components/DropdownButton.jsx
+++ b/packages/web/app/components/DropdownButton.jsx
@@ -131,6 +131,7 @@ export const DropdownButton = React.memo(
     actions,
     style,
     className,
+    disabled = false,
     hasPermission = true,
     MainButtonComponent = MainButton,
   }) => {
@@ -159,6 +160,7 @@ export const DropdownButton = React.memo(
           size={size}
           color="primary"
           disableElevation
+          disabled={disabled}
           style={{ borderColor: Colors.primary }}
           onClick={event => handleClick(event, 0)}
         >
@@ -168,7 +170,7 @@ export const DropdownButton = React.memo(
       );
     }
 
-    const isOpen = Boolean(anchorEl);
+    const isOpen = anchorEl && !disabled && hasPermission;
 
     return (
       <Container style={style} className={className} ref={anchorRef}>
@@ -178,7 +180,7 @@ export const DropdownButton = React.memo(
           color="primary"
           disableElevation
           style={{ width: '100%' }}
-          disabled={!hasPermission}
+          disabled={disabled || !hasPermission}
         >
           <MainButtonComponent onClick={event => handleClick(event, 0)}>
             {!hasPermission && <LockIcon />}

--- a/packages/web/app/utils/fileSystemAccess.js
+++ b/packages/web/app/utils/fileSystemAccess.js
@@ -6,22 +6,31 @@ const sanitizeFileName = fileName => {
     .trim('-'); // prevent leading or trailing hyphen
 };
 
-const FILE_TYPES = {
-  DEFAULT: { description: 'File', accept: { 'application/binary': ['.bin', ''] } },
-  csv: { description: 'CSV Files', accept: { 'text/csv': ['.csv'] } },
-  jpeg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
-  jpg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
-  json: { description: 'JSON Files', accept: { 'application/json': ['.json'] } },
-  pdf: { description: 'PDF Files', accept: { 'application/pdf': ['.pdf'] } },
-  png: { description: 'PNG Images', accept: { 'image/png': ['.png'] } },
-  sql: { description: 'SQL Files', accept: { 'text/sql': ['.sql'] } },
-  xlsx: {
+const FILE_TYPES = [
+  { description: 'File', accept: { 'application/binary': ['.bin'] } },
+  { description: 'CSV Files', accept: { 'text/csv': ['.csv'] } },
+  { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
+  { description: 'JSON Files', accept: { 'application/json': ['.json'] } },
+  { description: 'PDF Files', accept: { 'application/pdf': ['.pdf'] } },
+  { description: 'PNG Images', accept: { 'image/png': ['.png'] } },
+  { description: 'SQL Files', accept: { 'text/sql': ['.sql'] } },
+  {
     description: 'Excel Workbook',
     accept: { 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'] },
   },
-};
+];
 
-const createFileSystemHandle = async ({ defaultFileName, filetype }) =>
+const DEFAULT_FILE_TYPE = FILE_TYPES[0];
+
+const fileTypeFromExtension = extension =>
+  FILE_TYPES.find(fileType =>
+    Object.entries(fileType.accept).some(([, exts]) => exts.includes(extension)),
+  ) ?? DEFAULT_FILE_TYPE;
+
+const fileTypeFromMimeType = mimeType =>
+  FILE_TYPES.find(fileType => Object.keys(fileType.accept).includes(mimeType)) ?? DEFAULT_FILE_TYPE;
+
+const createFileSystemHandle = ({ defaultFileName, filetype }) =>
   window.showSaveFilePicker({
     suggestedName: sanitizeFileName(`${defaultFileName}`),
     types: [filetype],
@@ -30,9 +39,19 @@ const createFileSystemHandle = async ({ defaultFileName, filetype }) =>
 export const saveFile = async ({
   defaultFileName,
   data, // The file data to write, in the form of an ArrayBuffer, TypedArray, DataView, Blob, or string.
-  extension, // The file extension.
+  extension = null, // The file extension.
+  mimetype = null,
 }) => {
-  const filetype = FILE_TYPES[(extension ?? '').toLowerCase()] ?? FILE_TYPES.DEFAULT;
+  let filetype;
+  if (mimetype) {
+    filetype = fileTypeFromMimeType(mimetype);
+  } else if (extension?.startsWith('.')) {
+    filetype = fileTypeFromExtension(extension.toLowerCase());
+  } else if (extension) {
+    filetype = fileTypeFromExtension(`.${extension.toLowerCase()}`);
+  } else {
+    filetype = DEFAULT_FILE_TYPE;
+  }
 
   if ('showSaveFilePicker' in window) {
     const fileHandle = await createFileSystemHandle({ defaultFileName, filetype });

--- a/packages/web/app/utils/fileSystemAccess.js
+++ b/packages/web/app/utils/fileSystemAccess.js
@@ -34,14 +34,13 @@ export const saveFile = async ({
 }) => {
   const filetype = FILE_TYPES[(extension ?? '').toLowerCase()] ?? FILE_TYPES.DEFAULT;
 
-  try {
+  if ('showSaveFilePicker' in window) {
     const fileHandle = await createFileSystemHandle({ defaultFileName, filetype });
     const writable = await fileHandle.createWritable();
     await writable.write(data);
     await writable.close();
-  } catch (_) {
+  } else {
     // fallback to non-file-picker download if it's not available
-    // or if the Transient User Activation window has closed
     const blob = new Blob([data], {
       type: Object.keys(filetype.accept)?.[0] ?? 'application/binary',
     });

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -1,10 +1,8 @@
 import * as XLSX from 'xlsx';
-import { saveFile } from './fileSystemAccess';
-
 const stringifyIfNonDateObject = val =>
   typeof val === 'object' && !(val instanceof Date) && val !== null ? JSON.stringify(val) : val;
 
-export async function saveExcelFile({ data, metadata, defaultFileName = '', bookType }) {
+export function prepareExcelFile({ data, metadata, defaultFileName = '', bookType }) {
   const stringifiedData = data.map(row => row.map(stringifyIfNonDateObject));
 
   const book = XLSX.utils.book_new();
@@ -18,9 +16,9 @@ export async function saveExcelFile({ data, metadata, defaultFileName = '', book
   XLSX.utils.book_append_sheet(book, metadataSheet, 'metadata');
 
   const xlsxDataArray = XLSX.write(book, { bookType, type: 'array' });
-  await saveFile({
+  return {
     defaultFileName,
     data: xlsxDataArray,
     extension: bookType,
-  });
+  };
 }

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -75,12 +75,11 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
           base64: true,
         });
 
-        const fileExtension = extension(document.type);
-
         await saveFile({
           defaultFileName: document.name,
           data: base64ToUint8Array(data),
-          extensions: [fileExtension],
+          extension: extension(document.type),
+          mimetype: document.type,
         });
 
         notifySuccess('Successfully downloaded file');

--- a/packages/web/app/views/reports/EmailField.jsx
+++ b/packages/web/app/views/reports/EmailField.jsx
@@ -48,7 +48,7 @@ const validateCommaSeparatedEmails = async emails => {
   return '';
 };
 
-export const EmailField = () => (
+export const EmailField = (props = {}) => (
   <Field
     name="emails"
     label={
@@ -63,5 +63,6 @@ export const EmailField = () => (
     rows={3}
     validate={validateCommaSeparatedEmails}
     required
+    {...props}
   />
 );

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -125,7 +125,7 @@ export const ReportGeneratorForm = () => {
   const [selectedReportId, setSelectedReportId] = useState(null);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [downloadedReport, setDownloadedReport] = useState(null);
+  const [dataReadyForSaving, setDataReadyForSaving] = useState(null);
 
   const reportsById = useMemo(() => keyBy(availableReports, 'id'), [availableReports]);
   const reportOptions = useMemo(
@@ -207,7 +207,7 @@ export const ReportGeneratorForm = () => {
           ['Filters:', filterString],
         ];
 
-        setDownloadedReport(
+        setDataReadyForSaving(
           prepareExcelFile({
             data: excelData,
             metadata,
@@ -246,12 +246,12 @@ export const ReportGeneratorForm = () => {
   const resetDownload = () => {
     setRequestError(null);
     setSuccessMessage(null);
-    setDownloadedReport(null);
+    setDataReadyForSaving(null);
   };
 
   const onDownload = async () => {
     try {
-      await saveFile(downloadedReport);
+      await saveFile(dataReadyForSaving);
       resetDownload();
       setSuccessMessage(
         <TranslatedText
@@ -425,11 +425,11 @@ export const ReportGeneratorForm = () => {
             </Alert>
           )}
           <Box display="flex" justifyContent="flex-end" gridGap="1em">
-            {downloadedReport ? (
+            {dataReadyForSaving ? (
               <Button onClick={onDownload} startIcon={<GetAppIcon />}>
                 <TranslatedText stringId="report.generate.action.download" fallback="Download" /> (
                 {(
-                  (downloadedReport.data.byteLength ?? downloadedReport.data.length) / 1024
+                  (dataReadyForSaving.data.byteLength ?? dataReadyForSaving.data.length) / 1024
                 ).toFixed(0)}{' '}
                 KB)
               </Button>

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -244,7 +244,6 @@ export const ReportGeneratorForm = () => {
   };
 
   const resetDownload = () => {
-    console.log('reset');
     setRequestError(null);
     setSuccessMessage(null);
     setDownloadedReport(null);

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { keyBy, orderBy } from 'lodash';
 import { format } from 'date-fns';
-import { Box, CircularProgress, Typography } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import styled from 'styled-components';
@@ -124,7 +124,6 @@ export const ReportGeneratorForm = () => {
   const [dataSource, setDataSource] = useState(REPORT_DATA_SOURCES.THIS_FACILITY);
   const [selectedReportId, setSelectedReportId] = useState(null);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
-  const [isGenerating, setIsGenerating] = useState(false);
   const [dataReadyForSaving, setDataReadyForSaving] = useState(null);
 
   const reportsById = useMemo(() => keyBy(availableReports, 'id'), [availableReports]);
@@ -186,7 +185,6 @@ export const ReportGeneratorForm = () => {
     );
 
     try {
-      setIsGenerating(true);
       if (dataSource === REPORT_DATA_SOURCES.THIS_FACILITY) {
         const excelData = await api.post(`reports/${reportId}`, {
           parameters: updatedFilters,
@@ -215,7 +213,6 @@ export const ReportGeneratorForm = () => {
             bookType,
           }),
         );
-        setIsGenerating(false);
       } else {
         await api.post(`reportRequest`, {
           reportId,
@@ -229,7 +226,6 @@ export const ReportGeneratorForm = () => {
             fallback="Report successfully requested. You will receive an email soon."
           />,
         );
-        setIsGenerating(false);
       }
     } catch (e) {
       setRequestError(
@@ -239,7 +235,6 @@ export const ReportGeneratorForm = () => {
           replacements={{ errorMessage: e.message }}
         />,
       );
-      setIsGenerating(false);
     }
   };
 
@@ -433,8 +428,6 @@ export const ReportGeneratorForm = () => {
                 ).toFixed(0)}{' '}
                 KB)
               </Button>
-            ) : isGenerating ? (
-              <CircularProgress />
             ) : (
               <FormSubmitDropdownButton
                 size="large"


### PR DESCRIPTION
### Changes

- Split the report download action into two steps: generate the report, and save it.
- Disable the generate button until a report is selected
- Add a spinner progress indicator
- Clear success/error/download state when the form is changed

### Checklist

- [x] Code is finished
- [x] Testing notes added to the Linear issue
- [x] Cherry-pick to 2.5

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->
