### PR TITLE
fix(appointments): remove old test

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -40,19 +40,6 @@ describe('Appointments', () => {
     // verify that the appointment returned is the one created above
     expect(result.body.data[0].id).toEqual(appointment.id);
   });
-  it('should be backwards compatible for appointments with locations', async () => {
-    const locationId = await randomRecordId(models, 'Location');
-    await models.Appointment.update(
-      {
-        locationId,
-      },
-      {
-        where: { id: appointment.id },
-      },
-    );
-    const result = await userApp.get('/api/appointments');
-    expect(result.body.data[0].locationGroup.id).toEqual(locationId);
-  });
   it('should cancel an appointment', async () => {
     const result = await userApp.put(`/api/appointments/${appointment.id}`).send({
       status: APPOINTMENT_STATUSES.CANCELLED,


### PR DESCRIPTION
### Changes

Remove failing backwards compatible test no longer valid after appointment calendar changes

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
