### PR TITLE
fix(omniserver): 2.17 fix: Flash of select facility screen when only 1 available facility

### DIFF
--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -21,7 +21,7 @@ const SET_SETTINGS = 'SET_SETTINGS';
 export const restoreSession = () => async (dispatch, getState, { api }) => {
   try {
     const loginInfo = await api.restoreSession();
-    handleLoginSuccess(dispatch, loginInfo);
+    await handleLoginSuccess(dispatch, loginInfo);
   } catch (e) {
     // no action required -- this just means we haven't logged in
   }
@@ -29,16 +29,15 @@ export const restoreSession = () => async (dispatch, getState, { api }) => {
 
 export const login = (email, password) => async (dispatch, getState, { api }) => {
   dispatch({ type: LOGIN_START });
-
   try {
     const loginInfo = await api.login(email, password);
-    handleLoginSuccess(dispatch, loginInfo);
+    await handleLoginSuccess(dispatch, loginInfo);
   } catch (error) {
     dispatch({ type: LOGIN_FAILURE, error: error.message });
   }
 };
 
-const handleLoginSuccess = (dispatch, loginInfo) => {
+const handleLoginSuccess = async (dispatch, loginInfo) => {
   const {
     user,
     token,
@@ -52,13 +51,13 @@ const handleLoginSuccess = (dispatch, loginInfo) => {
   } = loginInfo;
 
   if (facilityId) {
-    dispatch(setFacilityId(facilityId));
+    await dispatch(setFacilityId(facilityId));
   } else {
     // if there's just one facility the user has access to, select it immediately
     // otherwise they will be prompted to select a facility after login
     const onlyFacilityId = availableFacilities?.length === 1 ? availableFacilities[0].id : null;
     if (onlyFacilityId) {
-      dispatch(setFacilityId(onlyFacilityId));
+      await dispatch(setFacilityId(onlyFacilityId));
     }
   }
 
@@ -203,7 +202,6 @@ const actionHandlers = {
     user: action.user,
     ability: action.ability,
     availableFacilities: action.availableFacilities,
-    facilityId: action.facilityId,
     error: defaultState.error,
     token: action.token,
     localisation: action.localisation,


### PR DESCRIPTION
### Changes
Needed a few awaits due to setFacilityId being async and also remove the setting of facility id on login success as thats old news now. 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
