### PR TITLE
feat(pm2): calculate default memory and scale from os resources

### DIFF
--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -1,4 +1,10 @@
-const memory = process.env.TAMANU_MEMORY_ALLOCATION || 8192;
+const os = require('node:os');
+
+const totalMemoryMB = os.totalmem() / (1024**2);
+const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6);
+
+const availableThreads = os.availableParallelism();
+const defaultApiScale = Math.max(2, Math.floor(availableThreads / 2));
 
 module.exports = {
   apps: [
@@ -8,7 +14,7 @@ module.exports = {
       script: './dist/index.js',
       args: 'startServe',
       interpreter_args: `--max_old_space_size=${memory}`,
-      instances: 'max',
+      instances: +process.env.TAMANU_API_SCALE || defaultApiScale,
       exec_mode: 'cluster',
       env: {
         NODE_ENV: 'production',


### PR DESCRIPTION
### Changes

Using `'max'` spawns as many threads as there are CPU cores, but we explicitly don't want that, because we typically co-locate Postgres on the same machine as Tamanu, and also the task-runner is extraneous.

But the pm2 config is a Node.js script, so we can in fact query the actual number of cores and set the default amount of instances as half of available, or a minimum of 2.

And then just because, we also query the total available memory and use that to define the Node.js allocation, instead of hardcoding as 8G.
