### PR TITLE
ci(cd): Diff translations workaround for checkout action fetching tags on trigger tag push

### DIFF
--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -20,8 +20,6 @@ jobs:
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
 
-    - run: git fetch --tags
-
     - uses: actions/setup-node@v4
       with:
         node-version: 20.x

--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -19,7 +19,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
-        fetch-tags: true
+
+    - run: git fetch --tags
 
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
### Changes
Workaround to restore diff translations on release tag push
see https://github.com/actions/checkout/issues/1467

Further down we fetch the tags using `git fetch tags`

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
