### PR TITLE
fix(syncLookup): TAMOC-251: Save facility ID for appointments

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -230,7 +230,9 @@ describe('Sync Lookup data', () => {
       fake(PatientSecondaryId, { patientId: patient.id, typeId: referenceData.id }),
     );
     await Permission.create(fake(Permission, { roleId: role.id }));
-    await Appointment.create(fake(Appointment, { patientId: patient.id }));
+    await Appointment.create(
+      fake(Appointment, { patientId: patient.id, locationGroupId: locationGroup.id }),
+    );
     encounter1 = await Encounter.create(
       fake(Encounter, {
         patientId: patient.id,
@@ -632,7 +634,7 @@ describe('Sync Lookup data', () => {
       patientCount,
       fullSyncPatientsTable,
       sessionId,
-      [''],
+      [facility.id],
       null,
       simplestSessionConfig,
       simplestConfig,
@@ -652,12 +654,15 @@ describe('Sync Lookup data', () => {
         );
       }
 
+      // except for appointments, patient linked models should not spit out facilityId;
+      const expectedFacility = model.tableName === 'appointments' ? facility.id : null;
+
       expect(syncLookupRecord.dataValues).toEqual(
         expect.objectContaining({
           recordId: expect.anything(),
           recordType: model.tableName,
           patientId: expect.anything(),
-          facilityId: null, // patient linked models should not spit out facilityId
+          facilityId: expectedFacility,
           isDeleted: false,
         }),
       );

--- a/packages/shared/src/models/Appointment.js
+++ b/packages/shared/src/models/Appointment.js
@@ -80,7 +80,11 @@ export class Appointment extends Model {
     return {
       select: buildSyncLookupSelect(this, {
         patientId: `${this.tableName}.patient_id`,
+        facilityId: 'location_groups.facility_id',
       }),
+      joins: `
+        JOIN location_groups ON appointments.location_group_id = location_groups.id
+      `,
     };
   }
 }


### PR DESCRIPTION
### Changes

We missed a spot to be able to discriminate which record should be pulled!