### PR TITLE
fix(settings): NASS-1363: Settings deleted_at handling

### DIFF
--- a/packages/central-server/__tests__/models/Setting.test.js
+++ b/packages/central-server/__tests__/models/Setting.test.js
@@ -17,7 +17,9 @@ describe('Setting', () => {
   });
 
   afterEach(async () => {
-    await Setting.truncate();
+    await Setting.truncate({
+      force: true,
+    });
   });
 
   afterAll(async () => {

--- a/packages/shared/src/migrations/1728609178353-updateSettingsUniqueIndex.js
+++ b/packages/shared/src/migrations/1728609178353-updateSettingsUniqueIndex.js
@@ -1,7 +1,5 @@
 export async function up(query) {
-  await query.sequelize.query(
-    'alter table settings drop constraint  settings_alive_key_unique_cnt',
-  );
+  await query.sequelize.query('ALTER TABLE settings DROP CONSTRAINT settings_alive_key_unique_cnt');
   await query.addConstraint('settings', {
     name: 'settings_alive_key_unique_cnt',
     fields: ['key', 'facility_id'],
@@ -10,9 +8,7 @@ export async function up(query) {
 }
 
 export async function down(query) {
-  await query.sequelize.query(
-    'alter table settings drop constraint  settings_alive_key_unique_cnt',
-  );
+  await query.sequelize.query('ALTER TABLE settings DROP CONSTRAINT settings_alive_key_unique_cnt');
   await query.addConstraint('settings', {
     name: 'settings_alive_key_unique_cnt',
     fields: ['key', 'facility_id', 'deleted_at'],

--- a/packages/shared/src/migrations/1728609178353-updateSettingsUniqueIndex.js
+++ b/packages/shared/src/migrations/1728609178353-updateSettingsUniqueIndex.js
@@ -1,0 +1,21 @@
+export async function up(query) {
+  await query.sequelize.query(
+    'alter table settings drop constraint  settings_alive_key_unique_cnt',
+  );
+  await query.addConstraint('settings', {
+    name: 'settings_alive_key_unique_cnt',
+    fields: ['key', 'facility_id'],
+    type: 'UNIQUE',
+  });
+}
+
+export async function down(query) {
+  await query.sequelize.query(
+    'alter table settings drop constraint  settings_alive_key_unique_cnt',
+  );
+  await query.addConstraint('settings', {
+    name: 'settings_alive_key_unique_cnt',
+    fields: ['key', 'facility_id', 'deleted_at'],
+    type: 'UNIQUE',
+  });
+}

--- a/packages/shared/src/models/Setting.js
+++ b/packages/shared/src/models/Setting.js
@@ -158,13 +158,18 @@ export class Setting extends Model {
     const defaultsForScope = extractDefaults(schema);
 
     const existingByKey = keyBy(
-      await this.findAll({
-        where: {
-          key: records.map(r => r.key),
-          scope,
-          facilityId,
+      await this.findAll(
+        {
+          where: {
+            key: records.map(r => r.key),
+            scope,
+            facilityId,
+          },
         },
-      }),
+        {
+          paranoid: false,
+        },
+      ),
       'key',
     );
 
@@ -174,7 +179,10 @@ export class Setting extends Model {
         if (existing) {
           if (!isEqual(existing.value, record.value)) {
             // only update existing records that have changed
-            await this.update({ value: record.value }, { where: { id: existing.id } });
+            await this.update(
+              { value: record.value, deletedAt: null },
+              { where: { id: existing.id } },
+            );
           }
         } else {
           // only create records for values that differ from the defaults

--- a/packages/shared/src/models/Setting.js
+++ b/packages/shared/src/models/Setting.js
@@ -158,18 +158,14 @@ export class Setting extends Model {
     const defaultsForScope = extractDefaults(schema);
 
     const existingByKey = keyBy(
-      await this.findAll(
-        {
-          where: {
-            key: records.map(r => r.key),
-            scope,
-            facilityId,
-          },
+      await this.findAll({
+        where: {
+          key: records.map(r => r.key),
+          scope,
+          facilityId,
         },
-        {
-          paranoid: false,
-        },
-      ),
+        paranoid: false,
+      }),
       'key',
     );
 


### PR DESCRIPTION
### Changes
Fixes sync error due to the possibility to create duplicate entries with deleted_at

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
