### PR TITLE
fix(migration): SAV-744: Correction to down migration

### DIFF
--- a/packages/shared/src/migrations/1723105504782-alterSyncSessionErrorColumnToBeArray.js
+++ b/packages/shared/src/migrations/1723105504782-alterSyncSessionErrorColumnToBeArray.js
@@ -21,7 +21,7 @@ export async function down(query) {
   });
 
   await query.sequelize.query(`
-    UPDATE sync_sessions SET error = ARRAY[1]
+    UPDATE sync_sessions SET error = errors[1]
     WHERE errors IS NOT NULL;
   `);
 


### PR DESCRIPTION
### Changes

Uhhh okay so this should be okay because it's a down migration!

Previously we would store an array with a value of `1` which isn't right, instead, we only want to preserve the first (and presumably only) error