### PR TITLE
fix(surveys): NASS-1085: show message when form page is blank on mobile

### DIFF
--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -1,4 +1,5 @@
 import React, {
+  Fragment,
   MutableRefObject,
   ReactElement,
   useCallback,
@@ -105,6 +106,14 @@ export const FormFields = ({
   const screenComponents = components
     .filter(x => x.screenIndex === currentScreenIndex)
     .sort((a, b) => a.componentIndex - b.componentIndex);
+  const visibleComponents = screenComponents.filter(shouldShow);
+
+  const emptyStateMessage = (
+    <TranslatedText
+      stringId="general.form.blankPage"
+      fallback="This page has been intentionally left blank"
+    />
+  );
 
   const submitScreen = async (handleSubmit: () => Promise<void>): Promise<void> => {
     // Validate form on screen before moving to the next one
@@ -177,44 +186,53 @@ export const FormFields = ({
   return (
     <FullView key={currentScreenIndex}>
       <FormScreenView scrollViewRef={scrollViewRef}>
-        {screenComponents.filter(shouldShow).map((component, index) => {
-          const validationCriteria = component && component.getValidationCriteriaObject();
-          const mandatory = checkMandatory(validationCriteria.mandatory, {
-            encounterType: encounter?.encounterType,
-          });
-          return (
-            <React.Fragment key={component.id}>
-              <StyledView marginTop={index === 0 ? 0 : 20} flexDirection="row" alignItems="center">
-                <SectionHeader h3>
-                  {component.text || component.dataElement.defaultText || ''}
-                </SectionHeader>
-                {mandatory && (
-                  <StyledText
-                    marginLeft={screenPercentageToDP(0.5, Orientation.Width)}
-                    fontSize={screenPercentageToDP(1.6, Orientation.Height)}
-                    color={theme.colors.ALERT}
+        {visibleComponents.length === 0
+          ? emptyStateMessage
+          : visibleComponents.map((component, index) => {
+              const validationCriteria = component?.getValidationCriteriaObject();
+              const mandatory = checkMandatory(validationCriteria.mandatory, {
+                encounterType: encounter?.encounterType,
+              });
+              return (
+                <Fragment key={component.id}>
+                  <StyledView
+                    marginTop={index === 0 ? 0 : 20}
+                    flexDirection="row"
+                    alignItems="center"
                   >
-                    *
-                  </StyledText>
-                )}
-              </StyledView>
-              {component.detail ? (
-                <StyledText marginTop={4} fontSize={screenPercentageToDP(2.2, Orientation.Height)}>
-                  {component.detail}
-                </StyledText>
-              ) : null}
-              <ErrorBoundary errorComponent={SurveyQuestionErrorView}>
-                <SurveyQuestion
-                  key={component.id}
-                  component={component}
-                  patient={patient}
-                  zIndex={components.length - index}
-                  setPosition={setQuestionPosition(component.dataElement.code)}
-                />
-              </ErrorBoundary>
-            </React.Fragment>
-          );
-        })}
+                    <SectionHeader h3>
+                      {component.text || component.dataElement.defaultText || ''}
+                    </SectionHeader>
+                    {mandatory && (
+                      <StyledText
+                        marginLeft={screenPercentageToDP(0.5, Orientation.Width)}
+                        fontSize={screenPercentageToDP(1.6, Orientation.Height)}
+                        color={theme.colors.ALERT}
+                      >
+                        *
+                      </StyledText>
+                    )}
+                  </StyledView>
+                  {component.detail ? (
+                    <StyledText
+                      marginTop={4}
+                      fontSize={screenPercentageToDP(2.2, Orientation.Height)}
+                    >
+                      {component.detail}
+                    </StyledText>
+                  ) : null}
+                  <ErrorBoundary errorComponent={SurveyQuestionErrorView}>
+                    <SurveyQuestion
+                      key={component.id}
+                      component={component}
+                      patient={patient}
+                      zIndex={components.length - index}
+                      setPosition={setQuestionPosition(component.dataElement.code)}
+                    />
+                  </ErrorBoundary>
+                </Fragment>
+              );
+            })}
         {errors?.form && (
           <StyledText fontSize={16} color={theme.colors.ALERT} marginTop={20}>
             {errors.form}

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -143,7 +143,7 @@ export const FormFields = ({
     />
   );
 
-  const submitScreen = async (handleSubmit: () => Promise<void>) => {
+  const submitScreen = async (handleSubmit: () => Promise<void>): Promise<void> => {
     // Validate form on screen before moving to the next one
     const formErrors = await validateForm();
 
@@ -166,13 +166,13 @@ export const FormFields = ({
     }
   };
 
-  const onNavigateNext = async () => {
+  const onNavigateNext = async (): Promise<void> => {
     await submitScreen(async () => {
       setCurrentScreenIndex(Math.min(currentScreenIndex + 1, maxIndex));
     });
   };
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     await submitScreen(async () => {
       await submitForm();
       resetForm();

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -179,9 +179,10 @@ export const FormFields = ({
     });
   };
 
-  // We set the key on FullView so that React registers it as a whole new component, rather than a
-  // component whose contents happen to have changed. This means that each new page will start at
-  // the top, rather than the scroll position continuing across pages.
+  // Note: we set the key on FullView so that React registers it as a whole
+  // new component, rather than a component whose contents happen to have
+  // changed. This means that each new page will start at the top, rather than
+  // the scroll position continuing across pages.
   return (
     <FullView key={currentScreenIndex}>
       <FormScreenView scrollViewRef={scrollViewRef}>

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -98,6 +98,34 @@ export const FormFields = ({
     [patient.id],
   );
 
+  const shouldShow = useCallback(
+    (component: ISurveyScreenComponent) => checkVisibilityCriteria(component, components, values),
+    [values],
+  );
+
+  // Handle back button press or swipe right gesture
+  useEffect(() => {
+    const backAction = () => {
+      if (!onGoBack) {
+        return false;
+      }
+      onGoBack();
+      return true;
+    };
+
+    const backHandler = BackHandler.addEventListener('hardwareBackPress', backAction);
+
+    return () => backHandler.remove();
+  }, [currentScreenIndex]); // Re-subscribe if screen index changes, otherwise onGoBack() won't work.
+
+  if (encounterError) {
+    return <ErrorScreen error={encounterError} />;
+  }
+
+  if (isEncounterLoading) {
+    return <LoadingScreen />;
+  }
+
   const { encounter } = encounterResult || {};
   const maxIndex = components
     .map(x => x.screenIndex)
@@ -150,34 +178,6 @@ export const FormFields = ({
       resetForm();
     });
   };
-
-  const shouldShow = useCallback(
-    (component: ISurveyScreenComponent) => checkVisibilityCriteria(component, components, values),
-    [values],
-  );
-
-  // Handle back button press or swipe right gesture
-  useEffect(() => {
-    const backAction = () => {
-      if (!onGoBack) {
-        return false;
-      }
-      onGoBack();
-      return true;
-    };
-
-    const backHandler = BackHandler.addEventListener('hardwareBackPress', backAction);
-
-    return () => backHandler.remove();
-  }, [currentScreenIndex]); // Re-subscribe if screen index changes, otherwise onGoBack() won't work.
-
-  if (encounterError) {
-    return <ErrorScreen error={encounterError} />;
-  }
-
-  if (isEncounterLoading) {
-    return <LoadingScreen />;
-  }
 
   // Note: we set the key on FullView so that React registers it as a whole
   // new component, rather than a component whose contents happen to have

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -179,10 +179,9 @@ export const FormFields = ({
     });
   };
 
-  // Note: we set the key on FullView so that React registers it as a whole
-  // new component, rather than a component whose contents happen to have
-  // changed. This means that each new page will start at the top, rather than
-  // the scroll position continuing across pages.
+  // We set the key on FullView so that React registers it as a whole new component, rather than a
+  // component whose contents happen to have changed. This means that each new page will start at
+  // the top, rather than the scroll position continuing across pages.
   return (
     <FullView key={currentScreenIndex}>
       <FormScreenView scrollViewRef={scrollViewRef}>

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -143,7 +143,7 @@ export const FormFields = ({
     />
   );
 
-  const submitScreen = async (handleSubmit: () => Promise<void>): Promise<void> => {
+  const submitScreen = async (handleSubmit: () => Promise<void>) => {
     // Validate form on screen before moving to the next one
     const formErrors = await validateForm();
 
@@ -166,13 +166,13 @@ export const FormFields = ({
     }
   };
 
-  const onNavigateNext = async (): Promise<void> => {
     await submitScreen(() => {
+  const onNavigateNext = async () => {
       setCurrentScreenIndex(Math.min(currentScreenIndex + 1, maxIndex));
     });
   };
 
-  const onSubmit = async (): Promise<void> => {
+  const onSubmit = async () => {
     await submitScreen(async () => {
       await submitForm();
       resetForm();

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -166,8 +166,8 @@ export const FormFields = ({
     }
   };
 
-    await submitScreen(() => {
   const onNavigateNext = async () => {
+    await submitScreen(async () => {
       setCurrentScreenIndex(Math.min(currentScreenIndex + 1, maxIndex));
     });
   };


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked “on top of” #6191.

### Changes

If there are no visible questions/components on a page of a form/survey, it now shows

```
This page has been intentionally left blank
```

instead of just being empty.

![Screenshot_20240726_100028](https://github.com/user-attachments/assets/95346b45-6d75-415c-9e9b-3bc1cb4692ae)


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
