### PR TITLE
fix(mobile): SAV-574: Hide program registries from search if no permission 

### DIFF
--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -22,11 +22,16 @@ export class Suggester<ModelType extends BaseModelSubclass> {
 
   formatter: (entity: BaseModel) => OptionType;
 
-  constructor(model: ModelType, options, formatter = defaultFormatter) {
+  filter: (entity: BaseModel) => boolean;
+
+  constructor(model: ModelType, options, formatter = defaultFormatter, filter) {
     this.model = model;
     this.options = options;
     // If you don't provide a formatter, this assumes that your model has "name" and "id" fields
     this.formatter = formatter;
+    // Frontend filter applied to the data recieved. Use this to filter by permission
+    // by the model id: ({ id }) => ability.can('read', subject('noun', { id })),
+    this.filter = filter;
   }
 
   async fetch(options): Promise<BaseModel[]> {
@@ -58,7 +63,7 @@ export class Suggester<ModelType extends BaseModelSubclass> {
         },
       });
 
-      return data.map(this.formatter);
+      return data.filter(this.filter).map(this.formatter);
     } catch (e) {
       return [];
     }

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useNavigation } from '@react-navigation/core';
+import { subject } from '@casl/ability';
 
 //Components
 import { StyledView } from '~/ui/styled/common';
@@ -8,17 +9,24 @@ import { AutocompleteModalField } from '~/ui/components/AutocompleteModal/Autoco
 // Helpers
 import { Suggester } from '~/ui/helpers/suggester';
 import { useBackend } from '~/ui/hooks';
+import { useAuth } from '~/ui/contexts/AuthContext';
 import { VisibilityStatus } from '~/visibilityStatuses';
 
 export const ProgramRegistrySection = (): ReactElement => {
   const navigation = useNavigation();
   const { models } = useBackend();
+  const { ability } = useAuth();
 
-  const ProgramRegistrySuggester = new Suggester(models.ProgramRegistry, {
-    where: {
-      visibilityStatus: VisibilityStatus.Current,
+  const ProgramRegistrySuggester = new Suggester(
+    models.ProgramRegistry,
+    {
+      where: {
+        visibilityStatus: VisibilityStatus.Current,
+      },
     },
-  });
+    undefined,
+    ({ id }) => ability.can('read', subject('ProgramRegistry', { id })),
+  );
 
   return (
     <StyledView marginLeft={20} marginRight={20}>


### PR DESCRIPTION
### Changes

Quite unsure about the approach for this one. Ideally we would filter by permission in the query but the suggester logic really doesn't seem setup for that. I have gotten around it by adding in a front end "filter" that you can pass on suggester creation that checks permission however it feels a little bit too hacky 🤔 its the last release issue so I am trying to be conservative but im really not sure. Very open to suggestions if i am missing something. From what i can tell it hasn't really been done on mobile yet (with a suggester) we have a few select fields that filter by permission

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
