### PR TITLE
fix(mobile): release 2.15: Fix bug with large autocomplete results

### DIFF
--- a/packages/mobile/App/models/TranslatedString.ts
+++ b/packages/mobile/App/models/TranslatedString.ts
@@ -67,6 +67,10 @@ export class TranslatedString extends BaseModel {
         text: Like(`%${queryString}%`),
       },
       select: ['stringId', 'text'],
+      order: {
+        text: 'ASC'
+      },
+      take: 25
     });
 
     return referenceDataTranslations;

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -99,9 +99,11 @@ export class Suggester<ModelType extends BaseModelSubclass> {
         .createQueryBuilder('entity')
         .where(
           new Brackets(qb => {
-            qb.where(`${column} LIKE :search`, {
-              search: `%${search}%`,
-            }).orWhere('entity.id IN (:...suggestedIds)', { suggestedIds });
+            if (search) {
+              qb.where(`${column} LIKE :search`, {
+                search: `%${search}%`,
+              }).orWhere('entity.id IN (:...suggestedIds)', { suggestedIds });
+            }
           }),
         )
         .andWhere(
@@ -111,7 +113,8 @@ export class Suggester<ModelType extends BaseModelSubclass> {
             });
           }),
         )
-        .orderBy(`entity.${column}`, 'ASC');
+        .orderBy(`entity.${column}`, 'ASC')
+        .limit(25);
 
       if (relations) {
         relations.forEach(relation => {


### PR DESCRIPTION
### Changes

We discovered that if a reference data type has a lot of records. It will throw errors when being searched with an empty string (or any query that returns more than 999 values) due to a sqlite limitation when inserting ids into a query. To get around this i actually a added a limit of 25 to the suggester so that it acts the same as desktop. 

Currently even though its an autocomplete field, it actually returns every value in the db so this is just updating to reflect what we do on desktop.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
