### PR TITLE
fix(dataDeletion): Do not filter deleted records from sync

### DIFF
--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -239,8 +239,6 @@ export class Encounter extends Model {
           FROM encounters e
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
           WHERE (e.updated_at_sync_tick > :since OR lr.updated_at_sync_tick > :since)
-          AND lr.deleted_at IS NULL
-          AND e.deleted_at IS NULL
           ${
             patientIds.length > 0
               ? 'AND e.patient_id NOT IN (:patientIds) -- no need to sync if it would be synced anyway'

--- a/packages/shared/src/models/SurveyResponseAnswer.js
+++ b/packages/shared/src/models/SurveyResponseAnswer.js
@@ -54,14 +54,12 @@ export class SurveyResponseAnswer extends Model {
         WHERE encounters.patient_id in (:patientIds)
         AND surveys.is_sensitive = FALSE
         AND ${this.tableName}.updated_at_sync_tick > :since
-        AND encounters.deleted_at is null
       `;
     }
 
     return `
       ${joins}
       WHERE encounters.patient_id in (:patientIds)
-      AND encounters.deleted_at is null
       AND ${this.tableName}.updated_at_sync_tick > :since
     `;
   }

--- a/packages/shared/src/models/VitalLog.js
+++ b/packages/shared/src/models/VitalLog.js
@@ -72,14 +72,12 @@ export class VitalLog extends Model {
         WHERE encounters.patient_id in (:patientIds)
         AND surveys.is_sensitive = FALSE
         AND ${this.tableName}.updated_at_sync_tick > :since
-        AND encounters.deleted_at is null
       `;
     }
 
     return `
       ${joins}
       WHERE encounters.patient_id in (:patientIds)
-      AND encounters.deleted_at is null
       AND ${this.tableName}.updated_at_sync_tick > :since
     `;
   }

--- a/packages/shared/src/models/buildEncounterLinkedSyncFilter.js
+++ b/packages/shared/src/models/buildEncounterLinkedSyncFilter.js
@@ -19,6 +19,5 @@ export function buildEncounterLinkedSyncFilter(
     ${joins}
     WHERE encounters.patient_id IN (:patientIds)
     AND ${tablesToTraverse[0]}.updated_at_sync_tick > :since
-    AND encounters.deleted_at IS NULL
   `;
 }

--- a/packages/shared/src/models/buildNoteLinkedSyncFilter.js
+++ b/packages/shared/src/models/buildNoteLinkedSyncFilter.js
@@ -55,6 +55,5 @@ export function buildNoteLinkedSyncFilter(patientIds, sessionConfig) {
       ${whereOrs.join('\nOR ')}
     )
     AND notes.updated_at_sync_tick > :since
-    AND notes.deleted_at isnull
   `;
 }


### PR DESCRIPTION
### Changes

Even though this might appear as bloating the DB with deleted records, the thing is that we have to be able to send deleted records down, so that we can propagate deletions the right way. Otherwise, deleted records that are synced to more than one facility will still be available* when they get removed from one facility.

* "available" because they should NOT appear on the frontend, however the backend won't be erased.

We didn't catch this sooner because the sync filters were actually missing for referrals and document metadata, while encounters always synced regardless of their status (which is the way to go)