### PR TITLE
feat(permission): TAMOC-179: Implement TTL for permission cache

### DIFF
--- a/packages/central-server/__tests__/permissions/permissions.test.js
+++ b/packages/central-server/__tests__/permissions/permissions.test.js
@@ -8,6 +8,7 @@ import { permissionCache } from '@tamanu/shared/permissions/cache';
 import { fake } from '@tamanu/shared/test-helpers/fake';
 import { createTestContext } from '../utilities';
 import { makeRoleWithPermissions } from '../permissions';
+import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
 
 async function getAbilityForRoles(models, roleString) {
   const perms = await queryPermissionsForRoles(models, roleString);
@@ -150,6 +151,23 @@ describe('Permissions', () => {
 
       // Assert
       expect(permissionCache.isEmpty()).toBe(true);
+    });
+
+    describe('TTL', () => {
+      it('should not expire permissions before the TTL', async () => {
+        await addNewPermission();
+        await getPermissionsForRoles(ctx.store.models, 'writer');
+        expect(permissionCache.isEmpty()).toBe(false);
+        await sleepAsync(50);
+        expect(permissionCache.isEmpty()).toBe(false);
+      });
+      it('should expire permissions after the TTL', async () => {
+        await addNewPermission();
+        await getPermissionsForRoles(ctx.store.models, 'writer');
+        expect(permissionCache.isEmpty()).toBe(false);
+        await sleepAsync(60);
+        expect(permissionCache.isEmpty()).toBe(true);
+      });
     });
   });
 });

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -119,9 +119,7 @@
       "tokenLength": 6,
       "tokenExpiry": 20
     },
-    "permissionCache": {
-      "ttl": 60000
-    }
+    "permissionCacheTTL": 60000
   },
   "export": {
     "maxFileSizeInMB": 50

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -44,6 +44,9 @@
     "consoleLevel": "http",
     "color": true
   },
+  "permissionCache" {
+    "ttl": 60000
+  },
   "honeycomb": {
     "apiKey": "",
     "sampleRate": 100, // 100 = 1/100 = 1% of traces get sent to honeycomb

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -44,9 +44,6 @@
     "consoleLevel": "http",
     "color": true
   },
-  "permissionCache" {
-    "ttl": 60000
-  },
   "honeycomb": {
     "apiKey": "",
     "sampleRate": 100, // 100 = 1/100 = 1% of traces get sent to honeycomb
@@ -121,6 +118,9 @@
     "resetPassword": {
       "tokenLength": 6,
       "tokenExpiry": 20
+    },
+    "permissionCache": {
+      "ttl": 60000
     }
   },
   "export": {

--- a/packages/central-server/config/test.json5
+++ b/packages/central-server/config/test.json5
@@ -31,7 +31,8 @@
       "secret": "refreshSecret"
     },
     "reportNoUserError": true,
-    "useHardcodedPermissions": false
+    "useHardcodedPermissions": false,
+    "permissionCacheTTL": 60
   },
   "log": {
     "consoleLevel": "warn"

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -85,9 +85,7 @@
     "saltRounds": 12,
     "tokenDuration": "1h",
     "useHardcodedPermissions": true,
-    "permissionCache": {
-      "ttl": 60000
-    }
+    "permissionCacheTTL": 60000
   },
   "survey": {
     "defaultCodes": {

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -14,9 +14,6 @@
     "enabled": true,
     "level": "info"
   },
-  "permissionsCache" {
-    "ttl": 60000
-  },
   errors: {
     // enable to send errors to a bug tracking service
     enabled: false,
@@ -87,7 +84,10 @@
   "auth": {
     "saltRounds": 12,
     "tokenDuration": "1h",
-    "useHardcodedPermissions": true
+    "useHardcodedPermissions": true,
+    "permissionCache": {
+      "ttl": 60000
+    }
   },
   "survey": {
     "defaultCodes": {

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -14,6 +14,9 @@
     "enabled": true,
     "level": "info"
   },
+  "permissionsCache" {
+    "ttl": 60000
+  },
   errors: {
     // enable to send errors to a bug tracking service
     enabled: false,

--- a/packages/shared/config/test.json
+++ b/packages/shared/config/test.json
@@ -14,5 +14,10 @@
     "persistUpdateWorkerPoolSize": 5,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50
   },
+  "auth": {
+    "permissionCache": {
+      "ttl": 60000
+    }
+  },
   "countryTimeZone": "Australia/Melbourne"
 }

--- a/packages/shared/config/test.json
+++ b/packages/shared/config/test.json
@@ -14,10 +14,5 @@
     "persistUpdateWorkerPoolSize": 5,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50
   },
-  "auth": {
-    "permissionCache": {
-      "ttl": 60000
-    }
-  },
   "countryTimeZone": "Australia/Melbourne"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@casl/ability": "^4.1.0",
     "@honeycombio/opentelemetry-node": "^0.3.2",
+    "@isaacs/ttlcache": "^1.4.1",
     "@opentelemetry/api": "^1.4.0",
     "@opentelemetry/auto-instrumentations-node": "^0.36.0",
     "@opentelemetry/resources": "^1.9.1",
@@ -112,6 +113,7 @@
     "date-fns": "^2.19.0",
     "date-fns-tz": "^1.3.6",
     "json5": "^2.2.3",
+    "khmer-unicode-converter": "^0.0.6",
     "libhoney": "^3.1.1",
     "lodash": "^4.17.11",
     "multiparty": "^4.2.3",
@@ -119,7 +121,6 @@
     "semver-compare": "^1.0.0",
     "semver-diff": "^3.1.1",
     "shortid": "^2.2.14",
-    "tiny-async-pool": "^1.2.0",
-    "khmer-unicode-converter": "^0.0.6"
+    "tiny-async-pool": "^1.2.0"
   }
 }

--- a/packages/shared/src/permissions/cache.js
+++ b/packages/shared/src/permissions/cache.js
@@ -1,40 +1,25 @@
-import { isEmpty } from 'lodash';
 import config from 'config';
+import TTLCache from '@isaacs/ttlcache';
 
-const ttl = BigInt(config.permissionCache.ttl * 1000000);
+const { ttl } = config.auth.permissionCache;
 
 class PermissionCache {
-  cache = {};
-
-  expires = null;
+  cache = new TTLCache({ ttl });
 
   get(key) {
-    this.invalidateIfExpired();
-    return this.cache[key];
+    return this.cache.get(key);
   }
 
   set(key, value) {
-    this.cache[key] = value;
-    if (this.expires) return;
-    this.expires = process.hrtime.bigint() + ttl;
-  }
-
-  delete(key) {
-    delete this.cache[key];
+    this.cache.set(key, value);
   }
 
   reset() {
-    this.cache = {};
-    this.expires = null;
+    this.cache.clear();
   }
 
   isEmpty() {
-    return isEmpty(this.cache);
-  }
-
-  invalidateIfExpired() {
-    if (this.expires > process.hrtime.bigint()) return;
-    this.reset();
+    return this.cache.size === 0;
   }
 }
 

--- a/packages/shared/src/permissions/cache.js
+++ b/packages/shared/src/permissions/cache.js
@@ -1,7 +1,7 @@
 import config from 'config';
 import TTLCache from '@isaacs/ttlcache';
 
-const { ttl } = config.auth.permissionCache;
+const ttl = config.auth?.permissionCacheTTL;
 
 class PermissionCache {
   cache = new TTLCache({ ttl });

--- a/packages/shared/src/permissions/cache.js
+++ b/packages/shared/src/permissions/cache.js
@@ -1,22 +1,40 @@
 import { isEmpty } from 'lodash';
+import config from 'config';
+
+const ttl = config.permissionCache.ttl;
 
 class PermissionCache {
   cache = {};
 
+  expires = null;
+
   get(key) {
+    this.invalidateIfExpired();
     return this.cache[key];
   }
 
   set(key, value) {
     this.cache[key] = value;
+    if (this.expires) return;
+    this.expires = Date.now() + ttl;
+  }
+
+  delete(key) {
+    delete this.cache[key];
   }
 
   reset() {
     this.cache = {};
+    this.expires = null;
   }
 
   isEmpty() {
     return isEmpty(this.cache);
+  }
+
+  invalidateIfExpired() {
+    if (this.expires > Date.now()) return;
+    this.reset();
   }
 }
 

--- a/packages/shared/src/permissions/cache.js
+++ b/packages/shared/src/permissions/cache.js
@@ -1,7 +1,7 @@
 import { isEmpty } from 'lodash';
 import config from 'config';
 
-const ttl = config.permissionCache.ttl;
+const ttl = BigInt(config.permissionCache.ttl * 1000000);
 
 class PermissionCache {
   cache = {};
@@ -16,7 +16,7 @@ class PermissionCache {
   set(key, value) {
     this.cache[key] = value;
     if (this.expires) return;
-    this.expires = Date.now() + ttl;
+    this.expires = process.hrtime.bigint() + ttl;
   }
 
   delete(key) {
@@ -33,7 +33,7 @@ class PermissionCache {
   }
 
   invalidateIfExpired() {
-    if (this.expires > Date.now()) return;
+    if (this.expires > process.hrtime.bigint()) return;
     this.reset();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,11 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/ttlcache@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz#21fb23db34e9b6220c6ba023a0118a2dd3461ea2"
+  integrity sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
### Changes
- Implements a TTL on permission cache
- See card for diagnostic of why model hooks are not effective to invalidate cache in environments with multiple instances
- Using package that handles TTL using performance.now which is relative to the timeOrigin property which is a [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock): its current time never decreases and isn't subject to adjustments. (this was a recommendation from Tim Kennedy)

### Checklist

- [x] Code is finished
- [x] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
