### PR TITLE
fix(pm2): port conflict and memory adjustments (hotfix 2.16)

### DIFF
--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -1,7 +1,7 @@
 const os = require('node:os');
 
-const totalMemoryMB = os.totalmem() / (1024**2);
-const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6);
+const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
+const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
 
 const availableThreads = os.availableParallelism();
 const defaultApiScale = Math.max(2, Math.floor(availableThreads / 2));

--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -4,7 +4,9 @@ const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
 const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
 
 const availableThreads = os.availableParallelism();
-const defaultApiScale = Math.max(2, Math.floor(availableThreads / 2));
+const minimumApiScale = totalMemoryMB > 3000 ? 2 : 1;
+const maximumApiScale = 4; // more requires custom caddy config
+const defaultApiScale = Math.min(maximumApiScale, Math.max(minimumApiScale, Math.floor(availableThreads / 2)));
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
 

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -1,7 +1,7 @@
 const os = require('node:os');
 
-const totalMemoryMB = os.totalmem() / (1024**2);
-const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6);
+const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
+const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
 
 const availableThreads = os.availableParallelism();
 const defaultApiScale = Math.max(2, Math.floor(availableThreads / 2));

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -45,7 +45,7 @@ module.exports = {
       instances: 1,
       exec_mode: 'fork',
       env: {
-        PORT: +process.env.TAMANU_SYNC_PORT || 4000,
+        PORT: +process.env.TAMANU_SYNC_PORT || 5000,
         NODE_ENV: 'production',
       },
     },

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -4,7 +4,9 @@ const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
 const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
 
 const availableThreads = os.availableParallelism();
-const defaultApiScale = Math.max(2, Math.floor(availableThreads / 2));
+const minimumApiScale = totalMemoryMB > 3000 ? 2 : 1;
+const maximumApiScale = 4; // more requires custom caddy config
+const defaultApiScale = Math.min(maximumApiScale, Math.max(minimumApiScale, Math.floor(availableThreads / 2)));
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
 


### PR DESCRIPTION
- port conflict for sync/api on facility (probably from the macos port kerfuffle)
- nodejs doesn't support fractional memory setting
- if machine has <4GB memory ([which is minimum requirement!](https://beyond-essential.slab.com/posts/tamanu-compute-resource-recommendations-wipjcyn1?shr=wipjcyn1#hr6i1-facility-server)) then only scale api=1 by default
- don't scale above 4 api instances by default (due to caddy config, but also there shouldn't be a need + avoids contention)