### PR TITLE
fix(settings): release 2.19: Question code email should be validated as any string not email

### DIFF
--- a/packages/settings/src/schema/definitions/questionCodeIds.ts
+++ b/packages/settings/src/schema/definitions/questionCodeIds.ts
@@ -7,7 +7,4 @@ export const passportSchema = yup.string().nullable();
 
 export const nationalityIdSchema = yup.string().nullable();
 
-export const emailSchema = yup
-  .string()
-  .email()
-  .nullable();
+export const emailSchema = yup.string().nullable();


### PR DESCRIPTION
### Changes

Schema was expecting email for questionCodes.email with refer to a survey question code i.e pde-somthingSomthing
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
