### PR TITLE
fix(vaccine): 2.17 fix: Mobile missing scheduleVaccineId on multiple edits without returning to vaccine table

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
+++ b/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
@@ -135,7 +135,6 @@ export const NewVaccineTabComponent = ({
         navigation.navigate(Routes.HomeStack.VaccineStack.VaccineModalScreen, {
           vaccine: {
             ...vaccine,
-            scheduledVaccine: scheduledVaccineRecord,
             administeredVaccine: {
               ...updatedVaccine,
               encounter,
@@ -156,7 +155,7 @@ export const NewVaccineTabComponent = ({
     [isSubmitting],
   );
 
-  const vaccineObject = { ...vaccine, ...administeredVaccine };
+  const vaccineObject = { ...administeredVaccine, ...vaccine };
 
   return (
     <StyledSafeAreaView flex={1}>

--- a/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
+++ b/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
@@ -45,7 +45,6 @@ export const NewVaccineTabComponent = ({
   selectedPatient,
 }: NewVaccineTabProps): ReactElement => {
   const { vaccine } = route;
-  console.log('route, NewVaccineTabComponent', route);
   const { administeredVaccine } = vaccine;
   const navigation = useNavigation();
   const [isSubmitting, setSubmitting] = useState(false);
@@ -136,6 +135,7 @@ export const NewVaccineTabComponent = ({
         navigation.navigate(Routes.HomeStack.VaccineStack.VaccineModalScreen, {
           vaccine: {
             ...vaccine,
+            scheduledVaccine: scheduledVaccineRecord,
             administeredVaccine: {
               ...updatedVaccine,
               encounter,
@@ -166,7 +166,6 @@ export const NewVaccineTabComponent = ({
         patientId={selectedPatient.id}
         initialValues={{
           ...vaccineObject,
-          scheduledVaccineId: vaccineObject.scheduledVaccineId || vaccineObject.scheduledVaccine.id,
           date: vaccineObject.date ? parseISO(vaccineObject.date) : null,
         }}
         status={route.key as VaccineStatus}

--- a/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
+++ b/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
@@ -45,6 +45,7 @@ export const NewVaccineTabComponent = ({
   selectedPatient,
 }: NewVaccineTabProps): ReactElement => {
   const { vaccine } = route;
+  console.log('route, NewVaccineTabComponent', route);
   const { administeredVaccine } = vaccine;
   const navigation = useNavigation();
   const [isSubmitting, setSubmitting] = useState(false);
@@ -165,6 +166,7 @@ export const NewVaccineTabComponent = ({
         patientId={selectedPatient.id}
         initialValues={{
           ...vaccineObject,
+          scheduledVaccineId: vaccineObject.scheduledVaccineId || vaccineObject.scheduledVaccine.id,
           date: vaccineObject.date ? parseISO(vaccineObject.date) : null,
         }}
         status={route.key as VaccineStatus}


### PR DESCRIPTION
### Changes

To reproduce issue:
- Administer vaccine
- View vaccine
- Click edit and change to `NOT GIVEN`
- Do not click back to table and instead click edit agian
- Change to `GIVEN`
- Administered vaccine is missing its scheduledVaccineId

Ive played with this for a few hours and the issue is that `vaccine.scheduleVaccine` becomes null after multiple updates without returning to table view. This means that if it is submitted the table will error due to Administered vaccine with null scheduledVaccineId

My feeling is that this is an existing issue, having existed as far back as implementation of vaccine edit changes. It was noticed in 2.17 

The scheduled vaccine is already fetched in the submit so easily enough to pass that through to the subsequent load.
This fixes the issue in the cleanest way I could find.

 ~~Still I would really love to get to the bottom of why it becomes null in first place, but I feel pretty happy with this as a solution with the least risky changes to logic.
Keen for discussion.~~ 

**Update** latest commit addresses underlying issue! Basically the administered vaccines link to scheduled vaccine wipes the key. - as scheduled vaccine is not included into administered vaccine!

Leaving note to back apply where needed to effected versions.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
