### PR TITLE
fix(reports): release-fix-2.9: Apply startofday when explicitly filtering by a date

### DIFF
--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -1,4 +1,4 @@
-import { subDays, startOfDay, subYears, addDays, endOfDay } from 'date-fns';
+import { subDays, startOfDay, subYears, addDays, endOfDay, parseISO } from 'date-fns';
 import { REPORT_DEFAULT_DATE_RANGES } from '@tamanu/constants';
 
 const CATCH_ALL_FROM_DATE = '1970-01-01';
@@ -54,9 +54,7 @@ export const getReportQueryReplacements = async (
     toDate = getEndDate(dateRange, params.fromDate ? new Date(params.fromDate) : new Date());
   }
 
-  const fromDate = params.fromDate
-    ? startOfDay(new Date(params.fromDate))
-    : getStartDate(dateRange, toDate);
+  const fromDate = params.fromDate ? parseISO(params.fromDate) : getStartDate(dateRange, toDate);
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
   return {
     ...paramDefaults,

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -54,7 +54,9 @@ export const getReportQueryReplacements = async (
     toDate = getEndDate(dateRange, params.fromDate ? new Date(params.fromDate) : new Date());
   }
 
-  const fromDate = params.fromDate ? new Date(params.fromDate) : getStartDate(dateRange, toDate);
+  const fromDate = params.fromDate
+    ? startOfDay(new Date(params.fromDate))
+    : getStartDate(dateRange, toDate);
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
   return {
     ...paramDefaults,


### PR DESCRIPTION
### Changes

I actually think this is an old bug that has been made apparent by the correct application of the default date range which this was compared to. I have added startOfDay from date-fns to ensure that the filter date is not filtering out stuff from the start of day due to timezone differences. 

I think it is worth down the road replacing all these usages of new Date() with a more appropriate function for our handling of dates (parseISO)? but out of scope for a late release fix

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
