### PR TITLE
fix(locationBookings): Extract proper bookingType column

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
@@ -206,7 +206,7 @@ const PatientDetailsDisplay = ({ patient, onClick }) => {
 };
 
 const AppointDetailsDisplay = ({ appointment, isOvernight }) => {
-  const { startTime, endTime, clinician, locationGroup, location, type } = appointment;
+  const { startTime, endTime, clinician, locationGroup, location, bookingType } = appointment;
   return (
     <AppointmentDetailsContainer>
       <DetailsDisplay
@@ -246,7 +246,7 @@ const AppointDetailsDisplay = ({ appointment, isOvernight }) => {
           />
         }
       />
-      <BookingTypeDisplay type={type} isOvernight={isOvernight} />
+      <BookingTypeDisplay type={bookingType} isOvernight={isOvernight} />
     </AppointmentDetailsContainer>
   );
 };


### PR DESCRIPTION
### Changes

After renaming a column while adding appointmentType we created an error attempting to extract a column that no longer exists. This pr extracts out the correct property.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
