### PR TITLE
ci(cd): 2.7 fix: Add ghcr login step to package steps

### DIFF
--- a/.github/workflows/cd-package-frontend.yml
+++ b/.github/workflows/cd-package-frontend.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Pack frontend
     steps:
+      - name: Login to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
       - name: Pull image
         run: docker pull ghcr.io/beyondessential/tamanu-frontend:sha-${{ github.sha }}.amd64
 

--- a/.github/workflows/cd-package-servers.yml
+++ b/.github/workflows/cd-package-servers.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Login to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
       - name: Pull image
         run: docker pull ghcr.io/beyondessential/tamanu-${{ matrix.package }}:sha-${{ github.sha }}.amd64
 


### PR DESCRIPTION
### Changes
Trying adding the ghcr step to the pacakge actions as the docker pull is returning UNAUTHORIZED

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
