### PR TITLE
fix(mobile): release-fix-2.6: Mobile vaccine date validation timezone bug

### DIFF
--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineFormGiven.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineFormGiven.tsx
@@ -19,6 +19,8 @@ import { useLocalisation } from '~/ui/contexts/LocalisationContext';
 import { useSelector } from 'react-redux';
 import { ReduxStoreProps } from '~/ui/interfaces/ReduxStoreProps';
 import { PatientStateProps } from '~/ui/store/ducks/patient';
+import { parseISO } from 'date-fns';
+
 
 export const VaccineFormGiven = ({ navigation }: VaccineFormProps): JSX.Element => {
   const { values } = useFormikContext();
@@ -34,7 +36,7 @@ export const VaccineFormGiven = ({ navigation }: VaccineFormProps): JSX.Element 
     <StyledView paddingTop={10}>
       <DateGivenField
         required={!values.givenElsewhere}
-        min={selectedPatient?.dateOfBirth ? new Date(selectedPatient.dateOfBirth) : undefined}
+        min={selectedPatient?.dateOfBirth ? parseISO(selectedPatient.dateOfBirth) : undefined}
       />
 
       <BatchField />


### PR DESCRIPTION
### Changes

When setting the min date for the "date given" field on the vaccine form, we were using `new Date()` which takes timezone into account and causes weird behaviour. I have just replaced this with a date-fns function that will just parse the dob as is

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue
- [ ] Manual upgrade steps added to the Linear issue, if needed

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
