### PR TITLE
fix(webBuild): mui imports bloat breaking web build

### DIFF
--- a/packages/web/app/Root.jsx
+++ b/packages/web/app/Root.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { CssBaseline } from '@material-ui/core';
 import { ThemeProvider } from 'styled-components';
 import { MuiThemeProvider, StylesProvider } from '@material-ui/core/styles';
-import { LocalizationProvider as MuiLocalisationProvider } from '@mui/x-date-pickers';
+import { LocalizationProvider as MuiLocalisationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { Slide } from 'react-toastify';
 import { ApiContext } from './api';

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
@@ -1,8 +1,15 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
-import { Box, ClickAwayListener, IconButton, Paper, Popper, styled } from '@mui/material';
-import { Brightness2 as Overnight, Close, MoreVert } from '@mui/icons-material';
+import Box from '@mui/material/Box';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import IconButton from '@material-ui/core/IconButton';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import { styled } from '@mui/material/styles';
+import { default as Overnight } from '@mui/icons-material/Brightness2';
+import Close from '@mui/icons-material/Close';
+import MoreVert from '@mui/icons-material/MoreVert';
 import { debounce } from 'lodash';
 import { toast } from 'react-toastify';
 

--- a/packages/web/app/components/Field/CalendarField.jsx
+++ b/packages/web/app/components/Field/CalendarField.jsx
@@ -1,5 +1,5 @@
-import { Popper } from '@mui/material';
-import { DatePicker } from '@mui/x-date-pickers';
+import Popper from '@mui/material/Popper';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { add, endOfYear, startOfToday, startOfYear } from 'date-fns';
 import React, { useState } from 'react';
 import styled from 'styled-components';

--- a/packages/web/app/views/scheduling/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/DateSelector.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { Box } from '@material-ui/core';
-import { ArrowBackIos, ArrowForwardIos } from '@mui/icons-material';
-import { IconButton, styled } from '@mui/material';
+import ArrowBackIos from '@mui/icons-material/ArrowBackIos';
+import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos';
+import { styled } from '@mui/material/styles';
+import IconButton from '@mui/material/IconButton';
 import {
   addMonths,
   eachDayOfInterval,


### PR DESCRIPTION
### Changes
Into scheduling epic

Tree shaking not working for mui v6 and bloated modules transformed to 20k (double)
Doing default imports fixes for now

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
