### PR TITLE
tweak(servers): default sync api to port 4100

### DIFF
--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -30,7 +30,7 @@
     "timeout": 10000,
     "syncApiConnection": {
       "host": "http://localhost",
-      "port": 5000,
+      "port": 4100,
     },
     "persistedCacheBatchSize": 10000,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,


### PR DESCRIPTION
### Changes

Defaults Facility sync port to 4100.

I had previously changed to 4001, but this [could clash with facility API](https://github.com/beyondessential/tamanu/pull/6359). Port 5000 is used by default by macOS, unless AirPlay is disabled.

Fingers crossed this is less likely to conflict 🤞

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
