### PR TITLE
feat(dbmodel): KAM-281: Make source model generation edit-aware

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -16,7 +16,9 @@
     "pgsql-ast-parser": "^11.1.0",
     "yaml": "^2.2.1",
     "pg": "^8.5.1",
-    "config": "^3.3.9"
+    "config": "^3.3.9",
+    "inflection": "^1.13.4",
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "tape": "^5.7.5"

--- a/packages/scripts/src/dbt-generate-source.js
+++ b/packages/scripts/src/dbt-generate-source.js
@@ -412,7 +412,8 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns, genericC
 }
 
 async function handleTables(schemaPath, schemaName, dbtSrcs, sqlTables) {
-  const genericColNames = (await readTableDoc(schemaPath, 'generic'))?.columns.map(c => c.name) ?? [];
+  const genericColNames =
+    (await readTableDoc(schemaPath, 'generic'))?.columns.map(c => c.name) ?? [];
 
   const getName = srcOrTable =>
     srcOrTable.sources ? srcOrTable.sources[0].tables[0].name : srcOrTable.name;
@@ -490,7 +491,9 @@ const opts = program.opts();
 
 // This doesn't take untracked files into account.
 if (!opts.allowDirty && !checkClean()) {
-  console.error('Error: `database/` has uncommitted changes');
+  console.error(
+    `Error: 'database/' has uncommitted changes. Use --allow-dirty if you're sure. You may lose work!`,
+  );
   exit(1);
 }
 

--- a/packages/scripts/src/dbt-generate-source.js
+++ b/packages/scripts/src/dbt-generate-source.js
@@ -412,7 +412,7 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns, genericC
 }
 
 async function handleTables(schemaPath, schemaName, dbtSrcs, sqlTables) {
-  let genericColNames = (await readTableDoc(schemaPath, 'generic'))?.columns.map(c => c.name) ?? [];
+  const genericColNames = (await readTableDoc(schemaPath, 'generic'))?.columns.map(c => c.name) ?? [];
 
   const getName = srcOrTable =>
     srcOrTable.sources ? srcOrTable.sources[0].tables[0].name : srcOrTable.name;

--- a/packages/scripts/src/dbt-generate-source.js
+++ b/packages/scripts/src/dbt-generate-source.js
@@ -187,7 +187,9 @@ async function generateDataTests(column) {
  * @returns A column object, directly serialisable as dbt models.
  */
 function generateColumnModelDescription(tableName, columnName, hasGenericDoc) {
-  return `{{ doc('${hasGenericDoc ? 'generic' : tableName}__${columnName}') }}`;
+  return `{{ doc('${
+    hasGenericDoc ? 'generic' : tableName
+  }__${columnName}') }} in ${tableName}.`;
 }
 
 /**

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -153,10 +153,7 @@ async function readTableDoc(schemaPath, tableName) {
     doc.description = match[2].trim();
   }
 
-  while (true) {
-    const match = re.exec(text);
-    if (match === null) break;
-
+  for (let match = re.exec(text); match !== null; match = re.exec(text)) {
     doc.columns.push({
       name: match[1],
       description: match[2].trim(),

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -153,7 +153,8 @@ async function readTableDoc(schemaPath, tableName) {
     doc.description = match[2].trim();
   }
 
-  for (let match = re.exec(text); match !== null; match = re.exec(text)) {
+  let match;
+  while ((match = re.exec(text)) !== null) {
     doc.columns.push({
       name: match[1],
       description: match[2].trim(),

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -407,10 +407,7 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns, genericC
   await Promise.all(intersectionPromises);
 
   const tablePath = path.join(schemaPath, tableName);
-  // TODO: this formats the YAML aggresively. Specifically, it makes every sequences block-styled.
-  // THere's no API in the library to switch the style based on the length of the content.
-  // Preserving the collection style is possible (the code is git-stashed), but it adds newlines systemically.
-  // There's no way I can preserve line-breaking style of administered_vaccines.status.data_tests.accepted_values
+  // This writes files in a preffered format ignoring the original format.
   const modelPromise = fs.writeFile(tablePath + '.yml', YAML.stringify(dbtSrc));
   const docPromise = fs.writeFile(tablePath + '.md', stringifyTableDoc(out.doc));
   await Promise.all([modelPromise, docPromise]);

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -146,7 +146,7 @@ async function readTableDoc(schemaPath, tableName) {
     columns: [],
   };
 
-  // generic.md isn't for a particular talbe and thus doesn't have a D`table_*` section.
+  // generic.md isn't for a particular table and thus doesn't have a D`table_*` section.
   if (tableName !== 'generic') {
     const match = re.exec(text);
     if (match === null) return null;

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
 
-// TODO:
-// - [x] read a list of tables and clumns from existing `database/model`
-// - [ ] If the yml file exists but the table schema name within doesn't match, discard the existing and create a new file.
-//       I don't really need to throw it away? I'm rewriting everything wrong in that file anyways.
-
 process.env.SUPPRESS_NO_CONFIG_WARNING = 'y';
 const { default: config } = await import('config');
 import fs from 'node:fs/promises';
@@ -17,18 +12,25 @@ import _ from 'lodash';
 import { spawnSync } from 'child_process';
 import { exit } from 'node:process';
 
+/**
+ * @param {string} schemaPath The path to the dir with source model files for a schema
+ * @returns A list of source model files as JS objects.
+ */
 async function readTablesFromDbt(schemaPath) {
   const tablePromises = (await fs.readdir(schemaPath))
     .filter(tablePath => tablePath.endsWith('.yml'))
     .sort()
     .map(async tablePath => {
       const table = await fs.readFile(path.join(schemaPath, tablePath), { encoding: 'utf-8' });
-      // TODO: detect incorrect schema names and report
       return YAML.parse(table);
     });
   return await Promise.all(tablePromises);
 }
 
+/**
+ * @param {pg.Client} client
+ * @returns A list of "relevant" schema names exist in the DB
+ */
 async function getSchemas(client) {
   return (
     await client.query(
@@ -40,6 +42,11 @@ async function getSchemas(client) {
   ).rows.map(table => table.schema_name);
 }
 
+/**
+ * @param {pg.Client} client
+ * @param {string} schemaName
+ * @returns A list of table names that the given schema name has
+ */
 async function getTablesInSchema(client, schemaName) {
   return (
     await client.query(
@@ -52,6 +59,12 @@ async function getTablesInSchema(client, schemaName) {
   ).rows.map(table => table.table_name);
 }
 
+/**
+ * @param {pg.Client} client
+ * @param {string} schemaName
+ * @param {string} tableName
+ * @returns A list of columns exist within the given table.
+ */
 async function getColumnsInRelation(client, schemaName, tableName) {
   return (
     await client.query(
@@ -69,6 +82,13 @@ async function getColumnsInRelation(client, schemaName, tableName) {
   }));
 }
 
+/**
+ * @param {pg.Client} client
+ * @param {string} schemaName
+ * @param {string} tableName
+ * @param {string} columnName
+ * @returns A list of constrains exist for the given column
+ */
 async function getConstraintsForColumn(client, schemaName, tableName, columnName) {
   return (
     await client.query(
@@ -80,6 +100,11 @@ async function getConstraintsForColumn(client, schemaName, tableName, columnName
   ).rows;
 }
 
+/**
+ * @param {pg.Client} client
+ * @param {string} schemaName
+ * @returns A list of tables read from the DB as JS objects
+ */
 async function readTablesFromDB(client, schemaName) {
   const tablePromises = (await getTablesInSchema(client, schemaName)).map(async table => {
     return {
@@ -95,22 +120,38 @@ async function readTablesFromDB(client, schemaName) {
   return await Promise.all(tablePromises);
 }
 
+/**
+ * Reads a table document from a file and parse into a structured JS object.
+ *
+ * @param {string} schemaPath
+ * @param {string} tableName
+ * @returns A table document object or null if the doc doesn't exist
+ */
 async function readTableDoc(schemaPath, tableName) {
   const re = /\{%\s*docs\s+\w+?__(\w+)\s*%\}([^}]+)\{%\s+enddocs\s*%\}/g;
 
-  const text = await fs.readFile(path.join(schemaPath, `${tableName}.md`), {
-    encoding: 'utf-8',
-  });
-
-  const match = re.exec(text);
-  if (match === null) return null;
+  let text;
+  try {
+    text = await fs.readFile(path.join(schemaPath, `${tableName}.md`), {
+      encoding: 'utf-8',
+    });
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    return null;
+  }
 
   const doc = {
     name: tableName,
-    description: match[2].trim(),
     // Make columns a list to preserve the order.
     columns: [],
   };
+
+  // generic.md isn't for a particular talbe and thus doesn't have a D`table_*` section.
+  if (tableName !== 'generic') {
+    const match = re.exec(text);
+    if (match === null) return null;
+    doc.description = match[2].trim();
+  }
 
   while (true) {
     const match = re.exec(text);
@@ -125,6 +166,12 @@ async function readTableDoc(schemaPath, tableName) {
   return doc;
 }
 
+/**
+ * Generates a `data_tests` section based on column constraints.
+ *
+ * @param {object} column
+ * @returns A date test object, directly serialisable as dbt models.
+ */
 async function generateDataTests(column) {
   const dataTests = [];
   const isUnique = (await column.getConstraints()).some(
@@ -135,16 +182,27 @@ async function generateDataTests(column) {
   return dataTests;
 }
 
-async function generateColumnModel(tableName, column) {
+/**
+ * @param {string} tableName
+ * @param {object} column
+ * @param {boolean} hasGenericDoc If true, generates `description` to point to the generic document
+ * @returns A column object, directly serialisable as dbt models.
+ */
+async function generateColumnModel(tableName, column, hasGenericDoc) {
   const dataTests = await generateDataTests(column);
   return {
     name: column.name,
     data_type: column.data_type,
-    description: `{{ doc('${tableName}__${column.name}') }}`,
+    description: `{{ doc('${hasGenericDoc ? 'generic' : tableName}__${column.name}') }}`,
     data_tests: dataTests.length === 0 ? undefined : dataTests,
   };
 }
 
+/**
+ *
+ * @param {object} column
+ * @returns A column document object, directly serialisable.
+ */
 function generateColumnDoc(column) {
   return {
     name: column.name,
@@ -152,7 +210,13 @@ function generateColumnDoc(column) {
   };
 }
 
-async function generateTableModel(schemaName, table) {
+/**
+ * @param {string} schemaName
+ * @param {object} table
+ * @param {string[]} genericColNames
+ * @returns A table object, directly serialisable as dbt model.
+ */
+async function generateTableModel(schemaName, table, genericColNames) {
   return {
     version: 2,
     sources: [
@@ -166,7 +230,11 @@ async function generateTableModel(schemaName, table) {
             name: table.name,
             description: `{{ doc('table__${table.name}') }}`,
             tags: [],
-            columns: await Promise.all(table.columns.map(c => generateColumnModel(table.name, c))),
+            columns: await Promise.all(
+              table.columns.map(c =>
+                generateColumnModel(table.name, c, genericColNames.includes(c.name)),
+              ),
+            ),
           },
         ],
       },
@@ -174,14 +242,25 @@ async function generateTableModel(schemaName, table) {
   };
 }
 
-function generateTableDoc(table) {
+/**
+ *
+ * @param {object} table
+ * @param {string[]} genericColNames
+ * @returns A table document object, directly serialisable.
+ */
+function generateTableDoc(table, genericColNames) {
   return {
     name: table.name,
     description: 'TODO',
-    columns: table.columns.map(generateColumnDoc),
+    columns: table.columns.filter(c => !genericColNames.includes(c.name)).map(generateColumnDoc),
   };
 }
 
+/**
+ *
+ * @param {object} doc
+ * @returns A string form of the given table doc
+ */
 function stringifyTableDoc(doc) {
   const stringifyColumn = column => {
     return `
@@ -198,17 +277,31 @@ ${doc.description}
 ${doc.columns.map(stringifyColumn).join('')}`;
 }
 
-function fillMissingDocColumn(index, column, doc) {
-  if (doc.columns.some(c => c.name === column.name)) return;
+/**
+ * @param {number} index The array index of the given column in the order defined in the DB
+ * @param {object} column
+ * @param {boolean} hasGenericDoc If true, doesn't fill the missing document
+ * @param {object} doc The sink the generated doc get added
+ * @returns
+ */
+function fillMissingDocColumn(index, column, hasGenericDoc, doc) {
+  if (doc.columns.some(c => c.name === column.name) || hasGenericDoc) return;
 
   doc.columns.splice(index, 0, generateColumnDoc(column));
 }
 
-async function fillMissingDoc(schemaPath, table) {
+/**
+ * Generate a table document if it's missing and write as a file.
+ *
+ * @param {string} schemaPath
+ * @param {object} table
+ * @param {string[]} genericColNames
+ */
+async function fillMissingDoc(schemaPath, table, genericColNames) {
   let file;
   try {
     file = await fs.open(path.join(schemaPath, `${table.name}.md`), 'wx');
-    await file.write(stringifyTableDoc(generateTableDoc(table)));
+    await file.write(stringifyTableDoc(generateTableDoc(table, genericColNames)));
   } catch (err) {
     if (err.code !== 'EEXIST') throw err;
   } finally {
@@ -216,30 +309,58 @@ async function fillMissingDoc(schemaPath, table) {
   }
 }
 
+/**
+ * @param {string} tableName
+ * @param {object} column
+ * @param {object} out the sink the removal operation operates on
+ */
 async function handleRemovedColumn(tableName, column, out) {
   console.warn(`Removing ${column.name} in ${tableName}`);
   _.remove(out.dbtColumns, c => c.name === column.name);
   _.remove(out.doc.columns, c => c.name === column.name);
 }
 
-async function handleMissingColumn(tableName, index, column, out) {
-  const model = await generateColumnModel(tableName, column);
+/**
+ *
+ * @param {string} tableName
+ * @param {number} index The array index of the given column in the order defined in the DB
+ * @param {object} column
+ * @param {string[]} genericColNames
+ * @param {object} out the sink the addition operation operates on
+ */
+async function handleMissingColumn(tableName, index, column, genericColNames, out) {
+  const hasGenericDoc = genericColNames.includes(column.name);
+  const model = await generateColumnModel(tableName, column, hasGenericDoc);
   out.dbtColumns.splice(index, 0, model);
-  fillMissingDocColumn(index, column, out.doc);
+  fillMissingDocColumn(index, column, hasGenericDoc, out.doc);
 }
 
+/**
+ * Deletes the given table's source model and its document from the filesystem
+ *
+ * @param {string} schemaPath
+ * @param {object} table
+ */
 async function handleRemovedTable(schemaPath, table) {
   console.warn(`Removing ${table.name}`);
   const tablePath = path.join(schemaPath, table.name);
   await Promise.all([fs.rm(tablePath + '.yml'), fs.rm(tablePath + '.md', { force: true })]);
 }
 
-async function handleMissingTable(schemaPath, schemaName, table) {
+/**
+ * Generates the given table's source model and its document if missing. Then it writes as files.
+ *
+ * @param {string} schemaPath
+ * @param {string} schemaName
+ * @param {object} table
+ * @param {string[]} genericColNames
+ */
+async function handleMissingTable(schemaPath, schemaName, table, genericColNames) {
   const genModelPromise = (async () => {
-    const model = await generateTableModel(schemaName, table);
+    const model = await generateTableModel(schemaName, table, genericColNames);
     await fs.writeFile(path.join(schemaPath, `${table.name}.yml`), YAML.stringify(model));
   })();
-  const docPromise = fillMissingDoc(schemaPath, table);
+  const docPromise = fillMissingDoc(schemaPath, table, genericColNames);
   await Promise.all([genModelPromise, docPromise]);
 }
 
@@ -256,7 +377,7 @@ async function handleColumn(dbtColumn, sqlColumn) {
   if (dbtColumn.data_tests.length === 0) delete dbtColumn.data_tests;
 }
 
-async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns) {
+async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns, genericColNames) {
   const out = {
     dbtColumns: dbtSrc.sources[0].tables[0].columns,
     doc: await readTableDoc(schemaPath, tableName),
@@ -269,7 +390,7 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns) {
     handleRemovedColumn(tableName, column, out),
   );
   _.differenceBy(sqlColumns, out.dbtColumns, 'name').forEach(column =>
-    handleMissingColumn(tableName, sqlColumns.indexOf(column), column, out),
+    handleMissingColumn(tableName, sqlColumns.indexOf(column), column, genericColNames, out),
   );
 
   const intersectionPromises = _.intersectionBy(out.dbtColumns, sqlColumns, 'name').map(
@@ -277,7 +398,7 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns) {
       const sqlColumnIndex = sqlColumns.findIndex(c => c.name === dbtColumn.name);
       const sqlColumn = sqlColumns[sqlColumnIndex];
 
-      fillMissingDocColumn(sqlColumnIndex, dbtColumn, out.doc);
+      fillMissingDocColumn(sqlColumnIndex, dbtColumn, genericColNames, out.doc);
 
       await handleColumn(dbtColumn, sqlColumn);
     },
@@ -296,19 +417,22 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns) {
 }
 
 async function handleTables(schemaPath, schemaName, dbtSrcs, sqlTables) {
+  let genericColNames = (await readTableDoc(schemaPath, 'generic'))?.columns.map(c => c.name) ?? [];
+
   const getName = srcOrTable =>
     srcOrTable.sources ? srcOrTable.sources[0].tables[0].name : srcOrTable.name;
   const removedPromises = _.differenceBy(dbtSrcs, sqlTables, getName).map(src =>
     handleRemovedTable(schemaPath, src.sources[0].tables[0]),
   );
   const missingPromises = _.differenceBy(sqlTables, dbtSrcs, getName).map(table =>
-    handleMissingTable(schemaPath, schemaName, table),
+    handleMissingTable(schemaPath, schemaName, table, genericColNames),
   );
 
   const intersectionPromises = _.intersectionBy(dbtSrcs, sqlTables, getName).map(async dbtSrc => {
     const sqlTable = sqlTables.find(t => t.name === dbtSrc.sources[0].tables[0].name);
-    await fillMissingDoc(schemaPath, sqlTable);
-    await handleColumns(schemaPath, sqlTable.name, dbtSrc, sqlTable.columns);
+    dbtSrc.sources[0].schema = schemaName;
+    await fillMissingDoc(schemaPath, sqlTable, genericColNames);
+    await handleColumns(schemaPath, sqlTable.name, dbtSrc, sqlTable.columns, genericColNames);
   });
   await Promise.all([...removedPromises, ...missingPromises, ...intersectionPromises]);
 }
@@ -345,7 +469,7 @@ async function run(packageName) {
     return;
   }
 
-  console.log('Generating database models for', packageName);
+  console.log('Handling database models for', packageName);
   const schemaPromises = (await getSchemas(client)).map(s => handleSchema(client, packageName, s));
   await Promise.all(schemaPromises);
   await client.end();

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -383,7 +383,7 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns, genericC
 
   // This is expensive yet the most straightforward implementation to detect changes.
   // Algorithms that rely on sorted lists are out because we want preserve the original order of columns.
-  // May be able to use Map, but it doesn't have convinient set operations.
+  // May be able to use Map, but it doesn't have convenient set operations.
   _.differenceBy(out.dbtColumns, sqlColumns, 'name').forEach(column =>
     handleRemovedColumn(tableName, column, out),
   );
@@ -405,7 +405,7 @@ async function handleColumns(schemaPath, tableName, dbtSrc, sqlColumns, genericC
   await Promise.all(intersectionPromises);
 
   const tablePath = path.join(schemaPath, tableName);
-  // This writes files in a preffered format ignoring the original format.
+  // This writes files in a preferred format ignoring the original format.
   const modelPromise = fs.writeFile(tablePath + '.yml', YAML.stringify(dbtSrc));
   const docPromise = fs.writeFile(tablePath + '.md', stringifyTableDoc(out.doc));
   await Promise.all([modelPromise, docPromise]);
@@ -490,7 +490,7 @@ const opts = program.opts();
 
 // This doesn't take untracked files into account.
 if (!opts.allowDirty && !checkClean()) {
-  console.error('Error: `database/` has uncommited changes');
+  console.error('Error: `database/` has uncommitted changes');
   exit(1);
 }
 

--- a/packages/scripts/src/dbt-generate-source.mjs
+++ b/packages/scripts/src/dbt-generate-source.mjs
@@ -351,6 +351,11 @@ async function run(packageName) {
   await client.end();
 }
 
+function checkClean() {
+  const subprocess = spawnSync('git', ['status', '--porcelain=v2', 'database'], { shell: true });
+  return subprocess.stdout.length === 0;
+}
+
 program
   .description(
     `Generates a Source model in dbt.
@@ -365,11 +370,8 @@ program.parse();
 const opts = program.opts();
 
 // This doesn't take untracked files into account.
-if (
-  !opts.allowDirty &&
-  spawnSync('git', ['diff', '--quiet'], { stdio: 'inherit', shell: true }).status === 1
-) {
-  console.warn('The repo is dirty, terminating');
+if (!opts.allowDirty && !checkClean()) {
+  console.error('Error: `database/` has uncommited changes');
   exit(1);
 }
 


### PR DESCRIPTION
Running the script causes 400+ changes to `database/`. I inspected some while testing, but there may be some edge cases I missed.

### Changes

Adds a script that reads the DB and update the dot source models to match.
