### PR TITLE
feat(greenmask): KAM-253: add greenmask configs imaging

### DIFF
--- a/greenmask/imaging_requests.yml
+++ b/greenmask/imaging_requests.yml
@@ -1,6 +1,6 @@
 ---
 schema: public
-name: lab_requests
+name: imaging_requests
 transformers:
   - name: RandomString
     params:

--- a/greenmask/imaging_requests.yml
+++ b/greenmask/imaging_requests.yml
@@ -1,0 +1,27 @@
+---
+schema: public
+name: lab_requests
+transformers:
+  - name: RandomString
+    params:
+      column: display_id
+      min_length: 10
+      max_length: 10
+      symbols: 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+  - name: Masking
+    params:
+      column: reason_for_cancellation
+
+  - name: Template
+    params:
+      column: requested_date
+      template: '{{- fakerTimestamp -}}'
+
+  - name: Masking
+    params:
+      column: legacy_results
+
+  - name: SetNull
+    params:
+      column: requested_date_legacy

--- a/greenmask/imaging_results.yml
+++ b/greenmask/imaging_results.yml
@@ -1,0 +1,12 @@
+---
+schema: public
+name: imaging_results
+transformers:
+  - name: Template
+    params:
+      column: completed_at
+      template: '{{- fakerTimestamp -}}'
+
+  - name: Masking
+    params:
+      column: description


### PR DESCRIPTION
### Changes

Add Greenmask config files for tables:

- `imaging_results`,
- `imaging_requests`.

I assume it's fine to leave `imaging_request_areas` and `imaging_area_external_codes` alone as they're more general information.
