### PR TITLE
fix(labs): release-fix-2.9: Fix lab query search filter

### DIFF
--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -177,7 +177,7 @@ labRequest.get(
 
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(
       filters,
-      {},
+      filterParams,
     );
 
     const from = `


### PR DESCRIPTION
### Changes

I discovered while working on my epic that a small search filter bug was introduced when `getWhereClausesAndReplacementsFromFilters` was created. I just needed to add back filterParams to the argument to restore it to the same behaviour before the refactor.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
