### PR TITLE
feat(charting): SAV-698: Conciliate charting stuff

### DIFF
--- a/database/model/central-server/public/user_preferences.yml
+++ b/database/model/central-server/public/user_preferences.yml
@@ -10,7 +10,7 @@ sources:
           - system
         columns:
           - name: id
-            data_type: character varying(255)
+            data_type: uuid
             description: "{{ doc('generic__id') }} in user_preferences."
             data_tests:
               - unique

--- a/database/model/central-server/public/user_preferences.yml
+++ b/database/model/central-server/public/user_preferences.yml
@@ -10,8 +10,11 @@ sources:
           - system
         columns:
           - name: id
-            data_type: text
+            data_type: character varying(255)
             description: "{{ doc('generic__id') }} in user_preferences."
+            data_tests:
+              - unique
+              - not_null
           - name: created_at
             data_type: timestamp with time zone
             description: "{{ doc('generic__created_at') }} in user_preferences."
@@ -40,6 +43,7 @@ sources:
             data_type: character varying(255)
             description: "{{ doc('user_preferences__key') }}"
             data_tests:
+              - unique
               - not_null
           - name: value
             data_type: jsonb

--- a/packages/facility-server/__tests__/apiv1/User.test.js
+++ b/packages/facility-server/__tests__/apiv1/User.test.js
@@ -634,7 +634,7 @@ describe('User', () => {
       const result = await app.post('/api/user/userPreferences').send(userPreference);
       expect(result).toHaveSucceeded();
       expect(result.body).toMatchObject({
-        id: user.id,
+        id: expect.any(String),
         userId: user.id,
         ...userPreference,
       });

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -37,7 +37,7 @@ export async function up(query) {
   `);
   await query.removeColumn('user_preferences', 'id');
   await query.addColumn('user_preferences', 'id', {
-    type: DataTypes.STRING,
+    type: DataTypes.UUID,
     allowNull: true,
   });
   await query.sequelize.query(`
@@ -48,7 +48,7 @@ export async function up(query) {
     );
   `);
   await query.changeColumn('user_preferences', 'id', {
-    type: DataTypes.STRING,
+    type: DataTypes.UUID,
     allowNull: false,
     defaultValue: Sequelize.fn('uuid_generate_v4'),
   });

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -32,7 +32,7 @@ export async function up(query) {
   });
 
   const test = await query.sequelize.query(`
-    \d+ user_preferences;
+    \\d+ user_preferences;
   `);
   console.log(test);
 

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -31,6 +31,11 @@ export async function up(query) {
     allowNull: false,
   });
 
+  const test = await query.sequelize.query(`
+    \d+ user_preferences;
+  `);
+  console.log(test);
+
   await query.sequelize.query(`
     ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_pkey;
     ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_user_id_uk;

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -68,13 +68,14 @@ export async function down(query) {
     WHERE key != '${SELECTED_GRAPHED_VITALS_ON_FILTER_KEY}'
   `);
 
-  await query.removeColumn('user_preferences', 'key');
-  await query.removeColumn('user_preferences', 'value');
-
   await query.sequelize.query(`
     ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_pkey;
     ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_user_id_key_uk;
   `);
+
+  await query.removeColumn('user_preferences', 'key');
+  await query.removeColumn('user_preferences', 'value');
+
   await query.removeColumn('user_preferences', 'id');
   await query.addColumn('user_preferences', 'id', {
     type: `TEXT GENERATED ALWAYS AS ("user_id") STORED`,

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -39,7 +39,6 @@ export async function up(query) {
   await query.addColumn('user_preferences', 'id', {
     type: DataTypes.STRING,
     allowNull: true,
-    defaultValue: Sequelize.fn('uuid_generate_v4'),
   });
   await query.sequelize.query(`
     UPDATE user_preferences

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -31,11 +31,6 @@ export async function up(query) {
     allowNull: false,
   });
 
-  const test = await query.sequelize.query(`
-    \\d+ user_preferences;
-  `);
-  console.log(test);
-
   await query.sequelize.query(`
     ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_pkey;
     ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_user_id_uk;

--- a/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
+++ b/packages/shared/src/migrations/1726610686951-modifyUserPreferencesTable.js
@@ -38,6 +38,18 @@ export async function up(query) {
   await query.removeColumn('user_preferences', 'id');
   await query.addColumn('user_preferences', 'id', {
     type: DataTypes.STRING,
+    allowNull: true,
+    defaultValue: Sequelize.fn('uuid_generate_v4'),
+  });
+  await query.sequelize.query(`
+    UPDATE user_preferences
+    SET id = uuid_generate_v5(
+      uuid_generate_v5(uuid_nil(), 'user_preferences'),
+      user_id
+    );
+  `);
+  await query.changeColumn('user_preferences', 'id', {
+    type: DataTypes.STRING,
     allowNull: false,
     defaultValue: Sequelize.fn('uuid_generate_v4'),
   });

--- a/packages/shared/src/models/UserPreference.js
+++ b/packages/shared/src/models/UserPreference.js
@@ -4,10 +4,15 @@ import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 
 export class UserPreference extends Model {
-  static init({ primaryKey, ...options }) {
+  static init({ options }) {
     super.init(
       {
-        id: primaryKey,
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+          defaultValue: Sequelize.fn('uuid_generate_v4'),
+        },
         key: {
           type: DataTypes.STRING,
           allowNull: false,

--- a/packages/shared/src/models/UserPreference.js
+++ b/packages/shared/src/models/UserPreference.js
@@ -4,7 +4,7 @@ import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 
 export class UserPreference extends Model {
-  static init({ options }) {
+  static init(options) {
     super.init(
       {
         id: {

--- a/packages/shared/src/models/UserPreference.js
+++ b/packages/shared/src/models/UserPreference.js
@@ -4,17 +4,10 @@ import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 
 export class UserPreference extends Model {
-  static init(options) {
+  static init({ primaryKey, ...options }) {
     super.init(
       {
-        id: {
-          // User preference records use a user_id as the primary key, acting as a
-          // db-level enforcement of one per user, and simplifying sync
-          type: `TEXT GENERATED ALWAYS AS ("user_id")`,
-          set() {
-            // any sets of the convenience generated "id" field can be ignored, so do nothing here
-          },
-        },
+        id: primaryKey,
         key: {
           type: DataTypes.STRING,
           allowNull: false,
@@ -23,16 +16,12 @@ export class UserPreference extends Model {
           type: Sequelize.JSONB,
           allowNull: false,
         },
-        userId: {
-          type: DataTypes.STRING,
-          primaryKey: true,
-          references: {
-            model: 'users',
-            key: 'id',
-          },
-        },
       },
-      { syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL, ...options },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
+        indexes: [{ fields: ['user_id', 'key'], unique: true }],
+      },
     );
   }
 

--- a/packages/web/app/api/mutations/useUserPreferencesMutation.js
+++ b/packages/web/app/api/mutations/useUserPreferencesMutation.js
@@ -14,8 +14,11 @@ export const useUserPreferencesMutation = () => {
         ...newUserPreferences,
       });
     },
-    onSuccess: data => {
-      queryClient.setQueriesData(['userPreferences', currentUser.id], data);
+    onSuccess: requestData => {
+      queryClient.setQueriesData(['userPreferences', currentUser.id], oldPreferences => {
+        oldPreferences[requestData.key] = requestData.value;
+        return oldPreferences;
+      });
     },
   });
 };

--- a/packages/web/app/api/queries/useChartSurveyQuery.js
+++ b/packages/web/app/api/queries/useChartSurveyQuery.js
@@ -5,7 +5,7 @@ import { isErrorUnknownAllow404s, useApi } from '../index';
 export const useChartSurveyQuery = surveyId => {
   const api = useApi();
   const chartSurvey = useQuery(
-    ['chartSurvey'],
+    ['chartSurvey', surveyId],
     () => api.get(`survey/${surveyId}`, {}, { isErrorUnknown: isErrorUnknownAllow404s }),
     { enabled: Boolean(surveyId) },
   );

--- a/packages/web/app/api/queries/useEncounterChartsQuery.js
+++ b/packages/web/app/api/queries/useEncounterChartsQuery.js
@@ -70,7 +70,7 @@ export function getDatesAndRecords(data, surveyData, dateElementId) {
 
 export const useEncounterChartsQuery = (encounterId, surveyId) => {
   const api = useApi();
-  const chartQuery = useQuery(['encounterCharts', encounterId], () =>
+  const chartQuery = useQuery(['encounterCharts', encounterId, surveyId], () =>
     api.get(
       `encounter/${encounterId}/charts/${surveyId}`,
       { rowsPerPage: 50 },


### PR DESCRIPTION
### Changes

So most of the workflows were only partially working, navigation screwed things up and these issues came up. I'm just wary about solving first before doing other stuff.

Things fixed:
- When creating a new chart record entry, the mutation didn't actually set the expected format
- The user preferences table was still using user ID as primary key, which makes it so that we can't remember more than one category at once
- Selecting different chart types didn't update the table