### PR TITLE
fix(translations): no-issue: Use translations instead of strings for missed SearchFields

### DIFF
--- a/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
@@ -128,7 +128,7 @@ export const LabRequestsSearchBar = ({ status = '' }) => {
           }
           component={SearchField}
         />
-        <Field name="requestId" label="Test ID" component={SearchField} />
+        <Field name="requestId" label={<TranslatedText stringId="lab.requestId.label" fallback="Test ID" />} component={SearchField} />
         <Field
           name="category"
           label="Test category"

--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -21,6 +21,7 @@ import {
 import { AccessorField } from '../../patients/components/AccessorField';
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { Colors } from '../../../constants';
+import { TranslatedText } from '../../../components/Translation/TranslatedText';
 
 const StyledTableFormFields = styled(TableFormFields)`
   thead tr th {
@@ -215,7 +216,11 @@ export const FormContents = ({
     <>
       <Box display="flex" alignItems="flex-end" mb={2}>
         <Box mr={2} width="250px">
-          <Field label="Search" name="search" component={SearchField} />
+          <Field
+            label={<TranslatedText stringId="general.action.search" fallback="Search" />}
+            name="search"
+            component={SearchField}
+          />
         </Box>
         <OutlinedButton disabled={isSaving || !dirty} onClick={handleSave}>
           Save


### PR DESCRIPTION
### Changes

In converting the labels from searchfields into translations, we missed a couple which are now causing errors when rendered

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
