### PR TITLE
fix(vaccines): release-fix-2.17: Supply facility id to vaccination endpoint

### DIFF
--- a/packages/web/app/components/VaccineModal.jsx
+++ b/packages/web/app/components/VaccineModal.jsx
@@ -10,11 +10,13 @@ import { useApi, useSuggester } from '../api';
 import { reloadPatient } from '../store/patient';
 import { getCurrentUser } from '../store/auth';
 import { TranslatedText } from './Translation/TranslatedText';
+import { useAuth } from '../contexts/Auth';
 
 export const VaccineModal = ({ open, onClose, patientId, vaccineRecord }) => {
   const [currentTabKey, setCurrentTabKey] = useState(VACCINE_RECORDING_TYPES.GIVEN);
 
   const api = useApi();
+  const { facilityId } = useAuth();
   const countrySuggester = useSuggester('country');
   const dispatch = useDispatch();
   const currentUser = useSelector(getCurrentUser);
@@ -38,6 +40,7 @@ export const VaccineModal = ({ open, onClose, patientId, vaccineRecord }) => {
         patientId,
         status: currentTabKey,
         recorderId: currentUser.id,
+        facilityId,
       };
       if (dataToSubmit.circumstanceIds) {
         body.circumstanceIds = JSON.parse(dataToSubmit.circumstanceIds);
@@ -46,7 +49,7 @@ export const VaccineModal = ({ open, onClose, patientId, vaccineRecord }) => {
       await api.post(`patient/${patientId}/administeredVaccine`, body);
       dispatch(reloadPatient(patientId));
     },
-    [api, dispatch, patientId, currentUser.id, currentTabKey, countrySuggester],
+    [api, dispatch, patientId, currentUser.id, currentTabKey, countrySuggester, facilityId],
   );
 
   const getScheduledVaccines = useCallback(


### PR DESCRIPTION
### Changes

After the omniserver merge we werent posting the facilityId to the endpoint in order to properly fetch facility settings. This fixes that.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
