### PR TITLE
fix(ci): fetch full git history to generate release notes

### DIFF
--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
+        fetch-depth: 0 # fetch all history so we can generate release notes
+        fetch-tags: true
 
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
### Changes

💡 Locally, we have the full git history, so git-cliff works. In Actions by default, we only pull a shallow git history, for performance, but that means that git-cliff only sees the latest commit... which is the one we just created for the release, and isn't counted for release notes. So release notes are empty!

Merging to 2.7 as that's the first branch with that workflow, will then port to 2.8, 2.9, and main