### PR TITLE
ci: Apply missing 'fix release workflow' to 2.7

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -336,6 +336,7 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@v2
         with:
+          tag: ${{ github.ref_name }}
           append_body: true
           body: |
             ## Container images 🚢

--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -37,6 +37,7 @@ jobs:
         version=$(jq -r .version package.json)
         git commit --allow-empty -am "release: v$version"
         echo "current_version=$version" | tee -a $GITHUB_OUTPUT
+        echo "current_version_ref=$(git show-ref -s HEAD)" | tee -a $GITHUB_OUTPUT
         git tag -a "v$version" -m "release: v$version"
         git push --follow-tags
 
@@ -65,7 +66,8 @@ jobs:
 
         git cliff --topo-order --strip all --latest \
           --tag-pattern "$pattern" --tag "v$version" \
-        | tee RELEASE_NOTES.md
+          --output RELEASE_NOTES.md
+        cat RELEASE_NOTES.md
 
     - name: Determine the true latest version
       id: latest
@@ -85,6 +87,6 @@ jobs:
       with:
         name: v${{ steps.tagged.outputs.current_version }}
         tag_name: v${{ steps.tagged.outputs.current_version }}
-        target_commitish: v${{ steps.tagged.outputs.current_version }}
+        target_commitish: ${{ steps.tagged.outputs.current_version_ref }}
         body_path: RELEASE_NOTES.md
         make_latest: ${{ steps.latest.outputs.latest_version == steps.tagged.outputs.current_version }}


### PR DESCRIPTION
A committish in git parlance can be a branch, sha, tag, or [a number of other things][1]. However, it turns out that in the github REST API, it can only be a branch or sha. We used to use the tag here, but now switched to the exact sha ref.

[1]: https://stackoverflow.com/questions/23303549/what-are-commit-ish-and-tree-ish-in-git

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
