### PR TITLE
fix(server): websocket can not inject to api request

### DIFF
--- a/packages/facility-server/app/createApi.js
+++ b/packages/facility-server/app/createApi.js
@@ -63,20 +63,6 @@ import { version } from './serverInfo';
 
   express.use(getAuditMiddleware());
 
-  // index route for debugging connectivity
-  express.get('/$', (req, res) => {
-    res.send({
-      index: true,
-    });
-  });
-
-  express.use('/', routes);
-
-  // Dis-allow all other routes
-  express.get('*', (req, res) => {
-    res.status(404).end();
-  });
-
   if (errorMiddleware) {
     express.use(errorMiddleware);
   }

--- a/packages/facility-server/app/createApp.js
+++ b/packages/facility-server/app/createApp.js
@@ -1,5 +1,6 @@
 import { createApi } from './createApi';
 import { createWebsocket } from './createWebsocket';
+import routes from './routes';
 
 /**
  * @param {import('./ApplicationContext').ApplicationContext} ctx
@@ -7,6 +8,25 @@ import { createWebsocket } from './createWebsocket';
 export async function createApp(ctx) {
   const api = await createApi(ctx);
   const websocket = await createWebsocket(api.httpServer, ctx);
+  api.express.use((req, _, next) => {
+    req.websocketService = websocket?.websocketService;
+    req.websocketClientService = websocket?.websocketClientService;
+    next();
+  });
+
+  // index route for debugging connectivity
+  api.express.get('/$', (req, res) => {
+    res.send({
+      index: true,
+    });
+  });
+
+  api.express.use('/', routes);
+
+  // Dis-allow all other routes
+  api.express.get('*', (req, res) => {
+    res.status(404).end();
+  });
 
   return { express: api.express, server: api.httpServer, websocket };
 }

--- a/packages/facility-server/app/routes/apiv1/patient/patientContact.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientContact.js
@@ -19,7 +19,7 @@ patientContact.post(
     req.checkPermission('write', 'Patient');
     const { models, websocketClientService } = req;
     const patientContact = await models.PatientContact.create(req.body);
-    websocketClientService.emit(WS_EVENTS.PATIENT_CONTACT_INSERT, patientContact.dataValues);
+    websocketClientService?.emit(WS_EVENTS.PATIENT_CONTACT_INSERT, patientContact.dataValues);
     res.send(patientContact);
   }),
 );

--- a/packages/facility-server/app/routes/apiv1/telegram/telegramRoutes.js
+++ b/packages/facility-server/app/routes/apiv1/telegram/telegramRoutes.js
@@ -13,8 +13,8 @@ export const telegramRoutes = express.Router();
 const getTelegramBotInfo = async ws => {
   return await new Promise((resolve, reject) => {
     try {
-      ws.emit(WS_EVENTS.TELEGRAM_GET_BOT_INFO);
-      ws.listenOnce(WS_EVENTS.TELEGRAM_BOT_INFO, botInfo => resolve(botInfo));
+      ws?.emit(WS_EVENTS.TELEGRAM_GET_BOT_INFO);
+      ws?.listenOnce(WS_EVENTS.TELEGRAM_BOT_INFO, botInfo => resolve(botInfo));
     } catch (e) {
       reject(e);
     }
@@ -25,7 +25,7 @@ telegramRoutes.get(
   '/bot-info',
   expressAsyncHandler(async (req, res) => {
     req.flagPermissionChecked();
-    const botInfo = await getTelegramBotInfo(req.websocketClientService);
+    const botInfo = await getTelegramBotInfo(req?.websocketClientService);
     res.send(botInfo);
   }),
 );

--- a/packages/facility-server/app/services/websocketClientService.js
+++ b/packages/facility-server/app/services/websocketClientService.js
@@ -23,7 +23,7 @@ export const defineWebsocketClientService = injector => {
       contact.connectionDetails = { chatId };
       await contact.save();
 
-      injector.websocketService.emit(WS_EVENTS.TELEGRAM_SUBSCRIBE_SUCCESS, { contactId, chatId });
+      injector.websocketService?.emit(WS_EVENTS.TELEGRAM_SUBSCRIBE_SUCCESS, { contactId, chatId });
     },
   );
 
@@ -38,7 +38,7 @@ export const defineWebsocketClientService = injector => {
       if (!contact) return;
 
       await contact.destroy();
-      injector.websocketService.emit(WS_EVENTS.TELEGRAM_UNSUBSCRIBE_SUCCESS, { contactId });
+      injector.websocketService?.emit(WS_EVENTS.TELEGRAM_UNSUBSCRIBE_SUCCESS, { contactId });
     },
   );
 


### PR DESCRIPTION
### Changes

- Move route defination to createApp on facility

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
