### PR TITLE
fix(labs): SAV-555: Use proper sync filter

### DIFF
--- a/packages/shared/src/models/LabRequestAttachment.js
+++ b/packages/shared/src/models/LabRequestAttachment.js
@@ -1,6 +1,7 @@
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import { Sequelize } from 'sequelize';
+import { buildEncounterLinkedSyncFilter } from './buildEncounterLinkedSyncFilter';
 
 export class LabRequestAttachment extends Model {
   static init({ primaryKey, ...options }) {
@@ -36,7 +37,13 @@ export class LabRequestAttachment extends Model {
     });
   }
 
-  static buildSyncFilter() {
-    return null; // syncs everywhere
+  static buildPatientSyncFilter(patientIds, sessionConfig) {
+    if (sessionConfig.syncAllLabRequests) {
+      return ''; // include all lab tests
+    }
+    if (patientIds.length === 0) {
+      return null;
+    }
+    return buildEncounterLinkedSyncFilter([this.tableName, 'lab_requests', 'encounters']);
   }
 }

--- a/packages/shared/src/models/LabRequestAttachment.js
+++ b/packages/shared/src/models/LabRequestAttachment.js
@@ -39,7 +39,7 @@ export class LabRequestAttachment extends Model {
 
   static buildPatientSyncFilter(patientIds, sessionConfig) {
     if (sessionConfig.syncAllLabRequests) {
-      return ''; // include all lab tests
+      return ''; // include all lab request attachments
     }
     if (patientIds.length === 0) {
       return null;


### PR DESCRIPTION
### Changes

Lab request attachments are meant to sync everywhere, however, they will fail if the corresponding lab request is not there. For that reason, we need to apply a filter (similar to how lab tests work). Similarly, if labs are configured to sync everywhere, then we probably want this piece as well.