### PR TITLE
fix(fhir): SAV-653 + SAV-714: Fixing specimen attached issue

### DIFF
--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -66,8 +66,9 @@ labRequest.put(
         });
       }
 
-      labRequestData.specimenAttached = !!labRequestData.specimenTypeId;
-
+      if (labRequestData.specimenTypeId !== undefined) {
+        labRequestData.specimenAttached = !!labRequestData.specimenTypeId;
+      }
       await labRequestRecord.update(labRequestData);
     });
 

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -66,6 +66,8 @@ labRequest.put(
         });
       }
 
+      labRequestData.specimenAttached = labRequest.specimenTypeId !== null;
+
       await labRequestRecord.update(labRequestData);
     });
 

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -66,7 +66,7 @@ labRequest.put(
         });
       }
 
-      labRequestData.specimenAttached = labRequest.specimenTypeId !== null;
+      labRequestData.specimenAttached = !!labRequestData.specimenTypeId;
 
       await labRequestRecord.update(labRequestData);
     });
@@ -511,7 +511,7 @@ async function createLabRequest(
   const labRequestData = {
     ...labRequestBody,
     ...requestSampleDetails,
-    specimenAttached: requestSampleDetails.specimenTypeId ? 'yes' : 'no',
+    specimenAttached: !!requestSampleDetails.specimenTypeId,
     status: requestSampleDetails.sampleTime
       ? LAB_REQUEST_STATUSES.RECEPTION_PENDING
       : LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED,

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -16,6 +16,7 @@ import {
   MenuButton,
   MODAL_TRANSITION_DURATION,
   OutlinedButton,
+  TableButtonRow,
   Tile,
   TileContainer,
   TileTag,
@@ -171,7 +172,7 @@ export const LabRequestView = () => {
   const areLabRequestsReadOnly = !canWriteLabRequest || isHidden;
   const areLabTestsReadOnly = !canWriteLabTest || isHidden || isPublished;
   const hasAttachment = Boolean(labRequest.latestAttachment);
-  const canEnterResults = !isPublished && !areLabTestsReadOnly && !hasAttachment;
+  const canEnterResults = !isPublished && !areLabTestsReadOnly;
 
   // If the value of status is enteredInError or deleted, it should display to the user as Cancelled
   const displayStatus = areLabRequestsReadOnly ? LAB_REQUEST_STATUSES.CANCELLED : labRequest.status;
@@ -181,21 +182,21 @@ export const LabRequestView = () => {
   const actions =
     labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED
       ? [
-          {
-            label: <TranslatedText stringId="lab.action.recordSample" fallback="Record sample" />,
-            action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
-          },
-        ]
+        {
+          label: <TranslatedText stringId="lab.action.recordSample" fallback="Record sample" />,
+          action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+        },
+      ]
       : [
-          {
-            label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
-            action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
-          },
-          {
-            label: <TranslatedText stringId="lab.action.viewDetails" fallback="View details" />,
-            action: () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS),
-          },
-        ];
+        {
+          label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
+          action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+        },
+        {
+          label: <TranslatedText stringId="lab.action.viewDetails" fallback="View details" />,
+          action: () => handleChangeModalId(MODAL_IDS.SAMPLE_DETAILS),
+        },
+      ];
 
   const handleChangeStatus = () => {
     if (labRequest.status === LAB_REQUEST_STATUSES.SAMPLE_NOT_COLLECTED) return;
@@ -329,20 +330,18 @@ export const LabRequestView = () => {
         </FixedTileRow>
       </TopContainer>
       <BottomContainer>
-        {canEnterResults && (
-          <Box display="flex" justifyContent="flex-end" marginBottom="20px">
-            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}>
-              <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
-            </Button>
-          </Box>
-        )}
-        {hasAttachment && (
-          <Box display="flex" justifyContent="flex-end" marginBottom="20px">
+        <TableButtonRow variant="small">
+          {hasAttachment && (
             <Button onClick={() => handleChangeModalId(MODAL_IDS.VIEW_REPORT)}>
               <TranslatedText stringId="lab.action.viewReport" fallback="View report" />
             </Button>
-          </Box>
-        )}
+          )}
+          {canEnterResults && (
+            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)} margin="2000px">
+              <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
+            </Button>
+          )}
+        </TableButtonRow>
         <LabRequestResultsTable
           labRequest={labRequest}
           patient={patient}

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -337,7 +337,7 @@ export const LabRequestView = () => {
             </Button>
           )}
           {canEnterResults && (
-            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)} margin="2000px">
+            <Button onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}>
               <TranslatedText stringId="lab.action.enterResults" fallback="Enter results" />
             </Button>
           )}


### PR DESCRIPTION
### Changes

This contains the code of two existing (and PR approved) fixes: 
- https://github.com/beyondessential/tamanu/pull/5702
- https://github.com/beyondessential/tamanu/pull/6010
For [SAV-653](https://linear.app/bes/issue/SAV-653/bug-specimenattached-in-labrequest-not-updated-when-specimen-attached) & [SAV-714](https://linear.app/bes/issue/SAV-714/need-both-view-report-and-enter-results-buttons-for-lab-requests)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
