### PR TITLE
tweak(imaging): 2.18 fix: Imaging request change status submission

### DIFF
--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -825,7 +825,7 @@ export const globalSettings = {
               name: 'Imaging provider',
               description: '_',
               type: yup.string(),
-              defaultValue: '',
+              defaultValue: 'test',
             },
           },
         },

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -42,6 +42,7 @@ import { PrintModalButton } from './PrintModalButton';
 import { getReferenceDataStringId, TranslatedText } from '../../../components/Translation';
 import { useTranslation } from '../../../contexts/Translation';
 import { useSettings } from '../../../contexts/Settings';
+import { useAuth } from '../../../contexts/Auth';
 
 const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
   const { getLocalisation } = useLocalisation();
@@ -246,6 +247,7 @@ const ImagingResultsSection = ({ results }) => {
 
 const ImagingRequestInfoPane = React.memo(({ imagingRequest, onSubmit }) => {
   const api = useApi();
+  const { facilityId } = useAuth();
 
   const isCancelled = imagingRequest.status === IMAGING_REQUEST_STATUS_TYPES.CANCELLED;
   const getCanAddResult = values => values.status === IMAGING_REQUEST_STATUS_TYPES.COMPLETED;
@@ -259,7 +261,7 @@ const ImagingRequestInfoPane = React.memo(({ imagingRequest, onSubmit }) => {
           updatedValues.newResult = values.newResult;
         }
 
-        await api.put(`imagingRequest/${imagingRequest.id}`, updatedValues);
+        await api.put(`imagingRequest/${imagingRequest.id}`, { ...updatedValues, facilityId });
 
         onSubmit(updatedValues);
       }}


### PR DESCRIPTION
### Changes
- pass facility id in query in endpoint (omniserver conflict)
- set imaging provide setting as `test` default (this error was covered by previous and was created during definition of existing settings to schema)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
