### PR TITLE
fix(mobile): Make survey notifiable default 0 and not false

### DIFF
--- a/packages/mobile/App/migrations/1724205895000-surveyCompletionNotification.ts
+++ b/packages/mobile/App/migrations/1724205895000-surveyCompletionNotification.ts
@@ -10,7 +10,7 @@ export class surveyCompletionNotification1724205895000 implements MigrationInter
         name: 'notifiable',
         type: 'boolean',
         isNullable: false,
-        default: false,
+        default: 0,
       }),
     );
 


### PR DESCRIPTION
### Changes

We saw some errors on mobile build when klaus was testing on bluestacks.
sqlite expects 0,1 to represent boolean values

I think its the issue? altho it doesn't error on my local
![image (61)](https://github.com/user-attachments/assets/1b6f7fb3-407a-4faf-b773-c4d4ab2be672)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
