### PR TITLE
ci: avoid false positives for dbt up-to-date check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,8 @@ jobs:
       - name: Check model is up to date
         run: |
           npm run dbt-generate-model --fail-on-missing-config
-          if [[ -n $(git status --porcelain=v2) ]]; then
-              git diff
+          if [[ -n $(git status --porcelain=v2 database) ]]; then
+              git diff -- database
               echo "The dbt model is behind the Tamanu database!"
               echo "Run 'npm run dbt-generate-model' and commit the result."
               exit 1


### PR DESCRIPTION
### Changes

The check would verify that there's no diff across the entire reop, which there can be in some merges. Restrict it to only look at the `database` folder.