### PR TITLE
fix(translations): NASS-1295: fallback when replacement is loading

### DIFF
--- a/packages/web/app/components/DocumentPreview/DocumentPreviewModal.jsx
+++ b/packages/web/app/components/DocumentPreview/DocumentPreviewModal.jsx
@@ -52,7 +52,7 @@ const Preview = ({ documentType, attachmentId, ...props }) => {
 
 export const DocumentPreviewModal = ({ open, onClose, document = {} }) => {
   const [scrollPage, setScrollPage] = useState(1);
-  const [pageCount, setPageCount] = useState();
+  const [pageCount, setPageCount] = useState(0);
   const { onDownload, onPrintPDF } = useDocumentActions();
 
   const { type: documentType, attachmentId } = document;
@@ -72,7 +72,7 @@ export const DocumentPreviewModal = ({ open, onClose, document = {} }) => {
                 fallback="Page :scrollPage of :pageCount"
                 replacements={{
                   scrollPage,
-                  pageCount,
+                  pageCount: pageCount || '‒', // figure dash
                 }}
               />
             ) : null}

--- a/packages/web/app/components/DocumentPreview/DocumentPreviewModal.jsx
+++ b/packages/web/app/components/DocumentPreview/DocumentPreviewModal.jsx
@@ -52,7 +52,7 @@ const Preview = ({ documentType, attachmentId, ...props }) => {
 
 export const DocumentPreviewModal = ({ open, onClose, document = {} }) => {
   const [scrollPage, setScrollPage] = useState(1);
-  const [pageCount, setPageCount] = useState(0);
+  const [pageCount, setPageCount] = useState(null);
   const { onDownload, onPrintPDF } = useDocumentActions();
 
   const { type: documentType, attachmentId } = document;
@@ -72,7 +72,7 @@ export const DocumentPreviewModal = ({ open, onClose, document = {} }) => {
                 fallback="Page :scrollPage of :pageCount"
                 replacements={{
                   scrollPage,
-                  pageCount: pageCount || '‒', // figure dash
+                  pageCount: pageCount ?? '‒', // figure dash
                 }}
               />
             ) : null}


### PR DESCRIPTION
### Changes

Now falls back to the figure dash ( ‒ ) when the total page count is still loading.

Does **not** fix the current page number not updating. There’s some existing logic there, which doesn’t seem to be working on my system, but I didn’t want to mess with it. Figured it probably deserves its own card.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
