### PR TITLE
feat(scheduling): NASS-1378: Outpatient appointments date selector

### DIFF
--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -206,7 +206,7 @@ export const differenceInMilliseconds = (a, b) =>
 
 const locale = globalThis.navigator?.language ?? 'default';
 
-export const intlFormatDate = (date, formatOptions, fallback = 'Unknown') => {
+const intlFormatDate = (date, formatOptions, fallback = 'Unknown') => {
   if (!date) return fallback;
   return parseISO(date).toLocaleString(locale, formatOptions);
 };

--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -206,7 +206,7 @@ export const differenceInMilliseconds = (a, b) =>
 
 const locale = globalThis.navigator?.language ?? 'default';
 
-const intlFormatDate = (date, formatOptions, fallback = 'Unknown') => {
+export const intlFormatDate = (date, formatOptions, fallback = 'Unknown') => {
   if (!date) return fallback;
   return parseISO(date).toLocaleString(locale, formatOptions);
 };

--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -248,9 +248,3 @@ export const formatLong = date =>
     },
     'Date information not available',
   ); // "Thursday, 14 July 2022, 03:44 pm"
-
-/** @returns `true` if two dates lie on the same day in local time, else `false`. */
-export const areSameDay = (date1, date2) =>
-  date1.getDate() === date2.getDate() &&
-  date1.getMonth() === date2.getMonth() &&
-  date1.getFullYear() === date2.getFullYear();

--- a/packages/web/app/components/Appointments/AppointmentTile.jsx
+++ b/packages/web/app/components/Appointments/AppointmentTile.jsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { parseISO } from 'date-fns';
+import { isSameDay, parseISO } from 'date-fns';
 
 import { PriorityHigh as HighPriorityIcon } from '@material-ui/icons';
 import OvernightIcon from '@material-ui/icons/Brightness2';
 import { APPOINTMENT_STATUSES } from '@tamanu/constants';
-import { areSameDay } from '@tamanu/shared/utils/dateTime';
 
 import { Colors } from '../../constants';
 import { APPOINTMENT_STATUS_COLORS } from './appointmentStatusIndicators';
@@ -90,7 +89,7 @@ export const AppointmentTile = ({ appointment, selected = false, onClose, ...pro
   const endTime = parseISO(endTimeStr);
 
   const isHighPriority = false; // TODO
-  const isOvernight = !areSameDay(startTime, endTime);
+  const isOvernight = !isSameDay(startTime, endTime);
 
   return (
     <Wrapper

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -67,13 +67,11 @@ const StepperButton = styled(IconButton)`
   padding: 0.25rem;
 `;
 
-const getMonthInterval = date => {
-  const start = startOfDay(date);
-  return eachDayOfInterval({
-    start: startOfMonth(start),
-    end: endOfMonth(start),
+const getMonthInterval = date =>
+  eachDayOfInterval({
+    start: startOfMonth(date),
+    end: endOfMonth(date),
   });
-};
 
 const DayButton = ({ date, selected, onClick }) => (
   <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(date)}>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box } from '@material-ui/core';
 import { ArrowBackIos, ArrowForwardIos } from '@mui/icons-material';
 import { IconButton, styled } from '@mui/material';
@@ -84,14 +84,14 @@ const DayButton = ({ date, selected, onClick }) => (
   </DayWrapper>
 );
 
-export const DateSelector = ({ value = new Date(), onChange }) => {
+export const DateSelector = ({ value, onChange }) => {
   const [viewedDays, setViewedDays] = useState(getMonthInterval(value));
 
   const handleIncrement = () => setViewedDays(getMonthInterval(addMonths(viewedDays[0], 1)));
   const handleDecrement = () => setViewedDays(getMonthInterval(subMonths(viewedDays[0], 1)));
 
   const handleChange = day => {
-    onChange({
+  onChange({
       target: {
         value: day,
       },
@@ -119,12 +119,12 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
         <ArrowBackIos fontSize="0.5rem" />
       </StepperButton>
       <DaysWrapper>
-        {viewedDays.map(day => (
+        {viewedDays.map(date => (
           <DayButton
-            date={day}
-            selected={isSameDay(day, value)}
-            onClick={() => handleChange(day)}
-            key={`day-${day.getTime()}`}
+            date={date}
+            selected={isSameDay(date, value)}
+            onClick={() => handleChange(date)}
+            key={`day-button-${date.getTime()}`}
           />
         ))}
       </DaysWrapper>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -87,9 +87,10 @@ export const DateSelector = ({ initialDate = startOfDay(new Date()) }) => {
   const handleIncrement = () => setDays(getMonthInterval(addMonths(days[0], 1)));
 
   const handleSetToday = () => {
-    setSelectedDate(startOfDay(new Date()));
-    if (days[0].getMonth() !== new Date().getMonth()) {
-      setDays(getMonthInterval(new Date()));
+    const todayDate = startOfDay(new Date());
+    setSelectedDate(startOfDay(todayDate));
+    if (days[0].getMonth() !== todayDate.getMonth()) {
+      setDays(getMonthInterval(todayDate));
     }
   };
 

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -117,28 +117,25 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
   }, [value]);
 
   return (
-    <div>
-      <h2>Month {viewedDays[0].toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <MonthYearInput value={viewedDays[0]} onChange={handleCalenderChange} />
-        <TodayButton onClick={handleSetToday}>Today</TodayButton>
-        <StepperButton onClick={handleDecrement}>
-          <ArrowBackIos fontSize="0.5rem" />
-        </StepperButton>
-        <DaysWrapper>
-          {viewedDays.map(day => (
-            <DayButton
-              day={day}
-              selected={isSameDay(day, value)}
-              onClick={() => handleChange(day)}
-              key={`day-${day.getTime()}`}
-            />
-          ))}
-        </DaysWrapper>
-        <StepperButton onClick={handleIncrement}>
-          <ArrowForwardIos fontSize="0.5rem" />
-        </StepperButton>
-      </Box>
-    </div>
+    <Box display="flex" alignItems="center" justifyContent="space-between">
+      <MonthYearInput value={viewedDays[0]} onChange={handleCalenderChange} />
+      <TodayButton onClick={handleSetToday}>Today</TodayButton>
+      <StepperButton onClick={handleDecrement}>
+        <ArrowBackIos fontSize="0.5rem" />
+      </StepperButton>
+      <DaysWrapper>
+        {viewedDays.map(day => (
+          <DayButton
+            day={day}
+            selected={isSameDay(day, value)}
+            onClick={() => handleChange(day)}
+            key={`day-${day.getTime()}`}
+          />
+        ))}
+      </DaysWrapper>
+      <StepperButton onClick={handleIncrement}>
+        <ArrowForwardIos fontSize="0.5rem" />
+      </StepperButton>
+    </Box>
   );
 };

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -112,10 +112,10 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
         <DaysWrapper>
           {viewedDays.map(day => (
             <DayButton
-              key={`day-${day.getTime()}`}
               day={day}
               selected={value.getTime() === day.getTime()}
               onClick={() => handleChange(day)}
+              key={`day-${day.getTime()}`}
             />
           ))}
         </DaysWrapper>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -82,17 +82,13 @@ export const DateSelector = ({ initialDate = startOfDay(new Date()) }) => {
   const [days, setDays] = useState(getMonthInterval(initialDate));
   const [selectedDate, setSelectedDate] = useState(days.find(isToday));
 
-  const handleDecrement = async () => {
-    setDays(getMonthInterval(subMonths(days[0], 1)));
-  };
+  const handleDecrement = async () => setDays(getMonthInterval(subMonths(days[0], 1)));
 
-  const handleIncrement = () => {
-    setDays(getMonthInterval(addMonths(days[0], 1)));
-  };
+  const handleIncrement = () => setDays(getMonthInterval(addMonths(days[0], 1)));
 
   const handleSetToday = () => {
     setSelectedDate(startOfDay(new Date()));
-    if (!days.some(isToday)) {
+    if (days[0].getMonth() !== new Date().getMonth()) {
       setDays(getMonthInterval(new Date()));
     }
   };

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { Box } from '@material-ui/core';
 import { ArrowBackIos, ArrowForwardIos } from '@mui/icons-material';
 import { IconButton, styled } from '@mui/material';
@@ -11,7 +12,7 @@ import {
   subMonths,
   startOfDay,
 } from 'date-fns';
-import React, { useState } from 'react';
+
 import { BodyText, TextButton } from '../../components';
 import { Colors } from '../../constants';
 
@@ -66,8 +67,8 @@ const DayButton = ({ day, selected, onClick }) => {
   );
 };
 
-export const DateSelector = ({ date = startOfDay(new Date()) }) => {
-  const [days, setDays] = useState(getMonthInterval(date));
+export const DateSelector = ({ initialDate = startOfDay(new Date()) }) => {
+  const [days, setDays] = useState(getMonthInterval(initialDate));
   const [selectedDate, setSelectedDate] = useState(days.find(isToday));
 
   const handleDecrement = async () => {

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -87,7 +87,6 @@ export const DateSelector = ({ date = startOfDay(new Date()) }) => {
 
   return (
     <div>
-      <h1>DateSelector</h1>
       <h2>Month {days[0].toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
       <Box display="flex" alignItems="center" justifyContent="space-between">
         <TextButton onClick={handleSetToday}>Today</TextButton>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -31,9 +31,16 @@ const DayWrapper = styled(Box)`
   }
 `;
 
+const DaysWrapper = styled(Box)`
+  display: flex;
+  overflow: auto;
+  max-width: 100%;
+  padding-block: 8px;
+`;
+
 const WeekdayText = styled(BodyText)`
   color: ${({ $selected, $isWeekend }) =>
-    $selected ? Colors.white : $isWeekend ? Colors.softText : 'inherit'};
+    $selected ? Colors.white : $isWeekend ? Colors.softText : Colors.midText};
 `;
 
 const DayButton = ({ day, selected, onClick }) => {
@@ -75,14 +82,16 @@ export const DateSelector = ({ date = new Date() }) => {
         <IconButton onClick={handleDecrement}>
           <ArrowBackIos />
         </IconButton>
-        {days.map(day => (
-          <DayButton
-            key={`day-${day.getTime()}`}
-            day={day}
-            selected={selectedDate.getTime() === day.getTime()}
-            onClick={() => setSelectedDate(day)}
-          />
-        ))}
+        <DaysWrapper>
+          {days.map(day => (
+            <DayButton
+              key={`day-${day.getTime()}`}
+              day={day}
+              selected={selectedDate.getTime() === day.getTime()}
+              onClick={() => setSelectedDate(day)}
+            />
+          ))}
+        </DaysWrapper>
         <IconButton onClick={handleIncrement}>
           <ArrowForwardIos />
         </IconButton>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -6,14 +6,16 @@ import {
   eachDayOfInterval,
   endOfMonth,
   isToday,
+  isWeekend,
   startOfMonth,
   subMonths,
 } from 'date-fns';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { BodyText } from '../../components';
 import { Colors } from '../../constants';
 
 const DayWrapper = styled(Box)`
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -29,14 +31,19 @@ const DayWrapper = styled(Box)`
   }
 `;
 
-const DayButton = ({ day, selected, isToday }) => {
+const WeekdayText = styled(BodyText)`
+  color: ${({ $selected, $isWeekend }) =>
+    $selected ? Colors.white : $isWeekend ? Colors.softText : 'inherit'};
+`;
+
+const DayButton = ({ day, selected, onClick }) => {
   return (
-    <DayWrapper $selected={selected} $isToday={isToday}>
-      <BodyText color={selected ? Colors.white : 'textTertiary'}>
+    <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(day)}>
+      <WeekdayText $selected={selected} $isWeekend={isWeekend(day)}>
         {day.toLocaleDateString('default', {
           weekday: 'narrow',
         })}
-      </BodyText>
+      </WeekdayText>
       <BodyText>{day.getDate()}</BodyText>
     </DayWrapper>
   );
@@ -50,42 +57,30 @@ const getMonthInterval = date =>
 
 export const DateSelector = ({ date = new Date() }) => {
   const [days, setDays] = useState(getMonthInterval(date));
-  const [selectedIndex, setSelectedIndex] = useState(4);
-
-  const selectedDate = useMemo(() => days[selectedIndex], [days, selectedIndex]);
+  const [selectedDate, setSelectedDate] = useState(days.find(isToday));
 
   const handleDecrement = async () => {
-    if (selectedIndex > 0) {
-      setSelectedIndex(selectedIndex - 1);
-      return;
-    }
-    const newDays = getMonthInterval(subMonths(days[0], 1));
-    setDays(newDays);
-    setSelectedIndex(newDays.length - 1);
+    setDays(getMonthInterval(subMonths(days[0], 1)));
   };
 
   const handleIncrement = () => {
-    if (selectedIndex < days.length - 1) {
-      setSelectedIndex(selectedIndex + 1);
-      return;
-    }
     setDays(getMonthInterval(addMonths(days[0], 1)));
-    setSelectedIndex(0);
   };
 
   return (
     <div>
       <h1>DateSelector</h1>
+      <h2>Month {days[0].toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
       <Box display="flex" alignItems="center" gap="5px">
         <IconButton onClick={handleDecrement}>
           <ArrowBackIos />
         </IconButton>
-        {days.map((day, index) => (
+        {days.map(day => (
           <DayButton
             key={`day-${day.getTime()}`}
-            isToday={isToday(day)}
             day={day}
-            selected={index === selectedIndex}
+            selected={selectedDate.getTime() === day.getTime()}
+            onClick={() => setSelectedDate(day)}
           />
         ))}
         <IconButton onClick={handleIncrement}>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -13,11 +13,11 @@ import {
   startOfDay,
   isSameMonth,
   isSameDay,
+  format,
 } from 'date-fns';
 
 import { BodyText, MonthYearInput, TextButton } from '../../components';
 import { Colors } from '../../constants';
-import { intlFormatDate } from '@tamanu/shared/utils/dateTime';
 
 const DaysWrapper = styled(Box)`
   display: flex;
@@ -74,18 +74,14 @@ const getMonthInterval = date => {
   });
 };
 
-const DayButton = ({ date, selected, onClick }) => {
-  return (
-    <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(date)}>
-      <WeekdayText $selected={selected} $isWeekend={isWeekend(date)}>
-        {intlFormatDate(date, {
-          weekday: 'narrow',
-        })}
-      </WeekdayText>
-      <DateText>{date.getDate()}</DateText>
-    </DayWrapper>
-  );
-};
+const DayButton = ({ date, selected, onClick }) => (
+  <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(date)}>
+    <WeekdayText $selected={selected} $isWeekend={isWeekend(date)}>
+      {format(date, 'EEEEE')}
+    </WeekdayText>
+    <DateText>{date.getDate()}</DateText>
+  </DayWrapper>
+);
 
 export const DateSelector = ({ value = new Date(), onChange }) => {
   const [viewedDays, setViewedDays] = useState(getMonthInterval(value));

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -82,9 +82,8 @@ export const DateSelector = ({ initialDate = startOfDay(new Date()) }) => {
   const [days, setDays] = useState(getMonthInterval(initialDate));
   const [selectedDate, setSelectedDate] = useState(days.find(isToday));
 
-  const handleDecrement = async () => setDays(getMonthInterval(subMonths(days[0], 1)));
-
   const handleIncrement = () => setDays(getMonthInterval(addMonths(days[0], 1)));
+  const handleDecrement = () => setDays(getMonthInterval(subMonths(days[0], 1)));
 
   const handleSetToday = () => {
     const todayDate = startOfDay(new Date());

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -98,7 +98,8 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
   useEffect(() => {
     if (isSameMonth(value, viewedDays[0])) return;
     setViewedDays(getMonthInterval(value));
-  }, [value, viewedDays]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   return (
     <div>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -51,6 +51,14 @@ const DateText = styled(BodyText)`
   text-align: center;
 `;
 
+const TodayButton = styled(TextButton)`
+  margin-inline: 8px;
+  text-decoration: underline;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 const getMonthInterval = date =>
   eachDayOfInterval({
     start: startOfMonth(date),
@@ -93,7 +101,7 @@ export const DateSelector = ({ initialDate = startOfDay(new Date()) }) => {
     <div>
       <h2>Month {days[0].toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
       <Box display="flex" alignItems="center" justifyContent="space-between">
-        <TextButton onClick={handleSetToday}>Today</TextButton>
+        <TodayButton onClick={handleSetToday}>Today</TodayButton>
         <IconButton onClick={handleDecrement}>
           <ArrowBackIos />
         </IconButton>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -74,15 +74,15 @@ const getMonthInterval = date => {
   });
 };
 
-const DayButton = ({ day, selected, onClick }) => {
+const DayButton = ({ date, selected, onClick }) => {
   return (
-    <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(day)}>
-      <WeekdayText $selected={selected} $isWeekend={isWeekend(day)}>
-        {intlFormatDate({
+    <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(date)}>
+      <WeekdayText $selected={selected} $isWeekend={isWeekend(date)}>
+        {intlFormatDate(date, {
           weekday: 'narrow',
         })}
       </WeekdayText>
-      <DateText>{day.getDate()}</DateText>
+      <DateText>{date.getDate()}</DateText>
     </DayWrapper>
   );
 };
@@ -127,7 +127,7 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
       <DaysWrapper>
         {viewedDays.map(day => (
           <DayButton
-            day={day}
+            date={day}
             selected={isSameDay(day, value)}
             onClick={() => handleChange(day)}
             key={`day-${day.getTime()}`}

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -6,15 +6,14 @@ import {
   addMonths,
   eachDayOfInterval,
   endOfMonth,
+  format,
+  isSameDay,
+  isSameMonth,
+  isThisMonth,
   isToday,
   isWeekend,
   startOfMonth,
   subMonths,
-  startOfDay,
-  isSameMonth,
-  isSameDay,
-  format,
-  isThisMonth,
 } from 'date-fns';
 
 import { BodyText, MonthYearInput, TextButton } from '../../components';

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -100,12 +100,12 @@ export const DateSelector = ({ value, onChange }) => {
 
   const handleChangeToday = () => handleChange(new Date());
   const handleMonthYearChange = e => {
-    const date = e.target.value;
-    if (isThisMonth(date)) {
+    const newDate = e.target.value;
+    if (isThisMonth(newDate)) {
       handleChangeToday();
       return;
     }
-    handleChange(startOfMonth(date));
+    handleChange(startOfMonth(newDate));
   };
 
   return (

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -20,8 +20,8 @@ const DayWrapper = styled(Box)`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 8px;
-  padding-inline: 10px;
+  padding: 4px;
+  padding-inline: 6px;
   border-radius: 3px;
   background-color: ${({ $selected }) => ($selected ? Colors.primary : 'transparent')};
   color: ${({ $selected }) => ($selected ? Colors.white : 'inherit')};

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -1,0 +1,33 @@
+import { Box } from '@material-ui/core';
+import { ArrowBackIos, ArrowForwardIos, ArrowLeft, ArrowRight } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import { eachDayOfInterval } from 'date-fns';
+import React from 'react';
+
+export const DateSelector = () => {
+  const days = eachDayOfInterval({
+    start: new Date(2014, 9, 1),
+    end: new Date(2014, 9, 31),
+  });
+  console.log(days);
+  return (
+    <div>
+      <h1>DateSelector</h1>
+      <Box display="flex">
+        <IconButton>
+          <ArrowBackIos />
+        </IconButton>
+        {days.map((day, index) => (
+          <Box key={index} display="flex" alignItems="center">
+            {new Intl.DateTimeFormat('en-US', {
+              weekday: 'narrow',
+            }).format(day)}
+          </Box>
+        ))}
+        <IconButton>
+          <ArrowForwardIos />
+        </IconButton>
+      </Box>
+    </div>
+  );
+};

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -12,9 +12,10 @@ import {
   subMonths,
   startOfDay,
   isSameMonth,
+  isSameDay,
 } from 'date-fns';
 
-import { BodyText, TextButton } from '../../components';
+import { BodyText, MonthYearInput, TextButton } from '../../components';
 import { Colors } from '../../constants';
 
 const DaysWrapper = styled(Box)`
@@ -53,10 +54,15 @@ const WeekdayText = styled(DateText)`
 
 const TodayButton = styled(TextButton)`
   margin-inline: 8px;
+  font-size: 0.875rem;
   text-decoration: underline;
   &:hover {
     text-decoration: underline;
   }
+`;
+
+const StepperButton = styled(IconButton)`
+  padding: 4px;
 `;
 
 const getMonthInterval = date => {
@@ -90,6 +96,15 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
       },
     });
 
+  const handleCalenderChange = e => {
+    const date = e.target.value;
+    if (isSameMonth(date, new Date())) {
+      handleChange(new Date());
+    } else {
+      handleChange(startOfMonth(date));
+    }
+  };
+
   const handleIncrement = () => setViewedDays(getMonthInterval(addMonths(viewedDays[0], 1)));
   const handleDecrement = () => setViewedDays(getMonthInterval(subMonths(viewedDays[0], 1)));
 
@@ -105,23 +120,24 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
     <div>
       <h2>Month {viewedDays[0].toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
       <Box display="flex" alignItems="center" justifyContent="space-between">
+        <MonthYearInput value={viewedDays[0]} onChange={handleCalenderChange} />
         <TodayButton onClick={handleSetToday}>Today</TodayButton>
-        <IconButton onClick={handleDecrement}>
-          <ArrowBackIos />
-        </IconButton>
+        <StepperButton onClick={handleDecrement}>
+          <ArrowBackIos fontSize="0.5rem" />
+        </StepperButton>
         <DaysWrapper>
           {viewedDays.map(day => (
             <DayButton
               day={day}
-              selected={value.getTime() === day.getTime()}
+              selected={isSameDay(day, value)}
               onClick={() => handleChange(day)}
               key={`day-${day.getTime()}`}
             />
           ))}
         </DaysWrapper>
-        <IconButton onClick={handleIncrement}>
-          <ArrowForwardIos />
-        </IconButton>
+        <StepperButton onClick={handleIncrement}>
+          <ArrowForwardIos fontSize="0.5rem" />
+        </StepperButton>
       </Box>
     </div>
   );

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -17,6 +17,7 @@ import {
 
 import { BodyText, MonthYearInput, TextButton } from '../../components';
 import { Colors } from '../../constants';
+import { intlFormatDate } from '@tamanu/shared/utils/dateTime';
 
 const DaysWrapper = styled(Box)`
   display: flex;
@@ -77,7 +78,7 @@ const DayButton = ({ day, selected, onClick }) => {
   return (
     <DayWrapper onClick={onClick} $selected={selected} $isToday={isToday(day)}>
       <WeekdayText $selected={selected} $isWeekend={isWeekend(day)}>
-        {day.toLocaleDateString('default', {
+        {intlFormatDate({
           weekday: 'narrow',
         })}
       </WeekdayText>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -49,8 +49,11 @@ const DateText = styled(BodyText)`
 `;
 
 const WeekdayText = styled(DateText)`
-  color: ${({ $selected, $isWeekend }) =>
-    $selected ? Colors.white : $isWeekend ? Colors.softText : Colors.midText};
+  color: ${({ $selected, $isWeekend }) => {
+    if ($selected) return Colors.white;
+    if ($isWeekend) return Colors.softText;
+    return Colors.midText;
+  }};
 `;
 
 const TodayButton = styled(TextButton)`

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -86,37 +86,34 @@ const DayButton = ({ date, selected, onClick }) => (
 export const DateSelector = ({ value = new Date(), onChange }) => {
   const [viewedDays, setViewedDays] = useState(getMonthInterval(value));
 
-  const handleChange = day =>
+  const handleIncrement = () => setViewedDays(getMonthInterval(addMonths(viewedDays[0], 1)));
+  const handleDecrement = () => setViewedDays(getMonthInterval(subMonths(viewedDays[0], 1)));
+
+  const handleChange = day => {
     onChange({
       target: {
         value: day,
       },
     });
 
-  const handleCalenderChange = e => {
-    const date = e.target.value;
-    if (isSameMonth(date, new Date())) {
-      handleChange(new Date());
-    } else {
-      handleChange(startOfMonth(date));
-    }
+    if (isSameMonth(day, viewedDays[0])) return;
+    setViewedDays(getMonthInterval(day));
   };
 
-  const handleIncrement = () => setViewedDays(getMonthInterval(addMonths(viewedDays[0], 1)));
-  const handleDecrement = () => setViewedDays(getMonthInterval(subMonths(viewedDays[0], 1)));
-
-  const handleSetToday = () => handleChange(new Date());
-
-  useEffect(() => {
-    if (isSameMonth(value, viewedDays[0])) return;
-    setViewedDays(getMonthInterval(value));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  const handleMonthYearChange = e => {
+    const date = e.target.value;
+    const todayDate = new Date();
+    if (isSameMonth(date, todayDate)) {
+      handleChange(todayDate);
+      return;
+    }
+    handleChange(startOfMonth(date));
+  };
 
   return (
     <Box display="flex" alignItems="center" justifyContent="space-between">
-      <MonthYearInput value={viewedDays[0]} onChange={handleCalenderChange} />
-      <TodayButton onClick={handleSetToday}>Today</TodayButton>
+      <MonthYearInput value={viewedDays[0]} onChange={handleMonthYearChange} />
+      <TodayButton onClick={() => handleChange(new Date())}>Today</TodayButton>
       <StepperButton onClick={handleDecrement}>
         <ArrowBackIos fontSize="0.5rem" />
       </StepperButton>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -9,9 +9,10 @@ import {
   isWeekend,
   startOfMonth,
   subMonths,
+  startOfDay,
 } from 'date-fns';
 import React, { useState } from 'react';
-import { BodyText } from '../../components';
+import { BodyText, TextButton } from '../../components';
 import { Colors } from '../../constants';
 
 const DayWrapper = styled(Box)`
@@ -24,7 +25,8 @@ const DayWrapper = styled(Box)`
   border-radius: 3px;
   background-color: ${({ $selected }) => ($selected ? Colors.primary : 'transparent')};
   color: ${({ $selected }) => ($selected ? Colors.white : 'inherit')};
-  ${({ $isToday }) => $isToday && `border: 1px solid ${Colors.primary};`}
+  border: 1px solid ${({ $isToday }) => ($isToday ? Colors.primary : 'transparent')};
+  flex-grow: 1;
   & div {
     min-width: 18px;
     text-align: center;
@@ -34,14 +36,22 @@ const DayWrapper = styled(Box)`
 const DaysWrapper = styled(Box)`
   display: flex;
   overflow: auto;
-  max-width: 100%;
+  scrollbar-width: thin;
+  width: 100%;
   padding-block: 8px;
+  justify-content: space-between;
 `;
 
 const WeekdayText = styled(BodyText)`
   color: ${({ $selected, $isWeekend }) =>
     $selected ? Colors.white : $isWeekend ? Colors.softText : Colors.midText};
 `;
+
+const getMonthInterval = date =>
+  eachDayOfInterval({
+    start: startOfMonth(date),
+    end: endOfMonth(date),
+  });
 
 const DayButton = ({ day, selected, onClick }) => {
   return (
@@ -56,13 +66,7 @@ const DayButton = ({ day, selected, onClick }) => {
   );
 };
 
-const getMonthInterval = date =>
-  eachDayOfInterval({
-    start: startOfMonth(date),
-    end: endOfMonth(date),
-  });
-
-export const DateSelector = ({ date = new Date() }) => {
+export const DateSelector = ({ date = startOfDay(new Date()) }) => {
   const [days, setDays] = useState(getMonthInterval(date));
   const [selectedDate, setSelectedDate] = useState(days.find(isToday));
 
@@ -74,11 +78,19 @@ export const DateSelector = ({ date = new Date() }) => {
     setDays(getMonthInterval(addMonths(days[0], 1)));
   };
 
+  const handleSetToday = () => {
+    setSelectedDate(startOfDay(new Date()));
+    if (!days.some(isToday)) {
+      setDays(getMonthInterval(new Date()));
+    }
+  };
+
   return (
     <div>
       <h1>DateSelector</h1>
       <h2>Month {days[0].toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
-      <Box display="flex" alignItems="center" gap="5px">
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <TextButton onClick={handleSetToday}>Today</TextButton>
         <IconButton onClick={handleDecrement}>
           <ArrowBackIos />
         </IconButton>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -16,24 +16,6 @@ import {
 import { BodyText, TextButton } from '../../components';
 import { Colors } from '../../constants';
 
-const DayWrapper = styled(Box)`
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 4px;
-  padding-inline: 6px;
-  border-radius: 3px;
-  background-color: ${({ $selected }) => ($selected ? Colors.primary : 'transparent')};
-  color: ${({ $selected }) => ($selected ? Colors.white : 'inherit')};
-  border: 1px solid ${({ $isToday }) => ($isToday ? Colors.primary : 'transparent')};
-  flex-grow: 1;
-  & div {
-    min-width: 18px;
-    text-align: center;
-  }
-`;
-
 const DaysWrapper = styled(Box)`
   display: flex;
   overflow: auto;
@@ -43,9 +25,30 @@ const DaysWrapper = styled(Box)`
   justify-content: space-between;
 `;
 
+const DayWrapper = styled(Box)`
+  background-color: ${({ $selected }) => ($selected ? Colors.primary : 'transparent')};
+  border: 1px solid ${({ $isToday }) => ($isToday ? Colors.primary : 'transparent')};
+  color: ${({ $selected }) => ($selected ? Colors.white : 'inherit')};
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px;
+  padding-inline: 6px;
+  border-radius: 3px;
+  flex-grow: 1;
+`;
+
 const WeekdayText = styled(BodyText)`
   color: ${({ $selected, $isWeekend }) =>
     $selected ? Colors.white : $isWeekend ? Colors.softText : Colors.midText};
+  min-width: 18px;
+  text-align: center;
+`;
+
+const DateText = styled(BodyText)`
+  min-width: 18px;
+  text-align: center;
 `;
 
 const getMonthInterval = date =>
@@ -62,7 +65,7 @@ const DayButton = ({ day, selected, onClick }) => {
           weekday: 'narrow',
         })}
       </WeekdayText>
-      <BodyText>{day.getDate()}</BodyText>
+      <DateText>{day.getDate()}</DateText>
     </DayWrapper>
   );
 };

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -25,7 +25,7 @@ const DaysWrapper = styled(Box)`
   overflow: auto;
   scrollbar-width: thin;
   width: 100%;
-  padding-block: 8px;
+  padding-block: 0.5rem;
   justify-content: space-between;
 `;
 
@@ -37,15 +37,15 @@ const DayWrapper = styled(Box)`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 4px;
-  padding-inline: 6px;
+  padding: 0.25rem;
+  padding-inline: 0.375rem;
   border-radius: 3px;
   flex-grow: 1;
   user-select: none;
 `;
 
 const DateText = styled(BodyText)`
-  min-width: 18px;
+  min-width: 1.125rem;
   text-align: center;
 `;
 
@@ -55,7 +55,7 @@ const WeekdayText = styled(DateText)`
 `;
 
 const TodayButton = styled(TextButton)`
-  margin-inline: 8px;
+  margin-inline: 0.375rem;
   font-size: 0.875rem;
   text-decoration: underline;
   &:hover {
@@ -64,7 +64,7 @@ const TodayButton = styled(TextButton)`
 `;
 
 const StepperButton = styled(IconButton)`
-  padding: 4px;
+  padding: 0.25rem;
 `;
 
 const getMonthInterval = date => {
@@ -91,7 +91,7 @@ export const DateSelector = ({ value, onChange }) => {
   const handleDecrement = () => setViewedDays(getMonthInterval(subMonths(viewedDays[0], 1)));
 
   const handleChange = day => {
-  onChange({
+    onChange({
       target: {
         value: day,
       },

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -14,6 +14,7 @@ import {
   isSameMonth,
   isSameDay,
   format,
+  isThisMonth,
 } from 'date-fns';
 
 import { BodyText, MonthYearInput, TextButton } from '../../components';
@@ -100,11 +101,11 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
     setViewedDays(getMonthInterval(day));
   };
 
+  const handleChangeToday = () => handleChange(new Date());
   const handleMonthYearChange = e => {
     const date = e.target.value;
-    const todayDate = new Date();
-    if (isSameMonth(date, todayDate)) {
-      handleChange(todayDate);
+    if (isThisMonth(date)) {
+      handleChangeToday();
       return;
     }
     handleChange(startOfMonth(date));
@@ -113,7 +114,7 @@ export const DateSelector = ({ value = new Date(), onChange }) => {
   return (
     <Box display="flex" alignItems="center" justifyContent="space-between">
       <MonthYearInput value={viewedDays[0]} onChange={handleMonthYearChange} />
-      <TodayButton onClick={() => handleChange(new Date())}>Today</TodayButton>
+      <TodayButton onClick={handleChangeToday}>Today</TodayButton>
       <StepperButton onClick={handleDecrement}>
         <ArrowBackIos fontSize="0.5rem" />
       </StepperButton>

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -37,18 +37,17 @@ const DayWrapper = styled(Box)`
   padding-inline: 6px;
   border-radius: 3px;
   flex-grow: 1;
-`;
-
-const WeekdayText = styled(BodyText)`
-  color: ${({ $selected, $isWeekend }) =>
-    $selected ? Colors.white : $isWeekend ? Colors.softText : Colors.midText};
-  min-width: 18px;
-  text-align: center;
+  user-select: none;
 `;
 
 const DateText = styled(BodyText)`
   min-width: 18px;
   text-align: center;
+`;
+
+const WeekdayText = styled(DateText)`
+  color: ${({ $selected, $isWeekend }) =>
+    $selected ? Colors.white : $isWeekend ? Colors.softText : Colors.midText};
 `;
 
 const TodayButton = styled(TextButton)`

--- a/packages/web/stories/dateSelectorScheduling.stories.jsx
+++ b/packages/web/stories/dateSelectorScheduling.stories.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { DateSelector } from '../app/views/scheduling/DateSelector';
+
+export default {
+  argTypes: {},
+  title: 'DateSelectorScheduling',
+  component: DateSelector,
+};
+
+const Template = args => {
+  return <DateSelector {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/packages/web/stories/dateSelectorScheduling.stories.jsx
+++ b/packages/web/stories/dateSelectorScheduling.stories.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { DateSelector } from '../app/views/scheduling/DateSelector';
-import { startOfDay } from 'date-fns';
+import { isSameMonth, startOfDay, startOfMonth } from 'date-fns';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { MonthYearInput } from '../app/components';
@@ -14,11 +14,11 @@ export default {
 const Template = args => {
   const [value, setValue] = useState(startOfDay(new Date()));
   const handleChange = e => {
-    setValue(startOfDay(e.target.value));
+    setValue(e.target.value);
   };
+
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <MonthYearInput value={value} onChange={handleChange} />
       <DateSelector {...args} value={value} onChange={handleChange} />
     </LocalizationProvider>
   );

--- a/packages/web/stories/dateSelectorScheduling.stories.jsx
+++ b/packages/web/stories/dateSelectorScheduling.stories.jsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { DateSelector } from '../app/views/scheduling/DateSelector';
+import { startOfDay } from 'date-fns';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { MonthYearInput } from '../app/components';
 
 export default {
   argTypes: {},
@@ -8,7 +12,16 @@ export default {
 };
 
 const Template = args => {
-  return <DateSelector {...args} />;
+  const [value, setValue] = useState(startOfDay(new Date()));
+  const handleChange = e => {
+    setValue(startOfDay(e.target.value));
+  };
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <MonthYearInput value={value} onChange={handleChange} />
+      <DateSelector {...args} value={value} onChange={handleChange} />
+    </LocalizationProvider>
+  );
 };
 
 export const Default = Template.bind({});

--- a/packages/web/stories/dateSelectorScheduling.stories.jsx
+++ b/packages/web/stories/dateSelectorScheduling.stories.jsx
@@ -3,7 +3,7 @@ import { DateSelector } from '../app/views/scheduling/DateSelector';
 
 export default {
   argTypes: {},
-  title: 'DateSelectorScheduling',
+  title: 'SchedulingDateSelector',
   component: DateSelector,
 };
 

--- a/packages/web/stories/schedulingDateSelector.stories.jsx
+++ b/packages/web/stories/schedulingDateSelector.stories.jsx
@@ -1,13 +1,11 @@
 import React, { useState } from 'react';
 import { DateSelector } from '../app/views/scheduling/DateSelector';
-import { isSameMonth, startOfDay, startOfMonth } from 'date-fns';
+import { startOfDay } from 'date-fns';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { MonthYearInput } from '../app/components';
 
 export default {
-  argTypes: {},
-  title: 'SchedulingDateSelector',
+  title: 'Scheduling/DateSelector',
   component: DateSelector,
 };
 


### PR DESCRIPTION
### Changes

into scheduling epic

Add scheduling date select header with month stepper and incorporated month year input
- Currently implemented in story alone

Demo video showing all the requirements in ticket
https://github.com/user-attachments/assets/0d356947-e6f4-4381-980c-d9e94cc6d546

This includes some things like
- Resize to full width when smaller months
- When selecting a month from calendar - if it is **this** month - then go to today otherwise select the 1st.
- Clicking next will change month in that direction but not update selection
<img width="1227" alt="Screenshot 2024-10-21 at 12 04 10 PM" src="https://github.com/user-attachments/assets/c0e97925-428b-499b-8be4-2dd70b982d83">



### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
