### PR TITLE
fix(reminderMessages): EPI-794: Contact is not set to pending after retry the 2nd times

### DIFF
--- a/packages/web/app/components/ReminderContact/ReminderContactModal.jsx
+++ b/packages/web/app/components/ReminderContact/ReminderContactModal.jsx
@@ -70,12 +70,12 @@ export const ReminderContactModal = ({ onClose, open }) => {
   }, [open]);
 
   useEffect(() => {
-    if (!newContact.id) return;
+    if (activeView !== REMINDER_CONTACT_VIEWS.ADD_REMINDER_QR_CODE) return;
     setTimeout(() => {
       handleUpdatePendingContacts(false);
     }, DEFAULT_CONTACT_TIMEOUT);
     handleUpdatePendingContacts(true);
-  }, [newContact.id]);
+  }, [activeView]);
 
   const handleActiveView = value => {
     setActiveView(value);

--- a/packages/web/app/components/ReminderContact/ReminderContactModal.jsx
+++ b/packages/web/app/components/ReminderContact/ReminderContactModal.jsx
@@ -50,11 +50,11 @@ export const ReminderContactModal = ({ onClose, open }) => {
     setSuccessContactIds(prev => [...prev, data?.contactId]);
   }, []);
 
-  const handleUpdatePendingContacts = isTimerStarted => {
+  const handleUpdatePendingContacts = (newContactId, isTimerStarted) => {
     setPendingContacts(previousPendingContacts => ({
       ...previousPendingContacts,
-      [newContact.id]: {
-        ...previousPendingContacts[newContact.id],
+      [newContactId]: {
+        ...previousPendingContacts[newContactId],
         isTimerStarted,
       },
     }));
@@ -68,14 +68,6 @@ export const ReminderContactModal = ({ onClose, open }) => {
   useEffect(() => {
     setActiveView(REMINDER_CONTACT_VIEWS.REMINDER_CONTACT_LIST);
   }, [open]);
-
-  useEffect(() => {
-    if (activeView !== REMINDER_CONTACT_VIEWS.ADD_REMINDER_QR_CODE) return;
-    setTimeout(() => {
-      handleUpdatePendingContacts(false);
-    }, DEFAULT_CONTACT_TIMEOUT);
-    handleUpdatePendingContacts(true);
-  }, [activeView]);
 
   const handleActiveView = value => {
     setActiveView(value);
@@ -100,6 +92,10 @@ export const ReminderContactModal = ({ onClose, open }) => {
   const onContinue = newContact => {
     setNewContact(newContact);
     handleActiveView(REMINDER_CONTACT_VIEWS.ADD_REMINDER_QR_CODE);
+    setTimeout(() => {
+      handleUpdatePendingContacts(newContact.id, false);
+    }, DEFAULT_CONTACT_TIMEOUT);
+    handleUpdatePendingContacts(newContact.id, true);
   };
 
   const onBack = () => {

--- a/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
@@ -126,6 +126,7 @@ export const PatientDetailsForm = ({ patient, additionalData, birthData, onSubmi
             patientRegistryType={patientRegistryType}
             isRequiredPatientData={isRequiredPatientData}
             sexOptions={sexOptions}
+            isDetailsForm
           />
           <StyledPatientDetailSecondaryDetailsGroupWrapper>
             <SecondaryDetails

--- a/packages/web/app/forms/PatientDetailsForm/layouts/generic/GenericLayout.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/layouts/generic/GenericLayout.jsx
@@ -33,6 +33,7 @@ export const GenericPrimaryDetailsLayout = ({
   registeredBirthPlace,
   sexOptions,
   isRequiredPatientData,
+  isDetailsForm = false,
 }) => {
   const villageSuggester = useSuggester('village');
   const { facility } = useAuth();
@@ -44,7 +45,7 @@ export const GenericPrimaryDetailsLayout = ({
           stringId="patient.detail.subheading.general"
           fallback="General information"
         />
-        {isReminderContactEnabled ? <ReminderContactSection /> : null}
+        {isReminderContactEnabled && isDetailsForm && <ReminderContactSection />}
       </PatientDetailsHeading>
       <FormGrid>
         <LocalisedField


### PR DESCRIPTION
### Changes

- Fix the issue that status is not set to pending after retry the 2nd times on the same contact
- Fix the issue that the Reminder Contact button is shown on new patient form

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
