### PR TITLE
fix: release 2.10: Fix display of planned move translated reference data for triage

### DIFF
--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -106,7 +106,9 @@ triage.get(
           location_group.name AS location_group_name,
           complaint.name AS chief_complaint,
           planned_location_group.name AS planned_location_group_name,
-          planned_location.name AS planned_location_name
+          planned_location.name AS planned_location_name,
+          planned_location.id AS planned_location_id,
+          planned_location_group.id AS planned_location_group_id
         FROM triages
           LEFT JOIN encounters
            ON (encounters.id = triages.encounter_id)
@@ -127,7 +129,7 @@ triage.get(
           AND location.facility_id = :facility
           AND encounters.encounter_type IN (:triageEncounterTypes)
           AND encounters.deleted_at is null
-        ORDER BY encounter_type IN (:seenEncounterTypes) ASC, ${sortKey} ${sortDirection} NULLS LAST, Coalesce(arrival_time,triage_time) ASC 
+        ORDER BY encounter_type IN (:seenEncounterTypes) ASC, ${sortKey} ${sortDirection} NULLS LAST, Coalesce(arrival_time,triage_time) ASC
       `,
       {
         model: Triage,


### PR DESCRIPTION
Fix display of planned move translated reference data for triage

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
