### PR TITLE
ci(testDeterminism): ignore DO_NOT_SYNC models when testing determinism

### DIFF
--- a/packages/scripts/src/testDeterminism.js
+++ b/packages/scripts/src/testDeterminism.js
@@ -127,8 +127,7 @@ async function getHashesForTables(sequelize, tables) {
 
     const model = sequelize.modelManager.findModel(m => m.tableName === table);
 
-    // Redundant check in this case given
-    // that the test is to enforce data to be migrated exactly the same on central and facility
+    // No need for determinism test when data is not shared between central and facility
     if (model.syncDirection === SYNC_DIRECTIONS.DO_NOT_SYNC) continue;
 
     // get columns

--- a/packages/scripts/src/testDeterminism.js
+++ b/packages/scripts/src/testDeterminism.js
@@ -102,12 +102,6 @@ function isMigrationIgnored(path) {
   return !!module.NON_DETERMINISTIC;
 }
 
-function isModelIgnored(model) {
-  // Redundant check in this case given
-  // that the test is to enforce that data to be migrated exactly the same on central and facility
-  return model.syncDirection === SYNC_DIRECTIONS.DO_NOT_SYNC;
-}
-
 const UNHASHED_TABLES = [
   'SequelizeMeta',
   'columns',
@@ -133,7 +127,9 @@ async function getHashesForTables(sequelize, tables) {
 
     const model = sequelize.modelManager.findModel(m => m.tableName === table);
 
-    if (isModelIgnored(model)) continue;
+    // Redundant check in this case given
+    // that the test is to enforce data to be migrated exactly the same on central and facility
+    if (model.syncDirection === SYNC_DIRECTIONS.DO_NOT_SYNC) continue;
 
     // get columns
     const allColumns = await getColumnsForModel(model);


### PR DESCRIPTION
### Changes
From discussion with Edwin

 `Redundant check in this case given
 that the requirement is for data to be migrated exactly the same on central and facility`

- Tested that this works to resolve issue of failing due to changes to non synced data type `SyncQueuedDevices`

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
