### PR TITLE
fix(permissions): Release fix v2.9: Fix diagnosis export permission

### DIFF
--- a/packages/central-server/app/admin/index.js
+++ b/packages/central-server/app/admin/index.js
@@ -65,7 +65,7 @@ adminRoutes.get(
 
     for (const dataType of Object.values(includedDataTypes)) {
       // When it is ReferenceData, check if user has permission to list ReferenceData
-      if (REFERENCE_TYPE_VALUES.includes(dataType)) {
+      if (['diagnosis', ...REFERENCE_TYPE_VALUES].includes(dataType)) {
         req.checkPermission('list', 'ReferenceData');
         continue;
       }


### PR DESCRIPTION
### Changes

We handle 'diagnosis' in quite a strange way. We have a bunch of places in the app where we have to handle the fact that it is sometimes referred to as 'diagnosis' and sometimes as 'icd10'. In this case it is expecting 'diagnosis' but is recieving 'icd10' so we are getting a permission error.

I would love to standardise these one day (although it feels like it was done like this for a reason?) but i feel this fix is in line with our current pattern. See `referenceDataImporter.js`, `ReferenceDataExporter.js`, `loaders.js`



### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
