### PR TITLE
fix(pm2): add restart delay to avoid using 100% CPU when boot-looping

### DIFF
--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -19,7 +19,7 @@ function task(name, args, instances = 1, env = {}) {
     interpreter_args: `--max_old_space_size=${memory}`,
     instances,
     exec_mode: 'fork',
-	  restart_delay: 5000,
+    restart_delay: 5000,
     env: {
       NODE_ENV: 'production',
       ...env,

--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -10,57 +10,36 @@ const defaultApiScale = Math.min(maximumApiScale, Math.max(minimumApiScale, Math
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
 
+function task(name, args, instances = 1, env = {}) {
+  const base = {
+    name,
+    cwd,
+    script: './dist/index.js',
+    args,
+    interpreter_args: `--max_old_space_size=${memory}`,
+    instances,
+    exec_mode: 'fork',
+	  restart_delay: 5000,
+    env: {
+      NODE_ENV: 'production',
+      ...env,
+    },
+  };
+
+  if (env?.PORT) {
+    base.increment_var = 'PORT';
+  }
+
+  return base;
+}
+
 module.exports = {
   apps: [
-    {
-      name: 'tamanu-api',
-      cwd,
-      script: './dist/index.js',
-      args: 'startApi',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: +process.env.TAMANU_API_SCALE || defaultApiScale,
-      exec_mode: 'fork',
-      increment_var: 'PORT',
-      env: {
-        PORT: +process.env.TAMANU_API_PORT || 3000,
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'tamanu-tasks',
-      cwd,
-      script: './dist/index.js',
-      args: 'startTasks',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: 1,
-      exec_mode: 'fork',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'tamanu-fhir-worker-refresh',
-      cwd,
-      script: './dist/index.js',
-      args: 'startFhirWorker --topics=fhir.refresh.allFromUpstream,fhir.refresh.entireResource,fhir.refresh.fromUpstream',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: 1,
-      exec_mode: 'fork',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'tamanu-fhir-worker-resolver',
-      cwd,
-      script: './dist/index.js',
-      args: 'startFhirWorker --topics=fhir.resolver',
-      interpreter_args: `--max_old_space_size=${memory}`,
-      instances: 1,
-      exec_mode: 'fork',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
+    task('tamanu-api', 'startApi', +process.env.TAMANU_API_SCALE || defaultApiScale, {
+      PORT: +process.env.TAMANU_API_PORT || 3000,
+    }),
+    task('tamanu-tasks', 'startTasks'),
+    task('tamanu-fhir-refresh', 'startFhirWorker --topics=fhir.refresh.allFromUpstream,fhir.refresh.entireResource,fhir.refresh.fromUpstream'),
+    task('tamanu-fhir-resolve', 'startFhirWorker --topics=fhir.resolver'),
   ],
 };

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -20,6 +20,7 @@ function task(name, args, instances = 1, env = {}) {
     interpreter_args: `--max_old_space_size=${memory}`,
     instances,
     exec_mode: 'fork',
+	  restart_delay: 5000,
     env: {
       NODE_ENV: 'production',
       ...env,

--- a/packages/facility-server/pm2.config.cjs
+++ b/packages/facility-server/pm2.config.cjs
@@ -20,7 +20,7 @@ function task(name, args, instances = 1, env = {}) {
     interpreter_args: `--max_old_space_size=${memory}`,
     instances,
     exec_mode: 'fork',
-	  restart_delay: 5000,
+    restart_delay: 5000,
     env: {
       NODE_ENV: 'production',
       ...env,


### PR DESCRIPTION
### Changes

When the process fails to start immediately, pm2 has a default restart delay of 0ms, so it uses 100% CPU for no useful reason. A 5s wait between restarts is reasonable, and will ensure we can actually use the machine (e.g. to fix the problem).

Second commit brings over the task() abstraction to central which reduces a lot of the code duplication.