### PR TITLE
chore(referenceData): NASS-1364: remove unused maritalStatus as importable reference data

### DIFF
--- a/packages/constants/src/importable.ts
+++ b/packages/constants/src/importable.ts
@@ -32,7 +32,6 @@ export const REFERENCE_TYPES = {
   SETTLEMENT: 'settlement',
   OCCUPATION: 'occupation',
   PLACE_OF_BIRTH: 'placeOfBirth',
-  MARITAL_STATUS: 'maritalStatus',
   RELIGION: 'religion',
   REACTION: 'reaction',
   FAMILY_RELATION: 'familyRelation',


### PR DESCRIPTION
### Changes

This is a one liner really, other references treat marital status as a enum
- This is the second version of this ticket after discovering that this was the only obsolete type
### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
