### PR TITLE
fix/omniserver-epic: Prevent error on reloading bed management

### DIFF
--- a/packages/web/app/views/facility/BedManagement.jsx
+++ b/packages/web/app/views/facility/BedManagement.jsx
@@ -236,8 +236,8 @@ export const BedManagement = () => {
         title={<TranslatedText stringId="bedManagement.title" fallback="Bed management" />}
         subTitle={
           <TranslatedReferenceData
-            fallback={facility.name}
-            value={facility.id}
+            fallback={facility?.name}
+            value={facility?.id}
             category="facility"
           />
         }


### PR DESCRIPTION
### Changes

When restoring a session to the bed management page, we get an error from trying to acces the .name property of the facility before it has been loaded. I have just added optional chaining so that it doesnt throw an error and instead will just display the string once loaded. I toyed with the idea of adding a loading indicator but it seems excessive given all the loading indicators on this page. This is also generally how we handle this kind of situation in the app at the moment (just show nothing and let it pop in when loaded)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
