### PR TITLE
fix(facility): release fix 2.11: Error codes instead of server message

### DIFF
--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -159,7 +159,7 @@ export class TamanuApi {
         responseInterceptorChain[j++],
       );
     }
-    await responsePromise;
+    await responsePromise.catch(() => {});
 
     if (response.ok) {
       if (returnResponse) {


### PR DESCRIPTION
### Changes

In the khmer certificate font pr, I introduced some interceptor promise logic to the TamanuApi. This resulted in server errors coming through as just codes rather that the full server error string. Here's the pr for fixing it

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
