### PR TITLE
feat: EPI-1047: D3: Add location bookings component to patient summary page

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -74,6 +74,7 @@ const sortKeys = {
   location: Sequelize.col('location.name'),
   locationGroup: Sequelize.col('location_groups.name'),
   clinician: Sequelize.col('clinician.display_name'),
+  bookingType: Sequelize.col('bookingType.name'),
 };
 
 appointments.get(

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -55,6 +55,7 @@ const searchableFields = [
   'clinicianId',
   'locationId',
   'locationGroupId',
+  'patientId',
   'patient.first_name',
   'patient.last_name',
   'patient.display_id',

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -90,11 +90,6 @@ export const globalSettings = {
           type: yup.boolean(),
           defaultValue: false,
         },
-        enableLocationBooking:{
-          description: 'Enable location booking component on patient view',
-          type: yup.boolean(),
-          defaultValue: false,
-        },
         registerNewPatient: {
           description: 'Allow the creation of new patient on mobile',
           type: yup.boolean(),
@@ -1070,6 +1065,11 @@ export const globalSettings = {
               },
             },
           },
+        },
+        showLocationBookingsOnPatientView: {
+          description: 'Show location bookings component on patient view',
+          type: yup.boolean(),
+          defaultValue: false,
         },
       },
     },

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -90,6 +90,11 @@ export const globalSettings = {
           type: yup.boolean(),
           defaultValue: false,
         },
+        enableLocationBooking:{
+          description: 'Enable location booking component on patient view',
+          type: yup.boolean(),
+          defaultValue: false,
+        },
         registerNewPatient: {
           description: 'Allow the creation of new patient on mobile',
           type: yup.boolean(),

--- a/packages/web/app/components/Appointments/AppointmentTile.jsx
+++ b/packages/web/app/components/Appointments/AppointmentTile.jsx
@@ -1,8 +1,10 @@
 import { PriorityHigh as HighPriorityIcon } from '@material-ui/icons';
 import OvernightIcon from '@material-ui/icons/Brightness2';
 import { format, isSameDay, parseISO } from 'date-fns';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import queryString from 'query-string';
 
 import { APPOINTMENT_STATUSES } from '@tamanu/constants';
 
@@ -88,6 +90,15 @@ export const AppointmentTile = ({ appointment, onEdit, onCancel, ...props }) => 
   const ref = useRef(null);
   const [open, setOpen] = useState();
   const [localStatus, setLocalStatus] = useState(appointmentStatus);
+
+  const location = useLocation();
+  useEffect(() => {
+    const { appointmentId } = queryString.parse(location.search);
+    if (appointmentId && appointmentId === appointment.id) {
+      setOpen(true);
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [location.search]);
 
   const startTime = parseISO(startTimeStr);
   const endTime = parseISO(endTimeStr);

--- a/packages/web/app/components/Appointments/LocationBookingsTable.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingsTable.jsx
@@ -13,7 +13,7 @@ import { formatShortest, formatTime } from '../DateDisplay';
 import useOverflow from '../../hooks/useOverflow';
 import { TableTooltip } from '../Table/TableTooltip';
 import { MenuButton } from '../MenuButton';
-import { CancelLocationBookingModal } from '../Appointments/CancelModal/CancelLocationBookingModal';
+import { CancelLocationBookingModal } from './CancelModal/CancelLocationBookingModal';
 import { useTableSorting } from '../Table/useTableSorting';
 
 const TableTitle = styled(Typography)`
@@ -144,6 +144,7 @@ export const LocationBookingsTable = ({ patient }) => {
     initialSortKey: 'startTime',
     initialSortDirection: 'asc',
   });
+
   const appointments =
     useAppointmentsQuery({
       locationId: '',

--- a/packages/web/app/components/Scheduling/LocationBookingsTable.jsx
+++ b/packages/web/app/components/Scheduling/LocationBookingsTable.jsx
@@ -13,16 +13,30 @@ import useOverflow from '../../hooks/useOverflow';
 import { TableTooltip } from '../Table/TableTooltip';
 import { MenuButton } from '../MenuButton';
 import { CancelLocationBookingModal } from '../Appointments/CancelModal/CancelLocationBookingModal';
+import { useTableSorting } from '../Table/useTableSorting';
 
 const TableTitle = styled(Typography)`
   font-size: 16px;
   font-weight: 500;
   padding: 15px 0px;
   border-bottom: 1px solid ${Colors.outline};
+  position: sticky;
+  top: 0;
+  background-color: ${Colors.white};
+  z-index: 1;
 `;
 
 const StyledTable = styled(Table)`
+  max-height: 186px;
   padding: 0 20px;
+  thead {
+    tr {
+      position: sticky;
+      top: 55px;
+      background-color: ${Colors.white};
+      z-index: 1;
+    }
+  }
   .MuiTableCell-head {
     background-color: ${Colors.white};
     padding-top: 8px;
@@ -113,11 +127,17 @@ const CustomCellComponent = ({ value, $maxWidth }) => {
 };
 
 export const LocationBookingsTable = ({ patient }) => {
+  const { orderBy, order, onChangeOrderBy } = useTableSorting({
+    initialSortKey: 'startTime',
+    initialSortDirection: 'asc',
+  });
   const appointments =
     useAppointmentsQuery({
       locationId: '',
       all: true,
       patientId: patient?.id,
+      orderBy,
+      order,
     }).data?.data ?? [];
 
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
@@ -138,30 +158,32 @@ export const LocationBookingsTable = ({ patient }) => {
   
   const COLUMNS = [
     {
-      key: 'date',
+      key: 'startTime',
       title: <TranslatedText stringId="patient.bookings.table.column.date" fallback="Date" />,
       maxWidth: 200,
       accessor: ({ startTime, endTime }) => getDate({ startTime, endTime }),
     },
     {
-      key: 'location.name',
+      key: 'location',
       title: <TranslatedText stringId="patient.bookings.table.column.area" fallback="Area" />,
-      //accessor: ({ location }) => 'AGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General Clinic',
+      accessor: ({ location }) => location?.name,
       CellComponent: ({ value }) => <CustomCellComponent value={value} $maxWidth={190} />,
     },
     {
-      key: 'location.locationGroup.name',
+      key: 'locationGroup',
       title: <TranslatedText stringId="patient.bookings.table.column.location" fallback="Location" />,
+      accessor: ({ location }) => location?.locationGroup?.name,
       sortable: false,
     },
     {
-      key: 'bookingType.name',
+      key: 'bookingType',
       title: (
         <TranslatedText
           stringId="patient.bookings.table.column.bookingType"
           fallback="Booking type"
         />
       ),
+      accessor: ({ bookingType }) => bookingType?.name,
     },
     {
       key: '',
@@ -180,7 +202,7 @@ export const LocationBookingsTable = ({ patient }) => {
         data={appointments}
         columns={COLUMNS}
         noDataMessage={
-          <TranslatedText stringId="patient.bookings.table.noData" fallback="No invoices found" />
+          <TranslatedText stringId="patient.bookings.table.noData" fallback="No location bookings" />
         }
         allowExport={false}
         TableHeader={
@@ -189,6 +211,9 @@ export const LocationBookingsTable = ({ patient }) => {
           </TableTitle>
         }
         onClickRow={handleRowClick}
+        orderBy={orderBy}
+        order={order}
+        onChangeOrderBy={onChangeOrderBy}
       />
       <CancelLocationBookingModal
         appointment={selectedAppointment}

--- a/packages/web/app/components/Scheduling/LocationBookingsTable.jsx
+++ b/packages/web/app/components/Scheduling/LocationBookingsTable.jsx
@@ -1,0 +1,200 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+import { Box, Typography } from '@material-ui/core';
+import { toDateString } from '@tamanu/shared/utils/dateTime';
+
+import { useAppointmentsQuery } from '../../api/queries';
+import { Table } from '../Table';
+import { Colors } from '../../constants';
+import { TranslatedText } from '../Translation';
+import { formatShortest, formatTime } from '../DateDisplay';
+import useOverflow from '../../hooks/useOverflow';
+import { TableTooltip } from '../Table/TableTooltip';
+import { MenuButton } from '../MenuButton';
+import { CancelLocationBookingModal } from '../Appointments/CancelModal/CancelLocationBookingModal';
+
+const TableTitle = styled(Typography)`
+  font-size: 16px;
+  font-weight: 500;
+  padding: 15px 0px;
+  border-bottom: 1px solid ${Colors.outline};
+`;
+
+const StyledTable = styled(Table)`
+  padding: 0 20px;
+  .MuiTableCell-head {
+    background-color: ${Colors.white};
+    padding-top: 8px;
+    padding-bottom: 8px;
+    span {
+      font-weight: 400;
+      color: ${Colors.midText};
+    }
+    padding-left: 11px;
+    padding-right: 11px;
+    &:first-child {
+      padding-left: 0px;
+    }
+  }
+  .MuiTableCell-body {
+    padding: 11px;
+    &:first-child {
+      padding-left: 0px;
+    }
+    > div > div {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    &:last-child {
+      width: 28px;
+      button {
+        position: relative;
+        left: 26px;
+      }
+      > div > div {
+        overflow: visible;
+      }
+    }
+  }
+  .MuiTableBody-root .MuiTableRow-root:not(.statusRow) {
+    cursor: ${props => (props.onClickRow ? 'pointer' : '')};
+    &:hover {
+      background-color: ${props => (props.onClickRow ? Colors.veryLightBlue : '')};
+    }
+  }
+`;
+
+const LowerCaseText = styled.span`
+  text-transform: lowercase;
+`;
+
+const Container = styled.div`
+  margin: 0 30px 30px 30px;
+`;
+
+const getFormattedTime = time => {
+  return formatTime(time).replace(' ', '');
+};
+
+const getDate = ({ startTime, endTime }) => {
+  const startDate = toDateString(startTime);
+  const endDate = toDateString(endTime);
+  let dateTimeString;
+
+  if (startDate === endDate) {
+    dateTimeString = `${formatShortest(startTime)} ${getFormattedTime(
+      startTime,
+    )} - ${getFormattedTime(endTime)}`;
+  } else {
+    dateTimeString = `${formatShortest(startTime)} - ${formatShortest(endTime)}`;
+  }
+  return <LowerCaseText>{dateTimeString}</LowerCaseText>;
+};
+
+const CustomCellContainer = styled(Box)`
+  white-space: nowrap;
+`;
+
+const CustomCellComponent = ({ value, $maxWidth }) => {
+  const [ref, isOverflowing] = useOverflow();
+  return (
+    <CustomCellContainer ref={ref} maxWidth={$maxWidth}>
+      {!isOverflowing ? (
+        value
+      ) : (
+        <TableTooltip title={value}>
+          <div>{value}</div>
+        </TableTooltip>
+      )}
+    </CustomCellContainer>
+  );
+};
+
+export const LocationBookingsTable = ({ patient }) => {
+  const appointments =
+    useAppointmentsQuery({
+      locationId: '',
+      all: true,
+      patientId: patient?.id,
+    }).data?.data ?? [];
+
+  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [selectedAppointment, setSelectedAppointment] = useState({});
+  const history = useHistory();
+
+  const actions = [
+    {
+      label: <TranslatedText stringId="general.action.cancel" fallback="Cancel" />,
+      action: () => setIsCancelModalOpen(true),
+    },
+  ];
+
+  const handleRowClick = (_, data) => {
+    const { id, startTime } = data;
+    history.push(`/appointments/locations?appointmentId=${id}&date=${toDateString(startTime)}`);
+  }
+  
+  const COLUMNS = [
+    {
+      key: 'date',
+      title: <TranslatedText stringId="patient.bookings.table.column.date" fallback="Date" />,
+      maxWidth: 200,
+      accessor: ({ startTime, endTime }) => getDate({ startTime, endTime }),
+    },
+    {
+      key: 'location.name',
+      title: <TranslatedText stringId="patient.bookings.table.column.area" fallback="Area" />,
+      //accessor: ({ location }) => 'AGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General ClinicAGCFJ - Adult General Clinic',
+      CellComponent: ({ value }) => <CustomCellComponent value={value} $maxWidth={190} />,
+    },
+    {
+      key: 'location.locationGroup.name',
+      title: <TranslatedText stringId="patient.bookings.table.column.location" fallback="Location" />,
+      sortable: false,
+    },
+    {
+      key: 'bookingType.name',
+      title: (
+        <TranslatedText
+          stringId="patient.bookings.table.column.bookingType"
+          fallback="Booking type"
+        />
+      ),
+    },
+    {
+      key: '',
+      title: '',
+      dontCallRowInput: true,
+      sortable: false,
+      CellComponent: ({ data }) => <div onMouseEnter={() => setSelectedAppointment(data)}>
+        <MenuButton actions={actions} />
+      </div>,
+    },
+  ];
+
+  return (
+    <Container>
+      <StyledTable
+        data={appointments}
+        columns={COLUMNS}
+        noDataMessage={
+          <TranslatedText stringId="patient.bookings.table.noData" fallback="No invoices found" />
+        }
+        allowExport={false}
+        TableHeader={
+          <TableTitle>
+            <TranslatedText stringId="patient.bookings.table.title" fallback="Location bookings" />
+          </TableTitle>
+        }
+        onClickRow={handleRowClick}
+      />
+      <CancelLocationBookingModal
+        appointment={selectedAppointment}
+        open={isCancelModalOpen}
+        onClose={() => setIsCancelModalOpen(false)} 
+      />
+    </Container>
+  );
+};

--- a/packages/web/app/components/Scheduling/LocationBookingsTable.jsx
+++ b/packages/web/app/components/Scheduling/LocationBookingsTable.jsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { Box, Typography } from '@material-ui/core';
 import { toDateString } from '@tamanu/shared/utils/dateTime';
+import Brightness2Icon from '@material-ui/icons/Brightness2';
 
 import { useAppointmentsQuery } from '../../api/queries';
 import { Table } from '../Table';
@@ -24,6 +25,11 @@ const TableTitle = styled(Typography)`
   top: 0;
   background-color: ${Colors.white};
   z-index: 1;
+`;
+
+const OvernightIcon = styled(Brightness2Icon)`
+  color: ${Colors.primary};
+  font-size: 12px;
 `;
 
 const StyledTable = styled(Table)`
@@ -80,8 +86,11 @@ const StyledTable = styled(Table)`
   }
 `;
 
-const LowerCaseText = styled.span`
+const DateText = styled.div`
   text-transform: lowercase;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;
 
 const Container = styled.div`
@@ -96,15 +105,19 @@ const getDate = ({ startTime, endTime }) => {
   const startDate = toDateString(startTime);
   const endDate = toDateString(endTime);
   let dateTimeString;
+  const isOvernight = startDate !== endDate;
 
-  if (startDate === endDate) {
+  if (!isOvernight) {
     dateTimeString = `${formatShortest(startTime)} ${getFormattedTime(
       startTime,
     )} - ${getFormattedTime(endTime)}`;
   } else {
     dateTimeString = `${formatShortest(startTime)} - ${formatShortest(endTime)}`;
   }
-  return <LowerCaseText>{dateTimeString}</LowerCaseText>;
+  return <DateText>
+    <span>{dateTimeString}</span>
+    {isOvernight && <OvernightIcon />}  
+  </DateText>;
 };
 
 const CustomCellContainer = styled(Box)`

--- a/packages/web/app/views/patients/panes/HistoryPane.jsx
+++ b/packages/web/app/views/patients/panes/HistoryPane.jsx
@@ -17,10 +17,10 @@ export const HistoryPane = React.memo(({ patient, additionalData, disabled }) =>
   const { ability } = useAuth();
   const { getSetting } = useSettings();
 
-  const enableLocationBooking = getSetting('features.enableLocationBooking');
+  const showLocationBookingsSetting = getSetting('layouts.showLocationBookingsOnPatientView');
   const canListAppointment = ability.can('list', 'Appointment');
   const canReadAppointment = ability.can('read', 'Appointment');
-  const showLocationBookings = enableLocationBooking && canListAppointment && canReadAppointment;
+  const showLocationBookings = showLocationBookingsSetting && canListAppointment && canReadAppointment;
 
   const onViewEncounter = useCallback(
     id => {

--- a/packages/web/app/views/patients/panes/HistoryPane.jsx
+++ b/packages/web/app/views/patients/panes/HistoryPane.jsx
@@ -6,6 +6,7 @@ import { ContentPane } from '../../../components';
 import { PatientEncounterSummary } from '../components/PatientEncounterSummary';
 import { PatientHistory } from '../../../components/PatientHistory';
 import { EncounterModal } from '../../../components/EncounterModal';
+import { LocationBookingsTable } from '../../../components/Scheduling/LocationBookingsTable';
 
 export const HistoryPane = React.memo(({ patient, additionalData, disabled }) => {
   const [isModalOpen, setModalOpen] = useState(false);
@@ -43,6 +44,7 @@ export const HistoryPane = React.memo(({ patient, additionalData, disabled }) =>
         patient={patient}
         patientBillingTypeId={additionalData?.patientBillingTypeId}
       />
+      <LocationBookingsTable />
     </>
   );
 });

--- a/packages/web/app/views/patients/panes/HistoryPane.jsx
+++ b/packages/web/app/views/patients/panes/HistoryPane.jsx
@@ -6,7 +6,7 @@ import { ContentPane } from '../../../components';
 import { PatientEncounterSummary } from '../components/PatientEncounterSummary';
 import { PatientHistory } from '../../../components/PatientHistory';
 import { EncounterModal } from '../../../components/EncounterModal';
-import { LocationBookingsTable } from '../../../components/Scheduling/LocationBookingsTable';
+import { LocationBookingsTable } from '../../../components/Appointments/LocationBookingsTable'; 
 import { useAuth } from '../../../contexts/Auth';
 import { useSettings } from '../../../contexts/Settings';
 

--- a/packages/web/app/views/patients/panes/HistoryPane.jsx
+++ b/packages/web/app/views/patients/panes/HistoryPane.jsx
@@ -7,11 +7,20 @@ import { PatientEncounterSummary } from '../components/PatientEncounterSummary';
 import { PatientHistory } from '../../../components/PatientHistory';
 import { EncounterModal } from '../../../components/EncounterModal';
 import { LocationBookingsTable } from '../../../components/Scheduling/LocationBookingsTable';
+import { useAuth } from '../../../contexts/Auth';
+import { useSettings } from '../../../contexts/Settings';
 
 export const HistoryPane = React.memo(({ patient, additionalData, disabled }) => {
   const [isModalOpen, setModalOpen] = useState(false);
   const { navigateToEncounter } = usePatientNavigation();
   const { loadEncounter } = useEncounter();
+  const { ability } = useAuth();
+  const { getSetting } = useSettings();
+
+  const enableLocationBooking = getSetting('features.enableLocationBooking');
+  const canListAppointment = ability.can('list', 'Appointment');
+  const canReadAppointment = ability.can('read', 'Appointment');
+  const showLocationBookings = enableLocationBooking && canListAppointment && canReadAppointment;
 
   const onViewEncounter = useCallback(
     id => {
@@ -44,7 +53,7 @@ export const HistoryPane = React.memo(({ patient, additionalData, disabled }) =>
         patient={patient}
         patientBillingTypeId={additionalData?.patientBillingTypeId}
       />
-      <LocationBookingsTable />
+      {showLocationBookings && <LocationBookingsTable />}
     </>
   );
 });

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -1,6 +1,8 @@
-import { formatISO, isSameDay, isSameMonth, isThisMonth, startOfToday } from 'date-fns';
+import { formatISO, isSameDay, isSameMonth, isThisMonth, parseISO, startOfToday } from 'date-fns';
 import React, { useEffect } from 'react';
 import styled, { css } from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import queryString from 'query-string';
 
 import { isStartOfThisWeek } from '@tamanu/shared/utils/dateTime';
 
@@ -97,6 +99,15 @@ export const LocationBookingsCalendarHeader = ({ selectedMonthState, displayedDa
   const [monthOf, setMonthOf] = selectedMonthState;
   const isFirstDisplayedDate = date => isSameDay(date, displayedDates[0]);
   useEffect(() => (isThisMonth(monthOf) ? scrollToThisWeek : scrollToBeginning)(), [monthOf]);
+
+  const location = useLocation();
+  useEffect(() => {
+    const { date } = queryString.parse(location.search);
+    if (date) {
+      const parsedDate = parseISO(date);
+      setMonthOf(parsedDate);
+    }
+  }, [location.search]);
 
   return (
     <CarouselGrid.HeaderRow>


### PR DESCRIPTION
### Changes

- Add location bookings table to patient summary page
- Save date and appointmentId to the URL to redirect from the location bookings table to the calendar
- Allow querying by patientId in the appointments API endpoint
- Add permission check and feature flag `enableLocationBooking` to show/hide the table

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
