### PR TITLE
feat(settings): NASS-1388: Add autocomplete awareness to getSettings with possible settings paths

### DIFF
--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -12,6 +12,7 @@ import { log, initBugsnag } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings/reader';
 
 /**
+ * @typedef {import('./services/EmailService').EmailService} EmailService
  * @typedef {import('@tamanu/settings').CentralSettingPath} CentralSettingPath
  * @typedef {import('@tamanu/settings').ReadSettings} ReadSettings
  */

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -55,7 +55,6 @@ export class ApplicationContext {
 
     this.settings = new ReadSettings(this.store.models);
 
-    this.settings.get('')
     this.telegramBotService = await defineSingletonTelegramBotService({
       config,
       models: this.store.models,

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -12,8 +12,8 @@ import { log, initBugsnag } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings/reader';
 
 /**
- * @typedef {import('./services/EmailService').EmailService} EmailService
- * @typedef {import('@tamanu/settings').CentralReadSettings} SettingsReader
+ * @typedef {import('@tamanu/settings').CentralSettingPath} CentralSettingPath
+ * @typedef {import('@tamanu/settings').ReadSettings} ReadSettings
  */
 
 export class ApplicationContext {
@@ -30,7 +30,7 @@ export class ApplicationContext {
 
   integrations = null;
 
-  /** @type {SettingsReader | null} */
+  /**@type {ReadSettings<CentralSettingPath> | null} */
   settings = null;
 
   closeHooks = [];

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -12,14 +12,8 @@ import { log, initBugsnag } from '@tamanu/shared/services/logging';
 import { ReadSettings } from '@tamanu/settings/reader';
 
 /**
- * @typedef {import('@tamanu/settings/reader').ReadSettings} ReadSettings
- * @typedef {import('@tamanu/settings').CentralSettingPath} CentralSettingPath
  * @typedef {import('./services/EmailService').EmailService} EmailService
- *
- * @typedef {Object} CentralScopedReadSettings
- * @property {(path: CentralScopedReadSettings) => ?} get
- *
- * @typedef {CentralScopedReadSettings & ReadSettings} SettingsReader
+ * @typedef {import('@tamanu/settings').CentralReadSettings} SettingsReader
  */
 
 export class ApplicationContext {
@@ -61,6 +55,7 @@ export class ApplicationContext {
 
     this.settings = new ReadSettings(this.store.models);
 
+    this.settings.get('')
     this.telegramBotService = await defineSingletonTelegramBotService({
       config,
       models: this.store.models,

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -6,15 +6,9 @@ import { VERSION } from './middleware/versionCompatibility.js';
 import { ReadSettings } from '@tamanu/settings/reader';
 
 /**
- * @typedef {import('@tamanu/settings/reader').ReadSettings} ReadSettings
- * @typedef {import('@tamanu/settings').FacilitySettingPath} FacilitySettingPath
+ * @typedef {import('@tamanu/settings').FacilityReadSettings} SettingsReader
  * @typedef {import('sequelize').Sequelize} Sequelize
  * @typedef {import('@tamanu/shared/models')} Models
- *
- * @typedef {Object} FacilityScopedReadSettings
- * @property {(path: FacilitySettingPath) => ?} get
- *
- * @typedef {FacilityScopedReadSettings & ReadSettings} SettingsReader
  */
 
 export class ApplicationContext {
@@ -48,7 +42,7 @@ export class ApplicationContext {
     this.sequelize = database.sequelize;
     this.models = database.models;
     this.settings = new ReadSettings(this.models, config.serverFacilityId);
-
+    this.settings.get(''
     if (config.db.reportSchemas?.enabled) {
       this.reportSchemaStores = await initReporting();
     }

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -6,7 +6,8 @@ import { VERSION } from './middleware/versionCompatibility.js';
 import { ReadSettings } from '@tamanu/settings/reader';
 
 /**
- * @typedef {import('@tamanu/settings').FacilityReadSettings} SettingsReader
+ * @typedef {import('@tamanu/settings').FacilitySettingPath} FacilitySettingPath
+ * @typedef {import('@tamanu/settings').ReadSettings} ReadSettings
  * @typedef {import('sequelize').Sequelize} Sequelize
  * @typedef {import('@tamanu/shared/models')} Models
  */
@@ -19,7 +20,7 @@ export class ApplicationContext {
   models = null;
 
   /**
-   * @type {SettingsReader | null}
+   * @type {ReadSettings<FacilitySettingPath> | null}
    */
   settings = null;
 

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -5,12 +5,29 @@ import { closeDatabase, initDatabase, initReporting } from './database';
 import { VERSION } from './middleware/versionCompatibility.js';
 import { ReadSettings } from '@tamanu/settings/reader';
 
+/**
+ * @typedef {import('@tamanu/settings/reader').ReadSettings} ReadSettings
+ * @typedef {import('@tamanu/settings').FacilitySettingPath} FacilitySettingPath
+ * @typedef {import('sequelize').Sequelize} Sequelize
+ * @typedef {import('@tamanu/shared/models')} Models
+ *
+ * @typedef {Object} FacilityScopedReadSettings
+ * @property {(path: FacilitySettingPath) => ?} get
+ *
+ * @typedef {FacilityScopedReadSettings & ReadSettings} SettingsReader
+ */
+
 export class ApplicationContext {
-  /** @type {import('sequelize').Sequelize | null} */
+  /** @type {Sequelize | null} */
   sequelize = null;
 
-  /** @type {import('@tamanu/shared/models') | null} */
+  /** @type {Models | null} */
   models = null;
+
+  /**
+   * @type {SettingsReader | null}
+   */
+  settings = null;
 
   reportSchemaStores = null;
 

--- a/packages/facility-server/app/ApplicationContext.js
+++ b/packages/facility-server/app/ApplicationContext.js
@@ -42,7 +42,6 @@ export class ApplicationContext {
     this.sequelize = database.sequelize;
     this.models = database.models;
     this.settings = new ReadSettings(this.models, config.serverFacilityId);
-    this.settings.get(''
     if (config.db.reportSchemas?.enabled) {
       this.reportSchemaStores = await initReporting();
     }

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -8,6 +8,7 @@ export {
   facilityDefaults,
   validateSettings,
   getScopedSchema,
+  SettingPath,
   isSetting,
 } from './schema';
 export { ReadSettings, buildSettings } from './reader';

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -9,6 +9,7 @@ export {
   validateSettings,
   getScopedSchema,
   SettingPath,
+  FrontEndExposedSettingPath,
   isSetting,
 } from './schema';
 export { ReadSettings, buildSettings } from './reader';

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -10,8 +10,10 @@ export {
   getScopedSchema,
   SettingPath,
   FrontEndExposedSettingPath,
+  FacilitySettingPath,
+  CentralSettingPath,
   isSetting,
 } from './schema';
-export { ReadSettings, FacilityReadSettings, CentralReadSettings, buildSettings } from './reader';
+export { ReadSettings, buildSettings } from './reader';
 export { facilityTestSettings, centralTestSettings, globalTestSettings } from './test';
 export { buildSettingsReaderMiddleware } from './middleware';

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -1,4 +1,3 @@
-export { settingsCache } from './cache';
 export {
   centralSettings,
   globalSettings,
@@ -10,10 +9,8 @@ export {
   getScopedSchema,
   SettingPath,
   FrontEndExposedSettingPath,
-  FacilitySettingPath,
-  CentralSettingPath,
   isSetting,
 } from './schema';
-export { ReadSettings, buildSettings } from './reader';
+export { ReadSettings, FacilityReadSettings, CentralReadSettings, buildSettings } from './reader';
 export { facilityTestSettings, centralTestSettings, globalTestSettings } from './test';
 export { buildSettingsReaderMiddleware } from './middleware';

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -1,3 +1,4 @@
+export { settingsCache } from './cache';
 export {
   centralSettings,
   globalSettings,

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -10,6 +10,8 @@ export {
   getScopedSchema,
   SettingPath,
   FrontEndExposedSettingPath,
+  FacilitySettingPath,
+  CentralSettingPath,
   isSetting,
 } from './schema';
 export { ReadSettings, buildSettings } from './reader';

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { CentralSettingPath, FacilitySettingPath } from 'schema';
 import { get as lodashGet, pick } from 'lodash';
 import { buildSettings, SettingPath } from '..';
@@ -54,6 +53,7 @@ export class ReadSettings {
 }
 
 export type FacilityReadSettings = ReadSettings & {
+  // eslint-disable-next-line no-unused-vars
   get(key: FacilitySettingPath): Promise<unknown>;
 };
 export type CentralReadSettings = ReadSettings & {

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+import { CentralSettingPath, FacilitySettingPath } from 'schema';
 import { get as lodashGet, pick } from 'lodash';
 import { buildSettings, SettingPath } from '..';
 import { settingsCache } from '../cache';
@@ -26,7 +28,7 @@ export class ReadSettings {
 
   async get(key: SettingPath) {
     const settings = await this.getAll();
-    return lodashGet(settings, key);
+    return lodashGet(settings, key as string);
   }
 
   // This is what is called on login. This gets only settings relevant to
@@ -50,3 +52,10 @@ export class ReadSettings {
     return settings;
   }
 }
+
+export type FacilityReadSettings = ReadSettings & {
+  get(key: FacilitySettingPath): Promise<unknown>;
+};
+export type CentralReadSettings = ReadSettings & {
+  get(key: CentralSettingPath): Promise<unknown>;
+};

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -17,7 +17,7 @@ export const KEYS_EXPOSED_TO_FRONT_END = [
   'fields',
 ] as const;
 
-export class ReadSettings<Paths = SettingPath> {
+export class ReadSettings<Path = SettingPath> {
   models: Models;
   facilityId?: string;
   constructor(models: Models, facilityId?: string) {
@@ -25,7 +25,7 @@ export class ReadSettings<Paths = SettingPath> {
     this.facilityId = facilityId;
   }
 
-  async get(key: Paths) {
+  async get(key: Path) {
     const settings = await this.getAll();
     return lodashGet(settings, key as string);
   }

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { CentralSettingPath, FacilitySettingPath } from 'schema';
 import { get as lodashGet, pick } from 'lodash';
 import { buildSettings, SettingPath } from '..';
@@ -53,7 +54,6 @@ export class ReadSettings {
 }
 
 export type FacilityReadSettings = ReadSettings & {
-  // eslint-disable-next-line no-unused-vars
   get(key: FacilitySettingPath): Promise<unknown>;
 };
 export type CentralReadSettings = ReadSettings & {

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,5 +1,5 @@
 import { get as lodashGet, pick } from 'lodash';
-import { buildSettings, SettingPath } from '../index';
+import { buildSettings, SettingPath } from '..';
 import { settingsCache } from '../cache';
 import { Models } from './readers/SettingsDBReader';
 

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -3,7 +3,7 @@ import { buildSettings, SettingPath } from '..';
 import { settingsCache } from '../cache';
 import { Models } from './readers/SettingsDBReader';
 
-const KEYS_EXPOSED_TO_FRONT_END = [
+export const KEYS_EXPOSED_TO_FRONT_END = [
   'customisations',
   'features',
   'imagingPriorities',
@@ -14,7 +14,7 @@ const KEYS_EXPOSED_TO_FRONT_END = [
   'upcomingVaccinations',
   'vaccinations',
   'fields',
-];
+] as const;
 
 export class ReadSettings {
   models: Models;

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-vars */
-import { CentralSettingPath, FacilitySettingPath } from 'schema';
 import { get as lodashGet, pick } from 'lodash';
 import { buildSettings, SettingPath } from '..';
 import { settingsCache } from '../cache';
@@ -18,7 +17,7 @@ export const KEYS_EXPOSED_TO_FRONT_END = [
   'fields',
 ] as const;
 
-export class ReadSettings {
+export class ReadSettings<Paths = SettingPath> {
   models: Models;
   facilityId?: string;
   constructor(models: Models, facilityId?: string) {
@@ -26,7 +25,7 @@ export class ReadSettings {
     this.facilityId = facilityId;
   }
 
-  async get(key: SettingPath) {
+  async get(key: Paths) {
     const settings = await this.getAll();
     return lodashGet(settings, key as string);
   }
@@ -52,10 +51,3 @@ export class ReadSettings {
     return settings;
   }
 }
-
-export type FacilityReadSettings = ReadSettings & {
-  get(key: FacilitySettingPath): Promise<unknown>;
-};
-export type CentralReadSettings = ReadSettings & {
-  get(key: CentralSettingPath): Promise<unknown>;
-};

--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -1,5 +1,5 @@
 import { get as lodashGet, pick } from 'lodash';
-import { buildSettings } from '../index';
+import { buildSettings, SettingPath } from '../index';
 import { settingsCache } from '../cache';
 import { Models } from './readers/SettingsDBReader';
 
@@ -24,7 +24,7 @@ export class ReadSettings {
     this.facilityId = facilityId;
   }
 
-  async get(key: string) {
+  async get(key: SettingPath) {
     const settings = await this.getAll();
     return lodashGet(settings, key);
   }

--- a/packages/settings/src/schema/index.ts
+++ b/packages/settings/src/schema/index.ts
@@ -3,3 +3,4 @@ export * from './facility';
 export * from './global';
 export * from './validation';
 export * from './utils';
+export * from './types';

--- a/packages/settings/src/schema/types/Setting.ts
+++ b/packages/settings/src/schema/types/Setting.ts
@@ -7,9 +7,3 @@ export interface Setting<T = any> {
   unit?: string;
   defaultValue: T;
 }
-
-export interface SettingsSchema {
-  name?: string;
-  description?: string;
-  properties: Record<string, Setting | SettingsSchema>;
-}

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -17,19 +17,19 @@ type Join<K, P> = K extends string | number
 type IsSetting<T> = T extends Setting ? true : false;
 
 // Extended utility type to exclude 'properties', 'description', 'name', and other ignored keys
-type RemovePropertiesKey<T> = T extends object
+type RemoveSchemaKeys<T> = T extends object
   ? IsSetting<T> extends true
     ? ''
     : {
         [K in keyof T]: K extends 'properties' | 'description' | 'name'
-          ? RemovePropertiesKey<T[K]>
+          ? RemoveSchemaKeys<T[K]>
           : K extends string | number
-          ? Join<K, RemovePropertiesKey<T[K]>>
+          ? Join<K, RemoveSchemaKeys<T[K]>>
           : never;
       }[keyof T]
   : '';
 
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 
-export type SettingPath = RemovePropertiesKey<SchemaProperties>;
+export type SettingPath = RemoveSchemaKeys<SchemaProperties>;
 

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -1,6 +1,7 @@
 import { centralSettings } from "../central";
 import { facilitySettings } from "../facility";
 import { globalSettings } from "../global";
+import { Setting } from "./Setting";
 
 // Type to generate the dot prefix
 type DotPrefix<T extends string> = T extends '' ? '' : `.${T}`;
@@ -13,7 +14,7 @@ type Join<K, P> = K extends string | number
   : never;
 
 // Utility type to check if an object is a leaf node
-type IsLeafNode<T> = T extends { type: any; defaultValue: any } ? true : false;
+type IsLeafNode<T> = T extends Setting ? true : false;
 
 // Extended utility type to exclude 'properties', 'description', 'name', and other ignored keys
 type RemovePropertiesKey<T> = T extends object
@@ -31,3 +32,4 @@ type RemovePropertiesKey<T> = T extends object
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 
 export type SettingPath = RemovePropertiesKey<SchemaProperties>;
+

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -31,5 +31,3 @@ type RemovePropertiesKey<T> = T extends object
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 
 export type SettingPath = RemovePropertiesKey<SchemaProperties>;
-
-const getSetting = (path: SettingPath) => path

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -1,0 +1,31 @@
+import { centralSettings } from "../central";
+import { facilitySettings } from "../facility";
+import { globalSettings } from "../global";
+
+type DotPrefix<T extends string> = T extends '' ? '' : `.${T}`;
+
+// Utility type to concatenate keys, skipping `.properties`
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${Extract<K, string>}${DotPrefix<Extract<P, string>>}`
+    : never
+  : never;
+
+// Utility type to check if an object is a leaf node
+type IsLeafNode<T> = T extends { type: any; defaultValue: any } ? true : false;
+
+type RemovePropertiesKey<T> = T extends object
+  ? IsLeafNode<T> extends true
+    ? ''
+    : {
+        [K in keyof T]: K extends 'properties'
+          ? RemovePropertiesKey<T[K]>
+          : K extends string | number
+          ? Join<K, RemovePropertiesKey<T[K]>>
+          : never;
+      }[keyof T]
+  : '';
+
+type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
+
+export type SettingPath = RemovePropertiesKey<SchemaProperties>;

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -1,16 +1,16 @@
-import { centralSettings } from "../central";
-import { facilitySettings } from "../facility";
-import { globalSettings } from "../global";
-import { Setting } from "./Setting";
-import { SettingsSchema } from "./SettingsSchema";
+import { centralSettings } from '../central';
+import { facilitySettings } from '../facility';
+import { globalSettings } from '../global';
+import { Setting } from './Setting';
+import { SettingsSchema } from './SettingsSchema';
 
 // Type to generate the dot prefix
-type DotPrefix<T extends string> = T extends '' ? '' : `.${T}`;
+type Subscript<T extends string> = T extends '' ? '' : `.${T}`;
 
 // Utility type to join keys
 type Join<K, P> = K extends string
   ? P extends string
-    ? `${Extract<K, string>}${DotPrefix<Extract<P, string>>}`
+    ? `${Extract<K, string>}${Subscript<Extract<P, string>>}`
     : never
   : never;
 

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -13,12 +13,12 @@ type Join<K, P> = K extends string | number
     : never
   : never;
 
-// Utility type to check if an object is a leaf node
-type IsLeafNode<T> = T extends Setting ? true : false;
+// Utility type to check if an object is a setting
+type IsSetting<T> = T extends Setting ? true : false;
 
 // Extended utility type to exclude 'properties', 'description', 'name', and other ignored keys
 type RemovePropertiesKey<T> = T extends object
-  ? IsLeafNode<T> extends true
+  ? IsSetting<T> extends true
     ? ''
     : {
         [K in keyof T]: K extends 'properties' | 'description' | 'name'

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -3,6 +3,7 @@ import { facilitySettings } from '../facility';
 import { globalSettings } from '../global';
 import { Setting } from './Setting';
 import { SettingsSchema } from './SettingsSchema';
+import {KEYS_EXPOSED_TO_FRONT_END} from '../../reader/ReadSettings'
 
 // Type to generate the dot prefix
 type Subscript<T extends string> = T extends '' ? '' : `.${T}`;
@@ -27,7 +28,13 @@ type RemoveSchemaKeys<T> = T extends object
       }[keyof T]
   : '';
 
+// Extract paths that start with a specific key
+type StartsWith<T extends string, U extends string> = T extends `${U}.${string}` ? T : never;
+
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 
-export type SettingPath = RemoveSchemaKeys<SchemaProperties>;
+export type SettingPath = RemoveSchemaKeys<SchemaProperties>
+
+// Filters paths based on KEYS_EXPOSED_TO_FRONT_END
+export type FrontEndExposedSettingPath = StartsWith<SettingPath, typeof KEYS_EXPOSED_TO_FRONT_END[number]>;
 

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -14,12 +14,9 @@ type Join<K, P> = K extends string
     : never
   : never;
 
-// Utility type to check if an object is a setting
-type IsSetting<T> = T extends Setting ? true : false;
-
-// Extended utility type to exclude 'properties', 'description', 'name', and other ignored keys
+// Extended utility type to exclude settings schema keys like 'properties', 'description', 'name'
 type RemoveSchemaKeys<T> = T extends object
-  ? IsSetting<T> extends true
+  ? T extends Setting
     ? ''
     : {
         [K in keyof T]: K extends keyof SettingsSchema

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -38,6 +38,5 @@ type CentralScopedProperties = typeof centralSettings.properties | typeof global
 export type SettingPath = RemoveSchemaKeys<SchemaProperties>
 export type FacilitySettingPath = RemoveSchemaKeys<FacilityScopedProperties>
 export type CentralSettingPath = RemoveSchemaKeys<CentralScopedProperties>
-
 export type FrontEndExposedSettingPath = StartsWith<FacilitySettingPath, typeof KEYS_EXPOSED_TO_FRONT_END[number]>;
 

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -32,7 +32,12 @@ type RemoveSchemaKeys<T> = T extends object
 type StartsWith<T extends string, U extends string> = T extends `${U}${Subscript<string>}` ? T : never;
 
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
+type FacilityScopedProperties = typeof facilitySettings.properties | typeof globalSettings.properties;
+type CentralScopedProperties = typeof centralSettings.properties | typeof globalSettings.properties;
 
 export type SettingPath = RemoveSchemaKeys<SchemaProperties>
-export type FrontEndExposedSettingPath = StartsWith<SettingPath, typeof KEYS_EXPOSED_TO_FRONT_END[number]>;
+export type FacilitySettingPath = RemoveSchemaKeys<FacilityScopedProperties>
+export type CentralSettingPath = RemoveSchemaKeys<CentralScopedProperties>
+
+export type FrontEndExposedSettingPath = StartsWith<FacilitySettingPath, typeof KEYS_EXPOSED_TO_FRONT_END[number]>;
 

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -2,13 +2,14 @@ import { centralSettings } from "../central";
 import { facilitySettings } from "../facility";
 import { globalSettings } from "../global";
 import { Setting } from "./Setting";
+import { SettingsSchema } from "./SettingsSchema";
 
 // Type to generate the dot prefix
 type DotPrefix<T extends string> = T extends '' ? '' : `.${T}`;
 
 // Utility type to join keys
-type Join<K, P> = K extends string | number
-  ? P extends string | number
+type Join<K, P> = K extends string
+  ? P extends string
     ? `${Extract<K, string>}${DotPrefix<Extract<P, string>>}`
     : never
   : never;
@@ -21,9 +22,9 @@ type RemoveSchemaKeys<T> = T extends object
   ? IsSetting<T> extends true
     ? ''
     : {
-        [K in keyof T]: K extends 'properties' | 'description' | 'name'
+        [K in keyof T]: K extends keyof SettingsSchema
           ? RemoveSchemaKeys<T[K]>
-          : K extends string | number
+          : K extends string
           ? Join<K, RemoveSchemaKeys<T[K]>>
           : never;
       }[keyof T]

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -3,7 +3,7 @@ import { facilitySettings } from '../facility';
 import { globalSettings } from '../global';
 import { Setting } from './Setting';
 import { SettingsSchema } from './SettingsSchema';
-import {KEYS_EXPOSED_TO_FRONT_END} from '../../reader/ReadSettings'
+import { KEYS_EXPOSED_TO_FRONT_END } from '../../reader/ReadSettings'
 
 // Type to generate the dot prefix
 type Subscript<T extends string> = T extends '' ? '' : `.${T}`;
@@ -29,7 +29,7 @@ type RemoveSchemaKeys<T> = T extends object
   : '';
 
 // Extract paths that start with a specific key
-type StartsWith<T extends string, U extends string> = T extends `${U}.${string}` ? T : never;
+type StartsWith<T extends string, U extends string> = T extends `${U}${Subscript<string>}` ? T : never;
 
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -2,9 +2,10 @@ import { centralSettings } from "../central";
 import { facilitySettings } from "../facility";
 import { globalSettings } from "../global";
 
+// Type to generate the dot prefix
 type DotPrefix<T extends string> = T extends '' ? '' : `.${T}`;
 
-// Utility type to concatenate keys, skipping `.properties`
+// Utility type to join keys
 type Join<K, P> = K extends string | number
   ? P extends string | number
     ? `${Extract<K, string>}${DotPrefix<Extract<P, string>>}`
@@ -14,11 +15,12 @@ type Join<K, P> = K extends string | number
 // Utility type to check if an object is a leaf node
 type IsLeafNode<T> = T extends { type: any; defaultValue: any } ? true : false;
 
+// Extended utility type to exclude 'properties', 'description', 'name', and other ignored keys
 type RemovePropertiesKey<T> = T extends object
   ? IsLeafNode<T> extends true
     ? ''
     : {
-        [K in keyof T]: K extends 'properties'
+        [K in keyof T]: K extends 'properties' | 'description' | 'name'
           ? RemovePropertiesKey<T[K]>
           : K extends string | number
           ? Join<K, RemovePropertiesKey<T[K]>>
@@ -29,3 +31,5 @@ type RemovePropertiesKey<T> = T extends object
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 
 export type SettingPath = RemovePropertiesKey<SchemaProperties>;
+
+const getSetting = (path: SettingPath) => path

--- a/packages/settings/src/schema/types/SettingPath.ts
+++ b/packages/settings/src/schema/types/SettingPath.ts
@@ -34,7 +34,5 @@ type StartsWith<T extends string, U extends string> = T extends `${U}.${string}`
 type SchemaProperties = typeof globalSettings.properties | typeof facilitySettings.properties | typeof centralSettings.properties;
 
 export type SettingPath = RemoveSchemaKeys<SchemaProperties>
-
-// Filters paths based on KEYS_EXPOSED_TO_FRONT_END
 export type FrontEndExposedSettingPath = StartsWith<SettingPath, typeof KEYS_EXPOSED_TO_FRONT_END[number]>;
 

--- a/packages/settings/src/schema/types/SettingsSchema.ts
+++ b/packages/settings/src/schema/types/SettingsSchema.ts
@@ -1,0 +1,7 @@
+import { Setting } from './Setting';
+
+export interface SettingsSchema {
+  name?: string;
+  description?: string;
+  properties: Record<string, Setting | SettingsSchema>;
+}

--- a/packages/settings/src/schema/types/index.ts
+++ b/packages/settings/src/schema/types/index.ts
@@ -1,0 +1,3 @@
+export * from './Setting';
+export * from './SettingsSchema';
+export * from './SettingPath';

--- a/packages/web/app/components/TriageDashboard.jsx
+++ b/packages/web/app/components/TriageDashboard.jsx
@@ -24,7 +24,6 @@ const useTriageData = () => {
   const api = useApi();
   const [data, setData] = useState([]);
   const { getSetting } = useSettings();
-
   const triageCategories = getSetting('triageCategories');
 
   useEffect(() => {

--- a/packages/web/app/components/TriageDashboard.jsx
+++ b/packages/web/app/components/TriageDashboard.jsx
@@ -24,6 +24,7 @@ const useTriageData = () => {
   const api = useApi();
   const [data, setData] = useState([]);
   const { getSetting } = useSettings();
+
   const triageCategories = getSetting('triageCategories');
 
   useEffect(() => {

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 
 /**
  * @typedef {Object} SettingsContextType
- * @property {(path: SettingPath) => any} getSetting - Function to retrieve a setting by path.
+ * @property {(path: SettingPath) => any} getSetting
  */
 
 /** @type {React.Context<SettingsContextType | undefined>} */

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -4,9 +4,6 @@ import { get } from 'lodash';
 
 /**
  * @typedef {import("@tamanu/settings").FrontEndExposedSettingPath} SettingPath
- */
-
-/**
  * @typedef {Object} SettingsContextType
  * @property {(path: SettingPath) => ?} getSetting
  */

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { get } from 'lodash';
 
 /**
- * @typedef {import("@tamanu/settings").SettingPath} SettingPath
+ * @typedef {import("@tamanu/settings").FrontEndExposedSettingPath} SettingPath
  */
 
 /**

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -2,7 +2,17 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
 
-const SettingsContext = React.createContext(null);
+/**
+ * @typedef {import("@tamanu/settings").SettingPath} SettingPath
+ */
+
+/**
+ * @typedef {Object} SettingsContextType
+ * @property {(path: SettingPath) => any} getSetting - Function to retrieve a setting by path.
+ */
+
+/** @type {React.Context<SettingsContextType | undefined>} */
+const SettingsContext = React.createContext();
 
 export const useSettings = () => {
   const context = useContext(SettingsContext);

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 
 /**
  * @typedef {Object} SettingsContextType
- * @property {(path: SettingPath) => any} getSetting
+ * @property {(path: SettingPath) => ?} getSetting
  */
 
 /** @type {React.Context<SettingsContextType | undefined>} */


### PR DESCRIPTION
### Changes
We discussed if this was possible and decided it would be a bit hectic - but asking AI some questions and it came up with a workable type which after applying to our context and a bit of js doc magic it works to auto complete all available keys without any duplication or transformation of the schema.

On web! using js-doc import typedef:
<img width="551" alt="Screenshot 2024-09-03 at 3 29 43 PM" src="https://github.com/user-attachments/assets/8d63c73b-3236-4207-9ec9-67037d43b11b">


In ts package:
<img width="560" alt="Screenshot 2024-09-03 at 3 24 40 PM" src="https://github.com/user-attachments/assets/df9f22f4-1b8b-4fd3-a8b3-46cc3eea9e7b">
<img width="500" alt="Screenshot 2024-09-03 at 3 24 25 PM" src="https://github.com/user-attachments/assets/783f6523-d1db-4784-b8d2-040ee29ef913">

In mobile: can integrate once part of monorepo

I feel it is somewhat difficult to read but its pretty abstracted away.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
