### PR TITLE
tweak(settingsAdmin): Fix few issues with admin panel

### DIFF
--- a/packages/web/app/components/Field/AutocompleteField.jsx
+++ b/packages/web/app/components/Field/AutocompleteField.jsx
@@ -128,17 +128,16 @@ export class AutocompleteInput extends Component {
   }
 
   updateValue = async (allowFreeTextForExistingValue = false) => {
-    const { value, suggester, options, controlled } = this.props;
+    const { value, suggester, options } = this.props;
 
     if (!suggester) {
-      if (controlled) {
-        this.setState({
-          selectedOption: {
-            value: options?.find(option => option.value === value)?.label || '',
-            tag: null,
-          },
-        });
-      }
+      const selectedOption = options?.find(option => option.value === value);
+      this.setState({
+        selectedOption: {
+          value: selectedOption?.label || '',
+          tag: null,
+        },
+      });
       return;
     }
     if (value === '') {

--- a/packages/web/app/components/Field/AutocompleteField.jsx
+++ b/packages/web/app/components/Field/AutocompleteField.jsx
@@ -222,7 +222,7 @@ export class AutocompleteInput extends Component {
   };
 
   attemptAutoFill = async () => {
-    const { autofill, name } = this.props;
+    const { autofill, controlled, name } = this.props;
     if (!autofill) {
       return false;
     }
@@ -231,12 +231,14 @@ export class AutocompleteInput extends Component {
       return false;
     }
     const autoSelectOption = suggestions[0];
-    this.setState({
-      selectedOption: {
-        value: autoSelectOption.label,
-        tag: autoSelectOption.tag,
-      },
-    });
+    if (!controlled) {
+      this.setState({
+        selectedOption: {
+          value: autoSelectOption.label,
+          tag: autoSelectOption.tag,
+        },
+      });
+    }
     this.handleSuggestionChange({ value: autoSelectOption.value, name });
     return true;
   };

--- a/packages/web/app/components/Field/AutocompleteField.jsx
+++ b/packages/web/app/components/Field/AutocompleteField.jsx
@@ -449,6 +449,7 @@ AutocompleteInput.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
+  // Only determine input state when supplied value has changed
   controlled: PropTypes.bool,
   suggester: PropTypes.shape({
     fetchCurrentOption: PropTypes.func.isRequired,

--- a/packages/web/app/components/Field/AutocompleteField.jsx
+++ b/packages/web/app/components/Field/AutocompleteField.jsx
@@ -128,9 +128,17 @@ export class AutocompleteInput extends Component {
   }
 
   updateValue = async (allowFreeTextForExistingValue = false) => {
-    const { value, suggester } = this.props;
+    const { value, suggester, options, controlled } = this.props;
 
     if (!suggester) {
+      if (controlled) {
+        this.setState({
+          selectedOption: {
+            value: options?.find(option => option.value === value)?.label || '',
+            tag: null,
+          },
+        });
+      }
       return;
     }
     if (value === '') {
@@ -235,22 +243,27 @@ export class AutocompleteInput extends Component {
   };
 
   handleInputChange = (event, { newValue }) => {
+    const { controlled } = this.props;
     if (!newValue) {
       // when deleting field contents, clear the selection
       this.handleSuggestionChange({ value: undefined, label: '' });
     }
     if (typeof newValue !== 'undefined') {
-      this.setState(prevState => {
-        const newSuggestion = prevState.suggestions.find(suggest => suggest.label === newValue);
-        return { selectedOption: { value: newValue, tag: newSuggestion?.tag ?? null } };
-      });
+      if (!controlled) {
+        this.setState(prevState => {
+          const newSuggestion = prevState.suggestions.find(suggest => suggest.label === newValue);
+          return { selectedOption: { value: newValue, tag: newSuggestion?.tag ?? null } };
+        });
+      }
     }
   };
 
   handleClearValue = () => {
-    const { onChange, name } = this.props;
+    const { onChange, name, controlled } = this.props;
     onChange({ target: { value: undefined, name } });
-    this.setState({ selectedOption: { value: '', tag: null } });
+    if (!controlled) {
+      this.setState({ selectedOption: { value: '', tag: null } });
+    }
   };
 
   clearOptions = () => {
@@ -437,7 +450,7 @@ AutocompleteInput.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
-
+  controlled: PropTypes.bool,
   suggester: PropTypes.shape({
     fetchCurrentOption: PropTypes.func.isRequired,
     fetchSuggestions: PropTypes.func.isRequired,

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -5,8 +5,18 @@ import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { useQueryClient } from '@tanstack/react-query';
 import { PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
-import { DateDisplay, FormSeparatorLine, FormSubmitCancelRow, TranslatedText } from '../components';
-import { BaseSelectField, Field, Form, OuterLabelFieldWrapper } from '../components/Field';
+import {
+	DateDisplay,
+	FormSeparatorLine,
+	FormSubmitCancelRow,
+	TranslatedText,
+} from '../components';
+import {
+	BaseSelectField,
+	Field,
+	Form,
+	OuterLabelFieldWrapper,
+} from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { SurveyQuestion } from '../components/Surveys';
 import { getValidationSchema } from '../utils';
@@ -24,25 +34,34 @@ const Text = styled(Typography)`
 `;
 
 const DeleteEntryButton = ({ disabled, onClick }) => (
-  <Box display="flex" alignSelf="start" marginTop="18px">
-    <IconButton color="primary" edge="start" disabled={disabled} onClick={onClick} disableRipple>
-      <DeleteOutlineIcon fontSize="small" />
-      <Text>
-        <TranslatedText stringId="encounter.vitals.action.deleteEntry" fallback="Delete entry" />
-      </Text>
-    </IconButton>
-  </Box>
+	<Box display="flex" alignSelf="start" marginTop="18px">
+		<IconButton
+			color="primary"
+			edge="start"
+			disabled={disabled}
+			onClick={onClick}
+			disableRipple
+		>
+			<DeleteOutlineIcon fontSize="small" />
+			<Text>
+				<TranslatedText
+					stringId="encounter.vitals.action.deleteEntry"
+					fallback="Delete entry"
+				/>
+			</Text>
+		</IconButton>
+	</Box>
 );
 
 const getEditVitalData = (vitalComponent, mandatoryVitalEditReason) => {
-  const reasonForChangeMockComponent = {
-    dataElement: { type: PROGRAM_DATA_ELEMENT_TYPES.SELECT },
-    validationCriteria: JSON.stringify({ mandatory: mandatoryVitalEditReason }),
-    dataElementId: 'reasonForChange',
-  };
-  const editVitalData = [reasonForChangeMockComponent];
-  if (vitalComponent) editVitalData.push(vitalComponent);
-  return { components: editVitalData };
+	const reasonForChangeMockComponent = {
+		dataElement: { type: PROGRAM_DATA_ELEMENT_TYPES.SELECT },
+		validationCriteria: JSON.stringify({ mandatory: mandatoryVitalEditReason }),
+		dataElementId: 'reasonForChange',
+	};
+	const editVitalData = [reasonForChangeMockComponent];
+	if (vitalComponent) editVitalData.push(vitalComponent);
+	return { components: editVitalData };
 };
 
 const LogContainer = styled(Box)`
@@ -64,146 +83,167 @@ const LogTextSmall = styled(Typography)`
 `;
 
 const HistoryLog = ({ logData, vitalLabel, vitalEditReasons }) => {
-  const { date, newValue, reasonForChange, userDisplayName } = logData;
-  const reasonForChangeOption = vitalEditReasons.find(option => option.value === reasonForChange);
-  const reasonForChangeLabel = reasonForChangeOption?.label ?? 'Unknown';
-  return (
-    <LogContainer>
-      <LogText>
-        {vitalLabel}: {newValue === '' ? 'Entry deleted' : newValue}
-      </LogText>
-      {reasonForChange && (
-        <LogText>
-          <TranslatedText
-            stringId="encounter.vitals.editReason.label"
-            fallback="Reason for change to record"
-          />
-          : {reasonForChangeLabel}
-        </LogText>
-      )}
-      <LogTextSmall>
-        {userDisplayName} <DateDisplay date={date} showTime shortYear />
-      </LogTextSmall>
-    </LogContainer>
-  );
+	const { date, newValue, reasonForChange, userDisplayName } = logData;
+	const reasonForChangeOption = vitalEditReasons.find(
+		(option) => option.value === reasonForChange,
+	);
+	const reasonForChangeLabel = reasonForChangeOption?.label ?? 'Unknown';
+	return (
+		<LogContainer>
+			<LogText>
+				{vitalLabel}: {newValue === '' ? 'Entry deleted' : newValue}
+			</LogText>
+			{reasonForChange && (
+				<LogText>
+					<TranslatedText
+						stringId="encounter.vitals.editReason.label"
+						fallback="Reason for change to record"
+					/>
+					: {reasonForChangeLabel}
+				</LogText>
+			)}
+			<LogTextSmall>
+				{userDisplayName} <DateDisplay date={date} showTime shortYear />
+			</LogTextSmall>
+		</LogContainer>
+	);
 };
 
 export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose }) => {
-  const { getTranslation } = useTranslation();
-  const [isDeleted, setIsDeleted] = useState(false);
-  const api = useApi();
-  const queryClient = useQueryClient();
-  const { encounter } = useEncounter();
+	const { getTranslation } = useTranslation();
+	const [isDeleted, setIsDeleted] = useState(false);
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const { encounter } = useEncounter();
 
-  const { getSetting } = useSettings();
-  const mandatoryVitalEditReason = getSetting('features.mandatoryVitalEditReason');
-  const vitalEditReasons = getSetting('vitalEditReasons');
+	const { getSetting } = useSettings();
+	const mandatoryVitalEditReason = getSetting(
+		'features.mandatoryVitalEditReason',
+	);
+	const vitalEditReasons = getSetting('vitalEditReasons');
 
-  const initialValue = dataPoint.value;
-  const showDeleteEntryButton = ['', undefined].includes(initialValue) === false;
-  const valueName = dataPoint.component.dataElement.id;
-  const editVitalData = getEditVitalData(dataPoint.component, mandatoryVitalEditReason);
-  const validationSchema = getValidationSchema(editVitalData, getTranslation, {
-    encounterType: encounter.encounterType,
-  });
-  const handleDeleteEntry = useCallback(
-    setFieldValue => {
-      setFieldValue(valueName, '');
-      setIsDeleted(true);
-    },
-    [valueName],
-  );
-  const handleSubmit = async data => {
-    const newShapeData = {
-      date: getCurrentDateTimeString(),
-    };
-    Object.entries(data).forEach(([key, value]) => {
-      if (key === valueName) newShapeData.newValue = value;
-      else newShapeData[key] = value;
-    });
+	const initialValue = dataPoint.value;
+	const showDeleteEntryButton =
+		['', undefined].includes(initialValue) === false;
+	const valueName = dataPoint.component.dataElement.id;
+	const editVitalData = getEditVitalData(
+		dataPoint.component,
+		mandatoryVitalEditReason,
+	);
+	const validationSchema = getValidationSchema(editVitalData, getTranslation, {
+		encounterType: encounter.encounterType,
+	});
+	const handleDeleteEntry = useCallback(
+		(setFieldValue) => {
+			setFieldValue(valueName, '');
+			setIsDeleted(true);
+		},
+		[valueName],
+	);
+	const handleSubmit = async (data) => {
+		const newShapeData = {
+			date: getCurrentDateTimeString(),
+		};
+		Object.entries(data).forEach(([key, value]) => {
+			if (key === valueName) newShapeData.newValue = value;
+			else newShapeData[key] = value;
+		});
 
-    // The survey response answer might not exist
-    if (dataPoint.answerId) {
-      await api.put(`surveyResponseAnswer/vital/${dataPoint.answerId}`, newShapeData);
-    } else {
-      const newVitalData = {
-        ...newShapeData,
-        dataElementId: valueName,
-        encounterId: encounter.id,
-        recordedDate: dataPoint.recordedDate,
-      };
-      await api.post('surveyResponseAnswer/vital', newVitalData);
-    }
-    queryClient.invalidateQueries(['encounterVitals', encounter.id]);
-    handleClose();
-  };
-  const validateFn = values => {
-    const errors = {};
-    if (values[valueName] === initialValue) {
-      errors[valueName] = 'New value cannot be the same as previous value.';
-    }
-    return errors;
-  };
+		// The survey response answer might not exist
+		if (dataPoint.answerId) {
+			await api.put(
+				`surveyResponseAnswer/vital/${dataPoint.answerId}`,
+				newShapeData,
+			);
+		} else {
+			const newVitalData = {
+				...newShapeData,
+				dataElementId: valueName,
+				encounterId: encounter.id,
+				recordedDate: dataPoint.recordedDate,
+			};
+			await api.post('surveyResponseAnswer/vital', newVitalData);
+		}
+		queryClient.invalidateQueries(['encounterVitals', encounter.id]);
+		handleClose();
+	};
+	const validateFn = (values) => {
+		const errors = {};
+		if (values[valueName] === initialValue) {
+			errors[valueName] = 'New value cannot be the same as previous value.';
+		}
+		return errors;
+	};
 
-  return (
-    <Form
-      onSubmit={handleSubmit}
-      validationSchema={validationSchema}
-      initialValues={{ [valueName]: initialValue }}
-      formType={FORM_TYPES.EDIT_FORM}
-      validate={validateFn}
-      render={({ setFieldValue, submitForm }) => (
-        <FormGrid columns={4}>
-          <SurveyQuestion component={dataPoint.component} disabled={isDeleted} />
-          {showDeleteEntryButton && (
-            <DeleteEntryButton
-              disabled={isDeleted}
-              onClick={() => handleDeleteEntry(setFieldValue)}
-            />
-          )}
-          <Field
-            required={mandatoryVitalEditReason}
-            component={BaseSelectField}
-            label={
-              <TranslatedText
-                stringId="encounter.vitals.editReason.label"
-                fallback="Reason for change to record"
-              />
-            }
-            name="reasonForChange"
-            options={vitalEditReasons}
-            style={{ gridColumn: '1 / 4' }}
-          />
-          <FormSeparatorLine />
-          <OuterLabelFieldWrapper
-            label={<TranslatedText stringId="encounter.vitals.history.label" fallback="History" />}
-            style={{ gridColumn: '1 / -1' }}
-          >
-            <Box
-              height="162px"
-              overflow="auto"
-              padding="13px 12px 13px 15px"
-              bgcolor="white"
-              border="1px solid #dedede"
-              borderRadius="3px"
-            >
-              {dataPoint.historyLogs.map(log => (
-                <HistoryLog
-                  key={log.date}
-                  vitalLabel={vitalLabel}
-                  vitalEditReasons={vitalEditReasons}
-                  logData={log}
-                />
-              ))}
-            </Box>
-          </OuterLabelFieldWrapper>
-          <FormSubmitCancelRow
-            onCancel={handleClose}
-            onConfirm={submitForm}
-            confirmText={<TranslatedText stringId="general.action.save" fallback="Save" />}
-          />
-        </FormGrid>
-      )}
-    />
-  );
+	return (
+		<Form
+			onSubmit={handleSubmit}
+			validationSchema={validationSchema}
+			initialValues={{ [valueName]: initialValue }}
+			formType={FORM_TYPES.EDIT_FORM}
+			validate={validateFn}
+			render={({ setFieldValue, submitForm }) => (
+				<FormGrid columns={4}>
+					<SurveyQuestion
+						component={dataPoint.component}
+						disabled={isDeleted}
+					/>
+					{showDeleteEntryButton && (
+						<DeleteEntryButton
+							disabled={isDeleted}
+							onClick={() => handleDeleteEntry(setFieldValue)}
+						/>
+					)}
+					<Field
+						required={mandatoryVitalEditReason}
+						component={BaseSelectField}
+						label={
+							<TranslatedText
+								stringId="encounter.vitals.editReason.label"
+								fallback="Reason for change to record"
+							/>
+						}
+						name="reasonForChange"
+						options={vitalEditReasons}
+						style={{ gridColumn: '1 / 4' }}
+					/>
+					<FormSeparatorLine />
+					<OuterLabelFieldWrapper
+						label={
+							<TranslatedText
+								stringId="encounter.vitals.history.label"
+								fallback="History"
+							/>
+						}
+						style={{ gridColumn: '1 / -1' }}
+					>
+						<Box
+							height="162px"
+							overflow="auto"
+							padding="13px 12px 13px 15px"
+							bgcolor="white"
+							border="1px solid #dedede"
+							borderRadius="3px"
+						>
+							{dataPoint.historyLogs.map((log) => (
+								<HistoryLog
+									key={log.date}
+									vitalLabel={vitalLabel}
+									vitalEditReasons={vitalEditReasons}
+									logData={log}
+								/>
+							))}
+						</Box>
+					</OuterLabelFieldWrapper>
+					<FormSubmitCancelRow
+						onCancel={handleClose}
+						onConfirm={submitForm}
+						confirmText={
+							<TranslatedText stringId="general.action.save" fallback="Save" />
+						}
+					/>
+				</FormGrid>
+			)}
+		/>
+	);
 };

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -5,24 +5,13 @@ import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { useQueryClient } from '@tanstack/react-query';
 import { PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/shared/utils/dateTime';
-import {
-	DateDisplay,
-	FormSeparatorLine,
-	FormSubmitCancelRow,
-	TranslatedText,
-} from '../components';
-import {
-	BaseSelectField,
-	Field,
-	Form,
-	OuterLabelFieldWrapper,
-} from '../components/Field';
+import { DateDisplay, FormSeparatorLine, FormSubmitCancelRow, TranslatedText } from '../components';
+import { BaseSelectField, Field, Form, OuterLabelFieldWrapper } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { SurveyQuestion } from '../components/Surveys';
 import { getValidationSchema } from '../utils';
 import { Colors, FORM_TYPES } from '../constants';
 import { useApi } from '../api';
-import { useAuth } from '../contexts/Auth';
 import { useEncounter } from '../contexts/Encounter';
 import { useSettings } from '../contexts/Settings';
 import { useTranslation } from '../contexts/Translation';
@@ -35,34 +24,25 @@ const Text = styled(Typography)`
 `;
 
 const DeleteEntryButton = ({ disabled, onClick }) => (
-	<Box display="flex" alignSelf="start" marginTop="18px">
-		<IconButton
-			color="primary"
-			edge="start"
-			disabled={disabled}
-			onClick={onClick}
-			disableRipple
-		>
-			<DeleteOutlineIcon fontSize="small" />
-			<Text>
-				<TranslatedText
-					stringId="encounter.vitals.action.deleteEntry"
-					fallback="Delete entry"
-				/>
-			</Text>
-		</IconButton>
-	</Box>
+  <Box display="flex" alignSelf="start" marginTop="18px">
+    <IconButton color="primary" edge="start" disabled={disabled} onClick={onClick} disableRipple>
+      <DeleteOutlineIcon fontSize="small" />
+      <Text>
+        <TranslatedText stringId="encounter.vitals.action.deleteEntry" fallback="Delete entry" />
+      </Text>
+    </IconButton>
+  </Box>
 );
 
 const getEditVitalData = (vitalComponent, mandatoryVitalEditReason) => {
-	const reasonForChangeMockComponent = {
-		dataElement: { type: PROGRAM_DATA_ELEMENT_TYPES.SELECT },
-		validationCriteria: JSON.stringify({ mandatory: mandatoryVitalEditReason }),
-		dataElementId: 'reasonForChange',
-	};
-	const editVitalData = [reasonForChangeMockComponent];
-	if (vitalComponent) editVitalData.push(vitalComponent);
-	return { components: editVitalData };
+  const reasonForChangeMockComponent = {
+    dataElement: { type: PROGRAM_DATA_ELEMENT_TYPES.SELECT },
+    validationCriteria: JSON.stringify({ mandatory: mandatoryVitalEditReason }),
+    dataElementId: 'reasonForChange',
+  };
+  const editVitalData = [reasonForChangeMockComponent];
+  if (vitalComponent) editVitalData.push(vitalComponent);
+  return { components: editVitalData };
 };
 
 const LogContainer = styled(Box)`
@@ -84,167 +64,146 @@ const LogTextSmall = styled(Typography)`
 `;
 
 const HistoryLog = ({ logData, vitalLabel, vitalEditReasons }) => {
-	const { date, newValue, reasonForChange, userDisplayName } = logData;
-	const reasonForChangeOption = vitalEditReasons.find(
-		(option) => option.value === reasonForChange,
-	);
-	const reasonForChangeLabel = reasonForChangeOption?.label ?? 'Unknown';
-	return (
-		<LogContainer>
-			<LogText>
-				{vitalLabel}: {newValue === '' ? 'Entry deleted' : newValue}
-			</LogText>
-			{reasonForChange && (
-				<LogText>
-					<TranslatedText
-						stringId="encounter.vitals.editReason.label"
-						fallback="Reason for change to record"
-					/>
-					: {reasonForChangeLabel}
-				</LogText>
-			)}
-			<LogTextSmall>
-				{userDisplayName} <DateDisplay date={date} showTime shortYear />
-			</LogTextSmall>
-		</LogContainer>
-	);
+  const { date, newValue, reasonForChange, userDisplayName } = logData;
+  const reasonForChangeOption = vitalEditReasons.find(option => option.value === reasonForChange);
+  const reasonForChangeLabel = reasonForChangeOption?.label ?? 'Unknown';
+  return (
+    <LogContainer>
+      <LogText>
+        {vitalLabel}: {newValue === '' ? 'Entry deleted' : newValue}
+      </LogText>
+      {reasonForChange && (
+        <LogText>
+          <TranslatedText
+            stringId="encounter.vitals.editReason.label"
+            fallback="Reason for change to record"
+          />
+          : {reasonForChangeLabel}
+        </LogText>
+      )}
+      <LogTextSmall>
+        {userDisplayName} <DateDisplay date={date} showTime shortYear />
+      </LogTextSmall>
+    </LogContainer>
+  );
 };
 
 export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose }) => {
-	const { getTranslation } = useTranslation();
-	const [isDeleted, setIsDeleted] = useState(false);
-	const api = useApi();
-	const queryClient = useQueryClient();
-	const { encounter } = useEncounter();
+  const { getTranslation } = useTranslation();
+  const [isDeleted, setIsDeleted] = useState(false);
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const { encounter } = useEncounter();
 
-	const { getSetting } = useSettings();
-	const mandatoryVitalEditReason = getSetting(
-		'features.mandatoryVitalEditReason',
-	);
-	const vitalEditReasons = getSetting('vitalEditReasons');
+  const { getSetting } = useSettings();
+  const mandatoryVitalEditReason = getSetting('features.mandatoryVitalEditReason');
+  const vitalEditReasons = getSetting('vitalEditReasons');
 
-	const initialValue = dataPoint.value;
-	const showDeleteEntryButton =
-		['', undefined].includes(initialValue) === false;
-	const valueName = dataPoint.component.dataElement.id;
-	const editVitalData = getEditVitalData(
-		dataPoint.component,
-		mandatoryVitalEditReason,
-	);
-	const validationSchema = getValidationSchema(editVitalData, getTranslation, {
-		encounterType: encounter.encounterType,
-	});
-	const handleDeleteEntry = useCallback(
-		(setFieldValue) => {
-			setFieldValue(valueName, '');
-			setIsDeleted(true);
-		},
-		[valueName],
-	);
-	const handleSubmit = async (data) => {
-		const newShapeData = {
-			date: getCurrentDateTimeString(),
-		};
-		Object.entries(data).forEach(([key, value]) => {
-			if (key === valueName) newShapeData.newValue = value;
-			else newShapeData[key] = value;
-		});
+  const initialValue = dataPoint.value;
+  const showDeleteEntryButton = ['', undefined].includes(initialValue) === false;
+  const valueName = dataPoint.component.dataElement.id;
+  const editVitalData = getEditVitalData(dataPoint.component, mandatoryVitalEditReason);
+  const validationSchema = getValidationSchema(editVitalData, getTranslation, {
+    encounterType: encounter.encounterType,
+  });
+  const handleDeleteEntry = useCallback(
+    setFieldValue => {
+      setFieldValue(valueName, '');
+      setIsDeleted(true);
+    },
+    [valueName],
+  );
+  const handleSubmit = async data => {
+    const newShapeData = {
+      date: getCurrentDateTimeString(),
+    };
+    Object.entries(data).forEach(([key, value]) => {
+      if (key === valueName) newShapeData.newValue = value;
+      else newShapeData[key] = value;
+    });
 
-		// The survey response answer might not exist
-		if (dataPoint.answerId) {
-			await api.put(
-				`surveyResponseAnswer/vital/${dataPoint.answerId}`,
-				newShapeData,
-			);
-		} else {
-			const newVitalData = {
-				...newShapeData,
-				dataElementId: valueName,
-				encounterId: encounter.id,
-				recordedDate: dataPoint.recordedDate,
-			};
-			await api.post('surveyResponseAnswer/vital', newVitalData);
-		}
-		queryClient.invalidateQueries(['encounterVitals', encounter.id]);
-		handleClose();
-	};
-	const validateFn = (values) => {
-		const errors = {};
-		if (values[valueName] === initialValue) {
-			errors[valueName] = 'New value cannot be the same as previous value.';
-		}
-		return errors;
-	};
+    // The survey response answer might not exist
+    if (dataPoint.answerId) {
+      await api.put(`surveyResponseAnswer/vital/${dataPoint.answerId}`, newShapeData);
+    } else {
+      const newVitalData = {
+        ...newShapeData,
+        dataElementId: valueName,
+        encounterId: encounter.id,
+        recordedDate: dataPoint.recordedDate,
+      };
+      await api.post('surveyResponseAnswer/vital', newVitalData);
+    }
+    queryClient.invalidateQueries(['encounterVitals', encounter.id]);
+    handleClose();
+  };
+  const validateFn = values => {
+    const errors = {};
+    if (values[valueName] === initialValue) {
+      errors[valueName] = 'New value cannot be the same as previous value.';
+    }
+    return errors;
+  };
 
-	return (
-		<Form
-			onSubmit={handleSubmit}
-			validationSchema={validationSchema}
-			initialValues={{ [valueName]: initialValue }}
-			formType={FORM_TYPES.EDIT_FORM}
-			validate={validateFn}
-			render={({ setFieldValue, submitForm }) => (
-				<FormGrid columns={4}>
-					<SurveyQuestion
-						component={dataPoint.component}
-						disabled={isDeleted}
-					/>
-					{showDeleteEntryButton && (
-						<DeleteEntryButton
-							disabled={isDeleted}
-							onClick={() => handleDeleteEntry(setFieldValue)}
-						/>
-					)}
-					<Field
-						required={mandatoryVitalEditReason}
-						component={BaseSelectField}
-						label={
-							<TranslatedText
-								stringId="encounter.vitals.editReason.label"
-								fallback="Reason for change to record"
-							/>
-						}
-						name="reasonForChange"
-						options={vitalEditReasons}
-						style={{ gridColumn: '1 / 4' }}
-					/>
-					<FormSeparatorLine />
-					<OuterLabelFieldWrapper
-						label={
-							<TranslatedText
-								stringId="encounter.vitals.history.label"
-								fallback="History"
-							/>
-						}
-						style={{ gridColumn: '1 / -1' }}
-					>
-						<Box
-							height="162px"
-							overflow="auto"
-							padding="13px 12px 13px 15px"
-							bgcolor="white"
-							border="1px solid #dedede"
-							borderRadius="3px"
-						>
-							{dataPoint.historyLogs.map((log) => (
-								<HistoryLog
-									key={log.date}
-									vitalLabel={vitalLabel}
-									vitalEditReasons={vitalEditReasons}
-									logData={log}
-								/>
-							))}
-						</Box>
-					</OuterLabelFieldWrapper>
-					<FormSubmitCancelRow
-						onCancel={handleClose}
-						onConfirm={submitForm}
-						confirmText={
-							<TranslatedText stringId="general.action.save" fallback="Save" />
-						}
-					/>
-				</FormGrid>
-			)}
-		/>
-	);
+  return (
+    <Form
+      onSubmit={handleSubmit}
+      validationSchema={validationSchema}
+      initialValues={{ [valueName]: initialValue }}
+      formType={FORM_TYPES.EDIT_FORM}
+      validate={validateFn}
+      render={({ setFieldValue, submitForm }) => (
+        <FormGrid columns={4}>
+          <SurveyQuestion component={dataPoint.component} disabled={isDeleted} />
+          {showDeleteEntryButton && (
+            <DeleteEntryButton
+              disabled={isDeleted}
+              onClick={() => handleDeleteEntry(setFieldValue)}
+            />
+          )}
+          <Field
+            required={mandatoryVitalEditReason}
+            component={BaseSelectField}
+            label={
+              <TranslatedText
+                stringId="encounter.vitals.editReason.label"
+                fallback="Reason for change to record"
+              />
+            }
+            name="reasonForChange"
+            options={vitalEditReasons}
+            style={{ gridColumn: '1 / 4' }}
+          />
+          <FormSeparatorLine />
+          <OuterLabelFieldWrapper
+            label={<TranslatedText stringId="encounter.vitals.history.label" fallback="History" />}
+            style={{ gridColumn: '1 / -1' }}
+          >
+            <Box
+              height="162px"
+              overflow="auto"
+              padding="13px 12px 13px 15px"
+              bgcolor="white"
+              border="1px solid #dedede"
+              borderRadius="3px"
+            >
+              {dataPoint.historyLogs.map(log => (
+                <HistoryLog
+                  key={log.date}
+                  vitalLabel={vitalLabel}
+                  vitalEditReasons={vitalEditReasons}
+                  logData={log}
+                />
+              ))}
+            </Box>
+          </OuterLabelFieldWrapper>
+          <FormSubmitCancelRow
+            onCancel={handleClose}
+            onConfirm={submitForm}
+            confirmText={<TranslatedText stringId="general.action.save" fallback="Save" />}
+          />
+        </FormGrid>
+      )}
+    />
+  );
 };

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -140,19 +140,12 @@ export const EditorView = memo(
 
     useEffect(handleChangeScope, [scope]);
 
-    const checkDismissChanges = async () => {
-      const dismissChanges = await handleShowWarningModal();
-      if (dismissChanges) {
-        await resetForm();
-      }
-      return dismissChanges;
-    };
-
     const handleChangeCategory = async e => {
       const newCategory = e.target.value;
       if (newCategory !== category && dirty) {
-        const dismissed = await checkDismissChanges();
-        if (!dismissed) return;
+        const dismissChanges = await handleShowWarningModal();
+        if (!dismissChanges) return;
+        await resetForm();
       }
       setSubCategory(null);
       setCategory(newCategory);
@@ -194,7 +187,6 @@ export const EditorView = memo(
               <StyledDynamicSelectField
                 required
                 placeholder=""
-                // Only determine input state by supplied value
                 controlled
                 label={
                   <TranslatedText

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -12,7 +12,6 @@ import { Category } from './components/Category';
 const SettingsWrapper = styled.div`
   background-color: ${Colors.white};
   border: 1px solid ${Colors.outline};
-  margin-top: 1.25rem;
 `;
 
 const StyledDynamicSelectField = styled(DynamicSelectField)`

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -158,13 +158,8 @@ export const EditorView = memo(
       setCategory(newCategory);
     };
 
-    const handleChangeSubcategory = async e => {
-      const newSubCategory = e.target.value;
-      if (newSubCategory && newSubCategory !== subCategory && dirty) {
-        const dismissed = await checkDismissChanges();
-        if (!dismissed) return;
-      }
-      setSubCategory(newSubCategory);
+    const handleChangeSubcategory = e => {
+      setSubCategory(e.target.value);
     };
 
     const getSettingPath = path =>
@@ -199,7 +194,7 @@ export const EditorView = memo(
               <StyledDynamicSelectField
                 required
                 placeholder=""
-                // Prevent the internal handling of input state as it is externally handled
+                // Only determine input state by supplied value
                 controlled
                 label={
                   <TranslatedText
@@ -220,8 +215,6 @@ export const EditorView = memo(
                         fallback="Select sub-category"
                       />
                     }
-                    // Prevent the internal handling of input state as it is externally handled
-                    controlled
                     placeholder=""
                     value={subCategory}
                     onChange={handleChangeSubcategory}

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -199,6 +199,8 @@ export const EditorView = memo(
               <StyledDynamicSelectField
                 required
                 placeholder=""
+                // Prevent the internal handling of input state as it is externally handled
+                controlled
                 label={
                   <TranslatedText
                     stringId="admin.settings.category.label"
@@ -218,6 +220,8 @@ export const EditorView = memo(
                         fallback="Select sub-category"
                       />
                     }
+                    // Prevent the internal handling of input state as it is externally handled
+                    controlled
                     placeholder=""
                     value={subCategory}
                     onChange={handleChangeSubcategory}

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -12,6 +12,7 @@ import { Category } from './components/Category';
 const SettingsWrapper = styled.div`
   background-color: ${Colors.white};
   border: 1px solid ${Colors.outline};
+  margin-top: 1.25rem;
 `;
 
 const StyledDynamicSelectField = styled(DynamicSelectField)`

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -92,6 +92,9 @@ export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope
   const editMode = typeof settingsEditString === 'string';
   const isEditorVisible = scope !== SETTINGS_SCOPES.FACILITY || facilityId;
 
+  if (!isEditorVisible) {
+    return null;
+  }
   return (
     <SettingsWrapper>
       <StyledTopBar>
@@ -121,16 +124,14 @@ export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope
         </StyledButtonRow>
       </StyledTopBar>
       <EditorWrapper>
-        {isEditorVisible && (
-          <JSONEditor
-            onChange={onChangeSettings}
-            value={editMode ? settingsEditString : settingsViewString}
-            editMode={editMode}
-            error={jsonError}
-            placeholder="No settings found for this server/facility"
-            fontSize={14}
-          />
-        )}
+        <JSONEditor
+          onChange={onChangeSettings}
+          value={editMode ? settingsEditString : settingsViewString}
+          editMode={editMode}
+          error={jsonError}
+          placeholder="No settings found for this server/facility"
+          fontSize={14}
+        />
       </EditorWrapper>
       <DefaultSettingsModal
         open={isDefaultModalOpen}

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -14,6 +14,7 @@ import { Colors } from '../../../constants';
 const SettingsWrapper = styled.div`
   background-color: ${Colors.white};
   border: 1px solid ${Colors.outline};
+  margin-top: 1.25rem;
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -10,6 +10,7 @@ import { DefaultSettingsModal } from './components/DefaultSettingsModal';
 import { notifyError } from '../../../utils';
 import { TranslatedText } from '../../../components/Translation';
 import { Colors } from '../../../constants';
+import { isNull } from 'lodash';
 
 const SettingsWrapper = styled.div`
   background-color: ${Colors.white};
@@ -89,7 +90,7 @@ export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope
     }
   };
 
-  const editMode = typeof settingsEditString === 'string';
+  const editMode = !isNull(settingsEditString);
   const isEditorVisible = scope !== SETTINGS_SCOPES.FACILITY || facilityId;
 
   if (!isEditorVisible) {

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -20,8 +20,8 @@ const SettingsWrapper = styled.div`
   flex-direction: column;
 `;
 
-export const ContentPane = styled.div`
-  margin: 30px;
+const EditorWrapper = styled.div`
+  margin: 1.25rem;
   margin-top: 0;
   flex: 1;
 `;
@@ -120,7 +120,7 @@ export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope
           )}
         </StyledButtonRow>
       </StyledTopBar>
-      <ContentPane>
+      <EditorWrapper>
         {isEditorVisible && (
           <JSONEditor
             onChange={onChangeSettings}
@@ -131,7 +131,7 @@ export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope
             fontSize={14}
           />
         )}
-      </ContentPane>
+      </EditorWrapper>
       <DefaultSettingsModal
         open={isDefaultModalOpen}
         onClose={() => setIsDefaultModalOpen(false)}

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -40,93 +40,95 @@ const buildSettingsString = settings => {
   return JSON.stringify(settings, null, 2);
 };
 
-export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope, facilityId }) => {
-  const [settingsEditString, setSettingsEditString] = useState('');
-  const [jsonError, setJsonError] = useState(null);
-  const [isDefaultModalOpen, setIsDefaultModalOpen] = useState(false);
+export const JSONEditorView = React.memo(
+  ({ values, setValues, dirty, submitForm, scope, facilityId }) => {
+    const [settingsEditString, setSettingsEditString] = useState('');
+    const [jsonError, setJsonError] = useState(null);
+    const [isDefaultModalOpen, setIsDefaultModalOpen] = useState(false);
 
-  const settingsViewString = buildSettingsString(values.settings);
-  const hasSettingsChanged = settingsViewString !== settingsEditString;
+    const settingsViewString = buildSettingsString(values.settings);
+    const hasSettingsChanged = settingsViewString !== settingsEditString;
 
-  const updateSettingsEditString = value => {
-    setSettingsEditString(value);
-    setJsonError(null);
-  };
+    const updateSettingsEditString = value => {
+      setSettingsEditString(value);
+      setJsonError(null);
+    };
 
-  const turnOnEditMode = () =>
-    updateSettingsEditString(buildSettingsString(values.settings) || '{}');
-  const turnOffEditMode = () => updateSettingsEditString(null);
+    const turnOnEditMode = () =>
+      updateSettingsEditString(buildSettingsString(values.settings) || '{}');
+    const turnOffEditMode = () => updateSettingsEditString(null);
 
-  const onChangeSettings = newValue => updateSettingsEditString(newValue);
+    const onChangeSettings = newValue => updateSettingsEditString(newValue);
 
-  // Convert settings string from editor into object and post to backend
-  const saveSettings = async event => {
-    // Check if the JSON is valid and notify if not
-    try {
-      JSON.parse(settingsEditString);
-    } catch (error) {
-      notifyError(`Invalid JSON: ${error}`);
-      setJsonError(error);
-      return;
-    }
+    // Convert settings string from editor into object and post to backend
+    const saveSettings = async event => {
+      // Check if the JSON is valid and notify if not
+      try {
+        JSON.parse(settingsEditString);
+      } catch (error) {
+        notifyError(`Invalid JSON: ${error}`);
+        setJsonError(error);
+        return;
+      }
 
-    // Pass the parsed settings object to the form submit function
-    const settingsObject = JSON.parse(settingsEditString);
-    setValues({ ...values, settings: settingsObject });
+      // Pass the parsed settings object to the form submit function
+      const settingsObject = JSON.parse(settingsEditString);
+      setValues({ ...values, settings: settingsObject });
 
-    const submitted = await submitForm(event);
-    if (submitted) {
-      turnOffEditMode();
-    }
-  };
+      const submitted = await submitForm(event);
+      if (submitted) {
+        turnOffEditMode();
+      }
+    };
 
-  const editMode = !!settingsEditString;
-  const isEditorVisible = scope !== SETTINGS_SCOPES.FACILITY || facilityId;
+    const editMode = typeof settingsEditString === 'string';
+    const isEditorVisible = scope !== SETTINGS_SCOPES.FACILITY || facilityId;
 
-  return (
-    <SettingsWrapper>
-      <StyledTopBar>
-        <DefaultSettingsButton onClick={() => setIsDefaultModalOpen(true)}>
-          <Settings />
-          <TranslatedText
-            stringId="admin.settings.viewDefaultScope.message"
-            fallback="View default {scope} settings"
-          />
-        </DefaultSettingsButton>
-        <StyledButtonRow>
-          {editMode ? (
-            <>
-              <Button variant="outlined" onClick={turnOffEditMode}>
-                <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
+    return (
+      <SettingsWrapper>
+        <StyledTopBar>
+          <DefaultSettingsButton onClick={() => setIsDefaultModalOpen(true)}>
+            <Settings />
+            <TranslatedText
+              stringId="admin.settings.viewDefaultScope.message"
+              fallback="View default {scope} settings"
+            />
+          </DefaultSettingsButton>
+          <StyledButtonRow>
+            {editMode ? (
+              <>
+                <Button variant="outlined" onClick={turnOffEditMode}>
+                  <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
+                </Button>
+                <Button onClick={saveSettings} disabled={!hasSettingsChanged}>
+                  <TranslatedText stringId="general.action.save" fallback="Save" />
+                </Button>
+              </>
+            ) : (
+              <Button onClick={turnOnEditMode} disabled={!isEditorVisible}>
+                <TranslatedText stringId="general.action.edit" fallback="Edit" />
               </Button>
-              <Button onClick={saveSettings} disabled={!hasSettingsChanged}>
-                <TranslatedText stringId="general.action.save" fallback="Save" />
-              </Button>
-            </>
-          ) : (
-            <Button onClick={turnOnEditMode} disabled={!isEditorVisible}>
-              <TranslatedText stringId="general.action.edit" fallback="Edit" />
-            </Button>
+            )}
+          </StyledButtonRow>
+        </StyledTopBar>
+        <ContentPane>
+          {isEditorVisible && (
+            <JSONEditor
+              onChange={onChangeSettings}
+              value={editMode ? settingsEditString : settingsViewString}
+              editMode={editMode}
+              error={jsonError}
+              placeholder="No settings found for this server/facility"
+              fontSize={14}
+            />
           )}
-        </StyledButtonRow>
-      </StyledTopBar>
-      <ContentPane>
-        {isEditorVisible && (
-          <JSONEditor
-            onChange={onChangeSettings}
-            value={editMode ? settingsEditString : settingsViewString}
-            editMode={editMode}
-            error={jsonError}
-            placeholder="No settings found for this server/facility"
-            fontSize={14}
-          />
-        )}
-      </ContentPane>
-      <DefaultSettingsModal
-        open={isDefaultModalOpen}
-        onClose={() => setIsDefaultModalOpen(false)}
-        scope={scope}
-      />
-    </SettingsWrapper>
-  );
-});
+        </ContentPane>
+        <DefaultSettingsModal
+          open={isDefaultModalOpen}
+          onClose={() => setIsDefaultModalOpen(false)}
+          scope={scope}
+        />
+      </SettingsWrapper>
+    );
+  },
+);

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -4,7 +4,7 @@ import { Settings } from '@material-ui/icons';
 
 import { SETTINGS_SCOPES } from '@tamanu/constants';
 
-import { TextButton, ContentPane, ButtonRow, Button } from '../../../components';
+import { TextButton, ButtonRow, Button } from '../../../components';
 import { JSONEditor } from './components/JSONEditor';
 import { DefaultSettingsModal } from './components/DefaultSettingsModal';
 import { notifyError } from '../../../utils';
@@ -14,7 +14,15 @@ import { Colors } from '../../../constants';
 const SettingsWrapper = styled.div`
   background-color: ${Colors.white};
   border: 1px solid ${Colors.outline};
-  margin-top: 20px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ContentPane = styled.div`
+  margin: 30px;
+  margin-top: 0;
+  flex: 1;
 `;
 
 const StyledTopBar = styled.div`
@@ -90,7 +98,8 @@ export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope
           <Settings />
           <TranslatedText
             stringId="admin.settings.viewDefaultScope.message"
-            fallback="View default {scope} settings"
+            fallback="View default :scope settings"
+            replacements={{ scope }}
           />
         </DefaultSettingsButton>
         <StyledButtonRow>

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -40,95 +40,93 @@ const buildSettingsString = settings => {
   return JSON.stringify(settings, null, 2);
 };
 
-export const JSONEditorView = React.memo(
-  ({ values, setValues, dirty, submitForm, scope, facilityId }) => {
-    const [settingsEditString, setSettingsEditString] = useState('');
-    const [jsonError, setJsonError] = useState(null);
-    const [isDefaultModalOpen, setIsDefaultModalOpen] = useState(false);
+export const JSONEditorView = React.memo(({ values, setValues, submitForm, scope, facilityId }) => {
+  const [settingsEditString, setSettingsEditString] = useState(null);
+  const [jsonError, setJsonError] = useState(null);
+  const [isDefaultModalOpen, setIsDefaultModalOpen] = useState(false);
 
-    const settingsViewString = buildSettingsString(values.settings);
-    const hasSettingsChanged = settingsViewString !== settingsEditString;
+  const settingsViewString = buildSettingsString(values.settings);
+  const hasSettingsChanged = settingsViewString !== settingsEditString;
 
-    const updateSettingsEditString = value => {
-      setSettingsEditString(value);
-      setJsonError(null);
-    };
+  const updateSettingsEditString = value => {
+    setSettingsEditString(value);
+    setJsonError(null);
+  };
 
-    const turnOnEditMode = () =>
-      updateSettingsEditString(buildSettingsString(values.settings) || '{}');
-    const turnOffEditMode = () => updateSettingsEditString(null);
+  const turnOnEditMode = () =>
+    updateSettingsEditString(buildSettingsString(values.settings) || '{}');
+  const turnOffEditMode = () => updateSettingsEditString(null);
 
-    const onChangeSettings = newValue => updateSettingsEditString(newValue);
+  const onChangeSettings = newValue => updateSettingsEditString(newValue);
 
-    // Convert settings string from editor into object and post to backend
-    const saveSettings = async event => {
-      // Check if the JSON is valid and notify if not
-      try {
-        JSON.parse(settingsEditString);
-      } catch (error) {
-        notifyError(`Invalid JSON: ${error}`);
-        setJsonError(error);
-        return;
-      }
+  // Convert settings string from editor into object and post to backend
+  const saveSettings = async event => {
+    // Check if the JSON is valid and notify if not
+    try {
+      JSON.parse(settingsEditString);
+    } catch (error) {
+      notifyError(`Invalid JSON: ${error}`);
+      setJsonError(error);
+      return;
+    }
 
-      // Pass the parsed settings object to the form submit function
-      const settingsObject = JSON.parse(settingsEditString);
-      setValues({ ...values, settings: settingsObject });
+    // Pass the parsed settings object to the form submit function
+    const settingsObject = JSON.parse(settingsEditString);
+    setValues({ ...values, settings: settingsObject });
 
-      const submitted = await submitForm(event);
-      if (submitted) {
-        turnOffEditMode();
-      }
-    };
+    const submitted = await submitForm(event);
+    if (submitted) {
+      turnOffEditMode();
+    }
+  };
 
-    const editMode = typeof settingsEditString === 'string';
-    const isEditorVisible = scope !== SETTINGS_SCOPES.FACILITY || facilityId;
+  const editMode = typeof settingsEditString === 'string';
+  const isEditorVisible = scope !== SETTINGS_SCOPES.FACILITY || facilityId;
 
-    return (
-      <SettingsWrapper>
-        <StyledTopBar>
-          <DefaultSettingsButton onClick={() => setIsDefaultModalOpen(true)}>
-            <Settings />
-            <TranslatedText
-              stringId="admin.settings.viewDefaultScope.message"
-              fallback="View default {scope} settings"
-            />
-          </DefaultSettingsButton>
-          <StyledButtonRow>
-            {editMode ? (
-              <>
-                <Button variant="outlined" onClick={turnOffEditMode}>
-                  <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
-                </Button>
-                <Button onClick={saveSettings} disabled={!hasSettingsChanged}>
-                  <TranslatedText stringId="general.action.save" fallback="Save" />
-                </Button>
-              </>
-            ) : (
-              <Button onClick={turnOnEditMode} disabled={!isEditorVisible}>
-                <TranslatedText stringId="general.action.edit" fallback="Edit" />
+  return (
+    <SettingsWrapper>
+      <StyledTopBar>
+        <DefaultSettingsButton onClick={() => setIsDefaultModalOpen(true)}>
+          <Settings />
+          <TranslatedText
+            stringId="admin.settings.viewDefaultScope.message"
+            fallback="View default {scope} settings"
+          />
+        </DefaultSettingsButton>
+        <StyledButtonRow>
+          {editMode ? (
+            <>
+              <Button variant="outlined" onClick={turnOffEditMode}>
+                <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
               </Button>
-            )}
-          </StyledButtonRow>
-        </StyledTopBar>
-        <ContentPane>
-          {isEditorVisible && (
-            <JSONEditor
-              onChange={onChangeSettings}
-              value={editMode ? settingsEditString : settingsViewString}
-              editMode={editMode}
-              error={jsonError}
-              placeholder="No settings found for this server/facility"
-              fontSize={14}
-            />
+              <Button onClick={saveSettings} disabled={!hasSettingsChanged}>
+                <TranslatedText stringId="general.action.save" fallback="Save" />
+              </Button>
+            </>
+          ) : (
+            <Button onClick={turnOnEditMode} disabled={!isEditorVisible}>
+              <TranslatedText stringId="general.action.edit" fallback="Edit" />
+            </Button>
           )}
-        </ContentPane>
-        <DefaultSettingsModal
-          open={isDefaultModalOpen}
-          onClose={() => setIsDefaultModalOpen(false)}
-          scope={scope}
-        />
-      </SettingsWrapper>
-    );
-  },
-);
+        </StyledButtonRow>
+      </StyledTopBar>
+      <ContentPane>
+        {isEditorVisible && (
+          <JSONEditor
+            onChange={onChangeSettings}
+            value={editMode ? settingsEditString : settingsViewString}
+            editMode={editMode}
+            error={jsonError}
+            placeholder="No settings found for this server/facility"
+            fontSize={14}
+          />
+        )}
+      </ContentPane>
+      <DefaultSettingsModal
+        open={isDefaultModalOpen}
+        onClose={() => setIsDefaultModalOpen(false)}
+        scope={scope}
+      />
+    </SettingsWrapper>
+  );
+});

--- a/packages/web/app/views/administration/settings/JSONEditorView.jsx
+++ b/packages/web/app/views/administration/settings/JSONEditorView.jsx
@@ -29,7 +29,7 @@ const EditorWrapper = styled.div`
 const StyledTopBar = styled.div`
   display: flex;
   justify-content: space-between;
-  padding: 20px;
+  padding: 1.25rem;
 `;
 
 const StyledButtonRow = styled(ButtonRow)`

--- a/packages/web/app/views/administration/settings/SettingsView.jsx
+++ b/packages/web/app/views/administration/settings/SettingsView.jsx
@@ -44,8 +44,8 @@ const StyledTabDisplay = styled(TabDisplay)`
 
 const TabContainer = styled.div`
   height: 100%;
-  padding: 20px;
-  padding-top: 10px;
+  padding: 1.25rem;
+  padding-top: 0.75rem;
   display: flex;
   flex-direction: column;
   background-color: ${Colors.background};

--- a/packages/web/app/views/administration/settings/SettingsView.jsx
+++ b/packages/web/app/views/administration/settings/SettingsView.jsx
@@ -35,7 +35,6 @@ const StyledAdminViewContainer = styled(AdminViewContainer)`
 `;
 
 const StyledTabDisplay = styled(TabDisplay)`
-  margin-top: 20px;
   height: 100%;
   border-top: 1px solid ${Colors.outline};
   > div:last-child {
@@ -46,6 +45,9 @@ const StyledTabDisplay = styled(TabDisplay)`
 const TabContainer = styled.div`
   height: 100%;
   padding: 20px;
+  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
   background-color: ${Colors.background};
 `;
 

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -4,7 +4,7 @@ import LockIcon from '@material-ui/icons/Lock';
 
 import { isSetting } from '@tamanu/settings';
 
-import { BodyText, Heading4, LargeBodyText } from '../../../../components';
+import { BodyText, Heading4, LargeBodyText, TranslatedText } from '../../../../components';
 import { Colors } from '../../../../constants';
 import { ThemedTooltip } from '../../../../components/Tooltip';
 import { SettingInput } from './SettingInput';
@@ -59,7 +59,19 @@ const CategoryTitle = memo(({ name, path, description }) => {
 });
 
 const SettingName = memo(({ name, path, description, disabled }) => (
-  <ThemedTooltip disableHoverListener={!description} title={description}>
+  <ThemedTooltip
+    disableHoverListener={!description && !disabled}
+    title={
+      disabled ? (
+        <TranslatedText
+          stringId="admin.settings.highRiskSettingTooltip"
+          fallback="User does not required permissions to update this setting"
+        />
+      ) : (
+        description
+      )
+    }
+  >
     <SettingNameLabel color={disabled && 'textTertiary'}>
       {formatSettingName(name, path.split('.').pop())}
       {disabled && <StyledLockIcon />}

--- a/packages/web/app/views/administration/settings/components/DefaultSettingsModal.jsx
+++ b/packages/web/app/views/administration/settings/components/DefaultSettingsModal.jsx
@@ -18,11 +18,11 @@ const StyledModal = styled(Modal)`
     height: 100%;
     display: flex;
     flex-direction: column;
-    > :last-child {
+    > :not(.MuiDialogTitle-root) {
       flex: 1;
       display: flex;
       flex-direction: column;
-      > :first-child {
+      > :not(.MuiDialogActions-root) {
         display: flex;
         flex-direction: column;
       }

--- a/packages/web/app/views/administration/settings/components/DefaultSettingsModal.jsx
+++ b/packages/web/app/views/administration/settings/components/DefaultSettingsModal.jsx
@@ -13,6 +13,23 @@ const SCOPE_DEFAULT_SETTINGS = {
   [SETTINGS_SCOPES.FACILITY]: facilityDefaults,
 };
 
+const StyledModal = styled(Modal)`
+  .MuiPaper-root {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    > :last-child {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      > :first-child {
+        display: flex;
+        flex-direction: column;
+      }
+    }
+  }
+`;
+
 const Description = styled.div`
   font-size: 14px;
   margin-bottom: 18px;
@@ -21,11 +38,11 @@ const Description = styled.div`
 export const DefaultSettingsModal = React.memo(({ scope, open, onClose }) => {
   const defaultSettingsForScope = JSON.stringify(SCOPE_DEFAULT_SETTINGS[scope], null, 2);
   return (
-    <Modal open={open} onClose={onClose} width="lg" title={`Default ${scope} settings`}>
+    <StyledModal open={open} onClose={onClose} width="lg" title={`Default ${scope} settings`}>
       <Description>
         These are the fallback values for keys not defined in {scope} settings
       </Description>
       <JSONEditor value={defaultSettingsForScope} editMode={false} />
-    </Modal>
+    </StyledModal>
   );
 });

--- a/packages/web/app/views/administration/settings/components/JSONEditor.jsx
+++ b/packages/web/app/views/administration/settings/components/JSONEditor.jsx
@@ -81,8 +81,8 @@ export const JSONEditor = React.memo(
 
     return (
       <StyledJSONEditor
-        height="600px"
         width="100%"
+        height="100%"
         mode="json"
         showPrintMargin={false}
         placeholder={placeholder}

--- a/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
+++ b/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
@@ -14,7 +14,7 @@ const ScopeSelectInput = styled(SelectInput)`
 
 const ScopeDynamicSelectInput = styled(DynamicSelectField)`
   width: 300px;
-  margin-top: 8px;
+  margin-top: 0.5rem;
 `;
 
 const SCOPE_OPTIONS = [

--- a/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
+++ b/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
@@ -10,12 +10,11 @@ import { TranslatedText } from '../../../../components/Translation';
 
 const ScopeSelectInput = styled(SelectInput)`
   width: 300px;
-  margin-bottom: 5px;
 `;
 
 const ScopeDynamicSelectInput = styled(DynamicSelectField)`
   width: 300px;
-  margin-bottom: 10px;
+  margin-top: 8px;
 `;
 
 const SCOPE_OPTIONS = [

--- a/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
+++ b/packages/web/app/views/administration/settings/components/ScopeSelectorFields.jsx
@@ -10,11 +10,12 @@ import { TranslatedText } from '../../../../components/Translation';
 
 const ScopeSelectInput = styled(SelectInput)`
   width: 300px;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 `;
 
 const ScopeDynamicSelectInput = styled(DynamicSelectField)`
   width: 300px;
+  margin-bottom: 10px;
 `;
 
 const SCOPE_OPTIONS = [

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -12,7 +12,7 @@ import {
 } from '../../../../components';
 import { JSONEditor } from './JSONEditor';
 import { Colors } from '../../../../constants';
-import { ConditionalTooltip, ThemedTooltip } from '../../../../components/Tooltip';
+import { ConditionalTooltip } from '../../../../components/Tooltip';
 
 const Unit = styled.div`
   font-size: 15px; // Match TextField
@@ -78,8 +78,11 @@ export const SettingInput = ({
 }) => {
   const { type } = typeSchema;
   const [error, setError] = useState(null);
-  const normalize = val => (val === null || val === '') ? '' : val;
-  const isUnchangedFromDefault = useMemo(() => isEqual(normalize(value), normalize(defaultValue)), [value, defaultValue]);
+  const normalize = val => (val === null || val === '' ? '' : val);
+  const isUnchangedFromDefault = useMemo(() => isEqual(normalize(value), normalize(defaultValue)), [
+    value,
+    defaultValue,
+  ]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
### Changes

So the only annoying thing is that we have to make that controlled flag.
This basically means that it will only update internal state of selections when the external value prop is updated.
This means that it won't remove the inputs value when cleared until we actually set the value state to null etc.

We need something like this for the dismiss changes logic.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
