### PR TITLE
fix: release-2.18: EPI-1044: Fix calculated question still display if left empty

### DIFF
--- a/packages/shared/__tests__/utils/calculations.test.js
+++ b/packages/shared/__tests__/utils/calculations.test.js
@@ -78,6 +78,45 @@ describe('Survey calculations', () => {
       expect(calculations.TEST).toEqual(1024);
     });
 
+    it('should supports 0 value variables', () => {
+      const survey = makeDummySurvey([
+        { code: 'TEST_1' },
+        { code: 'TEST_2' },
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: 'TEST_1 + TEST_2' },
+      ]);
+      const calculations = runCalculations(survey, {
+        TEST_1: 0,
+        TEST_2: 0,
+      });
+      expect(calculations.TEST).toEqual(0);
+    });
+
+    it('should treat undefined variable as 0', () => {
+      const survey = makeDummySurvey([
+        { code: 'TEST_1' },
+        { code: 'TEST_2' },
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: '(TEST_1 + TEST_2)*100' },
+      ]);
+      const calculations = runCalculations(survey, {
+        TEST_1: 12,
+        TEST_2: undefined,
+      });
+      expect(calculations.TEST).toEqual(1200);
+    });
+
+    it('should returns null if all variables are undefined', () => {
+      const survey = makeDummySurvey([
+        { code: 'TEST_1' },
+        { code: 'TEST_2' },
+        { code: 'TEST', type: 'CalculatedQuestion', calculation: '(TEST_1 + TEST_2)/2' },
+      ]);
+      const calculations = runCalculations(survey, {
+        TEST_1: undefined,
+        TEST_2: undefined,
+      });
+      expect(calculations.TEST).toEqual(null);
+    });
+
     it('should use second-order substitutions', () => {
       const survey = makeDummySurvey([
         { code: 'TEST_1' },

--- a/packages/shared/src/utils/calculations.js
+++ b/packages/shared/src/utils/calculations.js
@@ -24,7 +24,7 @@ export function runCalculations(components, values) {
   const inputValues = {};
   // calculation expression use "code"
   for (const c of components) {
-    inputValues[c.dataElement.code] = values[c.dataElement.id] || '';
+    inputValues[c.dataElement.code] = values[c.dataElement.id] ?? '';
   }
   const calculatedValues = {};
   for (const c of components) {
@@ -35,7 +35,7 @@ export function runCalculations(components, values) {
 
         const relevantInputs = {};
         for (const variable of requiredVariables) {
-          relevantInputs[variable] = inputValues[variable] || '';
+          relevantInputs[variable] = inputValues[variable] ?? '';
         }
 
         const isInputsEmpty = Object.values(relevantInputs).every(value => value === '');

--- a/packages/shared/src/utils/calculations.js
+++ b/packages/shared/src/utils/calculations.js
@@ -40,7 +40,7 @@ export function runCalculations(components, values) {
 
         const isInputsEmpty = Object.values(relevantInputs).every(value => value === '');
 
-        if (isInputsEmpty) {
+        if (requiredVariables.length && isInputsEmpty) {
           // Skip calculation if every input is empty
           calculatedValues[c.dataElement.id] = null;
           continue;

--- a/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
@@ -128,12 +128,7 @@ const SurveyResponsesPrintoutComponent = ({
 }) => {
   const { watermark, logo } = certificateData;
 
-  const surveyAnswerRows = getSurveyAnswerRows(surveyResponse).filter(({ answer, type }) => {
-    if (type === PROGRAM_DATA_ELEMENT_TYPES.CALCULATED) {
-      return !!Number(answer);
-    }
-    return !!answer;
-  });
+  const surveyAnswerRows = getSurveyAnswerRows(surveyResponse).filter(({ answer }) => answer);
 
   const groupedAnswerRows = Object.values(
     surveyAnswerRows.reduce((acc, item) => {

--- a/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
@@ -77,9 +77,10 @@ const ResultBox = ({ resultText, resultName }) => (
 
 const getAnswers = ({ answer, type }) => {
   switch (type) {
-    case PROGRAM_DATA_ELEMENT_TYPES.RESULT:
+    case PROGRAM_DATA_ELEMENT_TYPES.RESULT: {
       const { strippedResultText } = separateColorText(answer);
       return strippedResultText;
+    }
     case PROGRAM_DATA_ELEMENT_TYPES.CHECKBOX:
       return convertBinaryToYesNo(answer);
     case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED:

--- a/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
@@ -11,7 +11,12 @@ import { withLanguageContext } from '../pdf/languageContext';
 import { Page } from '../pdf/Page';
 import { Text } from '../pdf/Text';
 import { PatientDetails } from './printComponents/PatientDetails';
-import { getResultName, getSurveyAnswerRows, separateColorText } from './surveyAnswers';
+import {
+  convertBinaryToYesNo,
+  getResultName,
+  getSurveyAnswerRows,
+  separateColorText,
+} from './surveyAnswers';
 import { SurveyResponseDetails } from './printComponents/SurveyResponseDetails';
 import { formatShort } from '../dateTime';
 
@@ -36,7 +41,7 @@ const pageStyles = StyleSheet.create({
     paddingBottom: 4,
     borderBottom: '0.5px solid black',
     marginBottom: 8,
-    alignSelf: 'flex-end'
+    alignSelf: 'flex-end',
   },
   itemText: {
     fontSize: 9,
@@ -48,7 +53,7 @@ const pageStyles = StyleSheet.create({
     borderBottom: '2px solid black',
     height: 2,
     width: '100%',
-    marginTop: '-6px'
+    marginTop: '-6px',
   },
   resultBox: {
     paddingTop: 7,
@@ -72,6 +77,13 @@ const ResultBox = ({ resultText, resultName }) => (
 
 const getAnswers = ({ answer, type }) => {
   switch (type) {
+    case PROGRAM_DATA_ELEMENT_TYPES.RESULT:
+      const { strippedResultText } = separateColorText(answer);
+      return strippedResultText;
+    case PROGRAM_DATA_ELEMENT_TYPES.CHECKBOX:
+      return convertBinaryToYesNo(answer);
+    case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED:
+      return parseFloat(answer).toFixed(1);
     case PROGRAM_DATA_ELEMENT_TYPES.PHOTO:
       return 'Image file - Refer to Tamanu to view';
     case PROGRAM_DATA_ELEMENT_TYPES.SUBMISSION_DATE:
@@ -88,9 +100,7 @@ const ResponseItem = ({ row }) => {
   return (
     <View style={pageStyles.item} wrap={false}>
       <Text style={pageStyles.itemText}>{name}</Text>
-      <Text style={[pageStyles.itemText, pageStyles.boldText]}>
-        {getAnswers({ answer, type })}
-      </Text>
+      <Text style={[pageStyles.itemText, pageStyles.boldText]}>{getAnswers({ answer, type })}</Text>
     </View>
   );
 };
@@ -101,7 +111,7 @@ const ResponsesGroup = ({ rows }) => {
       {rows.map(row => (
         <ResponseItem key={row.id} row={row} />
       ))}
-      <View style={pageStyles.boldDivider}/>
+      <View style={pageStyles.boldDivider} />
     </View>
   );
 };
@@ -117,7 +127,12 @@ const SurveyResponsesPrintoutComponent = ({
 }) => {
   const { watermark, logo } = certificateData;
 
-  const surveyAnswerRows = getSurveyAnswerRows(surveyResponse).filter(({ answer }) => answer);
+  const surveyAnswerRows = getSurveyAnswerRows(surveyResponse).filter(({ answer, type }) => {
+    if (type === PROGRAM_DATA_ELEMENT_TYPES.CALCULATED) {
+      return !!Number(answer);
+    }
+    return !!answer;
+  });
 
   const groupedAnswerRows = Object.values(
     surveyAnswerRows.reduce((acc, item) => {
@@ -136,7 +151,7 @@ const SurveyResponsesPrintoutComponent = ({
       <Page size="A4" style={pageStyles.body}>
         {watermark && <Watermark src={watermark} />}
         <MultiPageHeader
-          documentName={!isReferral ? "Program form" : "Referral"}
+          documentName={!isReferral ? 'Program form' : 'Referral'}
           documentSubname={surveyResponse.title}
           patientId={patientData.displayId}
           patientName={getName(patientData)}
@@ -145,7 +160,7 @@ const SurveyResponsesPrintoutComponent = ({
           <LetterheadSection
             getLocalisation={getLocalisation}
             logoSrc={logo}
-            certificateTitle={!isReferral ? "Program form" : "Referral"}
+            certificateTitle={!isReferral ? 'Program form' : 'Referral'}
             certificateSubtitle={surveyResponse.title}
             letterheadConfig={certificateData}
           />

--- a/packages/shared/src/utils/patientCertificates/surveyAnswers.js
+++ b/packages/shared/src/utils/patientCertificates/surveyAnswers.js
@@ -1,4 +1,4 @@
-import { PROGRAM_DATA_ELEMENT_TYPES, RESULT_COLORS } from "@tamanu/constants";
+import { PROGRAM_DATA_ELEMENT_TYPES, RESULT_COLORS } from '@tamanu/constants';
 
 const shouldShow = component => {
   switch (component.dataElement.type) {
@@ -8,6 +8,19 @@ const shouldShow = component => {
       return false;
     default:
       return true;
+  }
+};
+
+export const convertBinaryToYesNo = value => {
+  switch (value) {
+    case 'true':
+    case '1':
+      return 'Yes';
+    case 'false':
+    case '0':
+      return 'No';
+    default:
+      return value;
   }
 };
 
@@ -46,7 +59,7 @@ export const separateColorText = resultText => {
   };
 };
 
-export const getResultName = (components) => {
+export const getResultName = components => {
   const resultComponent = components.find(component => component.dataElement.type === 'Result');
   return resultComponent?.dataElement.defaultText;
 };


### PR DESCRIPTION
### Changes

- Make calculated answer returns null if all the question fields are left empty. It somehow returned 0.0 when calculated from empty strings
- Add missing display handler for RESULT, CHECKBOX and CALCULATED question type

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
