### PR TITLE
fix(sync): SAV-846: Use UUIDV4 as deviceId

### DIFF
--- a/packages/mobile/App/services/auth/AuthService.ts
+++ b/packages/mobile/App/services/auth/AuthService.ts
@@ -39,7 +39,7 @@ export class AuthService {
 
   async initialise(): Promise<void> {
     const server = await readConfig('syncServerLocation');
-    this.centralServer.connect(server);
+    await this.centralServer.connect(server);
   }
 
   async saveLocalUser(userData: Partial<IUser>, password: string): Promise<IUser> {
@@ -115,7 +115,7 @@ export class AuthService {
     const server = syncServerLocation || params.server;
 
     // create the sync source and log in to it
-    this.centralServer.connect(server);
+    await this.centralServer.connect(server);
     console.log(`Getting token from ${server}`);
     const {
       user,
@@ -153,13 +153,13 @@ export class AuthService {
 
   async requestResetPassword(params: ResetPasswordFormModel): Promise<void> {
     const { server, email } = params;
-    this.centralServer.connect(server);
+    await this.centralServer.connect(server);
     await this.centralServer.post('resetPassword', {}, { email });
   }
 
   async changePassword(params: ChangePasswordFormModel): Promise<void> {
     const { server, ...rest } = params;
-    this.centralServer.connect(server);
+    await this.centralServer.connect(server);
     await this.centralServer.post('changePassword', {}, { ...rest });
   }
 }

--- a/packages/mobile/App/services/sync/CentralServerConnection.test.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.test.ts
@@ -14,8 +14,8 @@ jest.mock('./utils', () => ({
   sleepAsync: jest.fn(),
 }));
 
-jest.mock('react-native-device-info', () => ({
-  getUniqueId: jest.fn().mockReturnValue('test-device-id'),
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('test-device-id'),
 }));
 
 jest.mock('/root/package.json', () => ({

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -1,6 +1,6 @@
 import mitt from 'mitt';
-import { getUniqueId } from 'react-native-device-info';
-import { readConfig } from '../config';
+import { v4 as uuidv4 } from 'uuid';
+import { readConfig, writeConfig } from '../config';
 import { FetchOptions, LoginResponse, SyncRecord } from './types';
 import {
   AuthenticationError,
@@ -60,9 +60,14 @@ export class CentralServerConnection {
 
   emitter = mitt();
 
-  connect(host: string): void {
+  async connect(host: string): void {
     this.host = host;
-    this.deviceId = `mobile-${getUniqueId()}`;
+    this.deviceId = await readConfig('deviceId');
+
+    if (!this.deviceId) {
+      this.deviceId = uuidv4();
+      await writeConfig('deviceId', this.deviceId);
+    }
   }
 
   async fetch(

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -65,7 +65,7 @@ export class CentralServerConnection {
     this.deviceId = await readConfig('deviceId');
 
     if (!this.deviceId) {
-      this.deviceId = uuidv4();
+      this.deviceId = `mobile-${uuidv4()}`;
       await writeConfig('deviceId', this.deviceId);
     }
   }


### PR DESCRIPTION
### Changes
- Use UUIDV4 as deviceId (please read the ticket for more context of why this needs to be changed)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
