### PR TITLE
fix(translations): release-fix-2.17: Use missed translation for placeholder prop

### DIFF
--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -72,7 +72,7 @@ export const NotGivenReasonField = (): JSX.Element => (
     component={SuggesterDropdown}
     name="notGivenReasonId"
     label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
-    selectPlaceholderText="Select"
+    selectPlaceholderText={<TranslatedText stringId="general.action.select" fallback="Select" />}
     referenceDataType={ReferenceDataType.VaccineNotGivenReason}
   />
 );


### PR DESCRIPTION
### Changes

Discovered in release that a field was erroring. On investigation this came from improperly supplying a string to a component that expected a translated string component.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
