### PR TITLE
fix(mediciReport): Fix missing locations in location history for Medici Report (hotfix 2.9.5)

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
@@ -340,4 +340,51 @@ describe(`Materialised - MediciReport`, () => {
       });
     });
   });
+
+  describe('materialise Location History in Medici Report', () => {
+    it('returns all locations for an encounter', async () => {
+      const { Location } = ctx.store.models;
+      const oldLocation = await Location.create(
+        fake(Location, {
+          facilityId: resources.facility.id,
+          locationGroupId: resources.locationGroup.id,
+        }),
+      );
+      const newLocation = await Location.create(
+        fake(Location, {
+          facilityId: resources.facility.id,
+          locationGroupId: resources.locationGroup.id,
+        }),
+      );
+
+      const { encounter } = await makeEncounter({
+        encounterType: 'emergency',
+        locationId: oldLocation.id,
+      });
+
+      await encounter.update({ locationId: newLocation.id });
+
+      const { MediciReport } = ctx.store.models;
+
+      await MediciReport.materialiseFromUpstream(encounter.id);
+      await MediciReport.resolveUpstreams();
+
+      const mediciReport = await MediciReport.findOne();
+
+      expect(mediciReport.dataValues).toMatchObject({
+        locations: [
+          {
+            facility: resources.facility.name,
+            location: oldLocation.name,
+            locationGroup: resources.locationGroup.name,
+          },
+          {
+            facility: resources.facility.name,
+            location: newLocation.name,
+            locationGroup: resources.locationGroup.name,
+          },
+        ],
+      });
+    });
+  });
 });

--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -43,7 +43,9 @@ const createLocalDateTimeStringFromUTC = (
 const fakeAllData = async (models, ctx) => {
   const { id: userId } = await models.User.create(fake(models.User));
   const { id: examinerId } = await models.User.create(fake(models.User));
-  const { id: facilityId } = await models.Facility.create(fake(models.Facility, { name: 'Ba Hospital' }));
+  const { id: facilityId } = await models.Facility.create(
+    fake(models.Facility, { name: 'Ba Hospital' }),
+  );
   const { id: departmentId } = await models.Department.create(
     fake(models.Department, { facilityId, name: 'Emergency dept.' }),
   );
@@ -471,6 +473,12 @@ describe('fijiAspenMediciReport', () => {
 
         // Location/Department
         locations: [
+          {
+            assignedTime: '2022-06-09T00:02:54+00:00',
+            facility: 'Ba Hospital',
+            location: 'Emergency room 1',
+            locationGroup: 'Emergency Department',
+          },
           {
             facility: 'Ba Hospital',
             location: 'Emergency room 2',


### PR DESCRIPTION
### Changes

We previously we relying on a `select distinct on (encounter_id)` to get the locations, which would lead to selecting the most recent location but not the history. Now using a `json_agg` much like other history fields

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
