### PR TITLE
fix: EPI-983: Dashboard is redirected after login even when it is hidden

### DIFF
--- a/packages/web/app/RoutingApp.jsx
+++ b/packages/web/app/RoutingApp.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Redirect, Route, Switch } from 'react-router';
+import React, { useEffect } from 'react';
+import { Redirect, Route, Switch, useHistory } from 'react-router';
 import { useSelector } from 'react-redux';
 
 import { SERVER_TYPES } from '@tamanu/constants';
@@ -29,6 +29,14 @@ export const RoutingApp = () => {
 
 export const RoutingFacilityApp = React.memo(() => {
   const sidebarMenuItems = useFacilitySidebar();
+  const history = useHistory();
+
+  useEffect(() => {
+    if (sidebarMenuItems.length > 0) {
+      history.push(sidebarMenuItems[0].path);
+    }
+  }, [sidebarMenuItems, history]);
+
   return (
     <App sidebar={<Sidebar items={sidebarMenuItems} />}>
       <UserActivityMonitor />

--- a/packages/web/app/RoutingApp.jsx
+++ b/packages/web/app/RoutingApp.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { Redirect, Route, Switch, useHistory } from 'react-router';
+import React from 'react';
+import { Redirect, Route, Switch } from 'react-router';
 import { useSelector } from 'react-redux';
 
 import { SERVER_TYPES } from '@tamanu/constants';
@@ -21,6 +21,7 @@ import { Sidebar, useCentralSidebar, useFacilitySidebar } from './components/Sid
 import { UserActivityMonitor } from './components/UserActivityMonitor';
 import { getServerType } from './store';
 import { DashboardView } from './views/dashboard/DashboardView';
+import { useSettings } from './contexts/Settings';
 
 export const RoutingApp = () => {
   const isCentralServer = useSelector(getServerType) === SERVER_TYPES.CENTRAL;
@@ -29,19 +30,13 @@ export const RoutingApp = () => {
 
 export const RoutingFacilityApp = React.memo(() => {
   const sidebarMenuItems = useFacilitySidebar();
-  const history = useHistory();
-
-  useEffect(() => {
-    if (sidebarMenuItems.length > 0) {
-      history.push(sidebarMenuItems[0].path);
-    }
-  }, [sidebarMenuItems, history]);
+  const { isSettingsLoaded } = useSettings();
 
   return (
     <App sidebar={<Sidebar items={sidebarMenuItems} />}>
       <UserActivityMonitor />
       <Switch>
-        <Redirect exact path="/" to={sidebarMenuItems[0].path} />
+        {isSettingsLoaded ? <Redirect exact path="/" to={sidebarMenuItems[0].path} /> : null}
         <Route path="/dashboard" component={DashboardView} />
         <Route path="/patients" component={PatientsRoutes} />
         <Route path="/appointments" component={AppointmentRoutes} />

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -21,16 +21,21 @@ export const useSettings = () => {
 
 export const SettingsProvider = ({ children }) => {
   const [settings, setSettings] = useState({});
+  const [isSettingsLoaded, setIsSettingsLoaded] = useState(false);
   const reduxSettings = useSelector(state => state.auth.settings);
 
   useEffect(() => {
     setSettings(reduxSettings);
+    if (reduxSettings) {
+      setIsSettingsLoaded(true);
+    }
   }, [reduxSettings]);
 
   return (
     <SettingsContext.Provider
       value={{
         getSetting: path => get(settings, path),
+        isSettingsLoaded,
       }}
     >
       {children}


### PR DESCRIPTION
### Changes

Fix the issue that the app redirect to dashboard even when dashboard setting is set to 'hidden', because setting data is not cached before login for the first time

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
