### PR TITLE
fix(appointments): Release fix v2.9: Use styled components instead of withStyles for appointment tooltip 

### DIFF
--- a/packages/web/app/components/Appointments/Appointment.jsx
+++ b/packages/web/app/components/Appointments/Appointment.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { withStyles } from '@material-ui/core/styles';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 import CancelIcon from '@material-ui/icons/Cancel';
@@ -11,22 +10,24 @@ import { PatientNameDisplay } from '../PatientNameDisplay';
 import { AppointmentDetail } from './AppointmentDetail';
 import { DateDisplay } from '../DateDisplay';
 
-const StyledTooltip = withStyles(() => ({
-  tooltip: {
-    backgroundColor: Colors.white,
-    color: Colors.darkestText,
-    fontSize: '0.9em',
-    padding: '0.75em 1em',
-    border: `1px solid ${Colors.outline}`,
-    maxWidth: 500,
-  },
-  arrow: {
-    color: Colors.outline,
-  },
-  popper: {
-    zIndex: 1200, // make it less than the dialog, which is 1300
-  },
-}))(Tooltip);
+const StyledTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))`
+  z-index: 1200; // make it less than the dialog, which is 1300
+
+  .MuiTooltip-tooltip {
+    background-color: ${Colors.white};
+    color: ${Colors.darkestText};
+    font-size: 0.9em;
+    padding: 0.75em 1em;
+    border: 1px solid ${Colors.outline};
+    max-width: 500px;
+  }
+
+  .MuiTooltip-arrow {
+    color: ${Colors.outline};
+  }
+`;
 
 export const Appointment = ({ appointment, onUpdated }) => {
   const { startTime, patient, status } = appointment;


### PR DESCRIPTION
### Changes

We have been having some weird behaviour with the appointment calendar tooltip for a while now. It was bought up in regression testing that the box was showing grey (unstyled) and i discovered that this spot is the only place in the codebase using `withStyles` which is now depreciated. I am relatively certain this is the cause of the weirdness so while i was here i converted this to styled components to keep in line with our codebase and to remove the last usage of `withStyles` 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
