### PR TITLE
ci(cd): Android fix central server override on test builds

### DIFF
--- a/.github/workflows/cd-package-android.yml
+++ b/.github/workflows/cd-package-android.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           cat <<EOF > serverOverrides.json
           {
-            "centralServers": [{"label": "Central Server", "value": "${{inputs.server}}" }]
+            "centralServers": [{"label": "Central Server", "value": "https://${{inputs.server}}" }]
           }
           EOF
 

--- a/.github/workflows/cd-package-android.yml
+++ b/.github/workflows/cd-package-android.yml
@@ -35,8 +35,6 @@ on:
         description: Central server override
         type: string
         required: false
-env:
-  APK_NAME: app.apk
 
 jobs:
   build:
@@ -113,7 +111,7 @@ jobs:
       - name: Upload final build
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.APK_NAME }}
+          name: android-release
           path: packages/mobile/android/app/build/outputs/apk/release/app-release.apk
           retention-days: 7
 
@@ -148,7 +146,7 @@ jobs:
         run: |
           aws s3 cp --no-progress \
             packages/mobile/android/app/build/outputs/apk/release/app-release.apk \
-            s3://bes-tamanu-release-clients/$target/android/${{inputs.branding}}/${{env.APK_NAME}}
+            s3://bes-tamanu-release-clients/$target/android/${{inputs.branding}}/app-release.apk
 
       - if: steps.destination.outputs.result != 'nowhere' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Changes
- Also rename the artefact folder to android-release - previously it was a zip named app.apk

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->  %mobile=always

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
