### PR TITLE
fix(admin): release 2.11: Use survey code instead of name for sheet name when exporting program

### DIFF
--- a/packages/central-server/app/admin/programExporter/exportProgram.js
+++ b/packages/central-server/app/admin/programExporter/exportProgram.js
@@ -79,7 +79,7 @@ export async function exportProgram(context, programId) {
       );
 
       surveySheets.push({
-        name: survey.name.replace(`(${country}) `, ''),
+        name: survey.code,
         data: [
           [
             'code',


### PR DESCRIPTION
### Changes

When export a program, currently we are exporting the surveys to each sheets, and the sheet name is the survey name. But the survey name isn't unique and the length of it may be greater than 31 characters then it may cause some errors. This pr is for fixing it, we will use survey code at sheet name instead name

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
