### PR TITLE
fix(fhir): SAV-813: ASPEN slow FHIR job queue processing (hotfix)

### DIFF
--- a/packages/central-server/app/subCommands/tasks.js
+++ b/packages/central-server/app/subCommands/tasks.js
@@ -18,13 +18,13 @@ export const tasks = async ({ skipMigrationCheck, provisioning }) => {
   await context.store.sequelize.assertUpToDate({ skipMigrationCheck });
 
   const stopScheduledTasks = await startScheduledTasks(context);
-  const worker = await startFhirWorkerTasks(context);
+  const workers = await startFhirWorkerTasks(context);
 
   for (const sig of ['SIGINT', 'SIGTERM']) {
     process.once(sig, async () => {
       log.info(`Received ${sig}, stopping scheduled tasks`);
       stopScheduledTasks();
-      await worker.stop();
+      await Promise.all(workers.map(worker => worker.stop()));
       context.close();
     });
   }

--- a/packages/central-server/app/tasks/fhir/index.js
+++ b/packages/central-server/app/tasks/fhir/index.js
@@ -1,6 +1,7 @@
 import { FhirWorker } from '@tamanu/shared/tasks';
 import { JOB_TOPICS } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
+import config from 'config';
 
 import { allFromUpstream } from './refresh/allFromUpstream';
 import { entireResource } from './refresh/entireResource';
@@ -8,14 +9,34 @@ import { fromUpstream } from './refresh/fromUpstream';
 import { resolver } from './resolver';
 
 export async function startFhirWorkerTasks({ store }) {
-  const worker = new FhirWorker(store, log);
-  await worker.start();
+  // This config is a temporary hack to allow us to use a different worker config for ASPEN
+  // Will address this properly in SAV-813
+  const { aspenParallelFhirWorkerEnabled } = config.integrations.fhir;
 
-  worker.setHandler(JOB_TOPICS.FHIR.REFRESH.ALL_FROM_UPSTREAM, allFromUpstream);
-  worker.setHandler(JOB_TOPICS.FHIR.REFRESH.ENTIRE_RESOURCE, entireResource);
-  worker.setHandler(JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM, fromUpstream);
-  worker.setHandler(JOB_TOPICS.FHIR.RESOLVER, resolver);
+  const workers = [];
+  if (aspenParallelFhirWorkerEnabled) {
+    const resolverWorker = new FhirWorker(store, log);
+    const refreshWorker = new FhirWorker(store, log);
 
-  worker.processQueueNow();
-  return worker;
+    resolverWorker.setHandler(JOB_TOPICS.FHIR.RESOLVER, resolver);
+    refreshWorker.setHandler(JOB_TOPICS.FHIR.REFRESH.ALL_FROM_UPSTREAM, allFromUpstream);
+    refreshWorker.setHandler(JOB_TOPICS.FHIR.REFRESH.ENTIRE_RESOURCE, entireResource);
+    refreshWorker.setHandler(JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM, fromUpstream);
+
+    workers.push(resolverWorker, refreshWorker);
+  } else {
+    const worker = new FhirWorker(store, log);
+
+    worker.setHandler(JOB_TOPICS.FHIR.REFRESH.ALL_FROM_UPSTREAM, allFromUpstream);
+    worker.setHandler(JOB_TOPICS.FHIR.REFRESH.ENTIRE_RESOURCE, entireResource);
+    worker.setHandler(JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM, fromUpstream);
+    worker.setHandler(JOB_TOPICS.FHIR.RESOLVER, resolver);
+
+    workers.push(worker);
+  }
+
+  await Promise.all(workers.map(worker => worker.start()));
+  workers.forEach(worker => worker.processQueueNow());
+
+  return workers;
 }


### PR DESCRIPTION
Add config to allow ASPEN to run 2 FhirWorkers which manage separate topics

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
