### PR TITLE
release: Revert bump version to 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanu",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "description": "This repo contains all the packages for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/api-client",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "API client for Tamanu Facility Server",
   "main": "dist/cjs/index.js",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/build-tooling",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "description": "Build tooling for Tamanu packages",
   "main": "index.mjs",
   "type": "module",

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/central-server",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "Central server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/constants",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "Shared constants",
   "main": "dist/cjs/index.js",

--- a/packages/csca/package.json
+++ b/packages/csca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csca",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "CSCA tooling for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/facility-server/package.json
+++ b/packages/facility-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/facility-server",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "Facility server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/meta-server/package.json
+++ b/packages/meta-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/meta-server",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "Meta server for Tamanu",
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamanuapp",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/packages/qr-tester/package.json
+++ b/packages/qr-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-tester",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "BES QR Code Tester App / Website",
   "author": "",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripts",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "main": "index.js",
   "license": "GPL-3.0-or-later",
   "scripts": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/settings",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "private": true,
   "description": "BES - Settings",
   "main": "dist/cjs/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamanu/shared",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "description": "Common code across Tamanu packages",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tamanu/web-frontend",
   "productName": "Tamanu",
-  "version": "2.18.0",
+  "version": "2.17.0",
   "description": "Tamanu Web application",
   "private": true,
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",


### PR DESCRIPTION
### Changes

We accidentally double bumped the version number during the `2.16` release

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
