### PR TITLE
tweak(sidebarLayouts): 2.17 fix: Incorrect path to sidebar layouts config

### DIFF
--- a/packages/web/app/components/Sidebar/useSidebar.js
+++ b/packages/web/app/components/Sidebar/useSidebar.js
@@ -51,5 +51,6 @@ const useSidebarFactory = (ITEMS, configKey) => {
   }, []).sort(sortTopLevelItems);
 };
 
-export const useFacilitySidebar = () => useSidebarFactory(FACILITY_MENU_ITEMS, 'layout.sidebar');
-export const useCentralSidebar = () => useSidebarFactory(CENTRAL_MENU_ITEMS, 'layout.centralSidebar');
+export const useFacilitySidebar = () => useSidebarFactory(FACILITY_MENU_ITEMS, 'layouts.sidebar');
+export const useCentralSidebar = () =>
+  useSidebarFactory(CENTRAL_MENU_ITEMS, 'layouts.centralSidebar');


### PR DESCRIPTION
just missing s
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
