### PR TITLE
fix(mobile): release 2.11: Mobile patient details form broken

### DIFF
--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
@@ -79,13 +79,15 @@ export const PatientAdditionalDataForm = ({
   );
 
   // Get the field group for this section of the additional data template
-  const { fields, dataFields } = isCustomSection
-    ? customSectionFields.map(({ id, name, fieldType, options }) => ({
-        id,
-        name,
-        fieldType,
-        options,
-      }))
+  const { fields, dataFields = null } = isCustomSection
+    ? {
+        fields: customSectionFields.map(({ id, name, fieldType, options }) => ({
+          id,
+          name,
+          fieldType,
+          options,
+        })),
+      }
     : additionalDataSections.find(({ sectionKey: key }) => key === sectionKey);
   const initialAdditionalData = getInitialAdditionalValues(additionalData, dataFields || fields);
   const initialCustomValues = getInitialCustomValues(customPatientFieldValues, fields);

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/index.tsx
@@ -18,7 +18,6 @@ import { PatientFieldDefinition } from '~/models/PatientFieldDefinition';
 import { CustomPatientFieldValues } from '~/ui/hooks/usePatientAdditionalData';
 import { NavigationProp } from '@react-navigation/native';
 
-// TODO: type and work out customSectionFields and additionalDataSections
 interface PatientAdditionalDataFormProps {
   patient: Patient;
   additionalData: PatientAdditionalData;
@@ -28,6 +27,7 @@ interface PatientAdditionalDataFormProps {
   customPatientFieldValues: CustomPatientFieldValues;
   isCustomSection?: boolean;
   customSectionFields?: any[];
+  sectionKey: Element;
 }
 
 export const PatientAdditionalDataForm = ({
@@ -79,15 +79,14 @@ export const PatientAdditionalDataForm = ({
   );
 
   // Get the field group for this section of the additional data template
-  const { fields, dataFields } = isCustomSection ? customSectionFields.map(({ id, name, fieldType, options }) => ({
-    id,
-    name,
-    fieldType,
-    options,
-  }))
-: additionalDataSections.find(
-    ({ sectionKey: key }) => key === sectionKey,
-  );
+  const { fields, dataFields } = isCustomSection
+    ? customSectionFields.map(({ id, name, fieldType, options }) => ({
+        id,
+        name,
+        fieldType,
+        options,
+      }))
+    : additionalDataSections.find(({ sectionKey: key }) => key === sectionKey);
   const initialAdditionalData = getInitialAdditionalValues(additionalData, dataFields || fields);
   const initialCustomValues = getInitialCustomValues(customPatientFieldValues, fields);
 

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/CustomComponents/AdditionalInfo.tsx
@@ -85,7 +85,7 @@ export const AdditionalInfo = ({
 
   const customSections = customPatientSections.map(([_categoryId, fields]) => {
     const title = fields[0].category.name;
-    const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues);
+    const onEditCallback = (): void => onEdit(null, title, true, fields, customPatientFieldValues, null);
     const mappedFields = fields.map(field => {
       const { id, name } = field;
       const [customFieldValue] = customPatientFieldValues[id] || [];

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditAdditionalInfo.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/EditAdditionalInfo.tsx
@@ -17,6 +17,7 @@ export const EditPatientAdditionalDataScreen = ({ navigation, route }): ReactEle
     isCustomSection,
     customSectionFields,
     customPatientFieldValues,
+    sectionKey,
   } = route.params;
   // additionalDataJSON might be undefined if record doesn't exist,
   // JSON.parse will break if it doesn't get a JSON object
@@ -46,6 +47,7 @@ export const EditPatientAdditionalDataScreen = ({ navigation, route }): ReactEle
         additionalDataSections={GENERIC_ADDITIONAL_DATA_SECTIONS}
         navigation={navigation}
         sectionTitle={sectionTitle}
+        sectionKey={sectionKey}
         customSectionFields={customSectionFields}
         isCustomSection={isCustomSection}
         customPatientFieldValues={customPatientFieldValues}

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/PatientDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/PatientDetails.tsx
@@ -19,6 +19,7 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
       isCustomSection,
       customSectionFields,
       customPatientFieldValues,
+      sectionKey
     ) => {
       navigation.navigate(Routes.HomeStack.PatientDetailsStack.Generic.EditPatientAdditionalData, {
         patientName: joinNames(patient),
@@ -28,6 +29,7 @@ export const PatientDetails = ({ patient, navigation }): ReactElement => {
         isCustomSection,
         customSectionFields,
         customPatientFieldValues,
+        sectionKey
       });
     },
     [navigation, patient],

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/fields.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/fields.tsx
@@ -40,7 +40,6 @@ const GENERIC_ADDITIONAL_DATA_FIELDS = {
   ],
 };
 
-// TODO: add scetion keys + datafields (omg) to all of these
 export const GENERIC_ADDITIONAL_DATA_SECTIONS = [
   {
     sectionKey: 'identificationInformation',

--- a/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/fields.tsx
+++ b/packages/mobile/App/ui/navigation/screens/home/PatientDetails/layouts/generic/fields.tsx
@@ -40,8 +40,10 @@ const GENERIC_ADDITIONAL_DATA_FIELDS = {
   ],
 };
 
+// TODO: add scetion keys + datafields (omg) to all of these
 export const GENERIC_ADDITIONAL_DATA_SECTIONS = [
   {
+    sectionKey: 'identificationInformation',
     title: (
       <TranslatedText
         stringId="patient.details.subheading.identificationInformation"
@@ -51,6 +53,7 @@ export const GENERIC_ADDITIONAL_DATA_SECTIONS = [
     fields: GENERIC_ADDITIONAL_DATA_FIELDS.IDENTIFICATION,
   },
   {
+    sectionKey: 'contactInformation',
     title: (
       <TranslatedText
         stringId="patient.details.subheading.contactInformation"
@@ -60,6 +63,7 @@ export const GENERIC_ADDITIONAL_DATA_SECTIONS = [
     fields: GENERIC_ADDITIONAL_DATA_FIELDS.CONTACT,
   },
   {
+    sectionKey: 'personalInformation',
     title: (
       <TranslatedText
         stringId="patient.details.subheading.personalInformation"
@@ -69,6 +73,7 @@ export const GENERIC_ADDITIONAL_DATA_SECTIONS = [
     fields: GENERIC_ADDITIONAL_DATA_FIELDS.PERSONAL,
   },
   {
+    sectionKey: 'otherInformation',
     title: (
       <TranslatedText
         stringId="patient.details.subheading.otherInformation"


### PR DESCRIPTION
### Changes

We made a tweak (adding a section key for comparison logic now that the title is translated) to the Cambodia patient details layout on mobile that we didn't carry over to the generic layout. This bug is a result of that.

This is another example of why i was somewhat opposed to this design/hack for the "cambodia" patient details as it is very bug prone.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
