### PR TITLE
fix(migration): remove deletionStatus column of patient_contacts table

### DIFF
--- a/packages/mobile/App/migrations/1729737377076-removeDeletionStatusColumnOfPatientContact.ts
+++ b/packages/mobile/App/migrations/1729737377076-removeDeletionStatusColumnOfPatientContact.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+const TABLE_NAME = 'patient_contact';
+const COLUMN_NAME = 'deletionStatus';
+
+export class removeDeletionStatusColumn1712707744000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.dropColumn(table, COLUMN_NAME);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.addColumn(
+      table,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+}

--- a/packages/mobile/App/models/PatientContact.ts
+++ b/packages/mobile/App/models/PatientContact.ts
@@ -20,9 +20,6 @@ export class PatientContact extends BaseModel implements IPatientContact {
   @Column({ nullable: true })
   connectionDetails: string;
 
-  @Column({ nullable: true })
-  deletionStatus: string;
-
   @ManyToOne(
     () => Patient,
     patient => patient.contacts,

--- a/packages/mobile/App/types/IPatientContact.ts
+++ b/packages/mobile/App/types/IPatientContact.ts
@@ -6,7 +6,6 @@ export interface IPatientContact {
   name: string;
   method: string;
   connectionDetails?: string;
-  deletionStatus?: string;
   patient: IPatient;
   patientId?: string;
   relationship: IReferenceData;

--- a/packages/shared/src/migrations/1729737377076-removeDeletionStatusColumnOfPatientContact.js
+++ b/packages/shared/src/migrations/1729737377076-removeDeletionStatusColumnOfPatientContact.js
@@ -1,0 +1,12 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(query) {
+  await query.removeColumn('patient_contacts', 'deletion_status');
+}
+
+export async function down(query) {
+  await query.addColumn('patient_contacts', 'deletion_status', {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  });
+}

--- a/packages/shared/src/models/PatientContact.js
+++ b/packages/shared/src/models/PatientContact.js
@@ -18,7 +18,6 @@ export class PatientContact extends Model {
           allowNull: false,
         },
         connectionDetails: Sequelize.JSONB,
-        deletionStatus: Sequelize.TEXT,
       },
       {
         ...options,


### PR DESCRIPTION
### Changes

- Remove the legacy column `deletionStatus` from `patient_contacts` table.
- Reference link to requirement https://beyondessential.slack.com/archives/GE9NHB95F/p1729589364350689

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
