### PR TITLE
tweak(patientLetter): 2.17 fix: Patient letter not displaying correct letterhead for logged in facility

### DIFF
--- a/packages/web/app/forms/PatientLetterForm.jsx
+++ b/packages/web/app/forms/PatientLetterForm.jsx
@@ -136,15 +136,15 @@ export const PatientLetterForm = ({ onSubmit, onCancel, editedObject, endpoint, 
         patientLetterData: {
           ...data,
           patient,
-          facilityId,
         },
+        facilityId,
         name: data.title,
         clinicianId: data.clinicianId,
       });
       const documentToOpen = printRequested ? document : null;
       onSubmit(documentToOpen);
     },
-    [api, endpoint, onSubmit, patient],
+    [api, endpoint, onSubmit, patient, facilityId],
   );
 
   const renderForm = props =>


### PR DESCRIPTION
was passing facilityId on wrong level to what the endpoint expected.
This lead to facility scoped letterhead settings not being displayed correctly.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
