### PR TITLE
style(labTests): 2.17 fix: Scroll whole page instead of squishing lab test table on smaller devices with multiple notes

### DIFF
--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -57,7 +57,6 @@ const BottomContainer = styled.div`
   background-color: ${Colors.white};
   padding: 18px 30px;
   display: flex;
-  overflow: hidden;
   flex-direction: column;
   flex: 1;
 `;


### PR DESCRIPTION
### Changes
- Felicity has signed off on this solution
- Issue is that table could become squished and become non usable on smaller screens when multiple notes where added.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
