### PR TITLE
fix(sync): Fix syncAllLabRequests encounters sync (Release 2.16 fix)

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -970,7 +970,7 @@ describe('Sync Lookup data', () => {
 
     let regularSyncPatientsTable;
 
-    beforeAll(async () => {
+    beforeAll(async () => {      
       // This patient is not marked for sync because there's no patient_facilities created
       // so all attached lab requests should not be synced unless syncAllLabRequest = true
       const patient2 = await models.Patient.create(fake(models.Patient));
@@ -1201,6 +1201,48 @@ describe('Sync Lookup data', () => {
       expect(labRequestLogIds).toEqual([labRequestLog1.id]);
       expect(labTestIds).toEqual([labTest1.id]);
       expect(labTestPanelRequests).toEqual([labTestPanelRequest1.id]);
+    });
+
+    it("Updates existing encounter's isLabRequest to be TRUE when encounter got lab request attached to it ", async () => {
+      const patient3 = await models.Patient.create(fake(models.Patient));
+
+      const encounter3 = await models.Encounter.create(
+        fake(models.Encounter, {
+          patientId: patient3.id,
+          departmentId: department.id,
+          locationId: location.id,
+          examinerId: examiner.id,
+          startDate: '2023-12-21T04:59:51.851Z',
+        }),
+      );
+
+      await centralSyncManager.updateLookupTable();
+
+      const nonLabRequestEncounterLookupData = await models.SyncLookup.findOne({
+        where: { recordId: encounter3.id },
+      });
+
+      expect(nonLabRequestEncounterLookupData.isLabRequest).toBeFalse();
+
+      const labRequest = await models.LabRequest.create(
+        fake(models.LabRequest, {
+          departmentId: department.id,
+          collectedById: examiner.id,
+          encounterId: encounter3.id,
+        }),
+      );
+
+      await centralSyncManager.updateLookupTable();
+
+      const labRequestLookupData = await models.SyncLookup.findOne({
+        where: { recordId: labRequest.id },
+      });
+      const labRequestEncounterLookupData = await models.SyncLookup.findOne({
+        where: { recordId: encounter3.id },
+      });
+
+      expect(labRequestLookupData).toBeDefined();
+      expect(labRequestEncounterLookupData.isLabRequest).toBeTrue();
     });
   });
 });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -970,7 +970,7 @@ describe('Sync Lookup data', () => {
 
     let regularSyncPatientsTable;
 
-    beforeAll(async () => {      
+    beforeAll(async () => {
       // This patient is not marked for sync because there's no patient_facilities created
       // so all attached lab requests should not be synced unless syncAllLabRequest = true
       const patient2 = await models.Patient.create(fake(models.Patient));

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -13,7 +13,7 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
   let fromId = '';
   let totalCount = 0;
   const attributes = model.getAttributes();
-  const { select, joins } = model.buildSyncLookupQueryDetails(sessionConfig) || {};
+  const { select, joins, where } = model.buildSyncLookupQueryDetails(sessionConfig) || {};
   const useUpdatedAtByFieldSum = !!attributes.updatedAtByField;
 
   while (fromId != null) {
@@ -60,7 +60,8 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
                : ''
            }
           ${joins || ''}
-          WHERE ${table}.updated_at_sync_tick > :since
+          WHERE
+          (${where || `${table}.updated_at_sync_tick > :since`})
           ${fromId ? `AND ${table}.id > :fromId` : ''}
           ORDER BY ${table}.id
           LIMIT :limit

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -281,19 +281,19 @@ export class Encounter extends Model {
       select: buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         encounterId: 'encounters.id',
-        isLabRequestValue: 'labs.encounter_id IS NOT NULL',
+        isLabRequestValue: 'new_labs.encounter_id IS NOT NULL',
       }),
       joins: `
         LEFT JOIN (
           SELECT DISTINCT encounter_id
           FROM lab_requests
-          WHERE updated_at_sync_tick > :since
-        ) AS labs ON labs.encounter_id = encounters.id
+          WHERE updated_at_sync_tick > :since -- to only include lab requests that recently got attached to the encounters
+        ) AS new_labs ON new_labs.encounter_id = encounters.id 
       `,
       where: `
-        encounters.updated_at_sync_tick > :since
+        encounters.updated_at_sync_tick > :since -- to include including normal encounters
         OR
-        labs.encounter_id IS NOT NULL
+        new_labs.encounter_id IS NOT NULL -- to include encounters that got lab requests recently attached to it
       `,
     };
   }

--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -80,7 +80,7 @@ export class Encounter extends Model {
         include: ['facility', 'locationGroup'],
       },
       'referralSource',
-      'diets'
+      'diets',
     ];
   }
 
@@ -198,7 +198,7 @@ export class Encounter extends Model {
       foreignKey: 'referralSourceId',
       as: 'referralSource',
     });
-    
+
     this.belongsToMany(models.ReferenceData, {
       through: models.EncounterDiet,
       as: 'diets',
@@ -287,7 +287,13 @@ export class Encounter extends Model {
         LEFT JOIN (
           SELECT DISTINCT encounter_id
           FROM lab_requests
+          WHERE updated_at_sync_tick > :since
         ) AS labs ON labs.encounter_id = encounters.id
+      `,
+      where: `
+        encounters.updated_at_sync_tick > :since
+        OR
+        labs.encounter_id IS NOT NULL
       `,
     };
   }


### PR DESCRIPTION
### Changes
- When an encounter is first created, the sync lookup data will have `isLabRequest` = false. When a new lab request is attached to it, SyncLookupRefresher currently does not pick up that encounter and change `isLabRequest` to true, causing FK constraint issue when syncing down because the encounter is not synced. This PR is to update the update lookup table logic to also include the encounters when a lab request has been attached to it

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
