### PR TITLE
fix(mobileTranslations): 2.17 fix: Issue with translated reference data usage in dropdown

### DIFF
--- a/packages/mobile/App/ui/components/Dropdown/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/index.tsx
@@ -9,7 +9,8 @@ import { Orientation, screenPercentageToDP } from '~/ui/helpers/screen';
 import { TextFieldErrorMessage } from '../TextField/TextFieldErrorMessage';
 import { useBackend } from '~/ui/hooks';
 import { TranslatedTextElement } from '../Translations/TranslatedText';
-import { TranslatedReferenceData } from '../Translations/TranslatedReferenceData';
+import { useTranslation } from '~/ui/contexts/TranslationContext';
+import { getReferenceDataStringId } from '../Translations/TranslatedReferenceData';
 
 const MIN_COUNT_FILTERABLE_BY_DEFAULT = 8;
 
@@ -25,7 +26,7 @@ export interface DropdownProps extends BaseInputProps {
   label?: string;
   labelColor?: string;
   labelFontSize?: string | number;
-  fieldFontSize?: number
+  fieldFontSize?: number;
   fixedHeight: boolean;
   searchPlaceholderText?: string;
   selectPlaceholderText?: string;
@@ -200,21 +201,19 @@ export const MultiSelectDropdown = ({ ...props }): ReactElement => (
 
 export const SuggesterDropdown = ({ referenceDataType, ...props }): ReactElement => {
   const { models } = useBackend();
+  const { getTranslation } = useTranslation();
   const [options, setOptions] = useState([]);
 
   useEffect(() => {
     (async (): Promise<void> => {
       const results = await models.ReferenceData.getSelectOptionsForType(referenceDataType);
-      const translatedResults = results.map(option => ({
-        label: (
-          <TranslatedReferenceData
-            category={referenceDataType}
-            value={option.value}
-            fallback={option.label}
-          />
-        ),
-        value: option.value,
-      }));
+      const translatedResults = results.map(option => {
+        const stringId = getReferenceDataStringId(option.value, referenceDataType);
+        return {
+          label: getTranslation(stringId, option.label),
+          value: option.value,
+        };
+      });
       setOptions(translatedResults);
     })();
   }, []);

--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -14,6 +14,7 @@ import { Suggester } from '~/ui/helpers/suggester';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
 import { TranslatedText, TranslatedTextElement } from '../../Translations/TranslatedText';
+import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 const InjectionSiteDropdown = ({ value, label, onChange, selectPlaceholderText }): JSX.Element => (
   <Dropdown
@@ -67,15 +68,19 @@ export const InjectionSiteField = (): JSX.Element => (
   />
 );
 
-export const NotGivenReasonField = (): JSX.Element => (
-  <Field
-    component={SuggesterDropdown}
-    name="notGivenReasonId"
-    label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
-    selectPlaceholderText={<TranslatedText stringId="general.action.select" fallback="Select" />}
-    referenceDataType={ReferenceDataType.VaccineNotGivenReason}
-  />
-);
+export const NotGivenReasonField = (): JSX.Element => {
+  const { getTranslation } = useTranslation();
+  console.log(getTranslation('general.action.select', 'Select'));
+  return (
+    <Field
+      component={SuggesterDropdown}
+      name="notGivenReasonId"
+      label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
+      selectPlaceholderText={getTranslation('general.action.select', 'Select')}
+      referenceDataType={ReferenceDataType.VaccineNotGivenReason}
+    />
+  );
+};
 
 export const VaccineLocationField = ({ navigation }: NavigationFieldProps): JSX.Element => (
   <LocationField navigation={navigation} required />

--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -14,7 +14,6 @@ import { Suggester } from '~/ui/helpers/suggester';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
 import { TranslatedText, TranslatedTextElement } from '../../Translations/TranslatedText';
-import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 const InjectionSiteDropdown = ({ value, label, onChange, selectPlaceholderText }): JSX.Element => (
   <Dropdown
@@ -68,19 +67,15 @@ export const InjectionSiteField = (): JSX.Element => (
   />
 );
 
-export const NotGivenReasonField = (): JSX.Element => {
-  const { getTranslation } = useTranslation();
-  console.log(getTranslation('general.action.select', 'Select'));
-  return (
-    <Field
-      component={SuggesterDropdown}
-      name="notGivenReasonId"
-      label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
-      selectPlaceholderText={getTranslation('general.action.select', 'Select')}
-      referenceDataType={ReferenceDataType.VaccineNotGivenReason}
-    />
-  );
-};
+export const NotGivenReasonField = (): JSX.Element => (
+  <Field
+    component={SuggesterDropdown}
+    name="notGivenReasonId"
+    label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
+    selectPlaceholderText={<TranslatedText stringId="general.action.select" fallback="Select" />}
+    referenceDataType={ReferenceDataType.VaccineNotGivenReason}
+  />
+);
 
 export const VaccineLocationField = ({ navigation }: NavigationFieldProps): JSX.Element => (
   <LocationField navigation={navigation} required />


### PR DESCRIPTION
### Changes
Fixes error with translated reference data usage in Select dropdown 

this is because multiselect tries to put selectedLabel in placeholder 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
