### PR TITLE
ci(cd): Make GHA mobile builds backwards compatible with appcenter

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -148,7 +148,9 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.release
+            if (System.getenv("ANDROID_SIGNING_STORE_PASSWORD")) {
+              signingConfig signingConfigs.release
+            }
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }


### PR DESCRIPTION
### Changes

- Makes it so you can do any release or test build stuff in appcenter if needed while we sort out release process training and some other things
- Gonna cherry-pick into 2.7 and 2.8
- Have confirmed that builds work in goth GHA and appcenter

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy --> %mobile=always

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
