### PR TITLE
fix(mobile): release 2.18 small fixes

### DIFF
--- a/packages/mobile/App/models/Setting.ts
+++ b/packages/mobile/App/models/Setting.ts
@@ -42,6 +42,7 @@ export class Setting extends BaseModel {
       }
       return null;
     };
+
     const scope = determineScope();
 
     const settingsQueryBuilder = this.getRepository()
@@ -77,7 +78,7 @@ export class Setting extends BaseModel {
 
     const settingsObject = {};
     for (const currentSetting of settings) {
-      setAtPath(settingsObject, currentSetting.key, JSON.parse(currentSetting.value));
+      setAtPath(settingsObject, currentSetting.key, JSON.parse(currentSetting.value ?? null));
     }
 
     if (key === '') {

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/index.tsx
@@ -10,7 +10,6 @@ import { SubmitSection } from './SubmitSection';
 import { generateId, getConfiguredPatientAdditionalDataFields } from '~/ui/helpers/patient';
 import { Patient } from '~/models/Patient';
 import { withPatient } from '~/ui/containers/Patient';
-import { useLocalisation } from '~/ui/contexts/LocalisationContext';
 import { Routes } from '~/ui/helpers/routes';
 import { ALL_ADDITIONAL_DATA_FIELDS } from '~/ui/helpers/additionalData';
 import { getPatientDetailsValidation } from './patientDetailsValidationSchema';
@@ -180,7 +179,6 @@ const FormComponent = ({ selectedPatient, setSelectedPatient, isEdit, children }
     [navigation, selectedPatient, setSelectedPatient, createOrUpdateOtherPatientData],
   );
 
-  const { getLocalisation } = useLocalisation();
   const { getSetting } = useSettings();
 
   return loading ? (
@@ -195,7 +193,7 @@ const FormComponent = ({ selectedPatient, setSelectedPatient, isEdit, children }
           selectedPatient,
           patientAdditionalData,
           customPatientFieldValues,
-          getLocalisation,
+          getSetting,
         )}
       >
         {({ handleSubmit }): JSX.Element => (


### PR DESCRIPTION
### Changes

This pr contains two 2.18 regression fixes:
- A missed usage of getSetting that was breaking patient details edit on mobile
- An edge case bug where an empty string value can cause a bug with getSetting on mobile

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
