### PR TITLE
feat(invoicing): EPI-950: Update getPotentialInvoiceItems with excluded lab test statuses

### DIFF
--- a/packages/facility-server/app/routes/apiv1/invoice/getPotentialInvoiceItems.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/getPotentialInvoiceItems.js
@@ -1,4 +1,9 @@
-import { OTHER_REFERENCE_TYPES, REFERENCE_TYPES, VISIBILITY_STATUSES } from '@tamanu/constants';
+import {
+  LAB_TEST_STATUSES,
+  OTHER_REFERENCE_TYPES,
+  REFERENCE_TYPES,
+  VISIBILITY_STATUSES,
+} from '@tamanu/constants';
 import { NotFoundError } from '@tamanu/shared/errors';
 import { QueryTypes } from 'sequelize';
 
@@ -69,7 +74,8 @@ filtered_labtests as (
 	from lab_tests lt
 	join lab_requests lr on lr.deleted_at is null and lr.id = lt.lab_request_id
 	join lab_test_types ltt on ltt.deleted_at is null and ltt.visibility_status = :visibilityStatus and ltt.id = lt.lab_test_type_id
-	where lt.deleted_at is null
+	where lt.status NOT IN (:excludedLabTestStatuses)
+	and lt.deleted_at is null
 	and lr.encounter_id = :encounterId
 ),
 filtered_products as (
@@ -102,6 +108,13 @@ join users u on u.deleted_at is null and coalesce(fpc."orderedByUserId",fi."orde
         encounterId,
         imagingType: REFERENCE_TYPES.IMAGING_TYPE,
         imagingTypes,
+        excludedLabTestStatuses: [
+          LAB_TEST_STATUSES.RECEPTION_PENDING,
+          LAB_TEST_STATUSES.CANCELLED,
+          LAB_TEST_STATUSES.DELETED,
+          LAB_TEST_STATUSES.SAMPLE_NOT_COLLECTED,
+          LAB_TEST_STATUSES.ENTERED_IN_ERROR,
+        ],
         labtestType: OTHER_REFERENCE_TYPES.LAB_TEST_TYPE,
         visibilityStatus: VISIBILITY_STATUSES.CURRENT,
       },


### PR DESCRIPTION
### Changes

This change improves the accuracy of the potential invoice items by excluding lab tests with statuses such as "Reception Pending," "Cancelled," "Deleted," "Sample Not Collected," and "Entered in Error."

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

