### PR TITLE
fix(mobile): TAMOC-196: Create corrective migration

### DIFF
--- a/packages/mobile/App/migrations/1718045677000-addMissedDeletedAtToTranslatedStringTable.ts
+++ b/packages/mobile/App/migrations/1718045677000-addMissedDeletedAtToTranslatedStringTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+/*
+  Even though the translated string table creation was created before the migration
+  that adds deletedAt to every table, it wasn't merged to main until much later.
+  All versions in the range [1.38, 2.3] include the deletedAt migration, which
+  will not run again when upgrading to >=2.4.
+
+  For this reason, we need to conditionally include the deletedAt column for that table.
+*/
+async function testSkipMigration(queryRunner: QueryRunner): Promise<boolean> {
+  const columns = await queryRunner.query("PRAGMA table_info('translated_string');");
+  return columns.any(c => c.name === 'deletedAt');
+}
+
+export class addMissedDeletedAtToTranslatedStringTable1718045677000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    if (await testSkipMigration(queryRunner)) {
+      console.log('Skipping migration because column was already added');
+      return;
+    }
+
+    const tableObject = await getTable(queryRunner, 'translated_string');
+    await queryRunner.addColumn(
+      tableObject,
+      new TableColumn({
+        name: 'deletedAt',
+        isNullable: true,
+        type: 'date',
+        default: null,
+      }),
+    );
+  }
+
+  async down(): Promise<void> {
+    // No down migration is needed because this is a corrective step -
+    // removing deletedAt will be taken care of in the intended migration
+  }
+}

--- a/packages/mobile/App/migrations/1718045677000-addMissedDeletedAtToTranslatedStringTable.ts
+++ b/packages/mobile/App/migrations/1718045677000-addMissedDeletedAtToTranslatedStringTable.ts
@@ -11,7 +11,7 @@ import { getTable } from './utils/queryRunner';
 */
 async function testSkipMigration(queryRunner: QueryRunner): Promise<boolean> {
   const columns = await queryRunner.query("PRAGMA table_info('translated_string');");
-  return columns.any(c => c.name === 'deletedAt');
+  return columns.some(c => c.name === 'deletedAt');
 }
 
 export class addMissedDeletedAtToTranslatedStringTable1718045677000 implements MigrationInterface {

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -45,6 +45,7 @@ import { addVisibilityStatusForSurvey1713696066000 } from './1713696066000-addVi
 import { addScopeToSettingsTable1691115215000 } from './1691115215000-addScopeToSettingsTable';
 import { addHealthCenterIdToPatientAdditionalData1712277225000 } from './1712277225000-addHealthCenterIdToPatientAdditionalData';
 import { addDietIdForEncounter1713722796000 } from './1713722796000-addDietIdForEncounter';
+import { addMissedDeletedAtToTranslatedStringTable1718045677000 } from './1718045677000-addMissedDeletedAtToTranslatedStringTable';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -93,4 +94,5 @@ export const migrationList = [
   addVisibilityStatusForSurvey1713696066000,
   addHealthCenterIdToPatientAdditionalData1712277225000,
   addDietIdForEncounter1713722796000,
+  addMissedDeletedAtToTranslatedStringTable1718045677000,
 ];


### PR DESCRIPTION
### Changes

The `deletedAt` column is missing from the `translated_string` table when upgrading the app. This happened because the feature was inside an epic branch (didn't hit main for a while) and the migration was created early on - this made it look like all was good, but there were several releases without it, causing havoc on upgrades, but not installing from scratch.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->