### PR TITLE
ci(images): KAM-257: build images on newer ARM64 runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -162,7 +162,7 @@ jobs:
           - arch: amd64
             runs-on: ubuntu-latest
           - arch: arm64
-            runs-on: Linux-ARM64
+            runs-on: Linux-ARM64-Ubuntu-24.04
         package:
           - name: central
             path: central-server


### PR DESCRIPTION
### Changes

The current runner is [getting deprecated](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy %imagesonly -->
