### PR TITLE
ci(android): ignore error for non critical steps

### DIFF
--- a/.github/workflows/cd-package-android.yml
+++ b/.github/workflows/cd-package-android.yml
@@ -116,6 +116,7 @@ jobs:
           retention-days: 7
 
       - name: Post comment with release link
+        continue-on-error: true
         if: github.event_name == 'pull_request' || github.event_name == 'issues'
         uses: actions/github-script@v7
         env:
@@ -191,6 +192,7 @@ jobs:
             s3://bes-tamanu-release-clients/$target/android/${{inputs.branding}}/app-release.apk
 
       - if: steps.destination.outputs.result != 'nowhere' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
         uses: softprops/action-gh-release@v2
         with:
           append_body: true


### PR DESCRIPTION
### Changes

Steps that post comments or add links to releases should not block uploads to S3 or builds in general if they fail.
