### PR TITLE
fix(invoicing): EPI-975: fix wrong sourceId for potential imaging request area

### DIFF
--- a/packages/facility-server/app/routes/apiv1/invoice/getPotentialInvoiceItems.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/getPotentialInvoiceItems.js
@@ -57,7 +57,10 @@ filtered_procedures as (
 filtered_imagings as (
 	select
 		:imagingType as "sourceType",
-		ir.id as "sourceId",
+		case
+			when fpa.id is not null then ira.id
+			else ir.id
+		end as "sourceId", --priority imaging request area id over imaging request id
 		coalesce(fpa.id, fp.id) as "productId", --priority imaging area price over imaging type price
 		ir."requested_date" as "date",
 		irt.code as "productCode",


### PR DESCRIPTION
### Changes

- Fix the issue where adding imaging request item from the potential item list cause the other imaging request with the same type to be vanished.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

