### PR TITLE
fix(web): NASS-1271: fix report export timeout error

### DIFF
--- a/packages/web/app/components/Field/RadioField.jsx
+++ b/packages/web/app/components/Field/RadioField.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import Radio from '@material-ui/core/Radio';
@@ -138,8 +138,8 @@ export const RadioInput = ({
           {...props}
         >
           {options.map(option => (
-            <>
-              {option.leftOptionalElement ? option.leftOptionalElement : null}
+            <Fragment key={option.value}>
+              {option.leftOptionalElement ?? null}
               <ControlLabel
                 key={option.value}
                 labelPlacement={option.description ? 'start' : 'end'}
@@ -178,7 +178,7 @@ export const RadioInput = ({
                     : DEFAULT_LABEL_THEME
                 }
               />
-            </>
+            </Fragment>
           ))}
         </StyledRadioGroup>
         {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/packages/web/app/utils/index.js
+++ b/packages/web/app/utils/index.js
@@ -5,4 +5,5 @@ export { flattenObject } from './flattenObject';
 export * from './getVisibleQuestions';
 export * from './invalidatePatientDataQueries';
 export { getBrandName, getBrandId } from './brandMode.js';
+export { sanitizeFileName } from './sanitizeFileName';
 export { yupAttemptTransformToNumber } from './validation.js';

--- a/packages/web/app/views/administration/reports/ReportsSelectFields.jsx
+++ b/packages/web/app/views/administration/reports/ReportsSelectFields.jsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../../api';
 import { BaseSelectField } from '../../../components';
 
-export const ReportSelectField = ({ includeNameChangeEvent, ...props }) => {
+export const ReportSelectField = ({ includeNameChangeEvent, setSelectedReportName, ...props }) => {
   delete props.error;
   delete props.helperText;
 
@@ -20,11 +20,14 @@ export const ReportSelectField = ({ includeNameChangeEvent, ...props }) => {
     <BaseSelectField
       {...props}
       onChange={event => {
+        const { value } = event.target;
+        const name = reportData.find(report => report.id === value)?.name;
+        setSelectedReportName(name);
+
         if (includeNameChangeEvent) {
-          const { value } = event.target;
-          const name = reportData.find(report => report.id === value)?.name;
           props.field.onChange({ target: { name: 'name', value: name } });
         }
+
         props.field.onChange(event);
       }}
       options={options}
@@ -40,6 +43,7 @@ export const VersionSelectField = props => {
     form: {
       values: { reportId },
     },
+    setSelectedVersionNumber,
   } = props;
 
   const query = useQuery(
@@ -63,6 +67,13 @@ export const VersionSelectField = props => {
   return (
     <BaseSelectField
       {...props}
+      onChange={event => {
+        const { value } = event.target;
+        const { versionNumber } = versionData.find(version => version.id === value);
+        setSelectedVersionNumber(versionNumber);
+
+        props.field.onChange(event);
+      }}
       options={options}
       error={!!fetchError || props.error}
       helperText={fetchError?.message || props.helperText}


### PR DESCRIPTION
> [!NOTE]
> This one branches off #6267.

### Changes

Applies the fix from #6267 to report exports from the admin panel.

(Previously, the suggested filename came from the API response. This forced us to wait for the API to finish responding to get a file handle. On slow networks, this can take too long and cause a SecurityError when presenting the Save File dialog.)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
