### PR TITLE
fix(programExport): Program export error on postgresql<=1.2

### DIFF
--- a/packages/central-server/app/admin/programExporter/exportProgram.js
+++ b/packages/central-server/app/admin/programExporter/exportProgram.js
@@ -34,7 +34,16 @@ export async function exportProgram(context, programId) {
       ['country', country],
       ['homeServer', country ? 'true' : ''],
       [],
-      ['code', 'name', 'surveyType', 'targetLocationId', 'targetDepartmentId', 'status', 'isSensitive', 'visibilityStatus'],
+      [
+        'code',
+        'name',
+        'surveyType',
+        'targetLocationId',
+        'targetDepartmentId',
+        'status',
+        'isSensitive',
+        'visibilityStatus',
+      ],
       ...surveys.map(survey => [
         survey.code,
         survey.name.replace(`(${country}) `, ''),
@@ -43,7 +52,7 @@ export async function exportProgram(context, programId) {
         '',
         'publish',
         survey.isSensitive,
-        survey.visibilityStatus
+        survey.visibilityStatus,
       ]),
     ],
   };
@@ -66,7 +75,7 @@ export async function exportProgram(context, programId) {
           pde.code,
           pde.type,
           pde.name,
-          pde.default_text text,
+          pde.default_text "text",
           pde.default_options options
         FROM survey_screen_components ssc
         JOIN program_data_elements pde ON concat(:surveyId, '-', pde.code) = ssc.id
@@ -98,7 +107,7 @@ export async function exportProgram(context, programId) {
             'detailLabel',
             'calculation',
             'config',
-            'visibilityStatus'
+            'visibilityStatus',
           ],
           ...surveyRecords.map(it => [
             it.code,
@@ -117,7 +126,7 @@ export async function exportProgram(context, programId) {
             '',
             it.calculation,
             it.config,
-            it.visibility_status
+            it.visibility_status,
           ]),
         ],
       });

--- a/packages/central-server/app/admin/programExporter/exportProgram.js
+++ b/packages/central-server/app/admin/programExporter/exportProgram.js
@@ -75,8 +75,8 @@ export async function exportProgram(context, programId) {
           pde.code,
           pde.type,
           pde.name,
-          pde.default_text "text",
-          pde.default_options options
+          pde.default_text as text,
+          pde.default_options as options
         FROM survey_screen_components ssc
         JOIN program_data_elements pde ON concat(:surveyId, '-', pde.code) = ssc.id
         WHERE ssc.survey_id = :surveyId


### PR DESCRIPTION
### Changes
Errored on palau demo as they are using 12

Will hotfix versions from when introduced

https://www.postgresql.org/docs/current/queries-select-lists.html#QUERIES-COLUMN-LABELS

Issue is you have to use as when using keywords as aliases in 12

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
