### PR TITLE
fix: EPI-999: Add notifications to the clinician dashboard

### DIFF
--- a/packages/web/app/api/mutations/useNotificationsMutation.js
+++ b/packages/web/app/api/mutations/useNotificationsMutation.js
@@ -1,21 +1,29 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '../useApi';
 import { notifyError } from '../../utils';
 
 export const useMarkAsRead = (id) => {
   const api = useApi();
+  const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: body => api.put(`notifications/markAsRead/${id}`, body),
+    mutationFn: body => {
+      api.put(`notifications/markAsRead/${id}`, body);
+      queryClient.invalidateQueries(['notifications', {}]);
+    },
     onError: error => notifyError(error.message),
   });
 };
 
 export const useMarkAllAsRead = () => {
   const api = useApi();
+  const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: body => api.put('notifications/markAllAsRead', body),
+    mutationFn: body => {
+      api.put('notifications/markAllAsRead', body)
+      queryClient.invalidateQueries(['notifications', {}]);
+    },
     onError: error => notifyError(error.message),
   });
 };

--- a/packages/web/app/components/Notification/NotificationDrawer.jsx
+++ b/packages/web/app/components/Notification/NotificationDrawer.jsx
@@ -14,7 +14,6 @@ import { TranslatedText } from '../Translation';
 import { useTranslation } from '../../contexts/Translation';
 import { formatShortest, formatTime } from '../DateDisplay';
 import { useMarkAllAsRead, useMarkAsRead } from '../../api/mutations';
-import { useQueryClient } from '@tanstack/react-query';
 import { LoadingIndicator } from '../LoadingIndicator';
 import { useLabRequest } from '../../contexts/LabRequest';
 import { useEncounter } from '../../contexts/Encounter';
@@ -138,13 +137,14 @@ const Card = ({ notification }) => {
   const { getTranslation } = useTranslation();
   const { loadEncounter } = useEncounter();
   const dispatch = useDispatch();
-  const { mutateAsync: markAsRead } = useMarkAsRead(notification.id);
+  const { mutateAsync: markAsRead, isLoading: isMarkingAsRead } = useMarkAsRead(notification.id);
   const { type, createdTime, status, patient, metadata } = notification;
   const { encounterId, id } = metadata;
 
   const history = useHistory();
 
   const onNotificationClick = async () => {
+    if (isMarkingAsRead) return;
     if (status === NOTIFICATION_STATUSES.UNREAD) {
       await markAsRead();
     }
@@ -174,12 +174,11 @@ const Card = ({ notification }) => {
 };
 
 export const NotificationDrawer = ({ open, onClose, notifications, isLoading }) => {
-  const queryClient = useQueryClient();
-  const { mutate: markAllAsRead } = useMarkAllAsRead();
+  const { mutate: markAllAsRead, isLoading: isMarkingAllAsRead } = useMarkAllAsRead();
   const { unreadNotifications = [], readNotifications = [] } = notifications;
 
   const onMarkAllAsRead = () => {
-    queryClient.invalidateQueries('notifications');
+    if (isMarkingAllAsRead) return;
     markAllAsRead();
   };
 

--- a/packages/web/app/components/Notification/NotificationDrawer.jsx
+++ b/packages/web/app/components/Notification/NotificationDrawer.jsx
@@ -9,7 +9,7 @@ import { useDispatch } from 'react-redux';
 
 import { labsIcon, radiologyIcon } from '../../constants/images';
 import { Colors } from '../../constants';
-import { BodyText, Heading5 } from '../Typography';
+import { BodyText, Heading3, Heading5 } from '../Typography';
 import { TranslatedText } from '../Translation';
 import { useTranslation } from '../../contexts/Translation';
 import { formatShortest, formatTime } from '../DateDisplay';
@@ -48,7 +48,7 @@ const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
       case LAB_REQUEST_STATUSES.INVALIDATED:
         return getTranslation(
           'notification.content.labRequest.invalidated',
-          'Lab results for :patientName (:displayId) are <strong>have been invalidated</strong>',
+          'Lab results for :patientName (:displayId) have been <strong>invalidated</strong>',
           { displayId, patientName },
         );
     }
@@ -132,6 +132,16 @@ const ReadTitle = styled.div`
   font-weight: 500;
 `;
 
+const NoDataContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 3px;
+  margin-bottom: 40px;
+`;
+
 const Card = ({ notification }) => {
   const { loadLabRequest } = useLabRequest();
   const { getTranslation } = useTranslation();
@@ -185,17 +195,38 @@ export const NotificationDrawer = ({ open, onClose, notifications, isLoading }) 
   return (
     <StyledDrawer open={open} onClose={onClose} anchor="right">
       <Title>
-        {
+        <TranslatedText
+          fallback="Notifications"
+          stringId="dashboard.notification.notifications.title"
+          replacements={{ count: unreadNotifications.length }}
+        />{' '}
+        {!!unreadNotifications.length && (
           <TranslatedText
-            fallback="Notifications (:count new)"
-            stringId="dashboard.notification.notifications.title"
-            replacements={{ count: unreadNotifications.length || '0' }}
+            fallback="(:count new)"
+            stringId="dashboard.notification.title.countNew"
+            replacements={{ count: unreadNotifications.length }}
           />
-        }
+        )}
         <CloseButton onClick={onClose}>
           <CloseIcon />
         </CloseButton>
       </Title>
+      {!unreadNotifications.length && !readNotifications.length && (
+        <NoDataContainer>
+          <Heading3 margin={0}>
+            <TranslatedText
+              fallback="No notifications to display "
+              stringId="dashboard.notification.empty.title"
+            />
+          </Heading3>
+          <BodyText>
+            <TranslatedText
+              fallback="Check back again later"
+              stringId="dashboard.notification.empty.subTitle"
+            />
+          </BodyText>
+        </NoDataContainer>
+      )}
       {!isLoading ? (
         <>
           {!!unreadNotifications.length && (


### PR DESCRIPTION
### Changes

- Fix imaging requests and lab requests data not loaded when redirected from notification
- Add no data message when notification is empty

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
