### PR TITLE
fix(mobile): release issue 2.10 add back custom section logic

### DIFF
--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -83,15 +83,16 @@ const CustomField = ({ fieldName, required }): ReactElement => {
 
   if (loading) return <ActivityIndicator />;
 
+  return getCustomFieldComponent(fieldType);
+};
+
+const getCustomFieldComponent = ({ id, name, options, fieldType }) => {
   return (
     <Field
-      name={fieldDefinition.id}
-      label={labels[fieldDefinition.id] || fieldDefinition.name}
-      component={PatientFieldDefinitionComponents[fieldDefinition.fieldType]}
-      options={fieldDefinition.options
-        ?.split(',')
-        ?.map(option => ({ label: option, value: option }))}
-      required={required}
+      name={id}
+      label={name}
+      component={PatientFieldDefinitionComponents[fieldType]}
+      options={options?.split(',')?.map(option => ({ label: option, value: option }))}
     />
   );
 };
@@ -116,7 +117,7 @@ function getComponentForField(
   throw new Error(`Unexpected field ${fieldName} for patient additional data.`);
 }
 
-export const PatientAdditionalDataFields = ({ fields, showMandatory = true }): ReactElement => {
+export const PatientAdditionalDataFields = ({ fields, isCustomSection, showMandatory = true }): ReactElement => {
   const { getLocalisation } = useLocalisation();
   const isHardCodedLayout = getLocalisation('layouts.patientDetails') !== 'generic';
   const [customFieldDefinitions, _, loading] = useBackendEffect(({ models }) =>
@@ -132,6 +133,7 @@ export const PatientAdditionalDataFields = ({ fields, showMandatory = true }): R
 
   // TODO: no custom fields are showing and instead it is showing hierarcy as custom fields are objects
 
+  if (isCustomSection) return fields.map(getCustomFieldComponent)
   if (loading) return [];
 
   return padFields.map((field: string | object, i: number) => {

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -123,7 +123,7 @@ function getComponentForField(
 }
 
 interface PatientAdditionalDataFieldsProps {
-  fields: (string | object)[];
+  fields: (string | PatientFieldDefinition)[];
   isCustomSection?: boolean;
   showMandatory?: boolean;
 }

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -87,7 +87,7 @@ const CustomField = ({ fieldName, required }): ReactElement => {
   return getCustomFieldComponent(fieldDefinition, required);
 };
 
-const getCustomFieldComponent = ({ id, name, options, fieldType }: PatientFieldDefinition, required?: boolean) => {
+const getCustomFieldComponent = ({ id, name, options, fieldType }: PatientFieldDefinition, required: boolean = false) => {
   return (
     <Field
       name={id}
@@ -133,7 +133,7 @@ export const PatientAdditionalDataFields = ({ fields, isCustomSection, showManda
     ? fields
     : getConfiguredPatientAdditionalDataFields(fields, showMandatory, getLocalisation);
 
-  if (isCustomSection) return fields.map(getCustomFieldComponent)
+  if (isCustomSection) return fields.map((field: PatientFieldDefinition) => getCustomFieldComponent(field))
     
   if (loading) return [];
 

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -130,6 +130,8 @@ export const PatientAdditionalDataFields = ({ fields, showMandatory = true }): R
     ? fields
     : getConfiguredPatientAdditionalDataFields(fields, showMandatory, getLocalisation);
 
+  // TODO: no custom fields are showing and instead it is showing hierarcy as custom fields are objects
+
   if (loading) return [];
 
   return padFields.map((field: string | object, i: number) => {

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -147,7 +147,7 @@ export const PatientAdditionalDataFields = ({
     : getConfiguredPatientAdditionalDataFields(fields as string[], showMandatory, getLocalisation);
 
   if (isCustomSection)
-    return fields.map((field: PatientFieldDefinition) => getCustomFieldComponent(field));
+    return fields.map(field => getCustomFieldComponent(field as PatientFieldDefinition));
 
   if (loading) return [];
 

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -87,7 +87,10 @@ const CustomField = ({ fieldName, required }): ReactElement => {
   return getCustomFieldComponent(fieldDefinition, required);
 };
 
-const getCustomFieldComponent = ({ id, name, options, fieldType }: PatientFieldDefinition, required: boolean = false) => {
+const getCustomFieldComponent = (
+  { id, name, options, fieldType }: PatientFieldDefinition,
+  required?: boolean,
+) => {
   return (
     <Field
       name={id}
@@ -102,7 +105,7 @@ const getCustomFieldComponent = ({ id, name, options, fieldType }: PatientFieldD
 function getComponentForField(
   fieldName: string,
   customFieldIds: string[],
-): React.FC<{ fieldName: string }> {
+): React.FC<{ fieldName: string; required: boolean }> {
   if (plainFields.includes(fieldName)) {
     return PlainField;
   }
@@ -119,7 +122,17 @@ function getComponentForField(
   throw new Error(`Unexpected field ${fieldName} for patient additional data.`);
 }
 
-export const PatientAdditionalDataFields = ({ fields, isCustomSection, showMandatory = true }): ReactElement => {
+interface PatientAdditionalDataFieldsProps {
+  fields: (string | object)[];
+  isCustomSection?: boolean;
+  showMandatory?: boolean;
+}
+
+export const PatientAdditionalDataFields = ({
+  fields,
+  isCustomSection,
+  showMandatory = true,
+}: PatientAdditionalDataFieldsProps): ReactElement[] => {
   const { getLocalisation } = useLocalisation();
   const isHardCodedLayout = getLocalisation('layouts.patientDetails') !== 'generic';
   const [customFieldDefinitions, _, loading] = useBackendEffect(({ models }) =>
@@ -131,10 +144,11 @@ export const PatientAdditionalDataFields = ({ fields, isCustomSection, showManda
 
   const padFields = isHardCodedLayout
     ? fields
-    : getConfiguredPatientAdditionalDataFields(fields, showMandatory, getLocalisation);
+    : getConfiguredPatientAdditionalDataFields(fields as string[], showMandatory, getLocalisation);
 
-  if (isCustomSection) return fields.map((field: PatientFieldDefinition) => getCustomFieldComponent(field))
-    
+  if (isCustomSection)
+    return fields.map((field: PatientFieldDefinition) => getCustomFieldComponent(field));
+
   if (loading) return [];
 
   return padFields.map((field: string | object, i: number) => {

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields.tsx
@@ -25,6 +25,7 @@ import { HierarchyFields } from '../../HierarchyFields';
 import { CAMBODIA_LOCATION_HIERARCHY_FIELDS } from '~/ui/navigation/screens/home/PatientDetails/layouts/cambodia/fields';
 import { isObject, isString } from 'lodash';
 import { labels } from '~/ui/navigation/screens/home/PatientDetails/layouts/generic/labels';
+import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
 
 const PlainField = ({ fieldName, required }): ReactElement => (
   // Outter styled view to momentarily add distance between fields
@@ -83,16 +84,17 @@ const CustomField = ({ fieldName, required }): ReactElement => {
 
   if (loading) return <ActivityIndicator />;
 
-  return getCustomFieldComponent(fieldType);
+  return getCustomFieldComponent(fieldDefinition, required);
 };
 
-const getCustomFieldComponent = ({ id, name, options, fieldType }) => {
+const getCustomFieldComponent = ({ id, name, options, fieldType }: PatientFieldDefinition, required?: boolean) => {
   return (
     <Field
       name={id}
       label={name}
       component={PatientFieldDefinitionComponents[fieldType]}
       options={options?.split(',')?.map(option => ({ label: option, value: option }))}
+      required={required}
     />
   );
 };
@@ -131,9 +133,8 @@ export const PatientAdditionalDataFields = ({ fields, isCustomSection, showManda
     ? fields
     : getConfiguredPatientAdditionalDataFields(fields, showMandatory, getLocalisation);
 
-  // TODO: no custom fields are showing and instead it is showing hierarcy as custom fields are objects
-
   if (isCustomSection) return fields.map(getCustomFieldComponent)
+    
   if (loading) return [];
 
   return padFields.map((field: string | object, i: number) => {

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -181,11 +181,13 @@ export const getInitialCustomValues = (
     return {};
   }
   // Copy values from data only in the specified fields
-  return fields.reduce((acc, field) => {
+  const values = {};
+  for (const field of fields) {
     const fieldId = isObject(field) ? field.id : field;
     const value = data[fieldId]?.[0]?.value;
-    return { ...acc, ...(value && { [fieldId]: value }) };
-  }, {});
+    if (value) values[fieldId] = value;
+  }
+  return values;
 };
 
 // Strip off unwanted fields from additional data and only keep specified ones
@@ -196,9 +198,11 @@ export const getInitialAdditionalValues = (
   if (!data) {
     return {};
   }
-  return fields.reduce((acc, field) => {
+  const values = {};
+  for (const field of fields) {
     const fieldName = isObject(field) ? field.name : field;
     const value = data[fieldName];
-    return { ...acc, ...(value && { [fieldName]: value }) };
-  }, {});
+    if (value) values[fieldName] = value;
+  }
+  return values;
 };

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -174,11 +174,12 @@ export const getInitialCustomValues = (data, fields): {} => {
     return {};
   }
   // Copy values from data only in the specified fields
-  // TODO: get this to work with both custom field concepts
   const values = {};
-  fields.forEach(fieldName => {
-    if (data[fieldName]) values[fieldName] = data[fieldName]?.[0]?.value;
-  });
+  fields
+    .map((field: object | string) => field.id || field) // This handles either an array of objects with custom field ids or just an array of field ids on its own
+    .forEach((fieldId: string) => {
+      if (data[fieldId]) values[fieldId] = data[fieldId]?.[0]?.value;
+    });
   return values;
 };
 

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -174,6 +174,7 @@ export const getInitialCustomValues = (data, fields): {} => {
     return {};
   }
   // Copy values from data only in the specified fields
+  // TODO: get this to work with both custom field concepts
   const values = {};
   fields.forEach(fieldName => {
     if (data[fieldName]) values[fieldName] = data[fieldName]?.[0]?.value;

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -13,6 +13,7 @@ import { yupAttemptTransformToNumber } from '~/ui/helpers/numeralTranslation';
 import { isObject, isString } from 'lodash';
 import { CustomPatientFieldValues } from '~/ui/hooks/usePatientAdditionalData';
 import { PatientAdditionalData } from '~/models/PatientAdditionalData';
+import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
 
 // All PatientAdditionalData plain fields sorted alphabetically
 export const plainFields = [
@@ -174,7 +175,7 @@ export const patientAdditionalDataValidationSchema = Yup.object().shape({
 export const getInitialCustomValues = (
   data: CustomPatientFieldValues,
   // TODO: upstream types are not defined
-  fields: ({ id: string } | string)[],
+  fields: (PatientFieldDefinition | string)[],
 ): { [key: string]: string } => {
   if (!data) {
     return {};
@@ -191,7 +192,7 @@ export const getInitialCustomValues = (
 export const getInitialAdditionalValues = (
   data: PatientAdditionalData,
   // TODO: upstream types are not defined
-  fields: ({ name: string } | string)[],
+  fields: (PatientFieldDefinition | string)[],
 ): { [key: string]: string } => {
   if (!data) {
     return {};

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -10,10 +10,11 @@ import {
   titleOptions,
 } from '~/ui/helpers/additionalData';
 import { yupAttemptTransformToNumber } from '~/ui/helpers/numeralTranslation';
-import { isObject, isString } from 'lodash';
+
 import { CustomPatientFieldValues } from '~/ui/hooks/usePatientAdditionalData';
 import { PatientAdditionalData } from '~/models/PatientAdditionalData';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
+import { isObject } from 'lodash';
 
 // All PatientAdditionalData plain fields sorted alphabetically
 export const plainFields = [
@@ -174,7 +175,6 @@ export const patientAdditionalDataValidationSchema = Yup.object().shape({
 // Strip off unwanted fields from additional data and only keep specified ones
 export const getInitialCustomValues = (
   data: CustomPatientFieldValues,
-  // TODO: upstream types are not defined
   fields: (PatientFieldDefinition | string)[],
 ): { [key: string]: string } => {
   if (!data) {
@@ -182,7 +182,7 @@ export const getInitialCustomValues = (
   }
   // Copy values from data only in the specified fields
   return fields.reduce((acc, field) => {
-    const fieldId = typeof field === 'object' ? field.id : field;
+    const fieldId = isObject(field) ? field.id : field;
     const value = data[fieldId]?.[0]?.value;
     return { ...acc, ...(value && { [fieldId]: value }) };
   }, {});
@@ -191,14 +191,13 @@ export const getInitialCustomValues = (
 // Strip off unwanted fields from additional data and only keep specified ones
 export const getInitialAdditionalValues = (
   data: PatientAdditionalData,
-  // TODO: upstream types are not defined
   fields: (PatientFieldDefinition | string)[],
 ): { [key: string]: string } => {
   if (!data) {
     return {};
   }
   return fields.reduce((acc, field) => {
-    const fieldName = typeof field === 'object' ? field.name : field;
+    const fieldName = isObject(field) ? field.name : field;
     const value = data[fieldName];
     return { ...acc, ...(value && { [fieldName]: value }) };
   }, {});

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -173,33 +173,32 @@ export const patientAdditionalDataValidationSchema = Yup.object().shape({
 // Strip off unwanted fields from additional data and only keep specified ones
 export const getInitialCustomValues = (
   data: CustomPatientFieldValues,
+  // TODO: upstream types are not defined
   fields: ({ id: string } | string)[],
 ): { [key: string]: string } => {
   if (!data) {
     return {};
   }
   // Copy values from data only in the specified fields
-  const values = {};
-  fields
-    .map(field => (typeof field === 'object' ? field.id : field)) // This handles either an array of objects with custom field ids or just an array of field ids on its own
-    .forEach((fieldId: string) => {
-      if (data[fieldId]) values[fieldId] = data[fieldId]?.[0]?.value;
-    });
-  return values;
+  return fields.reduce((acc, field) => {
+    const fieldId = typeof field === 'object' ? field.id : field;
+    const value = data[fieldId]?.[0]?.value;
+    return { ...acc, ...(value && { [fieldId]: value }) };
+  }, {});
 };
 
 // Strip off unwanted fields from additional data and only keep specified ones
 export const getInitialAdditionalValues = (
   data: PatientAdditionalData,
+  // TODO: upstream types are not defined
   fields: ({ name: string } | string)[],
 ): { [key: string]: string } => {
   if (!data) {
     return {};
   }
-  const values = {};
-  fields.forEach(field => {
-    if (isObject(field)) values[field.name] = data[field.name];
-    if (isString(field)) values[field] = data[field];
-  });
-  return values;
+  return fields.reduce((acc, field) => {
+    const fieldName = typeof field === 'object' ? field.name : field;
+    const value = data[fieldName];
+    return { ...acc, ...(value && { [fieldName]: value }) };
+  }, {});
 };

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -11,6 +11,8 @@ import {
 } from '~/ui/helpers/additionalData';
 import { yupAttemptTransformToNumber } from '~/ui/helpers/numeralTranslation';
 import { isObject, isString } from 'lodash';
+import { CustomPatientFieldValues } from '~/ui/hooks/usePatientAdditionalData';
+import { PatientAdditionalData } from '~/models/PatientAdditionalData';
 
 // All PatientAdditionalData plain fields sorted alphabetically
 export const plainFields = [
@@ -169,14 +171,17 @@ export const patientAdditionalDataValidationSchema = Yup.object().shape({
 });
 
 // Strip off unwanted fields from additional data and only keep specified ones
-export const getInitialCustomValues = (data, fields): {} => {
+export const getInitialCustomValues = (
+  data: CustomPatientFieldValues,
+  fields: ({ id: string } | string)[],
+): { [key: string]: string } => {
   if (!data) {
     return {};
   }
   // Copy values from data only in the specified fields
   const values = {};
   fields
-    .map((field: object | string) => field.id || field) // This handles either an array of objects with custom field ids or just an array of field ids on its own
+    .map(field => (typeof field === 'object' ? field.id : field)) // This handles either an array of objects with custom field ids or just an array of field ids on its own
     .forEach((fieldId: string) => {
       if (data[fieldId]) values[fieldId] = data[fieldId]?.[0]?.value;
     });
@@ -184,14 +189,17 @@ export const getInitialCustomValues = (data, fields): {} => {
 };
 
 // Strip off unwanted fields from additional data and only keep specified ones
-export const getInitialAdditionalValues = (data, fields): {} => {
+export const getInitialAdditionalValues = (
+  data: PatientAdditionalData,
+  fields: ({ name: string } | string)[],
+): { [key: string]: string } => {
   if (!data) {
     return {};
   }
   const values = {};
   fields.forEach(field => {
-    if (isString(data[field])) values[field] = data[field];
     if (isObject(field)) values[field.name] = data[field.name];
+    if (isString(field)) values[field] = data[field];
   });
   return values;
 };

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
@@ -64,18 +64,14 @@ export const PatientAdditionalDataForm = ({
     [navigation, patient.id],
   );
 
-  const section = isCustomSection
-    ? {
-        fields: customSectionFields.map(({ id, name, fieldType, options }) => ({
-          id,
-          name,
-          fieldType,
-          options,
-        })),
-      }
-    : additionalDataSections.find(({ title }) => title === sectionTitle);
-
-  const { fields } = section;
+  const fields = isCustomSection
+    ? customSectionFields.map(({ id, name, fieldType, options }) => ({
+        id,
+        name,
+        fieldType,
+        options,
+      }))
+    : additionalDataSections.find(({ title }) => title === sectionTitle)?.fields;
 
   return (
     <Form

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
@@ -15,6 +15,7 @@ import { SubmitButton } from '../SubmitButton';
 import { TranslatedText } from '/components/Translations/TranslatedText';
 import { FormScreenView } from '../FormScreenView';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
+import { Text } from 'react-native-paper';
 
 export const PatientAdditionalDataForm = ({
   patient,
@@ -23,6 +24,8 @@ export const PatientAdditionalDataForm = ({
   navigation,
   sectionTitle,
   customPatientFieldValues,
+  isCustomFields = false,
+  customSectionFields,
 }): ReactElement => {
   const scrollViewRef = useRef();
   // After save/update, the model will mark itself for upload and the
@@ -62,8 +65,18 @@ export const PatientAdditionalDataForm = ({
     [navigation, patient.id],
   );
 
-  // Get the field group for this section of the additional data template
-  const { fields } = additionalDataSections.find(({ title }) => title === sectionTitle);
+  const section = isCustomFields
+    ? {
+        fields: customSectionFields.map(({ id, name, fieldType, options }) => ({
+          id,
+          name,
+          fieldType,
+          options,
+        })),
+      }
+    : additionalDataSections.find(({ title }) => title === sectionTitle)
+
+  const { fields } = section;
 
   return (
     <Form
@@ -78,6 +91,9 @@ export const PatientAdditionalDataForm = ({
       {(): ReactElement => (
         <FormScreenView scrollViewRef={scrollViewRef}>
           <StyledView justifyContent="space-between">
+            <Text>isCustomFields: {isCustomFields}</Text>
+            <Text>section: {JSON.stringify(section)}</Text>
+            {/* <Text>{JSON.stringify(fields)}</Text> */}
             <PatientAdditionalDataFields fields={fields} showMandatory={false} />
             <SubmitButton
               buttonText={<TranslatedText stringId="general.action.save" fallback="Save" />}

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
@@ -15,6 +15,20 @@ import { SubmitButton } from '../SubmitButton';
 import { TranslatedText } from '/components/Translations/TranslatedText';
 import { FormScreenView } from '../FormScreenView';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
+import { CustomPatientFieldValues } from '~/ui/hooks/usePatientAdditionalData';
+import { NavigationProp } from '@react-navigation/native';
+
+// TODO: type and work out customSectionFields and additionalDataSections
+interface PatientAdditionalDataFormProps {
+  patient: Patient;
+  additionalData: PatientAdditionalData;
+  additionalDataSections: any;
+  navigation: NavigationProp<any>;
+  sectionTitle: string;
+  customPatientFieldValues: CustomPatientFieldValues;
+  isCustomSection?: boolean;
+  customSectionFields?: any[];
+}
 
 export const PatientAdditionalDataForm = ({
   patient,
@@ -25,7 +39,7 @@ export const PatientAdditionalDataForm = ({
   customPatientFieldValues,
   isCustomSection = false,
   customSectionFields,
-}): ReactElement => {
+}: PatientAdditionalDataFormProps): ReactElement => {
   const scrollViewRef = useRef();
   // After save/update, the model will mark itself for upload and the
   // patient for sync (see beforeInsert and beforeUpdate decorators).

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
@@ -15,7 +15,6 @@ import { SubmitButton } from '../SubmitButton';
 import { TranslatedText } from '/components/Translations/TranslatedText';
 import { FormScreenView } from '../FormScreenView';
 import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
-import { Text } from 'react-native-paper';
 
 export const PatientAdditionalDataForm = ({
   patient,
@@ -24,7 +23,7 @@ export const PatientAdditionalDataForm = ({
   navigation,
   sectionTitle,
   customPatientFieldValues,
-  isCustomFields = false,
+  isCustomSection = false,
   customSectionFields,
 }): ReactElement => {
   const scrollViewRef = useRef();
@@ -65,7 +64,7 @@ export const PatientAdditionalDataForm = ({
     [navigation, patient.id],
   );
 
-  const section = isCustomFields
+  const section = isCustomSection
     ? {
         fields: customSectionFields.map(({ id, name, fieldType, options }) => ({
           id,
@@ -74,7 +73,7 @@ export const PatientAdditionalDataForm = ({
           options,
         })),
       }
-    : additionalDataSections.find(({ title }) => title === sectionTitle)
+    : additionalDataSections.find(({ title }) => title === sectionTitle);
 
   const { fields } = section;
 
@@ -83,7 +82,7 @@ export const PatientAdditionalDataForm = ({
       initialValues={{
         ...getInitialAdditionalValues(additionalData, fields),
         ...getInitialCustomValues(customPatientFieldValues, fields),
-        ...patient
+        ...patient,
       }}
       validationSchema={patientAdditionalDataValidationSchema}
       onSubmit={onCreateOrEditAdditionalData}
@@ -91,10 +90,11 @@ export const PatientAdditionalDataForm = ({
       {(): ReactElement => (
         <FormScreenView scrollViewRef={scrollViewRef}>
           <StyledView justifyContent="space-between">
-            <Text>isCustomFields: {isCustomFields}</Text>
-            <Text>section: {JSON.stringify(section)}</Text>
-            {/* <Text>{JSON.stringify(fields)}</Text> */}
-            <PatientAdditionalDataFields fields={fields} showMandatory={false} />
+            <PatientAdditionalDataFields
+              fields={fields}
+              isCustomSection={isCustomSection}
+              showMandatory={false}
+            />
             <SubmitButton
               buttonText={<TranslatedText stringId="general.action.save" fallback="Save" />}
               marginTop={10}

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -41,6 +41,7 @@ export const AdditionalInfo = ({
 }: AdditionalInfoProps): ReactElement => {
   const { getBool } = useLocalisation();
   const {
+    customPatientSections,
     customPatientFieldValues,
     customPatientFieldDefinitions,
     patientAdditionalData,
@@ -59,7 +60,8 @@ export const AdditionalInfo = ({
   const isEditable = getBool('features.editPatientDetailsOnMobile');
 
   // Add edit callback and map the inner 'fields' array
-  const sections = dataSections.map(({ title, fields }) => {
+  const additionalSections = dataSections.map(({ title, fields }) => {
+    // TODO: this is for some reason triggering the isCustomFields logic down the line
     const onEditCallback = (): void =>
       onEdit(patientAdditionalData, title, customPatientFieldValues);
 
@@ -77,6 +79,18 @@ export const AdditionalInfo = ({
 
     return { title, fields: fieldsWithData, onEditCallback };
   });
+
+  const customSections = customPatientSections.map(([_categoryId, fields]) => {
+    const title = fields[0].category.name;
+    const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues);
+    const mappedFields = fields.map(field => [
+      field.name,
+      customPatientFieldValues[field.id]?.[0]?.value,
+    ]);
+    return { title, fields: mappedFields, onEditCallback, isCustomFields: true };
+  });
+
+  const sections = [...(additionalSections || []), ...(customSections || [])];
 
   return (
     <>

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -63,7 +63,7 @@ export const AdditionalInfo = ({
   const additionalSections = dataSections.map(({ title, fields }) => {
     // TODO: this is for some reason triggering the isCustomFields logic down the line
     const onEditCallback = (): void =>
-      onEdit(patientAdditionalData, title, customPatientFieldValues);
+      onEdit(patientAdditionalData, title, false, null, customPatientFieldValues);
 
     const fieldsWithData = fields.map(field => {
       if (field === 'villageId' || field.name === 'villageId')

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -86,16 +86,17 @@ export const AdditionalInfo = ({
   const customSections = customPatientSections.map(([_categoryId, fields]) => {
     const title = fields[0].category.name;
     const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues);
-    const mappedFields = fields.map(field => [
-      field.name,
-      customPatientFieldValues[field.id]?.[0]?.value,
-    ]);
+    const mappedFields = fields.map(field => {
+      const { id, name } = field;
+      const [customFieldValue] = customPatientFieldValues[id] || [];
+      return [name, customFieldValue?.value];
+    });
     return { title, fields: mappedFields, onEditCallback, isCustomSection: true };
   });
 
   const sections = isHardCodedLayout
     ? additionalSections
-    : [...(additionalSections || []), ...(customSections || [])];
+    : [...additionalSections, ...customSections];
 
   return (
     <>

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -42,7 +42,7 @@ export const AdditionalInfo = ({
   onEdit,
   dataSections,
 }: AdditionalInfoProps): ReactElement => {
-  const { getBool } = useLocalisation();
+  const { getBool, getLocalisation } = useLocalisation();
   const {
     customPatientSections,
     customPatientFieldValues,
@@ -51,6 +51,7 @@ export const AdditionalInfo = ({
     loading,
     error,
   } = usePatientAdditionalData(patient.id);
+  const isHardCodedLayout = getLocalisation('layouts.patientDetails') !== 'generic';
 
   const customDataById = mapValues(customPatientFieldValues, nestedObject => nestedObject[0].value);
 
@@ -82,7 +83,6 @@ export const AdditionalInfo = ({
     return { title, fields: fieldsWithData, onEditCallback };
   });
 
-  // TODO: filter out of cambodia mode
   const customSections = customPatientSections.map(([_categoryId, fields]) => {
     const title = fields[0].category.name;
     const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues);
@@ -93,7 +93,9 @@ export const AdditionalInfo = ({
     return { title, fields: mappedFields, onEditCallback, isCustomSection: true };
   });
 
-  const sections = [...(additionalSections || []), ...(customSections || [])];
+  const sections = isHardCodedLayout
+    ? additionalSections
+    : [...(additionalSections || []), ...(customSections || [])];
 
   return (
     <>

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -18,7 +18,7 @@ interface AdditionalInfoProps {
   onEdit: (
     additionalInfo: PatientAdditionalData,
     sectionTitle: Element,
-    isCustomSection: Boolean,
+    isCustomSection: boolean,
     fields: PatientFieldDefinition[],
     customPatientFieldValues: CustomPatientFieldValues,
   ) => void;

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -61,7 +61,6 @@ export const AdditionalInfo = ({
 
   // Add edit callback and map the inner 'fields' array
   const additionalSections = dataSections.map(({ title, fields }) => {
-    // TODO: this is for some reason triggering the isCustomFields logic down the line
     const onEditCallback = (): void =>
       onEdit(patientAdditionalData, title, false, null, customPatientFieldValues);
 
@@ -87,7 +86,7 @@ export const AdditionalInfo = ({
       field.name,
       customPatientFieldValues[field.id]?.[0]?.value,
     ]);
-    return { title, fields: mappedFields, onEditCallback, isCustomFields: true };
+    return { title, fields: mappedFields, onEditCallback, isCustomSection: true };
   });
 
   const sections = [...(additionalSections || []), ...(customSections || [])];

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -12,11 +12,14 @@ import {
 import { mapValues } from 'lodash';
 import { PatientAdditionalData } from '~/models/PatientAdditionalData';
 import { Patient } from '~/models/Patient';
+import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
 
 interface AdditionalInfoProps {
   onEdit: (
     additionalInfo: PatientAdditionalData,
     sectionTitle: Element,
+    isCustomSection: Boolean,
+    fields: PatientFieldDefinition[],
     customPatientFieldValues: CustomPatientFieldValues,
   ) => void;
   patient: Patient;
@@ -79,6 +82,7 @@ export const AdditionalInfo = ({
     return { title, fields: fieldsWithData, onEditCallback };
   });
 
+  // TODO: filter out of cambodia mode
   const customSections = customPatientSections.map(([_categoryId, fields]) => {
     const title = fields[0].category.name;
     const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues);

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditAdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditAdditionalInfo.tsx
@@ -14,6 +14,8 @@ export const EditPatientAdditionalDataScreen = ({ navigation, route }): ReactEle
     patient,
     additionalDataJSON,
     sectionTitle,
+    isCustomFields,
+    customSectionFields,
     customPatientFieldValues,
   } = route.params;
   // additionalDataJSON might be undefined if record doesn't exist,
@@ -44,6 +46,8 @@ export const EditPatientAdditionalDataScreen = ({ navigation, route }): ReactEle
         additionalDataSections={GENERIC_ADDITIONAL_DATA_SECTIONS}
         navigation={navigation}
         sectionTitle={sectionTitle}
+        customSectionFields={customSectionFields}
+        isCustomFields={isCustomFields}
         customPatientFieldValues={customPatientFieldValues}
       />
     </FullView>

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditAdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditAdditionalInfo.tsx
@@ -14,7 +14,7 @@ export const EditPatientAdditionalDataScreen = ({ navigation, route }): ReactEle
     patient,
     additionalDataJSON,
     sectionTitle,
-    isCustomFields,
+    isCustomSection,
     customSectionFields,
     customPatientFieldValues,
   } = route.params;
@@ -47,7 +47,7 @@ export const EditPatientAdditionalDataScreen = ({ navigation, route }): ReactEle
         navigation={navigation}
         sectionTitle={sectionTitle}
         customSectionFields={customSectionFields}
-        isCustomFields={isCustomFields}
+        isCustomSection={isCustomSection}
         customPatientFieldValues={customPatientFieldValues}
       />
     </FullView>

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/PatientDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/PatientDetails.tsx
@@ -16,7 +16,7 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
     (
       additionalData,
       sectionTitle,
-      isCustomFields,
+      isCustomSection,
       customSectionFields,
       customPatientFieldValues,
     ) => {
@@ -25,7 +25,7 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
         patient,
         additionalDataJSON: JSON.stringify(additionalData),
         sectionTitle,
-        isCustomFields,
+        isCustomSection,
         customSectionFields,
         customPatientFieldValues,
       });

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/PatientDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/PatientDetails.tsx
@@ -16,6 +16,8 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
     (
       additionalData,
       sectionTitle,
+      isCustomFields,
+      customSectionFields,
       customPatientFieldValues,
     ) => {
       navigation.navigate(Routes.HomeStack.PatientDetailsStack.Generic.EditPatientAdditionalData, {
@@ -23,6 +25,8 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
         patient,
         additionalDataJSON: JSON.stringify(additionalData),
         sectionTitle,
+        isCustomFields,
+        customSectionFields,
         customPatientFieldValues,
       });
     },
@@ -32,7 +36,11 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
   return (
     <>
       <GeneralInfo patient={patient} onEdit={onEditGeneralInfo} />
-      <AdditionalInfo patient={patient} onEdit={editPatientAdditionalData} dataSections={GENERIC_ADDITIONAL_DATA_SECTIONS} />
+      <AdditionalInfo
+        patient={patient}
+        onEdit={editPatientAdditionalData}
+        dataSections={GENERIC_ADDITIONAL_DATA_SECTIONS}
+      />
     </>
   );
 };


### PR DESCRIPTION
### Changes

Most of this pr is just restoring old logic for the custom section handling. When we were working on cambodia mode we changed up this logic to allow custom fields to be hardcoded within the other sections (general and pad). This meant that we were checking by field rather than by section in order to grab the relevant component and update the correct information. In doing this we accidentally removed the logic that allows for entire new custom sections (not used in cambodia). This just restores the old logic and renames the flag from `isCustomFields` to `isCustomSection` to make it a bit clearer and to differentiate the logic for whole custom sections and individual hardcoded custom fields

Also worth noting that this is a 2.10 release fix that i am trying to restore to its original behaviour. I know Tom has done some great work in 2.11 that resolves some of the hacky parts/unstable code as part of this feature.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
