### PR TITLE
ci(android): fix android workflow failing on main

### DIFF
--- a/.github/workflows/cd-package-android.yml
+++ b/.github/workflows/cd-package-android.yml
@@ -116,6 +116,7 @@ jobs:
           retention-days: 7
 
       - name: Post comment with release link
+        if: github.event_name == 'pull_request' || github.event_name == 'issues'
         uses: actions/github-script@v7
         env:
           ARTIFACT_URL: ${{ steps.artifact-upload.outputs.artifact-url }}
@@ -125,6 +126,7 @@ jobs:
             const { ARTIFACT_URL, BUILD_NUMBER } = process.env;
             const { repo, owner } = context.repo;
             const { number: issue_number } = context.issue;
+            if (!issue_number) return;
             const params = {
               issue_number,
               owner,


### PR DESCRIPTION
### Changes

The android workflow fails when running on main because there's no PR to post a comment to.