### PR TITLE
fix(web): Release-fix-v2.6: Reload patient details on survey submit

### DIFF
--- a/packages/web/app/views/programs/ProgramsView.jsx
+++ b/packages/web/app/views/programs/ProgramsView.jsx
@@ -35,6 +35,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
   const [startTime, setStartTime] = useState(null);
   const [surveys, setSurveys] = useState(null);
   const { setProgramRegistryIdByProgramId } = useProgramRegistryContext();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     if (params.encounterId) {
@@ -99,6 +100,7 @@ const SurveyFlow = ({ patient, currentUser }) => {
       endTime: getCurrentDateTimeString(),
       answers: getAnswersFromData(data, survey),
     });
+    dispatch(reloadPatient(patient.id));
     if (params?.encounterId && encounter && !encounter.endDate) {
       navigateToEncounter(params.encounterId, { tab: ENCOUNTER_TAB_NAMES.FORMS });
     } else {


### PR DESCRIPTION
### Changes

Not sure if this ever worked but when using the "writeToPatient" functionality we discovered that changes to basic patient details wouldnt show until you left and returned to the patient view (or triggered reloadPatient some other way). The fix for this was just to reload the patient after a survey has submitted.

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
