### PR TITLE
fix(web): release-fix-v2.6: Only change order for configurable patient fields

### DIFF
--- a/packages/web/app/forms/PatientDetailsForm/useFilterPatientFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/useFilterPatientFields.jsx
@@ -8,9 +8,14 @@ export const useFilterPatientFields = ({ fields, filterByMandatory }) => {
   const fieldsToShow = useMemo(() => {
     const checkCondition = fieldName =>
       !fields[fieldName].condition || fields[fieldName].condition();
-    const checkMandatory = fieldName =>
-      !isBoolean(filterByMandatory) ||
-      getLocalisation(`fields.${fieldName}.requiredPatientData`) === filterByMandatory;
+    const checkMandatory = fieldName => {
+      const requiredConfiguration = getLocalisation(`fields.${fieldName}.requiredPatientData`);
+      return (
+        !isBoolean(filterByMandatory) ||
+        !isBoolean(requiredConfiguration) ||
+        requiredConfiguration === filterByMandatory
+      ); 
+    };
 
     return Object.keys(fields)
       .filter(fieldName => checkMandatory(fieldName) && checkCondition(fieldName))


### PR DESCRIPTION
### Changes

We disovered a bug where the displayId field is never showing up. This was because of a recent change to configurable fields. I just needed to add in a small line to check that the field is actually configurable before changing any ordering logic. With this line of code added we now keep original behaviour for a component if it isnt configurable

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue
- [ ] Manual upgrade steps added to the Linear issue, if needed

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
