### PR TITLE
fix: revert-tamoc-169

### DIFF
--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -99,7 +99,7 @@ export function DownloadDataButton({ exportName, columns, data }) {
     await saveFile({
       defaultFileName: `${exportName}-${getCurrentDateString()}`,
       data: xlsxDataArray,
-      extension: 'xlsx',
+      extensions: ['xlsx'],
     });
   };
 

--- a/packages/web/app/utils/fileSystemAccess.js
+++ b/packages/web/app/utils/fileSystemAccess.js
@@ -1,50 +1,40 @@
 const sanitizeFileName = fileName => {
   return fileName
-    .trim() // prevent leading or trailing whitespace
     .replace(/CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9]/g, 'download') // replace windows reserved filenames
     .replace(/[-<>:"/\\|?*\s]+/g, '-') // replace any consecutive windows reserved characters
     .trim('-'); // prevent leading or trailing hyphen
 };
 
 const FILE_TYPES = {
-  DEFAULT: { description: 'File', accept: { 'application/binary': ['.bin', ''] } },
-  csv: { description: 'CSV Files', accept: { 'text/csv': ['.csv'] } },
-  jpeg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
-  jpg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg', '.jpg'] } },
-  json: { description: 'JSON Files', accept: { 'application/json': ['.json'] } },
   pdf: { description: 'PDF Files', accept: { 'application/pdf': ['.pdf'] } },
-  png: { description: 'PNG Images', accept: { 'image/png': ['.png'] } },
-  sql: { description: 'SQL Files', accept: { 'text/sql': ['.sql'] } },
+  jpeg: { description: 'JPEG Files', accept: { 'image/jpeg': ['.jpeg'] } },
   xlsx: {
     description: 'Excel Workbook',
     accept: { 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'] },
   },
+  csv: { description: 'CSV Files', accept: { 'text/csv': ['.csv'] } },
+  json: { description: 'JSON Files', accept: { 'application/json': ['.json'] } },
+  sql: { description: 'SQL Files', accept: { 'text/sql': ['.sql'] } },
 };
 
-const createFileSystemHandle = async ({ defaultFileName, filetype }) =>
-  window.showSaveFilePicker({
+const buildTypesArray = extensions => extensions.map(ext => FILE_TYPES[ext]).filter(Boolean);
+
+export const createFileSystemHandle = async ({ defaultFileName, extensions }) => {
+  const types = buildTypesArray(extensions);
+  const fileHandle = await window.showSaveFilePicker({
     suggestedName: sanitizeFileName(`${defaultFileName}`),
-    types: [filetype],
+    types,
   });
+  return fileHandle;
+};
 
 export const saveFile = async ({
   defaultFileName,
   data, // The file data to write, in the form of an ArrayBuffer, TypedArray, DataView, Blob, or string.
-  extension, // The file extension.
+  extensions, // An array of possible extensions. If only one is in the array it will default to this extension.
 }) => {
-  const filetype = FILE_TYPES[(extension ?? '').toLowerCase()] ?? FILE_TYPES.DEFAULT;
-
-  try {
-    const fileHandle = await createFileSystemHandle({ defaultFileName, filetype });
-    const writable = await fileHandle.createWritable();
-    await writable.write(data);
-    await writable.close();
-  } catch (_) {
-    // fallback to non-file-picker download if it's not available
-    // or if the Transient User Activation window has closed
-    const blob = new Blob([data], {
-      type: Object.keys(filetype.accept)?.[0] ?? 'application/binary',
-    });
-    open(URL.createObjectURL(blob), '_blank');
-  }
+  const fileHandle = await createFileSystemHandle({ defaultFileName, extensions });
+  const writable = await fileHandle.createWritable();
+  await writable.write(data);
+  await writable.close();
 };

--- a/packages/web/app/utils/saveExcelFile.js
+++ b/packages/web/app/utils/saveExcelFile.js
@@ -21,6 +21,6 @@ export async function saveExcelFile({ data, metadata, defaultFileName = '', book
   await saveFile({
     defaultFileName,
     data: xlsxDataArray,
-    extension: bookType,
+    extensions: [bookType],
   });
 }

--- a/packages/web/app/views/administration/components/ExporterView.jsx
+++ b/packages/web/app/views/administration/components/ExporterView.jsx
@@ -39,7 +39,7 @@ export const ExporterView = memo(({ title, endpoint, dataTypes, dataTypesSelecta
       await saveFile({
         defaultFileName: `${title} export ${getCurrentDateTimeString()}`,
         data: blob,
-        extension: 'xlsx',
+        extensions: ['xlsx'],
       });
     },
     [api, title, endpoint],

--- a/packages/web/app/views/administration/reports/ExportReportView.jsx
+++ b/packages/web/app/views/administration/reports/ExportReportView.jsx
@@ -41,7 +41,7 @@ export const ExportReportView = () => {
       await saveFile({
         defaultFileName: filename,
         data,
-        extension: format,
+        extensions: [format],
       });
     } catch (err) {
       toast.error(`Failed to export: ${err.message}`);

--- a/packages/web/app/views/patients/panes/DocumentsPane.jsx
+++ b/packages/web/app/views/patients/panes/DocumentsPane.jsx
@@ -81,7 +81,7 @@ export const DocumentsPane = React.memo(({ encounter, patient }) => {
           defaultFileName: document.name,
           data: base64ToUint8Array(data),
           extensions: [fileExtension],
-        });
+        })
 
         notifySuccess('Successfully downloaded file');
       } catch (error) {


### PR DESCRIPTION
### Changes

This is the Original ticket for the change: https://linear.app/bes/issue/TAMOC-169/file-picker-doesnt-work-if-report-takes-more-than-a-second

In the next release SAV-639 will be completed which fully resolves the issue.


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
