### PR TITLE
tweak(scheduling): Use default mui imports to fix tree shaking bug

### DIFF
--- a/packages/web/app/Root.jsx
+++ b/packages/web/app/Root.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { CssBaseline } from '@material-ui/core';
 import { ThemeProvider } from 'styled-components';
 import { MuiThemeProvider, StylesProvider } from '@material-ui/core/styles';
-import { ThemeProvider as MuiLatestThemeProvider } from '@mui/material';
+import MuiLatestThemeProvider from '@mui/material/styles/ThemeProvider';
 import { LocalizationProvider as MuiLocalisationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { Slide } from 'react-toastify';

--- a/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, styled } from '@mui/material';
+import Box from '@mui/material/Box'
+import styled from '@mui/system/styled';
 import { Colors } from '../../../constants';
 import { ConfirmCancelRow } from '../../ButtonRow';
 

--- a/packages/web/app/components/Drawer.jsx
+++ b/packages/web/app/components/Drawer.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { Drawer as MuiDrawer } from '@mui/material';
+import MuiDrawer from '@mui/material/Drawer'
 
 import { BodyText, Heading4 } from './Typography';
 import { Colors } from '../constants';

--- a/packages/web/app/components/Field/SearchMultiSelectField.jsx
+++ b/packages/web/app/components/Field/SearchMultiSelectField.jsx
@@ -7,7 +7,7 @@ import ListItemText from '@mui/material/ListItemText';
 import styled from '@mui/system/styled';
 import Button from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
-import { Search } from '@mui/icons-material';
+import Search from '@mui/icons-material/Search'
 
 import { CheckboxIconChecked, CheckboxIconUnchecked } from '../Icons/CheckboxIcon';
 import { Colors } from '../../constants';

--- a/packages/web/app/components/Field/SearchMultiSelectField.jsx
+++ b/packages/web/app/components/Field/SearchMultiSelectField.jsx
@@ -4,7 +4,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Checkbox from '@mui/material/Checkbox';
 import Box from '@mui/material/Box';
 import ListItemText from '@mui/material/ListItemText';
-import styled from '@mui/material/styled';
+import styled from '@mui/system/styled';
 import Button from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
 import { Search } from '@mui/icons-material';

--- a/packages/web/app/components/Field/SearchMultiSelectField.jsx
+++ b/packages/web/app/components/Field/SearchMultiSelectField.jsx
@@ -1,14 +1,12 @@
 import React, { useState } from 'react';
-import {
-  Menu,
-  MenuItem,
-  Checkbox,
-  Box,
-  ListItemText,
-  styled,
-  Button,
-  InputAdornment,
-} from '@mui/material';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Checkbox from '@mui/material/Checkbox';
+import Box from '@mui/material/Box';
+import ListItemText from '@mui/material/ListItemText';
+import styled from '@mui/material/styled';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
 import { Search } from '@mui/icons-material';
 
 import { CheckboxIconChecked, CheckboxIconUnchecked } from '../Icons/CheckboxIcon';

--- a/packages/web/app/views/scheduling/locationBookings/CalendarSearchBar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/CalendarSearchBar.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import styled from '@mui/material/styled';
+import styled from '@mui/system/styled';
 import { Field, Form, SearchField, TextButton, TranslatedText } from '../../../components';
 import { useTranslation } from '../../../contexts/Translation';
 import { useFormikContext } from 'formik';

--- a/packages/web/app/views/scheduling/locationBookings/CalendarSearchBar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/CalendarSearchBar.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { styled } from '@mui/material';
+import styled from '@mui/material/styled';
 import { Field, Form, SearchField, TextButton, TranslatedText } from '../../../components';
 import { useTranslation } from '../../../contexts/Translation';
 import { useFormikContext } from 'formik';


### PR DESCRIPTION
### Changes

Using the default imports significantly reduces bundle size and allows it to build

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
