### PR TITLE
fix(dataDeletion): EPI-565: Properly hide deleted vitals in mobile

### DIFF
--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -235,6 +235,7 @@ export class Patient extends BaseModel implements IPatient {
         ON encounter.id = response.encounterId
       WHERE encounter.patientId = $1
         AND body IS NOT NULL
+        AND answer.deleted_at IS NULL
       ORDER BY answer.createdAt desc LIMIT $2
     `, [patientId, 500]);
 

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -234,7 +234,7 @@ export class Patient extends BaseModel implements IPatient {
       INNER JOIN encounter
         ON encounter.id = response.encounterId
       WHERE encounter.patientId = $1
-        AND body IS NOT NULL
+        AND answer.body IS NOT NULL
         AND answer.deleted_at IS NULL
       ORDER BY answer.createdAt desc LIMIT $2
     `, [patientId, 500]);

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -233,7 +233,7 @@ export class Patient extends BaseModel implements IPatient {
         ON pde.id = answer.dataElementId
       INNER JOIN encounter
         ON encounter.id = response.encounterId
-        AND encounter.patientId = $1
+      WHERE encounter.patientId = $1
         AND body IS NOT NULL
       ORDER BY answer.createdAt desc LIMIT $2
     `, [patientId, 500]);

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -215,34 +215,28 @@ export class Patient extends BaseModel implements IPatient {
 
   static async getVitals(patientId: string): Promise<any> {
     const repo = this.getRepository();
-    const results = await repo.query(
-      `SELECT
-           answer.id, pde.name, answer.dataElementId, answer.responseId, ssc.config, ssc.validationCriteria, answer.body
-        FROM
-        survey_response_answer answer
-        INNER JOIN
-        survey_response response
-        ON
-        response.id = responseId
-        INNER JOIN
-        survey_screen_component ssc
-        ON
-        ssc.dataElementId = answer.dataElementId
-        INNER JOIN
-        program_data_element pde
-        ON
-        pde.id = answer.dataElementId
-        INNER JOIN
-        encounter
-        ON
-        encounter.id = response.encounterId
-        AND
-        encounter.patientId = $1
-        AND
-        body IS NOT NULL
-        ORDER BY answer.createdAt desc LIMIT $2`,
-      [patientId, 500],
-    );
+    const results = await repo.query(`
+      SELECT
+        answer.id,
+        pde.name,
+        answer.dataElementId,
+        answer.responseId,
+        ssc.config,
+        ssc.validationCriteria,
+        answer.body
+      FROM survey_response_answer answer
+      INNER JOIN survey_response response
+        ON response.id = responseId
+      INNER JOIN survey_screen_component ssc
+        ON ssc.dataElementId = answer.dataElementId
+      INNER JOIN program_data_element pde
+        ON pde.id = answer.dataElementId
+      INNER JOIN encounter
+        ON encounter.id = response.encounterId
+        AND encounter.patientId = $1
+        AND body IS NOT NULL
+      ORDER BY answer.createdAt desc LIMIT $2
+    `, [patientId, 500]);
 
     const library = groupBy(results, 'responseId');
 


### PR DESCRIPTION
### Changes

This was missed unfortunately. I used the opportunity to prettify the query a bit. I think only checking for survey response answer deletion is enough given that deleting survey responses or the encounter that contain them should trigger a cascade effect