### PR TITLE
tweak(locationBooking): Ensure that location field state is cleared between multiple create booking 

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -8,7 +8,7 @@ import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
 
 import { usePatientSuggester, useSuggester } from '../../../api';
 import { useLocationBookingMutation } from '../../../api/mutations';
-import { Colors } from '../../../constants';
+import { Colors, FORM_TYPES } from '../../../constants';
 import { useTranslation } from '../../../contexts/Translation';
 import { notifyError, notifySuccess } from '../../../utils';
 import { FormSubmitCancelRow } from '../../ButtonRow';
@@ -171,7 +171,9 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
     resetForm();
   };
 
-  const renderForm = ({ values, resetForm, setFieldValue, dirty }) => {
+  const renderForm = ({ values, resetForm, setFieldValue, dirty, ...rest }) => {
+    console.log(rest);
+
     const warnAndResetForm = async () => {
       const confirmed = !dirty || (await handleShowWarningModal());
       if (!confirmed) return;
@@ -268,6 +270,7 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
       <Form
         enableReinitialize
         initialValues={initialValues}
+        formType={isEdit ? FORM_TYPES.EDIT_FORM : FORM_TYPES.CREATE_FORM}
         onSubmit={handleSubmit}
         render={renderForm}
         suppressErrorDialog

--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -171,9 +171,7 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
     resetForm();
   };
 
-  const renderForm = ({ values, resetForm, setFieldValue, dirty, ...rest }) => {
-    console.log(rest);
-
+  const renderForm = ({ values, resetForm, setFieldValue, dirty }) => {
     const warnAndResetForm = async () => {
       const confirmed = !dirty || (await handleShowWarningModal());
       if (!confirmed) return;

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -76,8 +76,8 @@ export const LocationBookingsView = () => {
     setIsDrawerOpen(false);
   };
 
-  const openBookingForm = prepopulationValues => {
-    setSelectedAppointment(prepopulationValues);
+  const openBookingForm = async prepopulationValues => {
+    await setSelectedAppointment(prepopulationValues);
     setIsDrawerOpen(true);
   };
 

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -86,6 +86,11 @@ export const LocationBookingsView = () => {
     setIsCancelModalOpen(true);
   };
 
+  const handleNewBooking = async () => {
+    await setSelectedAppointment(null);
+    openBookingForm({});
+  };
+
   const locationsQuery = useLocationsQuery({
     facilityId,
     bookableOnly: true,
@@ -99,7 +104,7 @@ export const LocationBookingsView = () => {
     <Wrapper>
       <LocationBookingsTopBar>
         <CalendarSearchBar onFilterChange={handleFilterChange} />
-        <NewBookingButton onClick={() => openBookingForm({})}>
+        <NewBookingButton onClick={handleNewBooking}>
           <PlusIcon />
           <TranslatedText
             stringId="locationBooking.calendar.bookLocation"
@@ -126,11 +131,13 @@ export const LocationBookingsView = () => {
         open={isCancelModalOpen}
         onClose={() => setIsCancelModalOpen(false)}
       />
-      <LocationBookingDrawer
-        initialValues={selectedAppointment}
-        open={isDrawerOpen}
-        onClose={closeBookingForm}
-      />
+      {selectedAppointment && (
+        <LocationBookingDrawer
+          initialValues={selectedAppointment}
+          open={isDrawerOpen}
+          onClose={closeBookingForm}
+        />
+      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
### Changes

Pretty annoying thing with state managed inside location group & location field.
Even tho we changed it to reinit as initalValues changed - it would still cause stuck state when initalValues are {} - in the case of multiple create bookings.

await is required - to preserve animation and also to ensure there is a render between the null and the {}

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
