### PR TITLE
tweak(mobile): SAV-771: Misc fixes

### DIFF
--- a/packages/mobile/App/migrations/1686083400000-addSpecimenTypeAndCollectedByToLabRequest.ts
+++ b/packages/mobile/App/migrations/1686083400000-addSpecimenTypeAndCollectedByToLabRequest.ts
@@ -57,6 +57,6 @@ export class addSpecimenTypeAndCollectedByToLabRequest1686083400000 implements M
       fk => fk.columnNames.indexOf(collectedByIdColumn) !== 0,
     );
     await queryRunner.dropForeignKey(labRequestTable, collectedByFK);
-    await queryRunner.dropColumn(labRequestTable, collectedByFK);
+    await queryRunner.dropColumn(labRequestTable, collectedByIdColumn);
   }
 }

--- a/packages/mobile/App/models/modelsMap.ts
+++ b/packages/mobile/App/models/modelsMap.ts
@@ -34,7 +34,6 @@ import { Facility } from './Facility';
 import { Department } from './Department';
 import { Location } from './Location';
 import { LocationGroup } from './LocationGroup';
-import { BaseModel } from './BaseModel';
 import { LabRequest } from './LabRequest';
 import { LabTest } from './LabTest';
 import { LabTestType } from './LabTestType';
@@ -98,4 +97,7 @@ export const MODELS_MAP = {
   LegacyNoteItem,
   Note,
 };
-export const MODELS_ARRAY: typeof BaseModel[] = Object.values(MODELS_MAP);
+
+type AllValuesOfObject<T extends object> = Array<T[keyof T]>;
+export type ArrayOfModels = AllValuesOfObject<typeof MODELS_MAP>;
+export const MODELS_ARRAY: ArrayOfModels = Object.values(MODELS_MAP);

--- a/packages/mobile/App/services/sync/utils/getModelsForDirection.ts
+++ b/packages/mobile/App/services/sync/utils/getModelsForDirection.ts
@@ -4,7 +4,7 @@ import { MODELS_MAP } from '~/models/modelsMap';
 export const getModelsForDirection = (
   models: typeof MODELS_MAP,
   direction: SYNC_DIRECTIONS,
-): typeof MODELS_MAP =>  Object.fromEntries(
+): Partial<typeof MODELS_MAP> =>  Object.fromEntries(
     Object.entries(models).filter(
       ([, model]) => [direction, SYNC_DIRECTIONS.BIDIRECTIONAL].includes(model.syncDirection),
     ),

--- a/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/pushOutgoingChanges.ts
@@ -13,7 +13,7 @@ import { calculatePageLimit } from './calculatePageLimit';
  */
 export const pushOutgoingChanges = async (
   centralServer: CentralServerConnection,
-  outgoingModels: typeof MODELS_MAP,
+  outgoingModels: Partial<typeof MODELS_MAP>,
   sessionId: string,
   changes: SyncRecord[],
   progressCallback: (total: number, progressCount: number) => void,

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
@@ -95,7 +95,7 @@ export const saveChangesForModel = async (
 export const saveIncomingChanges = async (
   sessionId: string,
   incomingChangesCount: number,
-  incomingModels: typeof MODELS_MAP,
+  incomingModels: Partial<typeof MODELS_MAP>,
   progressCallback: (total: number, batchTotal: number, progressMessage: string) => void,
 ): Promise<void> => {
   const sortedModels = await sortInDependencyOrder(incomingModels);

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
@@ -113,7 +113,8 @@ export const saveIncomingChanges = async (
       const batchString = Buffer.from(base64, 'base64').toString();
 
       const batch = JSON.parse(batchString);
-      const sanitizedBatch = model.sanitizePulledRecordData
+      const hasSanitizeMethod = 'sanitizePulledRecordData' in model;
+      const sanitizedBatch = hasSanitizeMethod
         ? model.sanitizePulledRecordData(batch)
         : batch;
 

--- a/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
@@ -27,7 +27,7 @@ const buildToSyncRecord = (model: typeof BaseModel, record: object): SyncRecord 
  * @returns
  */
 export const snapshotOutgoingChanges = async (
-  outgoingModels: typeof MODELS_MAP,
+  outgoingModels: Partial<typeof MODELS_MAP>,
   since: number,
 ): Promise<SyncRecord[]> => {
   let outgoingChanges = [];

--- a/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
@@ -7,7 +7,7 @@ import { MODELS_MAP } from '../../../models/modelsMap';
 import { extractIncludedColumns } from './extractIncludedColumns';
 import { Database } from '~/infra/db';
 
-const buildToSyncRecord = (model: typeof BaseModel, record: object): SyncRecord => {
+const buildToSyncRecord = (model: typeof BaseModel, record: object): Omit<SyncRecord, 'id'> => {
   const includedColumns = extractIncludedColumns(model);
   const data = pick(record, includedColumns) as SyncRecordData;
 

--- a/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/snapshotOutgoingChanges.ts
@@ -44,7 +44,8 @@ export const snapshotOutgoingChanges = async (
         withDeleted: true,
       });
       const syncRecordsForModel = changesForModel.map(change => buildToSyncRecord(model, change));
-      const sanitizedSyncRecords = model.sanitizeRecordDataForPush
+      const hasSanitizeMethod = 'sanitizeRecordDataForPush' in model;
+      const sanitizedSyncRecords = hasSanitizeMethod
         ? model.sanitizeRecordDataForPush(syncRecordsForModel)
         : syncRecordsForModel;
 

--- a/packages/mobile/App/services/sync/utils/sortInDependencyOrder.ts
+++ b/packages/mobile/App/services/sync/utils/sortInDependencyOrder.ts
@@ -16,7 +16,7 @@ type DependencyMap = {
  * }
  * @returns
  */
-const getDependencyMap = async (models: typeof MODELS_MAP): Promise<DependencyMap> => {
+const getDependencyMap = async (models: Partial<typeof MODELS_MAP>): Promise<DependencyMap> => {
   const entityManager = getManager();
   const dependencyMap = {};
   const tableNameToModelName = getTableNameToModelName(models);
@@ -45,7 +45,7 @@ const getDependencyMap = async (models: typeof MODELS_MAP): Promise<DependencyMa
  * @param models
  * @returns
  */
-const getTableNameToModelName = (models: typeof MODELS_MAP): { [key: string]: string } => {
+const getTableNameToModelName = (models: Partial<typeof MODELS_MAP>): { [key: string]: string } => {
   const tableNameToModelName = {};
 
   Object.values(models).forEach(model => {
@@ -64,7 +64,7 @@ const getTableNameToModelName = (models: typeof MODELS_MAP): { [key: string]: st
  * @returns
  */
 export const sortInDependencyOrder = async (
-  models: typeof MODELS_MAP,
+  models: Partial<typeof MODELS_MAP>,
 ): Promise<typeof BaseModel[]> => {
   const dependencyMap = await getDependencyMap(models);
   const sorted = [];

--- a/packages/mobile/App/services/sync/utils/sortInDependencyOrder.ts
+++ b/packages/mobile/App/services/sync/utils/sortInDependencyOrder.ts
@@ -1,7 +1,6 @@
 import { getManager } from 'typeorm';
 
-import { MODELS_MAP } from '../../../models/modelsMap';
-import { BaseModel } from '../../../models/BaseModel';
+import { MODELS_MAP, ArrayOfModels } from '../../../models/modelsMap';
 
 type DependencyMap = {
   [tableName: string]: string[];
@@ -65,7 +64,7 @@ const getTableNameToModelName = (models: Partial<typeof MODELS_MAP>): { [key: st
  */
 export const sortInDependencyOrder = async (
   models: Partial<typeof MODELS_MAP>,
-): Promise<typeof BaseModel[]> => {
+): Promise<ArrayOfModels> => {
   const dependencyMap = await getDependencyMap(models);
   const sorted = [];
   const stillToSort = { ...models };


### PR DESCRIPTION
### Changes

So most of this is `style` but at least the migration file is a true fix. We probably never encountered any issues because we never have run down migrations on mobile?

In here:
- Specify <Partial> when using a subset of models (MODELS_MAP)
- Fix migration file by passing the column name instead of the foreign key object
- Change the way to check if a prop exists before using it
- Specify <Omit> key from type
- Create and use a specific type for an array of models

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
