### PR TITLE
fix(fhir): RISPACS Hotfix golive hotfix 2.5

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/ImagingStudy.test.js
@@ -1,7 +1,10 @@
 import { Op } from 'sequelize';
 
 import { fake, fakeReferenceData, showError } from '@tamanu/shared/test-helpers';
-import { IMAGING_REQUEST_STATUS_TYPES } from '@tamanu/constants';
+import {
+  IMAGING_REQUEST_STATUS_TYPES,
+  FHIR_IMAGING_STUDY_STATUS,
+} from '@tamanu/constants';
 import { fakeUUID } from '@tamanu/shared/utils/generateId';
 import { sleepAsync } from '@tamanu/shared/utils/sleepAsync';
 
@@ -124,7 +127,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           basedOn: [
             {
               type: 'ServiceRequest',
-              reference: `/ServiceRequest/${mat.id}`,
+              reference: `ServiceRequest/${mat.id}`,
             },
           ],
           note: [{ text: 'This is an okay note' }, { text: 'This is another note' }],
@@ -348,6 +351,50 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
         expect(ires.description).toEqual('This is a fine note\n\nThis is another note');
       }));
 
+
+    it('ImagingStudy can cancel a ImagingRequest', () =>
+      showError(async () => {
+        // arrange
+        const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
+        const ir = await ImagingRequest.create(
+          fake(ImagingRequest, {
+            requestedById: resources.practitioner.id,
+            encounterId: encounter.id,
+            locationId: resources.location.id,
+            status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+            priority: 'routine',
+            requestedDate: '2022-03-04 15:30:00',
+          }),
+        );
+        await ir.setAreas([resources.area1.id, resources.area2.id]);
+        await ir.reload();
+        const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+
+        await FhirServiceRequest.resolveUpstreams();
+
+        // act
+        const response = await app.post(PATH).send({
+          resourceType: 'ImagingStudy',
+          status: 'cancelled',
+          basedOn: [
+            {
+              type: 'ServiceRequest',
+              reference: `ServiceRequest/${mat.id}`,
+            },
+          ]
+        });
+
+        // assert
+        expect(response).toHaveSucceeded();
+        expect(response.status).toBe(201);
+        await ir.reload();
+        const notes = await ir.getNotes();
+        notes.sort((a,b) => a.createdAt < b.createdAt);
+        expect(ir.status).toEqual(IMAGING_REQUEST_STATUS_TYPES.CANCELLED);
+        expect(notes[0].content).toEqual('Request cancelled. Reason: Cancelled externally via API.');
+        expect(ir.reasonForCancellation).toEqual('Cancelled externally via API');
+      }));
+
     describe('errors', () => {
       it('returns invalid if the resourceType does not match', async () => {
         // act
@@ -404,7 +451,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
           basedOn: [
             {
               type: 'ServiceRequest',
-              reference: `/ServiceRequest/${mat.id}`,
+              reference: `ServiceRequest/${mat.id}`,
             },
           ],
           note: [{ text: 'A note' }],
@@ -420,7 +467,7 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
               code: 'value',
               diagnostics: expect.any(String),
               details: {
-                text: "ImagingStudy status must be 'final'",
+                text: `ImagingStudy status must be either '${FHIR_IMAGING_STUDY_STATUS.AVAILABLE}' or '${FHIR_IMAGING_STUDY_STATUS.CANCELLED}'`,
               },
             },
           ],
@@ -503,6 +550,179 @@ describe(`Materialised FHIR - ImagingStudy`, () => {
         });
         expect(response.status).toBe(400);
       });
+
+      it('returns invalid if posting results to cancelled request', () =>
+        showError(async () => {
+          // arrange
+          const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
+          const ir = await ImagingRequest.create(
+            fake(ImagingRequest, {
+              requestedById: resources.practitioner.id,
+              encounterId: encounter.id,
+              locationId: resources.location.id,
+              priority: 'routine',
+              requestedDate: '2022-03-04 15:30:00',
+              status: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+            }),
+          );
+          await ir.setAreas([resources.area1.id, resources.area2.id]);
+          await ir.reload();
+          const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+
+          await FhirServiceRequest.resolveUpstreams();
+
+          // act
+
+          const response = await app.post(PATH).send({
+            resourceType: 'ImagingStudy',
+            status: 'final',
+            identifier: [
+              {
+                system: 'http://example.com',
+                value: 'ACCESSION',
+              },
+            ],
+            basedOn: [
+              {
+                type: 'ServiceRequest',
+                reference: `ServiceRequest/${mat.id}`,
+              },
+            ],
+            note: [{ text: 'This is a fair note' }, { text: 'This is another note' }],
+          });
+
+          // assert
+          expect(response.body).toMatchObject({
+            resourceType: 'OperationOutcome',
+            id: expect.any(String),
+            issue: [
+              {
+                severity: 'error',
+                code: 'invalid',
+                diagnostics: expect.any(String),
+                details: {
+                  text: 'ImagingRequest has been cancelled',
+                },
+              },
+            ],
+          });
+          expect(response.status).toBe(400);
+        }));
+      it('returns invalid if posting results to entered-in-error request', () =>
+        showError(async () => {
+          // arrange
+          const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
+          const ir = await ImagingRequest.create(
+            fake(ImagingRequest, {
+              requestedById: resources.practitioner.id,
+              encounterId: encounter.id,
+              locationId: resources.location.id,
+              priority: 'routine',
+              requestedDate: '2022-03-04 15:30:00',
+              status: IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
+            }),
+          );
+          await ir.setAreas([resources.area1.id, resources.area2.id]);
+          await ir.reload();
+          const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+
+          await FhirServiceRequest.resolveUpstreams();
+
+          // act
+
+          const response = await app.post(PATH).send({
+            resourceType: 'ImagingStudy',
+            status: 'final',
+            identifier: [
+              {
+                system: 'http://example.com',
+                value: 'ACCESSION',
+              },
+            ],
+            basedOn: [
+              {
+                type: 'ServiceRequest',
+                reference: `ServiceRequest/${mat.id}`,
+              },
+            ],
+            note: [{ text: 'This is a fair note' }, { text: 'This is another note' }],
+          });
+
+          // assert
+          expect(response.body).toMatchObject({
+            resourceType: 'OperationOutcome',
+            id: expect.any(String),
+            issue: [
+              {
+                severity: 'error',
+                code: 'invalid',
+                diagnostics: expect.any(String),
+                details: {
+                  text: 'ImagingRequest has been cancelled',
+                },
+              },
+            ],
+          });
+          expect(response.status).toBe(400);
+        }));
+
+      it('returns invalid if posting results to a deleted ImagingRequest', () =>
+        showError(async () => {
+          // arrange
+          const { FhirServiceRequest, ImagingRequest } = ctx.store.models;
+          const ir = await ImagingRequest.create(
+            fake(ImagingRequest, {
+              requestedById: resources.practitioner.id,
+              encounterId: encounter.id,
+              locationId: resources.location.id,
+              priority: 'routine',
+              requestedDate: '2022-03-04 15:30:00',
+              status: IMAGING_REQUEST_STATUS_TYPES.DELETED,
+            }),
+          );
+          await ir.setAreas([resources.area1.id, resources.area2.id]);
+          await ir.reload();
+          const mat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+
+          await FhirServiceRequest.resolveUpstreams();
+
+          // act
+
+          const response = await app.post(PATH).send({
+            resourceType: 'ImagingStudy',
+            status: 'final',
+            identifier: [
+              {
+                system: 'http://example.com',
+                value: 'ACCESSION',
+              },
+            ],
+            basedOn: [
+              {
+                type: 'ServiceRequest',
+                reference: `ServiceRequest/${mat.id}`,
+              },
+            ],
+            note: [{ text: 'This is a fair note' }, { text: 'This is another note' }],
+          });
+
+          // assert
+          expect(response.body).toMatchObject({
+            resourceType: 'OperationOutcome',
+            id: expect.any(String),
+            issue: [
+              {
+                severity: 'error',
+                code: 'deleted',
+                diagnostics: expect.any(String),
+                details: {
+                  text: 'ImagingRequest has been deleted',
+                },
+              },
+            ],
+          });
+          expect(response.status).toBe(410);
+        }));
     });
   });
 });

--- a/packages/central-server/app/hl7fhir/materialised/create.js
+++ b/packages/central-server/app/hl7fhir/materialised/create.js
@@ -31,7 +31,9 @@ export function createHandler(FhirResource) {
     );
 
     const resource = new FhirResource(validated);
-    const upstream = await resource.pushUpstream();
+    const upstream = await resource.pushUpstream({
+      requesterId: req.user?.id,
+    });
 
     if (FhirResource.CAN_DO.has(FHIR_INTERACTIONS.INTERNAL.MATERIALISE)) {
       FhirMaterialiseJob.enqueue({ resource: FhirResource.fhirName, upstreamId: upstream.id });

--- a/packages/central-server/app/localisation.js
+++ b/packages/central-server/app/localisation.js
@@ -479,6 +479,7 @@ const rootLocalisationSchema = yup
             .required()
             .max(31),
           label: yup.string().required(),
+          hidden: yup.boolean(),
         }),
       )
       .test({

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -838,27 +838,38 @@
       "imagingCancellationReasons": [
         {
           "value": "clinical",
-          "label": "Clinical reason"
+          "label": "Clinical reason",
+          "hidden": false
         },
         {
           "value": "duplicate",
-          "label": "Duplicate"
+          "label": "Duplicate",
+          "hidden": false
         },
         {
           "value": "entered-in-error",
-          "label": "Entered in error"
+          "label": "Entered in error",
+          "hidden": false
         },
         {
           "value": "patient-discharged",
-          "label": "Patient discharged"
+          "label": "Patient discharged",
+          "hidden": false
         },
         {
           "value": "patient-refused",
-          "label": "Patient refused"
+          "label": "Patient refused",
+          "hidden": false
+        },
+        {
+          "value": "cancelled-externally",
+          "label": "Cancelled externally via API",
+          "hidden": true
         },
         {
           "value": "other",
-          "label": "Other"
+          "label": "Other",
+          "hidden": false
         }
       ],
       "labsCancellationReasons": [

--- a/packages/central-server/config/test.json5
+++ b/packages/central-server/config/test.json5
@@ -45,6 +45,7 @@
         "alpha-3": "UTO"
       },
       "imagingTypes": {
+        "orthopantomography": { "label": "Orthopantomography" },
         "xRay": { "label": "X-Ray" },
         "ctScan": { "label": "CT Scan" },
         "ultrasound": { "label": "Ultrasound" },

--- a/packages/constants/src/fhir.ts
+++ b/packages/constants/src/fhir.ts
@@ -233,6 +233,15 @@ export const FHIR_DIAGNOSTIC_REPORT_STATUS = {
   UNKNOWN: 'unknown',
 };
 
+export const FHIR_IMAGING_STUDY_STATUS = {
+  REGISTERED: 'registered',
+  AVAILABLE: 'available',
+  FINAL_INVALID_LEGACY: 'final', // this needs to be supported but is not valid FHIR
+  CANCELLED: 'cancelled',
+  ENTERED_IN_ERROR: 'entered-in-error',
+  UNKNOWN: 'unknown',
+};
+
 export const FHIR_ENCOUNTER_CLASS_DISPLAY = {
   IMP: 'inpatient encounter',
   AMB: 'ambulatory encounter',

--- a/packages/constants/src/imaging.ts
+++ b/packages/constants/src/imaging.ts
@@ -1,37 +1,39 @@
 import { IMAGING_REQUEST_STATUS_TYPES } from './statuses';
 
 export const IMAGING_AREA_TYPES = {
-  X_RAY_IMAGING_AREA: 'xRayImagingArea',
-  ULTRASOUND_IMAGING_AREA: 'ultrasoundImagingArea',
-  CT_SCAN_IMAGING_AREA: 'ctScanImagingArea',
-  ECHOCARDIOGRAM_IMAGING_AREA: 'echocardiogramImagingArea',
-  MRI_IMAGING_AREA: 'mriImagingArea',
-  MAMMOGRAM_IMAGING_AREA: 'mammogramImagingArea',
-  ECG_IMAGING_AREA: 'ecgImagingArea',
-  HOLTER_MONITOR_IMAGING_AREA: 'holterMonitorImagingArea',
-  ENDOSCOPY_IMAGING_AREA: 'endoscopyImagingArea',
-  FLUROSCOPY_IMAGING_AREA: 'fluroscopyImagingArea',
   ANGIOGRAM_IMAGING_AREA: 'angiogramImagingArea',
   COLONOSCOPY_IMAGING_AREA: 'colonoscopyImagingArea',
-  VASCULAR_STUDY_IMAGING_AREA: 'vascularStudyImagingArea',
+  CT_SCAN_IMAGING_AREA: 'ctScanImagingArea',
+  ECG_IMAGING_AREA: 'ecgImagingArea',
+  ECHOCARDIOGRAM_IMAGING_AREA: 'echocardiogramImagingArea',
+  ENDOSCOPY_IMAGING_AREA: 'endoscopyImagingArea',
+  FLUROSCOPY_IMAGING_AREA: 'fluroscopyImagingArea',
+  HOLTER_MONITOR_IMAGING_AREA: 'holterMonitorImagingArea',
+  ORTHOPANTOMOGRAPHY_IMAGING_AREA: 'orthopantomographyImagingArea',
+  MRI_IMAGING_AREA: 'mriImagingArea',
+  MAMMOGRAM_IMAGING_AREA: 'mammogramImagingArea',
   STRESS_TEST_IMAGING_AREA: 'stressTestImagingArea',
+  ULTRASOUND_IMAGING_AREA: 'ultrasoundImagingArea',
+  VASCULAR_STUDY_IMAGING_AREA: 'vascularStudyImagingArea',
+  X_RAY_IMAGING_AREA: 'xRayImagingArea',
 };
 
 export const IMAGING_TYPES = {
-  X_RAY: 'xRay',
-  CT_SCAN: 'ctScan',
-  ULTRASOUND: 'ultrasound',
-  MRI: 'mri',
-  ECG: 'ecg',
-  HOLTER_MONITOR: 'holterMonitor',
-  ECHOCARDIOGRAM: 'echocardiogram',
-  MAMMOGRAM: 'mammogram',
-  ENDOSCOPY: 'endoscopy',
-  FLUROSCOPY: 'fluroscopy',
   ANGIOGRAM: 'angiogram',
   COLONOSCOPY: 'colonoscopy',
-  VASCULAR_STUDY: 'vascularStudy',
+  CT_SCAN: 'ctScan',
+  ECG: 'ecg',
+  ECHOCARDIOGRAM: 'echocardiogram',
+  ENDOSCOPY: 'endoscopy',
+  FLUROSCOPY: 'fluroscopy',
+  HOLTER_MONITOR: 'holterMonitor',
+  MAMMOGRAM: 'mammogram',
+  ORTHOPANTOMOGRAPHY: 'orthopantomography',
+  MRI: 'mri',
   STRESS_TEST: 'stressTest',
+  ULTRASOUND: 'ultrasound',
+  VASCULAR_STUDY: 'vascularStudy',
+  X_RAY: 'xRay',
 };
 
 export const IMAGING_TYPES_VALUES = Object.values(IMAGING_TYPES);
@@ -39,6 +41,7 @@ export const IMAGING_TYPES_VALUES = Object.values(IMAGING_TYPES);
 export const AREA_TYPE_TO_IMAGING_TYPE = {
   [IMAGING_AREA_TYPES.X_RAY_IMAGING_AREA]: IMAGING_TYPES.X_RAY,
   [IMAGING_AREA_TYPES.CT_SCAN_IMAGING_AREA]: IMAGING_TYPES.CT_SCAN,
+  [IMAGING_AREA_TYPES.ORTHOPANTOMOGRAPHY_IMAGING_AREA]: IMAGING_TYPES.ORTHOPANTOMOGRAPHY,
   [IMAGING_AREA_TYPES.ULTRASOUND_IMAGING_AREA]: IMAGING_TYPES.ULTRASOUND,
   [IMAGING_AREA_TYPES.MRI_IMAGING_AREA]: IMAGING_TYPES.MRI,
   [IMAGING_AREA_TYPES.ECG_IMAGING_AREA]: IMAGING_TYPES.ECG,
@@ -80,7 +83,7 @@ export const IMAGING_TABLE_VERSIONS: { [key: string]: ImagingTableVersion } =
     Object.keys(IMAGING_TABLE_STATUS_GROUPINGS).map((key) => {
       const statuses =
         IMAGING_TABLE_STATUS_GROUPINGS[
-          key as keyof typeof IMAGING_TABLE_STATUS_GROUPINGS
+        key as keyof typeof IMAGING_TABLE_STATUS_GROUPINGS
         ];
       return [
         key,

--- a/packages/constants/src/importable.ts
+++ b/packages/constants/src/importable.ts
@@ -43,6 +43,7 @@ export const GENERAL_IMPORTABLE_DATA_TYPES = [
   'nationality',
   'nursingZone',
   'occupation',
+  'orthopantomographyImagingArea',
   'patient',
   'patientBillingType',
   'patientFieldDefinition',

--- a/packages/shared/src/migrations/1718333204958-expandImagingRequestCancellationReason.js
+++ b/packages/shared/src/migrations/1718333204958-expandImagingRequestCancellationReason.js
@@ -1,0 +1,14 @@
+export const NON_DETERMINISTIC = true;
+export async function up(query) {
+  await query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    ALTER COLUMN reason_for_cancellation TYPE CHARACTER VARYING(1024);
+  `);
+}
+
+export async function down(query) {
+  await query.sequelize.query(`
+    ALTER TABLE imaging_requests
+    ALTER COLUMN reason_for_cancellation TYPE CHARACTER VARYING(31);
+  `);
+}

--- a/packages/shared/src/models/fhir/ImagingStudy/FhirImagingStudy.js
+++ b/packages/shared/src/models/fhir/ImagingStudy/FhirImagingStudy.js
@@ -3,9 +3,11 @@ import { DataTypes } from 'sequelize';
 import * as yup from 'yup';
 
 import {
+  FHIR_IMAGING_STUDY_STATUS,
   FHIR_INTERACTIONS,
   FHIR_ISSUE_TYPE,
   IMAGING_REQUEST_STATUS_TYPES,
+  NOTE_TYPES,
 } from '@tamanu/constants';
 import { FhirResource } from '../Resource';
 
@@ -47,20 +49,8 @@ export class FhirImagingStudy extends FhirResource {
 
   // This is currently very hardcoded for Aspen's use case.
   // We'll need to make it more generic at some point, but not today!
-  async pushUpstream() {
-    const { FhirServiceRequest, ImagingRequest, ImagingResult } = this.sequelize.models;
-
-    const results = this.note.map(n => n.text).join('\n\n');
-
-    const imagingAccessCode = this.identifier.find(
-      i => i?.system === config.hl7.dataDictionaries.imagingStudyAccessionId,
-    )?.value;
-    if (!imagingAccessCode) {
-      throw new Invalid('Need to have Accession Number identifier', {
-        code: FHIR_ISSUE_TYPE.INVALID.STRUCTURE,
-      });
-    }
-
+  async pushUpstream({ requesterId }) {
+    const { FhirServiceRequest, ImagingRequest } = this.sequelize.models;
     const serviceRequestFhirId = this.basedOn
       .map(ref => ref.fhirTypeAndId())
       .filter(Boolean)
@@ -108,31 +98,82 @@ export class FhirImagingStudy extends FhirResource {
       });
     }
 
-    if (this.status !== 'final') {
-      throw new Invalid(`ImagingStudy status must be 'final'`, {
+    if (![
+      FHIR_IMAGING_STUDY_STATUS.AVAILABLE,
+      FHIR_IMAGING_STUDY_STATUS.FINAL_INVALID_LEGACY,
+      FHIR_IMAGING_STUDY_STATUS.CANCELLED
+    ].includes(this.status)) {
+      throw new Invalid(`ImagingStudy status must be either '${FHIR_IMAGING_STUDY_STATUS.AVAILABLE}' or '${FHIR_IMAGING_STUDY_STATUS.CANCELLED}'`, {
         code: FHIR_ISSUE_TYPE.INVALID.VALUE,
       });
     }
 
     const imagingRequest = await ImagingRequest.findByPk(serviceRequest.upstreamId);
-    if (!imagingRequest) {
+    if (!imagingRequest || imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.DELETED) {
       // this is only a possibility when using a FHIR basedOn reference
-      throw new Deleted('ImagingRequest has been deleted in Tamanu');
+      throw new Deleted('ImagingRequest has been deleted');
     }
 
+    if ([
+      IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+      IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
+    ].includes(imagingRequest.status)) {
+      throw new Invalid('ImagingRequest has been cancelled');
+    }
+
+    if ([
+      FHIR_IMAGING_STUDY_STATUS.AVAILABLE,
+      FHIR_IMAGING_STUDY_STATUS.FINAL_INVALID_LEGACY,
+    ].includes(this.status)) {
+      return await this.attachResults(imagingRequest);
+    }
+
+    if (this.status === FHIR_IMAGING_STUDY_STATUS.CANCELLED) {
+      return await this.cancelRequest(imagingRequest, requesterId);
+    }
+  }
+
+  async cancelRequest(imagingRequest, requesterId) {
+    const reasons = config.localisation?.data?.imagingCancellationReasons || [];
+    const cancelledReason = reasons.find(reason => reason.value === 'cancelled-externally')?.label;
+    imagingRequest.set({
+      status: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+      reasonForCancellation: cancelledReason,
+    });
+    await this.sequelize.transaction(async () => {
+      await imagingRequest.createNote({
+        noteType: NOTE_TYPES.OTHER,
+        content: `Request cancelled. Reason: ${cancelledReason}.`,
+        authorId: requesterId,
+      });
+      await imagingRequest.save();
+    });
+  }
+
+  async attachResults(imagingRequest) {
+    const imagingAccessCode = this.identifier.find(
+      i => i?.system === config.hl7.dataDictionaries.imagingStudyAccessionId,
+    )?.value;
+    if (!imagingAccessCode) {
+      throw new Invalid('Need to have Accession Number identifier', {
+        code: FHIR_ISSUE_TYPE.INVALID.STRUCTURE,
+      });
+    }
+    const { ImagingResult } = this.sequelize.models;
     let result = await ImagingResult.findOne({
       where: {
         imagingRequestId: imagingRequest.id,
         externalCode: imagingAccessCode,
       },
     });
+    const resultNotes = this.note.map(n => n.text).join('\n\n');
     if (result) {
-      result.set({ description: results });
+      result.set({ description: resultNotes });
       await result.save();
     } else {
       result = await ImagingResult.create({
         imagingRequestId: imagingRequest.id,
-        description: results,
+        description: resultNotes,
         externalCode: imagingAccessCode,
         completedAt: this.started ? toDateTimeString(this.started) : getCurrentDateTimeString(),
       });

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -216,7 +216,8 @@ export const ImagingRequestForm = React.memo(
                   options={imagingAreas.map(area => ({
                     label: area.name,
                     value: area.id,
-                  }))}
+                  })).sort((area1, area2) => area1.label.localeCompare(area2.label))
+                  }
                   name="areas"
                   label={
                     <TranslatedText stringId="imaging.areas.label" fallback="Areas to be imaged" />

--- a/packages/web/app/views/patients/imagingRequest/CancelModalButton.jsx
+++ b/packages/web/app/views/patients/imagingRequest/CancelModalButton.jsx
@@ -25,7 +25,8 @@ export const CancelModalButton = ({ imagingRequest, onCancel }) => {
 
   const api = useApi();
   const { getLocalisation } = useLocalisation();
-  const cancellationReasonOptions = getLocalisation('imagingCancellationReasons') || [];
+  const allCancellationReasons = getLocalisation('imagingCancellationReasons') || [];
+  const cancellationReasonOptions = allCancellationReasons.filter(reason => !reason.hidden);
 
   const onConfirmCancel = async ({ reasonForCancellation }) => {
     const reasonText = cancellationReasonOptions.find(x => x.value === reasonForCancellation).label;

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import { pick } from 'lodash';
 import styled from 'styled-components';
 
-import { IMAGING_REQUEST_STATUS_TYPES, LAB_REQUEST_STATUS_CONFIG } from '@tamanu/constants';
+import { IMAGING_REQUEST_STATUS_TYPES, LAB_REQUEST_STATUS_CONFIG, NOTE_TYPES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 
 import { FORM_TYPES, IMAGING_REQUEST_STATUS_OPTIONS } from '../../../constants';
@@ -113,7 +113,10 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
       />
       <TextInput
         multiline
-        value={imagingRequest.note}
+        value={imagingRequest.notes
+          ?.filter(note => note.noteType === NOTE_TYPES.OTHER)
+          .map(note => note.content)
+          .join('\n')}
         label={<TranslatedText stringId="general.notes.label" fallback="Notes" />}
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled


### PR DESCRIPTION
* Adding new imaging types

* Removing CR as suplicate of Xray

* Add new imagingTypes to test config

* Remove dx

* remove dx

* Sorting function

* using localeCompare

* Cleaning up inner function

* Moving handling results to method

* Adding cancelled reason for external added to localisation

* Adding comment

* Updated for PR comments

* Fixing linting errors

* Changes from testing

* Extending column

* Removing extra comments

* Including Requester in pushUpstream

### Changes

[fix(web central): RISPACS Hotfix golive](https://github.com/beyondessential/tamanu/pull/6063)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy --> %opsref=k8s/pre-16

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
