### PR TITLE
fix(server): default value for created_at field in SocketIoAttachmentsTable migration

### DIFF
--- a/packages/shared/src/migrations/1714987069557-createSocketIoAttachmentsTable.js
+++ b/packages/shared/src/migrations/1714987069557-createSocketIoAttachmentsTable.js
@@ -17,7 +17,7 @@ export async function up(query) {
     },
     created_at: {
       type: DataTypes.DATE,
-      defaultValue: DataTypes.NOW,
+      defaultValue: Sequelize.fn('now'),
     },
     payload: {
       type: DataTypes.BLOB,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
