### PR TITLE
chore(mobile): Add local dev option to server select with special alias 10.0.2.2 to localhost 

### DIFF
--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -40,7 +40,7 @@ const fetchServers = async (): Promise<SelectOption[]> => {
     // If dev mode, add a local server option using special alias to localhost
     options.unshift({
       label: 'Local central server (port 3000)',
-      value: 'http://10.2.2.0:3000',
+      value: 'http://10.0.2.2:3000',
     });
   }
 

--- a/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
+++ b/packages/mobile/App/ui/components/ServerSelectorField/ServerSelector.tsx
@@ -31,10 +31,20 @@ const fetchServers = async (): Promise<SelectOption[]> => {
   const response = await fetch(`${metaServer}/servers`);
   const servers: Server[] = await response.json();
 
-  return servers.map(s => ({
+  const options = servers.map(s => ({
     label: s.name,
     value: s.host,
   }));
+
+  if (__DEV__) {
+    // If dev mode, add a local server option using special alias to localhost
+    options.unshift({
+      label: 'Local central server (port 3000)',
+      value: 'http://10.2.2.0:3000',
+    });
+  }
+
+  return options;
 };
 
 export const ServerSelector = ({ onChange, label, value, error }): ReactElement => {


### PR DESCRIPTION
### Changes

We could also do this using like a local server override or something - but this was the best way I thought to add the local host server at the start of a __DEV__ run.

I havnt thought much on this since I made up this draft, but I use this IP to save time in dev myself using a stashed server overrides file. 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
