### PR TITLE
feat(web): SAV-714: Need both View Report and Enter Results buttons in Lab Request 

### DIFF
--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -16,6 +16,7 @@ import {
   MenuButton,
   MODAL_TRANSITION_DURATION,
   OutlinedButton,
+  TableButtonRow,
   Tile,
   TileContainer,
   TileTag,
@@ -171,7 +172,7 @@ export const LabRequestView = () => {
   const areLabRequestsReadOnly = !canWriteLabRequest || isHidden;
   const areLabTestsReadOnly = !canWriteLabTest || isHidden || isPublished;
   const hasAttachment = Boolean(labRequest.latestAttachment);
-  const canEnterResults = !isPublished && !areLabTestsReadOnly && !hasAttachment;
+  const canEnterResults = !isPublished && !areLabTestsReadOnly;
 
   // If the value of status is enteredInError or deleted, it should display to the user as Cancelled
   const displayStatus = areLabRequestsReadOnly ? LAB_REQUEST_STATUSES.CANCELLED : labRequest.status;
@@ -181,21 +182,21 @@ export const LabRequestView = () => {
   const actions =
     labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
       ? [
-          {
-            label: <TranslatedText stringId="lab.action.recordSample" fallback="Record sample" />,
-            action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
-          },
-        ]
+        {
+          label: <TranslatedText stringId="lab.action.recordSample" fallback="Record sample" />,
+          action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+        },
+      ]
       : [
-          {
-            label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
-            action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
-          },
-          {
-            label: <TranslatedText stringId="lab.action.viewDetails" fallback="View details" />,
-            action: () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS),
-          },
-        ];
+        {
+          label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
+          action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+        },
+        {
+          label: <TranslatedText stringId="lab.action.viewDetails" fallback="View details" />,
+          action: () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS),
+        },
+      ];
 
   const handleChangeStatus = () => {
     if (labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED) return;
@@ -359,20 +360,18 @@ export const LabRequestView = () => {
         </FixedTileRow>
       </TopContainer>
       <BottomContainer>
-        {canEnterResults && (
-          <Box display="flex" justifyContent="flex-end" marginBottom="20px">
-            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}>
-              <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
-            </Button>
-          </Box>
-        )}
-        {hasAttachment && (
-          <Box display="flex" justifyContent="flex-end" marginBottom="20px">
+        <TableButtonRow variant="small">
+          {hasAttachment && (
             <Button onClick={() => handleChangeModalId(MODAL_IDS.VIEW_REPORT)}>
               <TranslatedText stringId="lab.action.viewReport" fallback="View report" />
             </Button>
-          </Box>
-        )}
+          )}
+          {canEnterResults && (
+            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)} margin="2000px">
+              <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
+            </Button>
+          )}
+        </TableButtonRow>
         <LabRequestResultsTable
           labRequest={labRequest}
           patient={patient}

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -367,7 +367,7 @@ export const LabRequestView = () => {
             </Button>
           )}
           {canEnterResults && (
-            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)} margin="2000px">
+            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}>
               <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
             </Button>
           )}


### PR DESCRIPTION
### Changes

Small UX fix: https://linear.app/bes/issue/SAV-714/need-both-view-report-and-enter-results-buttons-for-lab-requests


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
