### PR TITLE
repo: add kamaka codeownerships

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,3 +30,17 @@
 #
 /packages/central-server/config/default.json5  @beyondessential/tamanu-deployment-team
 /packages/facility-server/config/default.json5  @beyondessential/tamanu-deployment-team
+
+#
+# Kamaka needs to be across changes to the PM2 config files, as they're critical
+# to the deployment process on Windows.
+#
+pm2*.config.js  @passcod
+
+#
+# Kamaka owns the Github Actions workflows, for verification as breakage affects
+# the deployment processes and may have non-local effects.
+#
+/.github/actions/    @passcod
+/.github/scripts/    @passcod
+/.github/workflows/  @passcod

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,12 +35,12 @@
 # Kamaka needs to be across changes to the PM2 config files, as they're critical
 # to the deployment process on Windows.
 #
-pm2*.config.js  @passcod
+pm2*.config.js  @kamaka
 
 #
 # Kamaka owns the Github Actions workflows, for verification as breakage affects
 # the deployment processes and may have non-local effects.
 #
-/.github/actions/    @passcod
-/.github/scripts/    @passcod
-/.github/workflows/  @passcod
+/.github/actions/    @kamaka
+/.github/scripts/    @kamaka
+/.github/workflows/  @kamaka

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,10 +18,10 @@
 # Kamaka currently owns VDS-NC/EU-DCC/Signer and CSCA.
 # Same reasoning, but it's not core to Tamanu.
 #
-/packages/csca/src/                                          @kamaka
-/packages/central-server/integrations/EuDcc                  @kamaka
-/packages/central-server/integrations/Signer                 @kamaka
-/packages/central-server/integrations/VdsNc                  @kamaka
+/packages/csca/src/                                          @beyondessential/kamaka
+/packages/central-server/integrations/EuDcc                  @beyondessential/kamaka
+/packages/central-server/integrations/Signer                 @beyondessential/kamaka
+/packages/central-server/integrations/VdsNc                  @beyondessential/kamaka
 
 #
 # The deployment team are code owner of the default config files to make sure
@@ -35,12 +35,12 @@
 # Kamaka needs to be across changes to the PM2 config files, as they're critical
 # to the deployment process on Windows.
 #
-pm2*.config.js  @kamaka
+pm2*.config.js  @beyondessential/kamaka
 
 #
 # Kamaka owns the Github Actions workflows, for verification as breakage affects
 # the deployment processes and may have non-local effects.
 #
-/.github/actions/    @kamaka
-/.github/scripts/    @kamaka
-/.github/workflows/  @kamaka
+/.github/actions/    @beyondessential/kamaka
+/.github/scripts/    @beyondessential/kamaka
+/.github/workflows/  @beyondessential/kamaka

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,13 +15,13 @@
 /packages/mobile/App/services/sync/                     @edmofro @chris-bes
 
 #
-# Félix currently owns VDS-NC/EU-DCC/Signer and CSCA.
+# Kamaka currently owns VDS-NC/EU-DCC/Signer and CSCA.
 # Same reasoning, but it's not core to Tamanu.
 #
-/packages/csca/src/                                          @passcod
-/packages/central-server/integrations/EuDcc                  @passcod
-/packages/central-server/integrations/Signer                 @passcod
-/packages/central-server/integrations/VdsNc                  @passcod
+/packages/csca/src/                                          @kamaka
+/packages/central-server/integrations/EuDcc                  @kamaka
+/packages/central-server/integrations/Signer                 @kamaka
+/packages/central-server/integrations/VdsNc                  @kamaka
 
 #
 # The deployment team are code owner of the default config files to make sure


### PR DESCRIPTION
### Changes

- for PM2 configs, to avoid missing changes to deployment processes which may require e.g. caddy or container configuration
- for Github Actions, as a safety

Maybe we should have a github kamaka team so it doesn't fall to only me.