### PR TITLE
feat(permissions): SAV-304: Fix export reference data permissions

### DIFF
--- a/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
+++ b/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
@@ -1,3 +1,5 @@
+import qs from 'qs';
+
 import {
   createAdministeredVaccineData,
   createAllergy,
@@ -18,6 +20,7 @@ import { exporter } from '../../dist/admin/exporter';
 import { parseDate } from '@tamanu/shared/utils/dateTime';
 import { REFERENCE_TYPES } from '@tamanu/constants';
 import { writeExcelFile } from '../../dist/admin/exporter/excelUtils';
+import { makeRoleWithPermissions } from '../permissions';
 
 jest.mock('../../dist/admin/exporter/excelUtils', () => {
   const originalModule = jest.requireActual('../../dist/admin/exporter/excelUtils');
@@ -33,9 +36,11 @@ describe('Reference data exporter', () => {
   let ctx;
   let models;
   let store;
+  let app;
 
   beforeAll(async () => {
     ctx = await createTestContext();
+    app = await ctx.baseApp.asRole('practitioner');
     store = ctx.store;
     models = store.models;
   });
@@ -64,6 +69,43 @@ describe('Reference data exporter', () => {
     for (const model of modelsToDestroy) {
       await ctx.store.models[model].destroy({ where: {}, force: true });
     }
+  });
+
+  describe('Permissions check', () => {
+    beforeEach(async () => {
+      const { Permission, Role } = ctx.store.models;
+      await Permission.destroy({ where: {}, force: true });
+      await Role.destroy({ where: {}, force: true });
+    });
+
+    it('forbids export if having insufficient permission for reference data', async () => {
+      await makeRoleWithPermissions(models, 'practitioner', [
+        { verb: 'write', noun: 'EncounterDiagnosis' },
+      ]);
+
+      const result = await app
+        .get('/v1/admin/export/referenceData')
+        .query(qs.stringify({ includedDataTypes: ['allergy'] }));
+
+      expect(result).toBeForbidden();
+      expect(result.body.error.message).toBe('Cannot perform action "list" on ReferenceData.');
+    });
+
+    it('allows export if having sufficient permission for reference data', async () => {
+      await makeRoleWithPermissions(models, 'practitioner', [
+        { verb: 'list', noun: 'ReferenceData' },
+      ]);
+
+      const result = await app
+        .get('/v1/admin/export/referenceData')
+        .query(qs.stringify({ includedDataTypes: ['allergy'] }))
+        .responseType('blob');
+
+      // when downloading a file, for some reasons,
+      // status of supertest is alwasy 404 even tho we are sure that it is successful
+      // So below is a work around by checking if the response body is buffer to make sure the file is downloaded properly
+      expect(Buffer.isBuffer(result.body)).toBeTrue();
+    });
   });
 
   it('Should export empty data if no data type selected', async () => {

--- a/packages/central-server/app/admin/index.js
+++ b/packages/central-server/app/admin/index.js
@@ -64,11 +64,14 @@ adminRoutes.get(
     const { includedDataTypes = [] } = query;
 
     for (const dataType of includedDataTypes) {
+      // When it is ReferenceData, check if user has permission to list ReferenceData
       if (REFERENCE_TYPE_VALUES.includes(dataType)) {
         req.checkPermission('list', 'ReferenceData');
         continue;
       }
   
+      // Otherwise, if it is other types (eg: patient, lab_test_types,... ones that have their own models)
+      // check the permission against the models
       const nonReferenceDataModelName = upperFirst(dataType);
       req.checkPermission('list', nonReferenceDataModelName);
     }

--- a/packages/central-server/app/admin/index.js
+++ b/packages/central-server/app/admin/index.js
@@ -61,9 +61,9 @@ adminRoutes.get(
   '/export/referenceData',
   asyncHandler(async (req, res) => {
     const { store, query } = req;
-    const { includedDataTypes = [] } = query;
+    const { includedDataTypes = {} } = query;
 
-    for (const dataType of includedDataTypes) {
+    for (const dataType of Object.values(includedDataTypes)) {
       // When it is ReferenceData, check if user has permission to list ReferenceData
       if (REFERENCE_TYPE_VALUES.includes(dataType)) {
         req.checkPermission('list', 'ReferenceData');

--- a/packages/central-server/app/admin/surveyResponsesImporter/surveyResponsesImporter.js
+++ b/packages/central-server/app/admin/surveyResponsesImporter/surveyResponsesImporter.js
@@ -3,7 +3,7 @@ import { readFile } from 'xlsx';
 
 import { importSurveyResponses } from './importSurveyResponses';
 
-export async function surveyResponsesImporter({ errors, models, stats, file }) {
+export async function surveyResponsesImporter({ errors, models, stats, file, checkPermission }) {
   const createContext = sheetName => ({
     errors,
     log: log.child({
@@ -14,6 +14,8 @@ export async function surveyResponsesImporter({ errors, models, stats, file }) {
   });
 
   log.info('Importing survey responses from file', { file });
+
+  checkPermission('create', 'SurveyResponse');
 
   const workbook = readFile(file);
 


### PR DESCRIPTION
### Changes
- Fix export reference data permissions

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
