### PR TITLE
fix(mobile): release v2.6 fix: Suggester filtering bug

### DIFF
--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -63,7 +63,11 @@ export class Suggester<ModelType extends BaseModelSubclass> {
         },
       });
 
-      return data.filter(this.filter).map(this.formatter);
+      if (this.filter) {
+        return data.filter(this.filter).map(this.formatter);
+      }
+      return data.map(this.formatter);
+
     } catch (e) {
       return [];
     }

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -63,11 +63,7 @@ export class Suggester<ModelType extends BaseModelSubclass> {
         },
       });
 
-      if (this.filter) {
-        return data.filter(this.filter).map(this.formatter);
-      }
-      return data.map(this.formatter);
-
+      return this.filter ? data.filter(this.filter).map(this.formatter) : data.map(this.formatter);
     } catch (e) {
       return [];
     }


### PR DESCRIPTION
We discovered a bug introduced in 2.5 where if no `filter` is defined when creating a suggester, you will get an empty list. I have just tweaked this to conditionally use it only if present


### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
