### PR TITLE
fix(mobile): EPI-760: fix error when isReminderContactEnabled is falsy

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/Screen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/Screen.tsx
@@ -125,7 +125,7 @@ const Screen = ({ navigation, selectedPatient }: BaseAppProps): ReactElement => 
               {`${getDisplayAge(selectedPatient.dateOfBirth, ageDisplayFormat)} old`}
             </StyledText>
           </StyledView>
-          {canReadReminderContacts && isReminderContactEnabled && (
+          {(canReadReminderContacts && isReminderContactEnabled) ? (
             <StyledView alignSelf="flex-end" alignItems="flex-end" marginRight={15}>
               <Button
                 marginTop={screenPercentageToDP(1.21, Orientation.Height)}
@@ -152,7 +152,7 @@ const Screen = ({ navigation, selectedPatient }: BaseAppProps): ReactElement => 
                 </StyledView>
               </Button>
             </StyledView>
-          )}
+          ) : null}
         </RowView>
         <HealthIdentificationRow patientId={selectedPatient.displayId} />
       </StyledSafeAreaView>

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/Screen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/Screen.tsx
@@ -125,7 +125,7 @@ const Screen = ({ navigation, selectedPatient }: BaseAppProps): ReactElement => 
               {`${getDisplayAge(selectedPatient.dateOfBirth, ageDisplayFormat)} old`}
             </StyledText>
           </StyledView>
-          {(canReadReminderContacts && isReminderContactEnabled) ? (
+          {canReadReminderContacts && !!isReminderContactEnabled && (
             <StyledView alignSelf="flex-end" alignItems="flex-end" marginRight={15}>
               <Button
                 marginTop={screenPercentageToDP(1.21, Orientation.Height)}
@@ -152,7 +152,7 @@ const Screen = ({ navigation, selectedPatient }: BaseAppProps): ReactElement => 
                 </StyledView>
               </Button>
             </StyledView>
-          ) : null}
+          )}
         </RowView>
         <HealthIdentificationRow patientId={selectedPatient.displayId} />
       </StyledSafeAreaView>


### PR DESCRIPTION
### Changes

- isReminderContactEnabled returns "0" when it's falsy, which results in a display error on mobile

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
