### PR TITLE
fix(sync): SAV-837: Avoid repull pushed changes from the previous sync session when using sync lookup

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -545,6 +545,7 @@ describe('Sync Lookup data', () => {
     });
     await models.LocalSystemFact.set(CURRENT_SYNC_TIME_KEY, 4);
     await models.LocalSystemFact.set(LOOKUP_UP_TO_TICK_KEY, -1);
+    await models.SyncDeviceTick.truncate({ force: true });
 
     jest.resetModules();
     jest.clearAllMocks();

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -572,6 +572,7 @@ describe('Sync Lookup data', () => {
       fullSyncPatientsTable,
       sessionId,
       '',
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -656,6 +657,7 @@ describe('Sync Lookup data', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -786,6 +788,7 @@ describe('Sync Lookup data', () => {
           regularSyncPatientsTable,
           sessionId,
           facility.id,
+          null,
           simplestSessionConfig,
           simplestConfig,
         );
@@ -838,6 +841,7 @@ describe('Sync Lookup data', () => {
           regularSyncPatientsTable,
           sessionId,
           facility.id,
+          null,
           simplestSessionConfig,
           simplestConfig,
         );
@@ -885,6 +889,7 @@ describe('Sync Lookup data', () => {
           regularSyncPatientsTable,
           sessionId,
           facility.id,
+          null,
           simplestSessionConfig,
           simplestConfig,
         );
@@ -944,6 +949,7 @@ describe('Sync Lookup data', () => {
       regularSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -1060,6 +1066,7 @@ describe('Sync Lookup data', () => {
         regularSyncPatientsTable,
         sessionId,
         facility.id,
+        null,
         sessionConfig,
         simplestConfig,
       );
@@ -1146,6 +1153,7 @@ describe('Sync Lookup data', () => {
         regularSyncPatientsTable,
         sessionId,
         facility.id,
+        null,
         sessionConfig,
         simplestConfig,
       );

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -52,6 +52,7 @@ describe('Sync Lookup data', () => {
     sync: {
       lookupTable: {
         enabled: true,
+        avoidRepull: true,
       },
       maxRecordsPerSnapshotChunk: 10000000,
     },
@@ -545,6 +546,7 @@ describe('Sync Lookup data', () => {
     await models.LocalSystemFact.set(CURRENT_SYNC_TIME_KEY, 4);
     await models.LocalSystemFact.set(LOOKUP_UP_TO_TICK_KEY, -1);
 
+    jest.resetModules();
     jest.clearAllMocks();
   });
 
@@ -1251,6 +1253,114 @@ describe('Sync Lookup data', () => {
 
       expect(labRequestLookupData).toBeDefined();
       expect(labRequestEncounterLookupData.isLabRequest).toBeTrue();
+    });
+  });
+
+  describe('avoidRepull', () => {
+    const snapshotOutgoingRecordsForFacility = async avoidRepull => {
+      const deviceId = 'facility-a';
+      await models.LocalSystemFact.set(CURRENT_SYNC_TIME_KEY, 4);
+      const pushedPatientFromCurrentFacility = await models.Patient.create(fake(models.Patient));
+
+      // Set new sync time so that it does not match the SyncDeviceTick record
+      // in order to have it included in the snapshot.
+      await models.LocalSystemFact.set(CURRENT_SYNC_TIME_KEY, 5);
+      const patientFromAnotherFacility = await models.Patient.create(fake(models.Patient));
+
+      await models.SyncDeviceTick.create({
+        deviceId,
+        persistedAtSyncTick: pushedPatientFromCurrentFacility.updatedAtSyncTick,
+      });
+
+      const actualConfig = jest.requireActual('config');
+      const { CentralSyncManager } = require('../../dist/sync/CentralSyncManager');
+      const config = {
+        ...actualConfig,
+        sync: {
+          ...actualConfig.sync,
+          lookupTable: {
+            enabled: true,
+            perModelUpdateTimeoutMs: 40000,
+            avoidRepull,
+          },
+        },
+      };
+      CentralSyncManager.overrideConfig(config);
+
+      const centralSyncManager = new CentralSyncManager(ctx);
+      await centralSyncManager.updateLookupTable();
+
+      const regularSyncPatientsTable = await createMarkedForSyncPatientsTable(
+        ctx.store.sequelize,
+        sessionId,
+        false,
+        facility.id,
+        10,
+      );
+
+      const sessionConfig = {
+        syncAllLabRequests: true,
+        isMobile: false,
+      };
+
+      const patientCount = 1;
+      await snapshotOutgoingChanges(
+        ctx.store,
+        { Patient: models.Patient },
+        SINCE,
+        patientCount,
+        regularSyncPatientsTable,
+        sessionId,
+        facility.id,
+        deviceId,
+        sessionConfig,
+        config,
+      );
+
+      const outgoingSnapshotRecords = await findSyncSnapshotRecords(
+        ctx.store.sequelize,
+        sessionId,
+        SYNC_SESSION_DIRECTION.OUTGOING,
+      );
+
+      return {
+        outgoingSnapshotRecords,
+        pushedPatientFromCurrentFacility,
+        patientFromAnotherFacility,
+      };
+    };
+    it("Avoids repull data for a device when 'avoidRepull' feature flag is enabled", async () => {
+      const {
+        outgoingSnapshotRecords,
+        pushedPatientFromCurrentFacility,
+        patientFromAnotherFacility,
+      } = await snapshotOutgoingRecordsForFacility(true);
+      const snapshotPushedPatientFromCurrentFacility = outgoingSnapshotRecords.find(
+        r => r.recordId === pushedPatientFromCurrentFacility.id,
+      );
+      const snapshotPatientFromAnotherFacility = outgoingSnapshotRecords.find(
+        r => r.recordId === patientFromAnotherFacility.id,
+      );
+
+      expect(snapshotPushedPatientFromCurrentFacility).not.toBeDefined();
+      expect(snapshotPatientFromAnotherFacility).toBeDefined();
+    });
+
+    it("Repulls data for a device when 'avoidRepull' feature flag is disabled", async () => {
+      const {
+        outgoingSnapshotRecords,
+        pushedPatientFromCurrentFacility,
+        patientFromAnotherFacility,
+      } = await snapshotOutgoingRecordsForFacility(false);
+      const snapshotPushedPatientFromCurrentFacility = outgoingSnapshotRecords.find(
+        r => r.recordId === pushedPatientFromCurrentFacility.id,
+      );
+      const snapshotPatientFromAnotherFacility = outgoingSnapshotRecords.find(
+        r => r.recordId === patientFromAnotherFacility.id,
+      );
+
+      expect(snapshotPushedPatientFromCurrentFacility).toBeDefined();
+      expect(snapshotPatientFromAnotherFacility).toBeDefined();
     });
   });
 });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -1026,7 +1026,7 @@ describe('CentralSyncManager', () => {
 
         // Push the encounter
         await centralSyncManager.addIncomingChanges(sessionId, changes);
-        await centralSyncManager.completePush(sessionId);
+        await centralSyncManager.completePush(sessionId, 'facility-a');
         await waitForPushCompleted(centralSyncManager, sessionId);
 
         // Start the snapshot for pull process

--- a/packages/central-server/__tests__/sync/sanitizeBuffer.test.js
+++ b/packages/central-server/__tests__/sync/sanitizeBuffer.test.js
@@ -50,6 +50,7 @@ describe('sanitize binary data', () => {
               true,
               syncSession.id,
               '',
+              null,
               {
                 syncAllLabRequests: false,
                 isMobile: false,

--- a/packages/central-server/__tests__/sync/snapshotOutgoingChanges.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/snapshotOutgoingChanges.syncLookup.test.js
@@ -110,6 +110,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       '',
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -173,6 +174,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       '',
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -240,6 +242,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -308,6 +311,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -362,6 +366,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -423,6 +428,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       simplestSessionConfig,
       simplestConfig,
     );
@@ -477,6 +483,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       {
         syncAllLabRequests: true,
         isMobile: false,
@@ -606,6 +613,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       {
         syncAllLabRequests: true,
         isMobile: false,
@@ -733,6 +741,7 @@ describe('snapshotOutgoingChanges', () => {
       fullSyncPatientsTable,
       sessionId,
       facility.id,
+      null,
       {
         syncAllLabRequests: true,
         isMobile: false,

--- a/packages/central-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/central-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -59,6 +59,7 @@ describe('snapshotOutgoingChanges', () => {
         fullSyncPatientsTable,
         sessionId,
         '',
+        null,
         simplestSessionConfig,
       );
       expect(result).toEqual(0);
@@ -95,6 +96,7 @@ describe('snapshotOutgoingChanges', () => {
         fullSyncPatientsTable,
         syncSession.id,
         '',
+        null,
         simplestSessionConfig,
       );
       expect(result).toEqual(1);
@@ -143,6 +145,7 @@ describe('snapshotOutgoingChanges', () => {
         fullSyncPatientsTable,
         syncSession.id,
         '',
+        null,
         simplestSessionConfig,
       );
       expect(result).toEqual(1);
@@ -182,6 +185,7 @@ describe('snapshotOutgoingChanges', () => {
         fullSyncPatientsTable,
         syncSession.id,
         '',
+        null,
         simplestSessionConfig,
       );
       expect(result).toEqual(2);
@@ -250,6 +254,7 @@ describe('snapshotOutgoingChanges', () => {
             true,
             syncSession.id,
             '',
+            null,
             simplestSessionConfig,
           );
         },
@@ -332,6 +337,7 @@ describe('snapshotOutgoingChanges', () => {
             true,
             syncSession.id,
             '',
+            null,
             simplestSessionConfig,
           );
         },
@@ -483,6 +489,7 @@ describe('snapshotOutgoingChanges', () => {
         incrementalSyncPatientsTable,
         syncSession.id,
         facilityId,
+        null,
         { ...simplestSessionConfig, syncAllLabRequests: true },
       );
 
@@ -532,6 +539,7 @@ describe('snapshotOutgoingChanges', () => {
         incrementalSyncPatientsTable,
         syncSession.id,
         facility.id,
+        null,
         { ...simplestSessionConfig, syncAllLabRequests: true },
       );
 
@@ -565,6 +573,7 @@ describe('snapshotOutgoingChanges', () => {
         true,
         syncSession.id,
         fakeUUID(),
+        null,
         { ...simplestSessionConfig, syncAllLabRequests: false },
       );
 

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -569,7 +569,7 @@ export class CentralSyncManager {
         return tock;
       });
 
-      await models.SyncPersistedTickToDevice.create({
+      await models.SyncDeviceTick.create({
         deviceId,
         persistedAtSyncTick,
       });

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -323,7 +323,7 @@ export class CentralSyncManager {
 
   async setupSnapshotForPull(
     sessionId,
-    { since, facilityId, tablesToInclude, tablesForFullResync, isMobile },
+    { since, facilityId, tablesToInclude, tablesForFullResync, isMobile, deviceId },
     unmarkSnapshotAsProcessing,
   ) {
     let transactionTimeout;
@@ -413,6 +413,7 @@ export class CentralSyncManager {
           fullSyncPatientsTable,
           sessionId,
           facilityId,
+          deviceId,
           {}, // sending empty session config because this snapshot attempt is only for syncing new marked for sync patients
         );
 
@@ -431,6 +432,7 @@ export class CentralSyncManager {
           incrementalSyncPatientsTable,
           sessionId,
           facilityId,
+          deviceId,
           sessionConfig,
         );
 
@@ -446,6 +448,7 @@ export class CentralSyncManager {
             incrementalSyncPatientsTable,
             sessionId,
             facilityId,
+            deviceId,
             sessionConfig,
           );
         }
@@ -531,7 +534,7 @@ export class CentralSyncManager {
     );
   }
 
-  async persistIncomingChanges(sessionId, tablesToInclude) {
+  async persistIncomingChanges(sessionId, deviceId, tablesToInclude) {
     const { sequelize, models } = this.store;
     const totalPushed = await countSyncSnapshotRecords(
       sequelize,
@@ -546,7 +549,7 @@ export class CentralSyncManager {
 
     try {
       // commit the changes to the db
-      await sequelize.transaction(async () => {
+      const persistedAtSyncTick = await sequelize.transaction(async () => {
         // we tick-tock the global clock to make sure there is a unique tick for these changes
         // n.b. this used to also be used for concurrency control, but that is now handled by
         // shared advisory locks taken using the current sync tick as the id, which are waited on
@@ -562,8 +565,14 @@ export class CentralSyncManager {
           { savedAtSyncTick: tock },
           { direction: SYNC_SESSION_DIRECTION.INCOMING },
         );
+
+        return tock;
       });
 
+      await models.SyncPersistedTickToDevice.create({
+        deviceId,
+        persistedAtSyncTick,
+      });
       // tick tock global clock so that if records are modified by adjustDataPostSyncPush(),
       // they will be picked up for pulling in the same session (specifically won't be removed by removeEchoedChanges())
       await this.tickTockGlobalClock();
@@ -598,12 +607,12 @@ export class CentralSyncManager {
     await insertSnapshotRecords(sequelize, sessionId, incomingSnapshotRecords);
   }
 
-  async completePush(sessionId, tablesToInclude) {
+  async completePush(sessionId, deviceId, tablesToInclude) {
     await this.connectToSession(sessionId);
 
     // don't await persisting, the client should asynchronously poll as it may take longer than
     // the http request timeout
-    this.persistIncomingChanges(sessionId, tablesToInclude);
+    this.persistIncomingChanges(sessionId, deviceId, tablesToInclude);
   }
 
   async checkPushComplete(sessionId) {

--- a/packages/central-server/app/sync/buildSyncRoutes.js
+++ b/packages/central-server/app/sync/buildSyncRoutes.js
@@ -121,6 +121,7 @@ export const buildSyncRoutes = ctx => {
         tablesToInclude,
         tablesForFullResync,
         isMobile,
+        deviceId,
       } = body;
       const since = parseInt(sinceString, 10);
       if (isNaN(since)) {
@@ -132,6 +133,7 @@ export const buildSyncRoutes = ctx => {
         tablesToInclude,
         tablesForFullResync,
         isMobile,
+        deviceId,
       });
       res.json({});
     }),
@@ -194,8 +196,8 @@ export const buildSyncRoutes = ctx => {
     asyncHandler(async (req, res) => {
       const { params, body } = req;
       const { sessionId } = params;
-      const { tablesToInclude } = body;
-      await syncManager.completePush(sessionId, tablesToInclude);
+      const { tablesToInclude, deviceId } = body;
+      await syncManager.completePush(sessionId, deviceId, tablesToInclude);
       res.json({});
     }),
   );

--- a/packages/central-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/central-server/app/sync/snapshotOutgoingChanges.js
@@ -192,8 +192,8 @@ function getPatientRelatedWhereClause(
   const recordTypesLinkedToPatients = Object.values(getPatientLinkedModels(models)).map(
     m => m.tableName,
   );
-  const allRecordTypesAreForPatients = recordTypes.every(
-    recordType => recordTypesLinkedToPatients.includes(recordType),
+  const allRecordTypesAreForPatients = recordTypes.every(recordType =>
+    recordTypesLinkedToPatients.includes(recordType),
   );
 
   if (allRecordTypesAreForPatients) {
@@ -219,6 +219,7 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
     markedForSyncPatientsTable,
     sessionId,
     facilityId,
+    deviceId,
     sessionConfig,
     config,
   ) => {
@@ -226,6 +227,7 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
     let totalCount = 0;
     const snapshotTableName = getSnapshotTableName(sessionId);
     const CHUNK_SIZE = config.sync.maxRecordsPerSnapshotChunk;
+    const { avoidRepull } = config.sync.lookupTable;
     const { syncAllLabRequests } = sessionConfig;
     const recordTypes = Object.values(outgoingModels).map(m => m.tableName);
     while (fromId != null) {
@@ -259,10 +261,10 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
           --- either no patient_id (meaning we don't care if the record is associate to a patient, eg: reference_data) 
           --- or patient_id has to match the marked for sync patient_ids, eg: encounters
           ${getPatientRelatedWhereClause(
-              store.models,
-              recordTypes,
-              patientCount,
-              markedForSyncPatientsTable,
+            store.models,
+            recordTypes,
+            patientCount,
+            markedForSyncPatientsTable,
           )}
           --- either no facility_id (meaning we don't care if the record is associate to a facility, eg: reference_data)
           --- or facility_id has to match the current facility, eg: patient_facilities
@@ -281,6 +283,11 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
           }
         )
         AND record_type IN (:recordTypes)
+        ${
+          avoidRepull && deviceId
+            ? 'AND (pushed_by_device_id <> :deviceId OR pushed_by_device_id IS NULL)'
+            : ''
+        }
         ORDER BY id
         LIMIT :limit
         RETURNING sync_lookup_id
@@ -299,6 +306,7 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
             limit: CHUNK_SIZE,
             fromId,
             recordTypes,
+            deviceId,
           },
         },
       );
@@ -313,6 +321,7 @@ const snapshotOutgoingChangesFromSyncLookup = withConfig(
       count: totalCount,
       since,
       sessionId,
+      deviceId,
     });
 
     return totalCount;
@@ -328,6 +337,7 @@ export const snapshotOutgoingChanges = withConfig(
     markedForSyncPatientsTable,
     sessionId,
     facilityId,
+    deviceId,
     sessionConfig,
     config,
   ) => {
@@ -346,6 +356,7 @@ export const snapshotOutgoingChanges = withConfig(
           markedForSyncPatientsTable,
           sessionId,
           facilityId,
+          deviceId,
           sessionConfig,
           config,
         )

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -33,7 +33,7 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
             record_type,
             is_deleted,
             updated_at_sync_tick,
-            ${avoidRepull ? 'pushed_by_device_id,' : ''}
+            pushed_by_device_id,
             data,
             
             patient_id,
@@ -64,7 +64,7 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
             avoidRepull
               ? `LEFT JOIN sync_device_ticks
                   ON persisted_at_sync_tick = ${table}.updated_at_sync_tick`
-              : ''
+              : 'LEFT JOIN (select NULL as device_id) AS sync_device_ticks ON 1 = 1'
           }
           ${joins || ''}
           WHERE

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -6,7 +6,7 @@ import { buildSyncLookupSelect } from '@tamanu/shared/sync';
 
 const updateLookupTableForModel = async (model, config, since, sessionConfig, syncLookupTick) => {
   const CHUNK_SIZE = config.sync.maxRecordsPerSnapshotChunk;
-  const { perModelUpdateTimeoutMs } = config.sync.lookupTable;
+  const { perModelUpdateTimeoutMs, avoidRepull } = config.sync.lookupTable;
 
   const { tableName: table } = model;
 
@@ -33,6 +33,7 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
             record_type,
             is_deleted,
             updated_at_sync_tick,
+            ${avoidRepull ? 'pushed_by_device_id,' : ''}
             data,
             
             patient_id,
@@ -59,6 +60,12 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
             ${table}.id = updated_at_by_field_summary.id`
                : ''
            }
+          ${
+            avoidRepull
+              ? `LEFT JOIN sync_persisted_tick_to_device
+                  ON persisted_at_sync_tick = ${table}.updated_at_sync_tick`
+              : ''
+          }
           ${joins || ''}
           WHERE
           (${where || `${table}.updated_at_sync_tick > :since`})
@@ -66,7 +73,7 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
           ORDER BY ${table}.id
           LIMIT :limit
           ON CONFLICT (record_id, record_type)
-          DO UPDATE SET 
+          DO UPDATE SET
             data = EXCLUDED.data,
             updated_at_sync_tick = EXCLUDED.updated_at_sync_tick,
             is_lab_request = EXCLUDED.is_lab_request,
@@ -74,7 +81,8 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
             encounter_id = EXCLUDED.encounter_id,
             facility_id = EXCLUDED.facility_id,
             updated_at_by_field_sum = EXCLUDED.updated_at_by_field_sum,
-            is_deleted = EXCLUDED.is_deleted
+            is_deleted = EXCLUDED.is_deleted,
+            pushed_by_device_id = EXCLUDED.pushed_by_device_id
           RETURNING record_id
         )
         SELECT MAX(record_id) as "maxId",

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -62,7 +62,7 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
            }
           ${
             avoidRepull
-              ? `LEFT JOIN sync_persisted_tick_to_device
+              ? `LEFT JOIN sync_device_ticks
                   ON persisted_at_sync_tick = ${table}.updated_at_sync_tick`
               : ''
           }

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -72,7 +72,7 @@
     "syncSessionTimeoutMs": null,
     snapshotTransactionTimeoutMs: null,
     "lookupTable": {
-      "enabled": true,
+      "enabled": false,
       "perModelUpdateTimeoutMs": null,
       "avoidRepull": true
     }
@@ -244,7 +244,7 @@
       "schedule": "* * * * *"
     },
     "syncLookupRefresher": {
-      "enabled": false,
+      "enabled": true,
       "schedule": "*/1 * * * *"
     }
   },

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -72,8 +72,9 @@
     "syncSessionTimeoutMs": null,
     snapshotTransactionTimeoutMs: null,
     "lookupTable": {
-      "enabled": false,
-      "perModelUpdateTimeoutMs": null
+      "enabled": true,
+      "perModelUpdateTimeoutMs": null,
+      "avoidRepull": true
     }
   },
   "loadshedder": {

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -245,7 +245,7 @@ export class CentralServerConnection {
   async initiatePull(sessionId, since) {
     // first, set the pull filter on the central server, which will kick of a snapshot of changes
     // to pull
-    const body = { since, facilityId: config.serverFacilityId };
+    const body = { since, facilityId: config.serverFacilityId, deviceId: this.deviceId };
     await this.fetch(`sync/${sessionId}/pull/initiate`, { method: 'POST', body });
 
     // then, poll the pull/ready endpoint until we get a valid response - it takes a while for
@@ -272,7 +272,10 @@ export class CentralServerConnection {
 
   async completePush(sessionId) {
     // first off, mark the push as complete on central
-    await this.fetch(`sync/${sessionId}/push/complete`, { method: 'POST' });
+    await this.fetch(`sync/${sessionId}/push/complete`, {
+      method: 'POST',
+      body: { deviceId: this.deviceId },
+    });
 
     // now poll the complete check endpoint until we get a valid response - it takes a while for
     // the pushed changes to finish persisting to the central database

--- a/packages/mobile/App/services/sync/CentralServerConnection.test.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.test.ts
@@ -123,7 +123,7 @@ describe('CentralServerConnection', () => {
       expect(postSpy).toBeCalledWith(
         expect.stringContaining(mockSessionId),
         {},
-        { tablesToInclude: mockTablesToInclude },
+        { tablesToInclude: mockTablesToInclude, deviceId: 'mobile-test-device-id' },
       );
       expect(mockSleepAsync).toHaveBeenCalledTimes(2);
     });

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -192,6 +192,7 @@ export class CentralServerConnection {
       tablesToInclude: tableNames,
       tablesForFullResync,
       isMobile: true,
+      deviceId: this.deviceId,
     };
     await this.post(`sync/${sessionId}/pull/initiate`, {}, body, {});
 
@@ -221,7 +222,11 @@ export class CentralServerConnection {
 
   async completePush(sessionId: string, tablesToInclude: string[]): Promise<void> {
     // first off, mark the push as complete on central
-    await this.post(`sync/${sessionId}/push/complete`, {}, { tablesToInclude });
+    await this.post(
+      `sync/${sessionId}/push/complete`,
+      {},
+      { tablesToInclude, deviceId: this.deviceId },
+    );
 
     // now poll the complete check endpoint until we get a valid response - it takes a while for
     // the pushed changes to finish persisting to the central database

--- a/packages/shared/src/migrations/1727675328212-addPatientIdIndexToSyncLookup.js
+++ b/packages/shared/src/migrations/1727675328212-addPatientIdIndexToSyncLookup.js
@@ -1,9 +1,15 @@
 export async function up(query) {
-  await query.addIndex('sync_lookup', {
-    fields: ['patient_id'],
-  });
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS
+      sync_lookup_patient_id
+    ON
+      sync_lookup (patient_id)
+  `);
 }
 
 export async function down(query) {
-  await query.removeIndex('sync_lookup', ['patient_id']);
+  await query.sequelize.query(`
+    DROP INDEX
+      sync_lookup_patient_id
+  `);
 }

--- a/packages/shared/src/migrations/1727736021166-addPushedByDeviceIdToSyncLookupTable.js
+++ b/packages/shared/src/migrations/1727736021166-addPushedByDeviceIdToSyncLookupTable.js
@@ -1,0 +1,11 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.addColumn('sync_lookup', 'pushed_by_device_id', {
+    type: DataTypes.TEXT,
+  });
+}
+
+export async function down(query) {
+  await query.removeColumn('sync_lookup', 'pushed_by_device_id');
+}

--- a/packages/shared/src/migrations/1727736021190-addSyncDeviceTicksTable.js
+++ b/packages/shared/src/migrations/1727736021190-addSyncDeviceTicksTable.js
@@ -2,7 +2,11 @@ import { DataTypes } from 'sequelize';
 
 export async function up(query) {
   await query.createTable('sync_device_ticks', {
+    id: {
+      type: `BIGINT GENERATED ALWAYS AS ("persisted_at_sync_tick") STORED`,
+    },
     persisted_at_sync_tick: {
+      primaryKey: true,
       type: DataTypes.BIGINT,
       allowNull: false,
     },

--- a/packages/shared/src/migrations/1727736021190-addSyncDeviceTicksTable.js
+++ b/packages/shared/src/migrations/1727736021190-addSyncDeviceTicksTable.js
@@ -1,7 +1,7 @@
 import { DataTypes } from 'sequelize';
 
 export async function up(query) {
-  await query.createTable('sync_persisted_tick_to_device', {
+  await query.createTable('sync_device_ticks', {
     persisted_at_sync_tick: {
       type: DataTypes.BIGINT,
       allowNull: false,
@@ -12,11 +12,11 @@ export async function up(query) {
     },
   });
 
-  await query.addIndex('sync_persisted_tick_to_device', {
+  await query.addIndex('sync_device_ticks', {
     fields: ['persisted_at_sync_tick'],
   });
 }
 
 export async function down(query) {
-  await query.dropTable('sync_persisted_tick_to_device');
+  await query.dropTable('sync_device_ticks');
 }

--- a/packages/shared/src/migrations/1727736021190-addSyncPersistedTickToDeviceTable.js
+++ b/packages/shared/src/migrations/1727736021190-addSyncPersistedTickToDeviceTable.js
@@ -1,0 +1,22 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.createTable('sync_persisted_tick_to_device', {
+    persisted_at_sync_tick: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    device_id: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  });
+
+  await query.addIndex('sync_persisted_tick_to_device', {
+    fields: ['persisted_at_sync_tick'],
+  });
+}
+
+export async function down(query) {
+  await query.dropTable('sync_persisted_tick_to_device');
+}

--- a/packages/shared/src/models/SyncDeviceTick.js
+++ b/packages/shared/src/models/SyncDeviceTick.js
@@ -6,6 +6,17 @@ export class SyncDeviceTick extends Model {
   static init({ primaryKey, ...options }) {
     super.init(
       {
+        id: {
+          // Sequelize always requires an id column
+          // so this is to enforce using persisted_at_sync_tick as the id.
+          // even tho we don't really need an id in this table.
+          // We don't use the value of persisted_at_sync_tick in id
+          // just so that it is clear about the type of tick that it is storing.
+          type: `BIGINT GENERATED ALWAYS AS ("persisted_at_sync_tick")`,
+          set() {
+            // any sets of the convenience generated "id" field can be ignored, so do nothing here
+          },
+        },
         persistedAtSyncTick: { type: DataTypes.BIGINT, primaryKey },
         deviceId: {
           type: DataTypes.TEXT,

--- a/packages/shared/src/models/SyncDeviceTick.js
+++ b/packages/shared/src/models/SyncDeviceTick.js
@@ -2,7 +2,7 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 
-export class SyncPersistedTickToDevice extends Model {
+export class SyncDeviceTick extends Model {
   static init({ primaryKey, ...options }) {
     super.init(
       {
@@ -13,7 +13,6 @@ export class SyncPersistedTickToDevice extends Model {
       },
       {
         ...options,
-        tableName: 'sync_persisted_tick_to_device',
         syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC,
         timestamps: false,
       },

--- a/packages/shared/src/models/SyncLookup.js
+++ b/packages/shared/src/models/SyncLookup.js
@@ -18,6 +18,7 @@ export class SyncLookup extends Model {
         isLabRequest: { type: DataTypes.BOOLEAN },
         isDeleted: { type: DataTypes.BOOLEAN },
         updatedAtByFieldSum: { type: DataTypes.BIGINT },
+        pushedByDeviceId: { type: DataTypes.TEXT },
       },
       {
         syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC,

--- a/packages/shared/src/models/SyncPersistedTickToDevice.js
+++ b/packages/shared/src/models/SyncPersistedTickToDevice.js
@@ -1,0 +1,22 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { Model } from './Model';
+
+export class SyncPersistedTickToDevice extends Model {
+  static init({ primaryKey, ...options }) {
+    super.init(
+      {
+        persistedAtSyncTick: { type: DataTypes.BIGINT, primaryKey },
+        deviceId: {
+          type: DataTypes.TEXT,
+        },
+      },
+      {
+        ...options,
+        tableName: 'sync_persisted_tick_to_device',
+        syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC,
+        timestamps: false,
+      },
+    );
+  }
+}

--- a/packages/shared/src/models/index.js
+++ b/packages/shared/src/models/index.js
@@ -119,3 +119,5 @@ export * from './TranslatedString';
 export * from './IPSRequest';
 export * from './SyncLookup';
 export * from './DebugLog';
+export * from './DebugLog';
+export * from './SyncPersistedTickToDevice';

--- a/packages/shared/src/models/index.js
+++ b/packages/shared/src/models/index.js
@@ -120,4 +120,4 @@ export * from './IPSRequest';
 export * from './SyncLookup';
 export * from './DebugLog';
 export * from './DebugLog';
-export * from './SyncPersistedTickToDevice';
+export * from './SyncDeviceTick';

--- a/packages/shared/src/services/migrations/constants.js
+++ b/packages/shared/src/services/migrations/constants.js
@@ -15,5 +15,5 @@ export const NON_SYNCING_TABLES = [
   'user_recently_viewed_patients',
   'sync_lookup',
   'debug_logs',
-  'sync_persisted_tick_to_device',
+  'sync_device_ticks',
 ];

--- a/packages/shared/src/services/migrations/constants.js
+++ b/packages/shared/src/services/migrations/constants.js
@@ -14,5 +14,6 @@ export const NON_SYNCING_TABLES = [
   'job_workers',
   'user_recently_viewed_patients',
   'sync_lookup',
-  'debug_logs'
+  'debug_logs',
+  'sync_persisted_tick_to_device',
 ];

--- a/packages/shared/src/sync/buildSyncLookupSelect.js
+++ b/packages/shared/src/sync/buildSyncLookupSelect.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { snake } from 'case';
 
 import { COLUMNS_EXCLUDED_FROM_SYNC } from './constants';
@@ -14,6 +15,7 @@ export function buildSyncLookupSelect(model, columns = {}) {
       '${table}',
       ${table}.deleted_at IS NOT NULL,
       COALESCE(:updatedAtSyncTick, ${table}.updated_at_sync_tick),
+      ${config.sync.lookupTable.avoidRepull ? 'sync_persisted_tick_to_device.device_id,' : ''}
       json_build_object(
         ${Object.keys(attributes)
           .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))

--- a/packages/shared/src/sync/buildSyncLookupSelect.js
+++ b/packages/shared/src/sync/buildSyncLookupSelect.js
@@ -1,4 +1,3 @@
-import config from 'config';
 import { snake } from 'case';
 
 import { COLUMNS_EXCLUDED_FROM_SYNC } from './constants';
@@ -15,7 +14,7 @@ export function buildSyncLookupSelect(model, columns = {}) {
       '${table}',
       ${table}.deleted_at IS NOT NULL,
       COALESCE(:updatedAtSyncTick, ${table}.updated_at_sync_tick),
-      ${config.sync.lookupTable.avoidRepull ? 'sync_device_ticks.device_id,' : ''}
+      sync_device_ticks.device_id,
       json_build_object(
         ${Object.keys(attributes)
           .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))

--- a/packages/shared/src/sync/buildSyncLookupSelect.js
+++ b/packages/shared/src/sync/buildSyncLookupSelect.js
@@ -15,7 +15,7 @@ export function buildSyncLookupSelect(model, columns = {}) {
       '${table}',
       ${table}.deleted_at IS NOT NULL,
       COALESCE(:updatedAtSyncTick, ${table}.updated_at_sync_tick),
-      ${config.sync.lookupTable.avoidRepull ? 'sync_persisted_tick_to_device.device_id,' : ''}
+      ${config.sync.lookupTable.avoidRepull ? 'sync_device_ticks.device_id,' : ''}
       json_build_object(
         ${Object.keys(attributes)
           .filter(a => !COLUMNS_EXCLUDED_FROM_SYNC.includes(a))


### PR DESCRIPTION
### Changes
- Avoid repull pushed changes from the previous sync session when using sync lookup

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
