### PR TITLE
fix(immunisationsTable): release-2-14: Fix query

### DIFF
--- a/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
@@ -267,6 +267,14 @@ describe('PatientVaccine', () => {
       expect(result.body.count).toEqual(5); // there are 5 recorded given vaccines in beforeAll
     });
 
+    it('Should get administered vaccines with pagination', async () => {
+      const result = await app.get(
+        `/api/patient/${patient.id}/administeredVaccines?page=0&rowsPerPage=10&orderBy=date&order=desc`,
+      );
+      expect(result).toHaveSucceeded();
+      expect(result.body.count).toEqual(5);
+    });
+
     it('Should include not given vaccines', async () => {
       const freshPatient = await models.Patient.create(await createDummyPatient(models));
       await recordAdministeredVaccine(freshPatient, scheduled1);

--- a/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientVaccine.test.js
@@ -268,11 +268,12 @@ describe('PatientVaccine', () => {
     });
 
     it('Should get administered vaccines with pagination', async () => {
+      const expectedOrder = ['vaccine 2 catchup', 'vaccine 1 routine', 'vaccine 1 routine'];
       const result = await app.get(
-        `/api/patient/${patient.id}/administeredVaccines?page=0&rowsPerPage=10&orderBy=date&order=desc`,
+        `/api/patient/${patient.id}/administeredVaccines?page=0&rowsPerPage=3&orderBy=vaccineDisplayName&order=desc`,
       );
       expect(result).toHaveSucceeded();
-      expect(result.body.count).toEqual(5);
+      expect(result.body.data.map(x => x.vaccineDisplayName)).toEqual(expectedOrder);
     });
 
     it('Should include not given vaccines', async () => {

--- a/packages/shared/src/models/Patient.js
+++ b/packages/shared/src/models/Patient.js
@@ -127,7 +127,18 @@ export class Patient extends Model {
         {
           model: models.Encounter,
           as: 'encounter',
-          include: models.Encounter.getFullReferenceAssociations(),
+          include: [
+            {
+              model: models.Location,
+              as: 'location',
+              include: [
+                {
+                  model: models.Facility,
+                  as: 'facility',
+                },
+              ],
+            },
+          ],
         },
         {
           model: models.Location,


### PR DESCRIPTION
### Changes

This one was painful to debug as there were no apparent changes to the code involved in the table. The SQL verbose output also wasn't good enough because the query was so long it didn't show up complete. Ended up doing a binary search between commits to find the culprit, only to scratch my head a little longer.

This is the PR that introduced the error: https://github.com/beyondessential/tamanu/pull/6213 and it's where we add diets as its own thing.

It didn't show up on our unit tests because we didn't have coverage with the table pagination API, which is ultimately what causes the issue. It seems to works great everywhere else when including the diet association, however, when limiting the query for some reason all goes south. The error complains about a missing scheduledVaccine table that is definitely there... I don't fully understand what is going on, so I decided to just smash the error - the query is complicated enough and this is a release fix.

Although tempting, I did not want to just exclude `diets` from the include, as including everything is what got us into this mess. I tracked everywhere where we use the `getAdministeredVaccines` method and realized we only ever use a nested include from encounters.

In the first commit, you can see a facility server test failing, which is the one this PR aims to fix