### PR TITLE
fix(appointments): release 2.15: Status bug breaking styling

### DIFF
--- a/packages/web/app/components/Appointments/Appointment.jsx
+++ b/packages/web/app/components/Appointments/Appointment.jsx
@@ -36,6 +36,12 @@ export const Appointment = ({ appointment, onUpdated }) => {
 
   const closeDetail = () => setDetailOpen(false);
 
+  const statusIcons = {
+    [APPOINTMENT_STATUSES.CONFIRMED]: <RadioButtonUncheckedIcon />,
+    [APPOINTMENT_STATUSES.ARRIVED]: <CheckCircleIcon />,
+    [APPOINTMENT_STATUSES.NO_SHOW]: <CancelIcon />,
+  };
+
   return (
     <StyledTooltip
       arrow
@@ -59,11 +65,7 @@ export const Appointment = ({ appointment, onUpdated }) => {
           </Box>
           <DateDisplay date={startTime} showDate={false} showTime />
         </div>
-        <div className="icon">
-          {status === APPOINTMENT_STATUSES.CONFIRMED && <RadioButtonUncheckedIcon />}
-          {status === APPOINTMENT_STATUSES.ARRIVED && <CheckCircleIcon />}
-          {status === APPOINTMENT_STATUSES.NO_SHOW && <CancelIcon />}
-        </div>
+        <div className="icon">{statusIcons[status]}</div>
       </StyledAppointment>
     </StyledTooltip>
   );

--- a/packages/web/app/components/Appointments/Appointment.jsx
+++ b/packages/web/app/components/Appointments/Appointment.jsx
@@ -9,6 +9,7 @@ import { Colors } from '../../constants';
 import { PatientNameDisplay } from '../PatientNameDisplay';
 import { AppointmentDetail } from './AppointmentDetail';
 import { DateDisplay } from '../DateDisplay';
+import { APPOINTMENT_STATUSES } from '@tamanu/constants';
 
 const StyledTooltip = styled(({ className, ...props }) => (
   <Tooltip {...props} classes={{ popper: className }} />
@@ -59,9 +60,9 @@ export const Appointment = ({ appointment, onUpdated }) => {
           <DateDisplay date={startTime} showDate={false} showTime />
         </div>
         <div className="icon">
-          {status === 'Confirmed' && <RadioButtonUncheckedIcon />}
-          {status === 'Arrived' && <CheckCircleIcon />}
-          {status === 'No-show' && <CancelIcon />}
+          {status === APPOINTMENT_STATUSES.CONFIRMED && <RadioButtonUncheckedIcon />}
+          {status === APPOINTMENT_STATUSES.ARRIVED && <CheckCircleIcon />}
+          {status === APPOINTMENT_STATUSES.NO_SHOW && <CancelIcon />}
         </div>
       </StyledAppointment>
     </StyledTooltip>

--- a/packages/web/app/components/Appointments/Appointment.jsx
+++ b/packages/web/app/components/Appointments/Appointment.jsx
@@ -30,17 +30,17 @@ const StyledTooltip = styled(({ className, ...props }) => (
   }
 `;
 
+const statusIcons = {
+  [APPOINTMENT_STATUSES.CONFIRMED]: <RadioButtonUncheckedIcon />,
+  [APPOINTMENT_STATUSES.ARRIVED]: <CheckCircleIcon />,
+  [APPOINTMENT_STATUSES.NO_SHOW]: <CancelIcon />,
+};
+
 export const Appointment = ({ appointment, onUpdated }) => {
   const { startTime, patient, status } = appointment;
   const [detailOpen, setDetailOpen] = useState(false);
 
   const closeDetail = () => setDetailOpen(false);
-
-  const statusIcons = {
-    [APPOINTMENT_STATUSES.CONFIRMED]: <RadioButtonUncheckedIcon />,
-    [APPOINTMENT_STATUSES.ARRIVED]: <CheckCircleIcon />,
-    [APPOINTMENT_STATUSES.NO_SHOW]: <CancelIcon />,
-  };
 
   return (
     <StyledTooltip

--- a/packages/web/app/components/Appointments/AppointmentDetail.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetail.jsx
@@ -57,9 +57,9 @@ const PatientInfoValue = styled.td`
   text-transform: capitalize;
 `;
 
-const APPOINTMENT_STATUS_OPTIONS = Object.entries(APPOINTMENT_STATUSES).map(([value, label]) => ({
-  value,
-  label,
+const APPOINTMENT_STATUS_OPTIONS = Object.values(APPOINTMENT_STATUSES).map(status => ({
+  value: status,
+  label: status,
 }));
 
 const PatientInfo = ({ patient }) => {

--- a/packages/web/app/components/Appointments/AppointmentDetail.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetail.jsx
@@ -321,6 +321,10 @@ export const AppointmentDetail = ({ appointment, onUpdated, onClose }) => {
             await updateAppointmentStatus(selectedOption.value);
           }}
           styles={{
+            placeholder: baseStyles => ({
+              ...baseStyles,
+              color: Colors.white,
+            }),
             valueContainer: baseStyles => ({
               ...baseStyles,
               color: Colors.white,


### PR DESCRIPTION
### Changes

Discovered on regression testing that some of the logic depending on 'status' was breaking on the appointments calendar. This was because the options were changed in a way where it was essentially passing around a capitalised version of the constant which was not triggering logic when it needed. Here i fixed the options array

This still needs to be incorporated into a "translated" select but i think out of scope of this release fix

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
