### PR TITLE
tweak(triage): 2.17 fix: colon instead of dash in triage system message

### DIFF
--- a/packages/shared/src/models/Encounter.js
+++ b/packages/shared/src/models/Encounter.js
@@ -288,7 +288,7 @@ export class Encounter extends Model {
           SELECT DISTINCT encounter_id
           FROM lab_requests
           WHERE updated_at_sync_tick > :since -- to only include lab requests that recently got attached to the encounters
-        ) AS new_labs ON new_labs.encounter_id = encounters.id 
+        ) AS new_labs ON new_labs.encounter_id = encounters.id
       `,
       where: `
         encounters.updated_at_sync_tick > :since -- to include including normal encounters
@@ -368,7 +368,7 @@ export class Encounter extends Model {
     }
 
     await this.addSystemNote(
-      `${department.name} triage score – ${triageRecord.score}`,
+      `${department.name} triage score: ${triageRecord.score}`,
       submittedTime,
       user,
     );


### PR DESCRIPTION
### Changes

https://linear.app/bes/issue/NASS-1324/create-a-system-note-showing-the-triage-score#comment-d719c48d

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
