### PR TITLE
tweak(outpatientAppointments): Same day warning query fix

### DIFF
--- a/packages/web/app/api/queries/index.js
+++ b/packages/web/app/api/queries/index.js
@@ -1,4 +1,8 @@
-export { useAppointmentsQuery } from './useAppointmentsQuery';
+export {
+  useAppointmentsQuery,
+  useOutpatientAppointmentsQuery,
+  useLocationBookingsQuery,
+} from './useAppointmentsQuery';
 export { useLocationsQuery } from './useLocationsQuery';
 export * from './useHierarchyTypesQuery';
 export * from './useVitalsSurveyQuery';

--- a/packages/web/app/api/queries/index.js
+++ b/packages/web/app/api/queries/index.js
@@ -1,8 +1,4 @@
-export {
-  useAppointmentsQuery,
-  useOutpatientAppointmentsQuery,
-  useLocationBookingsQuery,
-} from './useAppointmentsQuery';
+export { useOutpatientAppointmentsQuery, useLocationBookingsQuery } from './useAppointmentsQuery';
 export { useLocationsQuery } from './useLocationsQuery';
 export * from './useHierarchyTypesQuery';
 export * from './useVitalsSurveyQuery';

--- a/packages/web/app/api/queries/useAppointmentsQuery.js
+++ b/packages/web/app/api/queries/useAppointmentsQuery.js
@@ -15,4 +15,4 @@ export const useOutpatientAppointmentsQuery = (fetchOptions, useQueryOptions = {
   useAppointmentsQuery({ locationGroupId: '', ...fetchOptions }, useQueryOptions);
 
 export const useLocationBookingsQuery = (fetchOptions, useQueryOptions = {}) =>
-  useAppointmentsQuery({ locationId: '', locationGroupId: '', ...fetchOptions }, useQueryOptions);
+  useAppointmentsQuery({ locationId: '', ...fetchOptions }, useQueryOptions);

--- a/packages/web/app/api/queries/useAppointmentsQuery.js
+++ b/packages/web/app/api/queries/useAppointmentsQuery.js
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useApi } from '../useApi';
 
-export const useAppointmentsQuery = (fetchOptions, useQueryOptions = {}) => {
+const useAppointmentsQuery = (fetchOptions, useQueryOptions = {}) => {
   const api = useApi();
   return useQuery(
     ['appointments', fetchOptions],
@@ -10,3 +10,9 @@ export const useAppointmentsQuery = (fetchOptions, useQueryOptions = {}) => {
     useQueryOptions,
   );
 };
+
+export const useOutpatientAppointmentsQuery = (fetchOptions, useQueryOptions = {}) =>
+  useAppointmentsQuery({ locationGroupId: '', ...fetchOptions }, useQueryOptions);
+
+export const useLocationBookingsQuery = (fetchOptions, useQueryOptions = {}) =>
+  useAppointmentsQuery({ locationId: '', locationGroupId: '', ...fetchOptions }, useQueryOptions);

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -19,7 +19,7 @@ import styled, { css } from 'styled-components';
 
 import { maxValidDate, minValidDate } from '@tamanu/shared/utils/dateTime';
 
-import { useAppointmentsQuery } from '../../../../api/queries';
+import { useLocationBookingsQuery } from '../../../../api/queries';
 import { Colors } from '../../../../constants';
 import { useSettings } from '../../../../contexts/Settings';
 import { OuterLabelFieldWrapper } from '../../../Field';
@@ -105,7 +105,10 @@ export const TimeSlotPicker = ({
   const earliestRelevantTime = minValidDate([startOfDay(date), values.startTime]);
   const latestRelevantTime = maxValidDate([endOfDay(date), values.endTime]);
 
-  const { data: existingBookings, isFetching: isFetchingExistingBookings } = useAppointmentsQuery(
+  const {
+    data: existingBookings,
+    isFetching: isFetchingExistingBookings,
+  } = useLocationBookingsQuery(
     {
       after: earliestRelevantTime,
       before: latestRelevantTime,

--- a/packages/web/app/components/Appointments/LocationBookingsTable.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingsTable.jsx
@@ -5,7 +5,7 @@ import { Box } from '@material-ui/core';
 import { toDateString } from '@tamanu/shared/utils/dateTime';
 import Brightness2Icon from '@material-ui/icons/Brightness2';
 
-import { useAppointmentsQuery } from '../../api/queries';
+import { useLocationBookingsQuery } from '../../api/queries';
 import { Table } from '../Table';
 import { Colors } from '../../constants';
 import { TranslatedText } from '../Translation';
@@ -265,8 +265,7 @@ export const LocationBookingsTable = ({ patient }) => {
   });
 
   const appointments =
-    useAppointmentsQuery({
-      locationId: '',
+    useLocationBookingsQuery({
       all: true,
       patientId: patient?.id,
       orderBy,

--- a/packages/web/app/components/Appointments/OutpatientAppointmentsTable.jsx
+++ b/packages/web/app/components/Appointments/OutpatientAppointmentsTable.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { Box } from '@material-ui/core';
 import { toDateString } from '@tamanu/shared/utils/dateTime';
 
-import { useAppointmentsQuery } from '../../api/queries';
 import { Table } from '../Table';
 import { Colors } from '../../constants';
 import { TranslatedText } from '../Translation';
@@ -16,6 +15,7 @@ import { useTableSorting } from '../Table/useTableSorting';
 import { Button } from '../Button';
 import { CancelAppointmentModal } from './CancelModal/CancelAppointmentModal';
 import { PastAppointmentModal } from './PastAppointmentModal/PastAppointmentModal';
+import { useOutpatientAppointmentsQuery } from '../../api/queries/useAppointmentsQuery';
 
 const TableTitleContainer = styled(Box)`
   display: flex;
@@ -200,9 +200,7 @@ const NoDataContainer = styled.div`
 `;
 
 const getDate = ({ startTime }) => (
-  <DateText>
-    {`${formatShortest(startTime)} ${formatTime(startTime).replace(' ', '')}`}
-  </DateText>
+  <DateText>{`${formatShortest(startTime)} ${formatTime(startTime).replace(' ', '')}`}</DateText>
 );
 
 const CustomCellComponent = ({ value, $maxWidth }) => {
@@ -251,10 +249,7 @@ const TableHeader = ({ title }) => {
         </Button>
       </div>
       {isViewPastBookingsModalOpen && (
-        <PastAppointmentModal 
-          open={true} 
-          onClose={() => setIsViewPastBookingsModalOpen(false)}
-        />
+        <PastAppointmentModal open={true} onClose={() => setIsViewPastBookingsModalOpen(false)} />
       )}
     </TableTitleContainer>
   );
@@ -267,8 +262,7 @@ export const OutpatientAppointmentsTable = ({ patient }) => {
   });
 
   const appointments =
-    useAppointmentsQuery({
-      locationGroupId: '',
+    useOutpatientAppointmentsQuery({
       all: true,
       patientId: patient?.id,
       orderBy,

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
@@ -17,6 +17,7 @@ export const DateTimeFieldWithSameDayWarning = ({ isEdit }) => {
       before: values.startTime ? toDateTimeString(endOfDay(parseISO(values.startTime))) : null,
       all: true,
       patientId: values.patientId,
+      locationGroupId: '',
     },
     {
       enabled: !isEdit && !!(values.startTime && values.patientId),

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
@@ -4,20 +4,19 @@ import { endOfDay, parseISO, startOfDay } from 'date-fns';
 
 import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
 
-import { useAppointmentsQuery } from '../../../api/queries';
 import { TranslatedText } from '../../Translation';
 import { DateTimeField } from '../..';
+import { useOutpatientAppointmentsQuery } from '../../../api/queries/useAppointmentsQuery';
 
 export const DateTimeFieldWithSameDayWarning = ({ isEdit }) => {
   const { values } = useFormikContext();
 
-  const { data: existingAppointments, isFetched } = useAppointmentsQuery(
+  const { data: existingAppointments, isFetched } = useOutpatientAppointmentsQuery(
     {
       after: values.startTime ? toDateTimeString(startOfDay(parseISO(values.startTime))) : null,
       before: values.startTime ? toDateTimeString(endOfDay(parseISO(values.startTime))) : null,
       all: true,
       patientId: values.patientId,
-      locationGroupId: '',
     },
     {
       enabled: !isEdit && !!(values.startTime && values.patientId),

--- a/packages/web/app/components/Appointments/PastAppointmentModal/PastAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/PastAppointmentModal/PastAppointmentModal.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Modal } from '../../Modal';
 import { Table } from '../../Table';
 import { TranslatedText } from '../../Translation';
-import { useAppointmentsQuery } from '../../../api/queries';
+import { useOutpatientAppointmentsQuery } from '../../../api/queries';
 import { formatShortest, formatTime } from '../../DateDisplay';
 import { Colors } from '../../../constants';
 import { useTableSorting } from '../../Table/useTableSorting';
@@ -107,11 +107,7 @@ const getDate = ({ startTime }) => (
   </LowercaseText>
 );
 
-const getStatus = ({ status }) => (
-  <StatusBadge $status={status}>
-    {status}
-  </StatusBadge>
-);
+const getStatus = ({ status }) => <StatusBadge $status={status}>{status}</StatusBadge>;
 
 const COLUMNS = [
   {
@@ -157,10 +153,9 @@ export const PastAppointmentModal = ({ open, onClose, patient }) => {
   });
   const beforeDate = useMemo(() => new Date().toISOString(), []);
   const appointments =
-    useAppointmentsQuery({
+    useOutpatientAppointmentsQuery({
       all: true,
       patientId: patient?.id,
-      locationGroupId: '',
       before: beforeDate,
       after: '1970-01-01 00:00',
       orderBy,

--- a/packages/web/app/components/Appointments/PastBookingsModal.jsx
+++ b/packages/web/app/components/Appointments/PastBookingsModal.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Modal } from '../Modal';
 import { Table } from '../Table';
 import { TranslatedText } from '../Translation';
-import { useAppointmentsQuery } from '../../api/queries';
+import { useLocationBookingsQuery } from '../../api/queries';
 import { formatShortest, formatTime } from '../DateDisplay';
 import { Colors } from '../../constants';
 import { useTableSorting } from '../Table/useTableSorting';
@@ -194,15 +194,13 @@ export const PastBookingsModal = ({ onClose, patient }) => {
 
   const beforeDate = useMemo(() => new Date().toISOString(), []);
   const bookings =
-    useAppointmentsQuery({
+    useLocationBookingsQuery({
       all: true,
       patientId: patient?.id,
       before: beforeDate,
       after: '1970-01-01 00:00',
       orderBy,
       order,
-      locationId: '',
-      locationGroup: '',
     }).data?.data ?? [];
 
   return (

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -10,7 +10,7 @@ import {
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import { useAppointmentsQuery } from '../../../api/queries';
+import { useLocationBookingsQuery } from '../../../api/queries';
 import { APPOINTMENT_CALENDAR_CLASS, TranslatedText } from '../../../components';
 import { Colors } from '../../../constants';
 import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
@@ -93,11 +93,10 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
     clinicianId?.length > 0 || bookingTypeId?.length > 0 || !!patientNameOrId;
   const { data: locations } = locationsQuery;
 
-  const { data: appointmentsData } = useAppointmentsQuery({
+  const { data: appointmentsData } = useLocationBookingsQuery({
     after: displayedDates[0],
     before: endOfDay(displayedDates.at(-1)),
     all: true,
-    locationId: '',
     clinicianId,
     bookingTypeId,
     patientNameOrId,

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -4,10 +4,9 @@ import {
   endOfMonth,
   endOfWeek,
   startOfMonth,
-  startOfToday,
   startOfWeek,
 } from 'date-fns';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { useLocationBookingsQuery } from '../../../api/queries';
@@ -86,7 +85,7 @@ export const LocationBookingsCalendar = ({ locationsQuery, openBookingForm, open
   const displayedDates = getDisplayableDates(monthOf);
 
   useEffect(() => {
-    if (selectedCell.date) setMonthOf(selectedCell.date)
+    if (selectedCell.date) setMonthOf(selectedCell.date);
   }, [selectedCell.date, setMonthOf]);
 
   const {

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -57,6 +57,7 @@ const CalendarInnerWrapper = styled(Box)`
 const AppointmentTopBar = styled(TopBar).attrs({
   title: <TranslatedText stringId="scheduling.appointments.title" fallback="Appointments" />,
 })`
+  border-block-end: max(0.0625rem, 1px) ${Colors.outline} solid;
   flex-grow: 0;
   & .MuiToolbar-root {
     justify-content: flex-start;

--- a/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
+++ b/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 import { endOfDay } from 'date-fns';
 import { groupBy as lodashGroupBy } from 'lodash';
 
-import { useAppointmentsQuery } from '../../../api/queries';
 import { useLocationGroupsQuery } from '../../../api/queries/useLocationGroupsQuery';
 import { useUsersQuery } from '../../../api/queries/useUsersQuery';
 import { APPOINTMENT_GROUP_BY } from './OutpatientAppointmentsView';
+import { useOutpatientAppointmentsQuery } from '../../../api/queries/useAppointmentsQuery';
 
 export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate }) => {
   const {
@@ -28,10 +28,9 @@ export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate })
     data: appointmentData,
     error: appointmentError,
     isFetching: isFetchingAppointmentData,
-  } = useAppointmentsQuery({
+  } = useOutpatientAppointmentsQuery({
     after: selectedDate,
     before: endOfDay(selectedDate),
-    locationGroupId: '',
     all: true,
   });
 


### PR DESCRIPTION
### Changes
- Fix issue where existing appointments query inside the field was looking at all appointments (should only look at outpatient appointments)
- Refactor into two separate queries for outpatient appointments and location booking

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
