### PR TITLE
fix(web): SAV-731: Wrong cancellation note coming through

### DIFF
--- a/packages/shared/src/utils/notes.js
+++ b/packages/shared/src/utils/notes.js
@@ -5,11 +5,7 @@ notes: Array<SequelizeModel>
 noteType: string
 */
 export const getNoteWithType = (notes, noteType) => {
-  return getNotesWithType(notes, noteType)
-    .reduce(
-      (latest, note) => note.date > latest.date ? note : latest,
-      notes[0],
-    );
+  return getNotesWithType(notes, noteType)[0];
 };
 
 /*

--- a/packages/shared/src/utils/notes.js
+++ b/packages/shared/src/utils/notes.js
@@ -5,7 +5,11 @@ notes: Array<SequelizeModel>
 noteType: string
 */
 export const getNoteWithType = (notes, noteType) => {
-  return getNotesWithType(notes, noteType)[0];
+  return getNotesWithType(notes, noteType)
+    .reduce(
+      (latest, note) => note.date > latest.date ? note : latest,
+      notes[0],
+    );
 };
 
 /*

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import { pick } from 'lodash';
 import styled from 'styled-components';
 
-import { IMAGING_REQUEST_STATUS_TYPES, LAB_REQUEST_STATUS_CONFIG } from '@tamanu/constants';
+import { IMAGING_REQUEST_STATUS_TYPES, LAB_REQUEST_STATUS_CONFIG, NOTE_TYPES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
 
 import { IMAGING_REQUEST_STATUS_OPTIONS } from '../../../constants';
@@ -101,9 +101,9 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
       <TextInput
         multiline
         value={imagingRequest.notes
-          ?.filter(note => note.noteType === 'OTHER')
+          ?.filter(note => note.noteType === NOTE_TYPES.OTHER)
           .map(note => note.content)
-          .join(', ')}
+          .join('\n')}
         label="Notes"
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -100,7 +100,10 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
       />
       <TextInput
         multiline
-        value={imagingRequest.note}
+        value={imagingRequest.notes
+          ?.filter(note => note.noteType === 'OTHER')
+          .map(note => note.content)
+          .join(', ')}
         label="Notes"
         style={{ gridColumn: '1 / -1', minHeight: '60px' }}
         disabled


### PR DESCRIPTION
### Changes

https://linear.app/bes/issue/SAV-731/cancellation-note-is-not-coming-through-for-imagingstudy

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
