### PR TITLE
fix(postMigration): VIT-227: error creating trigger name longer than 64 chars

### DIFF
--- a/packages/shared/src/services/migrations/runPostMigration.js
+++ b/packages/shared/src/services/migrations/runPostMigration.js
@@ -44,7 +44,7 @@ const TABLES_WITHOUT_TRIGGER_QUERY = `
       FROM
         pg_trigger p
       WHERE
-        p.tgname = concat('set_', lower(t.table_name), '_updated_at_sync_tick')
+        p.tgname = substring(concat('set_', lower(t.table_name), '_updated_at_sync_tick'), 0, 64)
     )
   AND
     privileges.privilege_type = 'TRIGGER'


### PR DESCRIPTION
Fix a long-standing error:
`ERROR: trigger "set_patient_program_registration_conditions_updated_at_sync_tic" for relation "patient_program_registration_conditions" already exists`
This happens because PostgreSQL's maximum identifier length is 63 bytes, which equals 64 characters. The identifier `set_patient_program_registration_conditions_updated_at_sync_tick` exceeds this limit and is automatically truncated to `set_patient_program_registration_conditions_updated_at_sync_tic`. As a result, the table is falsely detected as not having a trigger, leading to re-creation of the trigger and causing the error.