### PR TITLE
db(source): KAM-291: document FHIR tables

### DIFF
--- a/database/model/central-server/fhir/encounters.md
+++ b/database/model/central-server/fhir/encounters.md
@@ -1,27 +1,49 @@
 {% docs fhir__table__encounters %}
-TODO
+FHIR data about encounters.
+
+"Encounter" means an interaction between a patient and a healthcare provider, for health services or
+when assessing the health status of the patient. Encounters are in the present and the past; future
+interactions are typically called "Appointments."
+
+These are materialised from `public.encounters`.
+
+<https://www.hl7.org/fhir/encounter.html>
 {% enddocs %}
 
 {% docs fhir__encounters__status %}
-TODO
+The status of the encounter.
+
+In Tamanu this can be one of two values:
+- in-progress (for current or open encounters)
+- discharged
 {% enddocs %}
 
 {% docs fhir__encounters__class %}
-TODO
+The general classification of the encounter.
+
+This is a complex type but in Tamanu represents only one of these three classes (or absent):
+- IMP (inpatient)
+- EMER (emergency)
+- OBSENC (observation)
 {% enddocs %}
 
 {% docs fhir__encounters__actual_period %}
-TODO
+The start and end (if present) dates of the encounter.
 {% enddocs %}
 
 {% docs fhir__encounters__subject %}
-TODO
+Reference to the patient involved in the encounter.
 {% enddocs %}
 
 {% docs fhir__encounters__location %}
-TODO
+The location of the encounter.
+
+This is a complex type which encodes many bits of information about the location, such as its name
+and internal ID, physical type, and status. Additionally there are two locations per encounter, one
+describing the ward or general hospital area, and one describing the bed or specific place within
+that area.
 {% enddocs %}
 
 {% docs fhir__encounters__service_provider %}
-TODO
+Reference to the facility where the encounter is taking place.
 {% enddocs %}

--- a/database/model/central-server/fhir/encounters.yml
+++ b/database/model/central-server/fhir/encounters.yml
@@ -36,6 +36,10 @@ sources:
             description: "{{ doc('fhir__encounters__status') }}"
             data_tests:
               - not_null
+              - accepted_values:
+                  values:
+                    - in-progress
+                    - discharged
           - name: class
             data_type: jsonb
             description: "{{ doc('fhir__encounters__class') }}"

--- a/database/model/central-server/fhir/immunizations.md
+++ b/database/model/central-server/fhir/immunizations.md
@@ -1,39 +1,55 @@
 {% docs fhir__table__immunizations %}
-TODO
+FHIR data about immunization (vaccines).
+
+Currently this resource is focused around COVID-19 use.
+
+These are materialised from `public.administered_vaccines`.
+
+<https://www.hl7.org/fhir/immunization.html>
 {% enddocs %}
 
 {% docs fhir__immunizations__status %}
-TODO
+Normalized status code for the vaccination.
+
+Tamanu has a larger set of values for vaccine status than FHIR, so a reduced mapping is done. One of:
+- completed
+- entered-in-error
+- not-done
 {% enddocs %}
 
 {% docs fhir__immunizations__vaccine_code %}
-TODO
+The name of the vaccine drug given, optionally accompanied by a coding for select medicines.
+
+A subset of [the AIRV register](https://www.healthterminologies.gov.au/integration/R4/fhir/ValueSet/australian-immunisation-register-vaccine-1) is supported.
 {% enddocs %}
 
 {% docs fhir__immunizations__patient %}
-TODO
+Reference to the patient to whom this vaccination concerns.
 {% enddocs %}
 
 {% docs fhir__immunizations__encounter %}
-TODO
+Reference to the encounter encompassing this vaccination event.
+
+In Tamanu, vaccinations can be given outside of an open encounter; this is encoded as an encounter
+being recorded solely for the one vaccination, and immediately closed.
 {% enddocs %}
 
 {% docs fhir__immunizations__occurrence_date_time %}
-TODO
+Timestamp recording when the vaccine was given.
 {% enddocs %}
 
 {% docs fhir__immunizations__lot_number %}
-TODO
+Lot number of the vaccine vial.
 {% enddocs %}
 
 {% docs fhir__immunizations__site %}
-TODO
+Body area where the vaccine was given.
 {% enddocs %}
 
 {% docs fhir__immunizations__performer %}
-TODO
+Reference to the practitioner who administered the vaccination.
 {% enddocs %}
 
 {% docs fhir__immunizations__protocol_applied %}
-TODO
+Label of the vaccine dose given.
 {% enddocs %}

--- a/database/model/central-server/fhir/immunizations.yml
+++ b/database/model/central-server/fhir/immunizations.yml
@@ -36,6 +36,11 @@ sources:
             description: "{{ doc('fhir__immunizations__status') }}"
             data_tests:
               - not_null
+              - accepted_values:
+                  values:
+                    - completed
+                    - entered-in-error
+                    - not-done
           - name: vaccine_code
             data_type: jsonb
             description: "{{ doc('fhir__immunizations__vaccine_code') }}"

--- a/database/model/central-server/fhir/job_workers.md
+++ b/database/model/central-server/fhir/job_workers.md
@@ -1,19 +1,42 @@
 {% docs fhir__table__job_workers %}
-TODO
+Worker registry for the FHIR job queue.
+
+See the `fhir.jobs` table for more.
+
+For workers to grab jobs from the queue, they first must register. Once a worker has registered, it
+must "heartbeat" regularly by calling `job_worker_heartbeat()`. The recommended hearbeat time is
+1/10th of the timeout, which is defined in the `public.settings` table at
+`key=fhir.worker.assumeDroppedAfter`. A worker may also voluntarily deregister (e.g. during a
+graceful shutdown).
+
+When a worker fails to heartbeat for longer than the timeout, or when it deregisters, it is
+considered "not alive". Jobs which were grabbed by a dead or no-longer-registered worker are
+considered "dropped" i.e. back in the pool for other workers to grab.
+
+This provides a system which is robust against restarts and failures without requiring a central
+daemon to track and manage worker state, nor persistent connections from the workers (which is how
+Gearman works).
+
+The function `job_worker_garbage_collect()` should be called occasionally (e.g. once a day) to clean
+out the table of dead workers.
+
+Worker management is done via SQL functions: `job_worker_register()`, `job_worker_heartbeat()`,
+`job_worker_deregister()`, `job_worker_garbage_collect()`. Additionally there's the querying
+function `job_worker_is_alive()`.
 {% enddocs %}
 
 {% docs fhir__job_workers__created_at %}
-TODO
+When the worker registered itself.
 {% enddocs %}
 
 {% docs fhir__job_workers__updated_at %}
-TODO
+Always set to `created_at`.
 {% enddocs %}
 
 {% docs fhir__job_workers__deleted_at %}
-TODO
+Unused: deregistered and dead workers are hard-deleted instead.
 {% enddocs %}
 
 {% docs fhir__job_workers__metadata %}
-TODO
+Arbitrary debugging information about the worker.
 {% enddocs %}

--- a/database/model/central-server/fhir/job_workers.md
+++ b/database/model/central-server/fhir/job_workers.md
@@ -23,6 +23,9 @@ out the table of dead workers.
 Worker management is done via SQL functions: `job_worker_register()`, `job_worker_heartbeat()`,
 `job_worker_deregister()`, `job_worker_garbage_collect()`. Additionally there's the querying
 function `job_worker_is_alive()`.
+
+This provides the possibility of decoupling part or whole of the job system from the Tamanu JS/TS
+codebase, while retaining identical handling.
 {% enddocs %}
 
 {% docs fhir__job_workers__created_at %}

--- a/database/model/central-server/fhir/job_workers.yml
+++ b/database/model/central-server/fhir/job_workers.yml
@@ -4,7 +4,7 @@ sources:
     schema: fhir
     description: "{{ doc('fhir__generic__schema') }}"
     __generator:
-      js_class: JobWorker
+      js_class: FhirJobWorker
     tables:
       - name: job_workers
         description: "{{ doc('fhir__table__job_workers') }}"

--- a/database/model/central-server/fhir/jobs.md
+++ b/database/model/central-server/fhir/jobs.md
@@ -10,6 +10,9 @@ include an integer priority instead of (high, normal, low) and the lack of retur
 
 Job management is done via SQL functions: `job_submit()`, `job_start()`, `job_complete()`,
 `job_fail()`, `job_grab()`. Some additional functions are used for debugging: `job_backlog()`.
+
+This provides the possibility of decoupling part or whole of the job system from the Tamanu JS/TS
+codebase, while retaining identical handling.
 {% enddocs %}
 
 {% docs fhir__jobs__created_at %}

--- a/database/model/central-server/fhir/jobs.md
+++ b/database/model/central-server/fhir/jobs.md
@@ -1,55 +1,109 @@
 {% docs fhir__table__jobs %}
-TODO
+Job queue for FHIR materialization.
+
+Materialization for FHIR is handled by jobs issued on a queue (this table) and processed by workers.
+Error state is preserved, but successful jobs are discarded.
+
+The job system was loosely based on <https://gearman.org/>: it supports multiple workers, timeouts,
+concurrency and uniqueness control, arbitrary payloads, and flexible prioritisation. Differences
+include an integer priority instead of (high, normal, low) and the lack of return values.
+
+Job management is done via SQL functions: `job_submit()`, `job_start()`, `job_complete()`,
+`job_fail()`, `job_grab()`. Some additional functions are used for debugging: `job_backlog()`.
 {% enddocs %}
 
 {% docs fhir__jobs__created_at %}
-TODO
+When the job was inserted into the queue.
 {% enddocs %}
 
 {% docs fhir__jobs__updated_at %}
-TODO
+When the job was updated (mostly due to status changes).
 {% enddocs %}
 
 {% docs fhir__jobs__deleted_at %}
-TODO
+Unused: successful jobs are hard-deleted instead.
 {% enddocs %}
 
 {% docs fhir__jobs__priority %}
-TODO
+Integer priority of the job. Higher numbers win.
+
+The default is 1000.
+
+Convention is to use hundreds in code (e.g. 1500 for "higher priority") and then increase/decrease
+by tens or lower for manual priority management (e.g. 1010 to manually bump some jobs up).
 {% enddocs %}
 
 {% docs fhir__jobs__status %}
-TODO
+Lifecycle status of the job.
+
+1. Starts at `Queued`
+2. A worker grabs the job from the backlog, which transitions it to `Grabbed`
+3. The worker starts working the job, transitioning it to `Started`
+4. The worker completes the job, which deletes it from the queue
+5. Or the worker fails the job, which sets its status to `Errored`
+6. Or the worker drops the job, which puts it back into the backlog.
+
+The backlog is defined as jobs that are `Queued` and/or that are `Grabbed`/`Started` but where the
+recorded grabbing worker is "no longer alive" -- which occurs after a heartbeat timeout. See the
+`fhir.job_workers` table.
 {% enddocs %}
 
 {% docs fhir__jobs__worker_id %}
-TODO
+ID of the worker which has grabbed this job for processing.
 {% enddocs %}
 
 {% docs fhir__jobs__started_at %}
-TODO
+Timestamp when the worker started processing the job.
+
+This may be a while after the job is grabbed, though in general it's pretty immediate.
 {% enddocs %}
 
 {% docs fhir__jobs__completed_at %}
-TODO
+When the job was completed.
+
+Rarely used as completed jobs are hard-deleted.
 {% enddocs %}
 
 {% docs fhir__jobs__errored_at %}
-TODO
+When the job failed.
+
+This implies that `status=Errored` and the `error` field is not null.
 {% enddocs %}
 
 {% docs fhir__jobs__error %}
-TODO
+Description or stack trace of the error which caused the job to fail.
 {% enddocs %}
 
 {% docs fhir__jobs__topic %}
-TODO
+Jobs are organised along topics.
+
+This is used to route jobs to job handlers.
+
+A worker can choose which topics it will handle, and have different concurrency settings per topic.
+
+In general it's expected that jobs with the same topic will use similar amounts of resources, and
+present a fairly uniform workload.
 {% enddocs %}
 
 {% docs fhir__jobs__discriminant %}
-TODO
+Value used to deduplicate jobs.
+
+By default this is set to a random value.
+
+If a job is submitted with the same `discriminant` as a job that's already `Queued`, `Grabbed`,
+or `Started`, the new job will be discarded. This can be used to enforce uniqueness or to prevent
+redundant work.
+
+When a job is failed, its discriminant is reset to a random value to avoid forbidding new jobs from
+being submitted while keeping the error records around.
+
+To make code easier discriminants are also enforced to be globally unique within the table, so it's
+a good idea to prefix a fixed discriminant with the topic it's for.
 {% enddocs %}
 
 {% docs fhir__jobs__payload %}
-TODO
+Arbitrary JSONB payload.
+
+The handlers for a particular topic interpret and enforce the schema of payloads, but the job system
+itself doesn't care.
 {% enddocs %}

--- a/database/model/central-server/fhir/jobs.yml
+++ b/database/model/central-server/fhir/jobs.yml
@@ -4,7 +4,7 @@ sources:
     schema: fhir
     description: "{{ doc('fhir__generic__schema') }}"
     __generator:
-      js_class: Job
+      js_class: FhirJob
     tables:
       - name: jobs
         description: "{{ doc('fhir__table__jobs') }}"
@@ -39,6 +39,12 @@ sources:
             description: "{{ doc('fhir__jobs__status') }}"
             data_tests:
               - not_null
+              - accepted_values:
+                  values:
+                    - Queued
+                    - Grabbed
+                    - Started
+                    - Errored
           - name: worker_id
             data_type: uuid
             description: "{{ doc('fhir__jobs__worker_id') }}"

--- a/database/model/central-server/fhir/non_fhir_medici_report.md
+++ b/database/model/central-server/fhir/non_fhir_medici_report.md
@@ -1,119 +1,123 @@
 {% docs fhir__table__non_fhir_medici_report %}
-TODO
+This is a hack specifically to provide an integration (Medici) with a custom endpoint.
+
+It has nothing to do with FHIR but reuses the FHIR API infrastructure for convenience.
+
+Do not use outside of this integration's context.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__patient_id %}
-TODO
+UUID of the patient.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__first_name %}
-TODO
+First name of the patient.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__last_name %}
-TODO
+Last name of the patient.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__date_of_birth %}
-TODO
+Patient date of birth.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__age %}
-TODO
+Patient age.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__sex %}
-TODO
+Patient sex.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__patient_billing_id %}
-TODO
+Billing ID for Medici purposes.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__patient_billing_type %}
-TODO
+Medici billing type.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__encounter_id %}
-TODO
+UUID of the encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__encounter_start_date %}
-TODO
+Start date of the encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__encounter_end_date %}
-TODO
+End date of the encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__discharge_date %}
-TODO
+Discharge date of the encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__encounter_type %}
-TODO
+Type of the encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__weight %}
-TODO
+Patient weight.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__visit_type %}
-TODO
+Encounter visit type.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__episode_end_status %}
-TODO
+Status at end of encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__encounter_discharge_disposition %}
-TODO
+Discharge disposition.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__triage_category %}
-TODO
+Triage category.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__wait_time %}
-TODO
+Wait time.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__departments %}
-TODO
+Departments involved.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__locations %}
-TODO
+Locations involved.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__reason_for_encounter %}
-TODO
+Reason for encounter.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__diagnoses %}
-TODO
+Diagnoses made.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__medications %}
-TODO
+Medications prescribed.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__vaccinations %}
-TODO
+Vaccinations done.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__procedures %}
-TODO
+Procedures done.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__lab_requests %}
-TODO
+Labs requested.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__imaging_requests %}
-TODO
+Imagings requested.
 {% enddocs %}
 
 {% docs fhir__non_fhir_medici_report__notes %}
-TODO
+Any associated notes and comments.
 {% enddocs %}

--- a/database/model/central-server/fhir/organizations.md
+++ b/database/model/central-server/fhir/organizations.md
@@ -5,7 +5,7 @@ These are materialised from `public.facilities`.
 
 This is mostly a stub resource that other, more clinically relevant, resources reference.
 
-<https://www.hl7.org/fhir/organizations.html>
+<https://www.hl7.org/fhir/organization.html>
 {% enddocs %}
 
 {% docs fhir__organizations__identifier %}

--- a/database/model/central-server/fhir/organizations.md
+++ b/database/model/central-server/fhir/organizations.md
@@ -1,15 +1,23 @@
 {% docs fhir__table__organizations %}
-TODO
+FHIR data about organizations.
+
+These are materialised from `public.facilities`.
+
+This is mostly a stub resource that other, more clinically relevant, resources reference.
+
+<https://www.hl7.org/fhir/organizations.html>
 {% enddocs %}
 
 {% docs fhir__organizations__identifier %}
-TODO
+The facility's code.
 {% enddocs %}
 
 {% docs fhir__organizations__name %}
-TODO
+The facility's name.
 {% enddocs %}
 
 {% docs fhir__organizations__active %}
-TODO
+Whether the facility is active.
+
+This is materialised from `visibility_status`.
 {% enddocs %}

--- a/database/model/central-server/fhir/practitioners.md
+++ b/database/model/central-server/fhir/practitioners.md
@@ -1,15 +1,21 @@
 {% docs fhir__table__practitioners %}
-TODO
+FHIR data about practitioners.
+
+These are materialised from `public.users`.
+
+<https://www.hl7.org/fhir/practitioner.html>
 {% enddocs %}
 
 {% docs fhir__practitioners__identifier %}
-TODO
+One or more identifiers:
+- The Tamanu internal UUID for the user
+- The Tamanu Display ID for the user, if present
 {% enddocs %}
 
 {% docs fhir__practitioners__name %}
-TODO
+The display name of the practitioner.
 {% enddocs %}
 
 {% docs fhir__practitioners__telecom %}
-TODO
+The practitioner's email.
 {% enddocs %}

--- a/database/model/central-server/fhir/practitioners.md
+++ b/database/model/central-server/fhir/practitioners.md
@@ -3,6 +3,8 @@ FHIR data about practitioners.
 
 These are materialised from `public.users`.
 
+This is mostly a stub resource that other, more clinically relevant, resources reference.
+
 <https://www.hl7.org/fhir/practitioner.html>
 {% enddocs %}
 

--- a/database/model/central-server/fhir/specimens.md
+++ b/database/model/central-server/fhir/specimens.md
@@ -1,15 +1,19 @@
 {% docs fhir__table__specimens %}
-TODO
+FHIR data about specimen, for laboratory testing.
+
+<https://www.hl7.org/fhir/specimen.html>
 {% enddocs %}
 
 {% docs fhir__specimens__collection %}
-TODO
+Who collected the specimen, from where, and at what time.
 {% enddocs %}
 
 {% docs fhir__specimens__request %}
-TODO
+Reference to the servicerequest this specimen is for.
 {% enddocs %}
 
 {% docs fhir__specimens__type %}
-TODO
+Coded type of the specimen.
+
+These codes are from Reference Data `type=specimenType`.
 {% enddocs %}


### PR DESCRIPTION
### Changes

Fill in documentation for all remaining TODOs in the fhir namespace.

This also includes a full description of the FHIR job queue system, which will surely be useful and was previously only in the original PR/commits.

