### PR TITLE
feat(pm2): start in single-process mode when we have 2GB memory (hotfix 2.16)

### DIFF
--- a/packages/facility-server/app/subCommands/startAll.js
+++ b/packages/facility-server/app/subCommands/startAll.js
@@ -57,8 +57,6 @@ async function startAll({ skipMigrationCheck }) {
   const { server: syncServer } = await createSyncApp(context);
 
   let { port: syncPort } = config.sync.syncApiConnection;
-  if (+process.env.PORT) { syncPort = +process.env.PORT; }
-  if (syncPort === port) { syncPort += 1; }
   syncServer.listen(syncPort, () => {
     log.info(`SYNC server is running on port ${syncPort}!`);
   });

--- a/packages/facility-server/app/tasks/SyncTask.js
+++ b/packages/facility-server/app/tasks/SyncTask.js
@@ -18,7 +18,7 @@ export class SyncTask extends ScheduledTask {
   }
 
   async run() {
-    return this.context.syncConnection.runSync({
+    return this.context.syncManager.runSync({
       type: 'scheduled',
       urgent: false,
     });

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -30,7 +30,7 @@
     "timeout": 10000,
     "syncApiConnection": {
       "host": "http://localhost",
-      "port": 5000,
+      "port": 4100,
     },
     "persistedCacheBatchSize": 10000,
     "pauseBetweenPersistedCacheBatchesInMilliseconds": 50,

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -2,54 +2,47 @@ const os = require('node:os');
 
 const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
 const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
+const lowMemory = totalMemoryMB < 2500;
 
 const availableThreads = os.availableParallelism();
-const minimumApiScale = totalMemoryMB > 3000 ? 2 : 1;
+const minimumApiScale = 2;
 const maximumApiScale = 4; // more requires custom caddy config
 const defaultApiScale = Math.min(maximumApiScale, Math.max(minimumApiScale, Math.floor(availableThreads / 2)));
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
 
-module.exports = {
-  apps: [
-    {
-      name: 'tamanu-api',
-      cwd,
-      script: './dist/index.js',
-      args: 'startApi',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: +process.env.TAMANU_API_SCALE || defaultApiScale,
-      exec_mode: 'fork',
-      increment_var: 'PORT',
-      env: {
-        PORT: +process.env.TAMANU_API_PORT || 4000,
-        NODE_ENV: 'production',
-      },
+function task(name, args, instances = 1, env = {}) {
+  const base = {
+    name,
+    cwd,
+    script: './dist/index.js',
+    args,
+    interpreter_args: `--max_old_space_size=${memory}`,
+    instances,
+    exec_mode: 'fork',
+    env: {
+      NODE_ENV: 'production',
+      ...env,
     },
-    {
-      name: 'tamanu-tasks',
-      cwd,
-      script: './dist/index.js',
-      args: 'startTasks',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: 1,
-      exec_mode: 'fork',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'tamanu-sync',
-      cwd,
-      script: './dist/index.js',
-      args: 'startSync',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: 1,
-      exec_mode: 'fork',
-      env: {
-        PORT: +process.env.TAMANU_SYNC_PORT || 5000,
-        NODE_ENV: 'production',
-      },
-    },
+  };
+
+  if (env?.PORT) {
+    base.increment_var = 'PORT';
+  }
+
+  return base;
+}
+
+module.exports ={
+  apps: lowMemory ? [
+    task('tamanu-all', 'startAll', 1, {
+      PORT: +process.env.TAMANU_API_PORT || 4000,
+    }),
+  ] : [
+    task('tamanu-api', 'startApi', +process.env.TAMANU_API_SCALE || defaultApiScale, {
+      PORT: +process.env.TAMANU_API_PORT || 4000,
+    }),
+    task('tamanu-tasks', 'startTasks'),
+    task('tamanu-sync', 'startSync'),
   ],
 };


### PR DESCRIPTION
### Changes

And fix the sync shim port being read from two different places.

And while we're at it, also fix the port conflict on macos, because the ci failure was because of the port config mismatch.

Finally, in a single-process context, `context.syncConnection` always exists, but in a multi-process context, the SyncTask should use `context.syncManager` instead.