### PR TITLE
fix(labs): NASS-1415: Show invalided status lab requests in published view

### DIFF
--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -122,14 +122,25 @@ labRequest.get(
       makeFilter(true, `lab_requests.status != :cancelled`, () => ({
         cancelled: LAB_REQUEST_STATUSES.CANCELLED,
       })),
-      makeFilter(true, `lab_requests.status != :invalidated`, () => ({
-        invalidated: LAB_REQUEST_STATUSES.INVALIDATED,
-      })),
+      makeFilter(
+        !filterParams?.statuses?.includes(LAB_REQUEST_STATUSES.INVALIDATED),
+        `lab_requests.status != :invalidated`,
+        () => ({
+          invalidated: LAB_REQUEST_STATUSES.INVALIDATED,
+        }),
+      ),
+      makeFilter(
+        !filterParams?.statuses?.includes(LAB_REQUEST_STATUSES.PUBLISHED),
+        'lab_requests.status != :published',
+        () => ({
+          published: LAB_REQUEST_STATUSES.PUBLISHED,
+        }),
+      ),
       makeDeletedAtIsNullFilter('lab_requests'),
       makeFilter(true, `lab_requests.status != :enteredInError`, () => ({
         enteredInError: LAB_REQUEST_STATUSES.ENTERED_IN_ERROR,
       })),
-      makeSimpleTextFilter('status', 'lab_requests.status'),
+      makeFilter(filterParams.statuses, 'lab_requests.status in (:statuses)'),
       makeSimpleTextFilter('requestId', 'lab_requests.display_id'),
       makeFilter(filterParams.category, 'category.id = :category'),
       makeSimpleTextFilter('priority', 'priority.id'),
@@ -169,13 +180,6 @@ labRequest.get(
             publishedDate: `${publishedDate}%`,
           };
         },
-      ),
-      makeFilter(
-        filterParams.status !== LAB_REQUEST_STATUSES.PUBLISHED,
-        'lab_requests.status != :published',
-        () => ({
-          published: LAB_REQUEST_STATUSES.PUBLISHED,
-        }),
       ),
       makeDeletedAtIsNullFilter('encounter'),
     ].filter(f => f);

--- a/packages/facility-server/app/routes/apiv1/labs.js
+++ b/packages/facility-server/app/routes/apiv1/labs.js
@@ -123,14 +123,14 @@ labRequest.get(
         cancelled: LAB_REQUEST_STATUSES.CANCELLED,
       })),
       makeFilter(
-        !filterParams?.statuses?.includes(LAB_REQUEST_STATUSES.INVALIDATED),
+        !filterParams.statuses?.includes(LAB_REQUEST_STATUSES.INVALIDATED),
         `lab_requests.status != :invalidated`,
         () => ({
           invalidated: LAB_REQUEST_STATUSES.INVALIDATED,
         }),
       ),
       makeFilter(
-        !filterParams?.statuses?.includes(LAB_REQUEST_STATUSES.PUBLISHED),
+        !filterParams.statuses?.includes(LAB_REQUEST_STATUSES.PUBLISHED),
         'lab_requests.status != :published',
         () => ({
           published: LAB_REQUEST_STATUSES.PUBLISHED,

--- a/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
@@ -28,7 +28,7 @@ const FacilityCheckbox = styled.div`
 `;
 
 export const LabRequestsSearchBar = ({ statuses }) => {
-  const publishedStatus = statuses.includes(LAB_REQUEST_STATUSES.PUBLISHED);
+  const publishedStatus = statuses?.includes(LAB_REQUEST_STATUSES.PUBLISHED);
   const { searchParameters, setSearchParameters } = useLabRequest(
     publishedStatus ? LabRequestSearchParamKeys.Published : LabRequestSearchParamKeys.All,
   );

--- a/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
@@ -213,6 +213,7 @@ export const LabRequestsSearchBar = ({ status = '' }) => {
                     LAB_REQUEST_STATUSES.DELETED,
                     LAB_REQUEST_STATUSES.ENTERED_IN_ERROR,
                     LAB_REQUEST_STATUSES.CANCELLED,
+                    LAB_REQUEST_STATUSES.INVALIDATED,
                   ].includes(option.value),
               )
             }

--- a/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/LabRequestsSearchBar.jsx
@@ -27,8 +27,8 @@ const FacilityCheckbox = styled.div`
   margin-top: 20px;
 `;
 
-export const LabRequestsSearchBar = ({ status = '' }) => {
-  const publishedStatus = status === LAB_REQUEST_STATUSES.PUBLISHED;
+export const LabRequestsSearchBar = ({ statuses }) => {
+  const publishedStatus = statuses.includes(LAB_REQUEST_STATUSES.PUBLISHED);
   const { searchParameters, setSearchParameters } = useLabRequest(
     publishedStatus ? LabRequestSearchParamKeys.Published : LabRequestSearchParamKeys.All,
   );

--- a/packages/web/app/views/LabRequestListingView.jsx
+++ b/packages/web/app/views/LabRequestListingView.jsx
@@ -16,7 +16,7 @@ const StyledContentPane = styled(ContentPane)`
   position: relative;
 `;
 
-const LabRequestListing = ({ status = '', searchParamKey = LabRequestSearchParamKeys.All }) => {
+const LabRequestListing = ({ statuses, searchParamKey = LabRequestSearchParamKeys.All }) => {
   const { loadEncounter } = useEncounter();
   const { loadLabRequest, searchParameters } = useLabRequest(searchParamKey);
 
@@ -28,7 +28,7 @@ const LabRequestListing = ({ status = '', searchParamKey = LabRequestSearchParam
         loadEncounter={loadEncounter}
         loadLabRequest={loadLabRequest}
         searchParameters={searchParameters}
-        status={status}
+        statuses={statuses}
       />
     </StyledContentPane>
   );
@@ -45,7 +45,7 @@ export const PublishedLabRequestListingView = () => (
   <PageContainer>
     <TopBar title="Published lab requests" />
     <LabRequestListing
-      status={LAB_REQUEST_STATUSES.PUBLISHED}
+      statuses={[LAB_REQUEST_STATUSES.PUBLISHED, LAB_REQUEST_STATUSES.INVALIDATED]}
       searchParamKey={LabRequestSearchParamKeys.Published}
     />
   </PageContainer>

--- a/packages/web/app/views/LabRequestListingView.jsx
+++ b/packages/web/app/views/LabRequestListingView.jsx
@@ -23,7 +23,7 @@ const LabRequestListing = ({ statuses, searchParamKey = LabRequestSearchParamKey
   return (
     <StyledContentPane>
       <SearchTableTitle>Lab request search</SearchTableTitle>
-      <LabRequestsSearchBar status={status} />
+      <LabRequestsSearchBar statuses={statuses} />
       <LabRequestsTable
         loadEncounter={loadEncounter}
         loadLabRequest={loadLabRequest}

--- a/packages/web/app/views/LabRequestsTable.jsx
+++ b/packages/web/app/views/LabRequestsTable.jsx
@@ -19,8 +19,8 @@ import { TranslatedText } from '../components/Translation/TranslatedText';
 import { useAuth } from '../contexts/Auth';
 
 export const LabRequestsTable = React.memo(
-  ({ status = '', loadEncounter, loadLabRequest, searchParameters }) => {
-    const publishedStatus = status === LAB_REQUEST_STATUSES.PUBLISHED;
+  ({ statuses, loadEncounter, loadLabRequest, searchParameters }) => {
+    const publishedStatus = statuses?.includes(LAB_REQUEST_STATUSES.PUBLISHED);
 
     const { facilityId } = useAuth();
 
@@ -74,6 +74,8 @@ export const LabRequestsTable = React.memo(
       );
     };
 
+    console.log('statuses', statuses);
+
     return (
       <SearchTableWithPermissionCheck
         verb="list"
@@ -85,7 +87,7 @@ export const LabRequestsTable = React.memo(
         onRowClick={selectLab}
         fetchOptions={{
           ...searchParameters,
-          ...(status && { status }),
+          ...(statuses && { statuses }),
           facilityId,
         }}
         initialSort={{

--- a/packages/web/app/views/LabRequestsTable.jsx
+++ b/packages/web/app/views/LabRequestsTable.jsx
@@ -74,8 +74,6 @@ export const LabRequestsTable = React.memo(
       );
     };
 
-    console.log('statuses', statuses);
-
     return (
       <SearchTableWithPermissionCheck
         verb="list"


### PR DESCRIPTION
### Changes
Request from Megan to get this into 2.17 based on identified issue whereby you cannot view invalided imaging requests anywhere in listing view. [See here](https://beyondessential.slack.com/archives/C03TRRG2GTC/p1727320827632939) 

- Remove 'Invalidated' from the list of statuses on the active requests page and exclude
- Include invalidated status in published listing view

Theres a refactor you could do here to handle statuses by just passing in the required ones, but as 2.17 fix tried to keep minimal 🤔 
 
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
