### PR TITLE
fix(mobile): TAMOC-178: hotfix-2.5: Suggester returns no data if filter is undefined

### DIFF
--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -14,6 +14,7 @@ interface SuggesterOptions<ModelType> extends FindManyOptions<ModelType> {
 }
 
 const defaultFormatter = (model): OptionType => ({ label: model.name, value: model.id });
+const defaultFilter = () => true;
 
 export class Suggester<ModelType extends BaseModelSubclass> {
   model: ModelType;
@@ -24,7 +25,7 @@ export class Suggester<ModelType extends BaseModelSubclass> {
 
   filter: (entity: BaseModel) => boolean;
 
-  constructor(model: ModelType, options, formatter = defaultFormatter, filter) {
+  constructor(model: ModelType, options, formatter = defaultFormatter, filter = defaultFilter) {
     this.model = model;
     this.options = options;
     // If you don't provide a formatter, this assumes that your model has "name" and "id" fields


### PR DESCRIPTION
### Changes
- I believe this was fixed in 2.6 but seemingly missed 2.5

### Checklist

- [x] Code is finished
- [n/a] Tests are written
- [n/a] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the changelog (find it [here](https://github.com/beyondessential/tamanu/releases) in the appropriate _draft_ release)
  - [ ] with a ticket reference (e.g. `TAN-123: a one line description`, keep the lists sorted)
  - [ ] any config/settings changes and manual deployment steps
  - [ ] any db schema or other changes that could impact downstream data analysis
- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
