### PR TITLE
fix: EPI-760: Cherry pick fix vaccine settings not working on facility server

### DIFF
--- a/packages/shared/src/models/Setting.js
+++ b/packages/shared/src/models/Setting.js
@@ -70,7 +70,7 @@ export class Setting extends Model {
   }
 
   static buildSyncFilter() {
-    return `WHERE (facility_id = :facilityId OR :facilityId IS NULL) AND ${this.tableName}.updated_at_sync_tick > :since`;
+    return `WHERE (facility_id = :facilityId OR facility_id IS NULL) AND ${this.tableName}.updated_at_sync_tick > :since`;
   }
 
   /**


### PR DESCRIPTION
### Changes

- Cherry-pick vaccine settings not working on facility server fix into epic/vaccination-reminders from this PR: https://github.com/beyondessential/tamanu/pull/5731

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
