### PR TITLE
ci(packaging): Use new repo for release packages

### DIFF
--- a/.github/workflows/cd-package-frontend.yml
+++ b/.github/workflows/cd-package-frontend.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   id-token: write # OIDC token for AWS
 
 jobs:
@@ -12,32 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Pack frontend
     steps:
-      - name: Configure AWS Credentials (image)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ap-southeast-2
-          role-to-assume: arn:aws:iam::143295493206:role/gha-image-pull
-          role-session-name: GHA@Tamanu=WebPackage
-
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Pull image
-        run: docker pull ${{ steps.login-ecr.outputs.registry }}/tamanu/frontend:sha-${{ github.sha }}.amd64
+        run: docker pull ghcr.io/beyondessential/tamanu-frontend:sha-${{ github.sha }}.amd64
 
       - name: Extract version from image
         id: version
         run: |
           set -x
-          docker image inspect ${{ steps.login-ecr.outputs.registry }}/tamanu/frontend:sha-${{ github.sha }}.amd64 \
+          docker image inspect ghcr.io/beyondessential/tamanu-frontend:sha-${{ github.sha }}.amd64 \
             | jq '"version=\(.[0] | .Config.Labels["org.opencontainers.image.version"])"' -r | tee -a "$GITHUB_OUTPUT"
 
       - name: Extract build from image and pack it
         run: |
           set -x
 
-          docker create --name web ${{ steps.login-ecr.outputs.registry }}/tamanu/frontend:sha-${{ github.sha }}.amd64
+          docker create --name web ghcr.io/beyondessential/tamanu-frontend:sha-${{ github.sha }}.amd64
           docker cp web:/app tamanu-web-${{ steps.version.outputs.version }}
           docker rm web
 

--- a/.github/workflows/cd-package-servers.yml
+++ b/.github/workflows/cd-package-servers.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   id-token: write # OIDC token for AWS
 
 jobs:
@@ -21,30 +22,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure AWS Credentials (image)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ap-southeast-2
-          role-to-assume: arn:aws:iam::143295493206:role/gha-image-pull
-          role-session-name: GHA@Tamanu=WebPackage
-
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Pull image
-        run: docker pull ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package }}:sha-${{ github.sha }}.amd64
+        run: docker pull ghcr.io/beyondessential/tamanu-${{ matrix.package }}:sha-${{ github.sha }}.amd64
 
       - name: Extract version from image
         id: version
         run: |
-          docker image inspect ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package }}:sha-${{ github.sha }}.amd64 \
+          docker image inspect ghcr.io/beyondessential/tamanu-${{ matrix.package }}:sha-${{ github.sha }}.amd64 \
             | jq '"version=\(.[0] | .Config.Labels["org.opencontainers.image.version"])"' -r | tee -a "$GITHUB_OUTPUT"
 
       - name: Extract files from image
         run: |
           set -x
-          docker create --name working ${{ steps.login-ecr.outputs.registry }}/tamanu/${{ matrix.package }}:sha-${{ github.sha }}.amd64
+          docker create --name working ghcr.io/beyondessential/tamanu-${{ matrix.package }}:sha-${{ github.sha }}.amd64
           docker cp working:/app release-v${{ steps.version.outputs.version }}
           docker rm working
 


### PR DESCRIPTION
The package workflows still use the old registry (in AWS) but the images are pushed to the Github registry.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
