### PR TITLE
fix(locationBookings): Fix cancel modal

### DIFF
--- a/packages/shared/src/models/Appointment.js
+++ b/packages/shared/src/models/Appointment.js
@@ -53,7 +53,6 @@ export class Appointment extends Model {
       foreignKey: 'locationGroupId',
     });
 
-    // Appointments are assigned a Location Group but the Location relation exists for legacy data
     this.belongsTo(models.Location, {
       as: 'location',
       foreignKey: 'locationId',

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
@@ -25,7 +25,7 @@ export const BookingsCell = ({
     onClick={e => {
       if (e.target.closest('.appointment-tile')) return;
       // Open form for creating new booking
-      openBookingForm({ date, startDate: date, locationId });
+      openBookingForm({ startTime: date, locationId });
     }}
   >
     {appointments?.map(a => (
@@ -35,7 +35,7 @@ export const BookingsCell = ({
         hideTime={!isSameDay(date, parseISO(a.startTime))}
         key={a.id}
         onCancel={() => openCancelModal(a)}
-        onEdit={() => openBookingForm(appointmentToFormValues(a))}
+        onEdit={() => openBookingForm(a)}
       />
     ))}
   </CarouselGrid.Cell>

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarBody.jsx
@@ -9,7 +9,6 @@ import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
 import { SkeletonRows } from './Skeletons';
 import {
-  appointmentToFormValues,
   partitionAppointmentsByDate,
   partitionAppointmentsByLocation,
 } from './utils';

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -14,6 +14,7 @@ import { useAuth } from '../../../contexts/Auth';
 import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CalendarSearchBar } from './CalendarSearchBar';
 import { LocationBookingsCalendar } from './LocationBookingsCalendar';
+import { appointmentToFormValues } from './utils';
 
 const PlusIcon = styled(AddRounded)`
   && {
@@ -132,7 +133,7 @@ export const LocationBookingsView = () => {
       />
       {selectedAppointment && (
         <LocationBookingDrawer
-          initialValues={selectedAppointment}
+          initialValues={appointmentToFormValues(selectedAppointment)}
           open={isDrawerOpen}
           onClose={closeBookingForm}
         />

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -14,7 +14,6 @@ import { useAuth } from '../../../contexts/Auth';
 import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CalendarSearchBar } from './CalendarSearchBar';
 import { LocationBookingsCalendar } from './LocationBookingsCalendar';
-import { appointmentToFormValues } from './utils';
 
 const PlusIcon = styled(AddRounded)`
   && {

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -82,7 +82,7 @@ export const LocationBookingsView = () => {
   };
 
   const openCancelModal = appointment => {
-    setSelectedAppointment(appointmentToFormValues(appointment));
+    setSelectedAppointment(appointment);
     setIsCancelModalOpen(true);
   };
 


### PR DESCRIPTION
### Changes

When the processing function `appointmentToFormValues` was added into the logic. It broke the cancel modal as that made use of the include relationships on the appointment object returned from the endpoint. I have reorganised the logic to only run this function when supplying to the form

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
