### PR TITLE
ci(cd): Use actual ref when checking namespace belongs to PR

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -3,6 +3,9 @@ name: CD Down
 on:
   workflow_call:
     inputs:
+      ref:
+        type: string
+        required: true
       deploy-name:
         type: string
         required: true
@@ -48,7 +51,7 @@ jobs:
               if kubectl -n tamanu-${{ inputs.deploy-name }} \
                 get configmap auto-deploy -o json \
                 | tee -a /dev/stderr \
-                | jq -e '.data | [.repo == "${{ github.repository }}", .ref == "${{ github.ref }}"] | all | not'
+                | jq -e '.data | [.repo == "${{ github.repository }}", .ref == "${{ inputs.ref }}"] | all | not'
               then
                 echo "Namespace doesn't belong to this branch, not deleting"
                 exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -300,6 +300,7 @@ jobs:
     name: Undeploy ${{ matrix.name }}
     uses: ./.github/workflows/cd-down.yml
     with:
+      ref: ${{ needs.config.outputs.ref }}
       deploy-name: ${{ matrix.name }}
       options: ${{ matrix.options }}
     secrets:


### PR DESCRIPTION
### Changes

When `cd-down` runs, it checks whether the K8s namespace it's going to bring down belongs to the branch the workflow runs for. Unfortunately in the case of PRs, the branch's `github.ref` is the name of a virtual branch github makes up to simulate the outcome of a merge of the branch to its target, and not the actual name of the branch, so the check fails.

### Checklist

- [x] Code is finished