### PR TITLE
fix(scheduling): make location bookings table empty state always visible

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -138,7 +138,7 @@ export const TimeSlotPicker = ({
    * coerces this into a contiguous selection. Note that this array has set semantics, and is not
    * guaranteed to have its elements in natural order.
    */
-  const handleChange = (event, newTogglesUnsorted) => {
+  const handleChange = (_event, newTogglesUnsorted) => {
     const newToggles = newTogglesUnsorted.toSorted();
 
     switch (variant) {

--- a/packages/web/app/views/scheduling/locationBookings/CarouselComponents.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/CarouselComponents.jsx
@@ -24,7 +24,7 @@ const Grid = styled.div`
     );
 `;
 
-const Row = styled.div`
+const Row = styled.div.attrs({ role: 'row' })`
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
@@ -42,7 +42,7 @@ const HeaderRow = styled(Row)`
   z-index: 2;
 `;
 
-const BaseCell = styled.div`
+const BaseCell = styled.div.attrs({ role: 'cell' })`
   min-block-size: var(--row-height);
   padding-block: 0.25rem;
   padding-inline: 0.5rem 1.5rem;
@@ -87,7 +87,10 @@ const RowHeaderCell = styled(HeaderCell)`
   text-wrap: balance;
 `;
 
-const BodyCell = styled(BaseCell).attrs({ as: UnstyledHtmlButton })`
+const BodyCell = styled(BaseCell).attrs({
+  as: UnstyledHtmlButton,
+  role: undefined,
+})`
   align-items: stretch;
   cursor: pointer;
   display: flex;

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -1,5 +1,6 @@
 import {
   eachDayOfInterval,
+  endOfDay,
   endOfMonth,
   endOfWeek,
   startOfMonth,
@@ -9,11 +10,14 @@ import {
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
+import { useAppointmentsQuery } from '../../../api/queries';
+import { APPOINTMENT_CALENDAR_CLASS } from '../../../components';
 import { Colors } from '../../../constants';
+import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
 import { LocationBookingsCalendarBody } from './LocationBookingsCalendarBody';
 import { LocationBookingsCalendarHeader } from './LocationBookingsCalendarHeader';
-import { APPOINTMENT_CALENDAR_CLASS } from '../../../components';
+import { partitionAppointmentsByLocation } from './utils';
 
 const getDisplayableDates = date => {
   const start = startOfWeek(startOfMonth(date), { weekStartsOn: 1 });
@@ -25,7 +29,10 @@ const Carousel = styled.div`
   background-color: ${Colors.white};
   border: max(0.0625rem, 1px) solid ${Colors.outline};
   border-radius: 0.2rem;
+  display: grid;
+  grid-template-rows: 1fr auto;
   margin: 1rem;
+  max-block-size: 100%;
   overflow: scroll;
   overscroll-behavior: contain;
   // Uncomment line below to re-enable scroll snap. Components in CarouselComponents still support
@@ -39,25 +46,65 @@ const Carousel = styled.div`
   }
 `;
 
+const EmptyState = styled.div`
+  color: ${Colors.primary};
+  font-weight: 500;
+  margin-block: 0.5rem;
+  padding: 0.5rem;
+  text-align: center;
+  margin-inline: 1rem;
+`;
+
+const EmptyStateMessage = () => (
+  <EmptyState>No bookings to display. Please try adjusting the search filters.</EmptyState>
+);
+
 export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, openCancelModal }) => {
   const selectedMonthState = useState(startOfToday());
   const [monthOf] = selectedMonthState;
   const displayedDates = getDisplayableDates(monthOf);
 
+  const { filters } = useLocationBookingsContext();
+  const areFiltersActive = Object.values(filters).some(
+    filter => filter !== null && filter.length > 0,
+  );
+
+  const { data: appointmentsData = [] } = useAppointmentsQuery({
+    after: displayedDates[0],
+    before: endOfDay(displayedDates.at(-1)),
+    all: true,
+    locationId: '',
+    clinicianId: filters.clinicianId,
+    bookingTypeId: filters.bookingTypeId,
+    patientNameOrId: filters.patientNameOrId,
+  });
+  const appointments = appointmentsData.data ?? [];
+  const appointmentsByLocation = partitionAppointmentsByLocation(appointments);
+
+  const { data: locations } = locationsQuery;
+  const filteredLocations = areFiltersActive
+    ? locations?.filter(location => appointmentsByLocation[location.id])
+    : locations;
+
   return (
-    <Carousel className={APPOINTMENT_CALENDAR_CLASS}>
-      <CarouselGrid.Root $dayCount={displayedDates.length}>
-        <LocationBookingsCalendarHeader
-          selectedMonthState={selectedMonthState}
-          displayedDates={displayedDates}
-        />
-        <LocationBookingsCalendarBody
-          locationsQuery={locationsQuery}
-          displayedDates={displayedDates}
-          openBookingForm={openBookingForm}
-          openCancelModal={openCancelModal}
-        />
-      </CarouselGrid.Root>
-    </Carousel>
+    <>
+      <Carousel className={APPOINTMENT_CALENDAR_CLASS}>
+        <CarouselGrid.Root $dayCount={displayedDates.length}>
+          <LocationBookingsCalendarHeader
+            selectedMonthState={selectedMonthState}
+            displayedDates={displayedDates}
+          />
+          <LocationBookingsCalendarBody
+            appointmentsByLocation={appointmentsByLocation}
+            displayedDates={displayedDates}
+            filteredLocations={filteredLocations}
+            locationsQuery={locationsQuery}
+            openBookingForm={openBookingForm}
+            openCancelModal={openCancelModal}
+          />
+        </CarouselGrid.Root>
+      </Carousel>
+      {filteredLocations?.length === 0 && <EmptyStateMessage />}
+    </>
   );
 };

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -55,7 +55,7 @@ const EmptyState = styled.div`
   margin-inline: 1rem;
 `;
 
-const EmptyStateMessage = () => (
+const emptyStateMessage = (
   <EmptyState>No bookings to display. Please try adjusting the search filters.</EmptyState>
 );
 
@@ -104,7 +104,7 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
           />
         </CarouselGrid.Root>
       </Carousel>
-      {filteredLocations?.length === 0 && <EmptyStateMessage />}
+      {filteredLocations?.length === 0 && emptyStateMessage}
     </>
   );
 };

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -25,6 +25,21 @@ const getDisplayableDates = date => {
   return eachDayOfInterval({ start, end });
 };
 
+const EmptyState = styled.div`
+  --border-style: max(0.0625rem, 1px) solid ${Colors.outline};
+  background-color: ${Colors.white};
+  border-block-end: var(--border-style);
+  border-end-end-radius: 0.2rem;
+  border-end-start-radius: 0.2rem;
+  border-inline: var(--border-style);
+  color: ${Colors.primary};
+  font-weight: 500;
+  margin-inline: 1rem;
+  padding-block: 0.75rem;
+  padding-inline: 0.5rem;
+  text-align: center;
+`;
+
 const Carousel = styled.div`
   background-color: ${Colors.white};
   border: max(0.0625rem, 1px) solid ${Colors.outline};
@@ -41,18 +56,19 @@ const Carousel = styled.div`
   // scroll offset.
   // scroll-snap-type: both mandatory;
 
+  /*
+   * Make the empty state message superficially look like a row in the table. (Empty state message
+   * is a sibling, not child, to prevent its text from scrolling off-screen.
+   */
+  &:has(+ ${EmptyState}) {
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
+    margin-block-end: 0;
+  }
+
   @media (prefers-reduced-motion: no-preference) {
     scroll-behavior: smooth;
   }
-`;
-
-const EmptyState = styled.div`
-  color: ${Colors.primary};
-  font-weight: 500;
-  margin-block: 0.5rem;
-  padding: 0.5rem;
-  text-align: center;
-  margin-inline: 1rem;
 `;
 
 const emptyStateMessage = (

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -11,7 +11,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppointmentsQuery } from '../../../api/queries';
-import { APPOINTMENT_CALENDAR_CLASS } from '../../../components';
+import { APPOINTMENT_CALENDAR_CLASS, TranslatedText } from '../../../components';
 import { Colors } from '../../../constants';
 import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
@@ -72,7 +72,12 @@ const Carousel = styled.div`
 `;
 
 const emptyStateMessage = (
-  <EmptyState>No bookings to display. Please try adjusting the search filters.</EmptyState>
+  <EmptyState>
+    <TranslatedText
+      stringId="locationBooking.calendar.noMatchingBookings"
+      fallback="No bookings to display. Please try adjusting the search filters."
+    />
+  </EmptyState>
 );
 
 export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, openCancelModal }) => {

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -64,11 +64,12 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
   const [monthOf] = selectedMonthState;
   const displayedDates = getDisplayableDates(monthOf);
 
-  const { filters } = useLocationBookingsContext();
+  const {
+    filters: { bookingTypeId, clinicianId, patientNameOrId },
+  } = useLocationBookingsContext();
   // When filtering only by location, don’t hide locations that contain no appointments
   const areNonLocationFiltersActive =
-    filters.clinicianId.length > 0 || filters.bookingTypeId.length > 0 || filters.patientNameOrId;
-
+    clinicianId?.length > 0 || bookingTypeId?.length > 0 || !!patientNameOrId;
   const { data: locations } = locationsQuery;
 
   const { data: appointmentsData } = useAppointmentsQuery({
@@ -76,9 +77,9 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
     before: endOfDay(displayedDates.at(-1)),
     all: true,
     locationId: '',
-    clinicianId: filters.clinicianId,
-    bookingTypeId: filters.bookingTypeId,
-    patientNameOrId: filters.patientNameOrId,
+    clinicianId,
+    bookingTypeId,
+    patientNameOrId,
   });
   const appointments = appointmentsData?.data ?? [];
   const appointmentsByLocation = partitionAppointmentsByLocation(appointments);

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -69,7 +69,7 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
     filter => filter !== null && filter.length > 0,
   );
 
-  const { data: appointmentsData = [] } = useAppointmentsQuery({
+  const { data: appointmentsData } = useAppointmentsQuery({
     after: displayedDates[0],
     before: endOfDay(displayedDates.at(-1)),
     all: true,
@@ -78,7 +78,7 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
     bookingTypeId: filters.bookingTypeId,
     patientNameOrId: filters.patientNameOrId,
   });
-  const appointments = appointmentsData.data ?? [];
+  const appointments = appointmentsData?.data ?? [];
   const appointmentsByLocation = partitionAppointmentsByLocation(appointments);
 
   const { data: locations } = locationsQuery;

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
@@ -1,18 +1,10 @@
-import { endOfDay, formatISO, isSameDay, parseISO } from 'date-fns';
+import { formatISO, isSameDay, parseISO } from 'date-fns';
 import React from 'react';
-import styled from 'styled-components';
 
-import { useAppointmentsQuery } from '../../../api/queries';
 import { AppointmentTile } from '../../../components/Appointments/AppointmentTile';
-import { Colors } from '../../../constants';
-import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
 import { SkeletonRows } from './Skeletons';
-import {
-  appointmentToFormValues,
-  partitionAppointmentsByDate,
-  partitionAppointmentsByLocation,
-} from './utils';
+import { appointmentToFormValues, partitionAppointmentsByDate } from './utils';
 
 export const BookingsCell = ({
   appointments,

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
@@ -73,53 +73,17 @@ export const BookingsRow = ({
   );
 };
 
-const StyledRow = styled(CarouselGrid.Row)`
-  color: ${Colors.primary};
-  font-weight: 500;
-  grid-template-columns: initial;
-  place-items: center;
-  margin-block: 0.5rem;
-`;
-
-const EmptyStateRow = () => (
-  <StyledRow>No bookings to display. Please try adjusting the search filters.</StyledRow>
-);
-
 export const LocationBookingsCalendarBody = ({
+  appointmentsByLocation,
   displayedDates,
+  filteredLocations,
   locationsQuery,
   openBookingForm,
   openCancelModal,
 }) => {
-  const { data: locations = [], isLoading: locationsAreLoading } = locationsQuery;
+  if (locationsQuery.isLoading) return <SkeletonRows colCount={displayedDates.length} />;
 
-  const { filters } = useLocationBookingsContext();
-
-  const { data: appointmentsData = [] } = useAppointmentsQuery({
-    after: displayedDates[0],
-    before: endOfDay(displayedDates.at(-1)),
-    all: true,
-    locationId: '',
-    clinicianId: filters.clinicianId,
-    bookingTypeId: filters.bookingTypeId,
-    patientNameOrId: filters.patientNameOrId,
-  });
-
-  if (locationsAreLoading) return <SkeletonRows colCount={displayedDates.length} />;
-  if (locations.length === 0) return <EmptyStateRow />;
-
-  const appointments = appointmentsData.data ?? [];
-  const appointmentsByLocation = partitionAppointmentsByLocation(appointments);
-
-  const areFiltersActive = Object.values(filters).some(
-    filter => filter !== null && filter.length > 0,
-  );
-
-  const filteredLocations = areFiltersActive
-    ? locations.filter(location => appointmentsByLocation[location.id])
-    : locations;
-
-  if (filteredLocations.length === 0) return <EmptyStateRow />;
+  if (filteredLocations?.length === 0) return null;
 
   return filteredLocations?.map(location => (
     <BookingsRow

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -1,13 +1,13 @@
 import { formatISO, isSameDay, isSameMonth, isThisMonth, parseISO, startOfToday } from 'date-fns';
-import React, { useEffect } from 'react';
-import styled, { css } from 'styled-components';
-import { useLocation } from 'react-router-dom';
 import queryString from 'query-string';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 
 import { isStartOfThisWeek } from '@tamanu/shared/utils/dateTime';
 
+import { Button, MonthYearInput, formatShort, formatWeekdayShort } from '../../../components';
 import { Colors } from '../../../constants';
-import { Button, formatShort, formatWeekdayShort, MonthYearInput } from '../../../components';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
 
 const StyledFirstHeaderCell = styled(CarouselGrid.FirstHeaderCell)`

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -107,7 +107,7 @@ export const LocationBookingsCalendarHeader = ({ selectedMonthState, displayedDa
       const parsedDate = parseISO(date);
       setMonthOf(parsedDate);
     }
-  }, [location.search]);
+  }, [location.search, setMonthOf]);
 
   return (
     <CarouselGrid.HeaderRow>

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -32,7 +32,7 @@ const LocationBookingsTopBar = styled(TopBar).attrs({
 
 const Wrapper = styled(PageContainer)`
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto 1fr auto;
   max-block-size: 100%;
 `;
 


### PR DESCRIPTION
### Changes

![Screenshot 2024-11-26T164839](https://github.com/user-attachments/assets/cd15116c-eb85-455a-946f-abca3860ab63)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
