### PR TITLE
fix(programs): NASS-1253: fix calculated questions

### DIFF
--- a/packages/shared/__tests__/utils/calculations.test.js
+++ b/packages/shared/__tests__/utils/calculations.test.js
@@ -106,6 +106,20 @@ describe('Survey calculations', () => {
       expect(calculations).toHaveProperty('TEST_BROKEN', null);
       expect(calculations).toHaveProperty('TEST_BROKEN_2', null);
     });
+
+    it('should handle undefined inputs in calculations', () => {
+      const survey = makeDummySurvey([
+        { code: 'INPUT_1' },
+        { code: 'INPUT_2' },
+        { code: 'INPUT_3' },
+        { code: 'TEST_1', type: 'CalculatedQuestion', calculation: 'INPUT_1 + INPUT_2 + INPUT_3' },
+      ]);
+      const calculations = runCalculations(survey, {
+        INPUT_1: 1,
+        INPUT_2: 2,
+      });
+      expect(calculations.TEST_1).toEqual(3);
+    });
   });
 
   describe('Results', () => {

--- a/packages/shared/__tests__/utils/calculations.test.js
+++ b/packages/shared/__tests__/utils/calculations.test.js
@@ -113,12 +113,14 @@ describe('Survey calculations', () => {
         { code: 'INPUT_2' },
         { code: 'INPUT_3' },
         { code: 'TEST_1', type: 'CalculatedQuestion', calculation: 'INPUT_1 + INPUT_2 + INPUT_3' },
+        { code: 'TEST_2', type: 'CalculatedQuestion', calculation: 'INPUT_2 * INPUT_3' },
       ]);
       const calculations = runCalculations(survey, {
         INPUT_1: 1,
         INPUT_2: 2,
       });
       expect(calculations.TEST_1).toEqual(3);
+      expect(calculations.TEST_2).toEqual(0);
     });
   });
 

--- a/packages/shared/src/utils/calculations.js
+++ b/packages/shared/src/utils/calculations.js
@@ -18,7 +18,7 @@ export function runCalculations(components, values) {
   const inputValues = {};
   // calculation expression use "code"
   for (const c of components) {
-    inputValues[c.dataElement.code] = values[c.dataElement.id];
+    inputValues[c.dataElement.code] = values[c.dataElement.id] || '';
   }
 
   const calculatedValues = {};


### PR DESCRIPTION
### Changes

Convert calculation inputs to an empty string if they are undefined so that the calculations don't fail if there is an empty input. This change results in feature parity between the survey calculations in the front end ui and the survey logic on the server.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
