### PR TITLE
fix(enums): release-fix 2.15: Reformat some enums for select fields

### DIFF
--- a/packages/constants/src/enumRegistry.ts
+++ b/packages/constants/src/enumRegistry.ts
@@ -9,7 +9,7 @@ import {
 import { NOTE_TYPE_LABELS } from './notes';
 import {
   REFERRAL_STATUS_LABELS,
-  APPOINTMENT_TYPES,
+  APPOINTMENT_TYPE_LABELS,
   APPOINTMENT_STATUSES,
   IMAGING_REQUEST_STATUS_LABELS,
 } from './statuses';
@@ -41,7 +41,7 @@ type EnumEntries = [EnumKeys, EnumValues][];
  */
 export const registeredEnums = {
   APPOINTMENT_STATUSES,
-  APPOINTMENT_TYPES,
+  APPOINTMENT_TYPE_LABELS,
   ASSET_NAME_LABELS,
   BIRTH_DELIVERY_TYPE_LABELS,
   BIRTH_TYPE_LABELS,
@@ -80,7 +80,7 @@ export const registeredEnums = {
  */
 export const translationPrefixes: Record<EnumKeys, string> = {
   APPOINTMENT_STATUSES: 'appointment.property.status',
-  APPOINTMENT_TYPES: 'appointment.property.types',
+  APPOINTMENT_TYPE_LABELS: 'appointment.property.types',
   ASSET_NAME_LABELS: 'asset.property.name',
   BIRTH_DELIVERY_TYPE_LABELS: 'birth.property.birthDeliveryType',
   BIRTH_TYPE_LABELS: 'birth.property.birthType',

--- a/packages/constants/src/enumRegistry.ts
+++ b/packages/constants/src/enumRegistry.ts
@@ -24,7 +24,7 @@ import {
 } from './reports';
 import { TEMPLATE_TYPE_LABELS } from './templates';
 import { LAB_REQUEST_STATUS_LABELS } from './labs';
-import { ASSET_NAMES } from './importable';
+import { ASSET_NAME_LABELS } from './importable';
 import { DIAGNOSIS_CERTAINTY_LABELS, PATIENT_ISSUE_LABELS } from './diagnoses';
 import { DRUG_ROUTE_LABELS, REPEATS_LABELS } from './medications';
 import { PLACE_OF_DEATHS, MANNER_OF_DEATHS } from './deaths';
@@ -42,7 +42,7 @@ type EnumEntries = [EnumKeys, EnumValues][];
 export const registeredEnums = {
   APPOINTMENT_STATUSES,
   APPOINTMENT_TYPES,
-  ASSET_NAMES,
+  ASSET_NAME_LABELS,
   BIRTH_DELIVERY_TYPE_LABELS,
   BIRTH_TYPE_LABELS,
   DIAGNOSIS_CERTAINTY_LABELS,
@@ -81,7 +81,7 @@ export const registeredEnums = {
 export const translationPrefixes: Record<EnumKeys, string> = {
   APPOINTMENT_STATUSES: 'appointment.property.status',
   APPOINTMENT_TYPES: 'appointment.property.types',
-  ASSET_NAMES: 'asset.property.name',
+  ASSET_NAME_LABELS: 'asset.property.name',
   BIRTH_DELIVERY_TYPE_LABELS: 'birth.property.birthDeliveryType',
   BIRTH_TYPE_LABELS: 'birth.property.birthType',
   DIAGNOSIS_CERTAINTY_LABELS: 'diagnosis.property.certainty',

--- a/packages/constants/src/importable.ts
+++ b/packages/constants/src/importable.ts
@@ -122,6 +122,17 @@ export const ASSET_NAMES = {
   VACCINATION_CERTIFICATE_FOOTER: 'vaccination-certificate-footer-img',
 };
 
+export const ASSET_NAME_LABELS = {
+  [ASSET_NAMES.LETTERHEAD_LOGO]: 'letterhead-logo',
+  [ASSET_NAMES.VACCINE_CERTIFICATE_WATERMARK]: 'vaccine-certificate-watermark',
+  [ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG]: 'certificate-bottom-half-img',
+  [ASSET_NAMES.DEATH_CERTIFICATE_BOTTOM_HALF_IMG]: 'death-certificate-bottom-half-img',
+  [ASSET_NAMES.COVID_VACCINATION_CERTIFICATE_FOOTER]: 'covid-vaccination-certificate-footer-img',
+  [ASSET_NAMES.COVID_CLEARANCE_CERTIFICATE_FOOTER]: 'covid-clearance-certificate-footer-img',
+  [ASSET_NAMES.COVID_TEST_CERTIFICATE_FOOTER]: 'covid-test-certificate-footer-img',
+  [ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER]: 'vaccination-certificate-footer-img',
+};
+
 export const ASSET_FALLBACK_NAMES = {
   [ASSET_NAMES.COVID_VACCINATION_CERTIFICATE_FOOTER]: ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG,
   [ASSET_NAMES.COVID_CLEARANCE_CERTIFICATE_FOOTER]: ASSET_NAMES.CERTIFICATE_BOTTOM_HALF_IMG,

--- a/packages/constants/src/statuses.ts
+++ b/packages/constants/src/statuses.ts
@@ -56,6 +56,13 @@ export const APPOINTMENT_TYPES = {
   OTHER: 'Other',
 };
 
+export const APPOINTMENT_TYPE_LABELS = {
+  [APPOINTMENT_TYPES.STANDARD]: 'Standard',
+  [APPOINTMENT_TYPES.EMERGENCY]: 'Emergency',
+  [APPOINTMENT_TYPES.SPECIALIST]: 'Specialist',
+  [APPOINTMENT_TYPES.OTHER]: 'Other',
+};
+
 export const APPOINTMENT_STATUSES = {
   CONFIRMED: 'Confirmed',
   ARRIVED: 'Arrived',

--- a/packages/web/app/components/Appointments/AppointmentForm.jsx
+++ b/packages/web/app/components/Appointments/AppointmentForm.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import * as yup from 'yup';
-import { APPOINTMENT_STATUSES, APPOINTMENT_TYPES } from '@tamanu/constants';
+import { APPOINTMENT_STATUSES, APPOINTMENT_TYPE_LABELS } from '@tamanu/constants';
 import { FormGrid } from '../FormGrid';
 import { AutocompleteField, DateTimeField, Field, Form, TranslatedSelectField } from '../Field';
 import { FormSubmitCancelRow } from '../ButtonRow';
@@ -102,7 +102,7 @@ export const AppointmentForm = props => {
               }
               name="type"
               component={TranslatedSelectField}
-              enumValues={APPOINTMENT_TYPES}
+              enumValues={APPOINTMENT_TYPE_LABELS}
               required
             />
           </FormGrid>

--- a/packages/web/app/components/SearchBar/AppointmentsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/AppointmentsSearchBar.jsx
@@ -11,7 +11,7 @@ import {
 } from '../Field';
 import { TranslatedText } from '../Translation/TranslatedText';
 import { useSuggester } from '../../api';
-import { APPOINTMENT_STATUSES, APPOINTMENT_TYPES } from '@tamanu/constants';
+import { APPOINTMENT_STATUSES, APPOINTMENT_TYPE_LABELS } from '@tamanu/constants';
 
 export const AppointmentsSearchBar = ({ onSearch }) => {
   const practitionerSuggester = useSuggester('practitioner');
@@ -70,7 +70,7 @@ export const AppointmentsSearchBar = ({ onSearch }) => {
         name="type"
         label={<TranslatedText stringId="appointment.type.label" fallback="Appointment type" />}
         component={TranslatedSelectField}
-        enumValues={APPOINTMENT_TYPES}
+        enumValues={APPOINTMENT_TYPE_LABELS}
         size="small"
       />
       <LocalisedField

--- a/packages/web/app/views/administration/AssetUploaderView.jsx
+++ b/packages/web/app/views/administration/AssetUploaderView.jsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useState } from 'react';
 import * as yup from 'yup';
-import { ASSET_NAMES, ASSET_NAME_LABELS } from '@tamanu/constants/importable';
+import { ASSET_NAME_LABELS } from '@tamanu/constants/importable';
 import { useApi } from '../../api';
 import { Field, Form, TranslatedSelectField } from '../../components/Field';
 import { FileChooserField, FILTER_IMAGES } from '../../components/Field/FileChooserField';

--- a/packages/web/app/views/administration/AssetUploaderView.jsx
+++ b/packages/web/app/views/administration/AssetUploaderView.jsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useState } from 'react';
 import * as yup from 'yup';
-import { ASSET_NAMES } from '@tamanu/constants/importable';
+import { ASSET_NAMES, ASSET_NAME_LABELS } from '@tamanu/constants/importable';
 import { useApi } from '../../api';
 import { Field, Form, TranslatedSelectField } from '../../components/Field';
 import { FileChooserField, FILTER_IMAGES } from '../../components/Field/FileChooserField';
@@ -91,7 +91,7 @@ export const AssetUploaderView = memo(() => {
             <FormGrid columns={1}>
               <Field
                 component={TranslatedSelectField}
-                enumValues={ASSET_NAMES}
+                enumValues={ASSET_NAME_LABELS}
                 label={<TranslatedText stringId="asset.name.label" fallback="Select asset" />}
                 name="name"
                 required

--- a/packages/web/app/views/scheduling/AppointmentsCalendar.jsx
+++ b/packages/web/app/views/scheduling/AppointmentsCalendar.jsx
@@ -18,7 +18,7 @@ import { useApi, useSuggester } from '../../api';
 import { TranslatedText } from '../../components/Translation/TranslatedText';
 import { useAuth } from '../../contexts/Auth';
 import { ErrorMessage } from '../../components/ErrorMessage';
-import { APPOINTMENT_TYPES } from '@tamanu/constants';
+import { APPOINTMENT_TYPE_LABELS } from '@tamanu/constants';
 
 const LeftContainer = styled.div`
   min-height: 100%;
@@ -192,7 +192,7 @@ export const AppointmentsCalendar = () => {
               }}
               value={appointmentType}
               name="appointmentType"
-              enumValues={APPOINTMENT_TYPES}
+              enumValues={APPOINTMENT_TYPE_LABELS}
             />
           </Section>
         </LeftContainer>


### PR DESCRIPTION
### Changes

Discovered in regression testing that some translated select fields were setup wrong and were saving capilatized strings to db. This pr formats them properly

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
