### PR TITLE
fix(reminderMessages): EPI-794: Use correct .env variable for websocket server

### DIFF
--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -62,7 +62,7 @@ export default async ({ mode }) => {
           changeOrigin: true,
         },
         '/socket.io': {
-          target: process.env.VITE_WSTARGET ?? 'ws://localhost:4000',
+          target: process.env.TAMANU_VITE_TARGET ?? 'https://facility-1.main.internal.tamanu.io',
           ws: true,
         }
       },


### PR DESCRIPTION
### Changes

- Use the same .env variable `process.env.TAMANU_VITE_TARGET` to specify both API and Websocket server

### Checklist

- [x] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
