### PR TITLE
fix: release 2.10 issue 16, display correct validation message

### DIFF
--- a/packages/web/app/forms/EmailAddressConfirmationForm.jsx
+++ b/packages/web/app/forms/EmailAddressConfirmationForm.jsx
@@ -19,6 +19,7 @@ export const EmailAddressConfirmationForm = React.memo(({ onCancel, onSubmit }) 
       validationSchema={Yup.object().shape({
         email: Yup.string()
           .email(getTranslation('validation.rule.validEmail', 'Must be a valid email address'))
+          .nullable()
           .required(),
         confirmEmail: Yup.string()
           .oneOf(

--- a/packages/web/app/forms/IPSQRCodeForm.jsx
+++ b/packages/web/app/forms/IPSQRCodeForm.jsx
@@ -3,7 +3,7 @@ import * as Yup from 'yup';
 import styled from 'styled-components';
 
 import { FormSubmitCancelRow } from '../components/ButtonRow';
-import { Form, Field, TextField } from '../components/Field';
+import { Field, Form, TextField } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { DateDisplay } from '../components';
 import { usePatientNavigation } from '../utils/usePatientNavigation';
@@ -16,6 +16,7 @@ const StyledPatientDetailsLink = styled.span`
   cursor: pointer;
   font-weight: bold;
   text-decoration: underline;
+
   &:hover {
     color: ${Colors.primary};
   }
@@ -102,6 +103,7 @@ export const IPSQRCodeForm = ({ patient, onSubmit, confirmDisabled, onCancel }) 
       validationSchema={Yup.object().shape({
         email: Yup.string()
           .email(getTranslation('validation.rule.validEmail', 'Must be a valid email address'))
+          .nullable()
           .required(),
         confirmEmail: Yup.string()
           .oneOf(


### PR DESCRIPTION
### Changes

Show the 'required' validation message for the email fields in the forms rather than the string validation message when the fields are null.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
