### PR TITLE
fix(web): release 2.13: can not export inpatient data

### DIFF
--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -26,7 +26,9 @@ const normalizeRecursively = (element, normalizeFn) => {
   if (!children) return normalizeFn(element);
 
   return cloneElement(element, {
-    children: Children.map(children, child => normalizeRecursively(child, normalizeFn)),
+    children: Array.isArray(children)
+      ? Children.map(children, child => normalizeRecursively(child, normalizeFn))
+      : normalizeRecursively(children, normalizeFn),
   });
 };
 

--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -235,7 +235,7 @@ const Row = React.memo(
         return (
           <StyledTableCell
             key={key}
-            onClick={dontCallRowInput ? preventInputCallback : e => onClickRow(e, passingData)}
+            onClick={dontCallRowInput ? preventInputCallback : e => onClickRow?.(e, passingData)}
             background={backgroundColor}
             $cellStyle={cellStyle}
             align={numeric ? 'right' : 'left'}


### PR DESCRIPTION
### Changes

In Inpatient table, we can't export the data due the diet column, because it's rendering a tooltip and a tooltip require only one child (as object) instead of an array of children, so it will cause error if you pass the array of children to the tooltip

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
