### PR TITLE
fix(appointments): Fix endpoint not retrieving cancelled appointments

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -47,7 +47,7 @@ describe('Appointments', () => {
     });
     expect(result).toHaveSucceeded();
     expect(result.body.status).toEqual(APPOINTMENT_STATUSES.CANCELLED);
-    const getResult = await userApp.get('/api/appointments', { includeCancelled: true });
+    const getResult = await userApp.get('/api/appointments?includeCancelled=true');
     expect(getResult).toHaveSucceeded();
     expect(getResult.body.count).toEqual(1);
     expect(getResult.body.data[0].status).toEqual(APPOINTMENT_STATUSES.CANCELLED);

--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -47,7 +47,7 @@ describe('Appointments', () => {
     });
     expect(result).toHaveSucceeded();
     expect(result.body.status).toEqual(APPOINTMENT_STATUSES.CANCELLED);
-    const getResult = await userApp.get('/api/appointments');
+    const getResult = await userApp.get('/api/appointments', { includeCancelled: true });
     expect(getResult).toHaveSucceeded();
     expect(getResult.body.count).toEqual(1);
     expect(getResult.body.data[0].status).toEqual(APPOINTMENT_STATUSES.CANCELLED);

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -90,6 +90,7 @@ appointments.get(
         order = 'ASC',
         orderBy = 'startTime',
         patientNameOrId,
+        includeCancelled = false,
         ...queries
       },
     } = req;
@@ -154,8 +155,8 @@ appointments.get(
       offset: all ? undefined : page * rowsPerPage,
       order: [[sortKeys[orderBy] || orderBy, order]],
       where: {
-        status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED },
         startTime: startTimeQuery,
+        ...(includeCancelled ? {} : { status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED } }),
         ...(patientNameOrId ? patientNameOrIdQuery : null),
         ...filters,
       },


### PR DESCRIPTION
### Changes

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
