### PR TITLE
fix(translations): Fix incorrectly passed prop for getTranslation to IDCardPrintout

### DIFF
--- a/packages/shared/src/utils/patientCertificates/IDCardPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/IDCardPrintout.jsx
@@ -77,17 +77,12 @@ const DetailsKey = props => <Text style={styles.detailsKey} {...props} />;
 const DetailsValue = props => <Text style={styles.detailsValue} {...props} />;
 const BarcodeRow = props => <View style={styles.barcodeRow} {...props} />;
 
-const DetailsRow = ({ name, value, getTranslation }) => {
-  const label =
-    getTranslation(`general.localisedField.${name}.label.short`) ||
-    getTranslation(`general.localisedField.${name}.label`);
-  return (
-    <InfoRow>
-      <DetailsKey>{`${label}: `}</DetailsKey>
-      <DetailsValue>{value}</DetailsValue>
-    </InfoRow>
-  );
-};
+const DetailsRow = ({ value, label }) => (
+  <InfoRow>
+    <DetailsKey>{`${label}: `}</DetailsKey>
+    <DetailsValue>{value}</DetailsValue>
+  </InfoRow>
+);
 
 const PatientPhoto = ({ patientImageData }) => {
   return (
@@ -127,26 +122,25 @@ const IDCardPrintoutComponent = ({
             <PatientPhoto patientImageData={patientImageData} />
             <Details>
               <DetailsRow
-                name="displayId"
                 value={patient.displayId}
-                getTranslation={getTranslation}
+                label={getTranslation('general.localisedField.displayId.label.short', 'NHN')}
               />
               <DetailsRow
-                name="lastName"
                 value={patient.lastName}
-                getTranslation={getTranslation}
+                label={getTranslation('general.localisedField.lastName.label', 'Last name')}
               />
               <DetailsRow
-                name="firstName"
                 value={patient.firstName}
-                getTranslation={getTranslation}
+                label={getTranslation('general.localisedField.firstName.label', 'First name')}
               />
               <DetailsRow
-                name="dateOfBirth"
                 value={getDOB(patient)}
-                getTranslation={getTranslation}
+                label={getTranslation('general.localisedField.dateOfBirth.label.short', 'DOB')}
               />
-              <DetailsRow name="sex" value={getSex(patient)} getTranslation={getTranslation} />
+              <DetailsRow
+                value={getSex(patient)}
+                label={getTranslation('general.localisedField.sex.label', 'Sex')}
+              />
             </Details>
           </MainContainer>
           <BarcodeRow>

--- a/packages/shared/src/utils/patientCertificates/IDCardPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/IDCardPrintout.jsx
@@ -104,7 +104,7 @@ const IDCardPrintoutComponent = ({
   patientImageData,
   cardDimensions,
   measures,
-  getLocalisation,
+  getTranslation,
 }) => {
   const pageStyles = StyleSheet.create({
     card: {
@@ -129,24 +129,24 @@ const IDCardPrintoutComponent = ({
               <DetailsRow
                 name="displayId"
                 value={patient.displayId}
-                getLocalisation={getLocalisation}
+                getTranslation={getTranslation}
               />
               <DetailsRow
                 name="lastName"
                 value={patient.lastName}
-                getLocalisation={getLocalisation}
+                getTranslation={getTranslation}
               />
               <DetailsRow
                 name="firstName"
                 value={patient.firstName}
-                getLocalisation={getLocalisation}
+                getTranslation={getTranslation}
               />
               <DetailsRow
                 name="dateOfBirth"
                 value={getDOB(patient)}
-                getLocalisation={getLocalisation}
+                getTranslation={getTranslation}
               />
-              <DetailsRow name="sex" value={getSex(patient)} getLocalisation={getLocalisation} />
+              <DetailsRow name="sex" value={getSex(patient)} getTranslation={getTranslation} />
             </Details>
           </MainContainer>
           <BarcodeRow>

--- a/packages/web/app/components/PatientPrinting/modals/PatientIDCardPage.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PatientIDCardPage.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { useLocalisation } from '../../../contexts/Localisation';
 import { Modal } from '../../Modal';
 import { PDFLoader, printPDF } from '../PDFLoader';
 import { IDCardPrintout } from '@tamanu/shared/utils/patientCertificates';
 import { useSettings } from '../../../contexts/Settings';
+import { useTranslation } from '../../../contexts/Translation';
 
 const cardDimensions = {
   width: '85.6mm',
@@ -11,8 +11,8 @@ const cardDimensions = {
 };
 
 export const PatientIDCardPage = React.memo(({ patient, imageData }) => {
-  const { getSetting } = useSettings()
-  const { getLocalisation } = useLocalisation();
+  const { getSetting } = useSettings();
+  const { getTranslation } = useTranslation();
   const measures = getSetting('printMeasures.idCardPage');
   const [open, setOpen] = useState(true);
 
@@ -30,7 +30,7 @@ export const PatientIDCardPage = React.memo(({ patient, imageData }) => {
           patientImageData={imageData}
           measures={measures}
           patient={patient}
-          getLocalisation={getLocalisation}
+          getTranslation={getTranslation}
         />
       </PDFLoader>
     </Modal>


### PR DESCRIPTION
### Changes

It seems like the prop being passed here wasn't correctly updated when this was changed.

However, once I fixed up the prop, I'm seeing `undefined` for the translated labels:
![image](https://github.com/user-attachments/assets/04ea57e1-2ed7-40f8-9e58-d42a37971b5b)

Hoping the reviewer knows the correct translation keys

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
