### PR TITLE
config(syncServer): default to port 4001

### DIFF
--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -30,7 +30,7 @@
     "timeout": 10000,
     "syncApiConnection": {
       "host": "http://localhost",
-      "port": 5000,
+      "port": 4001,
     },
     "persistedCacheBatchSize": 10000,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,


### PR DESCRIPTION
### Changes

macOS uses port 5000 (and, less relevantly, 7000) for system features. Given the number of devs using macOS, perhaps changing the default makes sense?

Suggesting 4001 here only because API server defaults to 4000

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->