### PR TITLE
refactor: named params for makeCertificate functions

### DIFF
--- a/packages/central-server/app/subCommands/generateVaccineCertificate.js
+++ b/packages/central-server/app/subCommands/generateVaccineCertificate.js
@@ -10,7 +10,12 @@ export const generateCertificate = async ({ patientId }) => {
   try {
     const patient = await Patient.findByPk(patientId);
     log.info(`Generating vaccine certificate for patient id "${patientId}"`);
-    const pdf = await makeVaccineCertificate(patient, 'Admin', null, store.models);
+    const pdf = await makeVaccineCertificate({
+      patient,
+      printedBy: 'Admin',
+      printedDate: null,
+      models: store.models,
+    });
     log.info(`Certificate output: `, pdf);
   } catch (error) {
     process.stderr.write(`Report failed: ${error.stack}\n`);

--- a/packages/central-server/app/tasks/CertificateNotificationProcessor/index.js
+++ b/packages/central-server/app/tasks/CertificateNotificationProcessor/index.js
@@ -149,16 +149,15 @@ export class CertificateNotificationProcessor extends ScheduledTask {
             }
 
             sublog.info('Generating vax certificate PDF', { uvci });
-            pdf = await makeCovidVaccineCertificate(
+            pdf = await makeCovidVaccineCertificate({
+              models,
+              language,
               patient,
               printedBy,
               printedDate,
-              models,
-              settings,
-              uvci,
               qrData,
-              language,
-            );
+              uvci,
+            });
             break;
           }
 
@@ -177,15 +176,15 @@ export class CertificateNotificationProcessor extends ScheduledTask {
             }
 
             sublog.info('Generating test certificate PDF');
-            pdf = await makeCovidCertificate(
-              CertificateTypes.test,
-              patient,
-              printedBy,
+            pdf = await makeCovidCertificate({
               models,
               settings,
-              qrData,
+              certType: CertificateTypes.test,
               language,
-            );
+              patient,
+              printedBy,
+              vdsData: qrData,
+            });
             break;
           }
 
@@ -193,28 +192,28 @@ export class CertificateNotificationProcessor extends ScheduledTask {
             template = 'covidClearanceCertificateEmail';
 
             sublog.info('Generating clearance certificate PDF');
-            pdf = await makeCovidCertificate(
-              CertificateTypes.clearance,
-              patient,
-              printedBy,
+            pdf = await makeCovidCertificate({
               models,
               settings,
-              qrData,
+              certType: CertificateTypes.clearance,
               language,
-            );
+              patient,
+              printedBy,
+              vdsData: qrData,
+            });
             break;
 
           case VACCINATION_CERTIFICATE:
             template = 'vaccineCertificateEmail';
-            pdf = await makeVaccineCertificate(
+            pdf = await makeVaccineCertificate({
+              models,
+              facilityName,
+              language,
               patient,
               printedBy,
               printedDate,
-              facilityName,
-              models,
-              language,
               translations,
-            );
+            });
             break;
 
           default:

--- a/packages/central-server/app/utils/makePatientCertificate.jsx
+++ b/packages/central-server/app/utils/makePatientCertificate.jsx
@@ -64,15 +64,15 @@ async function getPatientVaccines(models, patient) {
   return { certifiableVaccines, vaccines: vaccineData, patientData };
 }
 
-export const makeCovidVaccineCertificate = async (
+export const makeCovidVaccineCertificate = async ({
+  models,
+  language,
   patient,
   printedBy,
   printedDate,
-  models,
-  uvci,
   qrData = null,
-  language,
-) => {
+  uvci,
+}) => {
   const localisation = await getLocalisation();
   const getLocalisationData = key => get(localisation, key);
 
@@ -102,15 +102,15 @@ export const makeCovidVaccineCertificate = async (
   );
 };
 
-export const makeVaccineCertificate = async (
+export const makeVaccineCertificate = async ({
+  models,
   patient,
+  facilityName,
+  language,
   printedBy,
   printedDate,
-  facilityName,
-  models,
-  language,
   translations,
-) => {
+}) => {
   const localisation = await getLocalisation();
 
   const fileName = `vaccine-certificate-${patient.id}.pdf`;
@@ -138,15 +138,15 @@ export const makeVaccineCertificate = async (
   );
 };
 
-export const makeCovidCertificate = async (
-  certType,
-  patient,
-  printedBy,
+export const makeCovidCertificate = async ({
   models,
   settings,
-  vdsData = null,
+  certType,
   language,
-) => {
+  patient,
+  printedBy,
+  vdsData = null,
+}) => {
   const localisation = await getLocalisation();
   const getLocalisationData = key => get(localisation, key);
   const settingsObj = await settings.getAll();


### PR DESCRIPTION
> [!NOTE]
> Merges into #6316, because this change came out of that review

### Changes

Changes the signature of `make...Certificate` functions to use named parameters (it was beginning to get unwieldy).

