### PR TITLE
tweak(sync): SAV-740: Restart long running syncs

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -31,11 +31,17 @@ describe('CentralSyncManager', () => {
 
   const DEFAULT_CURRENT_SYNC_TIME_VALUE = 2;
 
-  const initializeCentralSyncManager = () => {
+  const initializeCentralSyncManager = config => {
     // Have to load test function within test scope so that we can mock dependencies per test case
     const {
       CentralSyncManager: TestCentralSyncManager,
     } = require('../../dist/sync/CentralSyncManager');
+
+    if (config) {
+      // Turn on syncAllEncountersForTheseVaccines config
+      TestCentralSyncManager.overrideConfig(config);
+    }
+
     return new TestCentralSyncManager(ctx);
   };
 
@@ -133,6 +139,38 @@ describe('CentralSyncManager', () => {
 
       await expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow(
         `Sync session '${sessionId}' encountered an error: Snapshot processing incomplete, likely because the central server restarted during the snapshot`,
+      );
+    });
+
+    it("does not throw an error when connecting to a session that has not taken longer than configured 'syncSessionTimeoutMs'", async () => {
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: { syncSessionTimeoutMs: 1000 },
+      });
+      const { sessionId } = await centralSyncManager.startSession();
+      await waitForSession(centralSyncManager, sessionId);
+
+      await sleepAsync(500);
+
+      // updated_at will be set to timestamp that is 500ms later
+      await centralSyncManager.connectToSession(sessionId);
+
+      expect(() => centralSyncManager.connectToSession(sessionId)).not.toThrow();
+    });
+
+    it("throws an error when connecting to a session that has taken longer than configured 'syncSessionTimeoutMs'", async () => {
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: { syncSessionTimeoutMs: 200 },
+      });
+      const { sessionId } = await centralSyncManager.startSession();
+      await waitForSession(centralSyncManager, sessionId);
+
+      await sleepAsync(500);
+
+      // updated_at will be set to timestamp that is 500ms later
+      await centralSyncManager.connectToSession(sessionId);
+
+      await expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow(
+        `Sync session '${sessionId}' encountered an error: Sync session ${sessionId} timed out`,
       );
     });
   });
@@ -944,17 +982,9 @@ describe('CentralSyncManager', () => {
         });
 
         it('syncs the configured vaccine encounters when it is enabled and client is mobile', async () => {
-          // Create the vaccines to be tested
-          const {
-            CentralSyncManager: TestCentralSyncManager,
-          } = require('../../dist/sync/CentralSyncManager');
-
-          // Turn on syncAllEncountersForTheseVaccines config
-          TestCentralSyncManager.overrideConfig({
+          const centralSyncManager = initializeCentralSyncManager({
             sync: { syncAllEncountersForTheseVaccines: ['drug-COVAX', 'drug-COVID-19-Pfizer'] },
           });
-
-          const centralSyncManager = new TestCentralSyncManager(ctx);
 
           const { sessionId } = await centralSyncManager.startSession();
           await waitForSession(centralSyncManager, sessionId);
@@ -978,16 +1008,9 @@ describe('CentralSyncManager', () => {
         });
 
         it('does not sync any vaccine encounters when it is disabled and client is mobile', async () => {
-          const {
-            CentralSyncManager: TestCentralSyncManager,
-          } = require('../../dist/sync/CentralSyncManager');
-
-          // Turn off syncAllEncountersForTheseVaccines config
-          TestCentralSyncManager.overrideConfig({
+          const centralSyncManager = initializeCentralSyncManager({
             sync: { syncAllEncountersForTheseVaccines: [] },
           });
-
-          const centralSyncManager = new TestCentralSyncManager(ctx);
 
           await models.PatientFacility.create({
             id: models.PatientFacility.generateId(),

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -38,7 +38,6 @@ describe('CentralSyncManager', () => {
     } = require('../../dist/sync/CentralSyncManager');
 
     if (config) {
-      // Turn on syncAllEncountersForTheseVaccines config
       TestCentralSyncManager.overrideConfig(config);
     }
 

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -291,13 +291,6 @@ export class CentralSyncManager {
       await this.store.sequelize.transaction(
         { isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ },
         async () => {
-          const { snapshotTransactionTimeoutMs } = this.constructor.config.sync;
-          if (snapshotTransactionTimeoutMs) {
-            transactionTimeout = setTimeout(() => {
-              throw new Error(`Snapshot for session ${sessionId} timed out`);
-            }, snapshotTransactionTimeoutMs);
-          }
-
           // full changes
           await snapshotOutgoingChanges(
             getPatientLinkedModels(modelsToInclude),

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -138,6 +138,16 @@ export class CentralSyncManager {
     if (session.completedAt) {
       throw new Error(`Sync session '${sessionId}' is already completed`);
     }
+
+    const { snapshotTransactionTimeoutMs } = this.constructor.config.sync;
+    if (
+      snapshotTransactionTimeoutMs &&
+      session.updatedAt - session.createdAt > snapshotTransactionTimeoutMs
+    ) {
+      session.error = `Snapshot for session ${sessionId} timed out`;
+      await session.save();
+    }
+
     if (session.error) {
       throw new Error(errorMessageFromSession(session));
     }

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -142,6 +142,7 @@ export class CentralSyncManager {
     const { snapshotTransactionTimeoutMs } = this.constructor.config.sync;
     if (
       snapshotTransactionTimeoutMs &&
+      !session.snapshotCompletedAt &&
       session.updatedAt - session.createdAt > snapshotTransactionTimeoutMs
     ) {
       session.error = `Snapshot for session ${sessionId} timed out`;

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -139,11 +139,11 @@ export class CentralSyncManager {
       throw new Error(`Sync session '${sessionId}' is already completed`);
     }
 
-    const { idleSyncSessionTimeoutMs } = this.constructor.config.sync;
+    const { syncSessionTimeoutMs } = this.constructor.config.sync;
     if (
-      idleSyncSessionTimeoutMs &&
+      syncSessionTimeoutMs &&
       !session.error &&
-      session.updatedAt - session.createdAt > idleSyncSessionTimeoutMs
+      session.updatedAt - session.createdAt > syncSessionTimeoutMs
     ) {
       session.error = `Snapshot for session ${sessionId} timed out`;
       await session.save();

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -139,12 +139,12 @@ export class CentralSyncManager {
       throw new Error(`Sync session '${sessionId}' is already completed`);
     }
 
-    const { snapshotTransactionTimeoutMs } = this.constructor.config.sync;
+    const { idleSyncSessionTimeoutMs } = this.constructor.config.sync;
     if (
-      snapshotTransactionTimeoutMs &&
+      idleSyncSessionTimeoutMs &&
       !session.snapshotCompletedAt &&
       !session.error &&
-      session.updatedAt - session.createdAt > snapshotTransactionTimeoutMs
+      session.updatedAt - session.createdAt > idleSyncSessionTimeoutMs
     ) {
       session.error = `Snapshot for session ${sessionId} timed out`;
       await session.save();

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -143,6 +143,7 @@ export class CentralSyncManager {
     if (
       snapshotTransactionTimeoutMs &&
       !session.snapshotCompletedAt &&
+      !session.error &&
       session.updatedAt - session.createdAt > snapshotTransactionTimeoutMs
     ) {
       session.error = `Snapshot for session ${sessionId} timed out`;

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -145,7 +145,7 @@ export class CentralSyncManager {
       !session.error &&
       session.updatedAt - session.createdAt > syncSessionTimeoutMs
     ) {
-      session.error = `Snapshot for session ${sessionId} timed out`;
+      session.error = `Sync session ${sessionId} timed out`;
       await session.save();
     }
 

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -142,7 +142,6 @@ export class CentralSyncManager {
     const { idleSyncSessionTimeoutMs } = this.constructor.config.sync;
     if (
       idleSyncSessionTimeoutMs &&
-      !session.snapshotCompletedAt &&
       !session.error &&
       session.updatedAt - session.createdAt > idleSyncSessionTimeoutMs
     ) {

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -70,7 +70,7 @@
     // at its very large default, maxRecordsPerPullSnapshotChunk is essentially "off"
     // can be turned on by lowering to some amount that seems appropriate if snapshot performance is an issue
     "maxRecordsPerPullSnapshotChunk": 1000000000,
-    snapshotTransactionTimeoutMs: null,
+    idleSyncSessionTimeoutMs: null,
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -70,7 +70,7 @@
     // at its very large default, maxRecordsPerPullSnapshotChunk is essentially "off"
     // can be turned on by lowering to some amount that seems appropriate if snapshot performance is an issue
     "maxRecordsPerPullSnapshotChunk": 1000000000,
-    idleSyncSessionTimeoutMs: null,
+    syncSessionTimeoutMs: null,
   },
   "loadshedder": {
     // paths are checked sequentially until a path matches a prefix


### PR DESCRIPTION
### Changes

This is meant to handle the long snapshots without restarting the server... this approach seems to work on my local tests (setting up a config very low and everytime it gets the error, increase with an external variable), however the logging is not great as we end up changing the error with the sync stale cleaner. Aside from that, servers do not restart and syncs start again!


```
sync-notes=# SELECT created_at, snapshot_started_at, completed_at, error FROM sync_sessions ORDER BY created_at DESC LIMIT 10;
         created_at         |      snapshot_started_at      |        completed_at        |                           error
----------------------------+-------------------------------+----------------------------+------------------------------------------------------------
 2024-08-04 20:22:00.453-05 | 2024-08-04 20:22:01.599723-05 | 2024-08-04 20:22:02.643-05 |
 2024-08-04 20:21:00.764-05 | 2024-08-04 20:21:01.912668-05 | 2024-08-04 20:21:02.96-05  |
 2024-08-04 20:20:00.711-05 | 2024-08-04 20:20:01.867901-05 | 2024-08-04 20:20:02.919-05 |
 2024-08-04 20:19:00.818-05 |                               | 2024-08-04 20:20:00.689-05 | Session marked as completed due to its device reconnecting
 2024-08-04 20:18:00.981-05 |                               | 2024-08-04 20:19:00.795-05 | Session marked as completed due to its device reconnecting
 2024-08-04 20:17:00.557-05 |                               | 2024-08-04 20:18:00.958-05 | Session marked as completed due to its device reconnecting
 2024-08-04 20:16:21.112-05 |                               | 2024-08-04 20:17:00.537-05 | Session marked as completed due to its device reconnecting
 2024-08-04 20:13:00.582-05 |                               | 2024-08-04 20:16:21.088-05 | Session marked as completed due to its device reconnecting
 2024-08-04 20:12:57.665-05 |                               | 2024-08-04 20:13:00.559-05 | Session marked as completed due to its device reconnecting
 2024-08-04 20:11:00.266-05 | 2024-08-04 20:11:01.400037-05 | 2024-08-04 20:11:02.445-05 |
(10 rows)
```

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
