### PR TITLE
ci: really run on all branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ on:
     # Release tags build the server/web packages only
     tags: ['v*.*.*']
     # All branches can potentially be controlled by special issues
-    branches: ['*']
+    branches: ['**']
 
 # makes jobs for the same thing queue behind each other, and if there is already one job pending
 # (not currently running) then that job is cancelled and the newer one remains in queue.


### PR DESCRIPTION
### Changes

Because of the specifics of glob matching github does in workflows, [you need to use `**` to match all branches](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) otherwise the matching ends at slashes.

This is the reason why pushes to `release/2.6` don't trigger auto deploys currently.

### Checklist

- [x] Code is finished