### PR TITLE
fix(fhir): SAV-662: imaging study cancel workflow HOTFIX 2.8

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 
 import { fake, fakeReferenceData, showError } from '@tamanu/shared/test-helpers';
-import { IMAGING_REQUEST_STATUS_TYPES } from '@tamanu/constants';
+import { IMAGING_REQUEST_STATUS_TYPES, FHIR_IMAGING_STUDY_STATUS } from '@tamanu/constants';
 import { fakeUUID } from '@tamanu/shared/utils/generateId';
 import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
 
@@ -420,7 +420,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               code: 'value',
               diagnostics: expect.any(String),
               details: {
-                text: "ImagingStudy status must be 'final'",
+                text: `ImagingStudy status must be either '${FHIR_IMAGING_STUDY_STATUS.AVAILABLE}' or '${FHIR_IMAGING_STUDY_STATUS.CANCELLED}'`,
               },
             },
           ],
@@ -503,6 +503,8 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
         });
         expect(response.status).toBe(400);
       });
+
+      test.todo('cannot update a imaging request that has been cancelled');
     });
   });
 });

--- a/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -557,10 +557,9 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               requestedById: resources.practitioner.id,
               encounterId: encounter.id,
               locationId: resources.location.id,
-              status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
               priority: 'routine',
               requestedDate: '2022-03-04 15:30:00',
-              status: 'cancelled',
+              status: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
             }),
           );
           await ir.setAreas([resources.area1.id, resources.area2.id]);

--- a/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -560,6 +560,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
               priority: 'routine',
               requestedDate: '2022-03-04 15:30:00',
+              status: 'cancelled',
             }),
           );
           await ir.setAreas([resources.area1.id, resources.area2.id]);
@@ -569,16 +570,6 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           await FhirServiceRequest.resolveUpstreams();
 
           // act
-          await app.post(PATH).send({
-            resourceType: 'ImagingStudy',
-            status: 'cancelled',
-            basedOn: [
-              {
-                type: 'ServiceRequest',
-                reference: `ServiceRequest/${mat.id}`,
-              },
-            ]
-          });
 
           const response = await app.post(PATH).send({
             resourceType: 'ImagingStudy',

--- a/packages/central-server/app/localisation.js
+++ b/packages/central-server/app/localisation.js
@@ -511,6 +511,7 @@ const rootLocalisationSchema = yup
             .required()
             .max(31),
           label: yup.string().required(),
+          hidden: yup.boolean(),
         }),
       )
       .test({

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -298,7 +298,6 @@
         "concurrency": 100,
         "resourceMaterialisationEnabled": {
           "Patient": true,
-
           "Encounter": false,
           "Immunization": false,
           "MediciReport": false,
@@ -889,6 +888,10 @@
         {
           "value": "patient-refused",
           "label": "Patient refused"
+        },
+        {
+          "value": "cancelled-externally",
+          "label": "Cancelled externally via API"
         },
         {
           "value": "other",

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -871,31 +871,38 @@
       "imagingCancellationReasons": [
         {
           "value": "clinical",
-          "label": "Clinical reason"
+          "label": "Clinical reason",
+          "hidden": false
         },
         {
           "value": "duplicate",
-          "label": "Duplicate"
+          "label": "Duplicate",
+          "hidden": false
         },
         {
           "value": "entered-in-error",
-          "label": "Entered in error"
+          "label": "Entered in error",
+          "hidden": false
         },
         {
           "value": "patient-discharged",
-          "label": "Patient discharged"
+          "label": "Patient discharged",
+          "hidden": false
         },
         {
           "value": "patient-refused",
-          "label": "Patient refused"
+          "label": "Patient refused",
+          "hidden": false
         },
         {
           "value": "cancelled-externally",
-          "label": "Cancelled externally via API"
+          "label": "Cancelled externally via API",
+          "hidden": true
         },
         {
           "value": "other",
-          "label": "Other"
+          "label": "Other",
+          "hidden": false
         }
       ],
       "labsCancellationReasons": [

--- a/packages/constants/src/fhir.ts
+++ b/packages/constants/src/fhir.ts
@@ -315,3 +315,4 @@ export const SCRUBBED_DATA_MESSAGE = 'Raw data removed from logs';
 export const SUPPORTED_CONTENT_TYPES = {
   PDF: 'application/pdf',
 };
+export const DEFAULT_REASON_CANCELLED_BY_API = 'cancelled externally via api';

--- a/packages/constants/src/fhir.ts
+++ b/packages/constants/src/fhir.ts
@@ -233,6 +233,15 @@ export const FHIR_DIAGNOSTIC_REPORT_STATUS = {
   UNKNOWN: 'unknown',
 };
 
+export const FHIR_IMAGING_STUDY_STATUS = {
+  REGISTERED: 'registered',
+  AVAILABLE: 'available',
+  FINAL_INVALID_LEGACY: 'final',
+  CANCELLED: 'cancelled',
+  ENTERED_IN_ERROR: 'entered-in-error',
+  UNKNOWN: 'unknown',
+};
+
 export const FHIR_ENCOUNTER_CLASS_DISPLAY = {
   IMP: 'inpatient encounter',
   AMB: 'ambulatory encounter',

--- a/packages/constants/src/fhir.ts
+++ b/packages/constants/src/fhir.ts
@@ -236,7 +236,7 @@ export const FHIR_DIAGNOSTIC_REPORT_STATUS = {
 export const FHIR_IMAGING_STUDY_STATUS = {
   REGISTERED: 'registered',
   AVAILABLE: 'available',
-  FINAL_INVALID_LEGACY: 'final',
+  FINAL_INVALID_LEGACY: 'final', // this needs to be supported but is not valid FHIR
   CANCELLED: 'cancelled',
   ENTERED_IN_ERROR: 'entered-in-error',
   UNKNOWN: 'unknown',

--- a/packages/shared/src/models/fhir/ImagingStudy/FhirImagingStudy.js
+++ b/packages/shared/src/models/fhir/ImagingStudy/FhirImagingStudy.js
@@ -135,7 +135,7 @@ export class FhirImagingStudy extends FhirResource {
     const cancelledReason = reasons.find(reason => reason.value == 'cancelled-externally')?.label;
     imagingRequest.set({
       status: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
-      reasonForCancellation: cancelledReason || DEFAULT_REASON_CANCELLED_BY_API,
+      reasonForCancellation: cancelledReason,
     });
     await imagingRequest.save();
   }

--- a/packages/shared/src/models/fhir/ImagingStudy/FhirImagingStudy.js
+++ b/packages/shared/src/models/fhir/ImagingStudy/FhirImagingStudy.js
@@ -7,7 +7,6 @@ import {
   FHIR_INTERACTIONS,
   FHIR_ISSUE_TYPE,
   IMAGING_REQUEST_STATUS_TYPES,
-  DEFAULT_REASON_CANCELLED_BY_API,
 } from '@tamanu/constants';
 import { FhirResource } from '../Resource';
 

--- a/packages/web/app/views/patients/imagingRequest/CancelModalButton.jsx
+++ b/packages/web/app/views/patients/imagingRequest/CancelModalButton.jsx
@@ -25,7 +25,8 @@ export const CancelModalButton = ({ imagingRequest, onCancel }) => {
 
   const api = useApi();
   const { getLocalisation } = useLocalisation();
-  const cancellationReasonOptions = getLocalisation('imagingCancellationReasons') || [];
+  const allCancellationReasons = getLocalisation('imagingCancellationReasons') || [];
+  const cancellationReasonOptions = allCancellationReasons.filter(reason => !reason.hidden);
 
   const onConfirmCancel = async ({ reasonForCancellation }) => {
     const reasonText = cancellationReasonOptions.find(x => x.value === reasonForCancellation).label;


### PR DESCRIPTION
### Changes

HOTFIX for 2.8 for [SAV-662](https://linear.app/bes/issue/SAV-662/imagingstudy-cancel-workflow#comment-1eb5c233)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
