### PR TITLE
fix(locationBookings): Fix patient name or id search regex

### DIFF
--- a/packages/facility-server/app/utils/query.js
+++ b/packages/facility-server/app/utils/query.js
@@ -36,8 +36,9 @@ export const makeDeletedAtIsNullFilter = table => {
 };
 
 // Escape wildcard characters _, % and backslash in pattern match
+const wildcardRegex = /([_%\\])/g;
 export const escapePatternWildcard = value => {
-  return value.replace(/([_%\\])/g, '\\$1');
+  return value.replace(wildcardRegex, '\\$1');
 };
 
 export const getWhereClausesAndReplacementsFromFilters = (allFilters, params = {}) => {

--- a/packages/facility-server/app/utils/query.js
+++ b/packages/facility-server/app/utils/query.js
@@ -37,7 +37,7 @@ export const makeDeletedAtIsNullFilter = table => {
 
 // Escape wildcard characters _, % and backslash in pattern match
 export const escapePatternWildcard = value => {
-  return value.replace(/[_%\\]/g, '\\$1');
+  return value.replace(/([_%\\])/g, '\\$1');
 };
 
 export const getWhereClausesAndReplacementsFromFilters = (allFilters, params = {}) => {


### PR DESCRIPTION
### Changes

In the original `escapePatternWilcard` function, the regular expression `value.replace(/[_%\\]/g, '\\$1')` attempted to reference a non-existent capturing group, causing errors when inputting these characters. This updates the code to use a capturing group.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
