### PR TITLE
fix(pdf): release-fix-v2.6: Timezone bug in pdfs

### DIFF
--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -203,7 +203,7 @@ const locale = globalThis.navigator?.language ?? 'default';
 
 const intlFormatDate = (date, formatOptions, fallback = 'Unknown') => {
   if (!date) return fallback;
-  return new Date(date).toLocaleString(locale, formatOptions);
+  return parseISO(date).toLocaleString(locale, formatOptions);
 };
 
 export const formatShortest = date =>


### PR DESCRIPTION
### Changes

We noticed in Da's testing who is a day behind in timezone, we were getting different DOBs on her end. It seems this was from the usage of new Date() in a recent util addition. Fix as per [these docs](https://beyond-essential.slab.com/posts/date-strings-0kifljra#ho6mz-integrating-with-the-outside-world)

### Checklist

- [ ] Code is finished
- [ ] Tests are written
- [ ] UI Screenshots added to the Linear issue
- [ ] Testing notes added to the Linear issue
- [ ] Manual upgrade steps added to the Linear issue, if needed

_Upon merging:_

- [ ] Update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly) or [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q) as needed
- [ ] Update the [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c) as needed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
