### PR TITLE
fix(mobile): Release fix v2.7: Survey autocomplete component error

### DIFF
--- a/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
@@ -4,9 +4,6 @@ import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
 import { AutocompleteModalField } from './AutocompleteModalField';
 import { SurveyScreenConfig } from '~/types';
-import { AutocompleteSourceToColumnMap } from '~/ui/helpers/constants';
-import { theme } from '~/ui/styled/theme';
-import { StyledText } from '~/ui/styled/common';
 import { getNameColumnForModel, getDisplayNameForModel } from '~/ui/helpers/fields';
 
 const useFilterByResource = ({ source, scope }: SurveyScreenConfig): object => {
@@ -23,16 +20,6 @@ export const SurveyQuestionAutocomplete = (props): JSX.Element => {
   const { models } = useBackend();
   const filter = useFilterByResource(props.config);
   const { source, where } = props.config;
-
-  const columnName = AutocompleteSourceToColumnMap[source];
-
-  if (!columnName) {
-    return (
-      <StyledText color={theme.colors.ALERT} fontWeight="bold">
-        Error: invalid source supplied for Autocomplete question: {props.name}
-      </StyledText>
-    );
-  }
 
   const suggester = new Suggester(
     models[source],

--- a/packages/mobile/App/ui/helpers/constants.ts
+++ b/packages/mobile/App/ui/helpers/constants.ts
@@ -245,13 +245,3 @@ export const NOTE_TYPES = {
 export const FORM_STATUSES = {
   SUBMIT_SCREEN_ATTEMPTED: 'SUBMIT_SCREEN_ATTEMPTED',
 };
-
-// also update /packages/lan/app/routes/apiv1/surveyResponse.js when this changes
-export const AutocompleteSourceToColumnMap = {
-  Department: 'name',
-  Facility: 'name',
-  Location: 'name',
-  LocationGroup: 'name',
-  ReferenceData: 'name',
-  User: 'displayName',
-};


### PR DESCRIPTION
### Changes

A new error on programs has started appearing for autocomplete fields not defined in a new constant `AutocompleteSourceToColumnMap`

While this may be a valid requirement, I am almost certain this was accidentally merged by one of the interns early on but waiting for exact confirmation. Its definitely not related to the card  it was merged in with (check the translate "Referrals" page on the [mobile translations epic](https://github.com/beyondessential/tamanu/pull/5538/commits/8bd7ef20e4eb0df27d209b7813e8e2543f707005)) and this is different behaviour to desktop from what i can tell

Edit: Have confirmed with Flynn that it seems like some changes that were accidentally pulled over and commited. Would be great to find the card it should be related to though 🤔 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
