### PR TITLE
fix(pdf): release-fix-2.6: Fix localisation in web worker getter for vaccine cert

### DIFF
--- a/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
+++ b/packages/shared/src/utils/patientCertificates/VaccineCertificate.jsx
@@ -16,6 +16,7 @@ import { H3 } from './Typography';
 import { LetterheadSection } from './LetterheadSection';
 import { getDisplayDate } from './getDisplayDate';
 import { SigningSection } from './SigningSection';
+import { get } from 'lodash';
 
 const columns = [
   {
@@ -49,7 +50,7 @@ const columns = [
     accessor: record => {
       const facility = record.givenElsewhere ? record.givenBy : record.location?.facility?.name;
       return facility || '';
-    }
+    },
   },
 ];
 
@@ -97,7 +98,7 @@ export const VaccineCertificate = ({
   localisation,
   extraPatientFields,
 }) => {
-  const getLocalisation = key => localisation[key];
+  const getLocalisation = key => get(localisation, key);
   const healthFacility = getLocalisation('templates.vaccineCertificate.healthFacility');
   const countryName = getLocalisation('country.name');
 


### PR DESCRIPTION
I missed this in a recently merged ticket for web worker vaccine cert, It was not getting localisation properly in the case of paths not on root of localisation.

Lodash get supports a path, i.e dot seperated accesor

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
