### PR TITLE
tweak(adminPanel): 2.17 fix: Comma seperate facilityIds for omniserver on sync status admin tab

### DIFF
--- a/packages/web/app/views/administration/SyncView.jsx
+++ b/packages/web/app/views/administration/SyncView.jsx
@@ -1,5 +1,6 @@
 import ms from 'ms';
 import React from 'react';
+import { Box } from '@mater ial-ui/core';
 
 import { DataFetchingTable, DateDisplay, PageContainer, TopBar } from '../../components';
 import { SYNC_LAST_COMPLETED_ENDPOINT } from './constants';
@@ -42,13 +43,15 @@ export const SyncView = React.memo(() => {
   return (
     <PageContainer>
       <TopBar title={<TranslatedText stringId="admin.syncStatus.title" fallback="Sync status" />} />
-      <p>
-        <TranslatedText
-          stringId="admin.syncStatus.times.message"
-          fallback="Times are in the server's timezone"
-        />
-      </p>
-      <LastSyncs />
+      <Box p={4}>
+        <p>
+          <TranslatedText
+            stringId="admin.syncStatus.times.message"
+            fallback="Times are in the server's timezone"
+          />
+        </p>
+        <LastSyncs />
+      </Box>
     </PageContainer>
   );
 });

--- a/packages/web/app/views/administration/SyncView.jsx
+++ b/packages/web/app/views/administration/SyncView.jsx
@@ -1,6 +1,6 @@
 import ms from 'ms';
 import React from 'react';
-import { Box } from '@mater ial-ui/core';
+import { Box } from '@material-ui/core';
 
 import { DataFetchingTable, DateDisplay, PageContainer, TopBar } from '../../components';
 import { SYNC_LAST_COMPLETED_ENDPOINT } from './constants';

--- a/packages/web/app/views/administration/SyncView.jsx
+++ b/packages/web/app/views/administration/SyncView.jsx
@@ -13,6 +13,7 @@ const LastSyncs = React.memo(props => (
         key: 'facilityIds',
         title: <TranslatedText stringId="general.facility.label.plural" fallback="Facilities" />,
         minWidth: 100,
+        accessor: ({ facilityIds }) => facilityIds.join(', '),
       },
       {
         key: 'completedAt',


### PR DESCRIPTION
Previously there was no space or delimiter 

<img width="738" alt="Screenshot 2024-10-03 at 6 56 21 AM" src="https://github.com/user-attachments/assets/7cfb172a-1e24-4c75-bf0d-53692e354d63">

Added some padding too as it looks so squished

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
