### PR TITLE
fix(settings): Make settings `value` column nullable on mobile

### DIFF
--- a/packages/mobile/App/migrations/1724900789000-removeSettingsValueNotNullConstraint.ts
+++ b/packages/mobile/App/migrations/1724900789000-removeSettingsValueNotNullConstraint.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+export class removeSettingsValueNotNullConstraint1724900789000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const tableObject = await getTable(queryRunner, 'setting');
+    await queryRunner.changeColumn(
+      tableObject,
+      'value',
+      new TableColumn({
+        name: 'value',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const tableObject = await getTable(queryRunner, 'setting');
+    await queryRunner.changeColumn(
+      tableObject,
+      'value',
+      new TableColumn({
+        name: 'value',
+        type: 'varchar',
+        isNullable: false,
+      }),
+    );
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -53,6 +53,7 @@ import { addSecondaryVillageIdToPatientAdditionalData1718236579000 } from './171
 import { addMissedDeletedAtToTranslatedStringTable1718045677000 } from './1718045677000-addMissedDeletedAtToTranslatedStringTable';
 import { addClinicianToEncounterDiagnosis1721636585000 } from './1721636585000-addClinicianToEncounterDiagnosis';
 import { surveyCompletionNotification1724205895000 } from './1724205895000-surveyCompletionNotification';
+import { removeSettingsValueNotNullConstraint1724900789000 } from './1724900789000-removeSettingsValueNotNullConstraint';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -109,4 +110,5 @@ export const migrationList = [
   addMissedDeletedAtToTranslatedStringTable1718045677000,
   addClinicianToEncounterDiagnosis1721636585000,
   surveyCompletionNotification1724205895000,
+  removeSettingsValueNotNullConstraint1724900789000,
 ];

--- a/packages/mobile/App/models/Setting.ts
+++ b/packages/mobile/App/models/Setting.ts
@@ -16,7 +16,7 @@ export class Setting extends BaseModel {
   @Column({ nullable: false })
   key: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   value: string;
 
   @Column({ nullable: false })
@@ -97,7 +97,7 @@ export class Setting extends BaseModel {
     const settingWithFacilityScope = await this.get('', facilityId);
     const settingWithGlobalScope = await this.get('');
     const settings = merge(settingWithGlobalScope, settingWithFacilityScope);
-    return getAtPath(settings, key)
+    return getAtPath(settings, key);
   }
 
   static sanitizePulledRecordData(rows) {


### PR DESCRIPTION
- On postgres side it is nullable but not on mobile - causing an easy mobile sync error if you explicitly set a setting null on admin panel (i.e to remove a setting)


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
