### PR TITLE
fix(patientDetails): TAMOC-207:  displayId validating against regex when value is unchanged on patient edit

### DIFF
--- a/packages/web/app/components/Field/DisplayIdField.jsx
+++ b/packages/web/app/components/Field/DisplayIdField.jsx
@@ -5,13 +5,15 @@ import { TextField } from './TextField';
 import { LocalisedField } from './LocalisedField';
 import { useTranslation } from '../../contexts/Translation';
 
-const useDisplayIdValidation = label => {
+const useDisplayIdValidation = (label, fieldName = 'displayId') => {
   const { initialValues } = useFormikContext();
   const { getLocalisation } = useLocalisation();
-  const pattern = getLocalisation('fields.displayId.pattern') || null;
+  const pattern = getLocalisation('fields.displayId.pattern');
   const regex = pattern ? new RegExp(pattern) : null;
   return value =>
-    value !== initialValues[name] && regex && !regex.test(value) ? `Invalid ${label}` : undefined;
+    value !== initialValues[fieldName] && regex && !regex.test(value)
+      ? `Invalid ${label}`
+      : undefined;
 };
 
 export const DisplayIdField = ({ required }) => {


### PR DESCRIPTION
### Changes

`name` variable was referencing a global - see how before it wasn't in scope at all
Restore the skipping of validation against regex pattern when prevValue === newValue on patient details edit submittion

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
