### PR TITLE
fix(vaccine): 2.17 fix: Mobile initial tab not selectable on editing not_given vaccine and fix update of state with subsequent edits

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
+++ b/packages/mobile/App/ui/navigation/screens/vaccine/newVaccineTabs/NewVaccineTab.tsx
@@ -135,6 +135,7 @@ export const NewVaccineTabComponent = ({
         navigation.navigate(Routes.HomeStack.VaccineStack.VaccineModalScreen, {
           vaccine: {
             ...vaccine,
+            scheduledVaccine,
             administeredVaccine: {
               ...updatedVaccine,
               encounter,
@@ -155,7 +156,7 @@ export const NewVaccineTabComponent = ({
     [isSubmitting],
   );
 
-  const vaccineObject = { ...administeredVaccine, ...vaccine };
+  const vaccineObject = { ...vaccine, ...administeredVaccine };
 
   return (
     <StyledSafeAreaView flex={1}>

--- a/packages/mobile/App/ui/navigation/stacks/NewVaccineTabs.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/NewVaccineTabs.tsx
@@ -1,11 +1,4 @@
-import React, {
-  FunctionComponent,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { FunctionComponent, ReactElement, useCallback, useMemo, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { NavigationProp, RouteProp } from '@react-navigation/native';
 
@@ -116,21 +109,9 @@ export const NewVaccineTabs = ({ navigation, route }: NewVaccineTabsProps): Reac
   );
 
   const [state, setState] = useState({
-    index: 0,
+    index: route.params.vaccine.status === VaccineStatus.NOT_GIVEN ? 1 : 0,
     routes,
   });
-
-  useEffect(() => {
-    switch (route.params.vaccine.status) {
-      case VaccineStatus.NOT_GIVEN:
-        setState({
-          index: 1,
-          routes,
-        });
-        break;
-      default:
-    }
-  }, [route, routes]);
 
   const scenes = {
     [VaccineStatus.GIVEN]: NewVaccineTab,


### PR DESCRIPTION
### Changes
- When editing a not given vaccine it would select given tab and not given would be unselectable
- Fix the display of updated vaccines on multiple edits (had to go back to my alternative solution from [fix(vaccine): 2.17 fix: Mobile missing scheduleVaccineId on multiple edits without returning to vaccine table](https://github.com/beyondessential/tamanu/pull/6513))

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
