### PR TITLE
fix(omniserver): Post array containing facility id on mobile

### DIFF
--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -156,7 +156,7 @@ export class CentralServerConnection {
       {
         urgent,
         lastSyncedTick,
-        facilityId,
+        facilityIds: [facilityId],
         deviceId: this.deviceId,
       },
     );
@@ -190,7 +190,7 @@ export class CentralServerConnection {
     const facilityId = await readConfig('facilityId', '');
     const body = {
       since,
-      facilityId,
+      facilityIds: [facilityId],
       tablesToInclude: tableNames,
       tablesForFullResync,
       isMobile: true,


### PR DESCRIPTION
### Changes

Needed to send facility ids as an array from mobile to match central server sync logic (although on mobile its always only a single facility)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
