### PR TITLE
ci(changelog): Clean up release note output

### DIFF
--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -60,14 +60,17 @@ jobs:
 
     - name: Generate release notes
       run: |
-        version=${{ steps.tagged.outputs.current_version }}
-        pattern="^v$(cut -d. -f-2 <<< "$version" | sed 's/[.]/[.]/g')[.]"
-        # 2.6.1 -> ^v2[.]6[.]
-
-        git cliff --topo-order --strip all --latest \
-          --tag-pattern "$pattern" --tag "v$version" \
-          --output RELEASE_NOTES.md
-        cat RELEASE_NOTES.md
+        git switch --detach "v${{ steps.tagged.outputs.current_version }}"
+        git cliff --strip all --current \
+          | node -e 'console.log(
+            (require("fs")
+              .readFileSync(0)
+              .toString()
+              .split(/^## Release notes.+/m)[1]??"") // sometimes cliff prints more than one release
+              .replace(/no[\s-]+issue:?\s?/ig, "") // remove "no issue" labels
+              .replace(/release[\s-]+fix[\s-]+v?[\d.]+:\s?/ig, "") // remove "release fix vX.Y" labels
+            )' \
+          | tee RELEASE_NOTES.md
 
     - name: Determine the true latest version
       id: latest

--- a/cliff.toml
+++ b/cliff.toml
@@ -12,22 +12,28 @@ body = """
 ## Release notes 📋
 
 {%- for commit in commits | sort(attribute="group") %}
-	{%- if commit.group -%}
-	{% else -%}
-        - **{{ commit.scope | striptags | trim }}:** \
-			{{ commit.message | upper_first }}\
-      {%- if commit.message is not matching(".*\\s+\\(#\\d+\\)\\s*$") %} ([`{{ commit.id | truncate(length=10, end="") }}`]($REPO/commit/{{ commit.id }})){%- endif -%}
-	{% endif -%}
+  {%- if commit.group -%}
+  {% else -%}
+  - **{{ commit.scope | striptags | trim }}:** \
+    {{ commit.message | upper_first }}\
+    {%- if commit.message is not matching(".*\\s+\\(#\\d+\\)\\s*$") %} ([`{{ commit.id | truncate(length=10, end="") }}`]($REPO/commit/{{ commit.id }})){%- endif -%}
+  {% endif -%}
 {% endfor -%}
 
-{% for group, commits in commits | filter(attribute="scope") | group_by(attribute="group") %}
-    ### {{ group | striptags | trim | upper_first }}
-    {% for commit in commits | sort(attribute="scope") %}
-        - **{{ commit.scope | striptags | trim }}:** \
-            {{ commit.message | upper_first }}\
-            {%- if commit.message is not matching(".*\\s+\\(#\\d+\\)\\s*$") %} ([`{{ commit.id | truncate(length=10, end="") }}`]($REPO/commit/{{ commit.id }})){%- endif -%}
-    {%- endfor -%}
-    {% raw %}\n{% endraw %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+  {%- for commit in commits | filter(attribute="scope") | sort(attribute="scope") %}
+  - **{{ commit.scope | striptags | trim }}:** \
+      {{ commit.message | upper_first }}\
+      {%- if commit.message is not matching(".*\\s+\\(#\\d+\\)\\s*$") %} ([`{{ commit.id | truncate(length=10, end="") }}`]($REPO/commit/{{ commit.id }})){%- endif -%}
+  {%- endfor %}
+  {% for commit in commits %}
+    {%- if commit.scope -%}
+    {% else -%}
+    - {{ commit.message | upper_first }}\
+      {%- if commit.message is not matching(".*\\s+\\(#\\d+\\)\\s*$") %} ([`{{ commit.id | truncate(length=10, end="") }}`]($REPO/commit/{{ commit.id }})){%- endif -%}
+    {% endif -%}
+  {%- endfor -%}
 {% endfor %}\n
 """
 postprocessors = [


### PR DESCRIPTION
### Changes

Cliff was outputting way too much, and not the correct things either, so fix that by checking out the exact tag we want and instructing it to write the "--current" release notes.

However, in this mode Cliff sometimes outputs more than one version's worth of release notes, and there's no way to limit that behaviour, so post-process the release notes to keep the top section only.

While we're at it, remove "no-issue" and "release-fix-vX.Y" labels often present in PR titles but with zero value in the changelog.

Finally, the cliff template was discarding commits without a scope (`topic(scope)`), because the template syntax is obnoxious, so fix that.
