### PR TITLE
feat(dbmodel): KAM-260: Add a script to generate source model from database

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "central-start": "yarn run central-start-dev",
     "central-migrate": "yarn run build-shared && TAMANU_ARGS=\"migrate\" yarn run central-start-dev",
     "central-migrate-down": "yarn run build-shared && TAMANU_ARGS=\"migrate down\" yarn run central-start-dev",
-    "build-report": "yarn build-shared && yarn workspace @tamanu/central-server build && yarn workspace @tamanu/central-server start report"
+    "build-report": "yarn build-shared && yarn workspace @tamanu/central-server build && yarn workspace @tamanu/central-server start report",
+    "generate-dbt-source": "node packages/scripts/src/dbt-generate-source.mjs"
   },
   "engines": {
     "node": "^20.9.0"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -13,7 +13,9 @@
     "google-spreadsheet": "^2.0.7",
     "commander": "^9.0.0",
     "object-hash": "^3.0.0",
-    "pgsql-ast-parser": "^11.1.0"
+    "pgsql-ast-parser": "^11.1.0",
+    "yaml": "^2.2.1",
+    "pg": "^8.5.1"
   },
   "devDependencies": {
     "tape": "^5.7.5"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -15,7 +15,8 @@
     "object-hash": "^3.0.0",
     "pgsql-ast-parser": "^11.1.0",
     "yaml": "^2.2.1",
-    "pg": "^8.5.1"
+    "pg": "^8.5.1",
+    "config": "^3.3.9"
   },
   "devDependencies": {
     "tape": "^5.7.5"

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -44,7 +44,6 @@ async function generateSource({ password, name, database, schemaName = name }) {
               columns: (await getColumnsInRelation(client, schemaName, table)).map(column => {
                 return {
                   name: column.column_name,
-                  // TODO: data_type_format_source
                   data_type: column.data_type,
                 };
               }),

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -1,10 +1,10 @@
-// This is a port of `generate_source` from https://github.com/dbt-labs/dbt-codegen.
+// This is a port of `generateSource` from https://github.com/dbt-labs/dbt-codegen.
 
 import { program } from 'commander';
 import YAML from 'yaml';
 import pg from 'pg';
 
-async function get_tables_in_schema(client, schemaName) {
+async function getTablesInSchema(client, schemaName) {
   return (
     await client.query(
       `SELECT DISTINCT lower(table_name) as table_name
@@ -16,7 +16,7 @@ async function get_tables_in_schema(client, schemaName) {
   ).rows.map(table => table.table_name);
 }
 
-async function get_columns_in_relation(client, schemaName, table) {
+async function getColumnsInRelation(client, schemaName, table) {
   return (
     await client.query(
       `SELECT lower(column_name) as column_name, lower(data_type) as data_type
@@ -27,7 +27,7 @@ async function get_columns_in_relation(client, schemaName, table) {
   ).rows;
 }
 
-async function generate_source({ password, name, database, schemaName = name }) {
+async function generateSource({ password, name, database, schemaName = name }) {
   const client = new pg.Client({ database, password });
   await client.connect();
   const sources = {
@@ -38,10 +38,10 @@ async function generate_source({ password, name, database, schemaName = name }) 
         database,
         schema_name: schemaName === name ? undefined : schemaName,
         tables: await Promise.all(
-          (await get_tables_in_schema(client, schemaName)).map(async table => {
+          (await getTablesInSchema(client, schemaName)).map(async table => {
             return {
               name: table,
-              columns: (await get_columns_in_relation(client, schemaName, table)).map(column => {
+              columns: (await getColumnsInRelation(client, schemaName, table)).map(column => {
                 return {
                   name: column.column_name,
                   // TODO: data_type_format_source
@@ -73,5 +73,5 @@ program
 
 program.parse();
 const opts = program.opts();
-const sources = await generate_source(opts);
+const sources = await generateSource(opts);
 console.log(YAML.stringify(sources));

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -1,7 +1,8 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
+import pg from 'pg';
 import { program } from 'commander';
 import YAML from 'yaml';
-import pg from 'pg';
 
 async function getTablesInSchema(client, schemaName) {
   return (
@@ -72,4 +73,4 @@ process.env['NODE_CONFIG_DIR'] = path.join(opts.package, 'config');
 const { default: config } = await import('config');
 
 const sources = await generateSource(config.db);
-console.log(YAML.stringify(sources));
+await fs.writeFile('database/model/sources.yml', YAML.stringify(sources));

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -1,0 +1,59 @@
+import { program } from 'commander'
+import YAML from 'yaml'
+import pg from 'pg'
+
+async function get_tables_in_schema(client, schemaName, tablePattern, exclude) {
+    const QUERY = 'SELECT DISTINCT lower(table_name) as table_name FROM information_schema.tables WHERE table_schema ilike $1 AND table_name ilike $2 AND table_name not ilike $3 ORDER BY lower(table_name)';
+    return (await client.query(QUERY, [schemaName, tablePattern, exclude])).rows.map(table => table.table_name);
+}
+
+async function get_columns_in_relation(client, schemaName, table) {
+    const QUERY = 'SELECT lower(column_name) as column_name, lower(data_type) as data_type FROM information_schema.columns WHERE table_schema ilike $1 and table_name = $2';
+    return (await client.query(QUERY, [schemaName, table])).rows;
+}
+
+async function generate_source({ password, name, database, schemaName = name, generateColumns, excludeDataTypes, tablePattern, exclude }) {
+    const client = new pg.Client({ database, password });
+    await client.connect();
+    const sources = {
+        version: 2,
+        sources: [
+            {
+                name: name.toLowerCase(),
+                database: database.toLowerCase(),
+                schema_name: schemaName ? schemaName.toLowerCase() : undefined, // TODO: what happens when undefined?
+                tables: await Promise.all((await get_tables_in_schema(client, schemaName, tablePattern, exclude))
+                    .map(async table => {
+                        return {
+                            name: table,
+                            columns: generateColumns ? (await get_columns_in_relation(client, schemaName, table))
+                                .map(column => {
+                                    return {
+                                        name: column.column_name,
+                                        // TODO: data_type_format_source
+                                        data_type: !excludeDataTypes ? column.data_type : undefined,
+                                    };
+                                }) : undefined
+                        };
+                    }))
+            }
+        ]
+    };
+    await client.end();
+    return sources;
+}
+
+program
+    .option('password')
+    .requiredOption('--name <string>')
+    .requiredOption('--database <string>')
+    .option('--schema-name <string>')
+    .option('--generate-columns')
+    .option('--exclude-data-types')
+    .option('--table-pattern <string>', '', '%')
+    .option('--exclude <string>', '', '')
+
+program.parse()
+const opts = program.opts();
+const sources = await generate_source(opts);
+console.log(YAML.stringify(sources));

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -1,59 +1,85 @@
-import { program } from 'commander'
-import YAML from 'yaml'
-import pg from 'pg'
+import { program } from 'commander';
+import YAML from 'yaml';
+import pg from 'pg';
 
 async function get_tables_in_schema(client, schemaName, tablePattern, exclude) {
-    const QUERY = 'SELECT DISTINCT lower(table_name) as table_name FROM information_schema.tables WHERE table_schema ilike $1 AND table_name ilike $2 AND table_name not ilike $3 ORDER BY lower(table_name)';
-    return (await client.query(QUERY, [schemaName, tablePattern, exclude])).rows.map(table => table.table_name);
+  return (
+    await client.query(
+      `SELECT DISTINCT lower(table_name) as table_name
+      FROM information_schema.tables
+      WHERE table_schema ilike $1 and table_name ilike $2 and table_name not ilike $3
+      ORDER BY lower(table_name)`,
+      [schemaName, tablePattern, exclude],
+    )
+  ).rows.map(table => table.table_name);
 }
 
 async function get_columns_in_relation(client, schemaName, table) {
-    const QUERY = 'SELECT lower(column_name) as column_name, lower(data_type) as data_type FROM information_schema.columns WHERE table_schema ilike $1 and table_name = $2';
-    return (await client.query(QUERY, [schemaName, table])).rows;
+  return (
+    await client.query(
+      `SELECT lower(column_name) as column_name, lower(data_type) as data_type
+      FROM information_schema.columns
+      WHERE table_schema ilike $1 and table_name = $2`,
+      [schemaName, table],
+    )
+  ).rows;
 }
 
-async function generate_source({ password, name, database, schemaName = name, generateColumns, excludeDataTypes, tablePattern, exclude }) {
-    const client = new pg.Client({ database, password });
-    await client.connect();
-    const sources = {
-        version: 2,
-        sources: [
-            {
-                name: name.toLowerCase(),
-                database: database.toLowerCase(),
-                schema_name: schemaName ? schemaName.toLowerCase() : undefined, // TODO: what happens when undefined?
-                tables: await Promise.all((await get_tables_in_schema(client, schemaName, tablePattern, exclude))
-                    .map(async table => {
-                        return {
-                            name: table,
-                            columns: generateColumns ? (await get_columns_in_relation(client, schemaName, table))
-                                .map(column => {
-                                    return {
-                                        name: column.column_name,
-                                        // TODO: data_type_format_source
-                                        data_type: !excludeDataTypes ? column.data_type : undefined,
-                                    };
-                                }) : undefined
-                        };
-                    }))
-            }
-        ]
-    };
-    await client.end();
-    return sources;
+async function generate_source({
+  password,
+  name,
+  database,
+  schemaName = name,
+  generateColumns,
+  excludeDataTypes,
+  tablePattern,
+  exclude,
+}) {
+  const client = new pg.Client({ database, password });
+  await client.connect();
+  const sources = {
+    version: 2,
+    sources: [
+      {
+        name: name.toLowerCase(),
+        database: database.toLowerCase(),
+        schema_name: schemaName ? schemaName.toLowerCase() : undefined, // TODO: what happens when undefined?
+        tables: await Promise.all(
+          (await get_tables_in_schema(client, schemaName, tablePattern, exclude)).map(
+            async table => {
+              return {
+                name: table,
+                columns: generateColumns
+                  ? (await get_columns_in_relation(client, schemaName, table)).map(column => {
+                      return {
+                        name: column.column_name,
+                        // TODO: data_type_format_source
+                        data_type: !excludeDataTypes ? column.data_type : undefined,
+                      };
+                    })
+                  : undefined,
+              };
+            },
+          ),
+        ),
+      },
+    ],
+  };
+  await client.end();
+  return sources;
 }
 
 program
-    .option('password')
-    .requiredOption('--name <string>')
-    .requiredOption('--database <string>')
-    .option('--schema-name <string>')
-    .option('--generate-columns')
-    .option('--exclude-data-types')
-    .option('--table-pattern <string>', '', '%')
-    .option('--exclude <string>', '', '')
+  .option('password')
+  .requiredOption('--name <string>')
+  .requiredOption('--database <string>')
+  .option('--schema-name <string>')
+  .option('--generate-columns')
+  .option('--exclude-data-types')
+  .option('--table-pattern <string>', '', '%')
+  .option('--exclude <string>', '', '');
 
-program.parse()
+program.parse();
 const opts = program.opts();
 const sources = await generate_source(opts);
 console.log(YAML.stringify(sources));

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -18,10 +18,10 @@ async function getSchemas(client) {
 async function getTablesInSchema(client, schemaName) {
   return (
     await client.query(
-      `SELECT DISTINCT lower(table_name) as table_name
+      `SELECT DISTINCT table_name
       FROM information_schema.tables
-      WHERE table_schema ilike $1
-      ORDER BY lower(table_name)`,
+      WHERE table_schema = $1
+      ORDER BY table_name`,
       [schemaName],
     )
   ).rows.map(table => table.table_name);
@@ -30,9 +30,9 @@ async function getTablesInSchema(client, schemaName) {
 async function getColumnsInRelation(client, schemaName, table) {
   return (
     await client.query(
-      `SELECT lower(column_name) as column_name, lower(data_type) as data_type
+      `SELECT column_name, data_type
       FROM information_schema.columns
-      WHERE table_schema ilike $1 and table_name = $2`,
+      WHERE table_schema = $1 and table_name = $2`,
       [schemaName, table],
     )
   ).rows;
@@ -43,7 +43,7 @@ async function generateSource({ host, port, name: database, username, password }
   await client.connect();
 
   const tasks = (await getSchemas(client)).map(async schemaName => {
-    await fs.mkdir(`database/model/${schemaName}`);
+    await fs.mkdir(`database/model/${schemaName}`, { recursive: true });
     const tasks = (await getTablesInSchema(client, schemaName)).map(async table => {
       const sources = {
         version: 2,

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -4,6 +4,17 @@ import pg from 'pg';
 import { program } from 'commander';
 import YAML from 'yaml';
 
+async function getSchemas(client) {
+  return (
+    await client.query(
+      `SELECT schema_name
+      FROM information_schema.schemata
+      WHERE schema_name not similar to 'pg%|information_schema|sync_snapshots|reporting'
+      ORDER BY schema_name`,
+    )
+  ).rows.map(table => table.schema_name);
+}
+
 async function getTablesInSchema(client, schemaName) {
   return (
     await client.query(
@@ -31,7 +42,7 @@ async function generateSource({ host, port, name: database, username, password }
   const client = new pg.Client({ host, port, user: username, database, password });
   await client.connect();
 
-  const tasks = ['public', 'fhir', 'logs'].map(async schemaName => {
+  const tasks = (await getSchemas(client)).map(async schemaName => {
     await fs.mkdir(`database/model/${schemaName}`);
     const tasks = (await getTablesInSchema(client, schemaName)).map(async table => {
       const sources = {

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -41,9 +41,9 @@ async function generate_source({
     version: 2,
     sources: [
       {
-        name: name.toLowerCase(),
-        database: database.toLowerCase(),
-        schema_name: schemaName ? schemaName.toLowerCase() : undefined, // TODO: what happens when undefined?
+        name,
+        database,
+        schema_name: schemaName === name ? undefined : schemaName,
         tables: await Promise.all(
           (await get_tables_in_schema(client, schemaName, tablePattern, exclude)).map(
             async table => {
@@ -70,14 +70,31 @@ async function generate_source({
 }
 
 program
-  .option('password')
-  .requiredOption('--name <string>')
-  .requiredOption('--database <string>')
-  .option('--schema-name <string>')
-  .option('--generate-columns')
-  .option('--exclude-data-types')
-  .option('--table-pattern <string>', '', '%')
-  .option('--exclude <string>', '', '');
+  .description('generates a Source model in dbt')
+  .option('--password')
+  .requiredOption('--name <string>', 'The name of your source', value => value.toLowerCase())
+  .requiredOption('--database <string>', 'The database that your source data is in', value =>
+    value.toLowerCase(),
+  )
+  .option(
+    '--schema-name <string>',
+    'The schema name that contains your source data (default: the same as `name`)',
+    value => value.toLowerCase(),
+  )
+  .option(
+    '--generate-columns',
+    'Whether you want to add the column names to your source definition',
+  )
+  .option(
+    '--exclude-data-types',
+    'Whether you want to add data types to your source columns definitions',
+  )
+  .option(
+    '--table-pattern <string>',
+    'A table prefix / postfix that you want to subselect from all available tables within a given schema',
+    '%',
+  )
+  .option('--exclude <string>', 'A string you want to exclude from the selection criteria', '');
 
 program.parse();
 const opts = program.opts();

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -1,3 +1,5 @@
+// This is a port of `generate_source` from https://github.com/dbt-labs/dbt-codegen.
+
 import { program } from 'commander';
 import YAML from 'yaml';
 import pg from 'pg';


### PR DESCRIPTION
### Changes

This adds a JavaScript to generate a Source model by reading DB schema from Postgres. This is better because running the original `generate_source` requires Python and a full dbt project, which is a lot for a this small task.
