### PR TITLE
tweak: Outpatient drawer warning model to show up on x press

### DIFF
--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -19,7 +19,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
-        fetch-tags: true
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
+        fetch-tags: true
 
     - uses: actions/setup-node@v4
       with:

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -17,7 +17,6 @@ import { useAppointmentMutation } from '../../../api/mutations';
 import { FormSubmitCancelRow } from '../../ButtonRow';
 import { Colors, FORM_TYPES } from '../../../constants';
 import { FormGrid } from '../../FormGrid';
-import { ClearIcon } from '../../Icons/ClearIcon';
 import { ConfirmModal } from '../../ConfirmModal';
 import { notifyError, notifySuccess } from '../../../utils';
 import { TranslatedText } from '../../Translation/TranslatedText';
@@ -27,17 +26,10 @@ import { Drawer } from '../../Drawer';
 import { TimeWithFixedDateField } from './TimeWithFixedDateField';
 import { APPOINTMENT_DRAWER_CLASS } from '../AppointmentDetailPopper';
 
-const CloseDrawerIcon = styled(ClearIcon)`
-  cursor: pointer;
-  position: absolute;
-  inset-block-start: 1rem;
-  inset-inline-end: 1rem;
-`;
-
 const IconLabel = styled.div`
   display: flex;
   align-items: center;
-`
+`;
 
 export const WarningModal = ({ open, setShowWarningModal, resolveFn }) => {
   const handleClose = confirmed => {
@@ -151,76 +143,103 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
     };
 
     return (
-      <FormGrid columns={1}>
-        <CloseDrawerIcon onClick={warnAndResetForm} />
-        <Field
-          name="patientId"
-          label={<TranslatedText stringId="general.form.patient.label" fallback="Patient" />}
-          component={AutocompleteField}
-          suggester={patientSuggester}
-          disabled={isEdit}
-          required
-        />
-        <Field
-          label={
-            <TranslatedText stringId="general.locationGroup.label" fallback="Location group" />
-          }
-          name="locationGroupId"
-          component={AutocompleteField}
-          suggester={locationGroupSuggester}
-          required
-        />
-        <Field
-          name="appointmentTypeId"
-          label={
+      <Drawer
+        PaperProps={{
+          // Used to exclude the drawer from click away listener on appointment details popper
+          className: APPOINTMENT_DRAWER_CLASS,
+        }}
+        open={open}
+        onClose={warnAndResetForm}
+        title={
+          isEdit ? (
             <TranslatedText
-              stringId="appointment.appointmentType.label"
-              fallback="Appointment type"
+              stringId="outpatientAppointment.form.edit.heading"
+              fallback="Modify outpatient appointment"
             />
-          }
-          component={DynamicSelectField}
-          suggester={appointmentTypeSuggester}
-          required
-        />
-        <Field
-          name="clinicianId"
-          label={<TranslatedText stringId="general.form.clinician.label" fallback="Clinician" />}
-          component={AutocompleteField}
-          suggester={clinicianSuggester}
-        />
-        <Field
-          name="startTime"
-          label={<TranslatedText stringId="general.dateAndTime.label" fallback="Date & time" />}
-          component={DateTimeField}
-          required
-          saveDateAsString
-        />
-        <Field
-          name="endTime"
-          disabled={!values.startTime}
-          date={parseISO(values.startTime)}
-          label={<TranslatedText stringId="general.endTime.label" fallback="End time" />}
-          component={TimeWithFixedDateField}
-          saveDateAsString
-        />
-        <Field
-          name="isHighPriority"
-          label={
-            <IconLabel>
-              <TranslatedText stringId="general.highPriority.label" fallback="High priority" />
-              <HighPriorityIcon
-                aria-label="High priority"
-                aria-hidden={undefined}
-                htmlColor={Colors.alert}
-                style={{ fontSize: 18 }}
+          ) : (
+            <TranslatedText
+              stringId="outpatientAppointment.form.new.heading"
+              fallback="New outpatient appointment"
+            />
+          )
+        }
+        description={
+          <TranslatedText
+            stringId="outpatientAppointment.form.new.description"
+            fallback="Select a patient from the below list and add relevant appointment details to create a new appointment"
+          />
+        }
+      >
+        <FormGrid columns={1}>
+          <Field
+            name="patientId"
+            label={<TranslatedText stringId="general.form.patient.label" fallback="Patient" />}
+            component={AutocompleteField}
+            suggester={patientSuggester}
+            disabled={isEdit}
+            required
+          />
+          <Field
+            label={
+              <TranslatedText stringId="general.locationGroup.label" fallback="Location group" />
+            }
+            name="locationGroupId"
+            component={AutocompleteField}
+            suggester={locationGroupSuggester}
+            required
+          />
+          <Field
+            name="appointmentTypeId"
+            label={
+              <TranslatedText
+                stringId="appointment.appointmentType.label"
+                fallback="Appointment type"
               />
-            </IconLabel>
-          }
-          component={CheckField}
-        />
+            }
+            component={DynamicSelectField}
+            suggester={appointmentTypeSuggester}
+            required
+          />
+          <Field
+            name="clinicianId"
+            label={<TranslatedText stringId="general.form.clinician.label" fallback="Clinician" />}
+            component={AutocompleteField}
+            suggester={clinicianSuggester}
+          />
+          <Field
+            name="startTime"
+            label={<TranslatedText stringId="general.dateAndTime.label" fallback="Date & time" />}
+            component={DateTimeField}
+            required
+            saveDateAsString
+          />
+          <Field
+            name="endTime"
+            disabled={!values.startTime}
+            date={parseISO(values.startTime)}
+            label={<TranslatedText stringId="general.endTime.label" fallback="End time" />}
+            component={TimeWithFixedDateField}
+            saveDateAsString
+          />
+          <Field
+            name="isHighPriority"
+            label={
+              <IconLabel>
+                <TranslatedText stringId="general.highPriority.label" fallback="High priority" />
+                <HighPriorityIcon
+                  aria-label="High priority"
+                  aria-hidden={undefined}
+                  htmlColor={Colors.alert}
+                  style={{ fontSize: 18 }}
+                />
+              </IconLabel>
+            }
+            component={CheckField}
+          />
 
-        <FormSubmitCancelRow onCancel={warnAndResetForm} />
-      </FormGrid>
+          <FormSubmitCancelRow onCancel={warnAndResetForm} />
+        </FormGrid>
+      </Drawer>
     );
   };
 
@@ -244,33 +263,7 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
     },
   );
   return (
-    <Drawer
-      PaperProps={{
-        // Used to exclude the drawer from click away listener on appointment details popper
-        className: APPOINTMENT_DRAWER_CLASS,
-      }}
-      open={open}
-      onClose={onClose}
-      title={
-        isEdit ? (
-          <TranslatedText
-            stringId="outpatientAppointment.form.edit.heading"
-            fallback="Modify outpatient appointment"
-          />
-        ) : (
-          <TranslatedText
-            stringId="outpatientAppointment.form.new.heading"
-            fallback="New outpatient appointment"
-          />
-        )
-      }
-      description={
-        <TranslatedText
-          stringId="outpatientAppointment.form.new.description"
-          fallback="Select a patient from the below list and add relevant appointment details to create a new appointment"
-        />
-      }
-    >
+    <>
       <Form
         onSubmit={async (values, { resetForm }) => {
           await handleSubmit(values);
@@ -288,6 +281,6 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
         setShowWarningModal={setShowWarningModal}
         resolveFn={resolveFn}
       />
-    </Drawer>
+    </>
   );
 };

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -181,7 +181,10 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
           />
           <Field
             label={
-              <TranslatedText stringId="general.locationGroup.label" fallback="Location group" />
+              <TranslatedText
+                stringId="general.localisedField.locationGroupId.label"
+                fallback="Area"
+              />
             }
             name="locationGroupId"
             component={AutocompleteField}
@@ -202,7 +205,12 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
           />
           <Field
             name="clinicianId"
-            label={<TranslatedText stringId="general.form.clinician.label" fallback="Clinician" />}
+            label={
+              <TranslatedText
+                stringId="general.localisedField.clinician.label"
+                fallback="Clinician"
+              />
+            }
             component={AutocompleteField}
             suggester={clinicianSuggester}
           />


### PR DESCRIPTION
### Changes

Basically just moved form to outside drawer and removed that custom close button from previous iteration on epic

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
