### PR TITLE
fix(deps): declare `query-string` as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71736,6 +71736,7 @@
         "prop-types": "^15.6.2",
         "qrcode": "^1.5.0",
         "qs": "^6.10.2",
+        "query-string": "^9.1.1",
         "react": "^18.2.0",
         "react-ace": "^10.1.0",
         "react-autosuggest": "^10.1.0",
@@ -72526,6 +72527,14 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "packages/web/node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/web/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -72534,6 +72543,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "packages/web/node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/web/node_modules/has-flag": {
@@ -72617,6 +72637,22 @@
         "node": ">=4"
       }
     },
+    "packages/web/node_modules/query-string": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.1.1.tgz",
+      "integrity": "sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/web/node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -72672,6 +72708,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "packages/web/node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/web/node_modules/supports-color": {

--- a/packages/web/app/components/Appointments/AppointmentTile.jsx
+++ b/packages/web/app/components/Appointments/AppointmentTile.jsx
@@ -1,10 +1,10 @@
 import { PriorityHigh as HighPriorityIcon } from '@material-ui/icons';
 import OvernightIcon from '@material-ui/icons/Brightness2';
 import { format, isSameDay, parseISO } from 'date-fns';
-import React, { useEffect, useRef, useState } from 'react';
-import styled, { css } from 'styled-components';
-import { useLocation } from 'react-router-dom';
 import queryString from 'query-string';
+import React, { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 
 import { APPOINTMENT_STATUSES } from '@tamanu/constants';
 

--- a/packages/web/app/components/Appointments/AppointmentTile.jsx
+++ b/packages/web/app/components/Appointments/AppointmentTile.jsx
@@ -107,7 +107,7 @@ export const AppointmentTile = ({
     const { appointmentId } = queryString.parse(location.search);
     if (appointmentId && appointmentId === appointment.id) {
       setOpen(true);
-      ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      ref.current.scrollIntoView({ block: 'center' });
     }
   }, [appointment.id, location.search]);
 

--- a/packages/web/app/components/Appointments/AppointmentTile.jsx
+++ b/packages/web/app/components/Appointments/AppointmentTile.jsx
@@ -109,7 +109,7 @@ export const AppointmentTile = ({
       setOpen(true);
       ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
-  }, [location.search]);
+  }, [appointment.id, location.search]);
 
   const startTime = parseISO(startTimeStr);
   const endTime = parseISO(endTimeStr);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -84,6 +84,7 @@
     "prop-types": "^15.6.2",
     "qrcode": "^1.5.0",
     "qs": "^6.10.2",
+    "query-string": "^9.1.1",
     "react": "^18.2.0",
     "react-ace": "^10.1.0",
     "react-autosuggest": "^10.1.0",


### PR DESCRIPTION
### Changes

Epic branch currently has a usage of `query-string` in `@tamanu/web-frontend`, but it only exists as a transitive dependency.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
