### PR TITLE
feat: EPI-973: Add tooltip for completed and not completed status icons

### DIFF
--- a/packages/web/app/components/Tasks/TasksTable.jsx
+++ b/packages/web/app/components/Tasks/TasksTable.jsx
@@ -164,7 +164,40 @@ const StyledDivider = styled(Divider)`
   margin-bottom: 5px;
 `;
 
-const getStatus = ({ status }) => {
+const StatusTooltip = styled.div`
+  text-align: center;
+`;
+
+const LowercaseText = styled.span`
+  text-transform: lowercase;
+`;
+
+const getCompletedTooltipText = ({ completedBy, completedTime, completedNote }) => (
+  <StatusTooltip>
+    <TranslatedText stringId="tasks.table.tooltip.completed" fallback="Completed" />
+    <div>{completedBy.displayName}</div>
+    <div>
+      <span color={Colors.midText}>{formatShortest(completedTime)} </span>
+      <LowercaseText>{formatTime(completedTime)}</LowercaseText>
+    </div>
+    <div>{completedNote}</div>
+  </StatusTooltip>
+);
+
+const getNotCompletedTooltipText = ({ notCompletedBy, notCompletedTime, notCompletedReason }) => (
+  <StatusTooltip>
+    <TranslatedText stringId="tasks.table.tooltip.notCompleted" fallback="Not completed" />
+    <div>{notCompletedBy.displayName}</div>
+    <div>
+      <span color={Colors.midText}>{formatShortest(notCompletedTime)} </span>
+      <LowercaseText>{formatTime(notCompletedTime)}</LowercaseText>
+    </div>
+    <div>{notCompletedReason.name}</div>
+  </StatusTooltip>
+);
+
+const getStatus = row => {
+  const { status } = row;
   switch (status) {
     case TASK_STATUSES.TODO:
       return (
@@ -173,9 +206,17 @@ const getStatus = ({ status }) => {
         </Box>
       );
     case TASK_STATUSES.COMPLETED:
-      return <StyledCheckCircleIcon />;
+      return (
+        <ThemedTooltip title={getCompletedTooltipText(row)}>
+          <StyledCheckCircleIcon />
+        </ThemedTooltip>
+      );
     case TASK_STATUSES.NON_COMPLETED:
-      return <StyledCancelIcon />;
+      return (
+        <ThemedTooltip title={getNotCompletedTooltipText(row)}>
+          <StyledCancelIcon />
+        </ThemedTooltip>
+      );
     default:
       break;
   }
@@ -249,7 +290,9 @@ const NotesCell = ({ row, hoveredRow, handleActionModalOpen }) => {
                 />
               }
             >
-              <IconButton onClick={() => handleActionModalOpen(TASK_STATUSES.NON_COMPLETED, row.id)}>
+              <IconButton
+                onClick={() => handleActionModalOpen(TASK_STATUSES.NON_COMPLETED, row.id)}
+              >
                 <StyledCancelIcon />
               </IconButton>
             </ThemedTooltip>


### PR DESCRIPTION
### Changes

Add tooltip for completed and not completed status icons to show status details

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
