### PR TITLE
test(fakeHelpers): SAV-752: Update PAD fake value

### DIFF
--- a/packages/shared/src/test-helpers/fake.js
+++ b/packages/shared/src/test-helpers/fake.js
@@ -334,7 +334,7 @@ const MODEL_SPECIFIC_OVERRIDES = {
       emergencyContactName: chance.name(),
       emergencyContactNumber: chance.phone(),
       secondaryVillageId: null,
-      updatedAtByField: {},
+      updatedAtByField: null,
     };
   },
   PatientFacility: ({ patientId = fakeUUID(), facilityId = fakeUUID() }) => {

--- a/packages/shared/src/test-helpers/fake.js
+++ b/packages/shared/src/test-helpers/fake.js
@@ -334,7 +334,7 @@ const MODEL_SPECIFIC_OVERRIDES = {
       emergencyContactName: chance.name(),
       emergencyContactNumber: chance.phone(),
       secondaryVillageId: null,
-      updatedAtByField: null,
+      updatedAtByField: null, // this is to allow the trigger to properly populate it
     };
   },
   PatientFacility: ({ patientId = fakeUUID(), facilityId = fakeUUID() }) => {


### PR DESCRIPTION
### Changes

When we create a PAD, nothing ever gets set on `updatedAtByField` that's actually set on the DB level, this emulates that. Having an empty object causes an error when trying to sync