### PR TITLE
tweak(web): error if `useSettings` used outside provider

### DIFF
--- a/packages/web/app/components/FormattedTableCell.jsx
+++ b/packages/web/app/components/FormattedTableCell.jsx
@@ -72,10 +72,10 @@ function getTooltip(float, config = {}, visibilityCriteria = {}) {
 
 export const formatValue = (value, config) => {
   const { rounding = 0, unit = '' } = config || {};
-  const float = parseFloat(value);
+  const float = Number.parseFloat(value);
 
   if (isNaN(float)) {
-    return value || '-';
+    return value || '—'; // em dash
   }
 
   const unitSuffix = unit && unit.length <= 2 ? unit : '';

--- a/packages/web/app/components/VitalsTable.jsx
+++ b/packages/web/app/components/VitalsTable.jsx
@@ -95,24 +95,22 @@ const MeasureCell = React.memo(({ value, data }) => {
       : visualisationConfig?.key;
 
   return (
-    <>
-      <Box flexDirection="row" display="flex" alignItems="center" justifyContent="space-between">
-        {value}
-        {hasVitalChart && (
-          <IconButton
-            size="small"
-            onClick={() => {
-              setChartKeys([chartKey]);
-              setIsInMultiChartsView(false);
-              setModalTitle(value);
-              setVitalChartModalOpen(true);
-            }}
-          >
-            <VitalVectorIcon />
-          </IconButton>
-        )}
-      </Box>
-    </>
+    <Box flexDirection="row" display="flex" alignItems="center" justifyContent="space-between">
+      {value}
+      {hasVitalChart && (
+        <IconButton
+          size="small"
+          onClick={() => {
+            setChartKeys([chartKey]);
+            setIsInMultiChartsView(false);
+            setModalTitle(value);
+            setVitalChartModalOpen(true);
+          }}
+        >
+          <VitalVectorIcon />
+        </IconButton>
+      )}
+    </Box>
   );
 });
 
@@ -145,27 +143,23 @@ const TitleCell = React.memo(({ value }) => {
   }
 
   return (
-    <>
-      <Box flexDirection="row" display="flex" alignItems="center" justifyContent="space-between">
-        {value}
-        {isSuccess &&
-          vitalsVisualisationConfigs &&
-          vitalsVisualisationConfigs.allGraphedChartKeys.length > 0 && (
-            <IconButton
-              size="small"
-              onClick={() => {
-                setChartKeys(chartKeys);
-                setIsInMultiChartsView(true);
-                setModalTitle('Vitals');
-                setVitalChartModalOpen(true);
-              }}
-            >
-              <VitalVectorIcon />
-            </IconButton>
-          )}
-        {isLoading && <CircularProgress size={14} />}
-      </Box>
-    </>
+    <Box flexDirection="row" display="flex" alignItems="center" justifyContent="space-between">
+      {value}
+      {isSuccess && vitalsVisualisationConfigs?.allGraphedChartKeys.length > 0 && (
+        <IconButton
+          size="small"
+          onClick={() => {
+            setChartKeys(chartKeys);
+            setIsInMultiChartsView(true);
+            setModalTitle('Vitals');
+            setVitalChartModalOpen(true);
+          }}
+        >
+          <VitalVectorIcon />
+        </IconButton>
+      )}
+      {isLoading && <CircularProgress size={14} />}
+    </Box>
   );
 });
 

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -13,7 +13,7 @@ export const useSettings = () => {
 };
 
 export const SettingsProvider = ({ children }) => {
-  const [settings, setSettings] = useState(null);
+  const [settings, setSettings] = useState({});
   const reduxSettings = useSelector(state => state.auth.settings);
 
   useEffect(() => {

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -1,15 +1,19 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
 
-const SettingsContext = React.createContext({
-  getSetting: () => {},
-});
+const SettingsContext = React.createContext(null);
 
-export const useSettings = () => useContext(SettingsContext);
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings has been called outside a SettingsProvider.');
+  }
+  return context;
+};
 
 export const SettingsProvider = ({ children }) => {
-  const [settings, setSettings] = useState({});
+  const [settings, setSettings] = useState(null);
   const reduxSettings = useSelector(state => state.auth.settings);
 
   useEffect(() => {

--- a/packages/web/app/views/patients/PatientLabTestsTable.jsx
+++ b/packages/web/app/views/patients/PatientLabTestsTable.jsx
@@ -169,7 +169,9 @@ export const PatientLabTestsTable = React.memo(
         ),
         accessor: row => {
           const range = row.normalRanges[patient?.sex];
-          const value = !range.min ? '—' /* em dash */ : `${range.min}–${range.max}`; /* en dash */
+          const value = !range.min
+            ? '—' // em dash
+            : `${range.min}–${range.max}`; // en dash
           return <CategoryCell>{value}</CategoryCell>;
         },
         sortable: false,

--- a/packages/web/app/views/patients/PatientLabTestsTable.jsx
+++ b/packages/web/app/views/patients/PatientLabTestsTable.jsx
@@ -169,7 +169,7 @@ export const PatientLabTestsTable = React.memo(
         ),
         accessor: row => {
           const range = row.normalRanges[patient?.sex];
-          const value = !range.min ? '-' : `${range.min}-${range.max}`;
+          const value = !range.min ? '–' : `${range.min}–${range.max}`; // en dash
           return <CategoryCell>{value}</CategoryCell>;
         },
         sortable: false,
@@ -199,11 +199,11 @@ export const PatientLabTestsTable = React.memo(
               );
             }
 
-            return <StyledButton disabled>-</StyledButton>;
+            return <StyledButton disabled>&mdash;</StyledButton>;
           },
           exportOverrides: {
             title: `${getTitle(date)}`,
-            accessor: row => row.results[date]?.result || '-',
+            accessor: row => row.results[date]?.result || '—', // em dash
           },
         })),
     ];

--- a/packages/web/app/views/patients/PatientLabTestsTable.jsx
+++ b/packages/web/app/views/patients/PatientLabTestsTable.jsx
@@ -169,7 +169,7 @@ export const PatientLabTestsTable = React.memo(
         ),
         accessor: row => {
           const range = row.normalRanges[patient?.sex];
-          const value = !range.min ? '–' : `${range.min}–${range.max}`; // en dash
+          const value = !range.min ? '—' /* em dash */ : `${range.min}–${range.max}`; /* en dash */
           return <CategoryCell>{value}</CategoryCell>;
         },
         sortable: false,

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -411,7 +411,7 @@ export const ReportGeneratorForm = () => {
                 setRequestError(null);
               }}
             >
-              {`Error: ${requestError}`}
+              Error: {requestError}
             </Alert>
           )}
           {successMessage && (


### PR DESCRIPTION
### Changes

- Sets default value of `Settings` context to `null`, and throws an error if this value is seen by `useSettings`
- Fixes `Error: [Object object]` issue in Report Generator
- Updates a few hyphens to the correct dashes
- Removes some redundant `React.Fragment`s

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
