### PR TITLE
fix(omniserver): NASS-1304: Pass logged in facility id to patientProgramRegistry endpoint

### DIFF
--- a/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -164,7 +164,7 @@ describe('PatientProgramRegistration', () => {
         patientId: patient.id,
         date: '2023-09-02 08:00:00',
         conditionIds: [programRegistryCondition.id],
-        facilityId,
+        registeringFacilityId: facilityId,
       });
 
       expect(result).toHaveSucceeded();
@@ -218,7 +218,7 @@ describe('PatientProgramRegistration', () => {
         programRegistryId: programRegistry1.id,
         registrationStatus: REGISTRATION_STATUSES.INACTIVE,
         date: '2023-09-02 09:00:00',
-        facilityId,
+        registeringFacilityId: facilityId,
       });
 
       expect(result).toHaveSucceeded();
@@ -262,7 +262,6 @@ describe('PatientProgramRegistration', () => {
           registeringFacilityId: facility.id,
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
           date: '2023-09-02 08:00:00',
-          facilityId,
         },
         {
           clinicianId: clinician.id,
@@ -272,7 +271,6 @@ describe('PatientProgramRegistration', () => {
           registeringFacilityId: facility.id,
           registrationStatus: REGISTRATION_STATUSES.INACTIVE,
           date: '2023-09-02 09:00:00',
-          facilityId,
         },
         {
           // Note this record won't show up as the status hasn't changed
@@ -281,25 +279,25 @@ describe('PatientProgramRegistration', () => {
           programRegistryId: registry.id,
           clinicalStatusId: status2.id,
           villageId: village.id,
+          registeringFacilityId: facility.id,
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
           date: '2023-09-02 10:00:00',
-          facilityId,
         },
         {
           patientId: patient.id,
           clinicalStatusId: status1.id,
           programRegistryId: registry.id,
+          registeringFacilityId: facility.id,
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
           date: '2023-09-02 11:00:00',
-          facilityId,
         },
         {
           patientId: patient.id,
           clinicalStatusId: status2.id,
           programRegistryId: registry.id,
+          registeringFacilityId: facility.id,
           registrationStatus: REGISTRATION_STATUSES.INACTIVE,
           date: '2023-09-02 11:30:00',
-          facilityId,
         },
       ];
 
@@ -563,7 +561,7 @@ describe('PatientProgramRegistration', () => {
             clinicianId: app.user.id,
             patientId: patient.id,
             date: TEST_DATE_EARLY,
-            facilityId,
+            registeringFacilityId: facilityId,
           });
 
         expect(result).toBeForbidden();
@@ -588,7 +586,7 @@ describe('PatientProgramRegistration', () => {
             clinicianId: app.user.id,
             patientId: patient.id,
             date: TEST_DATE_EARLY,
-            facilityId,
+            registeringFacilityId: facilityId,
           });
 
         expect(result).toHaveSucceeded();

--- a/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration.js
@@ -30,7 +30,7 @@ patientProgramRegistration.post(
   asyncHandler(async (req, res) => {
     const { db, models, params, body } = req;
     const { patientId } = params;
-    const { programRegistryId, facilityId } = body;
+    const { programRegistryId, registeringFacilityId } = body;
 
     req.checkPermission('read', 'Patient');
     const patient = await models.Patient.findByPk(patientId);
@@ -79,7 +79,7 @@ patientProgramRegistration.post(
         // as a side effect, mark for sync in the current facility
         models.PatientFacility.upsert({
           patientId,
-          facilityId,
+          facilityId: registeringFacilityId,
         }),
       ]);
     });

--- a/packages/web/app/views/programRegistry/PatientProgramRegistryForm.jsx
+++ b/packages/web/app/views/programRegistry/PatientProgramRegistryForm.jsx
@@ -62,6 +62,7 @@ export const PatientProgramRegistryForm = ({ onCancel, onSubmit, editedObject })
           conditionIds: data.conditionIds ? JSON.parse(data.conditionIds) : [],
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
           patientId: patient.id,
+          facilityId,
         });
       }}
       render={({ submitForm, values, setValues }) => {

--- a/packages/web/app/views/programRegistry/PatientProgramRegistryForm.jsx
+++ b/packages/web/app/views/programRegistry/PatientProgramRegistryForm.jsx
@@ -62,7 +62,6 @@ export const PatientProgramRegistryForm = ({ onCancel, onSubmit, editedObject })
           conditionIds: data.conditionIds ? JSON.parse(data.conditionIds) : [],
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
           patientId: patient.id,
-          facilityId,
         });
       }}
       render={({ submitForm, values, setValues }) => {


### PR DESCRIPTION
### Changes

Tiny fix into omniserver epic re not passing facilityId.
I do wonder if we are supposed to use registeredFacility form value or not 🤔 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
