### PR TITLE
fix(permission): Release fix v2.9: Wrong permission noun used on medication table

### DIFF
--- a/packages/web/app/components/MedicationTable.jsx
+++ b/packages/web/app/components/MedicationTable.jsx
@@ -133,7 +133,7 @@ export const DataFetchingMedicationTable = () => {
   return (
     <DataFetchingTableWithPermissionCheck
       verb="list"
-      noun="Medication"
+      noun="EncounterMedication"
       endpoint="medication"
       columns={FULL_LISTING_COLUMNS}
       noDataMessage={


### PR DESCRIPTION
### Changes

We added some new table permission checks in this release and we accidentally used the wrong noun when declaring the medications table. 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
