### PR TITLE
feat(appointments): NASS-1386: Cancel appointment workflow

### DIFF
--- a/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
@@ -57,12 +57,16 @@ const StyledConfirmCancelRow = styled(ConfirmCancelRow)`
   margin-top: 0;
 `;
 
+const BodyContainer = styled(FlexCol)`
+  gap: 1.75rem;
+`;
+
 export {
-  FlexCol,
   DetailDisplay,
   AppointmentDetailsContainer,
   AppointmentDetailsColumn,
   AppointmentDetailsColumnLeft,
   BottomModalContainer,
   StyledConfirmCancelRow,
+  BodyContainer,
 };

--- a/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Box, styled } from '@mui/material';
+import { Colors } from '../../../constants';
+import { ConfirmCancelRow } from '../../ButtonRow';
+
+const FlexCol = styled(Box)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const FlexRow = styled(Box)`
+  display: flex;
+  flex-direction: row;
+`;
+
+const Label = styled(`span`)`
+  font-weight: 400;
+  font-color: ${Colors.midText};
+`;
+
+const Value = styled(`span`)`
+  font-weight: 500;
+`;
+
+const DetailDisplay = ({ label, value }) => (
+  <FlexCol>
+    <Label>{label}</Label>
+    <Value>{value ?? '—'}</Value>
+  </FlexCol>
+);
+
+const AppointmentDetailsContainer = styled(FlexRow)`
+  font-size: 0.875rem;
+  background-color: ${Colors.white};
+  border: 1px solid ${Colors.outline};
+  padding-block: 1.5rem;
+`;
+
+const AppointmentDetailsColumn = styled(FlexCol)`
+  padding-inline: 1.5rem;
+  gap: 1.25rem;
+  width: 50%;
+`;
+
+const AppointmentDetailsColumnLeft = styled(AppointmentDetailsColumn)`
+  border-inline-end: 1px solid ${Colors.outline};
+`;
+
+const BottomModalContainer = styled(Box)`
+  padding-block: 2rem;
+  padding-inline: 2.5rem;
+  border-block-start: 1px solid ${Colors.outline};
+  background-color: ${Colors.background};
+`;
+
+const StyledConfirmCancelRow = styled(ConfirmCancelRow)`
+  margin-top: 0;
+`;
+
+export {
+  FlexCol,
+  DetailDisplay,
+  AppointmentDetailsContainer,
+  AppointmentDetailsColumn,
+  AppointmentDetailsColumnLeft,
+  BottomModalContainer,
+  StyledConfirmCancelRow,
+};

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -90,7 +90,7 @@ const BottomModalContent = ({ cancelBooking, onClose }) => (
 export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
   const queryClient = useQueryClient();
 
-  const { mutateAsync: cancelBooking } = useAppointmentMutation(
+  const { mutateAsync: mutateAppointment } = useAppointmentMutation(
     { isEdit: true },
     {
       onSuccess: () => {
@@ -121,7 +121,7 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
       bottomRowContent={
         <BottomModalContent
           cancelBooking={() =>
-            cancelBooking({ ...appointment, status: APPOINTMENT_STATUSES.CANCELLED })
+            mutateAppointment({ ...appointment, status: APPOINTMENT_STATUSES.CANCELLED })
           }
           onClose={onClose}
         />
@@ -132,7 +132,7 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
       <BodyContainer>
         <TranslatedText
           stringId="locationBooking.modal.cancel.text"
-          fallback="Are you sure you would like to cancel the below location booking?"
+          fallback="Are you sure you would like to cancel the below appointment?"
         />
         <AppointmentDetailsDisplay appointment={appointment} />
       </BodyContainer>

--- a/packages/web/app/components/Appointments/CancelModal/CancelLocationBookingModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelLocationBookingModal.jsx
@@ -1,66 +1,22 @@
 import React from 'react';
-import { Box, styled } from '@mui/material';
 import { toast } from 'react-toastify';
 
-import { BaseModal } from '../BaseModal';
-import { TranslatedReferenceData, TranslatedText } from '../Translation';
-import { Colors } from '../../constants';
-import { ConfirmCancelRow } from '../ButtonRow';
+import { BaseModal } from '../../BaseModal';
+import { TranslatedReferenceData, TranslatedText } from '../../Translation';
 import { APPOINTMENT_STATUSES, OTHER_REFERENCE_TYPES } from '@tamanu/constants';
-import { PatientNameDisplay } from '../PatientNameDisplay';
-import { formatDateRange } from '../../utils/dateTime';
-import { useAppointmentMutation } from '../../api/mutations';
+import { PatientNameDisplay } from '../../PatientNameDisplay';
+import { formatDateRange } from '../../../utils/dateTime';
+import { useLocationBookingMutation } from '../../../api/mutations';
 import { useQueryClient } from '@tanstack/react-query';
-
-const FlexCol = styled(Box)`
-  display: flex;
-  flex-direction: column;
-`;
-
-const FlexRow = styled(Box)`
-  display: flex;
-  flex-direction: row;
-`;
-
-const Label = styled(`span`)`
-  font-weight: 400;
-  font-color: ${Colors.midText};
-`;
-
-const Value = styled(`span`)`
-  font-weight: 500;
-`;
-
-const DetailDisplay = ({ label, value }) => (
-  <FlexCol>
-    <Label>{label}</Label>
-    <Value>{value ?? '—'}</Value>
-  </FlexCol>
-);
-
-const AppointmentDetailsContainer = styled(FlexRow)`
-  font-size: 0.875rem;
-  background-color: ${Colors.white};
-  border: 1px solid ${Colors.outline};
-  padding-block: 1.5rem;
-`;
-
-const AppointmentDetailsColumn = styled(FlexCol)`
-  padding-inline: 1.5rem;
-  gap: 1.25rem;
-  width: 50%;
-`;
-
-const BottomModalContainer = styled(Box)`
-  padding-block: 2rem;
-  padding-inline: 2.5rem;
-  border-block-start: 1px solid ${Colors.outline};
-  background-color: ${Colors.background};
-`;
-
-const StyledConfirmCancelRow = styled(ConfirmCancelRow)`
-  margin-top: 0;
-`;
+import {
+  AppointmentDetailsColumn,
+  AppointmentDetailsColumnLeft,
+  AppointmentDetailsContainer,
+  BottomModalContainer,
+  DetailDisplay,
+  FlexCol,
+  StyledConfirmCancelRow,
+} from './BaseModalComponents';
 
 const AppointmentDetailsDisplay = ({ appointment }) => {
   const {
@@ -75,7 +31,7 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
 
   return (
     <AppointmentDetailsContainer>
-      <AppointmentDetailsColumn sx={{ borderInlineEnd: `1px solid ${Colors.outline}` }}>
+      <AppointmentDetailsColumnLeft>
         <DetailDisplay
           label={
             <TranslatedText
@@ -110,7 +66,7 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
           label={<TranslatedText stringId="general.date.label" fallback="Date" />}
           value={formatDateRange(startTime, endTime)}
         />
-      </AppointmentDetailsColumn>
+      </AppointmentDetailsColumnLeft>
       <AppointmentDetailsColumn>
         <DetailDisplay
           label={<TranslatedText stringId="general.patient.label" fallback="Patient" />}
@@ -153,10 +109,10 @@ const BottomModalContent = ({ cancelBooking, onClose }) => (
   </BottomModalContainer>
 );
 
-export const CancelBookingModal = ({ appointment, open, onClose }) => {
+export const CancelLocationBookingModal = ({ appointment, open, onClose }) => {
   const queryClient = useQueryClient();
 
-  const { mutateAsync: cancelBooking } = useAppointmentMutation(
+  const { mutateAsync: cancelBooking } = useLocationBookingMutation(
     { isEdit: true },
     {
       onSuccess: () => {

--- a/packages/web/app/utils/dateTime.js
+++ b/packages/web/app/utils/dateTime.js
@@ -7,6 +7,11 @@ export * from '@tamanu/shared/utils/date';
 
 export const formatDateRange = (start, end) => {
   const formattedStart = getDateDisplay(start, { showDate: true, showTime: true });
+
+  if (!end) {
+    return formattedStart;
+  }
+
   const formattedEnd = getDateDisplay(end, {
     showDate: !isSameDay(parseISO(start), parseISO(end)),
     showTime: true,

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -9,7 +9,7 @@ import { LocationBookingsCalendar } from './LocationBookingsCalendar';
 import { BookLocationDrawer } from '../../../components/Appointments/LocationBookingForm/BookLocationDrawer';
 import { AddRounded } from '@material-ui/icons';
 import { useAuth } from '../../../contexts/Auth';
-import { CancelBookingModal } from '../../../components/Appointments/CancelBookingModal';
+import { CancelLocationBookingModal } from '../../../components/Appointments/CancelModal/CancelLocationBookingModal';
 
 const PlusIcon = styled(AddRounded)`
   && {
@@ -133,7 +133,7 @@ export const LocationBookingsView = () => {
         open={isDrawerOpen}
         onClose={closeBookingForm}
       />
-      <CancelBookingModal
+      <CancelLocationBookingModal
         appointment={selectedAppointment}
         open={isCancelModalOpen}
         onClose={() => setIsCancelModalOpen(false)}

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -11,6 +11,7 @@ import { Colors } from '../../../constants';
 import { OutpatientBookingCalendar } from './OutpatientBookingCalendar';
 import { GroupByAppointmentToggle } from './GroupAppointmentToggle';
 import { OutpatientAppointmentDrawer } from '../../../components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer';
+import { CancelAppointmentModal } from '../../../components/Appointments/CancelModal/CancelAppointmentModal';
 
 const Placeholder = styled.div`
   background-color: oklch(0% 0 0 / 3%);
@@ -80,6 +81,7 @@ export const APPOINTMENT_GROUP_BY = {
 };
 
 export const OutpatientAppointmentsView = () => {
+  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [selectedAppointment, setSelectedAppointment] = useState({});
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(startOfDay(new Date()));
@@ -87,6 +89,11 @@ export const OutpatientAppointmentsView = () => {
 
   const handleChangeDate = event => {
     setSelectedDate(event.target.value);
+  };
+
+  const handleOpenCancelModal = appointment => {
+    setSelectedAppointment(appointment);
+    setIsCancelModalOpen(true);
   };
 
   const handleCloseDrawer = () => setDrawerOpen(false);
@@ -113,6 +120,11 @@ export const OutpatientAppointmentsView = () => {
         onClose={handleCloseDrawer}
         open={drawerOpen}
       />
+      <CancelAppointmentModal
+        appointment={selectedAppointment}
+        open={isCancelModalOpen}
+        onClose={() => setIsCancelModalOpen(false)}
+      />
       <AppointmentTopBar>
         <GroupByAppointmentToggle value={groupBy} onChange={setGroupBy} />
         <Filters>
@@ -128,6 +140,7 @@ export const OutpatientAppointmentsView = () => {
         <DateSelector value={selectedDate} onChange={handleChangeDate} />
         <CalendarInnerWrapper>
           <OutpatientBookingCalendar
+            onCancel={handleOpenCancelModal}
             onOpenDrawer={handleOpenDrawer}
             groupBy={groupBy}
             selectedDate={selectedDate}

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -119,7 +119,7 @@ export const HeadCell = ({ title, count }) => (
   </HeadCellWrapper>
 );
 
-export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer }) => {
+export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer, onCancel }) => {
   const { data, isLoading, error } = useOutpatientAppointmentsCalendarData({
     groupBy,
     selectedDate,
@@ -160,7 +160,12 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer 
             <HeadCell title={cell[titleKey]} count={appointments?.length || 0} />
             <AppointmentColumnWrapper>
               {appointments.map(a => (
-                <AppointmentTile key={a.id} appointment={a} onEdit={() => onOpenDrawer(a)} />
+                <AppointmentTile
+                  key={a.id}
+                  appointment={a}
+                  onEdit={() => onOpenDrawer(a)}
+                  onCancel={() => onCancel(a)}
+                />
               ))}
             </AppointmentColumnWrapper>
           </ColumnWrapper>


### PR DESCRIPTION
### Changes

I've extracted all common components of the cancel appointment/booking modal into a separate file, then created a new CancelAppointmentModal & CancelLocationBookingModal - reasoning being that although they currently are very similar, there are differences in pretty much every text, the hook for mutating, etc. I didn't want to pass in a bunch of props. Additionally, the appointment cancel modal will deviate in a later change for adding the repeating appointments part. 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
