### PR TITLE
fix(survey): EPI-970: missing visualisationConfig column in vital survey export

### DIFF
--- a/packages/central-server/app/admin/programExporter/exportProgram.js
+++ b/packages/central-server/app/admin/programExporter/exportProgram.js
@@ -81,6 +81,7 @@ export async function exportProgram(context, programId) {
           pde.name,
           pde.default_text as text,
           pde.default_options as options
+          pde.visualisation_config
         FROM survey_screen_components ssc
         JOIN program_data_elements pde ON concat(:surveyId, '-', pde.code) = ssc.id
         WHERE ssc.survey_id = :surveyId
@@ -106,6 +107,7 @@ export async function exportProgram(context, programId) {
             'optionColors',
             'visibilityCriteria',
             'validationCriteria',
+            'visualisationConfig',
             'optionSet',
             'questionLabel',
             'detailLabel',
@@ -125,6 +127,7 @@ export async function exportProgram(context, programId) {
             '',
             it.visibility_criteria,
             it.validation_criteria,
+            it.visualisation_config,
             '',
             '',
             '',

--- a/packages/central-server/app/admin/programExporter/exportProgram.js
+++ b/packages/central-server/app/admin/programExporter/exportProgram.js
@@ -80,7 +80,7 @@ export async function exportProgram(context, programId) {
           pde.type,
           pde.name,
           pde.default_text as text,
-          pde.default_options as options
+          pde.default_options as options,
           pde.visualisation_config
         FROM survey_screen_components ssc
         JOIN program_data_elements pde ON concat(:surveyId, '-', pde.code) = ssc.id


### PR DESCRIPTION
### Changes

- Add visualisationConfig column in vital survey export

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

