### PR TITLE
fix(imagingPrintout): 2.17 fix: Maximum call stack error on imaging request printout

### DIFF
--- a/packages/constants/src/enumRegistry.ts
+++ b/packages/constants/src/enumRegistry.ts
@@ -1,11 +1,11 @@
-import { SEX_LABELS } from './patientFields.js';
+import { SEX_LABELS } from './patientFields';
 import {
   INVOICE_STATUS_LABELS,
   INVOICE_INSURER_PAYMENT_STATUS_LABELS,
   INVOICE_ITEMS_CATEGORY_LABELS,
   INVOICE_PATIENT_PAYMENT_STATUSES_LABELS,
-} from './invoices.js';
-import { NOTE_TYPE_LABELS } from './notes.js';
+} from './invoices';
+import { NOTE_TYPE_LABELS } from './notes';
 import {
   REFERRAL_STATUS_LABELS,
   APPOINTMENT_TYPE_LABELS,
@@ -27,7 +27,7 @@ import { DIAGNOSIS_CERTAINTY_LABELS, PATIENT_ISSUE_LABELS } from './diagnoses';
 import { DRUG_ROUTE_LABELS, REPEATS_LABELS } from './medications';
 import { PLACE_OF_DEATHS, MANNER_OF_DEATHS } from './deaths';
 import { LOCATION_AVAILABILITY_STATUS_LABELS } from './locations';
-import { IMAGING_TYPES } from './imaging.js';
+import { IMAGING_TYPES } from './imaging';
 
 type EnumKeys = keyof typeof registeredEnums;
 type EnumValues = typeof registeredEnums[EnumKeys];

--- a/packages/constants/src/enumRegistry.ts
+++ b/packages/constants/src/enumRegistry.ts
@@ -27,6 +27,7 @@ import { DIAGNOSIS_CERTAINTY_LABELS, PATIENT_ISSUE_LABELS } from './diagnoses';
 import { DRUG_ROUTE_LABELS, REPEATS_LABELS } from './medications';
 import { PLACE_OF_DEATHS, MANNER_OF_DEATHS } from './deaths';
 import { LOCATION_AVAILABILITY_STATUS_LABELS } from './locations';
+import { IMAGING_TYPES } from './imaging.js';
 
 type EnumKeys = keyof typeof registeredEnums;
 type EnumValues = typeof registeredEnums[EnumKeys];
@@ -45,6 +46,7 @@ export const registeredEnums = {
   BIRTH_TYPE_LABELS,
   DIAGNOSIS_CERTAINTY_LABELS,
   DRUG_ROUTE_LABELS,
+  IMAGING_TYPES,
   IMAGING_REQUEST_STATUS_LABELS,
   INJECTION_SITE_LABELS,
   INVOICE_INSURER_PAYMENT_STATUS_LABELS,
@@ -83,6 +85,7 @@ export const translationPrefixes: Record<EnumKeys, string> = {
   BIRTH_TYPE_LABELS: 'birth.property.birthType',
   DIAGNOSIS_CERTAINTY_LABELS: 'diagnosis.property.certainty',
   DRUG_ROUTE_LABELS: 'medication.property.route',
+  IMAGING_TYPES: 'imaging.property.type',
   IMAGING_REQUEST_STATUS_LABELS: 'imaging.property.status',
   INJECTION_SITE_LABELS: 'vaccine.property.injectionSite',
   INVOICE_INSURER_PAYMENT_STATUS_LABELS: 'invoice.property.insurerPaymentStatus',

--- a/packages/web/app/components/ImagingRequestModal.jsx
+++ b/packages/web/app/components/ImagingRequestModal.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { customAlphabet } from 'nanoid';
 
-import { useApi, useSuggester } from '../api';
+import { useApi } from '../api';
+import { Suggester } from '../utils/suggester';
 
 import { FormModal } from './FormModal';
 import { ImagingRequestForm } from '../forms/ImagingRequestForm';
@@ -14,7 +15,7 @@ const configureCustomRequestId = () => customAlphabet(ALPHABET_FOR_ID, 8);
 
 export const ImagingRequestModal = ({ open, onClose, encounter }) => {
   const api = useApi();
-  const practitionerSuggester = useSuggester('practitioner');
+  const practitionerSuggester = new Suggester(api, 'practitioner');
   const generateDisplayId = configureCustomRequestId();
   const [requestId, setRequestId] = useState();
 

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -114,7 +114,7 @@ export const ImagingRequestForm = React.memo(
         }}
         formType={editedObject ? FORM_TYPES.EDIT_FORM : FORM_TYPES.CREATE_FORM}
         validationSchema={yup.object().shape({
-          requestedById: foreignKey(),
+          requestedById: foreignKey(requiredValidationMessage),
           requestedDate: yup.date().required(requiredValidationMessage),
           imagingType: foreignKey(requiredValidationMessage),
           areas: yup.string().when('imagingType', {

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -31,7 +31,6 @@ import { TranslatedReferenceData, TranslatedText } from '../components/Translati
 import { useTranslation } from '../contexts/Translation';
 import { IMAGING_TYPES } from '@tamanu/constants';
 import { renderToText } from '../utils';
-import { useAuth } from '../contexts/Auth';
 import { camelCase } from 'lodash';
 
 function getEncounterTypeLabel(type) {
@@ -46,7 +45,6 @@ function getEncounterLabel(encounter) {
 
 const FormSubmitActionDropdown = React.memo(({ requestId, encounter, submitForm }) => {
   const dispatch = useDispatch();
-  const { facilityId } = useAuth();
   const { loadEncounter } = useEncounter();
   const { navigateToImagingRequest } = usePatientNavigation();
   const [awaitingPrintRedirect, setAwaitingPrintRedirect] = useState();
@@ -55,7 +53,7 @@ const FormSubmitActionDropdown = React.memo(({ requestId, encounter, submitForm 
   useEffect(() => {
     (async () => {
       if (awaitingPrintRedirect && requestId) {
-        await dispatch(reloadImagingRequest(requestId, facilityId));
+        await dispatch(reloadImagingRequest(requestId));
         navigateToImagingRequest(requestId, 'print');
       }
     })();
@@ -116,7 +114,7 @@ export const ImagingRequestForm = React.memo(
         }}
         formType={editedObject ? FORM_TYPES.EDIT_FORM : FORM_TYPES.CREATE_FORM}
         validationSchema={yup.object().shape({
-          requestedById: foreignKey(requiredValidationMessage),
+          requestedById: foreignKey(),
           requestedDate: yup.date().required(requiredValidationMessage),
           imagingType: foreignKey(requiredValidationMessage),
           areas: yup.string().when('imagingType', {

--- a/packages/web/app/store/imagingRequest.js
+++ b/packages/web/app/store/imagingRequest.js
@@ -5,7 +5,7 @@ const IMAGING_LOAD_START = 'IMAGING_LOAD_START';
 const IMAGING_LOAD_ERROR = 'IMAGING_LOAD_ERROR';
 const IMAGING_LOAD_FINISH = 'IMAGING_LOAD_FINISH';
 
-export const reloadImagingRequest = id => async (dispatch, getState, { api }) => {
+export const reloadImagingRequest = id => async (dispatch, _getState, { api }) => {
   dispatch({ type: IMAGING_LOAD_START, id });
   try {
     const imagingRequest = await api.get(`imagingRequest/${id}`);

--- a/packages/web/app/store/imagingRequest.js
+++ b/packages/web/app/store/imagingRequest.js
@@ -5,7 +5,7 @@ const IMAGING_LOAD_START = 'IMAGING_LOAD_START';
 const IMAGING_LOAD_ERROR = 'IMAGING_LOAD_ERROR';
 const IMAGING_LOAD_FINISH = 'IMAGING_LOAD_FINISH';
 
-export const reloadImagingRequest = id => async (dispatch, _getState, { api }) => {
+export const reloadImagingRequest = id => async (dispatch, getState, { api }) => {
   dispatch({ type: IMAGING_LOAD_START, id });
   try {
     const imagingRequest = await api.get(`imagingRequest/${id}`);


### PR DESCRIPTION
### Changes

Main issue:
- Issue caused by the change to useSuggester hook instead of instantiated suggester. 
- Reverted this to previous versions usage as no different behind scenes.

Side cleanups that I feel are required as part of release fixes and not nit picky
- Also noticed that imaging types is not registered in enums so an extra error on local dev
- And lastly unrelated but confusing - reloadImagingRequest was being passed a param it didn't require ( I remember why this happened, due to a small refactor to using the getState param to access it and not passing it explicitly )

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
