### PR TITLE
fix(mobile): release fix v2.17: Fix placeholder text bug on dropdown

### DIFF
--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -14,6 +14,7 @@ import { Suggester } from '~/ui/helpers/suggester';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
 import { TranslatedText, TranslatedTextElement } from '../../Translations/TranslatedText';
+import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 const InjectionSiteDropdown = ({ value, label, onChange, selectPlaceholderText }): JSX.Element => (
   <Dropdown
@@ -58,24 +59,33 @@ export const BatchField = (): JSX.Element => (
   />
 );
 
-export const InjectionSiteField = (): JSX.Element => (
-  <Field
-    component={InjectionSiteDropdown}
-    name="injectionSite"
-    label={<TranslatedText stringId="vaccine.form.injectionSite.label" fallback="Injection site" />}
-    selectPlaceholderText="Select"
-  />
-);
+export const InjectionSiteField = (): JSX.Element => {
+  const { getTranslation } = useTranslation();
+  return (
+    <Field
+      component={InjectionSiteDropdown}
+      name="injectionSite"
+      label={
+        <TranslatedText stringId="vaccine.form.injectionSite.label" fallback="Injection site" />
+      }
+      selectPlaceholderText={getTranslation('general.action.select', 'Select')}
+    />
+  );
+};
 
-export const NotGivenReasonField = (): JSX.Element => (
-  <Field
-    component={SuggesterDropdown}
-    name="notGivenReasonId"
-    label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
-    selectPlaceholderText={<TranslatedText stringId="general.action.select" fallback="Select" />}
-    referenceDataType={ReferenceDataType.VaccineNotGivenReason}
-  />
-);
+export const NotGivenReasonField = (): JSX.Element => {
+  const { getTranslation } = useTranslation();
+
+  return (
+    <Field
+      component={SuggesterDropdown}
+      name="notGivenReasonId"
+      label={<TranslatedText stringId="vaccine.form.reason.label" fallback="Reason" />}
+      selectPlaceholderText={getTranslation('general.action.select', 'Select')}
+      referenceDataType={ReferenceDataType.VaccineNotGivenReason}
+    />
+  );
+};
 
 export const VaccineLocationField = ({ navigation }: NavigationFieldProps): JSX.Element => (
   <LocationField navigation={navigation} required />


### PR DESCRIPTION
### Changes

The mobile dropdown/multiselect component is quite fragile and this is the last release issue so went for the lightest touch possible. Ideally the select/multiselect component on mobile needs a big cleanup.

It was throwing an error as we try to supply a react element to the textinput placeholder prop in some situations. This just updates the logic to supply the translated string rather than a react element to the component (in line with other usages of this prop)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
