### PR TITLE
fix: release 2.10: Mobile vaccination status when weeksFromBirthDue is 0

### DIFF
--- a/packages/mobile/App/ui/helpers/getVaccineStatus.ts
+++ b/packages/mobile/App/ui/helpers/getVaccineStatus.ts
@@ -56,14 +56,15 @@ const getDaysUntilDue = (
 ) => {
   const { weeksFromBirthDue, weeksFromLastVaccinationDue } = scheduledVaccine;
   const { dateOfBirth } = patient;
-  const weeksFromDue = weeksFromBirthDue || weeksFromLastVaccinationDue;
-  const baselineDate = weeksFromBirthDue ? dateOfBirth : lastDose?.date;
+  const hasWeeksFromBirthDue = Number.isInteger(weeksFromBirthDue);
+  const weeksFromDue = hasWeeksFromBirthDue ? weeksFromBirthDue : weeksFromLastVaccinationDue;
+  const baselineDate = hasWeeksFromBirthDue ? dateOfBirth : lastDose?.date;
   return weeksFromDue * 7 - differenceInDays(new Date(), parseISO(baselineDate));
 };
 
 export const getLastDose = ({ scheduledVaccine, patientAdministeredVaccines }: VaccineData) => {
   const { vaccine, index, weeksFromLastVaccinationDue } = scheduledVaccine;
-  if (!weeksFromLastVaccinationDue) return null;
+  if (!Number.isInteger(weeksFromLastVaccinationDue)) return null;
   return patientAdministeredVaccines?.find(administeredVaccine => {
     const scheduledVaccine = administeredVaccine.scheduledVaccine as IScheduledVaccine;
     return scheduledVaccine.index === index - 1 && scheduledVaccine.vaccine.id === vaccine.id;


### PR DESCRIPTION
### Changes

This is a classic
When it was set to 0 (birth) it failed to show correct status
Now it checks integer in all cases when checking value for truthyness

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
