### PR TITLE
fix(settings): NASS-889: Settings for front end generated in appropriate scope

### DIFF
--- a/packages/central-server/app/auth/login.js
+++ b/packages/central-server/app/auth/login.js
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import { JWT_TOKEN_TYPES } from '@tamanu/constants/auth';
 import { BadAuthenticationError } from '@tamanu/shared/errors';
 import { getPermissionsForRoles } from '@tamanu/shared/permissions/rolesToPermissions';
+import { ReadSettings } from '@tamanu/settings';
 import { getLocalisation } from '../localisation';
 import { convertFromDbRecord } from '../convertDbRecord';
 import {
@@ -64,11 +65,12 @@ const getRefreshToken = async (models, { refreshSecret, userId, deviceId }) => {
 
 export const login = ({ secret, refreshSecret }) =>
   asyncHandler(async (req, res) => {
-    const { store, body, settings } = req;
+    const { store, body } = req;
     const { models } = store;
     const { email, password, facilityId, deviceId } = body;
 
-    const settingsObject = await settings.getFrontEndSettings();
+    const settingsReader = new ReadSettings(models, facilityId);
+    const settingsObject = await settingsReader.getFrontEndSettings();
     settingsObject.countryTimeZone = config.countryTimeZone; // This needs to be in config but also needs to be front end accessible
 
     if (!email || !password) {

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -126,14 +126,14 @@ async function centralServerLoginWithLocalFallback(models, email, password, devi
 }
 
 export async function loginHandler(req, res, next) {
-  const { body, models, deviceId } = req;
+  const { body, models, deviceId, settings } = req;
   const { email, password } = body;
 
   // no permission needed for login
   req.flagPermissionChecked();
 
   try {
-    const { central, user, localisation, settings } = await centralServerLoginWithLocalFallback(
+    const { central, user, localisation } = await centralServerLoginWithLocalFallback(
       models,
       email,
       password,
@@ -154,7 +154,7 @@ export async function loginHandler(req, res, next) {
       server: {
         facility: facility?.forResponse() ?? null,
       },
-      settings,
+      settings: await settings.getFrontEndSettings(),
     });
   } catch (e) {
     next(e);


### PR DESCRIPTION
### Changes
Previously all logins received central scoped settings i.e global + central settings marked for front end usage

To fix:
- Front end settings should be scoped to facility and not use the central servers initialised reader when loging in.
- This also means that if local fallback login is used it will still return settings.
- It is however valid to return settings from central in the case of admin panel central server login

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
