### PR TITLE
fix: EPI-932: Record deleted task still appear in task set table

### DIFF
--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -293,6 +293,7 @@ createSuggester(
             attributes: [],
             where: {
               type: relationType,
+              deleted_at: null,
             },
           },
           include: {


### PR DESCRIPTION
### Changes

Fix task still appears in task set table when deleted_at has value in the reference_data_relation table

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
