### PR TITLE
tweak(outpatientAppointments): startTime as datestring and checkbox click boundary

### DIFF
--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field, useFormikContext } from 'formik';
-import { endOfDay, startOfDay } from 'date-fns';
+import { endOfDay, parseISO, startOfDay } from 'date-fns';
 
 import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
 
@@ -13,8 +13,8 @@ export const DateTimeFieldWithSameDayWarning = ({ isEdit }) => {
 
   const { data: existingAppointments, isFetched } = useAppointmentsQuery(
     {
-      after: values.startTime ? toDateTimeString(startOfDay(new Date(values.startTime))) : null,
-      before: values.startTime ? toDateTimeString(endOfDay(new Date(values.startTime))) : null,
+      after: values.startTime ? toDateTimeString(startOfDay(parseISO(values.startTime))) : null,
+      before: values.startTime ? toDateTimeString(endOfDay(parseISO(values.startTime))) : null,
       all: true,
       patientId: values.patientId,
     },
@@ -34,6 +34,7 @@ export const DateTimeFieldWithSameDayWarning = ({ isEdit }) => {
       name="startTime"
       label={<TranslatedText stringId="general.dateAndTime.label" fallback="Date & time" />}
       component={DateTimeField}
+      saveDateAsString
       required
       save
       helperText={

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
@@ -13,8 +13,8 @@ export const DateTimeFieldWithSameDayWarning = ({ isEdit }) => {
 
   const { data: existingAppointments, isFetched } = useAppointmentsQuery(
     {
-      after: values.startTime ? toDateTimeString(startOfDay(new Date(values.startTime))) : null,
-      before: values.startTime ? toDateTimeString(endOfDay(new Date(values.startTime))) : null,
+      after: values.startTime ? toDateTimeString(startOfDay(parseISO(values.startTime))) : null,
+      before: values.startTime ? toDateTimeString(endOfDay(parseISO(values.startTime))) : null,
       all: true,
       patientId: values.patientId,
     },

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
@@ -13,8 +13,8 @@ export const DateTimeFieldWithSameDayWarning = ({ isEdit }) => {
 
   const { data: existingAppointments, isFetched } = useAppointmentsQuery(
     {
-      after: values.startTime ? toDateTimeString(startOfDay(parseISO(values.startTime))) : null,
-      before: values.startTime ? toDateTimeString(endOfDay(parseISO(values.startTime))) : null,
+      after: values.startTime ? toDateTimeString(startOfDay(new Date(values.startTime))) : null,
+      before: values.startTime ? toDateTimeString(endOfDay(new Date(values.startTime))) : null,
       all: true,
       patientId: values.patientId,
     },

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -260,6 +260,7 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
           />
           <Field
             name="isHighPriority"
+            style={{ width: 'fit-content' }}
             label={
               <IconLabel>
                 <TranslatedText stringId="general.highPriority.label" fallback="High priority" />


### PR DESCRIPTION
### Changes
- Start time was being treated as UTC
Flic noticed that the same day warning text could display on day ahead incorrectly, noticed this is due to the field missing that prop 😫
- Flic noticed The checkbox was clickable in the whitespace  so made it fit-content

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
