### PR TITLE
fix(vaccine): 2.17 fix: Mobile vaccine state out of sync when editing existing vaccine without changing status

### DIFF
--- a/packages/mobile/App/ui/components/VaccinesTable/index.tsx
+++ b/packages/mobile/App/ui/components/VaccinesTable/index.tsx
@@ -152,14 +152,12 @@ export const VaccinesTable = ({
       if (!cellData) return <CellContent vaccineStatus={VaccineStatus.UNKNOWN} />;
       const { vaccineStatus, dueStatus, scheduledVaccine } = cellData;
       const status = vaccineStatus || dueStatus.status || VaccineStatus.UNKNOWN;
-      const cellId = `${categoryName}-${scheduledVaccine?.id}-${status}`;
       return (
         <VaccineTableCell
           onPress={onPressItem}
           data={cellData}
           status={status}
-          key={`vaccine-table-cell-${cellId}`}
-          id={cellId}
+          key={`vaccine-table-cell-${categoryName}-${scheduledVaccine?.id}}`}
         />
       );
     },


### PR DESCRIPTION
### Changes

This issue is triggered only following this path

Edit an existing vaccine without changing its status, then click back to table view and then click into the vaccine that you just edited. State was previously out of sync until the route is reloaded (i.e click back to patient view)

Tested performance impact and was not noticeable
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
