### PR TITLE
fix(mobile): release fix v2.10: Fix patient details heading

### DIFF
--- a/packages/mobile/App/ui/components/StackHeader/index.tsx
+++ b/packages/mobile/App/ui/components/StackHeader/index.tsx
@@ -13,8 +13,8 @@ import { ArrowLeftIcon, KebabIcon } from '../Icons';
 import { Orientation, screenPercentageToDP } from '/helpers/screen';
 
 type HeaderTitleProps = {
-  title: string;
-  subtitle: string;
+  title: Element;
+  subtitle: Element;
 };
 
 const HeaderTitle = ({ subtitle, title }: HeaderTitleProps): ReactElement => (
@@ -29,8 +29,8 @@ const HeaderTitle = ({ subtitle, title }: HeaderTitleProps): ReactElement => (
 );
 
 type StackHeaderProps = {
-  title: string;
-  subtitle: string;
+  title: Element;
+  subtitle: Element;
   onGoBack: () => void;
   onRightSideIconTap?: () => void;
 };

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/LocalisedPatientDetailsLayout.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/LocalisedPatientDetailsLayout.tsx
@@ -10,6 +10,10 @@ const CUSTOM_PATIENT_DETAIL_LAYOUTS = {
   CAMBODIA: 'cambodia',
 };
 
+
+// This is a temporary hard-coded implementation of the alternative cambodia patient details form. Ideally this would
+// be more configurable/dynamically generated. For now now bug fixes/changes within GenericPatientDetails also
+// need to be applied to CambodiaPatientDetails
 export const LocalisedPatientDetailsLayout = ({ patient, navigation }) => {
   const { getLocalisation } = useLocalisation();
   const layout = getLocalisation('layouts.patientDetails');

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/cambodia/EditGeneralInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/cambodia/EditGeneralInfo.tsx
@@ -90,7 +90,13 @@ export const EditPatientScreen = ({ route, isEdit = true }): ReactElement => {
     <FullView background={theme.colors.BACKGROUND_GREY}>
       <StatusBar barStyle="light-content" />
       <StackHeader
-        title={`${isEdit ? 'Edit' : 'New'} Patient`}
+        title={
+          isEdit ? (
+            <TranslatedText stringId="patient.details.action.edit" fallback="Edit Patient" />
+          ) : (
+            <TranslatedText stringId="patient.register.title" fallback="Register New Patient" />
+          )
+        }
         subtitle={route?.params?.patientName}
         onGoBack={onGoBack}
       />

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditGeneralInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditGeneralInfo.tsx
@@ -10,6 +10,7 @@ import { KeyInformationSection } from '~/ui/components/Forms/NewPatientForm/Pati
 import { LocationDetailsSection } from '~/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection';
 import { PatientAdditionalDataFields } from '~/ui/components/Forms/PatientAdditionalDataForm/PatientAdditionalDataFields';
 import { ALL_ADDITIONAL_DATA_FIELDS } from '~/ui/helpers/additionalData';
+import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
 
 export const EditPatientScreen = ({ route, isEdit = true }): ReactElement => {
   const navigation = useNavigation();
@@ -21,7 +22,13 @@ export const EditPatientScreen = ({ route, isEdit = true }): ReactElement => {
     <FullView background={theme.colors.BACKGROUND_GREY}>
       <StatusBar barStyle="light-content" />
       <StackHeader
-        title={`${isEdit ? 'Edit' : 'New'} Patient`}
+        title={
+          isEdit ? (
+            <TranslatedText stringId="patient.details.action.edit" fallback="Edit Patient" />
+          ) : (
+            <TranslatedText stringId="patient.register.title" fallback="Register New Patient" />
+          )
+        }
         subtitle={route?.params?.patientName}
         onGoBack={onGoBack}
       />


### PR DESCRIPTION
### Changes

When refactoring patient details for cambodia mode I accidentally introduced a change in the text for the new patient form. I have not correctly assigned the appropriate translated text string.

This is a great example of why i was hesitant to implement the cambodia patient details in this way. I had to make the same change in two places so hopefully we dont run into bugs in the future from these diverging files. In this pr i also added a comment to LocalisedPatientDetailsLayout to explain why it is like this as I imagine this will be a bit shocking for someone coming across it. Am also going to add this to the maintanence sprint so it hopefully gets resolved sooner rather than later

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
