### PR TITLE
fix(vaccines): SAV-768: Given elsewhere reset when changing vaccine name HOTFIX 2.11

### DIFF
--- a/packages/web/app/forms/VaccineForm.jsx
+++ b/packages/web/app/forms/VaccineForm.jsx
@@ -203,7 +203,6 @@ export const VaccineForm = ({
 
   return (
     <Form
-      enableReinitialize
       onSubmit={async data => onSubmit({ ...data, category })}
       showInlineErrorsOnly
       initialValues={initialValues}


### PR DESCRIPTION
### Changes
- Given elsewhere reset when changing vaccine name

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
