### PR TITLE
fix(mobile): TAMOC-211: User proper keys

### DIFF
--- a/packages/mobile/App/types/MenuOptionButtonProps.ts
+++ b/packages/mobile/App/types/MenuOptionButtonProps.ts
@@ -3,6 +3,7 @@ import { IconWithSizeProps } from '~/ui/interfaces/WithSizeProps';
 
 export interface MenuOptionButtonProps {
   Icon?: FC<IconWithSizeProps>;
+  key: string;
   title: string;
   onPress: () => void;
   fontWeight?: number;

--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/PatientHome/CustomComponents/PatientMenuButtons.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/PatientHome/CustomComponents/PatientMenuButtons.tsx
@@ -16,7 +16,7 @@ export const PatientMenuButtons = ({ list }: PatientMenuListProps): ReactElement
       scrollEnabled={false}
       showsVerticalScrollIndicator={false}
       data={list}
-      keyExtractor={(item): string => item.title}
+      keyExtractor={(item): string => item.key}
       renderItem={({ item }): ReactElement => <MenuOptionButton {...item} />}
       ItemSeparatorComponent={Separator}
     />

--- a/packages/mobile/App/ui/navigation/screens/home/Tabs/PatientHome/CustomComponents/VisitTypeButtonList.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/Tabs/PatientHome/CustomComponents/VisitTypeButtonList.tsx
@@ -31,7 +31,7 @@ export const VisitTypeButtonList = ({ list }: VisitTypeButtonsProps): ReactEleme
       {
         <StyledRowView>
           {list.map(buttonProps => (
-            <MenuButtonContainer key={buttonProps.title}>
+            <MenuButtonContainer key={buttonProps.key}>
               <PatientMenuButton {...buttonProps} />
             </MenuButtonContainer>
           ))}


### PR DESCRIPTION
### Changes

Previously we used the title prop as react render keys... for some reason. Given that we recently added translations, title is now and object, which serialized becomes [object Object] and makes react think all are the same. With this shift, we have non repeated keys, which should improve performance and it's the proper way

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->