### PR TITLE
ci(cd): diff translations workaround for checkout step error when fetching tags on a tag push trigger

### DIFF
--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -23,8 +23,6 @@ jobs:
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
 
-    - run: git fetch --tags
-
     - uses: actions/setup-node@v4
       with:
         node-version: 20.x
@@ -50,7 +48,7 @@ jobs:
           | grep -E '^v[0-9]+[.][0-9]+[.][0-9]+$' \
           | cut -c2- \
           | sort --version-sort \
-          | grep -B 1 ${{steps.currentv.outputs.current_version}} \
+          | grep -B 1 2.18.1 \
           | head -n 1 \
           | sed 's/^/previous_version=/' \
           | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -1,6 +1,9 @@
 name: Diff Translations
 
 on:
+  pull_request:
+    types:
+      - synchronize
   push:
     tags:
       - 'v*'

--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -19,7 +19,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
-        fetch-tags: true
+
+    - run: git fetch --tags
 
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
### Changes
See https://github.com/actions/checkout/issues/1467
Need to test this on release-2.18

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
