### PR TITLE
fix(scheduling): NASS-1384: z-index layering error

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper.jsx
@@ -63,6 +63,7 @@ const ControlsContainer = styled(FlexRow)`
   inset-block-start: 0.5rem;
   inset-inline-end: 0.5rem;
   gap: 0.125rem;
+  z-index: 1;
 `;
 
 const PatientDetailsContainer = styled(FlexCol)`


### PR DESCRIPTION
### Changes

Our dropdown menu was showing behind a border of the appointment popper. This was because of a styling bug that was introduced when i set it to position: relative in order to position the tag.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
