### PR TITLE
fix(provisioning): missing mandatory argument introduced by #4850

### DIFF
--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -50,6 +50,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
     models: store.models,
     stats,
     includedDataTypes: [...GENERAL_IMPORTABLE_DATA_TYPES, ...PERMISSION_IMPORTABLE_DATA_TYPES],
+    checkPermission: () => true,
   };
 
   for (const {
@@ -178,7 +179,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
   /// ////////
   /// PROGRAMS
 
-  const programOptions = { errors, models: store.models, stats };
+  const programOptions = { errors, models: store.models, stats, checkPermission: () => true };
 
   for (const { file: programFile = null, url: programUrl = null, ...rest } of programs) {
     if (!programFile && !programUrl) {


### PR DESCRIPTION
### Changes

#4850 introduced a mandatory argument to the importer functions, but forgot to update the provisioner, so that broke the provisioner.

### Checklist

- [x] Code is finished