### PR TITLE
fix(scheduling): fix ‘invalid interval’ error when booking overnight on nonempty day 

### DIFF
--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -8,6 +8,8 @@ import {
   isMatch,
   isSameDay,
   isValid,
+  max,
+  min,
   parseISO,
   startOfDay,
   startOfWeek,
@@ -270,3 +272,13 @@ export const datetimeCustomValidation = z.string().refine(
     message: 'Invalid datetime format, expected YYYY-MM-DD HH:MM:SS',
   },
 );
+
+export const maxValidDate = dates => {
+  const validDates = dates.filter(isValid);
+  return validDates.length === 0 ? null : max(validDates);
+};
+
+export const minValidDate = dates => {
+  const validDates = dates.filter(isValid);
+  return validDates.length === 0 ? null : min(validDates);
+};

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -313,10 +313,9 @@ export const TimeSlotPicker = ({
           <SkeletonTimeSlotToggles />
         ) : (
           timeSlots.map(timeSlot => {
-            const isBooked =
-              bookedIntervals.some(bookedInterval =>
-                areIntervalsOverlapping(timeSlot, bookedInterval),
-              ) ?? false;
+            const isBooked = bookedIntervals.some(bookedInterval =>
+              areIntervalsOverlapping(timeSlot, bookedInterval),
+            );
 
             const onMouseEnter = () => {
               if (selectedToggles.length > 1) return;

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -107,19 +107,13 @@ export const TimeSlotPicker = ({
   });
   const [hoverRange, setHoverRange] = useState(null);
 
-  const getEarliestRelevantTime = useCallback(
-    () => minValidDate([startOfDay(date), values.startTime]),
-    [date, values.startTime],
-  );
-  const getLatestRelevantTime = useCallback(() => maxValidDate([endOfDay(date), values.endTime]), [
-    date,
-    values.endTime,
-  ]);
+  const earliestRelevantTime = minValidDate([startOfDay(date), values.startTime]);
+  const latestRelevantTime = maxValidDate([endOfDay(date), values.endTime]);
 
   const { data: existingBookings, isFetching: isFetchingTodaysBookings } = useAppointmentsQuery(
     {
-      after: getEarliestRelevantTime(),
-      before: getLatestRelevantTime(),
+      after: earliestRelevantTime,
+      before: latestRelevantTime,
       all: true,
       locationId: values.locationId,
     },
@@ -302,13 +296,13 @@ export const TimeSlotPicker = ({
         case TIME_SLOT_PICKER_VARIANTS.START:
           targetSelection = {
             start: timeSlot.start,
-            end: getLatestRelevantTime(),
+            end: latestRelevantTime,
           };
           break;
 
         case TIME_SLOT_PICKER_VARIANTS.END:
           targetSelection = {
-            start: getEarliestRelevantTime(),
+            start: earliestRelevantTime,
             end: timeSlot.end,
           };
           break;
@@ -321,8 +315,8 @@ export const TimeSlotPicker = ({
       bookedIntervals,
       values.startTime,
       values.endTime,
-      getLatestRelevantTime,
-      getEarliestRelevantTime,
+      latestRelevantTime,
+      earliestRelevantTime,
     ],
   );
 

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -101,8 +101,14 @@ export const TimeSlotPicker = ({
   });
   const [hoverRange, setHoverRange] = useState(null);
 
-  const getEarliestRelevantTime = () => minValidDate([startOfDay(date), values.startTime]);
-  const getLatestRelevantTime = () => maxValidDate([endOfDay(date), values.endTime]);
+  const getEarliestRelevantTime = useCallback(
+    () => minValidDate([startOfDay(date), values.startTime]),
+    [date, values.startTime],
+  );
+  const getLatestRelevantTime = useCallback(() => maxValidDate([endOfDay(date), values.endTime]), [
+    date,
+    values.endTime,
+  ]);
 
   const { data: existingBookings, isFetching: isFetchingTodaysBookings } = useAppointmentsQuery(
     {


### PR DESCRIPTION
### Changes

Turns out `date-fns`’ `min` and `max` functions return `Invalid Date` if _anything_ in the date array isn’t a valid date (or convertible to one)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
