### PR TITLE
refactor(translations): NASS-1228:  Mobile + Web translations logic consistency

### DIFF
--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -21,13 +21,20 @@ export const TranslatedText = ({
   fallback,
   replacements,
   uppercase = false,
+  lowercase = false,
 }: TranslatedTextProps): ReactElement => {
   const { debugMode, getTranslation } = useTranslation();
   const translation = useMemo(
-    () => getTranslation(stringId, fallback?.split('\\n').join('\n'), replacements, uppercase),
-    [getTranslation, stringId, fallback, replacements, uppercase],
+    () =>
+      getTranslation(
+        stringId,
+        fallback?.split('\\n').join('\n'),
+        replacements,
+        uppercase,
+        lowercase,
+      ),
+    [getTranslation, stringId, fallback, replacements, uppercase, lowercase],
   );
-  // const translation = getTranslation(stringId, fallback, replacements);
 
   const isDebugMode = __DEV__ && debugMode;
 

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import styled from 'styled-components';
 import { StyledText } from '~/ui/styled/common';
 import { TranslatedTextProps, useTranslation } from '~/ui/contexts/TranslationContext';
@@ -23,13 +23,13 @@ export const TranslatedText = ({
   uppercase = false,
 }: TranslatedTextProps): ReactElement => {
   const { debugMode, getTranslation } = useTranslation();
-  const translation = getTranslation(stringId, fallback, replacements);
+  const translation = useMemo(
+    () => getTranslation(stringId, fallback?.split('\\n').join('\n'), replacements, uppercase),
+    [getTranslation, stringId, fallback, replacements, uppercase],
+  );
+  // const translation = getTranslation(stringId, fallback, replacements);
 
   const isDebugMode = __DEV__ && debugMode;
 
-  return (
-    <TextWrapper $isDebugMode={isDebugMode}>
-      {uppercase ? translation.toUpperCase() : translation}
-    </TextWrapper>
-  );
+  return <TextWrapper $isDebugMode={isDebugMode}>{translation}</TextWrapper>;
 };

--- a/packages/shared/src/utils/translation/translationFactory.js
+++ b/packages/shared/src/utils/translation/translationFactory.js
@@ -52,12 +52,9 @@ export const translationFactory = translations => (
   };
   if (!translations)
     return { value: replaceStringVariables(fallback, replacementConfig, translations) };
+  const translation = translations[stringId] ?? fallback;
   return {
-    value: replaceStringVariables(
-      translations[stringId] ?? fallback,
-      replacementConfig,
-      translations,
-    ),
+    value: replaceStringVariables(translation, replacementConfig, translations),
     notExisting: !translations[stringId],
   };
 };


### PR DESCRIPTION
### Changes

The main comment on the ticket was that replacements for translations in mobile were handled in the component, but it seems like it has already been moved to the mobile translation, so what I have done is refactor the replacements logic with the replacementsConfig stuff from desktop so that setting uppercase is handled there rather than the component.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
