### PR TITLE
fix(translation): NASS-1284: Mobile context behaving unpredictably

### DIFF
--- a/packages/mobile/App/ui/components/Forms/SignInForm.tsx
+++ b/packages/mobile/App/ui/components/Forms/SignInForm.tsx
@@ -47,7 +47,7 @@ export const SignInForm: FunctionComponent<any> = ({ onError, onSuccess }) => {
   const [existingHost, setExistingHost] = useState('');
   const passwordRef = useRef(null);
   const { signIn } = useAuth();
-  const { getTranslation, refreshTranslations } = useTranslation();
+  const { getTranslation } = useTranslation();
 
   const handleSignIn = useCallback(
     async (values: SignInFormModelValues) => {
@@ -58,7 +58,6 @@ export const SignInForm: FunctionComponent<any> = ({ onError, onSuccess }) => {
           return;
         }
         await signIn(values);
-        refreshTranslations();
 
         onSuccess();
       } catch (error) {

--- a/packages/mobile/App/ui/contexts/TranslationContext.tsx
+++ b/packages/mobile/App/ui/contexts/TranslationContext.tsx
@@ -34,7 +34,6 @@ interface TranslationContextData {
   setLanguageOptions: (languageOptions: []) => void;
   getTranslation: GetTranslationFunction;
   setLanguage: (language: string) => void;
-  refreshTranslations: () => void;
   host: string;
   setHost: (host: string) => void;
 }
@@ -96,10 +95,6 @@ export const TranslationProvider = ({ children }: PropsWithChildren<object>): Re
     return replaceStringVariables(translation, replacements, translations);
   };
 
-  const refreshTranslations = async () => {
-    setLanguageState(language);
-  };
-
   const writeLanguage = async (languageCode: string) => {
     await writeConfig('language', languageCode);
   };
@@ -132,7 +127,6 @@ export const TranslationProvider = ({ children }: PropsWithChildren<object>): Re
         setLanguageOptions,
         getTranslation,
         setLanguage,
-        refreshTranslations,
         host,
         setHost,
       }}


### PR DESCRIPTION
### Changes

It seems that refresh translations is interferring with the built in useEffect that ensures the language state is up to date with the selected language. Im not totally sure why this was added so am going to check with Daniel who added it first in the yup pr.

I discovered through testing that it seems to work as expected without this.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
