### PR TITLE
ci: Add cd option to only build images without deploying

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,18 +45,6 @@ jobs:
   config:
     name: Workflow config
     runs-on: ubuntu-latest
-    outputs:
-      ref: ${{ steps.ref.outputs.result }}
-      sha: ${{ steps.sha.outputs.sha }}
-      up: ${{ steps.config.outputs.up }}
-      down: ${{ steps.config.outputs.down }}
-      go-up: ${{ steps.config.outputs.go-up == 'true' }}
-      go-down: ${{ steps.config.outputs.go-down == 'true' }}
-
-      # we need to build images when:
-      # - we want to bring deploys up, AND the images for this commit don't yet exist, or
-      # - we're doing a release, because images are both a product and how we make other artifacts.
-      build-images: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || steps.config.outputs.go-up == 'true') && steps.check-images-exist.outputs.exist != 'yes' }}
     steps:
       - uses: actions/checkout@v4
       - name: Figure branch ref and sha
@@ -111,8 +99,9 @@ jobs:
             console.log(allDeploys);
 
             const matrix = ({ name, control, options }) => ({ name, control, options: JSON.stringify(options) });
-            const up = allDeploys.filter(deploy => deploy.enabled && !deploy.options.pause).map(matrix);
-            const down = allDeploys.filter(deploy => !deploy.enabled && !deploy.options.pause).map(matrix);
+            const filter = ({ options: { pause, imagesonly } }) => !pause && !imagesonly;
+            const up = allDeploys.filter(deploy => deploy.enabled && filter(deploy)).map(matrix);
+            const down = allDeploys.filter(deploy => !deploy.enabled && filter(deploy)).map(matrix);
             console.log('Going UP', up.length);
             console.log('Going DOWN', down.length);
 
@@ -120,10 +109,11 @@ jobs:
             core.setOutput('down', JSON.stringify(down));
             core.setOutput('go-up', !!up.length);
             core.setOutput('go-down', !!down.length);
+            core.setOutput('images', !!up.length || allDeploys.some(deploy => deploy.options.imagesonly && !deploy.options.pause));
 
       - name: Check the images exist
         id: check-images-exist
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || steps.config.outputs.go-up == 'true'
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || steps.config.outputs.images == 'true'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
           for repo in central facility frontend meta; do
@@ -137,6 +127,19 @@ jobs:
             fi
           done
           echo exist=no | tee -a $GITHUB_OUTPUT
+    outputs:
+      ref: ${{ steps.ref.outputs.result }}
+      sha: ${{ steps.sha.outputs.sha }}
+      up: ${{ steps.config.outputs.up }}
+      down: ${{ steps.config.outputs.down }}
+      go-up: ${{ steps.config.outputs.go-up == 'true' }}
+      go-down: ${{ steps.config.outputs.go-down == 'true' }}
+
+      # we need to build images when:
+      # - we want to bring deploys up, AND the images for this commit don't yet exist, or
+      # - we want to build images only, AND the images for this commit don't yet exist, or
+      # - we're doing a release, because images are both a product and how we make other artifacts.
+      build-images: ${{ ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || steps.config.outputs.images == 'true') && steps.check-images-exist.outputs.exist != 'yes' }}
 
   images:
     needs: config

--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -60,6 +60,7 @@ const OPTIONS = [
   { key: 'opsstack', defaultValue: 'tamanu/on-k8s' },
   { key: 'k8score', defaultValue: 'tamanu-internal-main' },
   { key: 'pause', defaultValue: false, presence: true },
+  { key: 'imagesonly', defaultValue: false, presence: true },
 
   { key: 'apis', defaultValue: 2, parse: input => intBounds(input, [0, 5]) },
   {


### PR DESCRIPTION
### Changes

This is occasionally useful e.g. when deploying UATs or to Itis. Currently this requires making a deploy go up and then remembering to cancel the up just after the images are done but before Pulumi starts, which is annoying. With this it will be a matter of adding `%imagesonly` to the deploy config line.

### Checklist

- [x] Code is finished
- [x] Updated the [config reference](https://beyond-essential.slab.com/posts/tamanu-auto-deploys-kubernetes-kkovoquc)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy --> %imagesonly
