### PR TITLE
test(sync): SAV-752: Add script to benchmark performance of sync

### DIFF
--- a/packages/facility-server/app/index.js
+++ b/packages/facility-server/app/index.js
@@ -9,6 +9,7 @@ import {
   migrateAppointmentsToLocationGroupsCommand,
   migrateCommand,
   reportCommand,
+  shellCommand,
   startAllCommand,
   startApiCommand,
   startSyncCommand,
@@ -30,6 +31,7 @@ async function run() {
   program.addCommand(syncCommand);
   program.addCommand(migrateCommand);
   program.addCommand(migrateAppointmentsToLocationGroupsCommand);
+  program.addCommand(shellCommand);
 
   await program.parseAsync(process.argv);
 }

--- a/packages/facility-server/app/subCommands/index.js
+++ b/packages/facility-server/app/subCommands/index.js
@@ -4,4 +4,5 @@ export { syncCommand } from './sync';
 export { startAllCommand } from './startAll';
 export { startApiCommand, startSyncCommand } from './startApp';
 export { startTasksCommand } from './startTasks';
+export { shellCommand } from './shell';
 export * from './migrateAppointmentsToLocationGroups';

--- a/packages/facility-server/app/subCommands/shell.js
+++ b/packages/facility-server/app/subCommands/shell.js
@@ -1,0 +1,36 @@
+import config from 'config';
+import repl from 'repl';
+import { homedir } from 'os';
+import { join } from 'path';
+import { Command } from 'commander';
+
+import { log } from '@tamanu/shared/services/logging';
+
+import { version } from '../serverInfo';
+import { ApplicationContext } from '../ApplicationContext';
+
+export const shell = async ({ skipMigrationCheck }) => {
+  log.info(`Starting shell in Facility Server ${version} ${config.serverFacilityId}`);
+
+  const context = await new ApplicationContext().init();
+
+  await context.sequelize.assertUpToDate({ skipMigrationCheck });
+
+  const replServer = await new Promise((resolve, reject) => {
+    repl.start().setupHistory(join(homedir(), '.tamanu_repl_history'), (err, srv) => {
+      if (err) reject(err);
+      else resolve(srv);
+    });
+  });
+
+  Object.assign(replServer.context, {
+    context,
+    models: context.models,
+  });
+
+  return new Promise(resolve => {
+    replServer.on('exit', () => resolve());
+  });
+};
+
+export const shellCommand = new Command('shell').description('Start a Node.js shell').action(shell);

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -172,7 +172,6 @@ async function createAdministeredVaccine(models, facilityId) {
   return administeredVaccine;
 }
 
-
 async function createAppointment(models, facilityId) {
   const { Appointment, Location, PatientFacility } = models;
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -332,10 +332,13 @@ async function simulateUsage(models, sequelize, hours = 1) {
 
 // IMPORTANT NOTE: YOU SHOULD NEVER RUN THIS IN A PRODUCTION ENVIRONMENT
 // AS IT WILL INTRODUCE MOCK RECORDS INTO THE DATABASE.
-// Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!):
-// const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
-// // This will run for one hour (well, a bit longer but for simplicity sake, around that)
-// await simulateUsage(models, context.sequelize);
+
+/*
+  Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!),
+  also, this example will run for one hour (well, a bit longer but for simplicity sake an hour)
+  const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
+  await simulateUsage(models, context.sequelize);
+*/
 
 module.exports = {
   simulateUsage: simulateUsage,

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -50,7 +50,7 @@ async function createEncounter(models, facilityId) {
   const department = await Department.findOne({ where: { facilityId } });
   const examiner = await User.findOne();
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
-  const encounter = await models.Encounter.create(
+  const encounter = await Encounter.create(
     fake(Encounter, {
       locationId: location.id,
       departmentId: department.id,

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -80,6 +80,7 @@ async function createProgramSurveyResponse(models, facilityId) {
   return response;
 }
 
+
 /*
   AdministeredVaccine: 551,
   Appointment: 448,
@@ -90,10 +91,8 @@ async function createProgramSurveyResponse(models, facilityId) {
   PatientBirthData: 6,
   PatientCommunication: 3,
   PatientCondition: 32,
-
   Procedure: 555,
   Referral: 3,
-  SurveyResponse: 710,
   SurveyResponseAnswer: 9439,
   Triage: 14,
 */

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -4,7 +4,12 @@ const { v4: uuidv4 } = require('uuid');
 const { fake } = require('@tamanu/shared/test-helpers/fake');
 const { randomReferenceData } = require('@tamanu/shared/demoData/patients');
 const { sleepAsync } = require('@tamanu/shared/utils/sleepAsync');
-const { NOTE_RECORD_TYPES, REFERENCE_TYPES, IMAGING_TYPES_VALUES } = require('@tamanu/constants');
+const {
+  NOTE_RECORD_TYPES,
+  REFERENCE_TYPES,
+  IMAGING_TYPES_VALUES,
+  IMAGING_REQUEST_STATUS_TYPES,
+} = require('@tamanu/constants');
 const { getCurrentDateTimeString } = require('@tamanu/shared/utils/dateTime');
 
 const DAILY_CREATION_STATS = {
@@ -208,11 +213,19 @@ async function createImagingRequest(models, facilityId) {
     }),
   );
 
+  if (imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED) {
+    await models.ImagingResult.create({
+      completedAt: getCurrentDateTimeString(),
+      imagingRequestId: imagingRequest.id,
+      description: chance.sentence(),
+      completedById: clinician.id,
+    });
+  }
+
   return imagingRequest;
 }
 
 /*
-  ImagingResult: 30,
   PatientBirthData: 6,
   PatientCommunication: 3,
   PatientCondition: 32,

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -127,7 +127,7 @@ async function createAdministeredVaccine(models, facilityId) {
   const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
   const scheduledVaccine = await ScheduledVaccine.findOne();
 
-  const procedure = await AdministeredVaccine.create(
+  const administeredVaccine = await AdministeredVaccine.create(
     fake(AdministeredVaccine, {
       status: 'GIVEN',
       date: getCurrentDateTimeString(),
@@ -136,7 +136,7 @@ async function createAdministeredVaccine(models, facilityId) {
     }),
   );
 
-  return procedure;
+  return administeredVaccine;
 }
 
 /*

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -116,10 +116,10 @@ async function createProgramSurveyResponse(models, facilityId) {
     include: { association: 'dataElement' },
   });
   const answers = {};
-  sscs.forEach(ssc => {
-    if (ssc.dataElement.type in SIMPLE_PDE_TYPES_HANDLERS) {
+  sscs
+    .filter(ssc => ssc.dataElement.type in SIMPLE_PDE_TYPES_HANDLERS)
+    .forEach(ssc => {
       answers[ssc.dataElement.id] = SIMPLE_PDE_TYPES_HANDLERS[ssc.dataElement.type]();
-    }
   });
 
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -1,0 +1,154 @@
+const config = require('config');
+const Chance = require('chance');
+const { v4: uuidv4 } = require('uuid');
+const { fake } = require('@tamanu/shared/test-helpers/fake');
+const { sleepAsync } = require('@tamanu/shared/utils/sleepAsync');
+
+const DAILY_CREATION_STATS = {
+  AdministeredVaccine: 551,
+  Appointment: 448,
+  Encounter: 930,
+  ImagingRequest: 32,
+  ImagingResult: 30,
+  LabTest: 530,
+  Note: 1700,
+  PatientBirthData: 6,
+  PatientCommunication: 3,
+  PatientCondition: 32,
+  Patient: 51,
+  Procedure: 555,
+  Referral: 3,
+  SurveyResponse: 710,
+  SurveyResponseAnswer: 9439,
+  Triage: 14,
+};
+
+const DAY_DURATION_MS = 24 * 60 * 60 * 1000;
+const INSERT_INTERVAL_MS = 20000;
+
+// How many times we can split the day in the given interval
+const TIMES_PER_DAY = DAY_DURATION_MS / INSERT_INTERVAL_MS;
+
+const chance = new Chance();
+
+async function createPatient(models, facilityId) {
+  const { Patient, PatientAdditionalData, PatientFacility } = models;
+  const patient = await Patient.create(fake(Patient, { displayId: uuidv4() }));
+  await PatientAdditionalData.create(fake(PatientAdditionalData, { patientId: patient.id }));
+  await PatientFacility.create({
+    id: PatientFacility.generateId(),
+    patientId: patient.id,
+    facilityId,
+  });
+  return patient;
+}
+
+async function createEncounter(models, facilityId) {
+  const { Encounter, Location, Department, User, PatientFacility } = models;
+
+  const location = await Location.findOne({ where: { facilityId } });
+  const department = await Department.findOne({ where: { facilityId } });
+  const examiner = await User.findOne();
+  const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
+  const encounter = await models.Encounter.create(
+    fake(Encounter, {
+      locationId: location.id,
+      departmentId: department.id,
+      examinerId: examiner.id,
+      patientId: patientFacility.patientId,
+    }),
+  );
+
+  return encounter;
+}
+
+async function createProgramSurveyResponse(models, facilityId) {
+  const { Encounter, PatientFacility, Survey, SurveyResponse, SurveyScreenComponent } = models;
+  const survey = await Survey.findOne();
+  const ssc = await SurveyScreenComponent.findOne({ where: { surveyId: survey.id } });
+  const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
+  const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
+  const response = await SurveyResponse.createWithAnswers({
+    patientId: patientFacility.patientId,
+    encounterId: encounter.id,
+    surveyId: survey.id,
+    answers: {
+      [ssc.dataElementId]: chance.string(),
+    },
+  });
+
+  return response;
+}
+
+// Likelihood should be a percentage number so from 0 to 100
+function calculateLikelihood(modelName, ratio = 1) {
+  const dailyTotal = DAILY_CREATION_STATS[modelName];
+  if (!dailyTotal) throw new Error(`Invalid stat for model ${modelName}`);
+  return ratio * 100 * (dailyTotal / TIMES_PER_DAY);
+}
+
+const ACTIONS = {
+  newPatient: {
+    likelihood: calculateLikelihood('Patient'),
+    generator: createPatient,
+  },
+  newEncounter: {
+    likelihood: calculateLikelihood('Encounter'),
+    generator: createEncounter,
+  },
+  newSurveyResponse: {
+    likelihood: calculateLikelihood('SurveyResponse'),
+    generator: createProgramSurveyResponse,
+  },
+};
+const ACTIONS_ENTRIES = Object.entries(ACTIONS);
+
+function startOrAdd(key, obj) {
+  if (obj[key]) {
+    obj[key]++;
+  } else {
+    obj[key] = 1;
+  }
+}
+
+async function simulateUsage(models, sequelize, hours = 1) {
+  const facilityId = config.serverFacilityId;
+  const totalLoops = hours * 60 * 60 * 1000 / INSERT_INTERVAL_MS;
+  const actionsTaken = {};
+
+  for (let i = 0; i < totalLoops; i++) {
+    let successfulActions = 0;
+    for (const [actionName, actionProps] of ACTIONS_ENTRIES) {
+      const { likelihood, generator } = actionProps;
+      if (chance.bool({ likelihood })) {
+        try {
+          await sequelize.transaction(async () => {
+            await generator(models, facilityId);
+            successfulActions++;
+            startOrAdd(actionName, actionsTaken);
+          });
+        } catch (e) {
+          console.log(e);
+        }
+      }
+    }
+
+    console.log(`Successful actions: ${successfulActions}`);
+
+    // Do every X seconds to spread records evenly
+    await sleepAsync(INSERT_INTERVAL_MS);
+  }
+
+  console.log(`Finished usage simulation. Ran for ${hours} hours in ${totalLoops} loops.`);
+  console.log(JSON.stringify(actionsTaken));
+}
+
+// TODO: simulate usage for a while that is cancellable, track creation count, generate other models
+// Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!):
+// const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
+// // This will run for one hour (well, a bit longer but for simplicity sake, around that)
+// await simulateUsage(models, context.sequelize);
+
+module.exports = {
+  simulateUsage: simulateUsage,
+};

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -80,6 +80,26 @@ async function createProgramSurveyResponse(models, facilityId) {
   return response;
 }
 
+/*
+  AdministeredVaccine: 551,
+  Appointment: 448,
+  ImagingRequest: 32,
+  ImagingResult: 30,
+  LabTest: 530,
+  Note: 1700,
+  PatientBirthData: 6,
+  PatientCommunication: 3,
+  PatientCondition: 32,
+
+  Procedure: 555,
+  Referral: 3,
+  SurveyResponse: 710,
+  SurveyResponseAnswer: 9439,
+  Triage: 14,
+*/
+
+
+
 // Likelihood should be a percentage number so from 0 to 100
 function calculateLikelihood(modelName, ratio = 1) {
   const dailyTotal = DAILY_CREATION_STATS[modelName];
@@ -143,7 +163,7 @@ async function simulateUsage(models, sequelize, hours = 1) {
   console.log(JSON.stringify(actionsTaken));
 }
 
-// TODO: simulate usage for a while that is cancellable, track creation count, generate other models
+// TODO:  track creation count, generate other models
 // Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!):
 // const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
 // // This will run for one hour (well, a bit longer but for simplicity sake, around that)

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -121,8 +121,25 @@ async function createProcedure(models, facilityId) {
   return procedure;
 }
 
+async function createAdministeredVaccine(models, facilityId) {
+  const { AdministeredVaccine, Encounter, PatientFacility, ScheduledVaccine } = models;
+  const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
+  const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
+  const scheduledVaccine = await ScheduledVaccine.findOne();
+
+  const procedure = await AdministeredVaccine.create(
+    fake(AdministeredVaccine, {
+      status: 'GIVEN',
+      date: getCurrentDateTimeString(),
+      scheduledVaccineId: scheduledVaccine.id,
+      encounterId: encounter.id,
+    }),
+  );
+
+  return procedure;
+}
+
 /*
-  AdministeredVaccine: 551,
   Appointment: 448,
   ImagingRequest: 32,
   ImagingResult: 30,
@@ -164,6 +181,10 @@ const ACTIONS = {
   newProcedure: {
     likelihood: calculateLikelihood('Procedure'),
     generator: createProcedure,
+  },
+  newAdministeredVaccine: {
+    likelihood: calculateLikelihood('AdministeredVaccine'),
+    generator: createAdministeredVaccine,
   },
 };
 const ACTIONS_ENTRIES = Object.entries(ACTIONS);

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -14,6 +14,8 @@ const {
 } = require('@tamanu/constants');
 const { getCurrentDateTimeString } = require('@tamanu/shared/utils/dateTime');
 
+// These stats were gathered by the data team from three different deployments,
+// then, we grabbed the max on each model.
 // Even though not all stats are being used, they might be handy to have around
 const DAILY_CREATION_STATS = {
   AdministeredVaccine: 551,

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -163,7 +163,6 @@ async function simulateUsage(models, sequelize, hours = 1) {
   console.log(JSON.stringify(actionsTaken));
 }
 
-// TODO: generate other models
 // Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!):
 // const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
 // // This will run for one hour (well, a bit longer but for simplicity sake, around that)

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -3,6 +3,7 @@ const Chance = require('chance');
 const { v4: uuidv4 } = require('uuid');
 const { fake } = require('@tamanu/shared/test-helpers/fake');
 const { randomReferenceData } = require('@tamanu/shared/demoData/patients');
+const { randomRecord } = require('@tamanu/shared/demoData/utilities');
 const { sleepAsync } = require('@tamanu/shared/utils/sleepAsync');
 const {
   NOTE_RECORD_TYPES,
@@ -52,11 +53,11 @@ async function createPatient(models, facilityId) {
 }
 
 async function createEncounter(models, facilityId) {
-  const { Encounter, Location, Department, User, PatientFacility } = models;
+  const { Encounter, Location, Department, PatientFacility } = models;
 
   const location = await Location.findOne({ where: { facilityId } });
   const department = await Department.findOne({ where: { facilityId } });
-  const examiner = await User.findOne();
+  const examiner = await randomRecord(models, 'User');
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const encounter = await Encounter.create(
     fake(Encounter, {
@@ -71,8 +72,8 @@ async function createEncounter(models, facilityId) {
 }
 
 async function createProgramSurveyResponse(models, facilityId) {
-  const { Encounter, PatientFacility, Survey, SurveyResponse, SurveyScreenComponent } = models;
-  const survey = await Survey.findOne();
+  const { Encounter, PatientFacility, SurveyResponse, SurveyScreenComponent } = models;
+  const survey = await randomRecord(models, 'Survey');
   const ssc = await SurveyScreenComponent.findOne({ where: { surveyId: survey.id } });
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
@@ -89,10 +90,10 @@ async function createProgramSurveyResponse(models, facilityId) {
 }
 
 async function createNote(models, facilityId) {
-  const { Encounter, Note, PatientFacility, User } = models;
+  const { Encounter, Note, PatientFacility } = models;
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
-  const author = await User.findOne();
+  const author = await randomRecord(models, 'User');
 
   const note = await Note.create(
     fake(Note, {
@@ -127,10 +128,10 @@ async function createProcedure(models, facilityId) {
 }
 
 async function createAdministeredVaccine(models, facilityId) {
-  const { AdministeredVaccine, Encounter, PatientFacility, ScheduledVaccine } = models;
+  const { AdministeredVaccine, Encounter, PatientFacility } = models;
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
-  const scheduledVaccine = await ScheduledVaccine.findOne();
+  const scheduledVaccine = await randomRecord(models, 'ScheduledVaccine');
 
   const administeredVaccine = await AdministeredVaccine.create(
     fake(AdministeredVaccine, {
@@ -146,10 +147,10 @@ async function createAdministeredVaccine(models, facilityId) {
 
 
 async function createAppointment(models, facilityId) {
-  const { Appointment, Location, PatientFacility, User } = models;
+  const { Appointment, Location, PatientFacility } = models;
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const location = await Location.findOne({ where: { facilityId } });
-  const clinician = await User.findOne();
+  const clinician = await randomRecord(models, 'User');
 
   const appointment = await Appointment.create(
     fake(Appointment, {
@@ -197,11 +198,11 @@ async function createLabTest(models, facilityId) {
 }
 
 async function createImagingRequest(models, facilityId) {
-  const { Encounter, ImagingRequest, Location, PatientFacility, User } = models;
+  const { Encounter, ImagingRequest, Location, PatientFacility } = models;
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
   const location = await Location.findOne({ where: { facilityId } });
-  const clinician = await User.findOne();
+  const clinician =  await randomRecord(models, 'User');
 
   const imagingRequest = await ImagingRequest.create(
     fake(ImagingRequest, {

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -163,6 +163,8 @@ async function simulateUsage(models, sequelize, hours = 1) {
   console.log(JSON.stringify(actionsTaken));
 }
 
+// IMPORTANT NOTE: YOU SHOULD NEVER RUN THIS IN A PRODUCTION ENVIRONMENT
+// AS IT WILL INTRODUCE MOCK RECORDS INTO THE DATABASE.
 // Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!):
 // const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
 // // This will run for one hour (well, a bit longer but for simplicity sake, around that)

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -105,7 +105,7 @@ async function createProcedure(models, facilityId) {
   const { Encounter, PatientFacility, Procedure } = models;
   const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
   const encounter = await Encounter.findOne({ where: { patientId: patientFacility.patientId } });
-  const procedureType = randomReferenceData(models, REFERENCE_TYPES.PROCEDURE_TYPE);
+  const procedureType = await randomReferenceData(models, REFERENCE_TYPES.PROCEDURE_TYPE);
 
   const procedure = await Procedure.create(
     fake(Procedure, {

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -163,7 +163,7 @@ async function simulateUsage(models, sequelize, hours = 1) {
   console.log(JSON.stringify(actionsTaken));
 }
 
-// TODO:  track creation count, generate other models
+// TODO: generate other models
 // Usage (note that if you -await- the function you WILL NOT be able to cancel it until it's done!):
 // const { simulateUsage } = require('@tamanu/facility-server/scripts/simulateUsage.js');
 // // This will run for one hour (well, a bit longer but for simplicity sake, around that)

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -139,8 +139,26 @@ async function createAdministeredVaccine(models, facilityId) {
   return administeredVaccine;
 }
 
+
+async function createAppointment(models, facilityId) {
+  const { Appointment, Location, PatientFacility, User } = models;
+  const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
+  const location = await Location.findOne({ where: { facilityId } });
+  const clinician = await User.findOne();
+
+  const appointment = await Appointment.create(
+    fake(Appointment, {
+      startTime: getCurrentDateTimeString(),
+      patientId: patientFacility.patientId,
+      clinicianId: clinician.id,
+      locationId: location.id,
+    }),
+  );
+
+  return appointment;
+}
+
 /*
-  Appointment: 448,
   ImagingRequest: 32,
   ImagingResult: 30,
   LabTest: 530,
@@ -185,6 +203,10 @@ const ACTIONS = {
   newAdministeredVaccine: {
     likelihood: calculateLikelihood('AdministeredVaccine'),
     generator: createAdministeredVaccine,
+  },
+  newAppointment: {
+    likelihood: calculateLikelihood('Appointment'),
+    generator: createAppointment,
   },
 };
 const ACTIONS_ENTRIES = Object.entries(ACTIONS);

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -225,10 +225,23 @@ async function createImagingRequest(models, facilityId) {
   return imagingRequest;
 }
 
+async function createPatientCondition(models, facilityId) {
+  const { PatientFacility, PatientCondition } = models;
+  const patientFacility = await PatientFacility.findOne({ where: { facilityId } });
+  const condition = await randomReferenceData(models, REFERENCE_TYPES.ICD10);
+
+  const patientCondition = await PatientCondition.create({
+    conditionId: condition.id,
+    patientId: patientFacility.id,
+    note: chance.sentence(),
+  });
+
+  return patientCondition;
+}
+
 /*
   PatientBirthData: 6,
   PatientCommunication: 3,
-  PatientCondition: 32,
   Referral: 3,
   SurveyResponseAnswer: 9439,
   Triage: 14,
@@ -279,6 +292,10 @@ const ACTIONS = {
   newImagingRequest: {
     likelihood: calculateLikelihood('ImagingRequest'),
     generator: createImagingRequest,
+  },
+  newPatientCondition: {
+    likelihood: calculateLikelihood('PatientCondition'),
+    generator: createPatientCondition,
   },
 };
 const ACTIONS_ENTRIES = Object.entries(ACTIONS);

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -239,16 +239,6 @@ async function createPatientCondition(models, facilityId) {
   return patientCondition;
 }
 
-/*
-  PatientBirthData: 6,
-  PatientCommunication: 3,
-  Referral: 3,
-  SurveyResponseAnswer: 9439,
-  Triage: 14,
-*/
-
-
-
 // Likelihood should be a percentage number so from 0 to 100
 function calculateLikelihood(modelName, ratio = 1) {
   const dailyTotal = DAILY_CREATION_STATS[modelName];

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -233,7 +233,7 @@ async function createPatientCondition(models, facilityId) {
 
   const patientCondition = await PatientCondition.create({
     conditionId: condition.id,
-    patientId: patientFacility.id,
+    patientId: patientFacility.patientId,
     note: chance.sentence(),
   });
 

--- a/packages/facility-server/scripts/simulateUsage.js
+++ b/packages/facility-server/scripts/simulateUsage.js
@@ -40,15 +40,11 @@ const TIMES_PER_DAY = DAY_DURATION_MS / INSERT_INTERVAL_MS;
 
 const chance = new Chance();
 
-async function createPatient(models, facilityId) {
-  const { Patient, PatientAdditionalData, PatientFacility } = models;
+async function createPatient(models) {
+  const { Patient, PatientAdditionalData } = models;
   const patient = await Patient.create(fake(Patient, { displayId: uuidv4() }));
   await PatientAdditionalData.create(fake(PatientAdditionalData, { patientId: patient.id }));
-  await PatientFacility.create({
-    id: PatientFacility.generateId(),
-    patientId: patient.id,
-    facilityId,
-  });
+
   return patient;
 }
 


### PR DESCRIPTION
### Changes

Okay so the strongest addition here is just to bring the `shell` command to facility server. This allows us to run JS scripts easily withing the app context.

I think this script is a good first step towards sync benchmarking - the simulation happens at the facility level. This does not help us to stress test facilities, but that's not the goal here (though I'd argue it'd be a good template when we do that).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

