### PR TITLE
fix(outpatientAppointments): Missed change handlers for this date input

### DIFF
--- a/packages/web/app/components/Field/CalendarField.jsx
+++ b/packages/web/app/components/Field/CalendarField.jsx
@@ -143,6 +143,10 @@ export const MonthYearInput = ({
       minDate={minDate}
       maxDate={maxDate}
       value={value}
+      onBlur={e => onChange(new Date(e.target.value))}
+      onKeyDown={e => {
+        if (e.key === 'Enter') onChange(new Date(e.target.value));
+      }}
       {...props}
     />
   );

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -108,10 +108,7 @@ export const LocationBookingsCalendarHeader = ({ monthOf, updateMonth, displayed
         <MonthPicker
           value={monthOf}
           onAccept={updateMonth}
-          onBlur={e => updateMonth(new Date(e.target.value))}
-          onKeyDown={e => {
-            if (e.key === 'Enter') updateMonth(new Date(e.target.value));
-          }}
+          onChange={updateMonth}
         />
         <StyledButton onClick={() => updateMonth(startOfToday())}>This week</StyledButton>
       </StyledFirstHeaderCell>

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -198,10 +198,6 @@ export const DateSelector = ({ value, onChange }) => {
   return (
     <Wrapper onKeyDown={handleOnKeyDown}>
       <StyledMonthYearInput
-        onBlur={e => handleMonthYearChange(new Date(e.target.value))}
-        onKeyDown={e => {
-          if (e.key === 'Enter') handleMonthYearChange(new Date(e.target.value))
-        }}
         value={viewedDays[0]}
         onChange={handleMonthYearChange}
       />

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -197,7 +197,14 @@ export const DateSelector = ({ value, onChange }) => {
 
   return (
     <Wrapper onKeyDown={handleOnKeyDown}>
-      <StyledMonthYearInput value={viewedDays[0]} onChange={handleMonthYearChange} />
+      <StyledMonthYearInput
+        onBlur={e => handleMonthYearChange(new Date(e.target.value))}
+        onKeyDown={e => {
+          if (e.key === 'Enter') handleMonthYearChange(new Date(e.target.value))
+        }}
+        value={viewedDays[0]}
+        onChange={handleMonthYearChange}
+      />
       <TodayButton onClick={handleChangeToday}>Today</TodayButton>
       <StepperWrapper>
         <StepperButton onClick={handleDecrement}>


### PR DESCRIPTION
### Changes

This change refactors some duplicated code and makes it so that both datepicker objects in the calendar views also update the state of the calendar on blur and on enter key press

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
