### PR TITLE
fix(translations): release 2.15: Add 2 missing translatable yup error labels

### DIFF
--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/patientDetailsValidationSchema.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/patientDetailsValidationSchema.tsx
@@ -188,7 +188,13 @@ export const getPatientDetailsValidation = getBool => {
         />,
       ),
     ),
-    ethnicityId: requiredWhenConfiguredMandatory(getBool, 'ethnicityId', Yup.string()),
+    ethnicityId: requiredWhenConfiguredMandatory(
+      getBool,
+      'ethnicityId',
+      Yup.string().translatedLabel(
+        <TranslatedText stringId="general.localisedField.ethnicityId.label" fallback="Ethnicity" />,
+      ),
+    ),
     patientBillingTypeId: requiredWhenConfiguredMandatory(
       getBool,
       'patientBillingTypeId',

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -114,7 +114,7 @@ export const ImagingRequestForm = React.memo(
         }}
         formType={editedObject ? FORM_TYPES.EDIT_FORM : FORM_TYPES.CREATE_FORM}
         validationSchema={yup.object().shape({
-          requestedById: foreignKey(),
+          requestedById: foreignKey(requiredValidationMessage),
           requestedDate: yup.date().required(requiredValidationMessage),
           imagingType: foreignKey(requiredValidationMessage),
           areas: yup.string().when('imagingType', {


### PR DESCRIPTION
### Changes
- 2 missed spots for translated labels

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
