### PR TITLE
fix(web): Release fix 2.9: remove duplicate divider line on revert death modal

### DIFF
--- a/packages/web/app/components/RecordDeathSection.jsx
+++ b/packages/web/app/components/RecordDeathSection.jsx
@@ -33,17 +33,12 @@ const Content = styled.p`
   line-height: 18px;
 `;
 
-const ComponentDivider = styled(Divider)`
-  margin: 0 -${MODAL_PADDING_LEFT_AND_RIGHT}px 30px -${MODAL_PADDING_LEFT_AND_RIGHT}px;
-`;
-
 const customContent = (
   <div>
     <Content>
       Are you sure you want to revert the patient death record? This will not reopen any previously
       closed encounters.
     </Content>
-    <ComponentDivider />
   </div>
 );
 

--- a/packages/web/app/components/RecordDeathSection.jsx
+++ b/packages/web/app/components/RecordDeathSection.jsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { Divider, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import { Colors } from '../constants';
 import { useApi } from '../api';
 import { ConfirmModal } from './ConfirmModal';


### PR DESCRIPTION
### Changes

In the data deletion project it appears they added a standard divider line to the `<ConfirmModal />`. The revert death modal had a divider already manually declared so this is just deleting that to remove the duplicate and keep in line with the other confirm modals.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
