### PR TITLE
fix(translations): release-fix-v2.8: use string util rather than component for replacement

### DIFF
--- a/packages/web/app/components/DateDisplay.jsx
+++ b/packages/web/app/components/DateDisplay.jsx
@@ -128,7 +128,7 @@ const DateTooltip = ({ date, children, timeOnlyTooltip }) => {
 
 export const getDateDisplay = (
   dateValue,
-  { showDate = true, showTime = false, showExplicitDate = false, shortYear = false },
+  { showDate = true, showTime = false, showExplicitDate = false, shortYear = false } = {},
 ) => {
   const dateObj = parseDate(dateValue);
 

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -10,7 +10,6 @@ import {
   AutocompleteField,
   Button,
   ButtonRow,
-  DateDisplay,
   DateField,
   Field,
   Form,
@@ -20,6 +19,7 @@ import {
   NumberField,
   SelectField,
   TextField,
+  getDateDisplay
 } from '../components';
 import { FORM_TYPES } from '../constants';
 import { TranslatedText } from '../components/Translation/TranslatedText';
@@ -99,7 +99,7 @@ const DiscontinuedLabel = ({ medication }) => {
       <TranslatedText
         stringId="medication.detail.discontinued.discontinuedAt"
         fallback="Discontinued at: :date"
-        replacements={{ date: <DateDisplay date={discontinuedDate} /> }}
+        replacements={{ date: getDateDisplay(discontinuedDate, {}) }}
       />
       <br />
       <TranslatedText

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -99,7 +99,7 @@ const DiscontinuedLabel = ({ medication }) => {
       <TranslatedText
         stringId="medication.detail.discontinued.discontinuedAt"
         fallback="Discontinued at: :date"
-        replacements={{ date: getDateDisplay(discontinuedDate, {}) }}
+        replacements={{ date: getDateDisplay(discontinuedDate) }}
       />
       <br />
       <TranslatedText


### PR DESCRIPTION
### Changes

Currently our replacements logic for translations only wants to take either strings or TranslatedText components (otherwise they will show as [object Object]. Maybe we should find a way to support this in the future but for now we need to use the underlying util that generates a string for DateDisplay rather than the component itself.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
