### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -372,6 +372,7 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@v2
         with:
+          tag: ${{ github.ref_name }}
           append_body: true
           body: |
             ## Container images 🚢

--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -37,6 +37,7 @@ jobs:
         version=$(jq -r .version package.json)
         git commit --allow-empty -am "release: v$version"
         echo "current_version=$version" | tee -a $GITHUB_OUTPUT
+        echo "current_version_ref=$(git show-ref -s HEAD)" | tee -a $GITHUB_OUTPUT
         git tag -a "v$version" -m "release: v$version"
         git push --follow-tags
 
@@ -65,7 +66,8 @@ jobs:
 
         git cliff --topo-order --strip all --latest \
           --tag-pattern "$pattern" --tag "v$version" \
-        | tee RELEASE_NOTES.md
+          --output RELEASE_NOTES.md
+        cat RELEASE_NOTES.md
 
     - name: Determine the true latest version
       id: latest
@@ -85,6 +87,6 @@ jobs:
       with:
         name: v${{ steps.tagged.outputs.current_version }}
         tag_name: v${{ steps.tagged.outputs.current_version }}
-        target_commitish: v${{ steps.tagged.outputs.current_version }}
+        target_commitish: ${{ steps.tagged.outputs.current_version_ref }}
         body_path: RELEASE_NOTES.md
         make_latest: ${{ steps.latest.outputs.latest_version == steps.tagged.outputs.current_version }}


### PR DESCRIPTION
A committish in git parlance can be a branch, sha, tag, or [a number of other things][1]. However, it turns out that [in the github REST API][2], it can only be a branch or sha. That causes the release process to [fail validation on the last step][3]:

```
Run softprops/action-gh-release@v2
  with:
    name: v2.7.0
    tag_name: v2.7.0
    target_commitish: v2.7.0
    body_path: RELEASE_NOTES.md
    make_latest: true
    token: ***
👩‍🏭 Creating new GitHub release for tag v2.7.0 using commit "v2.7.0"...
⚠️ GitHub release failed with status: 422
{"message":"Validation Failed","errors":[{"resource":"Release","code":"invalid","field":"target_commitish"}],"documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release"}
Skip retry - validation failed
```

We used to use the tag here, but now switched to the exact sha ref.

[1]: https://stackoverflow.com/questions/23303549/what-are-commit-ish-and-tree-ish-in-git
[2]: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
[3]: https://github.com/beyondessential/tamanu/actions/runs/9106278210/job/25033227578