### PR TITLE
tweak(printouts): release 2.20 fix: Update package-lock for pdf font fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13892,26 +13892,6 @@
         "jay-peg": "^1.0.2"
       }
     },
-    "node_modules/@react-pdf/layout": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-3.12.1.tgz",
-      "integrity": "sha512-BxSeykDxvADlpe4OGtQ7NH46QXq3uImAYsTHOPLCwbXMniQ1O3uCBx7H+HthxkCNshgYVPp9qS3KyvQv/oIZwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "2.2.1",
-        "@react-pdf/image": "^2.3.6",
-        "@react-pdf/pdfkit": "^3.1.10",
-        "@react-pdf/primitives": "^3.1.1",
-        "@react-pdf/stylesheet": "^4.2.5",
-        "@react-pdf/textkit": "^4.4.1",
-        "@react-pdf/types": "^2.5.0",
-        "cross-fetch": "^3.1.5",
-        "emoji-regex": "^10.3.0",
-        "queue": "^6.0.1",
-        "yoga-layout": "^2.0.1"
-      }
-    },
     "node_modules/@react-pdf/pdfkit": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-3.1.10.tgz",
@@ -13981,6 +13961,26 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer/node_modules/@react-pdf/layout": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-3.11.5.tgz",
+      "integrity": "sha512-VLOzWIODUKw0ZTrS9XDkwl3q1OHKG8qd6OyCZZ7Q8/SijAh9ho70HEc/f1ffBFmM0nGrKMG0M3L0/7z1XKmOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "2.2.1",
+        "@react-pdf/image": "^2.3.6",
+        "@react-pdf/pdfkit": "^3.1.9",
+        "@react-pdf/primitives": "^3.1.1",
+        "@react-pdf/stylesheet": "^4.2.4",
+        "@react-pdf/textkit": "^4.4.1",
+        "@react-pdf/types": "^2.4.1",
+        "cross-fetch": "^3.1.5",
+        "emoji-regex": "^10.3.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^2.0.1"
       }
     },
     "node_modules/@react-pdf/stylesheet": {


### PR DESCRIPTION
Had to run `npm update` on the overrided package to update lock

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
