### PR TITLE
fix: release 2.10: Upcoming vaccination last updated effected by timezone

### DIFF
--- a/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
+++ b/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
@@ -11,7 +11,7 @@ import { RefreshUpcomingVaccinations } from '../../dist/tasks/RefreshMaterialize
 
 jest.mock('@tamanu/shared/utils/dateTime', () => ({
   ...jest.requireActual('@tamanu/shared/utils/dateTime'),
-  getCurrentISO8601DateString: jest.fn(() => '2021-01-01 00:00:00:000Z'),
+  getCurrentISO8601DateString: jest.fn(() => '2021-01-01 00:00:00.000Z'),
 }));
 
 const createPatient = async (models, overrides) => {

--- a/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
+++ b/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
@@ -199,7 +199,7 @@ describe('Upcoming vaccinations', () => {
       const res = await app.get('/api/upcomingVaccinations/updateStats');
       expect(res).toHaveStatus(200);
       expect(res.body).toEqual({
-        lastRefreshed: '2021-01-01 00:00:00:000Z',
+        lastRefreshed: '2021-01-01 00:00:00.000Z',
         schedule: '*/50 * * * *',
       });
     });

--- a/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
+++ b/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { subDays } from 'date-fns';
-import { createTestContext } from '../utilities';
+import { createTestContext, withDateUnsafelyFaked } from '../utilities';
 
 import { createScheduledVaccine } from '@tamanu/shared/demoData/vaccines';
 import { toDateString } from '@tamanu/shared/utils/dateTime';
@@ -8,11 +8,6 @@ import { VACCINE_STATUS, REFERENCE_TYPES, VACCINE_CATEGORIES } from '@tamanu/con
 import { fake } from '@tamanu/shared/test-helpers/fake';
 
 import { RefreshUpcomingVaccinations } from '../../dist/tasks/RefreshMaterializedView';
-
-jest.mock('@tamanu/shared/utils/dateTime', () => ({
-  ...jest.requireActual('@tamanu/shared/utils/dateTime'),
-  getCurrentDateTimeString: jest.fn(() => '2021-01-01 00:00:00'),
-}));
 
 const createPatient = async (models, overrides) => {
   return models.Patient.create({
@@ -194,12 +189,14 @@ describe('Upcoming vaccinations', () => {
 
   describe('Refresh stats', () => {
     it('returns the last updated time and cron schedule for a upcoming vaccinations materialized view', async () => {
-      const task = new RefreshUpcomingVaccinations(ctx);
-      await task.run();
-      const res = await app.get('/api/upcomingVaccinations/updateStats');
+      const res = await withDateUnsafelyFaked(new Date('2021-01-01T00:00:000Z'), async () => {
+        const task = new RefreshUpcomingVaccinations(ctx);
+        await task.run();
+        return app.get('/api/upcomingVaccinations/updateStats');
+      });
       expect(res).toHaveStatus(200);
       expect(res.body).toEqual({
-        lastRefreshed: '2021-01-01 00:00:00',
+        lastRefreshed: '2021-01-01T00:00:00.000Z',
         schedule: '*/50 * * * *',
       });
     });

--- a/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
+++ b/packages/facility-server/__tests__/apiv1/UpcomingVaccinations.test.js
@@ -11,7 +11,7 @@ import { RefreshUpcomingVaccinations } from '../../dist/tasks/RefreshMaterialize
 
 jest.mock('@tamanu/shared/utils/dateTime', () => ({
   ...jest.requireActual('@tamanu/shared/utils/dateTime'),
-  getCurrentISODateString: jest.fn(() => '2021-01-01 00:00:00:000Z'),
+  getCurrentISO8601DateString: jest.fn(() => '2021-01-01 00:00:00:000Z'),
 }));
 
 const createPatient = async (models, overrides) => {

--- a/packages/facility-server/__tests__/utilities.js
+++ b/packages/facility-server/__tests__/utilities.js
@@ -193,30 +193,3 @@ export async function createTestContext({ enableReportInstances } = {}) {
 
   return context;
 }
-
-/* eslint-disable no-constructor-return,require-atomic-updates */
-// This helper is a race condition waiting to happen, but it's hard to avoid in
-// cases where we need control over the date without changing all instances of
-// Date.now() and new Date in the codebase and dependencies, or wrapping the
-// test runner to override the system clock. Use sparingly.
-export async function withDateUnsafelyFaked(fakeDate, fn) {
-  const OldDate = global.Date;
-  try {
-    global.Date = class extends OldDate {
-      constructor(...args) {
-        if (args.length > 0) {
-          return new OldDate(...args);
-        }
-        return fakeDate;
-      }
-
-      static now() {
-        return fakeDate.valueOf();
-      }
-    };
-    return await fn();
-  } finally {
-    global.Date = OldDate;
-  }
-}
-/* eslint-enable no-constructor-return,require-atomic-updates */

--- a/packages/facility-server/__tests__/utilities.js
+++ b/packages/facility-server/__tests__/utilities.js
@@ -193,3 +193,30 @@ export async function createTestContext({ enableReportInstances } = {}) {
 
   return context;
 }
+
+/* eslint-disable no-constructor-return,require-atomic-updates */
+// This helper is a race condition waiting to happen, but it's hard to avoid in
+// cases where we need control over the date without changing all instances of
+// Date.now() and new Date in the codebase and dependencies, or wrapping the
+// test runner to override the system clock. Use sparingly.
+export async function withDateUnsafelyFaked(fakeDate, fn) {
+  const OldDate = global.Date;
+  try {
+    global.Date = class extends OldDate {
+      constructor(...args) {
+        if (args.length > 0) {
+          return new OldDate(...args);
+        }
+        return fakeDate;
+      }
+
+      static now() {
+        return fakeDate.valueOf();
+      }
+    };
+    return await fn();
+  } finally {
+    global.Date = OldDate;
+  }
+}
+/* eslint-enable no-constructor-return,require-atomic-updates */

--- a/packages/facility-server/app/tasks/RefreshMaterializedView.js
+++ b/packages/facility-server/app/tasks/RefreshMaterializedView.js
@@ -8,7 +8,6 @@ import {
   NOTIFY_CHANNELS,
 } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
-import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 
 const buildRefreshMaterializedViewTask = viewName =>
   class RefreshMaterializedView extends ScheduledTask {
@@ -39,7 +38,7 @@ const buildRefreshMaterializedViewTask = viewName =>
       });
       await this.models.LocalSystemFact.set(
         `${MATERIALIZED_VIEW_LAST_REFRESHED_AT_KEY_NAMESPACE}:${this.viewName}`,
-        getCurrentDateTimeString(),
+        new Date().toISOString(),
       );
     }
   };

--- a/packages/facility-server/app/tasks/RefreshMaterializedView.js
+++ b/packages/facility-server/app/tasks/RefreshMaterializedView.js
@@ -8,6 +8,7 @@ import {
   NOTIFY_CHANNELS,
 } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
+import { getCurrentISO8601DateString } from '@tamanu/shared/utils/dateTime';
 
 const buildRefreshMaterializedViewTask = viewName =>
   class RefreshMaterializedView extends ScheduledTask {
@@ -38,7 +39,7 @@ const buildRefreshMaterializedViewTask = viewName =>
       });
       await this.models.LocalSystemFact.set(
         `${MATERIALIZED_VIEW_LAST_REFRESHED_AT_KEY_NAMESPACE}:${this.viewName}`,
-        new Date().toISOString(),
+        getCurrentISO8601DateString(),
       );
     }
   };

--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -80,6 +80,10 @@ export function getCurrentDateString() {
   return formatISO9075(new Date(), { representation: 'date' });
 }
 
+export function getCurrentISODateString() {
+  return new Date().toISOString();
+}
+
 export function convertISO9075toRFC3339(dateString) {
   // parseISO does not support null values
   const parsedDate = dateString === null ? new Date() : parseISO(dateString);

--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -80,7 +80,8 @@ export function getCurrentDateString() {
   return formatISO9075(new Date(), { representation: 'date' });
 }
 
-export function getCurrentISODateString() {
+// Don't use this function when using a datestring or datetimestring column
+export function getCurrentISO8601DateString() {
   return new Date().toISOString();
 }
 

--- a/packages/web/app/components/Table/UpdateStatsDisplay.jsx
+++ b/packages/web/app/components/Table/UpdateStatsDisplay.jsx
@@ -5,7 +5,7 @@ import { TranslatedText } from '../Translation';
 import styled from 'styled-components';
 import { Colors } from '../../constants';
 import { useParsedCronExpression } from '../../utils/useParsedCronExpression';
-import { formatDistanceToNow, parseISO } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns';
 import { useTranslation } from '../../contexts/Translation';
 
 const SmallText = styled(BodyText)`
@@ -37,7 +37,7 @@ export const UpdateStatsDisplay = ({
 
   const dateAsDistanceToNow = useCallback(
     date =>
-      formatDistanceToNow(parseISO(date), {
+      formatDistanceToNow(new Date(date), {
         addSuffix: getTranslation('schedule.distanceFromNow.suffix', 'ago'),
       }),
     [getTranslation],


### PR DESCRIPTION
### Changes

Treatment of dates for relative to now date display needs to just use new date iso string. Then displays correctly no matter the orientation of server timezone and clients timezone.

Just fixing sum wackyness with test
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
