### PR TITLE
fix(settings): Release fix v2.17: Settings context bug

### DIFF
--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -73,14 +73,13 @@ export class TamanuApi {
       permissions,
       centralHost,
       role,
-      settings,
     } = await response.json();
     server.type = serverType;
     server.centralHost = centralHost;
     this.setToken(token);
 
     const { user, ability } = await this.fetchUserData(permissions);
-    return { user, token, localisation, server, availableFacilities, ability, role, settings };
+    return { user, token, localisation, server, availableFacilities, ability, role };
   }
 
   async fetchUserData(permissions) {

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -65,7 +65,7 @@ export async function centralServerLogin(models, email, password, deviceId) {
   });
 
   // we've logged in as a valid central user - update local database to match
-  const { user, localisation, allowedFacilities, settings } = response;
+  const { user, localisation, allowedFacilities } = response;
   const { id, ...userDetails } = user;
 
   await models.User.sequelize.transaction(async () => {
@@ -82,7 +82,7 @@ export async function centralServerLogin(models, email, password, deviceId) {
     });
   });
 
-  return { central: true, user, localisation, allowedFacilities, settings };
+  return { central: true, user, localisation, allowedFacilities };
 }
 
 async function localLogin(models, email, password) {
@@ -148,7 +148,6 @@ export async function loginHandler(req, res, next) {
       user,
       localisation,
       allowedFacilities,
-      settings,
     } = await centralServerLoginWithLocalFallback(models, email, password, deviceId);
 
     // check if user has access to any facilities on this server
@@ -176,7 +175,6 @@ export async function loginHandler(req, res, next) {
       role: role?.forResponse() ?? null,
       serverType: SERVER_TYPES.FACILITY,
       availableFacilities,
-      settings,
     });
   } catch (e) {
     next(e);

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -174,7 +174,6 @@ export class TamanuApi extends ApiClient {
       availableFacilities,
       permissions,
       role,
-      settings,
     } = output;
     saveToLocalStorage({
       token,
@@ -183,7 +182,6 @@ export class TamanuApi extends ApiClient {
       availableFacilities,
       permissions,
       role,
-      settings,
     });
     return output;
   }

--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -47,7 +47,6 @@ const handleLoginSuccess = async (dispatch, loginInfo) => {
     facilityId,
     ability,
     role,
-    settings,
   } = loginInfo;
 
   if (facilityId) {
@@ -70,7 +69,6 @@ const handleLoginSuccess = async (dispatch, loginInfo) => {
     availableFacilities,
     ability,
     role,
-    settings,
   });
 };
 
@@ -207,7 +205,6 @@ const actionHandlers = {
     localisation: action.localisation,
     server: action.server,
     role: action.role,
-    settings: action.settings,
     resetPassword: defaultState.resetPassword,
     changePassword: defaultState.changePassword,
   }),


### PR DESCRIPTION
In omniserver we set the redux settings for the context through the setFacility handler. This was implemented however we also kept the code which was setting the redux settings through login which was overwriting the correct settings with `undefined`. Here i removed from the login handler logic so that settings are only set through setFacility and arent overwritten

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
