### PR TITLE
fix(settings): Add default to non-null new column in mobile

### DIFF
--- a/packages/mobile/App/migrations/1691115215000-addScopeToSettingsTable.ts
+++ b/packages/mobile/App/migrations/1691115215000-addScopeToSettingsTable.ts
@@ -13,6 +13,7 @@ export class addScopeToSettingsTable1691115215000 implements MigrationInterface 
         name: columnName,
         type: 'varchar',
         isNullable: false,
+        default: 'global',
       }),
     );
   }


### PR DESCRIPTION
### Changes

2.8 hotfix to mobile

When there was already data in the table, this migration was failing trying to add a non-null column with no default.

- [ ] Deploy #deploy %mobile=always