### PR TITLE
tweak(translations): Allow note column on translation spreadsheet

### DIFF
--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -92,7 +92,8 @@ export function administeredVaccineLoader(item) {
   ];
 }
 
-export function translatedStringLoader({ stringId, ...languages }) {
+export function translatedStringLoader(item) {
+  const { stringId, ...languages } = stripNotes(item);
   return Object.entries(languages)
     .filter(([, text]) => text.trim())
     .map(([language, text]) => ({


### PR DESCRIPTION
### Changes

Our master translation spreadsheet makes use of the "note" column to track the version that the string was introduced. To enable this I just made use of the "stripNotes" function already in loaders.js to stop error on import

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
