### PR TITLE
fix(mobile): release-v2.20: fix sync errors on mobile

### DIFF
--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -239,7 +239,7 @@ export async function importRows(
       if (isTranslatable && isValidTable) {
         translationRecordsForSheet.push({
           stringId: `${REFERENCE_DATA_TRANSLATION_PREFIX}.${dataType}.${values.id}`,
-          text: extractRecordName(values, dataType),
+          text: extractRecordName(values, dataType) ?? '',
           language: ENGLISH_LANGUAGE_CODE,
         });
       }

--- a/packages/mobile/App/migrations/1731998974975-updateReferenceDataRelationIndex.ts
+++ b/packages/mobile/App/migrations/1731998974975-updateReferenceDataRelationIndex.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class updateReferenceDataRelationIndex1714605577000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Remove the old index
+    await queryRunner.query(`DROP INDEX IF EXISTS reference_data_id_type`);
+
+    // Add the new index
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX reference_data_relations_unique_index
+      ON reference_data_relation (referenceDataId, referenceDataParentId, type)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove the new index
+    await queryRunner.query(`DROP INDEX IF EXISTS reference_data_relations_unique_index`);
+
+    // Re-add the old index
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX reference_data_id_type
+      ON reference_data_relation (referenceDataId, type)
+    `);
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -55,6 +55,7 @@ import { addClinicianToEncounterDiagnosis1721636585000 } from './1721636585000-a
 import { addUserFacilityTable1723076064000 } from './1723076064000-addUserFacilityTable';
 import { surveyCompletionNotification1724205895000 } from './1724205895000-surveyCompletionNotification';
 import { removeSettingsValueNotNullConstraint1724900789000 } from './1724900789000-removeSettingsValueNotNullConstraint';
+import { updateReferenceDataRelationIndex1714605577000 } from './1731998974975-updateReferenceDataRelationIndex';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -113,4 +114,5 @@ export const migrationList = [
   addUserFacilityTable1723076064000,
   surveyCompletionNotification1724205895000,
   removeSettingsValueNotNullConstraint1724900789000,
+  updateReferenceDataRelationIndex1714605577000
 ];


### PR DESCRIPTION
### Changes

- There are two reason for errors on syncing process on mobile:
1. Import `taskTemplate` will create two `translated_string` records (cuz we need to add one record to `reference_data` table and the other one to `task_templates` table). The first `translated_string` record (from `reference_data` instance) is valid but the second one (from `task_template` instance) is not cuz we can't extract name from this instance. This case will happen for `all referenceData type` which need to extend its data like `taskTemplate`, so just leave the `translated_string` records duplicated and set the text to "" to avoid syncing error on mobile.

<img width="1188" alt="image" src="https://github.com/user-attachments/assets/a2f78968-ff1b-49db-9c34-8c7107c393fc">

2. TableIndex for referenceDataRelation hasn't been updated on mobile

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
