### PR TITLE
fix(reports): release-2-14: Fix vaccine category field used in reports 

### DIFF
--- a/packages/constants/src/enumRegistry.ts
+++ b/packages/constants/src/enumRegistry.ts
@@ -13,7 +13,7 @@ import {
   APPOINTMENT_STATUSES,
   IMAGING_REQUEST_STATUS_LABELS,
 } from './statuses';
-import { VACCINE_STATUS_LABELS, INJECTION_SITE_LABELS, VACCINE_CATEGORIES } from './vaccines';
+import { VACCINE_STATUS_LABELS, INJECTION_SITE_LABELS, VACCINE_CATEGORY_LABELS } from './vaccines';
 import { BIRTH_DELIVERY_TYPE_LABELS, BIRTH_TYPE_LABELS } from './births';
 import { IMAGING_TYPES } from './imaging';
 import {
@@ -68,7 +68,7 @@ export const registeredEnums = {
   REPORT_STATUS_LABELS,
   SEX_LABELS,
   TEMPLATE_TYPE_LABELS,
-  VACCINE_CATEGORIES,
+  VACCINE_CATEGORY_LABELS,
   VACCINE_STATUS_LABELS,
 };
 
@@ -107,7 +107,7 @@ export const translationPrefixes: Record<EnumKeys, string> = {
   REPORT_STATUS_LABELS: 'report.property.status',
   SEX_LABELS: 'patient.property.sex',
   TEMPLATE_TYPE_LABELS: 'template.property.type',
-  VACCINE_CATEGORIES: 'vaccine.property.category',
+  VACCINE_CATEGORY_LABELS: 'vaccine.property.category',
   VACCINE_STATUS_LABELS: 'vaccine.property.status',
 };
 

--- a/packages/web/app/views/reports/VaccineCategoryField.jsx
+++ b/packages/web/app/views/reports/VaccineCategoryField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { VACCINE_CATEGORIES } from '@tamanu/constants';
+import { VACCINE_CATEGORY_LABELS } from '@tamanu/constants';
 
 import { Field, TranslatedSelectField } from '../../components';
 import { TranslatedText } from '../../components/Translation/TranslatedText';
@@ -11,6 +11,6 @@ export const VaccineCategoryField = ({ name = 'category', required, label }) => 
     label={label ?? <TranslatedText stringId="vaccine.category.label" fallback="Category" />}
     component={TranslatedSelectField}
     required={required}
-    enumValues={VACCINE_CATEGORIES}
+    enumValues={VACCINE_CATEGORY_LABELS}
   />
 );


### PR DESCRIPTION
Wrong enum here

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
