### PR TITLE
fix(sync): SAV-806: Fix sync status toast

### DIFF
--- a/packages/facility-server/app/routes/sync/sync.js
+++ b/packages/facility-server/app/routes/sync/sync.js
@@ -49,6 +49,7 @@ sync.get(
     ).map(num => parseInt(num));
     const lastCompletedDurationMs = syncManager.lastDurationMs;
     const { lastCompletedAt } = syncManager;
+    const lastCompletedAgo = lastCompletedAt ? new Date() - new Date(lastCompletedAt) : 0;
 
     const isSyncRunning = syncManager.isSyncRunning();
     const currentDuration = isSyncRunning ? new Date().getTime() - syncManager.currentStartTime : 0;
@@ -57,6 +58,7 @@ sync.get(
       lastCompletedPull,
       lastCompletedPush,
       lastCompletedAt,
+      lastCompletedAgo,
       lastCompletedDurationMs,
       currentDuration,
       isSyncRunning,

--- a/packages/facility-server/app/sync/FacilitySyncManager.js
+++ b/packages/facility-server/app/sync/FacilitySyncManager.js
@@ -77,8 +77,8 @@ export class FacilitySyncManager {
       return { enabled: false };
     }
 
-    // if there is a currently running sync, and already another one 
-    // queued up to run after that, just wait for that next sync run 
+    // if there is a currently running sync, and already another one
+    // queued up to run after that, just wait for that next sync run
     // (which will definitely sync any changes made up until the time this sync was requested)
     if (this.nextSyncPromise) {
       const result = await this.nextSyncPromise;
@@ -118,7 +118,10 @@ export class FacilitySyncManager {
       );
     }
 
-    log.info('FacilitySyncManager.attemptStart', { reason: this.reason });
+    const startTime = new Date().getTime();
+    this.currentStartTime = startTime;
+
+    log.info('FacilitySyncManager.attemptStart', { reason: this.reason, startTime });
 
     const pullSince = (await this.models.LocalSystemFact.get(LAST_SUCCESSFUL_SYNC_PULL_KEY)) || -1;
 
@@ -142,9 +145,6 @@ export class FacilitySyncManager {
 
     // clear previous temp data, in case last session errored out or server was restarted
     await dropAllSnapshotTables(this.sequelize);
-
-    const startTime = new Date().getTime();
-    this.currentStartTime = startTime;
 
     log.info('FacilitySyncManager.receivedSessionInfo', {
       sessionId,

--- a/packages/web/app/components/HiddenSyncAvatar.jsx
+++ b/packages/web/app/components/HiddenSyncAvatar.jsx
@@ -53,7 +53,7 @@ function formatDuration(milliseconds) {
 export const HiddenSyncAvatar = ({ children, onClick, ...props }) => {
   const [loading, setLoading] = useState(false);
   const api = useApi();
-  
+
   const handleEvent = useCallback(
     async cb => {
       if (loading) return;
@@ -77,7 +77,7 @@ export const HiddenSyncAvatar = ({ children, onClick, ...props }) => {
           <TranslatedText
             stringId="sidebar.avatar.notification.startingManualSync"
             fallback="Starting manual sync..."
-          />
+          />,
         );
         const { message } = await api.post(`sync/run`);
         toast.success(
@@ -85,43 +85,49 @@ export const HiddenSyncAvatar = ({ children, onClick, ...props }) => {
             stringId="sidebar.avatar.notification.manualSync"
             fallback={`Manual sync: ${message}`}
             replacements={{ message }}
-          />
+          />,
         );
       });
       return;
     }
 
-    if (event.ctrlKey) {
+    if (event.ctrlKey || event.altKey) {
       handleEvent(async () => {
         const status = await api.get('/sync/status');
         const parts = [];
         if (status.lastCompletedAt === 0) {
-          parts.push(<div>
-            <TranslatedText
-              stringId="sidebar.avatar.notification.facilityNotSync"
-              fallback="Facility server has not synced since last restart."
-            />
-          </div>);
+          parts.push(
+            <div>
+              <TranslatedText
+                stringId="sidebar.avatar.notification.facilityNotSync"
+                fallback="Facility server has not synced since last restart."
+              />
+            </div>,
+          );
         } else {
-          const ago = formatDuration(new Date() - new Date(status.lastCompletedAt));
+          const ago = formatDuration(status.lastCompletedAgo);
           const took = formatDuration(status.lastCompletedDurationMs);
-          parts.push(<div>
-            <TranslatedText
-              stringId="sidebar.avatar.notification.facilityLastSync"
-              fallback={`Facility server last synced ${ago} ago (took ${took}).`}
-              replacements={{ ago, took }}
-            />
-          </div>);
+          parts.push(
+            <div>
+              <TranslatedText
+                stringId="sidebar.avatar.notification.facilityLastSync"
+                fallback={`Facility server last synced ${ago} ago (took ${took}).`}
+                replacements={{ ago, took }}
+              />
+            </div>,
+          );
         }
         if (status.isSyncRunning) {
           const duration = formatDuration(status.currentDuration);
-          parts.push(<div>
-            <TranslatedText
-              stringId="sidebar.notification.currentSyncRunning"
-              fallback={`Current sync has been running for ${duration}.`}
-              replacements={{ duration }}
-            />
-          </div>);
+          parts.push(
+            <div>
+              <TranslatedText
+                stringId="sidebar.notification.currentSyncRunning"
+                fallback={`Current sync has been running for ${duration}.`}
+                replacements={{ duration }}
+              />
+            </div>,
+          );
         }
         toast.info(<div>{parts}</div>);
       });


### PR DESCRIPTION
### Changes

Fixes the two issues reported in SAV-806

1. Our sync session start time was being recorded from part way through the sync logic, and notably was after some async work, so there was a significant period when the sync status would note the sync as running, but without a valid time.
2. The time "ago" was comparing Date.now() on two different computers, the facility server and the client. These clocks can be slightly out, so it wasn't accurate, and in this case was producing negative numbers.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
