### PR TITLE
fix(settings): Allow letterhead to be overriden for facility in ui

### DIFF
--- a/packages/settings/src/schema/definitions/index.ts
+++ b/packages/settings/src/schema/definitions/index.ts
@@ -1,3 +1,4 @@
 export { imagingPrioritiesDefault, imagingPrioritiesSchema } from './imagingPriorities';
 export { triageCategoriesDefault, triageCategoriesSchema } from './triageCategories';
 export { thresholdsDefault, thresholdsSchema } from './upcomingVaccinations';
+export { letterheadProperties } from './letterheadTemplate';

--- a/packages/settings/src/schema/definitions/letterheadTemplate.ts
+++ b/packages/settings/src/schema/definitions/letterheadTemplate.ts
@@ -1,0 +1,14 @@
+import * as yup from 'yup';
+
+export const letterheadProperties = {
+  letterhead: {
+    description: 'The text at the top of most patient PDFs',
+    properties: {
+      title: {
+        type: yup.string(),
+        defaultValue: 'TAMANU MINISTRY OF HEALTH & MEDICAL SERVICES',
+      },
+      subTitle: { type: yup.string(), defaultValue: 'PO Box 12345, Melbourne, Australia' },
+    },
+  },
+};

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 import { extractDefaults } from './utils';
+import { letterheadProperties } from './definitions';
 
 export const facilitySettings = {
   name: 'Facility server settings',
@@ -34,6 +35,12 @@ export const facilitySettings = {
             },
           },
         },
+      },
+    },
+    templates: {
+      description: 'Strings to be inserted into emails/PDFs',
+      properties: {
+        letterhead: letterheadProperties,
       },
     },
   },

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -40,7 +40,10 @@ export const facilitySettings = {
     templates: {
       description: 'Strings to be inserted into emails/PDFs',
       properties: {
-        letterhead: letterheadProperties,
+        letterhead: {
+          description: 'The text at the top of most patient PDFs',
+          properties: letterheadProperties,
+        },
       },
     },
   },

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -38,7 +38,7 @@ export const facilitySettings = {
       },
     },
     templates: {
-      description: 'Strings to be inserted into emails/PDFs',
+      description: 'Text to be inserted into emails/PDFs',
       properties: {
         letterhead: {
           description: 'The text at the top of most patient PDFs',

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -3,6 +3,7 @@ import { extractDefaults } from './utils';
 import {
   imagingPrioritiesDefault,
   imagingPrioritiesSchema,
+  letterheadProperties,
   thresholdsDefault,
   thresholdsSchema,
   triageCategoriesDefault,
@@ -833,13 +834,7 @@ export const globalSettings = {
       properties: {
         letterhead: {
           description: 'The text at the top of most patient PDFs',
-          properties: {
-            title: {
-              type: yup.string(),
-              defaultValue: 'TAMANU MINISTRY OF HEALTH & MEDICAL SERVICES',
-            },
-            subTitle: { type: yup.string(), defaultValue: 'PO Box 12345, Melbourne, Australia' },
-          },
+          properties: letterheadProperties,
         },
         signerRenewalEmail: {
           description: 'The email sent when the signer runs out',


### PR DESCRIPTION
### Changes

In order to allow the user to overide global settings in the ui we need to add the setting to both the facility and global schema. I have tested this and it works as expected

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
