### PR TITLE
fix(scheduling): Add click away listener to appointment details popper

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
-import { Box, IconButton, Paper, Popper, styled } from '@mui/material';
+import { Box, IconButton, Paper, Popper, ClickAwayListener, styled } from '@mui/material';
 import { MoreVert, Close, Brightness2 as Overnight } from '@mui/icons-material';
 import { debounce } from 'lodash';
 import { toast } from 'react-toastify';
@@ -314,15 +314,22 @@ export const AppointmentDetailPopper = ({
         },
       ]}
     >
-      <ControlsRow onClose={onClose} />
-      <StyledPaper elevation={0}>
-        <PatientDetailsDisplay patient={appointment.patient} onClick={handlePatientDetailsClick} />
-        <AppointDetailsDisplay appointment={appointment} isOvernight={isOvernight} />
-        <AppointmentStatusDisplay
-          selectedStatus={localStatus}
-          updateAppointmentStatus={updateAppointmentStatus}
-        />
-      </StyledPaper>
+      <ClickAwayListener onClickAway={onClose}>
+        <Box>
+          <ControlsRow onClose={onClose} />
+          <StyledPaper elevation={0}>
+            <PatientDetailsDisplay
+              patient={appointment.patient}
+              onClick={handlePatientDetailsClick}
+            />
+            <AppointDetailsDisplay appointment={appointment} isOvernight={isOvernight} />
+            <AppointmentStatusDisplay
+              selectedStatus={localStatus}
+              updateAppointmentStatus={updateAppointmentStatus}
+            />
+          </StyledPaper>
+        </Box>
+      </ClickAwayListener>
     </Popper>
   );
 };


### PR DESCRIPTION
Just was testing this and the popper wouldn't close when opening a new one.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
