### PR TITLE
fix(web): release 2.11, locale sort of imaging types

### DIFF
--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -18,10 +18,10 @@ import {
   Field,
   Form,
   ImagingPriorityField,
+  MultiselectField,
   SelectField,
   TextField,
   TextInput,
-  MultiselectField,
 } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { FormCancelButton } from '../components/Button';
@@ -29,8 +29,9 @@ import { ButtonRow } from '../components/ButtonRow';
 import { DateDisplay } from '../components/DateDisplay';
 import { FormSeparatorLine } from '../components/FormSeparatorLine';
 import { FormSubmitDropdownButton } from '../components/DropdownButton';
-import { TranslatedText, TranslatedReferenceData } from '../components/Translation';
+import { TranslatedReferenceData, TranslatedText } from '../components/Translation';
 import { useTranslation } from '../contexts/Translation';
+import { renderToText } from '../utils';
 
 function getEncounterTypeLabel(type) {
   return ENCOUNTER_OPTIONS.find(x => x.value === type).label;
@@ -212,13 +213,18 @@ export const ImagingRequestForm = React.memo(
                 options={imagingTypeOptions}
                 prefix="imaging.property.type"
               />
-              {imagingAreas.length ? (
+              {imagingAreas.length > 0 ? (
                 <Field
-                  options={imagingAreas.map(area => ({
-                    label: <TranslatedReferenceData fallback={area.name} value={area.id} category={area.type} />,
-                    value: area.id,
-                  })).sort((area1, area2) => area1.label.localeCompare(area2.label))
-                  }
+                  options={imagingAreas
+                    .map(({ id, name, type }) => ({
+                      label: <TranslatedReferenceData fallback={name} value={id} category={type} />,
+                      value: id,
+                    }))
+                    .sort((area1, area2) => {
+                      const str1 = renderToText(area1.label);
+                      const str2 = renderToText(area2.label);
+                      return str1.localeCompare(str2);
+                    })}
                   name="areas"
                   label={
                     <TranslatedText stringId="imaging.areas.label" fallback="Areas to be imaged" />

--- a/packages/web/app/utils/utils.jsx
+++ b/packages/web/app/utils/utils.jsx
@@ -1,4 +1,6 @@
 import React, { isValidElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import { each, isArray, toString } from 'lodash';
 import { toast } from 'react-toastify';
 import deepEqual from 'deep-equal';
@@ -19,9 +21,7 @@ export const prepareToastMessage = msg => {
   return (
     <>
       {messages.map(text => (
-        <div key={`err-msg-${text}`}>
-          {isValidElement(text) ? text : toString(text)}
-        </div>
+        <div key={`err-msg-${text}`}>{isValidElement(text) ? text : toString(text)}</div>
       ))}
     </>
   );
@@ -90,4 +90,19 @@ export const hexToRgba = (hex, opacity) => {
   const g = parseInt(hx.substring(2, 4), 16);
   const b = parseInt(hx.substring(4, 6), 16);
   return `rgba(${r},${g},${b},${opacity})`;
+};
+
+export const renderToText = element => {
+  if (!isValidElement(element)) {
+    throw new Error('`renderToString` has been called with an invalid element.');
+  }
+
+  const div = document.createElement('div');
+  const root = createRoot(div);
+  flushSync(() => {
+    root.render(element); // Force DOM update before reading innerText
+  });
+  const renderedString = div.innerText;
+  root.unmount();
+  return renderedString;
 };

--- a/packages/web/app/utils/utils.jsx
+++ b/packages/web/app/utils/utils.jsx
@@ -94,7 +94,7 @@ export const hexToRgba = (hex, opacity) => {
 
 export const renderToText = element => {
   if (!isValidElement(element)) {
-    throw new Error('`renderToString` has been called with an invalid element.');
+    throw new Error('`renderToText` has been called with an invalid element.');
   }
 
   const div = document.createElement('div');


### PR DESCRIPTION
### Changes

React components can’t be compared with `localCompare()`, which makes it unusable on `<TranslatedText>` and its derivatives. This PR renders it into a primitive string for sorting.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
