### PR TITLE
fix(dbmodel): non-generic column model description

### DIFF
--- a/database/model/central-server/fhir/encounters.yml
+++ b/database/model/central-server/fhir/encounters.yml
@@ -12,42 +12,42 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('encounters__id') }} in encounters."
+            description: "{{ doc('encounters__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('encounters__version_id') }} in encounters."
+            description: "{{ doc('encounters__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('encounters__upstream_id') }} in encounters."
+            description: "{{ doc('encounters__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('encounters__last_updated') }} in encounters."
+            description: "{{ doc('encounters__last_updated') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('encounters__status') }} in encounters."
+            description: "{{ doc('encounters__status') }}"
             data_tests:
               - not_null
           - name: class
             data_type: jsonb
-            description: "{{ doc('encounters__class') }} in encounters."
+            description: "{{ doc('encounters__class') }}"
           - name: actual_period
             data_type: jsonb
-            description: "{{ doc('encounters__actual_period') }} in encounters."
+            description: "{{ doc('encounters__actual_period') }}"
           - name: subject
             data_type: jsonb
-            description: "{{ doc('encounters__subject') }} in encounters."
+            description: "{{ doc('encounters__subject') }}"
           - name: location
             data_type: jsonb
-            description: "{{ doc('encounters__location') }} in encounters."
+            description: "{{ doc('encounters__location') }}"
           - name: service_provider
             data_type: jsonb
-            description: "{{ doc('encounters__service_provider') }} in encounters."
+            description: "{{ doc('encounters__service_provider') }}"

--- a/database/model/central-server/fhir/immunizations.yml
+++ b/database/model/central-server/fhir/immunizations.yml
@@ -12,62 +12,61 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('immunizations__id') }} in immunizations."
+            description: "{{ doc('immunizations__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('immunizations__version_id') }} in immunizations."
+            description: "{{ doc('immunizations__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('immunizations__upstream_id') }} in immunizations."
+            description: "{{ doc('immunizations__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp without time zone
-            description: "{{ doc('immunizations__last_updated') }} in immunizations."
+            description: "{{ doc('immunizations__last_updated') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('immunizations__status') }} in immunizations."
+            description: "{{ doc('immunizations__status') }}"
             data_tests:
               - not_null
           - name: vaccine_code
             data_type: jsonb
-            description: "{{ doc('immunizations__vaccine_code') }} in immunizations."
+            description: "{{ doc('immunizations__vaccine_code') }}"
             data_tests:
               - not_null
           - name: patient
             data_type: jsonb
-            description: "{{ doc('immunizations__patient') }} in immunizations."
+            description: "{{ doc('immunizations__patient') }}"
             data_tests:
               - not_null
           - name: encounter
             data_type: jsonb
-            description: "{{ doc('immunizations__encounter') }} in immunizations."
+            description: "{{ doc('immunizations__encounter') }}"
           - name: occurrence_date_time
             data_type: text
-            description: "{{ doc('immunizations__occurrence_date_time') }} in
-              immunizations."
+            description: "{{ doc('immunizations__occurrence_date_time') }}"
           - name: lot_number
             data_type: text
-            description: "{{ doc('immunizations__lot_number') }} in immunizations."
+            description: "{{ doc('immunizations__lot_number') }}"
           - name: site
             data_type: jsonb
-            description: "{{ doc('immunizations__site') }} in immunizations."
+            description: "{{ doc('immunizations__site') }}"
             data_tests:
               - not_null
           - name: performer
             data_type: jsonb
-            description: "{{ doc('immunizations__performer') }} in immunizations."
+            description: "{{ doc('immunizations__performer') }}"
             data_tests:
               - not_null
           - name: protocol_applied
             data_type: jsonb
-            description: "{{ doc('immunizations__protocol_applied') }} in immunizations."
+            description: "{{ doc('immunizations__protocol_applied') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/fhir/job_workers.yml
+++ b/database/model/central-server/fhir/job_workers.yml
@@ -12,25 +12,25 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('job_workers__id') }} in job_workers."
+            description: "{{ doc('job_workers__id') }}"
             data_tests:
               - unique
               - not_null
           - name: created_at
             data_type: timestamp with time zone
-            description: "{{ doc('job_workers__created_at') }} in job_workers."
+            description: "{{ doc('job_workers__created_at') }}"
             data_tests:
               - not_null
           - name: updated_at
             data_type: timestamp with time zone
-            description: "{{ doc('job_workers__updated_at') }} in job_workers."
+            description: "{{ doc('job_workers__updated_at') }}"
             data_tests:
               - not_null
           - name: deleted_at
             data_type: timestamp with time zone
-            description: "{{ doc('job_workers__deleted_at') }} in job_workers."
+            description: "{{ doc('job_workers__deleted_at') }}"
           - name: metadata
             data_type: jsonb
-            description: "{{ doc('job_workers__metadata') }} in job_workers."
+            description: "{{ doc('job_workers__metadata') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/fhir/jobs.yml
+++ b/database/model/central-server/fhir/jobs.yml
@@ -12,61 +12,61 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('jobs__id') }} in jobs."
+            description: "{{ doc('jobs__id') }}"
             data_tests:
               - unique
               - not_null
           - name: created_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__created_at') }} in jobs."
+            description: "{{ doc('jobs__created_at') }}"
             data_tests:
               - not_null
           - name: updated_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__updated_at') }} in jobs."
+            description: "{{ doc('jobs__updated_at') }}"
             data_tests:
               - not_null
           - name: deleted_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__deleted_at') }} in jobs."
+            description: "{{ doc('jobs__deleted_at') }}"
           - name: priority
             data_type: integer
-            description: "{{ doc('jobs__priority') }} in jobs."
+            description: "{{ doc('jobs__priority') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('jobs__status') }} in jobs."
+            description: "{{ doc('jobs__status') }}"
             data_tests:
               - not_null
           - name: worker_id
             data_type: uuid
-            description: "{{ doc('jobs__worker_id') }} in jobs."
+            description: "{{ doc('jobs__worker_id') }}"
           - name: started_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__started_at') }} in jobs."
+            description: "{{ doc('jobs__started_at') }}"
           - name: completed_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__completed_at') }} in jobs."
+            description: "{{ doc('jobs__completed_at') }}"
           - name: errored_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__errored_at') }} in jobs."
+            description: "{{ doc('jobs__errored_at') }}"
           - name: error
             data_type: text
-            description: "{{ doc('jobs__error') }} in jobs."
+            description: "{{ doc('jobs__error') }}"
           - name: topic
             data_type: text
-            description: "{{ doc('jobs__topic') }} in jobs."
+            description: "{{ doc('jobs__topic') }}"
             data_tests:
               - not_null
           - name: discriminant
             data_type: text
-            description: "{{ doc('jobs__discriminant') }} in jobs."
+            description: "{{ doc('jobs__discriminant') }}"
             data_tests:
               - unique
               - not_null
           - name: payload
             data_type: jsonb
-            description: "{{ doc('jobs__payload') }} in jobs."
+            description: "{{ doc('jobs__payload') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/fhir/non_fhir_medici_report.yml
+++ b/database/model/central-server/fhir/non_fhir_medici_report.yml
@@ -12,156 +12,124 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('non_fhir_medici_report__id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('non_fhir_medici_report__version_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__upstream_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('non_fhir_medici_report__last_updated') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__last_updated') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__patient_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__patient_id') }}"
             data_tests:
               - not_null
           - name: first_name
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__first_name') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__first_name') }}"
             data_tests:
               - not_null
           - name: last_name
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__last_name') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__last_name') }}"
             data_tests:
               - not_null
           - name: date_of_birth
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__date_of_birth') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__date_of_birth') }}"
           - name: age
             data_type: integer
-            description: "{{ doc('non_fhir_medici_report__age') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__age') }}"
           - name: sex
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__sex') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__sex') }}"
             data_tests:
               - not_null
           - name: patient_billing_id
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__patient_billing_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__patient_billing_id') }}"
           - name: patient_billing_type
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__patient_billing_type') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__patient_billing_type') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__encounter_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_id') }}"
             data_tests:
               - not_null
           - name: encounter_start_date
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__encounter_start_date') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_start_date') }}"
             data_tests:
               - not_null
           - name: encounter_end_date
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__encounter_end_date') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_end_date') }}"
           - name: discharge_date
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__discharge_date') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__discharge_date') }}"
           - name: encounter_type
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__encounter_type') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_type') }}"
           - name: weight
             data_type: numeric
-            description: "{{ doc('non_fhir_medici_report__weight') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__weight') }}"
           - name: visit_type
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__visit_type') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__visit_type') }}"
             data_tests:
               - not_null
           - name: episode_end_status
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__episode_end_status') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__episode_end_status') }}"
           - name: encounter_discharge_disposition
             data_type: jsonb
             description: "{{ doc('non_fhir_medici_report__encounter_discharge_disposition')
-              }} in non_fhir_medici_report."
+              }}"
           - name: triage_category
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__triage_category') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__triage_category') }}"
           - name: wait_time
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__wait_time') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__wait_time') }}"
           - name: departments
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__departments') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__departments') }}"
           - name: locations
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__locations') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__locations') }}"
           - name: reason_for_encounter
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__reason_for_encounter') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__reason_for_encounter') }}"
           - name: diagnoses
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__diagnoses') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__diagnoses') }}"
           - name: medications
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__medications') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__medications') }}"
           - name: vaccinations
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__vaccinations') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__vaccinations') }}"
           - name: procedures
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__procedures') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__procedures') }}"
           - name: lab_requests
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__lab_requests') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__lab_requests') }}"
           - name: imaging_requests
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__imaging_requests') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__imaging_requests') }}"
           - name: notes
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__notes') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__notes') }}"

--- a/database/model/central-server/fhir/organizations.yml
+++ b/database/model/central-server/fhir/organizations.yml
@@ -12,33 +12,33 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('organizations__id') }} in organizations."
+            description: "{{ doc('organizations__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('organizations__version_id') }} in organizations."
+            description: "{{ doc('organizations__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('organizations__upstream_id') }} in organizations."
+            description: "{{ doc('organizations__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('organizations__last_updated') }} in organizations."
+            description: "{{ doc('organizations__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('organizations__identifier') }} in organizations."
+            description: "{{ doc('organizations__identifier') }}"
           - name: name
             data_type: text
-            description: "{{ doc('organizations__name') }} in organizations."
+            description: "{{ doc('organizations__name') }}"
             data_tests:
               - not_null
           - name: active
             data_type: boolean
-            description: "{{ doc('organizations__active') }} in organizations."
+            description: "{{ doc('organizations__active') }}"

--- a/database/model/central-server/fhir/patients.yml
+++ b/database/model/central-server/fhir/patients.yml
@@ -12,66 +12,66 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('patients__id') }} in patients."
+            description: "{{ doc('patients__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('patients__version_id') }} in patients."
+            description: "{{ doc('patients__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('patients__upstream_id') }} in patients."
+            description: "{{ doc('patients__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp without time zone
-            description: "{{ doc('patients__last_updated') }} in patients."
+            description: "{{ doc('patients__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('patients__identifier') }} in patients."
+            description: "{{ doc('patients__identifier') }}"
             data_tests:
               - not_null
           - name: active
             data_type: boolean
-            description: "{{ doc('patients__active') }} in patients."
+            description: "{{ doc('patients__active') }}"
             data_tests:
               - not_null
           - name: name
             data_type: jsonb
-            description: "{{ doc('patients__name') }} in patients."
+            description: "{{ doc('patients__name') }}"
             data_tests:
               - not_null
           - name: telecom
             data_type: jsonb
-            description: "{{ doc('patients__telecom') }} in patients."
+            description: "{{ doc('patients__telecom') }}"
             data_tests:
               - not_null
           - name: gender
             data_type: text
-            description: "{{ doc('patients__gender') }} in patients."
+            description: "{{ doc('patients__gender') }}"
             data_tests:
               - not_null
           - name: birth_date
             data_type: text
-            description: "{{ doc('patients__birth_date') }} in patients."
+            description: "{{ doc('patients__birth_date') }}"
           - name: deceased_date_time
             data_type: text
-            description: "{{ doc('patients__deceased_date_time') }} in patients."
+            description: "{{ doc('patients__deceased_date_time') }}"
           - name: address
             data_type: jsonb
-            description: "{{ doc('patients__address') }} in patients."
+            description: "{{ doc('patients__address') }}"
             data_tests:
               - not_null
           - name: link
             data_type: jsonb
-            description: "{{ doc('patients__link') }} in patients."
+            description: "{{ doc('patients__link') }}"
           - name: extension
             data_type: jsonb
-            description: "{{ doc('patients__extension') }} in patients."
+            description: "{{ doc('patients__extension') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/fhir/practitioners.yml
+++ b/database/model/central-server/fhir/practitioners.yml
@@ -12,31 +12,31 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('practitioners__id') }} in practitioners."
+            description: "{{ doc('practitioners__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('practitioners__version_id') }} in practitioners."
+            description: "{{ doc('practitioners__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('practitioners__upstream_id') }} in practitioners."
+            description: "{{ doc('practitioners__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('practitioners__last_updated') }} in practitioners."
+            description: "{{ doc('practitioners__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('practitioners__identifier') }} in practitioners."
+            description: "{{ doc('practitioners__identifier') }}"
           - name: name
             data_type: jsonb
-            description: "{{ doc('practitioners__name') }} in practitioners."
+            description: "{{ doc('practitioners__name') }}"
           - name: telecom
             data_type: jsonb
-            description: "{{ doc('practitioners__telecom') }} in practitioners."
+            description: "{{ doc('practitioners__telecom') }}"

--- a/database/model/central-server/fhir/service_requests.yml
+++ b/database/model/central-server/fhir/service_requests.yml
@@ -12,73 +12,72 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('service_requests__id') }} in service_requests."
+            description: "{{ doc('service_requests__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('service_requests__version_id') }} in service_requests."
+            description: "{{ doc('service_requests__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying
-            description: "{{ doc('service_requests__upstream_id') }} in service_requests."
+            description: "{{ doc('service_requests__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp without time zone
-            description: "{{ doc('service_requests__last_updated') }} in service_requests."
+            description: "{{ doc('service_requests__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('service_requests__identifier') }} in service_requests."
+            description: "{{ doc('service_requests__identifier') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('service_requests__status') }} in service_requests."
+            description: "{{ doc('service_requests__status') }}"
           - name: intent
             data_type: text
-            description: "{{ doc('service_requests__intent') }} in service_requests."
+            description: "{{ doc('service_requests__intent') }}"
           - name: category
             data_type: jsonb
-            description: "{{ doc('service_requests__category') }} in service_requests."
+            description: "{{ doc('service_requests__category') }}"
             data_tests:
               - not_null
           - name: priority
             data_type: text
-            description: "{{ doc('service_requests__priority') }} in service_requests."
+            description: "{{ doc('service_requests__priority') }}"
           - name: order_detail
             data_type: jsonb
-            description: "{{ doc('service_requests__order_detail') }} in service_requests."
+            description: "{{ doc('service_requests__order_detail') }}"
             data_tests:
               - not_null
           - name: location_code
             data_type: jsonb
-            description: "{{ doc('service_requests__location_code') }} in service_requests."
+            description: "{{ doc('service_requests__location_code') }}"
             data_tests:
               - not_null
           - name: code
             data_type: jsonb
-            description: "{{ doc('service_requests__code') }} in service_requests."
+            description: "{{ doc('service_requests__code') }}"
           - name: subject
             data_type: jsonb
-            description: "{{ doc('service_requests__subject') }} in service_requests."
+            description: "{{ doc('service_requests__subject') }}"
           - name: requester
             data_type: jsonb
-            description: "{{ doc('service_requests__requester') }} in service_requests."
+            description: "{{ doc('service_requests__requester') }}"
           - name: occurrence_date_time
             data_type: text
-            description: "{{ doc('service_requests__occurrence_date_time') }} in
-              service_requests."
+            description: "{{ doc('service_requests__occurrence_date_time') }}"
           - name: encounter
             data_type: jsonb
-            description: "{{ doc('service_requests__encounter') }} in service_requests."
+            description: "{{ doc('service_requests__encounter') }}"
           - name: note
             data_type: jsonb
-            description: "{{ doc('service_requests__note') }} in service_requests."
+            description: "{{ doc('service_requests__note') }}"
           - name: specimen
             data_type: jsonb
-            description: "{{ doc('service_requests__specimen') }} in service_requests."
+            description: "{{ doc('service_requests__specimen') }}"

--- a/database/model/central-server/fhir/specimens.yml
+++ b/database/model/central-server/fhir/specimens.yml
@@ -12,31 +12,31 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('specimens__id') }} in specimens."
+            description: "{{ doc('specimens__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('specimens__version_id') }} in specimens."
+            description: "{{ doc('specimens__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('specimens__upstream_id') }} in specimens."
+            description: "{{ doc('specimens__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('specimens__last_updated') }} in specimens."
+            description: "{{ doc('specimens__last_updated') }}"
             data_tests:
               - not_null
           - name: collection
             data_type: jsonb
-            description: "{{ doc('specimens__collection') }} in specimens."
+            description: "{{ doc('specimens__collection') }}"
           - name: request
             data_type: jsonb
-            description: "{{ doc('specimens__request') }} in specimens."
+            description: "{{ doc('specimens__request') }}"
           - name: type
             data_type: jsonb
-            description: "{{ doc('specimens__type') }} in specimens."
+            description: "{{ doc('specimens__type') }}"

--- a/database/model/central-server/logs/debug_logs.yml
+++ b/database/model/central-server/logs/debug_logs.yml
@@ -12,17 +12,17 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('debug_logs__id') }} in debug_logs."
+            description: "{{ doc('debug_logs__id') }}"
             data_tests:
               - unique
               - not_null
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('debug_logs__type') }} in debug_logs."
+            description: "{{ doc('debug_logs__type') }}"
             data_tests:
               - not_null
           - name: info
             data_type: json
-            description: "{{ doc('debug_logs__info') }} in debug_logs."
+            description: "{{ doc('debug_logs__info') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/logs/fhir_writes.yml
+++ b/database/model/central-server/logs/fhir_writes.yml
@@ -12,35 +12,35 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('fhir_writes__id') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__id') }}"
             data_tests:
               - unique
               - not_null
           - name: created_at
             data_type: timestamp with time zone
-            description: "{{ doc('fhir_writes__created_at') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__created_at') }}"
             data_tests:
               - not_null
           - name: verb
             data_type: text
-            description: "{{ doc('fhir_writes__verb') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__verb') }}"
             data_tests:
               - not_null
           - name: url
             data_type: text
-            description: "{{ doc('fhir_writes__url') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__url') }}"
             data_tests:
               - not_null
           - name: body
             data_type: jsonb
-            description: "{{ doc('fhir_writes__body') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__body') }}"
             data_tests:
               - not_null
           - name: headers
             data_type: jsonb
-            description: "{{ doc('fhir_writes__headers') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__headers') }}"
             data_tests:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('fhir_writes__user_id') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__user_id') }}"

--- a/database/model/central-server/public/certifiable_vaccines.yml
+++ b/database/model/central-server/public/certifiable_vaccines.yml
@@ -30,41 +30,34 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in certifiable_vaccines."
           - name: vaccine_id
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__vaccine_id') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__vaccine_id') }}"
             data_tests:
               - unique
               - not_null
           - name: manufacturer_id
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__manufacturer_id') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__manufacturer_id') }}"
           - name: icd11_drug_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__icd11_drug_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__icd11_drug_code') }}"
             data_tests:
               - not_null
           - name: icd11_disease_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__icd11_disease_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__icd11_disease_code') }}"
             data_tests:
               - not_null
           - name: vaccine_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__vaccine_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__vaccine_code') }}"
             data_tests:
               - not_null
           - name: target_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__target_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__target_code') }}"
           - name: eu_product_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__eu_product_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__eu_product_code') }}"
           - name: maximum_dosage
             data_type: integer
             description: Default value is 1

--- a/database/model/central-server/public/certificate_notifications.yml
+++ b/database/model/central-server/public/certificate_notifications.yml
@@ -26,46 +26,37 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in certificate_notifications."
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__type') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__type') }}"
             data_tests:
               - not_null
           - name: require_signing
             data_type: boolean
-            description: "{{ doc('certificate_notifications__require_signing') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__require_signing') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__patient_id') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__patient_id') }}"
           - name: forward_address
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__forward_address') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__forward_address') }}"
           - name: lab_test_id
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__lab_test_id') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__lab_test_id') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__status') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__status') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('certificate_notifications__error') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__error') }}"
           - name: created_by
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__created_by') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__created_by') }}"
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__lab_request_id') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__lab_request_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
@@ -74,13 +65,10 @@ sources:
               - not_null
           - name: printed_date
             data_type: character(10)
-            description: "{{ doc('certificate_notifications__printed_date') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__printed_date') }}"
           - name: facility_name
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__facility_name') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__facility_name') }}"
           - name: language
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__language') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__language') }}"

--- a/database/model/central-server/public/death_revert_logs.yml
+++ b/database/model/central-server/public/death_revert_logs.yml
@@ -30,24 +30,22 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in death_revert_logs."
           - name: revert_time
             data_type: character(19)
-            description: "{{ doc('death_revert_logs__revert_time') }} in death_revert_logs."
+            description: "{{ doc('death_revert_logs__revert_time') }}"
             data_tests:
               - not_null
           - name: death_data_id
             data_type: character varying(255)
-            description: "{{ doc('death_revert_logs__death_data_id') }} in
-              death_revert_logs."
+            description: "{{ doc('death_revert_logs__death_data_id') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('death_revert_logs__patient_id') }} in death_revert_logs."
+            description: "{{ doc('death_revert_logs__patient_id') }}"
             data_tests:
               - not_null
           - name: reverted_by_id
             data_type: character varying(255)
-            description: "{{ doc('death_revert_logs__reverted_by_id') }} in
-              death_revert_logs."
+            description: "{{ doc('death_revert_logs__reverted_by_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/document_metadata.yml
+++ b/database/model/central-server/public/document_metadata.yml
@@ -17,39 +17,34 @@ sources:
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('document_metadata__name') }} in document_metadata."
+            description: "{{ doc('document_metadata__name') }}"
             data_tests:
               - not_null
           - name: type
             data_type: text
-            description: "{{ doc('document_metadata__type') }} in document_metadata."
+            description: "{{ doc('document_metadata__type') }}"
             data_tests:
               - not_null
           - name: document_created_at
             data_type: character(19)
-            description: "{{ doc('document_metadata__document_created_at') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_created_at') }}"
           - name: document_uploaded_at
             data_type: character(19)
-            description: "{{ doc('document_metadata__document_uploaded_at') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_uploaded_at') }}"
             data_tests:
               - not_null
           - name: document_owner
             data_type: text
-            description: "{{ doc('document_metadata__document_owner') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_owner') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__patient_id') }} in document_metadata."
+            description: "{{ doc('document_metadata__patient_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__encounter_id') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__encounter_id') }}"
           - name: attachment_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__attachment_id') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__attachment_id') }}"
             data_tests:
               - not_null
           - name: created_at
@@ -63,11 +58,10 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in document_metadata."
           - name: department_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__department_id') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__department_id') }}"
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__note') }} in document_metadata."
+            description: "{{ doc('document_metadata__note') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in document_metadata."
@@ -75,14 +69,12 @@ sources:
               - not_null
           - name: document_created_at_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('document_metadata__document_created_at_legacy') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_created_at_legacy') }}"
           - name: document_uploaded_at_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('document_metadata__document_uploaded_at_legacy') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_uploaded_at_legacy') }}"
           - name: source
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__source') }} in document_metadata."
+            description: "{{ doc('document_metadata__source') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/encounter_diets.yml
+++ b/database/model/central-server/public/encounter_diets.yml
@@ -25,7 +25,7 @@ sources:
                   field: id
           - name: diet_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_diets__diet_id') }} in encounter_diets."
+            description: "{{ doc('encounter_diets__diet_id') }}"
             data_tests:
               - not_null
               - dbt_utils.relationships_where:

--- a/database/model/central-server/public/encounter_history.yml
+++ b/database/model/central-server/public/encounter_history.yml
@@ -35,30 +35,27 @@ sources:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__encounter_id') }} in
-              encounter_history."
+            description: "{{ doc('encounter_history__encounter_id') }}"
             data_tests:
               - not_null
           - name: department_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__department_id') }} in
-              encounter_history."
+            description: "{{ doc('encounter_history__department_id') }}"
             data_tests:
               - not_null
           - name: location_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__location_id') }} in encounter_history."
+            description: "{{ doc('encounter_history__location_id') }}"
             data_tests:
               - not_null
           - name: examiner_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__examiner_id') }} in encounter_history."
+            description: "{{ doc('encounter_history__examiner_id') }}"
             data_tests:
               - not_null
           - name: encounter_type
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__encounter_type') }} in
-              encounter_history."
+            description: "{{ doc('encounter_history__encounter_type') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -68,7 +65,7 @@ sources:
               - not_null
           - name: actor_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__actor_id') }} in encounter_history."
+            description: "{{ doc('encounter_history__actor_id') }}"
           - name: change_type
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__change_type') }} in encounter_history."
+            description: "{{ doc('encounter_history__change_type') }}"

--- a/database/model/central-server/public/encounter_medications.yml
+++ b/database/model/central-server/public/encounter_medications.yml
@@ -35,91 +35,71 @@ sources:
               - not_null
           - name: end_date
             data_type: character(19)
-            description: "{{ doc('encounter_medications__end_date') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__end_date') }}"
           - name: prescription
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__prescription') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__prescription') }}"
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__note') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__note') }}"
           - name: indication
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__indication') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__indication') }}"
           - name: route
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__route') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__route') }}"
           - name: qty_morning
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_morning') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_morning') }}"
           - name: qty_lunch
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_lunch') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_lunch') }}"
           - name: qty_evening
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_evening') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_evening') }}"
           - name: qty_night
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_night') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_night') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__encounter_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__encounter_id') }}"
           - name: medication_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__medication_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__medication_id') }}"
           - name: prescriber_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__prescriber_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__prescriber_id') }}"
           - name: quantity
             data_type: integer
-            description: "{{ doc('encounter_medications__quantity') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__quantity') }}"
             data_tests:
               - not_null
           - name: discontinued
             data_type: boolean
-            description: "{{ doc('encounter_medications__discontinued') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinued') }}"
           - name: discontinuing_clinician_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__discontinuing_clinician_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinuing_clinician_id') }}"
           - name: discontinuing_reason
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__discontinuing_reason') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinuing_reason') }}"
           - name: repeats
             data_type: integer
-            description: "{{ doc('encounter_medications__repeats') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__repeats') }}"
           - name: is_discharge
             data_type: boolean
-            description: "{{ doc('encounter_medications__is_discharge') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__is_discharge') }}"
             data_tests:
               - not_null
           - name: discontinued_date
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__discontinued_date') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinued_date') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in encounter_medications."
           - name: end_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('encounter_medications__end_date_legacy') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__end_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/imaging_area_external_codes.yml
+++ b/database/model/central-server/public/imaging_area_external_codes.yml
@@ -36,21 +36,18 @@ sources:
               - not_null
           - name: area_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_area_external_codes__area_id') }} in
-              imaging_area_external_codes."
+            description: "{{ doc('imaging_area_external_codes__area_id') }}"
             data_tests:
               - unique
               - not_null
           - name: code
             data_type: text
-            description: "{{ doc('imaging_area_external_codes__code') }} in
-              imaging_area_external_codes."
+            description: "{{ doc('imaging_area_external_codes__code') }}"
             data_tests:
               - not_null
           - name: description
             data_type: text
-            description: "{{ doc('imaging_area_external_codes__description') }} in
-              imaging_area_external_codes."
+            description: "{{ doc('imaging_area_external_codes__description') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/imaging_request_areas.yml
+++ b/database/model/central-server/public/imaging_request_areas.yml
@@ -30,14 +30,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in imaging_request_areas."
           - name: imaging_request_id
             data_type: character varying
-            description: "{{ doc('imaging_request_areas__imaging_request_id') }} in
-              imaging_request_areas."
+            description: "{{ doc('imaging_request_areas__imaging_request_id') }}"
             data_tests:
               - not_null
           - name: area_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_request_areas__area_id') }} in
-              imaging_request_areas."
+            description: "{{ doc('imaging_request_areas__area_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/imaging_requests.yml
+++ b/database/model/central-server/public/imaging_requests.yml
@@ -30,45 +30,39 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in imaging_requests."
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__status') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__status') }}"
           - name: requested_date
             data_type: character(19)
-            description: "{{ doc('imaging_requests__requested_date') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__requested_date') }}"
             data_tests:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__encounter_id') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__encounter_id') }}"
           - name: requested_by_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__requested_by_id') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__requested_by_id') }}"
           - name: legacy_results
             data_type: text
-            description: "{{ doc('imaging_requests__legacy_results') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__legacy_results') }}"
           - name: completed_by_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__completed_by_id') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__completed_by_id') }}"
           - name: location_id
             data_type: character varying(255)
             description: "[Deprecated]"
           - name: imaging_type
             data_type: character varying(31)
-            description: "{{ doc('imaging_requests__imaging_type') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__imaging_type') }}"
           - name: requested_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('imaging_requests__requested_date_legacy') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__requested_date_legacy') }}"
           - name: priority
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__priority') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__priority') }}"
           - name: location_group_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__location_group_id') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__location_group_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in imaging_requests."
@@ -76,10 +70,9 @@ sources:
               - not_null
           - name: reason_for_cancellation
             data_type: character varying(1024)
-            description: "{{ doc('imaging_requests__reason_for_cancellation') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__reason_for_cancellation') }}"
           - name: display_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__display_id') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__display_id') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/imaging_results.yml
+++ b/database/model/central-server/public/imaging_results.yml
@@ -40,21 +40,20 @@ sources:
               - not_null
           - name: imaging_request_id
             data_type: character varying
-            description: "{{ doc('imaging_results__imaging_request_id') }} in
-              imaging_results."
+            description: "{{ doc('imaging_results__imaging_request_id') }}"
             data_tests:
               - not_null
           - name: completed_by_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_results__completed_by_id') }} in imaging_results."
+            description: "{{ doc('imaging_results__completed_by_id') }}"
           - name: description
             data_type: text
-            description: "{{ doc('imaging_results__description') }} in imaging_results."
+            description: "{{ doc('imaging_results__description') }}"
           - name: external_code
             data_type: text
-            description: "{{ doc('imaging_results__external_code') }} in imaging_results."
+            description: "{{ doc('imaging_results__external_code') }}"
           - name: completed_at
             data_type: character(19)
-            description: "{{ doc('imaging_results__completed_at') }} in imaging_results."
+            description: "{{ doc('imaging_results__completed_at') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/invoice_insurer_payments.yml
+++ b/database/model/central-server/public/invoice_insurer_payments.yml
@@ -17,27 +17,23 @@ sources:
               - not_null
           - name: invoice_payment_id
             data_type: uuid
-            description: "{{ doc('invoice_insurer_payments__invoice_payment_id') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__invoice_payment_id') }}"
             data_tests:
               - unique
               - not_null
           - name: insurer_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurer_payments__insurer_id') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__insurer_id') }}"
             data_tests:
               - not_null
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurer_payments__status') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__status') }}"
             data_tests:
               - not_null
           - name: reason
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurer_payments__reason') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__reason') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in invoice_insurer_payments."

--- a/database/model/central-server/public/invoice_insurers.yml
+++ b/database/model/central-server/public/invoice_insurers.yml
@@ -17,17 +17,17 @@ sources:
               - not_null
           - name: invoice_id
             data_type: uuid
-            description: "{{ doc('invoice_insurers__invoice_id') }} in invoice_insurers."
+            description: "{{ doc('invoice_insurers__invoice_id') }}"
             data_tests:
               - not_null
           - name: insurer_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurers__insurer_id') }} in invoice_insurers."
+            description: "{{ doc('invoice_insurers__insurer_id') }}"
             data_tests:
               - not_null
           - name: percentage
             data_type: numeric
-            description: "{{ doc('invoice_insurers__percentage') }} in invoice_insurers."
+            description: "{{ doc('invoice_insurers__percentage') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/central-server/public/invoice_item_discounts.yml
+++ b/database/model/central-server/public/invoice_item_discounts.yml
@@ -17,20 +17,17 @@ sources:
               - not_null
           - name: invoice_item_id
             data_type: uuid
-            description: "{{ doc('invoice_item_discounts__invoice_item_id') }} in
-              invoice_item_discounts."
+            description: "{{ doc('invoice_item_discounts__invoice_item_id') }}"
             data_tests:
               - not_null
           - name: percentage
             data_type: numeric
-            description: "{{ doc('invoice_item_discounts__percentage') }} in
-              invoice_item_discounts."
+            description: "{{ doc('invoice_item_discounts__percentage') }}"
             data_tests:
               - not_null
           - name: reason
             data_type: character varying(255)
-            description: "{{ doc('invoice_item_discounts__reason') }} in
-              invoice_item_discounts."
+            description: "{{ doc('invoice_item_discounts__reason') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in invoice_item_discounts."

--- a/database/model/central-server/public/invoice_items.yml
+++ b/database/model/central-server/public/invoice_items.yml
@@ -17,40 +17,40 @@ sources:
               - not_null
           - name: invoice_id
             data_type: uuid
-            description: "{{ doc('invoice_items__invoice_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__invoice_id') }}"
             data_tests:
               - not_null
           - name: order_date
             data_type: character(10)
-            description: "{{ doc('invoice_items__order_date') }} in invoice_items."
+            description: "{{ doc('invoice_items__order_date') }}"
             data_tests:
               - not_null
           - name: product_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__product_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_id') }}"
           - name: quantity
             data_type: integer
-            description: "{{ doc('invoice_items__quantity') }} in invoice_items."
+            description: "{{ doc('invoice_items__quantity') }}"
             data_tests:
               - not_null
           - name: product_name
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__product_name') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_name') }}"
             data_tests:
               - not_null
           - name: product_price
             data_type: numeric
-            description: "{{ doc('invoice_items__product_price') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_price') }}"
             data_tests:
               - not_null
           - name: ordered_by_user_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__ordered_by_user_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__ordered_by_user_id') }}"
             data_tests:
               - not_null
           - name: source_id
             data_type: uuid
-            description: "{{ doc('invoice_items__source_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__source_id') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in invoice_items."
@@ -64,16 +64,15 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in invoice_items."
           - name: product_code
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__product_code') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_code') }}"
             data_tests:
               - not_null
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__note') }} in invoice_items."
+            description: "{{ doc('invoice_items__note') }}"
           - name: product_discountable
             data_type: boolean
-            description: "{{ doc('invoice_items__product_discountable') }} in
-              invoice_items."
+            description: "{{ doc('invoice_items__product_discountable') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/invoice_patient_payments.yml
+++ b/database/model/central-server/public/invoice_patient_payments.yml
@@ -17,15 +17,13 @@ sources:
               - not_null
           - name: invoice_payment_id
             data_type: uuid
-            description: "{{ doc('invoice_patient_payments__invoice_payment_id') }} in
-              invoice_patient_payments."
+            description: "{{ doc('invoice_patient_payments__invoice_payment_id') }}"
             data_tests:
               - unique
               - not_null
           - name: method_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_patient_payments__method_id') }} in
-              invoice_patient_payments."
+            description: "{{ doc('invoice_patient_payments__method_id') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/central-server/public/invoice_payments.yml
+++ b/database/model/central-server/public/invoice_payments.yml
@@ -17,7 +17,7 @@ sources:
               - not_null
           - name: invoice_id
             data_type: uuid
-            description: "{{ doc('invoice_payments__invoice_id') }} in invoice_payments."
+            description: "{{ doc('invoice_payments__invoice_id') }}"
             data_tests:
               - not_null
           - name: date
@@ -27,13 +27,12 @@ sources:
               - not_null
           - name: receipt_number
             data_type: character varying(255)
-            description: "{{ doc('invoice_payments__receipt_number') }} in
-              invoice_payments."
+            description: "{{ doc('invoice_payments__receipt_number') }}"
             data_tests:
               - not_null
           - name: amount
             data_type: numeric
-            description: "{{ doc('invoice_payments__amount') }} in invoice_payments."
+            description: "{{ doc('invoice_payments__amount') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/central-server/public/invoice_products.yml
+++ b/database/model/central-server/public/invoice_products.yml
@@ -17,17 +17,17 @@ sources:
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('invoice_products__name') }} in invoice_products."
+            description: "{{ doc('invoice_products__name') }}"
             data_tests:
               - not_null
           - name: price
             data_type: numeric
-            description: "{{ doc('invoice_products__price') }} in invoice_products."
+            description: "{{ doc('invoice_products__price') }}"
             data_tests:
               - not_null
           - name: discountable
             data_type: boolean
-            description: "{{ doc('invoice_products__discountable') }} in invoice_products."
+            description: "{{ doc('invoice_products__discountable') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/central-server/public/invoices.yml
+++ b/database/model/central-server/public/invoices.yml
@@ -17,7 +17,7 @@ sources:
               - not_null
           - name: display_id
             data_type: character varying(255)
-            description: "{{ doc('invoices__display_id') }} in invoices."
+            description: "{{ doc('invoices__display_id') }}"
             data_tests:
               - not_null
           - name: date
@@ -27,12 +27,12 @@ sources:
               - not_null
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('invoices__status') }} in invoices."
+            description: "{{ doc('invoices__status') }}"
             data_tests:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('invoices__encounter_id') }} in invoices."
+            description: "{{ doc('invoices__encounter_id') }}"
             data_tests:
               - not_null
           - name: created_at
@@ -48,12 +48,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in invoices."
           - name: patient_payment_status
             data_type: character varying(255)
-            description: "{{ doc('invoices__patient_payment_status') }} in invoices."
+            description: "{{ doc('invoices__patient_payment_status') }}"
             data_tests:
               - not_null
           - name: insurer_payment_status
             data_type: character varying(255)
-            description: "{{ doc('invoices__insurer_payment_status') }} in invoices."
+            description: "{{ doc('invoices__insurer_payment_status') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/ips_requests.yml
+++ b/database/model/central-server/public/ips_requests.yml
@@ -30,27 +30,27 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in ips_requests."
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__patient_id') }} in ips_requests."
+            description: "{{ doc('ips_requests__patient_id') }}"
             data_tests:
               - not_null
           - name: created_by
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__created_by') }} in ips_requests."
+            description: "{{ doc('ips_requests__created_by') }}"
             data_tests:
               - not_null
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__status') }} in ips_requests."
+            description: "{{ doc('ips_requests__status') }}"
             data_tests:
               - not_null
           - name: email
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__email') }} in ips_requests."
+            description: "{{ doc('ips_requests__email') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('ips_requests__error') }} in ips_requests."
+            description: "{{ doc('ips_requests__error') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in ips_requests."

--- a/database/model/central-server/public/lab_request_attachments.yml
+++ b/database/model/central-server/public/lab_request_attachments.yml
@@ -30,24 +30,20 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_request_attachments."
           - name: attachment_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__attachment_id') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__attachment_id') }}"
             data_tests:
               - not_null
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__lab_request_id') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__lab_request_id') }}"
             data_tests:
               - not_null
           - name: title
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__title') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__title') }}"
           - name: replaced_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__replaced_by_id') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__replaced_by_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/lab_request_logs.yml
+++ b/database/model/central-server/public/lab_request_logs.yml
@@ -26,16 +26,15 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_request_logs."
           - name: status
             data_type: character varying(31)
-            description: "{{ doc('lab_request_logs__status') }} in lab_request_logs."
+            description: "{{ doc('lab_request_logs__status') }}"
             data_tests:
               - not_null
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_logs__lab_request_id') }} in
-              lab_request_logs."
+            description: "{{ doc('lab_request_logs__lab_request_id') }}"
           - name: updated_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_logs__updated_by_id') }} in lab_request_logs."
+            description: "{{ doc('lab_request_logs__updated_by_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_request_logs."

--- a/database/model/central-server/public/lab_requests.yml
+++ b/database/model/central-server/public/lab_requests.yml
@@ -30,52 +30,51 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_requests."
           - name: sample_time
             data_type: character(19)
-            description: "{{ doc('lab_requests__sample_time') }} in lab_requests."
+            description: "{{ doc('lab_requests__sample_time') }}"
           - name: requested_date
             data_type: character(19)
-            description: "{{ doc('lab_requests__requested_date') }} in lab_requests."
+            description: "{{ doc('lab_requests__requested_date') }}"
           - name: urgent
             data_type: boolean
             description: "[Deprecated]"
           - name: specimen_attached
             data_type: boolean
-            description: "{{ doc('lab_requests__specimen_attached') }} in lab_requests."
+            description: "{{ doc('lab_requests__specimen_attached') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__status') }} in lab_requests."
+            description: "{{ doc('lab_requests__status') }}"
           - name: senaite_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__senaite_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__senaite_id') }}"
           - name: sample_id
             data_type: character varying(255)
             description: "[Deprecated]"
           - name: requested_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__requested_by_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__requested_by_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__encounter_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__encounter_id') }}"
           - name: lab_test_category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_test_category_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__lab_test_category_id') }}"
           - name: display_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__display_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__display_id') }}"
             data_tests:
               - not_null
           - name: lab_test_priority_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_test_priority_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__lab_test_priority_id') }}"
           - name: lab_test_laboratory_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_test_laboratory_id') }} in
-              lab_requests."
+            description: "{{ doc('lab_requests__lab_test_laboratory_id') }}"
           - name: sample_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('lab_requests__sample_time_legacy') }} in lab_requests."
+            description: "{{ doc('lab_requests__sample_time_legacy') }}"
           - name: requested_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('lab_requests__requested_date_legacy') }} in lab_requests."
+            description: "{{ doc('lab_requests__requested_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_requests."
@@ -83,24 +82,22 @@ sources:
               - not_null
           - name: reason_for_cancellation
             data_type: character varying(31)
-            description: "{{ doc('lab_requests__reason_for_cancellation') }} in
-              lab_requests."
+            description: "{{ doc('lab_requests__reason_for_cancellation') }}"
           - name: published_date
             data_type: character(19)
-            description: "{{ doc('lab_requests__published_date') }} in lab_requests."
+            description: "{{ doc('lab_requests__published_date') }}"
           - name: department_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__department_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__department_id') }}"
           - name: lab_test_panel_request_id
             data_type: uuid
-            description: "{{ doc('lab_requests__lab_test_panel_request_id') }} in
-              lab_requests."
+            description: "{{ doc('lab_requests__lab_test_panel_request_id') }}"
           - name: lab_sample_site_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_sample_site_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__lab_sample_site_id') }}"
           - name: specimen_type_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__specimen_type_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__specimen_type_id') }}"
           - name: collected_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__collected_by_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__collected_by_id') }}"

--- a/database/model/central-server/public/lab_test_panel_lab_test_types.yml
+++ b/database/model/central-server/public/lab_test_panel_lab_test_types.yml
@@ -27,15 +27,13 @@ sources:
               lab_test_panel_lab_test_types."
           - name: lab_test_panel_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_panel_id') }} in
-              lab_test_panel_lab_test_types."
+            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_panel_id') }}"
             data_tests:
               - unique
               - not_null
           - name: lab_test_type_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_type_id') }} in
-              lab_test_panel_lab_test_types."
+            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_type_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/central-server/public/lab_test_panel_requests.yml
+++ b/database/model/central-server/public/lab_test_panel_requests.yml
@@ -30,14 +30,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_test_panel_requests."
           - name: lab_test_panel_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_requests__lab_test_panel_id') }} in
-              lab_test_panel_requests."
+            description: "{{ doc('lab_test_panel_requests__lab_test_panel_id') }}"
             data_tests:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_requests__encounter_id') }} in
-              lab_test_panel_requests."
+            description: "{{ doc('lab_test_panel_requests__encounter_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/lab_test_panels.yml
+++ b/database/model/central-server/public/lab_test_panels.yml
@@ -30,12 +30,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_test_panels."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panels__name') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__name') }}"
             data_tests:
               - not_null
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panels__code') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__code') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -45,10 +45,10 @@ sources:
               - not_null
           - name: external_code
             data_type: text
-            description: "{{ doc('lab_test_panels__external_code') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__external_code') }}"
           - name: category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panels__category_id') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__category_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_test_panels."

--- a/database/model/central-server/public/lab_test_types.yml
+++ b/database/model/central-server/public/lab_test_types.yml
@@ -30,46 +30,45 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_test_types."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__code') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__code') }}"
             data_tests:
               - not_null
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__name') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__name') }}"
             data_tests:
               - not_null
           - name: unit
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__unit') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__unit') }}"
             data_tests:
               - not_null
           - name: male_min
             data_type: double precision
-            description: "{{ doc('lab_test_types__male_min') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__male_min') }}"
           - name: male_max
             data_type: double precision
-            description: "{{ doc('lab_test_types__male_max') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__male_max') }}"
           - name: female_min
             data_type: double precision
-            description: "{{ doc('lab_test_types__female_min') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__female_min') }}"
           - name: female_max
             data_type: double precision
-            description: "{{ doc('lab_test_types__female_max') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__female_max') }}"
           - name: range_text
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__range_text') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__range_text') }}"
           - name: result_type
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__result_type') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__result_type') }}"
             data_tests:
               - not_null
           - name: options
             data_type: text
-            description: "{{ doc('lab_test_types__options') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__options') }}"
           - name: lab_test_category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__lab_test_category_id') }} in
-              lab_test_types."
+            description: "{{ doc('lab_test_types__lab_test_category_id') }}"
           - name: visibility_status
             data_type: text
             description: "{{ doc('generic__visibility_status') }} in lab_test_types."
@@ -80,4 +79,4 @@ sources:
               - not_null
           - name: external_code
             data_type: text
-            description: "{{ doc('lab_test_types__external_code') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__external_code') }}"

--- a/database/model/central-server/public/lab_tests.yml
+++ b/database/model/central-server/public/lab_tests.yml
@@ -35,41 +35,41 @@ sources:
               - not_null
           - name: status
             data_type: character varying(31)
-            description: "{{ doc('lab_tests__status') }} in lab_tests."
+            description: "{{ doc('lab_tests__status') }}"
             data_tests:
               - not_null
           - name: result
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__result') }} in lab_tests."
+            description: "{{ doc('lab_tests__result') }}"
             data_tests:
               - not_null
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__lab_request_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__lab_request_id') }}"
           - name: lab_test_type_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__lab_test_type_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__lab_test_type_id') }}"
           - name: category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__category_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__category_id') }}"
           - name: lab_test_method_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__lab_test_method_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__lab_test_method_id') }}"
           - name: laboratory_officer
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__laboratory_officer') }} in lab_tests."
+            description: "{{ doc('lab_tests__laboratory_officer') }}"
           - name: completed_date
             data_type: character(19)
-            description: "{{ doc('lab_tests__completed_date') }} in lab_tests."
+            description: "{{ doc('lab_tests__completed_date') }}"
           - name: verification
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__verification') }} in lab_tests."
+            description: "{{ doc('lab_tests__verification') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in lab_tests."
           - name: completed_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('lab_tests__completed_date_legacy') }} in lab_tests."
+            description: "{{ doc('lab_tests__completed_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_tests."

--- a/database/model/central-server/public/local_system_facts.yml
+++ b/database/model/central-server/public/local_system_facts.yml
@@ -26,9 +26,9 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in local_system_facts."
           - name: key
             data_type: character varying(255)
-            description: "{{ doc('local_system_facts__key') }} in local_system_facts."
+            description: "{{ doc('local_system_facts__key') }}"
             data_tests:
               - not_null
           - name: value
             data_type: text
-            description: "{{ doc('local_system_facts__value') }} in local_system_facts."
+            description: "{{ doc('local_system_facts__value') }}"

--- a/database/model/central-server/public/note_items.yml
+++ b/database/model/central-server/public/note_items.yml
@@ -31,21 +31,21 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in note_items."
           - name: note_page_id
             data_type: uuid
-            description: "{{ doc('note_items__note_page_id') }} in note_items."
+            description: "{{ doc('note_items__note_page_id') }}"
             data_tests:
               - not_null
           - name: revised_by_id
             data_type: character varying(255)
-            description: "{{ doc('note_items__revised_by_id') }} in note_items."
+            description: "{{ doc('note_items__revised_by_id') }}"
           - name: author_id
             data_type: character varying(255)
-            description: "{{ doc('note_items__author_id') }} in note_items."
+            description: "{{ doc('note_items__author_id') }}"
           - name: on_behalf_of_id
             data_type: character varying(255)
-            description: "{{ doc('note_items__on_behalf_of_id') }} in note_items."
+            description: "{{ doc('note_items__on_behalf_of_id') }}"
           - name: content
             data_type: text
-            description: "{{ doc('note_items__content') }} in note_items."
+            description: "{{ doc('note_items__content') }}"
             data_tests:
               - not_null
           - name: date

--- a/database/model/central-server/public/note_pages.yml
+++ b/database/model/central-server/public/note_pages.yml
@@ -31,17 +31,17 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in note_pages."
           - name: note_type
             data_type: character varying(255)
-            description: "{{ doc('note_pages__note_type') }} in note_pages."
+            description: "{{ doc('note_pages__note_type') }}"
             data_tests:
               - not_null
           - name: record_id
             data_type: character varying(255)
-            description: "{{ doc('note_pages__record_id') }} in note_pages."
+            description: "{{ doc('note_pages__record_id') }}"
             data_tests:
               - not_null
           - name: record_type
             data_type: character varying(255)
-            description: "{{ doc('note_pages__record_type') }} in note_pages."
+            description: "{{ doc('note_pages__record_type') }}"
             data_tests:
               - not_null
           - name: date

--- a/database/model/central-server/public/notes_legacy.yml
+++ b/database/model/central-server/public/notes_legacy.yml
@@ -31,12 +31,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in notes_legacy."
           - name: record_id
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__record_id') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__record_id') }}"
             data_tests:
               - not_null
           - name: record_type
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__record_type') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__record_type') }}"
             data_tests:
               - not_null
           - name: date
@@ -46,18 +46,18 @@ sources:
               - not_null
           - name: note_type
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__note_type') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__note_type') }}"
           - name: content
             data_type: text
-            description: "{{ doc('notes_legacy__content') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__content') }}"
             data_tests:
               - not_null
           - name: author_id
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__author_id') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__author_id') }}"
           - name: on_behalf_of_id
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__on_behalf_of_id') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__on_behalf_of_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in notes_legacy."

--- a/database/model/central-server/public/one_time_logins.yml
+++ b/database/model/central-server/public/one_time_logins.yml
@@ -17,12 +17,12 @@ sources:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('one_time_logins__user_id') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__user_id') }}"
             data_tests:
               - not_null
           - name: token
             data_type: character varying(255)
-            description: "{{ doc('one_time_logins__token') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__token') }}"
             data_tests:
               - not_null
           - name: created_at
@@ -36,9 +36,9 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in one_time_logins."
           - name: expires_at
             data_type: timestamp with time zone
-            description: "{{ doc('one_time_logins__expires_at') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__expires_at') }}"
             data_tests:
               - not_null
           - name: used_at
             data_type: timestamp with time zone
-            description: "{{ doc('one_time_logins__used_at') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__used_at') }}"

--- a/database/model/central-server/public/patient_additional_data.yml
+++ b/database/model/central-server/public/patient_additional_data.yml
@@ -20,138 +20,106 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_additional_data."
           - name: place_of_birth
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__place_of_birth') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__place_of_birth') }}"
           - name: primary_contact_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__primary_contact_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__primary_contact_number') }}"
           - name: secondary_contact_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__secondary_contact_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__secondary_contact_number') }}"
           - name: marital_status
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__marital_status') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__marital_status') }}"
           - name: city_town
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__city_town') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__city_town') }}"
           - name: street_village
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__street_village') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__street_village') }}"
           - name: educational_level
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__educational_level') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__educational_level') }}"
           - name: social_media
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__social_media') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__social_media') }}"
           - name: blood_type
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__blood_type') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__blood_type') }}"
           - name: title
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__title') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__title') }}"
           - name: ethnicity_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__ethnicity_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__ethnicity_id') }}"
           - name: nationality_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__nationality_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__nationality_id') }}"
           - name: country_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__country_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__country_id') }}"
           - name: division_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__division_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__division_id') }}"
           - name: subdivision_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__subdivision_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__subdivision_id') }}"
           - name: medical_area_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__medical_area_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__medical_area_id') }}"
           - name: nursing_zone_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__nursing_zone_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__nursing_zone_id') }}"
           - name: settlement_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__settlement_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__settlement_id') }}"
           - name: occupation_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__occupation_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__occupation_id') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__patient_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__patient_id') }}"
             data_tests:
               - unique
               - not_null
           - name: birth_certificate
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__birth_certificate') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__birth_certificate') }}"
           - name: driving_license
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__driving_license') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__driving_license') }}"
           - name: passport
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__passport') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__passport') }}"
           - name: religion_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__religion_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__religion_id') }}"
           - name: patient_billing_type_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__patient_billing_type_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__patient_billing_type_id') }}"
           - name: country_of_birth_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__country_of_birth_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__country_of_birth_id') }}"
           - name: registered_by_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__registered_by_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__registered_by_id') }}"
           - name: emergency_contact_name
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__emergency_contact_name') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__emergency_contact_name') }}"
           - name: emergency_contact_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__emergency_contact_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__emergency_contact_number') }}"
           - name: mother_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__mother_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__mother_id') }}"
           - name: father_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__father_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__father_id') }}"
           - name: id
             data_type: text
             description: "{{ doc('generic__id') }} in patient_additional_data."
           - name: updated_at_by_field
             data_type: json
-            description: "{{ doc('patient_additional_data__updated_at_by_field') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__updated_at_by_field') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
@@ -160,17 +128,13 @@ sources:
               - not_null
           - name: health_center_id
             data_type: text
-            description: "{{ doc('patient_additional_data__health_center_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__health_center_id') }}"
           - name: secondary_village_id
             data_type: text
-            description: "{{ doc('patient_additional_data__secondary_village_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__secondary_village_id') }}"
           - name: insurer_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__insurer_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__insurer_id') }}"
           - name: insurer_policy_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__insurer_policy_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__insurer_policy_number') }}"

--- a/database/model/central-server/public/patient_allergies.yml
+++ b/database/model/central-server/public/patient_allergies.yml
@@ -30,27 +30,24 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_allergies."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__note') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_allergies__recorded_date') }} in
-              patient_allergies."
+            description: "{{ doc('patient_allergies__recorded_date') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__patient_id') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__patient_id') }}"
           - name: practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__practitioner_id') }} in
-              patient_allergies."
+            description: "{{ doc('patient_allergies__practitioner_id') }}"
           - name: allergy_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__allergy_id') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__allergy_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_allergies__recorded_date_legacy') }} in
-              patient_allergies."
+            description: "{{ doc('patient_allergies__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_allergies."
@@ -58,4 +55,4 @@ sources:
               - not_null
           - name: reaction_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__reaction_id') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__reaction_id') }}"

--- a/database/model/central-server/public/patient_birth_data.yml
+++ b/database/model/central-server/public/patient_birth_data.yml
@@ -24,67 +24,52 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_birth_data."
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__patient_id') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__patient_id') }}"
             data_tests:
               - unique
               - not_null
           - name: birth_weight
             data_type: numeric
-            description: "{{ doc('patient_birth_data__birth_weight') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_weight') }}"
           - name: birth_length
             data_type: numeric
-            description: "{{ doc('patient_birth_data__birth_length') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_length') }}"
           - name: birth_delivery_type
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__birth_delivery_type') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_delivery_type') }}"
           - name: gestational_age_estimate
             data_type: double precision
-            description: "{{ doc('patient_birth_data__gestational_age_estimate') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__gestational_age_estimate') }}"
           - name: apgar_score_one_minute
             data_type: integer
-            description: "{{ doc('patient_birth_data__apgar_score_one_minute') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__apgar_score_one_minute') }}"
           - name: apgar_score_five_minutes
             data_type: integer
-            description: "{{ doc('patient_birth_data__apgar_score_five_minutes') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__apgar_score_five_minutes') }}"
           - name: apgar_score_ten_minutes
             data_type: integer
-            description: "{{ doc('patient_birth_data__apgar_score_ten_minutes') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__apgar_score_ten_minutes') }}"
           - name: time_of_birth
             data_type: character(19)
-            description: "{{ doc('patient_birth_data__time_of_birth') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__time_of_birth') }}"
           - name: birth_type
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__birth_type') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_type') }}"
           - name: attendant_at_birth
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__attendant_at_birth') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__attendant_at_birth') }}"
           - name: name_of_attendant_at_birth
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__name_of_attendant_at_birth') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__name_of_attendant_at_birth') }}"
           - name: birth_facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__birth_facility_id') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_facility_id') }}"
           - name: registered_birth_place
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__registered_birth_place') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__registered_birth_place') }}"
           - name: time_of_birth_legacy
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__time_of_birth_legacy') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__time_of_birth_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_birth_data."

--- a/database/model/central-server/public/patient_care_plans.yml
+++ b/database/model/central-server/public/patient_care_plans.yml
@@ -35,16 +35,13 @@ sources:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_care_plans__patient_id') }} in
-              patient_care_plans."
+            description: "{{ doc('patient_care_plans__patient_id') }}"
           - name: examiner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_care_plans__examiner_id') }} in
-              patient_care_plans."
+            description: "{{ doc('patient_care_plans__examiner_id') }}"
           - name: care_plan_id
             data_type: character varying(255)
-            description: "{{ doc('patient_care_plans__care_plan_id') }} in
-              patient_care_plans."
+            description: "{{ doc('patient_care_plans__care_plan_id') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in patient_care_plans."

--- a/database/model/central-server/public/patient_communications.yml
+++ b/database/model/central-server/public/patient_communications.yml
@@ -30,51 +30,40 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_communications."
           - name: type
             data_type: text
-            description: "{{ doc('patient_communications__type') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__type') }}"
             data_tests:
               - not_null
           - name: channel
             data_type: text
-            description: "{{ doc('patient_communications__channel') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__channel') }}"
             data_tests:
               - not_null
           - name: subject
             data_type: text
-            description: "{{ doc('patient_communications__subject') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__subject') }}"
           - name: content
             data_type: text
-            description: "{{ doc('patient_communications__content') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__content') }}"
           - name: status
             data_type: user-defined
-            description: "{{ doc('patient_communications__status') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__status') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('patient_communications__error') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__error') }}"
           - name: retry_count
             data_type: integer
-            description: "{{ doc('patient_communications__retry_count') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__retry_count') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_communications__patient_id') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__patient_id') }}"
           - name: destination
             data_type: character varying(255)
-            description: "{{ doc('patient_communications__destination') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__destination') }}"
           - name: attachment
             data_type: character varying(255)
-            description: "{{ doc('patient_communications__attachment') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__attachment') }}"
           - name: hash
             data_type: integer
-            description: "{{ doc('patient_communications__hash') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__hash') }}"

--- a/database/model/central-server/public/patient_conditions.yml
+++ b/database/model/central-server/public/patient_conditions.yml
@@ -30,32 +30,27 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_conditions."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__note') }} in patient_conditions."
+            description: "{{ doc('patient_conditions__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_conditions__recorded_date') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__recorded_date') }}"
             data_tests:
               - not_null
           - name: resolved
             data_type: boolean
-            description: "{{ doc('patient_conditions__resolved') }} in patient_conditions."
+            description: "{{ doc('patient_conditions__resolved') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__patient_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__patient_id') }}"
           - name: examiner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__examiner_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__examiner_id') }}"
           - name: condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__condition_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__condition_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_conditions__recorded_date_legacy') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_conditions."
@@ -63,13 +58,10 @@ sources:
               - not_null
           - name: resolution_date
             data_type: character(19)
-            description: "{{ doc('patient_conditions__resolution_date') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__resolution_date') }}"
           - name: resolution_practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__resolution_practitioner_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__resolution_practitioner_id') }}"
           - name: resolution_note
             data_type: text
-            description: "{{ doc('patient_conditions__resolution_note') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__resolution_note') }}"

--- a/database/model/central-server/public/patient_contacts.yml
+++ b/database/model/central-server/public/patient_contacts.yml
@@ -30,31 +30,28 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_contacts."
           - name: name
             data_type: text
-            description: "{{ doc('patient_contacts__name') }} in patient_contacts."
+            description: "{{ doc('patient_contacts__name') }}"
             data_tests:
               - not_null
           - name: method
             data_type: text
-            description: "{{ doc('patient_contacts__method') }} in patient_contacts."
+            description: "{{ doc('patient_contacts__method') }}"
             data_tests:
               - not_null
           - name: connection_details
             data_type: jsonb
-            description: "{{ doc('patient_contacts__connection_details') }} in
-              patient_contacts."
+            description: "{{ doc('patient_contacts__connection_details') }}"
           - name: deletion_status
             data_type: text
-            description: "{{ doc('patient_contacts__deletion_status') }} in
-              patient_contacts."
+            description: "{{ doc('patient_contacts__deletion_status') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_contacts__patient_id') }} in patient_contacts."
+            description: "{{ doc('patient_contacts__patient_id') }}"
             data_tests:
               - not_null
           - name: relationship_id
             data_type: character varying(255)
-            description: "{{ doc('patient_contacts__relationship_id') }} in
-              patient_contacts."
+            description: "{{ doc('patient_contacts__relationship_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/patient_death_data.yml
+++ b/database/model/central-server/public/patient_death_data.yml
@@ -17,86 +17,68 @@ sources:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__patient_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__patient_id') }}"
             data_tests:
               - not_null
           - name: clinician_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__clinician_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__clinician_id') }}"
             data_tests:
               - not_null
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__facility_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__facility_id') }}"
           - name: manner
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__manner') }} in patient_death_data."
+            description: "{{ doc('patient_death_data__manner') }}"
           - name: recent_surgery
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__recent_surgery') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__recent_surgery') }}"
           - name: last_surgery_date
             data_type: character(10)
-            description: "{{ doc('patient_death_data__last_surgery_date') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__last_surgery_date') }}"
           - name: last_surgery_reason_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__last_surgery_reason_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__last_surgery_reason_id') }}"
           - name: external_cause_date
             data_type: character(10)
-            description: "{{ doc('patient_death_data__external_cause_date') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_date') }}"
           - name: external_cause_location
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__external_cause_location') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_location') }}"
           - name: external_cause_notes
             data_type: text
-            description: "{{ doc('patient_death_data__external_cause_notes') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_notes') }}"
           - name: was_pregnant
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__was_pregnant') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__was_pregnant') }}"
           - name: pregnancy_contributed
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__pregnancy_contributed') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__pregnancy_contributed') }}"
           - name: fetal_or_infant
             data_type: boolean
-            description: "{{ doc('patient_death_data__fetal_or_infant') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__fetal_or_infant') }}"
           - name: stillborn
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__stillborn') }} in patient_death_data."
+            description: "{{ doc('patient_death_data__stillborn') }}"
           - name: birth_weight
             data_type: integer
-            description: "{{ doc('patient_death_data__birth_weight') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__birth_weight') }}"
           - name: within_day_of_birth
             data_type: boolean
-            description: "{{ doc('patient_death_data__within_day_of_birth') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__within_day_of_birth') }}"
           - name: hours_survived_since_birth
             data_type: integer
-            description: "{{ doc('patient_death_data__hours_survived_since_birth') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__hours_survived_since_birth') }}"
           - name: carrier_age
             data_type: integer
-            description: "{{ doc('patient_death_data__carrier_age') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__carrier_age') }}"
           - name: carrier_pregnancy_weeks
             data_type: integer
-            description: "{{ doc('patient_death_data__carrier_pregnancy_weeks') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__carrier_pregnancy_weeks') }}"
           - name: carrier_existing_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__carrier_existing_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__carrier_existing_condition_id') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in patient_death_data."
@@ -108,40 +90,33 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_death_data."
           - name: outside_health_facility
             data_type: boolean
-            description: "{{ doc('patient_death_data__outside_health_facility') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__outside_health_facility') }}"
           - name: primary_cause_time_after_onset
             data_type: integer
-            description: "{{ doc('patient_death_data__primary_cause_time_after_onset') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__primary_cause_time_after_onset') }}"
           - name: primary_cause_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__primary_cause_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__primary_cause_condition_id') }}"
           - name: antecedent_cause1_time_after_onset
             data_type: integer
             description: "{{ doc('patient_death_data__antecedent_cause1_time_after_onset')
-              }} in patient_death_data."
+              }}"
           - name: antecedent_cause1_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__antecedent_cause1_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__antecedent_cause1_condition_id') }}"
           - name: antecedent_cause2_time_after_onset
             data_type: integer
             description: "{{ doc('patient_death_data__antecedent_cause2_time_after_onset')
-              }} in patient_death_data."
+              }}"
           - name: antecedent_cause2_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__antecedent_cause2_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__antecedent_cause2_condition_id') }}"
           - name: external_cause_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_death_data__external_cause_date_legacy') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_date_legacy') }}"
           - name: last_surgery_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_death_data__last_surgery_date_legacy') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__last_surgery_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_death_data."
@@ -149,7 +124,7 @@ sources:
               - not_null
           - name: is_final
             data_type: boolean
-            description: "{{ doc('patient_death_data__is_final') }} in patient_death_data."
+            description: "{{ doc('patient_death_data__is_final') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -158,8 +133,7 @@ sources:
           - name: antecedent_cause3_time_after_onset
             data_type: integer
             description: "{{ doc('patient_death_data__antecedent_cause3_time_after_onset')
-              }} in patient_death_data."
+              }}"
           - name: antecedent_cause3_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__antecedent_cause3_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__antecedent_cause3_condition_id') }}"

--- a/database/model/central-server/public/patient_facilities.yml
+++ b/database/model/central-server/public/patient_facilities.yml
@@ -23,15 +23,13 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_facilities."
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_facilities__facility_id') }} in
-              patient_facilities."
+            description: "{{ doc('patient_facilities__facility_id') }}"
             data_tests:
               - unique
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_facilities__patient_id') }} in
-              patient_facilities."
+            description: "{{ doc('patient_facilities__patient_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/central-server/public/patient_family_histories.yml
+++ b/database/model/central-server/public/patient_family_histories.yml
@@ -30,34 +30,27 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_family_histories."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__note') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_family_histories__recorded_date') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__recorded_date') }}"
             data_tests:
               - not_null
           - name: relationship
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__relationship') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__relationship') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__patient_id') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__patient_id') }}"
           - name: practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__practitioner_id') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__practitioner_id') }}"
           - name: diagnosis_id
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__diagnosis_id') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__diagnosis_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_family_histories__recorded_date_legacy') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/patient_field_definition_categories.yml
+++ b/database/model/central-server/public/patient_field_definition_categories.yml
@@ -33,8 +33,7 @@ sources:
               patient_field_definition_categories."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definition_categories__name') }} in
-              patient_field_definition_categories."
+            description: "{{ doc('patient_field_definition_categories__name') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/patient_field_definitions.yml
+++ b/database/model/central-server/public/patient_field_definitions.yml
@@ -30,20 +30,17 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_field_definitions."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definitions__name') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__name') }}"
             data_tests:
               - not_null
           - name: field_type
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definitions__field_type') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__field_type') }}"
             data_tests:
               - not_null
           - name: options
             data_type: array
-            description: "{{ doc('patient_field_definitions__options') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__options') }}"
           - name: visibility_status
             data_type: character varying(255)
             description: "{{ doc('generic__visibility_status') }} in
@@ -52,8 +49,7 @@ sources:
               - not_null
           - name: category_id
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definitions__category_id') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__category_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/patient_field_values.yml
+++ b/database/model/central-server/public/patient_field_values.yml
@@ -24,20 +24,18 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_field_values."
           - name: value
             data_type: text
-            description: "{{ doc('patient_field_values__value') }} in patient_field_values."
+            description: "{{ doc('patient_field_values__value') }}"
             data_tests:
               - not_null
           - name: definition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_field_values__definition_id') }} in
-              patient_field_values."
+            description: "{{ doc('patient_field_values__definition_id') }}"
             data_tests:
               - unique
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_field_values__patient_id') }} in
-              patient_field_values."
+            description: "{{ doc('patient_field_values__patient_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/central-server/public/patient_issues.yml
+++ b/database/model/central-server/public/patient_issues.yml
@@ -30,24 +30,23 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_issues."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_issues__note') }} in patient_issues."
+            description: "{{ doc('patient_issues__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_issues__recorded_date') }} in patient_issues."
+            description: "{{ doc('patient_issues__recorded_date') }}"
             data_tests:
               - not_null
           - name: type
             data_type: user-defined
-            description: "{{ doc('patient_issues__type') }} in patient_issues."
+            description: "{{ doc('patient_issues__type') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_issues__patient_id') }} in patient_issues."
+            description: "{{ doc('patient_issues__patient_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_issues__recorded_date_legacy') }} in
-              patient_issues."
+            description: "{{ doc('patient_issues__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_issues."

--- a/database/model/central-server/public/patient_program_registrations.yml
+++ b/database/model/central-server/public/patient_program_registrations.yml
@@ -38,44 +38,37 @@ sources:
               - not_null
           - name: registration_status
             data_type: text
-            description: "{{ doc('patient_program_registrations__registration_status') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__registration_status') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__patient_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__patient_id') }}"
             data_tests:
               - not_null
           - name: program_registry_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__program_registry_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__program_registry_id') }}"
             data_tests:
               - not_null
           - name: clinical_status_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__clinical_status_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__clinical_status_id') }}"
           - name: clinician_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__clinician_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__clinician_id') }}"
             data_tests:
               - not_null
           - name: registering_facility_id
             data_type: character varying(255)
             description: "{{ doc('patient_program_registrations__registering_facility_id')
-              }} in patient_program_registrations."
+              }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__facility_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__facility_id') }}"
           - name: village_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__village_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__village_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
@@ -84,7 +77,6 @@ sources:
               - not_null
           - name: is_most_recent
             data_type: boolean
-            description: "{{ doc('patient_program_registrations__is_most_recent') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__is_most_recent') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/patient_secondary_ids.yml
+++ b/database/model/central-server/public/patient_secondary_ids.yml
@@ -26,8 +26,7 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_secondary_ids."
           - name: value
             data_type: character varying(255)
-            description: "{{ doc('patient_secondary_ids__value') }} in
-              patient_secondary_ids."
+            description: "{{ doc('patient_secondary_ids__value') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -37,14 +36,12 @@ sources:
               - not_null
           - name: type_id
             data_type: character varying(255)
-            description: "{{ doc('patient_secondary_ids__type_id') }} in
-              patient_secondary_ids."
+            description: "{{ doc('patient_secondary_ids__type_id') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_secondary_ids__patient_id') }} in
-              patient_secondary_ids."
+            description: "{{ doc('patient_secondary_ids__patient_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/patient_vrs_data.yml
+++ b/database/model/central-server/public/patient_vrs_data.yml
@@ -26,20 +26,18 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_vrs_data."
           - name: id_type
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__id_type') }} in patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__id_type') }}"
           - name: identifier
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__identifier') }} in patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__identifier') }}"
           - name: unmatched_village_name
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__unmatched_village_name') }} in
-              patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__unmatched_village_name') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__patient_id') }} in patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__patient_id') }}"
           - name: is_deleted_by_remote
             data_type: boolean
-            description: "{{ doc('patient_vrs_data__is_deleted_by_remote') }} in
-              patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__is_deleted_by_remote') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/permissions.yml
+++ b/database/model/central-server/public/permissions.yml
@@ -26,22 +26,22 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in permissions."
           - name: role_id
             data_type: character varying(255)
-            description: "{{ doc('permissions__role_id') }} in permissions."
+            description: "{{ doc('permissions__role_id') }}"
             data_tests:
               - not_null
           - name: noun
             data_type: character varying(255)
-            description: "{{ doc('permissions__noun') }} in permissions."
+            description: "{{ doc('permissions__noun') }}"
             data_tests:
               - not_null
           - name: verb
             data_type: character varying(255)
-            description: "{{ doc('permissions__verb') }} in permissions."
+            description: "{{ doc('permissions__verb') }}"
             data_tests:
               - not_null
           - name: object_id
             data_type: character varying(255)
-            description: "{{ doc('permissions__object_id') }} in permissions."
+            description: "{{ doc('permissions__object_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in permissions."

--- a/database/model/central-server/public/procedures.yml
+++ b/database/model/central-server/public/procedures.yml
@@ -30,7 +30,7 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in procedures."
           - name: completed
             data_type: boolean
-            description: "{{ doc('procedures__completed') }} in procedures."
+            description: "{{ doc('procedures__completed') }}"
           - name: date
             data_type: character(19)
             description: "{{ doc('generic__date') }} in procedures."
@@ -38,46 +38,46 @@ sources:
               - not_null
           - name: end_time
             data_type: character(19)
-            description: "{{ doc('procedures__end_time') }} in procedures."
+            description: "{{ doc('procedures__end_time') }}"
           - name: note
             data_type: text
-            description: "{{ doc('procedures__note') }} in procedures."
+            description: "{{ doc('procedures__note') }}"
           - name: completed_note
             data_type: text
-            description: "{{ doc('procedures__completed_note') }} in procedures."
+            description: "{{ doc('procedures__completed_note') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__encounter_id') }} in procedures."
+            description: "{{ doc('procedures__encounter_id') }}"
           - name: location_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__location_id') }} in procedures."
+            description: "{{ doc('procedures__location_id') }}"
           - name: procedure_type_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__procedure_type_id') }} in procedures."
+            description: "{{ doc('procedures__procedure_type_id') }}"
           - name: anaesthetic_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__anaesthetic_id') }} in procedures."
+            description: "{{ doc('procedures__anaesthetic_id') }}"
           - name: physician_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__physician_id') }} in procedures."
+            description: "{{ doc('procedures__physician_id') }}"
           - name: assistant_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__assistant_id') }} in procedures."
+            description: "{{ doc('procedures__assistant_id') }}"
           - name: anaesthetist_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__anaesthetist_id') }} in procedures."
+            description: "{{ doc('procedures__anaesthetist_id') }}"
           - name: start_time
             data_type: character(19)
-            description: "{{ doc('procedures__start_time') }} in procedures."
+            description: "{{ doc('procedures__start_time') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in procedures."
           - name: start_time_legacy
             data_type: character varying(255)
-            description: "{{ doc('procedures__start_time_legacy') }} in procedures."
+            description: "{{ doc('procedures__start_time_legacy') }}"
           - name: end_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('procedures__end_time_legacy') }} in procedures."
+            description: "{{ doc('procedures__end_time_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in procedures."

--- a/database/model/central-server/public/program_data_elements.yml
+++ b/database/model/central-server/public/program_data_elements.yml
@@ -30,28 +30,22 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in program_data_elements."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__code') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__code') }}"
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__name') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__name') }}"
           - name: indicator
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__indicator') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__indicator') }}"
           - name: default_text
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__default_text') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__default_text') }}"
           - name: default_options
             data_type: text
-            description: "{{ doc('program_data_elements__default_options') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__default_options') }}"
           - name: type
             data_type: character varying(31)
-            description: "{{ doc('program_data_elements__type') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__type') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -62,5 +56,4 @@ sources:
               - not_null
           - name: visualisation_config
             data_type: text
-            description: "{{ doc('program_data_elements__visualisation_config') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__visualisation_config') }}"

--- a/database/model/central-server/public/program_registries.yml
+++ b/database/model/central-server/public/program_registries.yml
@@ -30,19 +30,18 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in program_registries."
           - name: code
             data_type: text
-            description: "{{ doc('program_registries__code') }} in program_registries."
+            description: "{{ doc('program_registries__code') }}"
             data_tests:
               - unique
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('program_registries__name') }} in program_registries."
+            description: "{{ doc('program_registries__name') }}"
             data_tests:
               - not_null
           - name: currently_at_type
             data_type: text
-            description: "{{ doc('program_registries__currently_at_type') }} in
-              program_registries."
+            description: "{{ doc('program_registries__currently_at_type') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -50,8 +49,7 @@ sources:
             description: "{{ doc('generic__visibility_status') }} in program_registries."
           - name: program_id
             data_type: character varying(255)
-            description: "{{ doc('program_registries__program_id') }} in
-              program_registries."
+            description: "{{ doc('program_registries__program_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/program_registry_clinical_statuses.yml
+++ b/database/model/central-server/public/program_registry_clinical_statuses.yml
@@ -33,21 +33,18 @@ sources:
               program_registry_clinical_statuses."
           - name: code
             data_type: text
-            description: "{{ doc('program_registry_clinical_statuses__code') }} in
-              program_registry_clinical_statuses."
+            description: "{{ doc('program_registry_clinical_statuses__code') }}"
             data_tests:
               - unique
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('program_registry_clinical_statuses__name') }} in
-              program_registry_clinical_statuses."
+            description: "{{ doc('program_registry_clinical_statuses__name') }}"
             data_tests:
               - not_null
           - name: color
             data_type: text
-            description: "{{ doc('program_registry_clinical_statuses__color') }} in
-              program_registry_clinical_statuses."
+            description: "{{ doc('program_registry_clinical_statuses__color') }}"
           - name: visibility_status
             data_type: text
             description: "{{ doc('generic__visibility_status') }} in
@@ -55,7 +52,7 @@ sources:
           - name: program_registry_id
             data_type: character varying(255)
             description: "{{ doc('program_registry_clinical_statuses__program_registry_id')
-              }} in program_registry_clinical_statuses."
+              }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/program_registry_conditions.yml
+++ b/database/model/central-server/public/program_registry_conditions.yml
@@ -30,15 +30,13 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in program_registry_conditions."
           - name: code
             data_type: text
-            description: "{{ doc('program_registry_conditions__code') }} in
-              program_registry_conditions."
+            description: "{{ doc('program_registry_conditions__code') }}"
             data_tests:
               - unique
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('program_registry_conditions__name') }} in
-              program_registry_conditions."
+            description: "{{ doc('program_registry_conditions__name') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -47,8 +45,7 @@ sources:
               program_registry_conditions."
           - name: program_registry_id
             data_type: character varying(255)
-            description: "{{ doc('program_registry_conditions__program_registry_id') }} in
-              program_registry_conditions."
+            description: "{{ doc('program_registry_conditions__program_registry_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/programs.yml
+++ b/database/model/central-server/public/programs.yml
@@ -30,10 +30,10 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in programs."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('programs__code') }} in programs."
+            description: "{{ doc('programs__code') }}"
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('programs__name') }} in programs."
+            description: "{{ doc('programs__name') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in programs."

--- a/database/model/central-server/public/reference_data.yml
+++ b/database/model/central-server/public/reference_data.yml
@@ -30,17 +30,17 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in reference_data."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('reference_data__code') }} in reference_data."
+            description: "{{ doc('reference_data__code') }}"
             data_tests:
               - not_null
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('reference_data__type') }} in reference_data."
+            description: "{{ doc('reference_data__type') }}"
             data_tests:
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('reference_data__name') }} in reference_data."
+            description: "{{ doc('reference_data__name') }}"
             data_tests:
               - not_null
           - name: visibility_status

--- a/database/model/central-server/public/reference_data_relations.yml
+++ b/database/model/central-server/public/reference_data_relations.yml
@@ -30,18 +30,15 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in reference_data_relations."
           - name: reference_data_id
             data_type: text
-            description: "{{ doc('reference_data_relations__reference_data_id') }} in
-              reference_data_relations."
+            description: "{{ doc('reference_data_relations__reference_data_id') }}"
             data_tests:
               - unique
           - name: reference_data_parent_id
             data_type: text
-            description: "{{ doc('reference_data_relations__reference_data_parent_id') }} in
-              reference_data_relations."
+            description: "{{ doc('reference_data_relations__reference_data_parent_id') }}"
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('reference_data_relations__type') }} in
-              reference_data_relations."
+            description: "{{ doc('reference_data_relations__type') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/central-server/public/referrals.yml
+++ b/database/model/central-server/public/referrals.yml
@@ -30,19 +30,19 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in referrals."
           - name: referred_facility
             data_type: character varying(255)
-            description: "{{ doc('referrals__referred_facility') }} in referrals."
+            description: "{{ doc('referrals__referred_facility') }}"
           - name: initiating_encounter_id
             data_type: character varying(255)
-            description: "{{ doc('referrals__initiating_encounter_id') }} in referrals."
+            description: "{{ doc('referrals__initiating_encounter_id') }}"
           - name: completing_encounter_id
             data_type: character varying(255)
-            description: "{{ doc('referrals__completing_encounter_id') }} in referrals."
+            description: "{{ doc('referrals__completing_encounter_id') }}"
           - name: survey_response_id
             data_type: character varying(255)
-            description: "{{ doc('referrals__survey_response_id') }} in referrals."
+            description: "{{ doc('referrals__survey_response_id') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('referrals__status') }} in referrals."
+            description: "{{ doc('referrals__status') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/refresh_tokens.yml
+++ b/database/model/central-server/public/refresh_tokens.yml
@@ -17,22 +17,22 @@ sources:
               - not_null
           - name: refresh_id
             data_type: text
-            description: "{{ doc('refresh_tokens__refresh_id') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__refresh_id') }}"
             data_tests:
               - not_null
           - name: device_id
             data_type: text
-            description: "{{ doc('refresh_tokens__device_id') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__device_id') }}"
             data_tests:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('refresh_tokens__user_id') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__user_id') }}"
             data_tests:
               - not_null
           - name: expires_at
             data_type: timestamp with time zone
-            description: "{{ doc('refresh_tokens__expires_at') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__expires_at') }}"
             data_tests:
               - not_null
           - name: deleted_at

--- a/database/model/central-server/public/report_definition_versions.yml
+++ b/database/model/central-server/public/report_definition_versions.yml
@@ -26,36 +26,29 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in report_definition_versions."
           - name: version_number
             data_type: integer
-            description: "{{ doc('report_definition_versions__version_number') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__version_number') }}"
             data_tests:
               - not_null
           - name: notes
             data_type: text
-            description: "{{ doc('report_definition_versions__notes') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__notes') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('report_definition_versions__status') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__status') }}"
             data_tests:
               - not_null
           - name: query
             data_type: text
-            description: "{{ doc('report_definition_versions__query') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__query') }}"
           - name: query_options
             data_type: json
-            description: "{{ doc('report_definition_versions__query_options') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__query_options') }}"
           - name: report_definition_id
             data_type: character varying(255)
-            description: "{{ doc('report_definition_versions__report_definition_id') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__report_definition_id') }}"
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('report_definition_versions__user_id') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__user_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/report_definitions.yml
+++ b/database/model/central-server/public/report_definitions.yml
@@ -26,7 +26,7 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in report_definitions."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('report_definitions__name') }} in report_definitions."
+            description: "{{ doc('report_definitions__name') }}"
             data_tests:
               - unique
               - not_null
@@ -37,6 +37,6 @@ sources:
               - not_null
           - name: db_schema
             data_type: character varying(255)
-            description: "{{ doc('report_definitions__db_schema') }} in report_definitions."
+            description: "{{ doc('report_definitions__db_schema') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/report_requests.yml
+++ b/database/model/central-server/public/report_requests.yml
@@ -30,45 +30,42 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in report_requests."
           - name: report_type
             data_type: character varying(255)
-            description: "{{ doc('report_requests__report_type') }} in report_requests."
+            description: "{{ doc('report_requests__report_type') }}"
           - name: recipients
             data_type: text
-            description: "{{ doc('report_requests__recipients') }} in report_requests."
+            description: "{{ doc('report_requests__recipients') }}"
             data_tests:
               - not_null
           - name: parameters
             data_type: text
-            description: "{{ doc('report_requests__parameters') }} in report_requests."
+            description: "{{ doc('report_requests__parameters') }}"
           - name: status
             data_type: character varying(31)
-            description: "{{ doc('report_requests__status') }} in report_requests."
+            description: "{{ doc('report_requests__status') }}"
             data_tests:
               - not_null
           - name: requested_by_user_id
             data_type: character varying(255)
-            description: "{{ doc('report_requests__requested_by_user_id') }} in
-              report_requests."
+            description: "{{ doc('report_requests__requested_by_user_id') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('report_requests__error') }} in report_requests."
+            description: "{{ doc('report_requests__error') }}"
           - name: process_started_time
             data_type: timestamp with time zone
-            description: "{{ doc('report_requests__process_started_time') }} in
-              report_requests."
+            description: "{{ doc('report_requests__process_started_time') }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('report_requests__facility_id') }} in report_requests."
+            description: "{{ doc('report_requests__facility_id') }}"
           - name: export_format
             data_type: character varying(255)
-            description: "{{ doc('report_requests__export_format') }} in report_requests."
+            description: "{{ doc('report_requests__export_format') }}"
             data_tests:
               - not_null
           - name: report_definition_version_id
             data_type: character varying(255)
-            description: "{{ doc('report_requests__report_definition_version_id') }} in
-              report_requests."
+            description: "{{ doc('report_requests__report_definition_version_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in report_requests."

--- a/database/model/central-server/public/settings.yml
+++ b/database/model/central-server/public/settings.yml
@@ -32,16 +32,16 @@ sources:
               - unique
           - name: key
             data_type: text
-            description: "{{ doc('settings__key') }} in settings."
+            description: "{{ doc('settings__key') }}"
             data_tests:
               - unique
               - not_null
           - name: value
             data_type: jsonb
-            description: "{{ doc('settings__value') }} in settings."
+            description: "{{ doc('settings__value') }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('settings__facility_id') }} in settings."
+            description: "{{ doc('settings__facility_id') }}"
             data_tests:
               - unique
           - name: updated_at_sync_tick
@@ -51,6 +51,6 @@ sources:
               - not_null
           - name: scope
             data_type: text
-            description: "{{ doc('settings__scope') }} in settings."
+            description: "{{ doc('settings__scope') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/signers.yml
+++ b/database/model/central-server/public/signers.yml
@@ -30,42 +30,42 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in signers."
           - name: country_code
             data_type: character varying(255)
-            description: "{{ doc('signers__country_code') }} in signers."
+            description: "{{ doc('signers__country_code') }}"
             data_tests:
               - not_null
           - name: private_key
             data_type: bytea
-            description: "{{ doc('signers__private_key') }} in signers."
+            description: "{{ doc('signers__private_key') }}"
           - name: public_key
             data_type: bytea
-            description: "{{ doc('signers__public_key') }} in signers."
+            description: "{{ doc('signers__public_key') }}"
             data_tests:
               - not_null
           - name: request
             data_type: text
-            description: "{{ doc('signers__request') }} in signers."
+            description: "{{ doc('signers__request') }}"
             data_tests:
               - not_null
           - name: certificate
             data_type: text
-            description: "{{ doc('signers__certificate') }} in signers."
+            description: "{{ doc('signers__certificate') }}"
           - name: validity_period_start
             data_type: timestamp with time zone
-            description: "{{ doc('signers__validity_period_start') }} in signers."
+            description: "{{ doc('signers__validity_period_start') }}"
           - name: validity_period_end
             data_type: timestamp with time zone
-            description: "{{ doc('signers__validity_period_end') }} in signers."
+            description: "{{ doc('signers__validity_period_end') }}"
           - name: signatures_issued
             data_type: integer
-            description: "{{ doc('signers__signatures_issued') }} in signers."
+            description: "{{ doc('signers__signatures_issued') }}"
             data_tests:
               - not_null
           - name: request_sent_at
             data_type: timestamp with time zone
-            description: "{{ doc('signers__request_sent_at') }} in signers."
+            description: "{{ doc('signers__request_sent_at') }}"
           - name: working_period_start
             data_type: timestamp with time zone
-            description: "{{ doc('signers__working_period_start') }} in signers."
+            description: "{{ doc('signers__working_period_start') }}"
           - name: working_period_end
             data_type: timestamp with time zone
-            description: "{{ doc('signers__working_period_end') }} in signers."
+            description: "{{ doc('signers__working_period_end') }}"

--- a/database/model/central-server/public/socket_io_attachments.yml
+++ b/database/model/central-server/public/socket_io_attachments.yml
@@ -20,8 +20,7 @@ sources:
             description: "{{ doc('generic__created_at') }} in socket_io_attachments."
           - name: payload
             data_type: bytea
-            description: "{{ doc('socket_io_attachments__payload') }} in
-              socket_io_attachments."
+            description: "{{ doc('socket_io_attachments__payload') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/survey_response_answers.yml
+++ b/database/model/central-server/public/survey_response_answers.yml
@@ -30,24 +30,19 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in survey_response_answers."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('survey_response_answers__name') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__name') }}"
           - name: body
             data_type: text
-            description: "{{ doc('survey_response_answers__body') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__body') }}"
           - name: response_id
             data_type: character varying(255)
-            description: "{{ doc('survey_response_answers__response_id') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__response_id') }}"
           - name: data_element_id
             data_type: character varying(255)
-            description: "{{ doc('survey_response_answers__data_element_id') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__data_element_id') }}"
           - name: body_legacy
             data_type: text
-            description: "{{ doc('survey_response_answers__body_legacy') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__body_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/survey_responses.yml
+++ b/database/model/central-server/public/survey_responses.yml
@@ -30,38 +30,36 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in survey_responses."
           - name: start_time
             data_type: character(19)
-            description: "{{ doc('survey_responses__start_time') }} in survey_responses."
+            description: "{{ doc('survey_responses__start_time') }}"
           - name: end_time
             data_type: character(19)
-            description: "{{ doc('survey_responses__end_time') }} in survey_responses."
+            description: "{{ doc('survey_responses__end_time') }}"
           - name: result
             data_type: double precision
-            description: "{{ doc('survey_responses__result') }} in survey_responses."
+            description: "{{ doc('survey_responses__result') }}"
           - name: survey_id
             data_type: character varying(255)
-            description: "{{ doc('survey_responses__survey_id') }} in survey_responses."
+            description: "{{ doc('survey_responses__survey_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('survey_responses__encounter_id') }} in survey_responses."
+            description: "{{ doc('survey_responses__encounter_id') }}"
           - name: result_text
             data_type: text
-            description: "{{ doc('survey_responses__result_text') }} in survey_responses."
+            description: "{{ doc('survey_responses__result_text') }}"
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('survey_responses__user_id') }} in survey_responses."
+            description: "{{ doc('survey_responses__user_id') }}"
           - name: start_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('survey_responses__start_time_legacy') }} in
-              survey_responses."
+            description: "{{ doc('survey_responses__start_time_legacy') }}"
           - name: end_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('survey_responses__end_time_legacy') }} in
-              survey_responses."
+            description: "{{ doc('survey_responses__end_time_legacy') }}"
+          - name: notified
+            data_type: boolean
+            description: "{{ doc('survey_responses__notified') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in survey_responses."
             data_tests:
               - not_null
-          - name: notified
-            data_type: boolean
-            description: "{{ doc('survey_responses__notified') }} in survey_responses."

--- a/database/model/central-server/public/survey_screen_components.yml
+++ b/database/model/central-server/public/survey_screen_components.yml
@@ -30,48 +30,37 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in survey_screen_components."
           - name: screen_index
             data_type: integer
-            description: "{{ doc('survey_screen_components__screen_index') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__screen_index') }}"
           - name: component_index
             data_type: integer
-            description: "{{ doc('survey_screen_components__component_index') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__component_index') }}"
           - name: text
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__text') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__text') }}"
           - name: visibility_criteria
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__visibility_criteria') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__visibility_criteria') }}"
           - name: validation_criteria
             data_type: text
-            description: "{{ doc('survey_screen_components__validation_criteria') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__validation_criteria') }}"
           - name: detail
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__detail') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__detail') }}"
           - name: config
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__config') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__config') }}"
           - name: options
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__options') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__options') }}"
           - name: calculation
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__calculation') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__calculation') }}"
           - name: survey_id
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__survey_id') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__survey_id') }}"
           - name: data_element_id
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__data_element_id') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__data_element_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/central-server/public/surveys.yml
+++ b/database/model/central-server/public/surveys.yml
@@ -30,19 +30,19 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in surveys."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('surveys__code') }} in surveys."
+            description: "{{ doc('surveys__code') }}"
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('surveys__name') }} in surveys."
+            description: "{{ doc('surveys__name') }}"
           - name: program_id
             data_type: character varying(255)
-            description: "{{ doc('surveys__program_id') }} in surveys."
+            description: "{{ doc('surveys__program_id') }}"
           - name: survey_type
             data_type: character varying(255)
-            description: "{{ doc('surveys__survey_type') }} in surveys."
+            description: "{{ doc('surveys__survey_type') }}"
           - name: is_sensitive
             data_type: boolean
-            description: "{{ doc('surveys__is_sensitive') }} in surveys."
+            description: "{{ doc('surveys__is_sensitive') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -50,18 +50,18 @@ sources:
             description: "{{ doc('generic__updated_at_sync_tick') }} in surveys."
             data_tests:
               - not_null
-          - name: visibility_status
-            data_type: character varying(255)
-            description: "{{ doc('generic__visibility_status') }} in surveys."
-            data_tests:
-              - not_null
           - name: notifiable
             data_type: boolean
-            description: "{{ doc('surveys__notifiable') }} in surveys."
+            description: "{{ doc('surveys__notifiable') }}"
             data_tests:
               - not_null
           - name: notify_email_addresses
             data_type: array
-            description: "{{ doc('surveys__notify_email_addresses') }} in surveys."
+            description: "{{ doc('surveys__notify_email_addresses') }}"
+            data_tests:
+              - not_null
+          - name: visibility_status
+            data_type: character varying(255)
+            description: "{{ doc('generic__visibility_status') }} in surveys."
             data_tests:
               - not_null

--- a/database/model/central-server/public/sync_lookup.yml
+++ b/database/model/central-server/public/sync_lookup.yml
@@ -18,19 +18,19 @@ sources:
               - not_null
           - name: record_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__record_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__record_id') }}"
             data_tests:
               - unique
               - not_null
           - name: record_type
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__record_type') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__record_type') }}"
             data_tests:
               - unique
               - not_null
           - name: data
             data_type: json
-            description: "{{ doc('sync_lookup__data') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__data') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -40,23 +40,23 @@ sources:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__patient_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__patient_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__encounter_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__encounter_id') }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__facility_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__facility_id') }}"
           - name: is_lab_request
             data_type: boolean
-            description: "{{ doc('sync_lookup__is_lab_request') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__is_lab_request') }}"
             data_tests:
               - not_null
           - name: is_deleted
             data_type: boolean
-            description: "{{ doc('sync_lookup__is_deleted') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__is_deleted') }}"
             data_tests:
               - not_null
           - name: updated_at_by_field_sum
             data_type: bigint
-            description: "{{ doc('sync_lookup__updated_at_by_field_sum') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__updated_at_by_field_sum') }}"

--- a/database/model/central-server/public/sync_queued_devices.yml
+++ b/database/model/central-server/public/sync_queued_devices.yml
@@ -17,25 +17,22 @@ sources:
               - not_null
           - name: last_seen_time
             data_type: timestamp with time zone
-            description: "{{ doc('sync_queued_devices__last_seen_time') }} in
-              sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__last_seen_time') }}"
             data_tests:
               - not_null
           - name: facility_id
             data_type: text
-            description: "{{ doc('sync_queued_devices__facility_id') }} in
-              sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__facility_id') }}"
             data_tests:
               - not_null
           - name: last_synced_tick
             data_type: bigint
-            description: "{{ doc('sync_queued_devices__last_synced_tick') }} in
-              sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__last_synced_tick') }}"
             data_tests:
               - not_null
           - name: urgent
             data_type: boolean
-            description: "{{ doc('sync_queued_devices__urgent') }} in sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__urgent') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/central-server/public/sync_sessions.yml
+++ b/database/model/central-server/public/sync_sessions.yml
@@ -64,4 +64,4 @@ sources:
             description: "{{ doc('sync_sessions__snapshot_started_at') }}"
           - name: errors
             data_type: array
-            description: "{{ doc('sync_sessions__errors') }} in sync_sessions."
+            description: "{{ doc('sync_sessions__errors') }}"

--- a/database/model/central-server/public/templates.yml
+++ b/database/model/central-server/public/templates.yml
@@ -26,24 +26,24 @@ sources:
             description: "{{ doc('generic__updated_at') }} in templates."
           - name: name
             data_type: text
-            description: "{{ doc('templates__name') }} in templates."
+            description: "{{ doc('templates__name') }}"
             data_tests:
               - not_null
           - name: date_created
             data_type: character(10)
-            description: "{{ doc('templates__date_created') }} in templates."
+            description: "{{ doc('templates__date_created') }}"
           - name: title
             data_type: text
-            description: "{{ doc('templates__title') }} in templates."
+            description: "{{ doc('templates__title') }}"
           - name: body
             data_type: text
-            description: "{{ doc('templates__body') }} in templates."
+            description: "{{ doc('templates__body') }}"
           - name: visibility_status
             data_type: text
             description: "{{ doc('generic__visibility_status') }} in templates."
           - name: created_by_id
             data_type: character varying(255)
-            description: "{{ doc('templates__created_by_id') }} in templates."
+            description: "{{ doc('templates__created_by_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in templates."
@@ -51,6 +51,6 @@ sources:
               - not_null
           - name: type
             data_type: text
-            description: "{{ doc('templates__type') }} in templates."
+            description: "{{ doc('templates__type') }}"
             data_tests:
               - not_null

--- a/database/model/central-server/public/translated_strings.yml
+++ b/database/model/central-server/public/translated_strings.yml
@@ -14,19 +14,19 @@ sources:
             description: "{{ doc('generic__id') }} in translated_strings."
           - name: string_id
             data_type: text
-            description: "{{ doc('translated_strings__string_id') }} in translated_strings."
+            description: "{{ doc('translated_strings__string_id') }}"
             data_tests:
               - unique
               - not_null
           - name: language
             data_type: text
-            description: "{{ doc('translated_strings__language') }} in translated_strings."
+            description: "{{ doc('translated_strings__language') }}"
             data_tests:
               - unique
               - not_null
           - name: text
             data_type: text
-            description: "{{ doc('translated_strings__text') }} in translated_strings."
+            description: "{{ doc('translated_strings__text') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in translated_strings."

--- a/database/model/central-server/public/triages.yml
+++ b/database/model/central-server/public/triages.yml
@@ -30,40 +30,40 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in triages."
           - name: arrival_time
             data_type: character(19)
-            description: "{{ doc('triages__arrival_time') }} in triages."
+            description: "{{ doc('triages__arrival_time') }}"
           - name: triage_time
             data_type: character(19)
-            description: "{{ doc('triages__triage_time') }} in triages."
+            description: "{{ doc('triages__triage_time') }}"
           - name: closed_time
             data_type: character(19)
-            description: "{{ doc('triages__closed_time') }} in triages."
+            description: "{{ doc('triages__closed_time') }}"
           - name: score
             data_type: text
-            description: "{{ doc('triages__score') }} in triages."
+            description: "{{ doc('triages__score') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('triages__encounter_id') }} in triages."
+            description: "{{ doc('triages__encounter_id') }}"
           - name: practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('triages__practitioner_id') }} in triages."
+            description: "{{ doc('triages__practitioner_id') }}"
           - name: chief_complaint_id
             data_type: character varying(255)
-            description: "{{ doc('triages__chief_complaint_id') }} in triages."
+            description: "{{ doc('triages__chief_complaint_id') }}"
           - name: secondary_complaint_id
             data_type: character varying(255)
-            description: "{{ doc('triages__secondary_complaint_id') }} in triages."
+            description: "{{ doc('triages__secondary_complaint_id') }}"
           - name: arrival_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('triages__arrival_time_legacy') }} in triages."
+            description: "{{ doc('triages__arrival_time_legacy') }}"
           - name: triage_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('triages__triage_time_legacy') }} in triages."
+            description: "{{ doc('triages__triage_time_legacy') }}"
           - name: closed_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('triages__closed_time_legacy') }} in triages."
+            description: "{{ doc('triages__closed_time_legacy') }}"
           - name: arrival_mode_id
             data_type: character varying(255)
-            description: "{{ doc('triages__arrival_mode_id') }} in triages."
+            description: "{{ doc('triages__arrival_mode_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in triages."

--- a/database/model/central-server/public/user_facilities.yml
+++ b/database/model/central-server/public/user_facilities.yml
@@ -26,12 +26,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in user_facilities."
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('user_facilities__facility_id') }} in user_facilities."
+            description: "{{ doc('user_facilities__facility_id') }}"
             data_tests:
               - unique
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_facilities__user_id') }} in user_facilities."
+            description: "{{ doc('user_facilities__user_id') }}"
             data_tests:
               - unique
           - name: updated_at_sync_tick

--- a/database/model/central-server/public/user_localisation_caches.yml
+++ b/database/model/central-server/public/user_localisation_caches.yml
@@ -17,14 +17,12 @@ sources:
               - not_null
           - name: localisation
             data_type: text
-            description: "{{ doc('user_localisation_caches__localisation') }} in
-              user_localisation_caches."
+            description: "{{ doc('user_localisation_caches__localisation') }}"
             data_tests:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_localisation_caches__user_id') }} in
-              user_localisation_caches."
+            description: "{{ doc('user_localisation_caches__user_id') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in user_localisation_caches."

--- a/database/model/central-server/public/user_preferences.yml
+++ b/database/model/central-server/public/user_preferences.yml
@@ -27,14 +27,13 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in user_preferences."
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_preferences__user_id') }} in user_preferences."
+            description: "{{ doc('user_preferences__user_id') }}"
             data_tests:
               - unique
               - not_null
           - name: selected_graphed_vitals_on_filter
             data_type: character varying(255)
-            description: "{{ doc('user_preferences__selected_graphed_vitals_on_filter') }}
-              in user_preferences."
+            description: "{{ doc('user_preferences__selected_graphed_vitals_on_filter') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in user_preferences."

--- a/database/model/central-server/public/user_recently_viewed_patients.yml
+++ b/database/model/central-server/public/user_recently_viewed_patients.yml
@@ -33,15 +33,13 @@ sources:
               user_recently_viewed_patients."
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_recently_viewed_patients__user_id') }} in
-              user_recently_viewed_patients."
+            description: "{{ doc('user_recently_viewed_patients__user_id') }}"
             data_tests:
               - unique
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('user_recently_viewed_patients__patient_id') }} in
-              user_recently_viewed_patients."
+            description: "{{ doc('user_recently_viewed_patients__patient_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/facility-server/fhir/encounters.yml
+++ b/database/model/facility-server/fhir/encounters.yml
@@ -12,42 +12,42 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('encounters__id') }} in encounters."
+            description: "{{ doc('encounters__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('encounters__version_id') }} in encounters."
+            description: "{{ doc('encounters__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('encounters__upstream_id') }} in encounters."
+            description: "{{ doc('encounters__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('encounters__last_updated') }} in encounters."
+            description: "{{ doc('encounters__last_updated') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('encounters__status') }} in encounters."
+            description: "{{ doc('encounters__status') }}"
             data_tests:
               - not_null
           - name: class
             data_type: jsonb
-            description: "{{ doc('encounters__class') }} in encounters."
+            description: "{{ doc('encounters__class') }}"
           - name: actual_period
             data_type: jsonb
-            description: "{{ doc('encounters__actual_period') }} in encounters."
+            description: "{{ doc('encounters__actual_period') }}"
           - name: subject
             data_type: jsonb
-            description: "{{ doc('encounters__subject') }} in encounters."
+            description: "{{ doc('encounters__subject') }}"
           - name: location
             data_type: jsonb
-            description: "{{ doc('encounters__location') }} in encounters."
+            description: "{{ doc('encounters__location') }}"
           - name: service_provider
             data_type: jsonb
-            description: "{{ doc('encounters__service_provider') }} in encounters."
+            description: "{{ doc('encounters__service_provider') }}"

--- a/database/model/facility-server/fhir/immunizations.yml
+++ b/database/model/facility-server/fhir/immunizations.yml
@@ -12,62 +12,61 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('immunizations__id') }} in immunizations."
+            description: "{{ doc('immunizations__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('immunizations__version_id') }} in immunizations."
+            description: "{{ doc('immunizations__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('immunizations__upstream_id') }} in immunizations."
+            description: "{{ doc('immunizations__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('immunizations__last_updated') }} in immunizations."
+            description: "{{ doc('immunizations__last_updated') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('immunizations__status') }} in immunizations."
+            description: "{{ doc('immunizations__status') }}"
             data_tests:
               - not_null
           - name: vaccine_code
             data_type: jsonb
-            description: "{{ doc('immunizations__vaccine_code') }} in immunizations."
+            description: "{{ doc('immunizations__vaccine_code') }}"
             data_tests:
               - not_null
           - name: patient
             data_type: jsonb
-            description: "{{ doc('immunizations__patient') }} in immunizations."
+            description: "{{ doc('immunizations__patient') }}"
             data_tests:
               - not_null
           - name: encounter
             data_type: jsonb
-            description: "{{ doc('immunizations__encounter') }} in immunizations."
+            description: "{{ doc('immunizations__encounter') }}"
           - name: occurrence_date_time
             data_type: text
-            description: "{{ doc('immunizations__occurrence_date_time') }} in
-              immunizations."
+            description: "{{ doc('immunizations__occurrence_date_time') }}"
           - name: lot_number
             data_type: text
-            description: "{{ doc('immunizations__lot_number') }} in immunizations."
+            description: "{{ doc('immunizations__lot_number') }}"
           - name: site
             data_type: jsonb
-            description: "{{ doc('immunizations__site') }} in immunizations."
+            description: "{{ doc('immunizations__site') }}"
             data_tests:
               - not_null
           - name: performer
             data_type: jsonb
-            description: "{{ doc('immunizations__performer') }} in immunizations."
+            description: "{{ doc('immunizations__performer') }}"
             data_tests:
               - not_null
           - name: protocol_applied
             data_type: jsonb
-            description: "{{ doc('immunizations__protocol_applied') }} in immunizations."
+            description: "{{ doc('immunizations__protocol_applied') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/fhir/job_workers.yml
+++ b/database/model/facility-server/fhir/job_workers.yml
@@ -12,25 +12,25 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('job_workers__id') }} in job_workers."
+            description: "{{ doc('job_workers__id') }}"
             data_tests:
               - unique
               - not_null
           - name: created_at
             data_type: timestamp with time zone
-            description: "{{ doc('job_workers__created_at') }} in job_workers."
+            description: "{{ doc('job_workers__created_at') }}"
             data_tests:
               - not_null
           - name: updated_at
             data_type: timestamp with time zone
-            description: "{{ doc('job_workers__updated_at') }} in job_workers."
+            description: "{{ doc('job_workers__updated_at') }}"
             data_tests:
               - not_null
           - name: deleted_at
             data_type: timestamp with time zone
-            description: "{{ doc('job_workers__deleted_at') }} in job_workers."
+            description: "{{ doc('job_workers__deleted_at') }}"
           - name: metadata
             data_type: jsonb
-            description: "{{ doc('job_workers__metadata') }} in job_workers."
+            description: "{{ doc('job_workers__metadata') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/fhir/jobs.yml
+++ b/database/model/facility-server/fhir/jobs.yml
@@ -12,61 +12,61 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('jobs__id') }} in jobs."
+            description: "{{ doc('jobs__id') }}"
             data_tests:
               - unique
               - not_null
           - name: created_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__created_at') }} in jobs."
+            description: "{{ doc('jobs__created_at') }}"
             data_tests:
               - not_null
           - name: updated_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__updated_at') }} in jobs."
+            description: "{{ doc('jobs__updated_at') }}"
             data_tests:
               - not_null
           - name: deleted_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__deleted_at') }} in jobs."
+            description: "{{ doc('jobs__deleted_at') }}"
           - name: priority
             data_type: integer
-            description: "{{ doc('jobs__priority') }} in jobs."
+            description: "{{ doc('jobs__priority') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('jobs__status') }} in jobs."
+            description: "{{ doc('jobs__status') }}"
             data_tests:
               - not_null
           - name: worker_id
             data_type: uuid
-            description: "{{ doc('jobs__worker_id') }} in jobs."
+            description: "{{ doc('jobs__worker_id') }}"
           - name: started_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__started_at') }} in jobs."
+            description: "{{ doc('jobs__started_at') }}"
           - name: completed_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__completed_at') }} in jobs."
+            description: "{{ doc('jobs__completed_at') }}"
           - name: errored_at
             data_type: timestamp with time zone
-            description: "{{ doc('jobs__errored_at') }} in jobs."
+            description: "{{ doc('jobs__errored_at') }}"
           - name: error
             data_type: text
-            description: "{{ doc('jobs__error') }} in jobs."
+            description: "{{ doc('jobs__error') }}"
           - name: topic
             data_type: text
-            description: "{{ doc('jobs__topic') }} in jobs."
+            description: "{{ doc('jobs__topic') }}"
             data_tests:
               - not_null
           - name: discriminant
             data_type: text
-            description: "{{ doc('jobs__discriminant') }} in jobs."
+            description: "{{ doc('jobs__discriminant') }}"
             data_tests:
               - unique
               - not_null
           - name: payload
             data_type: jsonb
-            description: "{{ doc('jobs__payload') }} in jobs."
+            description: "{{ doc('jobs__payload') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/fhir/non_fhir_medici_report.yml
+++ b/database/model/facility-server/fhir/non_fhir_medici_report.yml
@@ -12,156 +12,124 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('non_fhir_medici_report__id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('non_fhir_medici_report__version_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__upstream_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('non_fhir_medici_report__last_updated') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__last_updated') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__patient_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__patient_id') }}"
             data_tests:
               - not_null
           - name: first_name
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__first_name') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__first_name') }}"
             data_tests:
               - not_null
           - name: last_name
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__last_name') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__last_name') }}"
             data_tests:
               - not_null
           - name: date_of_birth
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__date_of_birth') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__date_of_birth') }}"
           - name: age
             data_type: integer
-            description: "{{ doc('non_fhir_medici_report__age') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__age') }}"
           - name: sex
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__sex') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__sex') }}"
             data_tests:
               - not_null
           - name: patient_billing_id
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__patient_billing_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__patient_billing_id') }}"
           - name: patient_billing_type
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__patient_billing_type') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__patient_billing_type') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__encounter_id') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_id') }}"
             data_tests:
               - not_null
           - name: encounter_start_date
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__encounter_start_date') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_start_date') }}"
             data_tests:
               - not_null
           - name: encounter_end_date
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__encounter_end_date') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_end_date') }}"
           - name: discharge_date
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__discharge_date') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__discharge_date') }}"
           - name: encounter_type
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__encounter_type') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__encounter_type') }}"
           - name: weight
             data_type: numeric
-            description: "{{ doc('non_fhir_medici_report__weight') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__weight') }}"
           - name: visit_type
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__visit_type') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__visit_type') }}"
             data_tests:
               - not_null
           - name: episode_end_status
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__episode_end_status') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__episode_end_status') }}"
           - name: encounter_discharge_disposition
             data_type: jsonb
             description: "{{ doc('non_fhir_medici_report__encounter_discharge_disposition')
-              }} in non_fhir_medici_report."
+              }}"
           - name: triage_category
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__triage_category') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__triage_category') }}"
           - name: wait_time
             data_type: character varying(255)
-            description: "{{ doc('non_fhir_medici_report__wait_time') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__wait_time') }}"
           - name: departments
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__departments') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__departments') }}"
           - name: locations
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__locations') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__locations') }}"
           - name: reason_for_encounter
             data_type: text
-            description: "{{ doc('non_fhir_medici_report__reason_for_encounter') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__reason_for_encounter') }}"
           - name: diagnoses
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__diagnoses') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__diagnoses') }}"
           - name: medications
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__medications') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__medications') }}"
           - name: vaccinations
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__vaccinations') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__vaccinations') }}"
           - name: procedures
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__procedures') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__procedures') }}"
           - name: lab_requests
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__lab_requests') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__lab_requests') }}"
           - name: imaging_requests
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__imaging_requests') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__imaging_requests') }}"
           - name: notes
             data_type: jsonb
-            description: "{{ doc('non_fhir_medici_report__notes') }} in
-              non_fhir_medici_report."
+            description: "{{ doc('non_fhir_medici_report__notes') }}"

--- a/database/model/facility-server/fhir/organizations.yml
+++ b/database/model/facility-server/fhir/organizations.yml
@@ -12,33 +12,33 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('organizations__id') }} in organizations."
+            description: "{{ doc('organizations__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('organizations__version_id') }} in organizations."
+            description: "{{ doc('organizations__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('organizations__upstream_id') }} in organizations."
+            description: "{{ doc('organizations__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('organizations__last_updated') }} in organizations."
+            description: "{{ doc('organizations__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('organizations__identifier') }} in organizations."
+            description: "{{ doc('organizations__identifier') }}"
           - name: name
             data_type: text
-            description: "{{ doc('organizations__name') }} in organizations."
+            description: "{{ doc('organizations__name') }}"
             data_tests:
               - not_null
           - name: active
             data_type: boolean
-            description: "{{ doc('organizations__active') }} in organizations."
+            description: "{{ doc('organizations__active') }}"

--- a/database/model/facility-server/fhir/patients.yml
+++ b/database/model/facility-server/fhir/patients.yml
@@ -12,66 +12,66 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('patients__id') }} in patients."
+            description: "{{ doc('patients__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('patients__version_id') }} in patients."
+            description: "{{ doc('patients__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('patients__upstream_id') }} in patients."
+            description: "{{ doc('patients__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('patients__last_updated') }} in patients."
+            description: "{{ doc('patients__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('patients__identifier') }} in patients."
+            description: "{{ doc('patients__identifier') }}"
             data_tests:
               - not_null
           - name: active
             data_type: boolean
-            description: "{{ doc('patients__active') }} in patients."
+            description: "{{ doc('patients__active') }}"
             data_tests:
               - not_null
           - name: name
             data_type: jsonb
-            description: "{{ doc('patients__name') }} in patients."
+            description: "{{ doc('patients__name') }}"
             data_tests:
               - not_null
           - name: telecom
             data_type: jsonb
-            description: "{{ doc('patients__telecom') }} in patients."
+            description: "{{ doc('patients__telecom') }}"
             data_tests:
               - not_null
           - name: gender
             data_type: text
-            description: "{{ doc('patients__gender') }} in patients."
+            description: "{{ doc('patients__gender') }}"
             data_tests:
               - not_null
           - name: birth_date
             data_type: text
-            description: "{{ doc('patients__birth_date') }} in patients."
+            description: "{{ doc('patients__birth_date') }}"
           - name: deceased_date_time
             data_type: text
-            description: "{{ doc('patients__deceased_date_time') }} in patients."
+            description: "{{ doc('patients__deceased_date_time') }}"
           - name: address
             data_type: jsonb
-            description: "{{ doc('patients__address') }} in patients."
+            description: "{{ doc('patients__address') }}"
             data_tests:
               - not_null
           - name: link
             data_type: jsonb
-            description: "{{ doc('patients__link') }} in patients."
+            description: "{{ doc('patients__link') }}"
           - name: extension
             data_type: jsonb
-            description: "{{ doc('patients__extension') }} in patients."
+            description: "{{ doc('patients__extension') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/fhir/practitioners.yml
+++ b/database/model/facility-server/fhir/practitioners.yml
@@ -12,31 +12,31 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('practitioners__id') }} in practitioners."
+            description: "{{ doc('practitioners__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('practitioners__version_id') }} in practitioners."
+            description: "{{ doc('practitioners__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('practitioners__upstream_id') }} in practitioners."
+            description: "{{ doc('practitioners__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('practitioners__last_updated') }} in practitioners."
+            description: "{{ doc('practitioners__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('practitioners__identifier') }} in practitioners."
+            description: "{{ doc('practitioners__identifier') }}"
           - name: name
             data_type: jsonb
-            description: "{{ doc('practitioners__name') }} in practitioners."
+            description: "{{ doc('practitioners__name') }}"
           - name: telecom
             data_type: jsonb
-            description: "{{ doc('practitioners__telecom') }} in practitioners."
+            description: "{{ doc('practitioners__telecom') }}"

--- a/database/model/facility-server/fhir/service_requests.yml
+++ b/database/model/facility-server/fhir/service_requests.yml
@@ -12,73 +12,72 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('service_requests__id') }} in service_requests."
+            description: "{{ doc('service_requests__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('service_requests__version_id') }} in service_requests."
+            description: "{{ doc('service_requests__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying
-            description: "{{ doc('service_requests__upstream_id') }} in service_requests."
+            description: "{{ doc('service_requests__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('service_requests__last_updated') }} in service_requests."
+            description: "{{ doc('service_requests__last_updated') }}"
             data_tests:
               - not_null
           - name: identifier
             data_type: jsonb
-            description: "{{ doc('service_requests__identifier') }} in service_requests."
+            description: "{{ doc('service_requests__identifier') }}"
             data_tests:
               - not_null
           - name: status
             data_type: text
-            description: "{{ doc('service_requests__status') }} in service_requests."
+            description: "{{ doc('service_requests__status') }}"
           - name: intent
             data_type: text
-            description: "{{ doc('service_requests__intent') }} in service_requests."
+            description: "{{ doc('service_requests__intent') }}"
           - name: category
             data_type: jsonb
-            description: "{{ doc('service_requests__category') }} in service_requests."
+            description: "{{ doc('service_requests__category') }}"
             data_tests:
               - not_null
           - name: priority
             data_type: text
-            description: "{{ doc('service_requests__priority') }} in service_requests."
+            description: "{{ doc('service_requests__priority') }}"
           - name: order_detail
             data_type: jsonb
-            description: "{{ doc('service_requests__order_detail') }} in service_requests."
+            description: "{{ doc('service_requests__order_detail') }}"
             data_tests:
               - not_null
           - name: location_code
             data_type: jsonb
-            description: "{{ doc('service_requests__location_code') }} in service_requests."
+            description: "{{ doc('service_requests__location_code') }}"
             data_tests:
               - not_null
           - name: code
             data_type: jsonb
-            description: "{{ doc('service_requests__code') }} in service_requests."
+            description: "{{ doc('service_requests__code') }}"
           - name: subject
             data_type: jsonb
-            description: "{{ doc('service_requests__subject') }} in service_requests."
+            description: "{{ doc('service_requests__subject') }}"
           - name: requester
             data_type: jsonb
-            description: "{{ doc('service_requests__requester') }} in service_requests."
+            description: "{{ doc('service_requests__requester') }}"
           - name: occurrence_date_time
             data_type: text
-            description: "{{ doc('service_requests__occurrence_date_time') }} in
-              service_requests."
+            description: "{{ doc('service_requests__occurrence_date_time') }}"
           - name: encounter
             data_type: jsonb
-            description: "{{ doc('service_requests__encounter') }} in service_requests."
+            description: "{{ doc('service_requests__encounter') }}"
           - name: note
             data_type: jsonb
-            description: "{{ doc('service_requests__note') }} in service_requests."
+            description: "{{ doc('service_requests__note') }}"
           - name: specimen
             data_type: jsonb
-            description: "{{ doc('service_requests__specimen') }} in service_requests."
+            description: "{{ doc('service_requests__specimen') }}"

--- a/database/model/facility-server/fhir/specimens.yml
+++ b/database/model/facility-server/fhir/specimens.yml
@@ -12,31 +12,31 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('specimens__id') }} in specimens."
+            description: "{{ doc('specimens__id') }}"
             data_tests:
               - unique
               - not_null
           - name: version_id
             data_type: uuid
-            description: "{{ doc('specimens__version_id') }} in specimens."
+            description: "{{ doc('specimens__version_id') }}"
             data_tests:
               - not_null
           - name: upstream_id
             data_type: character varying(255)
-            description: "{{ doc('specimens__upstream_id') }} in specimens."
+            description: "{{ doc('specimens__upstream_id') }}"
             data_tests:
               - not_null
           - name: last_updated
             data_type: timestamp with time zone
-            description: "{{ doc('specimens__last_updated') }} in specimens."
+            description: "{{ doc('specimens__last_updated') }}"
             data_tests:
               - not_null
           - name: collection
             data_type: jsonb
-            description: "{{ doc('specimens__collection') }} in specimens."
+            description: "{{ doc('specimens__collection') }}"
           - name: request
             data_type: jsonb
-            description: "{{ doc('specimens__request') }} in specimens."
+            description: "{{ doc('specimens__request') }}"
           - name: type
             data_type: jsonb
-            description: "{{ doc('specimens__type') }} in specimens."
+            description: "{{ doc('specimens__type') }}"

--- a/database/model/facility-server/logs/debug_logs.yml
+++ b/database/model/facility-server/logs/debug_logs.yml
@@ -12,17 +12,17 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('debug_logs__id') }} in debug_logs."
+            description: "{{ doc('debug_logs__id') }}"
             data_tests:
               - unique
               - not_null
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('debug_logs__type') }} in debug_logs."
+            description: "{{ doc('debug_logs__type') }}"
             data_tests:
               - not_null
           - name: info
             data_type: json
-            description: "{{ doc('debug_logs__info') }} in debug_logs."
+            description: "{{ doc('debug_logs__info') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/logs/fhir_writes.yml
+++ b/database/model/facility-server/logs/fhir_writes.yml
@@ -12,35 +12,35 @@ sources:
         columns:
           - name: id
             data_type: uuid
-            description: "{{ doc('fhir_writes__id') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__id') }}"
             data_tests:
               - unique
               - not_null
           - name: created_at
             data_type: timestamp with time zone
-            description: "{{ doc('fhir_writes__created_at') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__created_at') }}"
             data_tests:
               - not_null
           - name: verb
             data_type: text
-            description: "{{ doc('fhir_writes__verb') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__verb') }}"
             data_tests:
               - not_null
           - name: url
             data_type: text
-            description: "{{ doc('fhir_writes__url') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__url') }}"
             data_tests:
               - not_null
           - name: body
             data_type: jsonb
-            description: "{{ doc('fhir_writes__body') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__body') }}"
             data_tests:
               - not_null
           - name: headers
             data_type: jsonb
-            description: "{{ doc('fhir_writes__headers') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__headers') }}"
             data_tests:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('fhir_writes__user_id') }} in fhir_writes."
+            description: "{{ doc('fhir_writes__user_id') }}"

--- a/database/model/facility-server/public/certifiable_vaccines.yml
+++ b/database/model/facility-server/public/certifiable_vaccines.yml
@@ -30,41 +30,34 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in certifiable_vaccines."
           - name: vaccine_id
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__vaccine_id') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__vaccine_id') }}"
             data_tests:
               - unique
               - not_null
           - name: manufacturer_id
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__manufacturer_id') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__manufacturer_id') }}"
           - name: icd11_drug_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__icd11_drug_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__icd11_drug_code') }}"
             data_tests:
               - not_null
           - name: icd11_disease_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__icd11_disease_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__icd11_disease_code') }}"
             data_tests:
               - not_null
           - name: vaccine_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__vaccine_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__vaccine_code') }}"
             data_tests:
               - not_null
           - name: target_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__target_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__target_code') }}"
           - name: eu_product_code
             data_type: character varying(255)
-            description: "{{ doc('certifiable_vaccines__eu_product_code') }} in
-              certifiable_vaccines."
+            description: "{{ doc('certifiable_vaccines__eu_product_code') }}"
           - name: maximum_dosage
             data_type: integer
             description: Default value is 1

--- a/database/model/facility-server/public/certificate_notifications.yml
+++ b/database/model/facility-server/public/certificate_notifications.yml
@@ -26,46 +26,37 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in certificate_notifications."
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__type') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__type') }}"
             data_tests:
               - not_null
           - name: require_signing
             data_type: boolean
-            description: "{{ doc('certificate_notifications__require_signing') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__require_signing') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__patient_id') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__patient_id') }}"
           - name: forward_address
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__forward_address') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__forward_address') }}"
           - name: lab_test_id
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__lab_test_id') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__lab_test_id') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__status') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__status') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('certificate_notifications__error') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__error') }}"
           - name: created_by
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__created_by') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__created_by') }}"
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__lab_request_id') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__lab_request_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
@@ -74,13 +65,10 @@ sources:
               - not_null
           - name: printed_date
             data_type: character(10)
-            description: "{{ doc('certificate_notifications__printed_date') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__printed_date') }}"
           - name: facility_name
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__facility_name') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__facility_name') }}"
           - name: language
             data_type: character varying(255)
-            description: "{{ doc('certificate_notifications__language') }} in
-              certificate_notifications."
+            description: "{{ doc('certificate_notifications__language') }}"

--- a/database/model/facility-server/public/death_revert_logs.yml
+++ b/database/model/facility-server/public/death_revert_logs.yml
@@ -30,24 +30,22 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in death_revert_logs."
           - name: revert_time
             data_type: character(19)
-            description: "{{ doc('death_revert_logs__revert_time') }} in death_revert_logs."
+            description: "{{ doc('death_revert_logs__revert_time') }}"
             data_tests:
               - not_null
           - name: death_data_id
             data_type: character varying(255)
-            description: "{{ doc('death_revert_logs__death_data_id') }} in
-              death_revert_logs."
+            description: "{{ doc('death_revert_logs__death_data_id') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('death_revert_logs__patient_id') }} in death_revert_logs."
+            description: "{{ doc('death_revert_logs__patient_id') }}"
             data_tests:
               - not_null
           - name: reverted_by_id
             data_type: character varying(255)
-            description: "{{ doc('death_revert_logs__reverted_by_id') }} in
-              death_revert_logs."
+            description: "{{ doc('death_revert_logs__reverted_by_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/document_metadata.yml
+++ b/database/model/facility-server/public/document_metadata.yml
@@ -17,39 +17,34 @@ sources:
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('document_metadata__name') }} in document_metadata."
+            description: "{{ doc('document_metadata__name') }}"
             data_tests:
               - not_null
           - name: type
             data_type: text
-            description: "{{ doc('document_metadata__type') }} in document_metadata."
+            description: "{{ doc('document_metadata__type') }}"
             data_tests:
               - not_null
           - name: document_created_at
             data_type: character(19)
-            description: "{{ doc('document_metadata__document_created_at') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_created_at') }}"
           - name: document_uploaded_at
             data_type: character(19)
-            description: "{{ doc('document_metadata__document_uploaded_at') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_uploaded_at') }}"
             data_tests:
               - not_null
           - name: document_owner
             data_type: text
-            description: "{{ doc('document_metadata__document_owner') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_owner') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__patient_id') }} in document_metadata."
+            description: "{{ doc('document_metadata__patient_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__encounter_id') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__encounter_id') }}"
           - name: attachment_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__attachment_id') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__attachment_id') }}"
             data_tests:
               - not_null
           - name: created_at
@@ -63,11 +58,10 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in document_metadata."
           - name: department_id
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__department_id') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__department_id') }}"
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__note') }} in document_metadata."
+            description: "{{ doc('document_metadata__note') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in document_metadata."
@@ -75,14 +69,12 @@ sources:
               - not_null
           - name: document_created_at_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('document_metadata__document_created_at_legacy') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_created_at_legacy') }}"
           - name: document_uploaded_at_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('document_metadata__document_uploaded_at_legacy') }} in
-              document_metadata."
+            description: "{{ doc('document_metadata__document_uploaded_at_legacy') }}"
           - name: source
             data_type: character varying(255)
-            description: "{{ doc('document_metadata__source') }} in document_metadata."
+            description: "{{ doc('document_metadata__source') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/encounter_diets.yml
+++ b/database/model/facility-server/public/encounter_diets.yml
@@ -25,7 +25,7 @@ sources:
                   field: id
           - name: diet_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_diets__diet_id') }} in encounter_diets."
+            description: "{{ doc('encounter_diets__diet_id') }}"
             data_tests:
               - not_null
               - dbt_utils.relationships_where:

--- a/database/model/facility-server/public/encounter_history.yml
+++ b/database/model/facility-server/public/encounter_history.yml
@@ -35,30 +35,27 @@ sources:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__encounter_id') }} in
-              encounter_history."
+            description: "{{ doc('encounter_history__encounter_id') }}"
             data_tests:
               - not_null
           - name: department_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__department_id') }} in
-              encounter_history."
+            description: "{{ doc('encounter_history__department_id') }}"
             data_tests:
               - not_null
           - name: location_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__location_id') }} in encounter_history."
+            description: "{{ doc('encounter_history__location_id') }}"
             data_tests:
               - not_null
           - name: examiner_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__examiner_id') }} in encounter_history."
+            description: "{{ doc('encounter_history__examiner_id') }}"
             data_tests:
               - not_null
           - name: encounter_type
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__encounter_type') }} in
-              encounter_history."
+            description: "{{ doc('encounter_history__encounter_type') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -68,7 +65,7 @@ sources:
               - not_null
           - name: actor_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__actor_id') }} in encounter_history."
+            description: "{{ doc('encounter_history__actor_id') }}"
           - name: change_type
             data_type: character varying(255)
-            description: "{{ doc('encounter_history__change_type') }} in encounter_history."
+            description: "{{ doc('encounter_history__change_type') }}"

--- a/database/model/facility-server/public/encounter_medications.yml
+++ b/database/model/facility-server/public/encounter_medications.yml
@@ -35,91 +35,71 @@ sources:
               - not_null
           - name: end_date
             data_type: character(19)
-            description: "{{ doc('encounter_medications__end_date') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__end_date') }}"
           - name: prescription
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__prescription') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__prescription') }}"
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__note') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__note') }}"
           - name: indication
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__indication') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__indication') }}"
           - name: route
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__route') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__route') }}"
           - name: qty_morning
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_morning') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_morning') }}"
           - name: qty_lunch
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_lunch') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_lunch') }}"
           - name: qty_evening
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_evening') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_evening') }}"
           - name: qty_night
             data_type: integer
-            description: "{{ doc('encounter_medications__qty_night') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__qty_night') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__encounter_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__encounter_id') }}"
           - name: medication_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__medication_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__medication_id') }}"
           - name: prescriber_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__prescriber_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__prescriber_id') }}"
           - name: quantity
             data_type: integer
-            description: "{{ doc('encounter_medications__quantity') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__quantity') }}"
             data_tests:
               - not_null
           - name: discontinued
             data_type: boolean
-            description: "{{ doc('encounter_medications__discontinued') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinued') }}"
           - name: discontinuing_clinician_id
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__discontinuing_clinician_id') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinuing_clinician_id') }}"
           - name: discontinuing_reason
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__discontinuing_reason') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinuing_reason') }}"
           - name: repeats
             data_type: integer
-            description: "{{ doc('encounter_medications__repeats') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__repeats') }}"
           - name: is_discharge
             data_type: boolean
-            description: "{{ doc('encounter_medications__is_discharge') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__is_discharge') }}"
             data_tests:
               - not_null
           - name: discontinued_date
             data_type: character varying(255)
-            description: "{{ doc('encounter_medications__discontinued_date') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__discontinued_date') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in encounter_medications."
           - name: end_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('encounter_medications__end_date_legacy') }} in
-              encounter_medications."
+            description: "{{ doc('encounter_medications__end_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/facility-server/public/imaging_area_external_codes.yml
+++ b/database/model/facility-server/public/imaging_area_external_codes.yml
@@ -36,21 +36,18 @@ sources:
               - not_null
           - name: area_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_area_external_codes__area_id') }} in
-              imaging_area_external_codes."
+            description: "{{ doc('imaging_area_external_codes__area_id') }}"
             data_tests:
               - unique
               - not_null
           - name: code
             data_type: text
-            description: "{{ doc('imaging_area_external_codes__code') }} in
-              imaging_area_external_codes."
+            description: "{{ doc('imaging_area_external_codes__code') }}"
             data_tests:
               - not_null
           - name: description
             data_type: text
-            description: "{{ doc('imaging_area_external_codes__description') }} in
-              imaging_area_external_codes."
+            description: "{{ doc('imaging_area_external_codes__description') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/facility-server/public/imaging_request_areas.yml
+++ b/database/model/facility-server/public/imaging_request_areas.yml
@@ -30,14 +30,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in imaging_request_areas."
           - name: imaging_request_id
             data_type: character varying
-            description: "{{ doc('imaging_request_areas__imaging_request_id') }} in
-              imaging_request_areas."
+            description: "{{ doc('imaging_request_areas__imaging_request_id') }}"
             data_tests:
               - not_null
           - name: area_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_request_areas__area_id') }} in
-              imaging_request_areas."
+            description: "{{ doc('imaging_request_areas__area_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/imaging_requests.yml
+++ b/database/model/facility-server/public/imaging_requests.yml
@@ -30,45 +30,39 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in imaging_requests."
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__status') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__status') }}"
           - name: requested_date
             data_type: character(19)
-            description: "{{ doc('imaging_requests__requested_date') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__requested_date') }}"
             data_tests:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__encounter_id') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__encounter_id') }}"
           - name: requested_by_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__requested_by_id') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__requested_by_id') }}"
           - name: legacy_results
             data_type: text
-            description: "{{ doc('imaging_requests__legacy_results') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__legacy_results') }}"
           - name: completed_by_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__completed_by_id') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__completed_by_id') }}"
           - name: location_id
             data_type: character varying(255)
             description: "[Deprecated]"
           - name: imaging_type
             data_type: character varying(31)
-            description: "{{ doc('imaging_requests__imaging_type') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__imaging_type') }}"
           - name: requested_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('imaging_requests__requested_date_legacy') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__requested_date_legacy') }}"
           - name: priority
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__priority') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__priority') }}"
           - name: location_group_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__location_group_id') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__location_group_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in imaging_requests."
@@ -76,10 +70,9 @@ sources:
               - not_null
           - name: reason_for_cancellation
             data_type: character varying(1024)
-            description: "{{ doc('imaging_requests__reason_for_cancellation') }} in
-              imaging_requests."
+            description: "{{ doc('imaging_requests__reason_for_cancellation') }}"
           - name: display_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_requests__display_id') }} in imaging_requests."
+            description: "{{ doc('imaging_requests__display_id') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/imaging_results.yml
+++ b/database/model/facility-server/public/imaging_results.yml
@@ -40,21 +40,20 @@ sources:
               - not_null
           - name: imaging_request_id
             data_type: character varying
-            description: "{{ doc('imaging_results__imaging_request_id') }} in
-              imaging_results."
+            description: "{{ doc('imaging_results__imaging_request_id') }}"
             data_tests:
               - not_null
           - name: completed_by_id
             data_type: character varying(255)
-            description: "{{ doc('imaging_results__completed_by_id') }} in imaging_results."
+            description: "{{ doc('imaging_results__completed_by_id') }}"
           - name: description
             data_type: text
-            description: "{{ doc('imaging_results__description') }} in imaging_results."
+            description: "{{ doc('imaging_results__description') }}"
           - name: external_code
             data_type: text
-            description: "{{ doc('imaging_results__external_code') }} in imaging_results."
+            description: "{{ doc('imaging_results__external_code') }}"
           - name: completed_at
             data_type: character(19)
-            description: "{{ doc('imaging_results__completed_at') }} in imaging_results."
+            description: "{{ doc('imaging_results__completed_at') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/invoice_insurer_payments.yml
+++ b/database/model/facility-server/public/invoice_insurer_payments.yml
@@ -17,27 +17,23 @@ sources:
               - not_null
           - name: invoice_payment_id
             data_type: uuid
-            description: "{{ doc('invoice_insurer_payments__invoice_payment_id') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__invoice_payment_id') }}"
             data_tests:
               - unique
               - not_null
           - name: insurer_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurer_payments__insurer_id') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__insurer_id') }}"
             data_tests:
               - not_null
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurer_payments__status') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__status') }}"
             data_tests:
               - not_null
           - name: reason
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurer_payments__reason') }} in
-              invoice_insurer_payments."
+            description: "{{ doc('invoice_insurer_payments__reason') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in invoice_insurer_payments."

--- a/database/model/facility-server/public/invoice_insurers.yml
+++ b/database/model/facility-server/public/invoice_insurers.yml
@@ -17,17 +17,17 @@ sources:
               - not_null
           - name: invoice_id
             data_type: uuid
-            description: "{{ doc('invoice_insurers__invoice_id') }} in invoice_insurers."
+            description: "{{ doc('invoice_insurers__invoice_id') }}"
             data_tests:
               - not_null
           - name: insurer_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_insurers__insurer_id') }} in invoice_insurers."
+            description: "{{ doc('invoice_insurers__insurer_id') }}"
             data_tests:
               - not_null
           - name: percentage
             data_type: numeric
-            description: "{{ doc('invoice_insurers__percentage') }} in invoice_insurers."
+            description: "{{ doc('invoice_insurers__percentage') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/facility-server/public/invoice_item_discounts.yml
+++ b/database/model/facility-server/public/invoice_item_discounts.yml
@@ -17,20 +17,17 @@ sources:
               - not_null
           - name: invoice_item_id
             data_type: uuid
-            description: "{{ doc('invoice_item_discounts__invoice_item_id') }} in
-              invoice_item_discounts."
+            description: "{{ doc('invoice_item_discounts__invoice_item_id') }}"
             data_tests:
               - not_null
           - name: percentage
             data_type: numeric
-            description: "{{ doc('invoice_item_discounts__percentage') }} in
-              invoice_item_discounts."
+            description: "{{ doc('invoice_item_discounts__percentage') }}"
             data_tests:
               - not_null
           - name: reason
             data_type: character varying(255)
-            description: "{{ doc('invoice_item_discounts__reason') }} in
-              invoice_item_discounts."
+            description: "{{ doc('invoice_item_discounts__reason') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in invoice_item_discounts."

--- a/database/model/facility-server/public/invoice_items.yml
+++ b/database/model/facility-server/public/invoice_items.yml
@@ -17,40 +17,40 @@ sources:
               - not_null
           - name: invoice_id
             data_type: uuid
-            description: "{{ doc('invoice_items__invoice_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__invoice_id') }}"
             data_tests:
               - not_null
           - name: order_date
             data_type: character(10)
-            description: "{{ doc('invoice_items__order_date') }} in invoice_items."
+            description: "{{ doc('invoice_items__order_date') }}"
             data_tests:
               - not_null
           - name: product_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__product_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_id') }}"
           - name: quantity
             data_type: integer
-            description: "{{ doc('invoice_items__quantity') }} in invoice_items."
+            description: "{{ doc('invoice_items__quantity') }}"
             data_tests:
               - not_null
           - name: product_name
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__product_name') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_name') }}"
             data_tests:
               - not_null
           - name: product_price
             data_type: numeric
-            description: "{{ doc('invoice_items__product_price') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_price') }}"
             data_tests:
               - not_null
           - name: ordered_by_user_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__ordered_by_user_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__ordered_by_user_id') }}"
             data_tests:
               - not_null
           - name: source_id
             data_type: uuid
-            description: "{{ doc('invoice_items__source_id') }} in invoice_items."
+            description: "{{ doc('invoice_items__source_id') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in invoice_items."
@@ -64,16 +64,15 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in invoice_items."
           - name: product_code
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__product_code') }} in invoice_items."
+            description: "{{ doc('invoice_items__product_code') }}"
             data_tests:
               - not_null
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('invoice_items__note') }} in invoice_items."
+            description: "{{ doc('invoice_items__note') }}"
           - name: product_discountable
             data_type: boolean
-            description: "{{ doc('invoice_items__product_discountable') }} in
-              invoice_items."
+            description: "{{ doc('invoice_items__product_discountable') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/invoice_patient_payments.yml
+++ b/database/model/facility-server/public/invoice_patient_payments.yml
@@ -17,15 +17,13 @@ sources:
               - not_null
           - name: invoice_payment_id
             data_type: uuid
-            description: "{{ doc('invoice_patient_payments__invoice_payment_id') }} in
-              invoice_patient_payments."
+            description: "{{ doc('invoice_patient_payments__invoice_payment_id') }}"
             data_tests:
               - unique
               - not_null
           - name: method_id
             data_type: character varying(255)
-            description: "{{ doc('invoice_patient_payments__method_id') }} in
-              invoice_patient_payments."
+            description: "{{ doc('invoice_patient_payments__method_id') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/facility-server/public/invoice_payments.yml
+++ b/database/model/facility-server/public/invoice_payments.yml
@@ -17,7 +17,7 @@ sources:
               - not_null
           - name: invoice_id
             data_type: uuid
-            description: "{{ doc('invoice_payments__invoice_id') }} in invoice_payments."
+            description: "{{ doc('invoice_payments__invoice_id') }}"
             data_tests:
               - not_null
           - name: date
@@ -27,13 +27,12 @@ sources:
               - not_null
           - name: receipt_number
             data_type: character varying(255)
-            description: "{{ doc('invoice_payments__receipt_number') }} in
-              invoice_payments."
+            description: "{{ doc('invoice_payments__receipt_number') }}"
             data_tests:
               - not_null
           - name: amount
             data_type: numeric
-            description: "{{ doc('invoice_payments__amount') }} in invoice_payments."
+            description: "{{ doc('invoice_payments__amount') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/facility-server/public/invoice_products.yml
+++ b/database/model/facility-server/public/invoice_products.yml
@@ -17,17 +17,17 @@ sources:
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('invoice_products__name') }} in invoice_products."
+            description: "{{ doc('invoice_products__name') }}"
             data_tests:
               - not_null
           - name: price
             data_type: numeric
-            description: "{{ doc('invoice_products__price') }} in invoice_products."
+            description: "{{ doc('invoice_products__price') }}"
             data_tests:
               - not_null
           - name: discountable
             data_type: boolean
-            description: "{{ doc('invoice_products__discountable') }} in invoice_products."
+            description: "{{ doc('invoice_products__discountable') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/facility-server/public/invoices.yml
+++ b/database/model/facility-server/public/invoices.yml
@@ -17,7 +17,7 @@ sources:
               - not_null
           - name: display_id
             data_type: character varying(255)
-            description: "{{ doc('invoices__display_id') }} in invoices."
+            description: "{{ doc('invoices__display_id') }}"
             data_tests:
               - not_null
           - name: date
@@ -27,12 +27,12 @@ sources:
               - not_null
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('invoices__status') }} in invoices."
+            description: "{{ doc('invoices__status') }}"
             data_tests:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('invoices__encounter_id') }} in invoices."
+            description: "{{ doc('invoices__encounter_id') }}"
             data_tests:
               - not_null
           - name: created_at
@@ -48,12 +48,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in invoices."
           - name: patient_payment_status
             data_type: character varying(255)
-            description: "{{ doc('invoices__patient_payment_status') }} in invoices."
+            description: "{{ doc('invoices__patient_payment_status') }}"
             data_tests:
               - not_null
           - name: insurer_payment_status
             data_type: character varying(255)
-            description: "{{ doc('invoices__insurer_payment_status') }} in invoices."
+            description: "{{ doc('invoices__insurer_payment_status') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/ips_requests.yml
+++ b/database/model/facility-server/public/ips_requests.yml
@@ -30,27 +30,27 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in ips_requests."
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__patient_id') }} in ips_requests."
+            description: "{{ doc('ips_requests__patient_id') }}"
             data_tests:
               - not_null
           - name: created_by
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__created_by') }} in ips_requests."
+            description: "{{ doc('ips_requests__created_by') }}"
             data_tests:
               - not_null
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__status') }} in ips_requests."
+            description: "{{ doc('ips_requests__status') }}"
             data_tests:
               - not_null
           - name: email
             data_type: character varying(255)
-            description: "{{ doc('ips_requests__email') }} in ips_requests."
+            description: "{{ doc('ips_requests__email') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('ips_requests__error') }} in ips_requests."
+            description: "{{ doc('ips_requests__error') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in ips_requests."

--- a/database/model/facility-server/public/lab_request_attachments.yml
+++ b/database/model/facility-server/public/lab_request_attachments.yml
@@ -30,24 +30,20 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_request_attachments."
           - name: attachment_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__attachment_id') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__attachment_id') }}"
             data_tests:
               - not_null
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__lab_request_id') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__lab_request_id') }}"
             data_tests:
               - not_null
           - name: title
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__title') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__title') }}"
           - name: replaced_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_attachments__replaced_by_id') }} in
-              lab_request_attachments."
+            description: "{{ doc('lab_request_attachments__replaced_by_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/facility-server/public/lab_request_logs.yml
+++ b/database/model/facility-server/public/lab_request_logs.yml
@@ -26,16 +26,15 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_request_logs."
           - name: status
             data_type: character varying(31)
-            description: "{{ doc('lab_request_logs__status') }} in lab_request_logs."
+            description: "{{ doc('lab_request_logs__status') }}"
             data_tests:
               - not_null
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_logs__lab_request_id') }} in
-              lab_request_logs."
+            description: "{{ doc('lab_request_logs__lab_request_id') }}"
           - name: updated_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_request_logs__updated_by_id') }} in lab_request_logs."
+            description: "{{ doc('lab_request_logs__updated_by_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_request_logs."

--- a/database/model/facility-server/public/lab_requests.yml
+++ b/database/model/facility-server/public/lab_requests.yml
@@ -30,52 +30,51 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_requests."
           - name: sample_time
             data_type: character(19)
-            description: "{{ doc('lab_requests__sample_time') }} in lab_requests."
+            description: "{{ doc('lab_requests__sample_time') }}"
           - name: requested_date
             data_type: character(19)
-            description: "{{ doc('lab_requests__requested_date') }} in lab_requests."
+            description: "{{ doc('lab_requests__requested_date') }}"
           - name: urgent
             data_type: boolean
             description: "[Deprecated]"
           - name: specimen_attached
             data_type: boolean
-            description: "{{ doc('lab_requests__specimen_attached') }} in lab_requests."
+            description: "{{ doc('lab_requests__specimen_attached') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__status') }} in lab_requests."
+            description: "{{ doc('lab_requests__status') }}"
           - name: senaite_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__senaite_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__senaite_id') }}"
           - name: sample_id
             data_type: character varying(255)
             description: "[Deprecated]"
           - name: requested_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__requested_by_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__requested_by_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__encounter_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__encounter_id') }}"
           - name: lab_test_category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_test_category_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__lab_test_category_id') }}"
           - name: display_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__display_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__display_id') }}"
             data_tests:
               - not_null
           - name: lab_test_priority_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_test_priority_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__lab_test_priority_id') }}"
           - name: lab_test_laboratory_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_test_laboratory_id') }} in
-              lab_requests."
+            description: "{{ doc('lab_requests__lab_test_laboratory_id') }}"
           - name: sample_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('lab_requests__sample_time_legacy') }} in lab_requests."
+            description: "{{ doc('lab_requests__sample_time_legacy') }}"
           - name: requested_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('lab_requests__requested_date_legacy') }} in lab_requests."
+            description: "{{ doc('lab_requests__requested_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_requests."
@@ -83,24 +82,22 @@ sources:
               - not_null
           - name: reason_for_cancellation
             data_type: character varying(31)
-            description: "{{ doc('lab_requests__reason_for_cancellation') }} in
-              lab_requests."
+            description: "{{ doc('lab_requests__reason_for_cancellation') }}"
           - name: published_date
             data_type: character(19)
-            description: "{{ doc('lab_requests__published_date') }} in lab_requests."
+            description: "{{ doc('lab_requests__published_date') }}"
           - name: department_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__department_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__department_id') }}"
           - name: lab_test_panel_request_id
             data_type: uuid
-            description: "{{ doc('lab_requests__lab_test_panel_request_id') }} in
-              lab_requests."
+            description: "{{ doc('lab_requests__lab_test_panel_request_id') }}"
           - name: lab_sample_site_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__lab_sample_site_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__lab_sample_site_id') }}"
           - name: specimen_type_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__specimen_type_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__specimen_type_id') }}"
           - name: collected_by_id
             data_type: character varying(255)
-            description: "{{ doc('lab_requests__collected_by_id') }} in lab_requests."
+            description: "{{ doc('lab_requests__collected_by_id') }}"

--- a/database/model/facility-server/public/lab_test_panel_lab_test_types.yml
+++ b/database/model/facility-server/public/lab_test_panel_lab_test_types.yml
@@ -27,15 +27,13 @@ sources:
               lab_test_panel_lab_test_types."
           - name: lab_test_panel_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_panel_id') }} in
-              lab_test_panel_lab_test_types."
+            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_panel_id') }}"
             data_tests:
               - unique
               - not_null
           - name: lab_test_type_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_type_id') }} in
-              lab_test_panel_lab_test_types."
+            description: "{{ doc('lab_test_panel_lab_test_types__lab_test_type_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/facility-server/public/lab_test_panel_requests.yml
+++ b/database/model/facility-server/public/lab_test_panel_requests.yml
@@ -30,14 +30,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_test_panel_requests."
           - name: lab_test_panel_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_requests__lab_test_panel_id') }} in
-              lab_test_panel_requests."
+            description: "{{ doc('lab_test_panel_requests__lab_test_panel_id') }}"
             data_tests:
               - not_null
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panel_requests__encounter_id') }} in
-              lab_test_panel_requests."
+            description: "{{ doc('lab_test_panel_requests__encounter_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/lab_test_panels.yml
+++ b/database/model/facility-server/public/lab_test_panels.yml
@@ -30,12 +30,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_test_panels."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panels__name') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__name') }}"
             data_tests:
               - not_null
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panels__code') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__code') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -45,10 +45,10 @@ sources:
               - not_null
           - name: external_code
             data_type: text
-            description: "{{ doc('lab_test_panels__external_code') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__external_code') }}"
           - name: category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_panels__category_id') }} in lab_test_panels."
+            description: "{{ doc('lab_test_panels__category_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_test_panels."

--- a/database/model/facility-server/public/lab_test_types.yml
+++ b/database/model/facility-server/public/lab_test_types.yml
@@ -30,46 +30,45 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in lab_test_types."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__code') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__code') }}"
             data_tests:
               - not_null
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__name') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__name') }}"
             data_tests:
               - not_null
           - name: unit
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__unit') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__unit') }}"
             data_tests:
               - not_null
           - name: male_min
             data_type: double precision
-            description: "{{ doc('lab_test_types__male_min') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__male_min') }}"
           - name: male_max
             data_type: double precision
-            description: "{{ doc('lab_test_types__male_max') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__male_max') }}"
           - name: female_min
             data_type: double precision
-            description: "{{ doc('lab_test_types__female_min') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__female_min') }}"
           - name: female_max
             data_type: double precision
-            description: "{{ doc('lab_test_types__female_max') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__female_max') }}"
           - name: range_text
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__range_text') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__range_text') }}"
           - name: result_type
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__result_type') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__result_type') }}"
             data_tests:
               - not_null
           - name: options
             data_type: text
-            description: "{{ doc('lab_test_types__options') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__options') }}"
           - name: lab_test_category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_test_types__lab_test_category_id') }} in
-              lab_test_types."
+            description: "{{ doc('lab_test_types__lab_test_category_id') }}"
           - name: visibility_status
             data_type: text
             description: "{{ doc('generic__visibility_status') }} in lab_test_types."
@@ -80,4 +79,4 @@ sources:
               - not_null
           - name: external_code
             data_type: text
-            description: "{{ doc('lab_test_types__external_code') }} in lab_test_types."
+            description: "{{ doc('lab_test_types__external_code') }}"

--- a/database/model/facility-server/public/lab_tests.yml
+++ b/database/model/facility-server/public/lab_tests.yml
@@ -35,41 +35,41 @@ sources:
               - not_null
           - name: status
             data_type: character varying(31)
-            description: "{{ doc('lab_tests__status') }} in lab_tests."
+            description: "{{ doc('lab_tests__status') }}"
             data_tests:
               - not_null
           - name: result
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__result') }} in lab_tests."
+            description: "{{ doc('lab_tests__result') }}"
             data_tests:
               - not_null
           - name: lab_request_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__lab_request_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__lab_request_id') }}"
           - name: lab_test_type_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__lab_test_type_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__lab_test_type_id') }}"
           - name: category_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__category_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__category_id') }}"
           - name: lab_test_method_id
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__lab_test_method_id') }} in lab_tests."
+            description: "{{ doc('lab_tests__lab_test_method_id') }}"
           - name: laboratory_officer
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__laboratory_officer') }} in lab_tests."
+            description: "{{ doc('lab_tests__laboratory_officer') }}"
           - name: completed_date
             data_type: character(19)
-            description: "{{ doc('lab_tests__completed_date') }} in lab_tests."
+            description: "{{ doc('lab_tests__completed_date') }}"
           - name: verification
             data_type: character varying(255)
-            description: "{{ doc('lab_tests__verification') }} in lab_tests."
+            description: "{{ doc('lab_tests__verification') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in lab_tests."
           - name: completed_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('lab_tests__completed_date_legacy') }} in lab_tests."
+            description: "{{ doc('lab_tests__completed_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in lab_tests."

--- a/database/model/facility-server/public/local_system_facts.yml
+++ b/database/model/facility-server/public/local_system_facts.yml
@@ -26,9 +26,9 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in local_system_facts."
           - name: key
             data_type: character varying(255)
-            description: "{{ doc('local_system_facts__key') }} in local_system_facts."
+            description: "{{ doc('local_system_facts__key') }}"
             data_tests:
               - not_null
           - name: value
             data_type: text
-            description: "{{ doc('local_system_facts__value') }} in local_system_facts."
+            description: "{{ doc('local_system_facts__value') }}"

--- a/database/model/facility-server/public/note_items.yml
+++ b/database/model/facility-server/public/note_items.yml
@@ -31,21 +31,21 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in note_items."
           - name: note_page_id
             data_type: uuid
-            description: "{{ doc('note_items__note_page_id') }} in note_items."
+            description: "{{ doc('note_items__note_page_id') }}"
             data_tests:
               - not_null
           - name: revised_by_id
             data_type: character varying(255)
-            description: "{{ doc('note_items__revised_by_id') }} in note_items."
+            description: "{{ doc('note_items__revised_by_id') }}"
           - name: author_id
             data_type: character varying(255)
-            description: "{{ doc('note_items__author_id') }} in note_items."
+            description: "{{ doc('note_items__author_id') }}"
           - name: on_behalf_of_id
             data_type: character varying(255)
-            description: "{{ doc('note_items__on_behalf_of_id') }} in note_items."
+            description: "{{ doc('note_items__on_behalf_of_id') }}"
           - name: content
             data_type: text
-            description: "{{ doc('note_items__content') }} in note_items."
+            description: "{{ doc('note_items__content') }}"
             data_tests:
               - not_null
           - name: date

--- a/database/model/facility-server/public/note_pages.yml
+++ b/database/model/facility-server/public/note_pages.yml
@@ -31,17 +31,17 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in note_pages."
           - name: note_type
             data_type: character varying(255)
-            description: "{{ doc('note_pages__note_type') }} in note_pages."
+            description: "{{ doc('note_pages__note_type') }}"
             data_tests:
               - not_null
           - name: record_id
             data_type: character varying(255)
-            description: "{{ doc('note_pages__record_id') }} in note_pages."
+            description: "{{ doc('note_pages__record_id') }}"
             data_tests:
               - not_null
           - name: record_type
             data_type: character varying(255)
-            description: "{{ doc('note_pages__record_type') }} in note_pages."
+            description: "{{ doc('note_pages__record_type') }}"
             data_tests:
               - not_null
           - name: date

--- a/database/model/facility-server/public/notes_legacy.yml
+++ b/database/model/facility-server/public/notes_legacy.yml
@@ -31,12 +31,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in notes_legacy."
           - name: record_id
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__record_id') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__record_id') }}"
             data_tests:
               - not_null
           - name: record_type
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__record_type') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__record_type') }}"
             data_tests:
               - not_null
           - name: date
@@ -46,18 +46,18 @@ sources:
               - not_null
           - name: note_type
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__note_type') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__note_type') }}"
           - name: content
             data_type: text
-            description: "{{ doc('notes_legacy__content') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__content') }}"
             data_tests:
               - not_null
           - name: author_id
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__author_id') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__author_id') }}"
           - name: on_behalf_of_id
             data_type: character varying(255)
-            description: "{{ doc('notes_legacy__on_behalf_of_id') }} in notes_legacy."
+            description: "{{ doc('notes_legacy__on_behalf_of_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in notes_legacy."

--- a/database/model/facility-server/public/one_time_logins.yml
+++ b/database/model/facility-server/public/one_time_logins.yml
@@ -17,12 +17,12 @@ sources:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('one_time_logins__user_id') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__user_id') }}"
             data_tests:
               - not_null
           - name: token
             data_type: character varying(255)
-            description: "{{ doc('one_time_logins__token') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__token') }}"
             data_tests:
               - not_null
           - name: created_at
@@ -36,9 +36,9 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in one_time_logins."
           - name: expires_at
             data_type: timestamp with time zone
-            description: "{{ doc('one_time_logins__expires_at') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__expires_at') }}"
             data_tests:
               - not_null
           - name: used_at
             data_type: timestamp with time zone
-            description: "{{ doc('one_time_logins__used_at') }} in one_time_logins."
+            description: "{{ doc('one_time_logins__used_at') }}"

--- a/database/model/facility-server/public/patient_additional_data.yml
+++ b/database/model/facility-server/public/patient_additional_data.yml
@@ -20,138 +20,106 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_additional_data."
           - name: place_of_birth
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__place_of_birth') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__place_of_birth') }}"
           - name: primary_contact_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__primary_contact_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__primary_contact_number') }}"
           - name: secondary_contact_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__secondary_contact_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__secondary_contact_number') }}"
           - name: marital_status
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__marital_status') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__marital_status') }}"
           - name: city_town
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__city_town') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__city_town') }}"
           - name: street_village
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__street_village') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__street_village') }}"
           - name: educational_level
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__educational_level') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__educational_level') }}"
           - name: social_media
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__social_media') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__social_media') }}"
           - name: blood_type
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__blood_type') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__blood_type') }}"
           - name: title
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__title') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__title') }}"
           - name: ethnicity_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__ethnicity_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__ethnicity_id') }}"
           - name: nationality_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__nationality_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__nationality_id') }}"
           - name: country_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__country_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__country_id') }}"
           - name: division_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__division_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__division_id') }}"
           - name: subdivision_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__subdivision_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__subdivision_id') }}"
           - name: medical_area_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__medical_area_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__medical_area_id') }}"
           - name: nursing_zone_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__nursing_zone_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__nursing_zone_id') }}"
           - name: settlement_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__settlement_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__settlement_id') }}"
           - name: occupation_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__occupation_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__occupation_id') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__patient_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__patient_id') }}"
             data_tests:
               - unique
               - not_null
           - name: birth_certificate
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__birth_certificate') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__birth_certificate') }}"
           - name: driving_license
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__driving_license') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__driving_license') }}"
           - name: passport
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__passport') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__passport') }}"
           - name: religion_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__religion_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__religion_id') }}"
           - name: patient_billing_type_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__patient_billing_type_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__patient_billing_type_id') }}"
           - name: country_of_birth_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__country_of_birth_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__country_of_birth_id') }}"
           - name: registered_by_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__registered_by_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__registered_by_id') }}"
           - name: emergency_contact_name
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__emergency_contact_name') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__emergency_contact_name') }}"
           - name: emergency_contact_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__emergency_contact_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__emergency_contact_number') }}"
           - name: mother_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__mother_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__mother_id') }}"
           - name: father_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__father_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__father_id') }}"
           - name: id
             data_type: text
             description: "{{ doc('generic__id') }} in patient_additional_data."
           - name: updated_at_by_field
             data_type: json
-            description: "{{ doc('patient_additional_data__updated_at_by_field') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__updated_at_by_field') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
@@ -160,17 +128,13 @@ sources:
               - not_null
           - name: health_center_id
             data_type: text
-            description: "{{ doc('patient_additional_data__health_center_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__health_center_id') }}"
           - name: secondary_village_id
             data_type: text
-            description: "{{ doc('patient_additional_data__secondary_village_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__secondary_village_id') }}"
           - name: insurer_id
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__insurer_id') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__insurer_id') }}"
           - name: insurer_policy_number
             data_type: character varying(255)
-            description: "{{ doc('patient_additional_data__insurer_policy_number') }} in
-              patient_additional_data."
+            description: "{{ doc('patient_additional_data__insurer_policy_number') }}"

--- a/database/model/facility-server/public/patient_allergies.yml
+++ b/database/model/facility-server/public/patient_allergies.yml
@@ -30,27 +30,24 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_allergies."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__note') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_allergies__recorded_date') }} in
-              patient_allergies."
+            description: "{{ doc('patient_allergies__recorded_date') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__patient_id') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__patient_id') }}"
           - name: practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__practitioner_id') }} in
-              patient_allergies."
+            description: "{{ doc('patient_allergies__practitioner_id') }}"
           - name: allergy_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__allergy_id') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__allergy_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_allergies__recorded_date_legacy') }} in
-              patient_allergies."
+            description: "{{ doc('patient_allergies__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_allergies."
@@ -58,4 +55,4 @@ sources:
               - not_null
           - name: reaction_id
             data_type: character varying(255)
-            description: "{{ doc('patient_allergies__reaction_id') }} in patient_allergies."
+            description: "{{ doc('patient_allergies__reaction_id') }}"

--- a/database/model/facility-server/public/patient_birth_data.yml
+++ b/database/model/facility-server/public/patient_birth_data.yml
@@ -24,67 +24,52 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_birth_data."
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__patient_id') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__patient_id') }}"
             data_tests:
               - unique
               - not_null
           - name: birth_weight
             data_type: numeric
-            description: "{{ doc('patient_birth_data__birth_weight') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_weight') }}"
           - name: birth_length
             data_type: numeric
-            description: "{{ doc('patient_birth_data__birth_length') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_length') }}"
           - name: birth_delivery_type
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__birth_delivery_type') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_delivery_type') }}"
           - name: gestational_age_estimate
             data_type: double precision
-            description: "{{ doc('patient_birth_data__gestational_age_estimate') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__gestational_age_estimate') }}"
           - name: apgar_score_one_minute
             data_type: integer
-            description: "{{ doc('patient_birth_data__apgar_score_one_minute') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__apgar_score_one_minute') }}"
           - name: apgar_score_five_minutes
             data_type: integer
-            description: "{{ doc('patient_birth_data__apgar_score_five_minutes') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__apgar_score_five_minutes') }}"
           - name: apgar_score_ten_minutes
             data_type: integer
-            description: "{{ doc('patient_birth_data__apgar_score_ten_minutes') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__apgar_score_ten_minutes') }}"
           - name: time_of_birth
             data_type: character(19)
-            description: "{{ doc('patient_birth_data__time_of_birth') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__time_of_birth') }}"
           - name: birth_type
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__birth_type') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_type') }}"
           - name: attendant_at_birth
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__attendant_at_birth') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__attendant_at_birth') }}"
           - name: name_of_attendant_at_birth
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__name_of_attendant_at_birth') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__name_of_attendant_at_birth') }}"
           - name: birth_facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__birth_facility_id') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__birth_facility_id') }}"
           - name: registered_birth_place
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__registered_birth_place') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__registered_birth_place') }}"
           - name: time_of_birth_legacy
             data_type: character varying(255)
-            description: "{{ doc('patient_birth_data__time_of_birth_legacy') }} in
-              patient_birth_data."
+            description: "{{ doc('patient_birth_data__time_of_birth_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_birth_data."

--- a/database/model/facility-server/public/patient_care_plans.yml
+++ b/database/model/facility-server/public/patient_care_plans.yml
@@ -35,16 +35,13 @@ sources:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_care_plans__patient_id') }} in
-              patient_care_plans."
+            description: "{{ doc('patient_care_plans__patient_id') }}"
           - name: examiner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_care_plans__examiner_id') }} in
-              patient_care_plans."
+            description: "{{ doc('patient_care_plans__examiner_id') }}"
           - name: care_plan_id
             data_type: character varying(255)
-            description: "{{ doc('patient_care_plans__care_plan_id') }} in
-              patient_care_plans."
+            description: "{{ doc('patient_care_plans__care_plan_id') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in patient_care_plans."

--- a/database/model/facility-server/public/patient_communications.yml
+++ b/database/model/facility-server/public/patient_communications.yml
@@ -30,51 +30,40 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_communications."
           - name: type
             data_type: text
-            description: "{{ doc('patient_communications__type') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__type') }}"
             data_tests:
               - not_null
           - name: channel
             data_type: text
-            description: "{{ doc('patient_communications__channel') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__channel') }}"
             data_tests:
               - not_null
           - name: subject
             data_type: text
-            description: "{{ doc('patient_communications__subject') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__subject') }}"
           - name: content
             data_type: text
-            description: "{{ doc('patient_communications__content') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__content') }}"
           - name: status
             data_type: user-defined
-            description: "{{ doc('patient_communications__status') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__status') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('patient_communications__error') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__error') }}"
           - name: retry_count
             data_type: integer
-            description: "{{ doc('patient_communications__retry_count') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__retry_count') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_communications__patient_id') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__patient_id') }}"
           - name: destination
             data_type: character varying(255)
-            description: "{{ doc('patient_communications__destination') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__destination') }}"
           - name: attachment
             data_type: character varying(255)
-            description: "{{ doc('patient_communications__attachment') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__attachment') }}"
           - name: hash
             data_type: integer
-            description: "{{ doc('patient_communications__hash') }} in
-              patient_communications."
+            description: "{{ doc('patient_communications__hash') }}"

--- a/database/model/facility-server/public/patient_conditions.yml
+++ b/database/model/facility-server/public/patient_conditions.yml
@@ -30,32 +30,27 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_conditions."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__note') }} in patient_conditions."
+            description: "{{ doc('patient_conditions__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_conditions__recorded_date') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__recorded_date') }}"
             data_tests:
               - not_null
           - name: resolved
             data_type: boolean
-            description: "{{ doc('patient_conditions__resolved') }} in patient_conditions."
+            description: "{{ doc('patient_conditions__resolved') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__patient_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__patient_id') }}"
           - name: examiner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__examiner_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__examiner_id') }}"
           - name: condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__condition_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__condition_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_conditions__recorded_date_legacy') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_conditions."
@@ -63,13 +58,10 @@ sources:
               - not_null
           - name: resolution_date
             data_type: character(19)
-            description: "{{ doc('patient_conditions__resolution_date') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__resolution_date') }}"
           - name: resolution_practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_conditions__resolution_practitioner_id') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__resolution_practitioner_id') }}"
           - name: resolution_note
             data_type: text
-            description: "{{ doc('patient_conditions__resolution_note') }} in
-              patient_conditions."
+            description: "{{ doc('patient_conditions__resolution_note') }}"

--- a/database/model/facility-server/public/patient_contacts.yml
+++ b/database/model/facility-server/public/patient_contacts.yml
@@ -30,31 +30,28 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_contacts."
           - name: name
             data_type: text
-            description: "{{ doc('patient_contacts__name') }} in patient_contacts."
+            description: "{{ doc('patient_contacts__name') }}"
             data_tests:
               - not_null
           - name: method
             data_type: text
-            description: "{{ doc('patient_contacts__method') }} in patient_contacts."
+            description: "{{ doc('patient_contacts__method') }}"
             data_tests:
               - not_null
           - name: connection_details
             data_type: jsonb
-            description: "{{ doc('patient_contacts__connection_details') }} in
-              patient_contacts."
+            description: "{{ doc('patient_contacts__connection_details') }}"
           - name: deletion_status
             data_type: text
-            description: "{{ doc('patient_contacts__deletion_status') }} in
-              patient_contacts."
+            description: "{{ doc('patient_contacts__deletion_status') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_contacts__patient_id') }} in patient_contacts."
+            description: "{{ doc('patient_contacts__patient_id') }}"
             data_tests:
               - not_null
           - name: relationship_id
             data_type: character varying(255)
-            description: "{{ doc('patient_contacts__relationship_id') }} in
-              patient_contacts."
+            description: "{{ doc('patient_contacts__relationship_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/patient_death_data.yml
+++ b/database/model/facility-server/public/patient_death_data.yml
@@ -17,86 +17,68 @@ sources:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__patient_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__patient_id') }}"
             data_tests:
               - not_null
           - name: clinician_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__clinician_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__clinician_id') }}"
             data_tests:
               - not_null
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__facility_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__facility_id') }}"
           - name: manner
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__manner') }} in patient_death_data."
+            description: "{{ doc('patient_death_data__manner') }}"
           - name: recent_surgery
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__recent_surgery') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__recent_surgery') }}"
           - name: last_surgery_date
             data_type: character(10)
-            description: "{{ doc('patient_death_data__last_surgery_date') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__last_surgery_date') }}"
           - name: last_surgery_reason_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__last_surgery_reason_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__last_surgery_reason_id') }}"
           - name: external_cause_date
             data_type: character(10)
-            description: "{{ doc('patient_death_data__external_cause_date') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_date') }}"
           - name: external_cause_location
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__external_cause_location') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_location') }}"
           - name: external_cause_notes
             data_type: text
-            description: "{{ doc('patient_death_data__external_cause_notes') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_notes') }}"
           - name: was_pregnant
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__was_pregnant') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__was_pregnant') }}"
           - name: pregnancy_contributed
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__pregnancy_contributed') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__pregnancy_contributed') }}"
           - name: fetal_or_infant
             data_type: boolean
-            description: "{{ doc('patient_death_data__fetal_or_infant') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__fetal_or_infant') }}"
           - name: stillborn
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__stillborn') }} in patient_death_data."
+            description: "{{ doc('patient_death_data__stillborn') }}"
           - name: birth_weight
             data_type: integer
-            description: "{{ doc('patient_death_data__birth_weight') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__birth_weight') }}"
           - name: within_day_of_birth
             data_type: boolean
-            description: "{{ doc('patient_death_data__within_day_of_birth') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__within_day_of_birth') }}"
           - name: hours_survived_since_birth
             data_type: integer
-            description: "{{ doc('patient_death_data__hours_survived_since_birth') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__hours_survived_since_birth') }}"
           - name: carrier_age
             data_type: integer
-            description: "{{ doc('patient_death_data__carrier_age') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__carrier_age') }}"
           - name: carrier_pregnancy_weeks
             data_type: integer
-            description: "{{ doc('patient_death_data__carrier_pregnancy_weeks') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__carrier_pregnancy_weeks') }}"
           - name: carrier_existing_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__carrier_existing_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__carrier_existing_condition_id') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in patient_death_data."
@@ -108,40 +90,33 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_death_data."
           - name: outside_health_facility
             data_type: boolean
-            description: "{{ doc('patient_death_data__outside_health_facility') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__outside_health_facility') }}"
           - name: primary_cause_time_after_onset
             data_type: integer
-            description: "{{ doc('patient_death_data__primary_cause_time_after_onset') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__primary_cause_time_after_onset') }}"
           - name: primary_cause_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__primary_cause_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__primary_cause_condition_id') }}"
           - name: antecedent_cause1_time_after_onset
             data_type: integer
             description: "{{ doc('patient_death_data__antecedent_cause1_time_after_onset')
-              }} in patient_death_data."
+              }}"
           - name: antecedent_cause1_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__antecedent_cause1_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__antecedent_cause1_condition_id') }}"
           - name: antecedent_cause2_time_after_onset
             data_type: integer
             description: "{{ doc('patient_death_data__antecedent_cause2_time_after_onset')
-              }} in patient_death_data."
+              }}"
           - name: antecedent_cause2_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__antecedent_cause2_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__antecedent_cause2_condition_id') }}"
           - name: external_cause_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_death_data__external_cause_date_legacy') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__external_cause_date_legacy') }}"
           - name: last_surgery_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_death_data__last_surgery_date_legacy') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__last_surgery_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_death_data."
@@ -149,7 +124,7 @@ sources:
               - not_null
           - name: is_final
             data_type: boolean
-            description: "{{ doc('patient_death_data__is_final') }} in patient_death_data."
+            description: "{{ doc('patient_death_data__is_final') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -158,8 +133,7 @@ sources:
           - name: antecedent_cause3_time_after_onset
             data_type: integer
             description: "{{ doc('patient_death_data__antecedent_cause3_time_after_onset')
-              }} in patient_death_data."
+              }}"
           - name: antecedent_cause3_condition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_death_data__antecedent_cause3_condition_id') }} in
-              patient_death_data."
+            description: "{{ doc('patient_death_data__antecedent_cause3_condition_id') }}"

--- a/database/model/facility-server/public/patient_facilities.yml
+++ b/database/model/facility-server/public/patient_facilities.yml
@@ -23,15 +23,13 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_facilities."
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_facilities__facility_id') }} in
-              patient_facilities."
+            description: "{{ doc('patient_facilities__facility_id') }}"
             data_tests:
               - unique
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_facilities__patient_id') }} in
-              patient_facilities."
+            description: "{{ doc('patient_facilities__patient_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/facility-server/public/patient_family_histories.yml
+++ b/database/model/facility-server/public/patient_family_histories.yml
@@ -30,34 +30,27 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_family_histories."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__note') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_family_histories__recorded_date') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__recorded_date') }}"
             data_tests:
               - not_null
           - name: relationship
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__relationship') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__relationship') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__patient_id') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__patient_id') }}"
           - name: practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__practitioner_id') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__practitioner_id') }}"
           - name: diagnosis_id
             data_type: character varying(255)
-            description: "{{ doc('patient_family_histories__diagnosis_id') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__diagnosis_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_family_histories__recorded_date_legacy') }} in
-              patient_family_histories."
+            description: "{{ doc('patient_family_histories__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/facility-server/public/patient_field_definition_categories.yml
+++ b/database/model/facility-server/public/patient_field_definition_categories.yml
@@ -33,8 +33,7 @@ sources:
               patient_field_definition_categories."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definition_categories__name') }} in
-              patient_field_definition_categories."
+            description: "{{ doc('patient_field_definition_categories__name') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/patient_field_definitions.yml
+++ b/database/model/facility-server/public/patient_field_definitions.yml
@@ -30,20 +30,17 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_field_definitions."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definitions__name') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__name') }}"
             data_tests:
               - not_null
           - name: field_type
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definitions__field_type') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__field_type') }}"
             data_tests:
               - not_null
           - name: options
             data_type: array
-            description: "{{ doc('patient_field_definitions__options') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__options') }}"
           - name: visibility_status
             data_type: character varying(255)
             description: "{{ doc('generic__visibility_status') }} in
@@ -52,8 +49,7 @@ sources:
               - not_null
           - name: category_id
             data_type: character varying(255)
-            description: "{{ doc('patient_field_definitions__category_id') }} in
-              patient_field_definitions."
+            description: "{{ doc('patient_field_definitions__category_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/patient_field_values.yml
+++ b/database/model/facility-server/public/patient_field_values.yml
@@ -24,20 +24,18 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_field_values."
           - name: value
             data_type: text
-            description: "{{ doc('patient_field_values__value') }} in patient_field_values."
+            description: "{{ doc('patient_field_values__value') }}"
             data_tests:
               - not_null
           - name: definition_id
             data_type: character varying(255)
-            description: "{{ doc('patient_field_values__definition_id') }} in
-              patient_field_values."
+            description: "{{ doc('patient_field_values__definition_id') }}"
             data_tests:
               - unique
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_field_values__patient_id') }} in
-              patient_field_values."
+            description: "{{ doc('patient_field_values__patient_id') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/facility-server/public/patient_issues.yml
+++ b/database/model/facility-server/public/patient_issues.yml
@@ -30,24 +30,23 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_issues."
           - name: note
             data_type: character varying(255)
-            description: "{{ doc('patient_issues__note') }} in patient_issues."
+            description: "{{ doc('patient_issues__note') }}"
           - name: recorded_date
             data_type: character(19)
-            description: "{{ doc('patient_issues__recorded_date') }} in patient_issues."
+            description: "{{ doc('patient_issues__recorded_date') }}"
             data_tests:
               - not_null
           - name: type
             data_type: user-defined
-            description: "{{ doc('patient_issues__type') }} in patient_issues."
+            description: "{{ doc('patient_issues__type') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_issues__patient_id') }} in patient_issues."
+            description: "{{ doc('patient_issues__patient_id') }}"
           - name: recorded_date_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('patient_issues__recorded_date_legacy') }} in
-              patient_issues."
+            description: "{{ doc('patient_issues__recorded_date_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in patient_issues."

--- a/database/model/facility-server/public/patient_program_registrations.yml
+++ b/database/model/facility-server/public/patient_program_registrations.yml
@@ -38,44 +38,37 @@ sources:
               - not_null
           - name: registration_status
             data_type: text
-            description: "{{ doc('patient_program_registrations__registration_status') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__registration_status') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__patient_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__patient_id') }}"
             data_tests:
               - not_null
           - name: program_registry_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__program_registry_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__program_registry_id') }}"
             data_tests:
               - not_null
           - name: clinical_status_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__clinical_status_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__clinical_status_id') }}"
           - name: clinician_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__clinician_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__clinician_id') }}"
             data_tests:
               - not_null
           - name: registering_facility_id
             data_type: character varying(255)
             description: "{{ doc('patient_program_registrations__registering_facility_id')
-              }} in patient_program_registrations."
+              }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__facility_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__facility_id') }}"
           - name: village_id
             data_type: character varying(255)
-            description: "{{ doc('patient_program_registrations__village_id') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__village_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in
@@ -84,7 +77,6 @@ sources:
               - not_null
           - name: is_most_recent
             data_type: boolean
-            description: "{{ doc('patient_program_registrations__is_most_recent') }} in
-              patient_program_registrations."
+            description: "{{ doc('patient_program_registrations__is_most_recent') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/patient_secondary_ids.yml
+++ b/database/model/facility-server/public/patient_secondary_ids.yml
@@ -26,8 +26,7 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_secondary_ids."
           - name: value
             data_type: character varying(255)
-            description: "{{ doc('patient_secondary_ids__value') }} in
-              patient_secondary_ids."
+            description: "{{ doc('patient_secondary_ids__value') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -37,14 +36,12 @@ sources:
               - not_null
           - name: type_id
             data_type: character varying(255)
-            description: "{{ doc('patient_secondary_ids__type_id') }} in
-              patient_secondary_ids."
+            description: "{{ doc('patient_secondary_ids__type_id') }}"
             data_tests:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_secondary_ids__patient_id') }} in
-              patient_secondary_ids."
+            description: "{{ doc('patient_secondary_ids__patient_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/patient_vrs_data.yml
+++ b/database/model/facility-server/public/patient_vrs_data.yml
@@ -26,20 +26,18 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in patient_vrs_data."
           - name: id_type
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__id_type') }} in patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__id_type') }}"
           - name: identifier
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__identifier') }} in patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__identifier') }}"
           - name: unmatched_village_name
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__unmatched_village_name') }} in
-              patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__unmatched_village_name') }}"
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('patient_vrs_data__patient_id') }} in patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__patient_id') }}"
           - name: is_deleted_by_remote
             data_type: boolean
-            description: "{{ doc('patient_vrs_data__is_deleted_by_remote') }} in
-              patient_vrs_data."
+            description: "{{ doc('patient_vrs_data__is_deleted_by_remote') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/permissions.yml
+++ b/database/model/facility-server/public/permissions.yml
@@ -26,22 +26,22 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in permissions."
           - name: role_id
             data_type: character varying(255)
-            description: "{{ doc('permissions__role_id') }} in permissions."
+            description: "{{ doc('permissions__role_id') }}"
             data_tests:
               - not_null
           - name: noun
             data_type: character varying(255)
-            description: "{{ doc('permissions__noun') }} in permissions."
+            description: "{{ doc('permissions__noun') }}"
             data_tests:
               - not_null
           - name: verb
             data_type: character varying(255)
-            description: "{{ doc('permissions__verb') }} in permissions."
+            description: "{{ doc('permissions__verb') }}"
             data_tests:
               - not_null
           - name: object_id
             data_type: character varying(255)
-            description: "{{ doc('permissions__object_id') }} in permissions."
+            description: "{{ doc('permissions__object_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in permissions."

--- a/database/model/facility-server/public/procedures.yml
+++ b/database/model/facility-server/public/procedures.yml
@@ -30,7 +30,7 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in procedures."
           - name: completed
             data_type: boolean
-            description: "{{ doc('procedures__completed') }} in procedures."
+            description: "{{ doc('procedures__completed') }}"
           - name: date
             data_type: character(19)
             description: "{{ doc('generic__date') }} in procedures."
@@ -38,46 +38,46 @@ sources:
               - not_null
           - name: end_time
             data_type: character(19)
-            description: "{{ doc('procedures__end_time') }} in procedures."
+            description: "{{ doc('procedures__end_time') }}"
           - name: note
             data_type: text
-            description: "{{ doc('procedures__note') }} in procedures."
+            description: "{{ doc('procedures__note') }}"
           - name: completed_note
             data_type: text
-            description: "{{ doc('procedures__completed_note') }} in procedures."
+            description: "{{ doc('procedures__completed_note') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__encounter_id') }} in procedures."
+            description: "{{ doc('procedures__encounter_id') }}"
           - name: location_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__location_id') }} in procedures."
+            description: "{{ doc('procedures__location_id') }}"
           - name: procedure_type_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__procedure_type_id') }} in procedures."
+            description: "{{ doc('procedures__procedure_type_id') }}"
           - name: anaesthetic_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__anaesthetic_id') }} in procedures."
+            description: "{{ doc('procedures__anaesthetic_id') }}"
           - name: physician_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__physician_id') }} in procedures."
+            description: "{{ doc('procedures__physician_id') }}"
           - name: assistant_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__assistant_id') }} in procedures."
+            description: "{{ doc('procedures__assistant_id') }}"
           - name: anaesthetist_id
             data_type: character varying(255)
-            description: "{{ doc('procedures__anaesthetist_id') }} in procedures."
+            description: "{{ doc('procedures__anaesthetist_id') }}"
           - name: start_time
             data_type: character(19)
-            description: "{{ doc('procedures__start_time') }} in procedures."
+            description: "{{ doc('procedures__start_time') }}"
           - name: date_legacy
             data_type: timestamp with time zone
             description: "{{ doc('generic__date_legacy') }} in procedures."
           - name: start_time_legacy
             data_type: character varying(255)
-            description: "{{ doc('procedures__start_time_legacy') }} in procedures."
+            description: "{{ doc('procedures__start_time_legacy') }}"
           - name: end_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('procedures__end_time_legacy') }} in procedures."
+            description: "{{ doc('procedures__end_time_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in procedures."

--- a/database/model/facility-server/public/program_data_elements.yml
+++ b/database/model/facility-server/public/program_data_elements.yml
@@ -30,28 +30,22 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in program_data_elements."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__code') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__code') }}"
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__name') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__name') }}"
           - name: indicator
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__indicator') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__indicator') }}"
           - name: default_text
             data_type: character varying(255)
-            description: "{{ doc('program_data_elements__default_text') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__default_text') }}"
           - name: default_options
             data_type: text
-            description: "{{ doc('program_data_elements__default_options') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__default_options') }}"
           - name: type
             data_type: character varying(31)
-            description: "{{ doc('program_data_elements__type') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__type') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -62,5 +56,4 @@ sources:
               - not_null
           - name: visualisation_config
             data_type: text
-            description: "{{ doc('program_data_elements__visualisation_config') }} in
-              program_data_elements."
+            description: "{{ doc('program_data_elements__visualisation_config') }}"

--- a/database/model/facility-server/public/program_registries.yml
+++ b/database/model/facility-server/public/program_registries.yml
@@ -30,19 +30,18 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in program_registries."
           - name: code
             data_type: text
-            description: "{{ doc('program_registries__code') }} in program_registries."
+            description: "{{ doc('program_registries__code') }}"
             data_tests:
               - unique
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('program_registries__name') }} in program_registries."
+            description: "{{ doc('program_registries__name') }}"
             data_tests:
               - not_null
           - name: currently_at_type
             data_type: text
-            description: "{{ doc('program_registries__currently_at_type') }} in
-              program_registries."
+            description: "{{ doc('program_registries__currently_at_type') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -50,8 +49,7 @@ sources:
             description: "{{ doc('generic__visibility_status') }} in program_registries."
           - name: program_id
             data_type: character varying(255)
-            description: "{{ doc('program_registries__program_id') }} in
-              program_registries."
+            description: "{{ doc('program_registries__program_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/program_registry_clinical_statuses.yml
+++ b/database/model/facility-server/public/program_registry_clinical_statuses.yml
@@ -33,21 +33,18 @@ sources:
               program_registry_clinical_statuses."
           - name: code
             data_type: text
-            description: "{{ doc('program_registry_clinical_statuses__code') }} in
-              program_registry_clinical_statuses."
+            description: "{{ doc('program_registry_clinical_statuses__code') }}"
             data_tests:
               - unique
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('program_registry_clinical_statuses__name') }} in
-              program_registry_clinical_statuses."
+            description: "{{ doc('program_registry_clinical_statuses__name') }}"
             data_tests:
               - not_null
           - name: color
             data_type: text
-            description: "{{ doc('program_registry_clinical_statuses__color') }} in
-              program_registry_clinical_statuses."
+            description: "{{ doc('program_registry_clinical_statuses__color') }}"
           - name: visibility_status
             data_type: text
             description: "{{ doc('generic__visibility_status') }} in
@@ -55,7 +52,7 @@ sources:
           - name: program_registry_id
             data_type: character varying(255)
             description: "{{ doc('program_registry_clinical_statuses__program_registry_id')
-              }} in program_registry_clinical_statuses."
+              }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/program_registry_conditions.yml
+++ b/database/model/facility-server/public/program_registry_conditions.yml
@@ -30,15 +30,13 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in program_registry_conditions."
           - name: code
             data_type: text
-            description: "{{ doc('program_registry_conditions__code') }} in
-              program_registry_conditions."
+            description: "{{ doc('program_registry_conditions__code') }}"
             data_tests:
               - unique
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('program_registry_conditions__name') }} in
-              program_registry_conditions."
+            description: "{{ doc('program_registry_conditions__name') }}"
             data_tests:
               - not_null
           - name: visibility_status
@@ -47,8 +45,7 @@ sources:
               program_registry_conditions."
           - name: program_registry_id
             data_type: character varying(255)
-            description: "{{ doc('program_registry_conditions__program_registry_id') }} in
-              program_registry_conditions."
+            description: "{{ doc('program_registry_conditions__program_registry_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/programs.yml
+++ b/database/model/facility-server/public/programs.yml
@@ -30,10 +30,10 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in programs."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('programs__code') }} in programs."
+            description: "{{ doc('programs__code') }}"
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('programs__name') }} in programs."
+            description: "{{ doc('programs__name') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in programs."

--- a/database/model/facility-server/public/reference_data.yml
+++ b/database/model/facility-server/public/reference_data.yml
@@ -30,17 +30,17 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in reference_data."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('reference_data__code') }} in reference_data."
+            description: "{{ doc('reference_data__code') }}"
             data_tests:
               - not_null
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('reference_data__type') }} in reference_data."
+            description: "{{ doc('reference_data__type') }}"
             data_tests:
               - not_null
           - name: name
             data_type: text
-            description: "{{ doc('reference_data__name') }} in reference_data."
+            description: "{{ doc('reference_data__name') }}"
             data_tests:
               - not_null
           - name: visibility_status

--- a/database/model/facility-server/public/reference_data_relations.yml
+++ b/database/model/facility-server/public/reference_data_relations.yml
@@ -30,18 +30,15 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in reference_data_relations."
           - name: reference_data_id
             data_type: text
-            description: "{{ doc('reference_data_relations__reference_data_id') }} in
-              reference_data_relations."
+            description: "{{ doc('reference_data_relations__reference_data_id') }}"
             data_tests:
               - unique
           - name: reference_data_parent_id
             data_type: text
-            description: "{{ doc('reference_data_relations__reference_data_parent_id') }} in
-              reference_data_relations."
+            description: "{{ doc('reference_data_relations__reference_data_parent_id') }}"
           - name: type
             data_type: character varying(255)
-            description: "{{ doc('reference_data_relations__type') }} in
-              reference_data_relations."
+            description: "{{ doc('reference_data_relations__type') }}"
             data_tests:
               - unique
               - not_null

--- a/database/model/facility-server/public/referrals.yml
+++ b/database/model/facility-server/public/referrals.yml
@@ -30,19 +30,19 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in referrals."
           - name: referred_facility
             data_type: character varying(255)
-            description: "{{ doc('referrals__referred_facility') }} in referrals."
+            description: "{{ doc('referrals__referred_facility') }}"
           - name: initiating_encounter_id
             data_type: character varying(255)
-            description: "{{ doc('referrals__initiating_encounter_id') }} in referrals."
+            description: "{{ doc('referrals__initiating_encounter_id') }}"
           - name: completing_encounter_id
             data_type: character varying(255)
-            description: "{{ doc('referrals__completing_encounter_id') }} in referrals."
+            description: "{{ doc('referrals__completing_encounter_id') }}"
           - name: survey_response_id
             data_type: character varying(255)
-            description: "{{ doc('referrals__survey_response_id') }} in referrals."
+            description: "{{ doc('referrals__survey_response_id') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('referrals__status') }} in referrals."
+            description: "{{ doc('referrals__status') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/refresh_tokens.yml
+++ b/database/model/facility-server/public/refresh_tokens.yml
@@ -17,22 +17,22 @@ sources:
               - not_null
           - name: refresh_id
             data_type: text
-            description: "{{ doc('refresh_tokens__refresh_id') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__refresh_id') }}"
             data_tests:
               - not_null
           - name: device_id
             data_type: text
-            description: "{{ doc('refresh_tokens__device_id') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__device_id') }}"
             data_tests:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('refresh_tokens__user_id') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__user_id') }}"
             data_tests:
               - not_null
           - name: expires_at
             data_type: timestamp with time zone
-            description: "{{ doc('refresh_tokens__expires_at') }} in refresh_tokens."
+            description: "{{ doc('refresh_tokens__expires_at') }}"
             data_tests:
               - not_null
           - name: deleted_at

--- a/database/model/facility-server/public/report_definition_versions.yml
+++ b/database/model/facility-server/public/report_definition_versions.yml
@@ -26,36 +26,29 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in report_definition_versions."
           - name: version_number
             data_type: integer
-            description: "{{ doc('report_definition_versions__version_number') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__version_number') }}"
             data_tests:
               - not_null
           - name: notes
             data_type: text
-            description: "{{ doc('report_definition_versions__notes') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__notes') }}"
           - name: status
             data_type: character varying(255)
-            description: "{{ doc('report_definition_versions__status') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__status') }}"
             data_tests:
               - not_null
           - name: query
             data_type: text
-            description: "{{ doc('report_definition_versions__query') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__query') }}"
           - name: query_options
             data_type: json
-            description: "{{ doc('report_definition_versions__query_options') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__query_options') }}"
           - name: report_definition_id
             data_type: character varying(255)
-            description: "{{ doc('report_definition_versions__report_definition_id') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__report_definition_id') }}"
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('report_definition_versions__user_id') }} in
-              report_definition_versions."
+            description: "{{ doc('report_definition_versions__user_id') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/report_definitions.yml
+++ b/database/model/facility-server/public/report_definitions.yml
@@ -26,7 +26,7 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in report_definitions."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('report_definitions__name') }} in report_definitions."
+            description: "{{ doc('report_definitions__name') }}"
             data_tests:
               - unique
               - not_null
@@ -37,6 +37,6 @@ sources:
               - not_null
           - name: db_schema
             data_type: character varying(255)
-            description: "{{ doc('report_definitions__db_schema') }} in report_definitions."
+            description: "{{ doc('report_definitions__db_schema') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/report_requests.yml
+++ b/database/model/facility-server/public/report_requests.yml
@@ -30,45 +30,42 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in report_requests."
           - name: report_type
             data_type: character varying(255)
-            description: "{{ doc('report_requests__report_type') }} in report_requests."
+            description: "{{ doc('report_requests__report_type') }}"
           - name: recipients
             data_type: text
-            description: "{{ doc('report_requests__recipients') }} in report_requests."
+            description: "{{ doc('report_requests__recipients') }}"
             data_tests:
               - not_null
           - name: parameters
             data_type: text
-            description: "{{ doc('report_requests__parameters') }} in report_requests."
+            description: "{{ doc('report_requests__parameters') }}"
           - name: status
             data_type: character varying(31)
-            description: "{{ doc('report_requests__status') }} in report_requests."
+            description: "{{ doc('report_requests__status') }}"
             data_tests:
               - not_null
           - name: requested_by_user_id
             data_type: character varying(255)
-            description: "{{ doc('report_requests__requested_by_user_id') }} in
-              report_requests."
+            description: "{{ doc('report_requests__requested_by_user_id') }}"
             data_tests:
               - not_null
           - name: error
             data_type: text
-            description: "{{ doc('report_requests__error') }} in report_requests."
+            description: "{{ doc('report_requests__error') }}"
           - name: process_started_time
             data_type: timestamp with time zone
-            description: "{{ doc('report_requests__process_started_time') }} in
-              report_requests."
+            description: "{{ doc('report_requests__process_started_time') }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('report_requests__facility_id') }} in report_requests."
+            description: "{{ doc('report_requests__facility_id') }}"
           - name: export_format
             data_type: character varying(255)
-            description: "{{ doc('report_requests__export_format') }} in report_requests."
+            description: "{{ doc('report_requests__export_format') }}"
             data_tests:
               - not_null
           - name: report_definition_version_id
             data_type: character varying(255)
-            description: "{{ doc('report_requests__report_definition_version_id') }} in
-              report_requests."
+            description: "{{ doc('report_requests__report_definition_version_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in report_requests."

--- a/database/model/facility-server/public/settings.yml
+++ b/database/model/facility-server/public/settings.yml
@@ -32,16 +32,16 @@ sources:
               - unique
           - name: key
             data_type: text
-            description: "{{ doc('settings__key') }} in settings."
+            description: "{{ doc('settings__key') }}"
             data_tests:
               - unique
               - not_null
           - name: value
             data_type: jsonb
-            description: "{{ doc('settings__value') }} in settings."
+            description: "{{ doc('settings__value') }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('settings__facility_id') }} in settings."
+            description: "{{ doc('settings__facility_id') }}"
             data_tests:
               - unique
           - name: updated_at_sync_tick
@@ -51,6 +51,6 @@ sources:
               - not_null
           - name: scope
             data_type: text
-            description: "{{ doc('settings__scope') }} in settings."
+            description: "{{ doc('settings__scope') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/signers.yml
+++ b/database/model/facility-server/public/signers.yml
@@ -30,42 +30,42 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in signers."
           - name: country_code
             data_type: character varying(255)
-            description: "{{ doc('signers__country_code') }} in signers."
+            description: "{{ doc('signers__country_code') }}"
             data_tests:
               - not_null
           - name: private_key
             data_type: bytea
-            description: "{{ doc('signers__private_key') }} in signers."
+            description: "{{ doc('signers__private_key') }}"
           - name: public_key
             data_type: bytea
-            description: "{{ doc('signers__public_key') }} in signers."
+            description: "{{ doc('signers__public_key') }}"
             data_tests:
               - not_null
           - name: request
             data_type: text
-            description: "{{ doc('signers__request') }} in signers."
+            description: "{{ doc('signers__request') }}"
             data_tests:
               - not_null
           - name: certificate
             data_type: text
-            description: "{{ doc('signers__certificate') }} in signers."
+            description: "{{ doc('signers__certificate') }}"
           - name: validity_period_start
             data_type: timestamp with time zone
-            description: "{{ doc('signers__validity_period_start') }} in signers."
+            description: "{{ doc('signers__validity_period_start') }}"
           - name: validity_period_end
             data_type: timestamp with time zone
-            description: "{{ doc('signers__validity_period_end') }} in signers."
+            description: "{{ doc('signers__validity_period_end') }}"
           - name: signatures_issued
             data_type: integer
-            description: "{{ doc('signers__signatures_issued') }} in signers."
+            description: "{{ doc('signers__signatures_issued') }}"
             data_tests:
               - not_null
           - name: request_sent_at
             data_type: timestamp with time zone
-            description: "{{ doc('signers__request_sent_at') }} in signers."
+            description: "{{ doc('signers__request_sent_at') }}"
           - name: working_period_start
             data_type: timestamp with time zone
-            description: "{{ doc('signers__working_period_start') }} in signers."
+            description: "{{ doc('signers__working_period_start') }}"
           - name: working_period_end
             data_type: timestamp with time zone
-            description: "{{ doc('signers__working_period_end') }} in signers."
+            description: "{{ doc('signers__working_period_end') }}"

--- a/database/model/facility-server/public/survey_response_answers.yml
+++ b/database/model/facility-server/public/survey_response_answers.yml
@@ -30,24 +30,19 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in survey_response_answers."
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('survey_response_answers__name') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__name') }}"
           - name: body
             data_type: text
-            description: "{{ doc('survey_response_answers__body') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__body') }}"
           - name: response_id
             data_type: character varying(255)
-            description: "{{ doc('survey_response_answers__response_id') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__response_id') }}"
           - name: data_element_id
             data_type: character varying(255)
-            description: "{{ doc('survey_response_answers__data_element_id') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__data_element_id') }}"
           - name: body_legacy
             data_type: text
-            description: "{{ doc('survey_response_answers__body_legacy') }} in
-              survey_response_answers."
+            description: "{{ doc('survey_response_answers__body_legacy') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/facility-server/public/survey_responses.yml
+++ b/database/model/facility-server/public/survey_responses.yml
@@ -30,36 +30,34 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in survey_responses."
           - name: start_time
             data_type: character(19)
-            description: "{{ doc('survey_responses__start_time') }} in survey_responses."
+            description: "{{ doc('survey_responses__start_time') }}"
           - name: end_time
             data_type: character(19)
-            description: "{{ doc('survey_responses__end_time') }} in survey_responses."
+            description: "{{ doc('survey_responses__end_time') }}"
           - name: result
             data_type: double precision
-            description: "{{ doc('survey_responses__result') }} in survey_responses."
+            description: "{{ doc('survey_responses__result') }}"
           - name: survey_id
             data_type: character varying(255)
-            description: "{{ doc('survey_responses__survey_id') }} in survey_responses."
+            description: "{{ doc('survey_responses__survey_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('survey_responses__encounter_id') }} in survey_responses."
+            description: "{{ doc('survey_responses__encounter_id') }}"
           - name: result_text
             data_type: text
-            description: "{{ doc('survey_responses__result_text') }} in survey_responses."
+            description: "{{ doc('survey_responses__result_text') }}"
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('survey_responses__user_id') }} in survey_responses."
+            description: "{{ doc('survey_responses__user_id') }}"
           - name: start_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('survey_responses__start_time_legacy') }} in
-              survey_responses."
+            description: "{{ doc('survey_responses__start_time_legacy') }}"
           - name: end_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('survey_responses__end_time_legacy') }} in
-              survey_responses."
+            description: "{{ doc('survey_responses__end_time_legacy') }}"
           - name: notified
             data_type: boolean
-            description: "{{ doc('survey_responses__notified') }} in survey_responses."
+            description: "{{ doc('survey_responses__notified') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in survey_responses."

--- a/database/model/facility-server/public/survey_screen_components.yml
+++ b/database/model/facility-server/public/survey_screen_components.yml
@@ -30,48 +30,37 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in survey_screen_components."
           - name: screen_index
             data_type: integer
-            description: "{{ doc('survey_screen_components__screen_index') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__screen_index') }}"
           - name: component_index
             data_type: integer
-            description: "{{ doc('survey_screen_components__component_index') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__component_index') }}"
           - name: text
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__text') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__text') }}"
           - name: visibility_criteria
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__visibility_criteria') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__visibility_criteria') }}"
           - name: validation_criteria
             data_type: text
-            description: "{{ doc('survey_screen_components__validation_criteria') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__validation_criteria') }}"
           - name: detail
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__detail') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__detail') }}"
           - name: config
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__config') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__config') }}"
           - name: options
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__options') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__options') }}"
           - name: calculation
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__calculation') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__calculation') }}"
           - name: survey_id
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__survey_id') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__survey_id') }}"
           - name: data_element_id
             data_type: character varying(255)
-            description: "{{ doc('survey_screen_components__data_element_id') }} in
-              survey_screen_components."
+            description: "{{ doc('survey_screen_components__data_element_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in

--- a/database/model/facility-server/public/surveys.yml
+++ b/database/model/facility-server/public/surveys.yml
@@ -30,19 +30,19 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in surveys."
           - name: code
             data_type: character varying(255)
-            description: "{{ doc('surveys__code') }} in surveys."
+            description: "{{ doc('surveys__code') }}"
           - name: name
             data_type: character varying(255)
-            description: "{{ doc('surveys__name') }} in surveys."
+            description: "{{ doc('surveys__name') }}"
           - name: program_id
             data_type: character varying(255)
-            description: "{{ doc('surveys__program_id') }} in surveys."
+            description: "{{ doc('surveys__program_id') }}"
           - name: survey_type
             data_type: character varying(255)
-            description: "{{ doc('surveys__survey_type') }} in surveys."
+            description: "{{ doc('surveys__survey_type') }}"
           - name: is_sensitive
             data_type: boolean
-            description: "{{ doc('surveys__is_sensitive') }} in surveys."
+            description: "{{ doc('surveys__is_sensitive') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -52,12 +52,12 @@ sources:
               - not_null
           - name: notifiable
             data_type: boolean
-            description: "{{ doc('surveys__notifiable') }} in surveys."
+            description: "{{ doc('surveys__notifiable') }}"
             data_tests:
               - not_null
           - name: notify_email_addresses
             data_type: array
-            description: "{{ doc('surveys__notify_email_addresses') }} in surveys."
+            description: "{{ doc('surveys__notify_email_addresses') }}"
             data_tests:
               - not_null
           - name: visibility_status

--- a/database/model/facility-server/public/sync_lookup.yml
+++ b/database/model/facility-server/public/sync_lookup.yml
@@ -18,19 +18,19 @@ sources:
               - not_null
           - name: record_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__record_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__record_id') }}"
             data_tests:
               - unique
               - not_null
           - name: record_type
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__record_type') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__record_type') }}"
             data_tests:
               - unique
               - not_null
           - name: data
             data_type: json
-            description: "{{ doc('sync_lookup__data') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__data') }}"
             data_tests:
               - not_null
           - name: updated_at_sync_tick
@@ -40,23 +40,23 @@ sources:
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__patient_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__patient_id') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__encounter_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__encounter_id') }}"
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('sync_lookup__facility_id') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__facility_id') }}"
           - name: is_lab_request
             data_type: boolean
-            description: "{{ doc('sync_lookup__is_lab_request') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__is_lab_request') }}"
             data_tests:
               - not_null
           - name: is_deleted
             data_type: boolean
-            description: "{{ doc('sync_lookup__is_deleted') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__is_deleted') }}"
             data_tests:
               - not_null
           - name: updated_at_by_field_sum
             data_type: bigint
-            description: "{{ doc('sync_lookup__updated_at_by_field_sum') }} in sync_lookup."
+            description: "{{ doc('sync_lookup__updated_at_by_field_sum') }}"

--- a/database/model/facility-server/public/sync_queued_devices.yml
+++ b/database/model/facility-server/public/sync_queued_devices.yml
@@ -17,25 +17,22 @@ sources:
               - not_null
           - name: last_seen_time
             data_type: timestamp with time zone
-            description: "{{ doc('sync_queued_devices__last_seen_time') }} in
-              sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__last_seen_time') }}"
             data_tests:
               - not_null
           - name: facility_id
             data_type: text
-            description: "{{ doc('sync_queued_devices__facility_id') }} in
-              sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__facility_id') }}"
             data_tests:
               - not_null
           - name: last_synced_tick
             data_type: bigint
-            description: "{{ doc('sync_queued_devices__last_synced_tick') }} in
-              sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__last_synced_tick') }}"
             data_tests:
               - not_null
           - name: urgent
             data_type: boolean
-            description: "{{ doc('sync_queued_devices__urgent') }} in sync_queued_devices."
+            description: "{{ doc('sync_queued_devices__urgent') }}"
             data_tests:
               - not_null
           - name: created_at

--- a/database/model/facility-server/public/sync_sessions.yml
+++ b/database/model/facility-server/public/sync_sessions.yml
@@ -64,4 +64,4 @@ sources:
             description: "{{ doc('sync_sessions__snapshot_started_at') }}"
           - name: errors
             data_type: array
-            description: "{{ doc('sync_sessions__errors') }} in sync_sessions."
+            description: "{{ doc('sync_sessions__errors') }}"

--- a/database/model/facility-server/public/templates.yml
+++ b/database/model/facility-server/public/templates.yml
@@ -26,24 +26,24 @@ sources:
             description: "{{ doc('generic__updated_at') }} in templates."
           - name: name
             data_type: text
-            description: "{{ doc('templates__name') }} in templates."
+            description: "{{ doc('templates__name') }}"
             data_tests:
               - not_null
           - name: date_created
             data_type: character(10)
-            description: "{{ doc('templates__date_created') }} in templates."
+            description: "{{ doc('templates__date_created') }}"
           - name: title
             data_type: text
-            description: "{{ doc('templates__title') }} in templates."
+            description: "{{ doc('templates__title') }}"
           - name: body
             data_type: text
-            description: "{{ doc('templates__body') }} in templates."
+            description: "{{ doc('templates__body') }}"
           - name: visibility_status
             data_type: text
             description: "{{ doc('generic__visibility_status') }} in templates."
           - name: created_by_id
             data_type: character varying(255)
-            description: "{{ doc('templates__created_by_id') }} in templates."
+            description: "{{ doc('templates__created_by_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in templates."
@@ -51,6 +51,6 @@ sources:
               - not_null
           - name: type
             data_type: text
-            description: "{{ doc('templates__type') }} in templates."
+            description: "{{ doc('templates__type') }}"
             data_tests:
               - not_null

--- a/database/model/facility-server/public/translated_strings.yml
+++ b/database/model/facility-server/public/translated_strings.yml
@@ -14,19 +14,19 @@ sources:
             description: "{{ doc('generic__id') }} in translated_strings."
           - name: string_id
             data_type: text
-            description: "{{ doc('translated_strings__string_id') }} in translated_strings."
+            description: "{{ doc('translated_strings__string_id') }}"
             data_tests:
               - unique
               - not_null
           - name: language
             data_type: text
-            description: "{{ doc('translated_strings__language') }} in translated_strings."
+            description: "{{ doc('translated_strings__language') }}"
             data_tests:
               - unique
               - not_null
           - name: text
             data_type: text
-            description: "{{ doc('translated_strings__text') }} in translated_strings."
+            description: "{{ doc('translated_strings__text') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in translated_strings."

--- a/database/model/facility-server/public/triages.yml
+++ b/database/model/facility-server/public/triages.yml
@@ -30,40 +30,40 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in triages."
           - name: arrival_time
             data_type: character(19)
-            description: "{{ doc('triages__arrival_time') }} in triages."
+            description: "{{ doc('triages__arrival_time') }}"
           - name: triage_time
             data_type: character(19)
-            description: "{{ doc('triages__triage_time') }} in triages."
+            description: "{{ doc('triages__triage_time') }}"
           - name: closed_time
             data_type: character(19)
-            description: "{{ doc('triages__closed_time') }} in triages."
+            description: "{{ doc('triages__closed_time') }}"
           - name: score
             data_type: text
-            description: "{{ doc('triages__score') }} in triages."
+            description: "{{ doc('triages__score') }}"
           - name: encounter_id
             data_type: character varying(255)
-            description: "{{ doc('triages__encounter_id') }} in triages."
+            description: "{{ doc('triages__encounter_id') }}"
           - name: practitioner_id
             data_type: character varying(255)
-            description: "{{ doc('triages__practitioner_id') }} in triages."
+            description: "{{ doc('triages__practitioner_id') }}"
           - name: chief_complaint_id
             data_type: character varying(255)
-            description: "{{ doc('triages__chief_complaint_id') }} in triages."
+            description: "{{ doc('triages__chief_complaint_id') }}"
           - name: secondary_complaint_id
             data_type: character varying(255)
-            description: "{{ doc('triages__secondary_complaint_id') }} in triages."
+            description: "{{ doc('triages__secondary_complaint_id') }}"
           - name: arrival_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('triages__arrival_time_legacy') }} in triages."
+            description: "{{ doc('triages__arrival_time_legacy') }}"
           - name: triage_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('triages__triage_time_legacy') }} in triages."
+            description: "{{ doc('triages__triage_time_legacy') }}"
           - name: closed_time_legacy
             data_type: timestamp with time zone
-            description: "{{ doc('triages__closed_time_legacy') }} in triages."
+            description: "{{ doc('triages__closed_time_legacy') }}"
           - name: arrival_mode_id
             data_type: character varying(255)
-            description: "{{ doc('triages__arrival_mode_id') }} in triages."
+            description: "{{ doc('triages__arrival_mode_id') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in triages."

--- a/database/model/facility-server/public/user_facilities.yml
+++ b/database/model/facility-server/public/user_facilities.yml
@@ -26,12 +26,12 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in user_facilities."
           - name: facility_id
             data_type: character varying(255)
-            description: "{{ doc('user_facilities__facility_id') }} in user_facilities."
+            description: "{{ doc('user_facilities__facility_id') }}"
             data_tests:
               - unique
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_facilities__user_id') }} in user_facilities."
+            description: "{{ doc('user_facilities__user_id') }}"
             data_tests:
               - unique
           - name: updated_at_sync_tick

--- a/database/model/facility-server/public/user_localisation_caches.yml
+++ b/database/model/facility-server/public/user_localisation_caches.yml
@@ -17,14 +17,12 @@ sources:
               - not_null
           - name: localisation
             data_type: text
-            description: "{{ doc('user_localisation_caches__localisation') }} in
-              user_localisation_caches."
+            description: "{{ doc('user_localisation_caches__localisation') }}"
             data_tests:
               - not_null
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_localisation_caches__user_id') }} in
-              user_localisation_caches."
+            description: "{{ doc('user_localisation_caches__user_id') }}"
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in user_localisation_caches."

--- a/database/model/facility-server/public/user_preferences.yml
+++ b/database/model/facility-server/public/user_preferences.yml
@@ -27,14 +27,13 @@ sources:
             description: "{{ doc('generic__deleted_at') }} in user_preferences."
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_preferences__user_id') }} in user_preferences."
+            description: "{{ doc('user_preferences__user_id') }}"
             data_tests:
               - unique
               - not_null
           - name: selected_graphed_vitals_on_filter
             data_type: character varying(255)
-            description: "{{ doc('user_preferences__selected_graphed_vitals_on_filter') }}
-              in user_preferences."
+            description: "{{ doc('user_preferences__selected_graphed_vitals_on_filter') }}"
           - name: updated_at_sync_tick
             data_type: bigint
             description: "{{ doc('generic__updated_at_sync_tick') }} in user_preferences."

--- a/database/model/facility-server/public/user_recently_viewed_patients.yml
+++ b/database/model/facility-server/public/user_recently_viewed_patients.yml
@@ -33,15 +33,13 @@ sources:
               user_recently_viewed_patients."
           - name: user_id
             data_type: character varying(255)
-            description: "{{ doc('user_recently_viewed_patients__user_id') }} in
-              user_recently_viewed_patients."
+            description: "{{ doc('user_recently_viewed_patients__user_id') }}"
             data_tests:
               - unique
               - not_null
           - name: patient_id
             data_type: character varying(255)
-            description: "{{ doc('user_recently_viewed_patients__patient_id') }} in
-              user_recently_viewed_patients."
+            description: "{{ doc('user_recently_viewed_patients__patient_id') }}"
             data_tests:
               - unique
               - not_null

--- a/packages/scripts/src/dbt-generate-source.js
+++ b/packages/scripts/src/dbt-generate-source.js
@@ -187,9 +187,9 @@ async function generateDataTests(column) {
  * @returns A column object, directly serialisable as dbt models.
  */
 function generateColumnModelDescription(tableName, columnName, hasGenericDoc) {
-  return `{{ doc('${
-    hasGenericDoc ? 'generic' : tableName
-  }__${columnName}') }} in ${tableName}.`;
+  return hasGenericDoc
+    ? `{{ doc('generic__${columnName}') }} in ${tableName}.`
+    : `{{ doc('${tableName}__${columnName}') }}`;
 }
 
 /**
@@ -377,7 +377,11 @@ async function handleMissingTable(schemaPath, schemaName, table, genericColNames
 async function handleColumn(tableName, dbtColumn, sqlColumn, hasGenericDoc) {
   dbtColumn.data_type = sqlColumn.data_type;
   if (dbtColumn.description === '') {
-    dbtColumn.description = generateColumnModelDescription(tableName, dbtColumn.name, hasGenericDoc);
+    dbtColumn.description = generateColumnModelDescription(
+      tableName,
+      dbtColumn.name,
+      hasGenericDoc,
+    );
   }
 
   const sqlDataTests = await generateDataTests(sqlColumn);


### PR DESCRIPTION
### Changes

Fix the issue where the `generate-dbt-source` script added "in table-name." postfixes to any column descriptions.
