### PR TITLE
fix(locationBookings): autoscroll to current week on initial load

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -235,14 +235,6 @@ appointments.get(
       return _filters;
     }, {});
 
-    console.log({
-      ...facilityIdQuery,
-      ...timeQueryWhereClause,
-      ...(includeCancelled ? {} : { status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED } }),
-      ...(patientNameOrId ? patientNameOrIdQuery : null),
-      ...filters,
-    });
-
     const { rows, count } = await Appointment.findAndCountAll({
       limit: all ? undefined : rowsPerPage,
       offset: all ? undefined : page * rowsPerPage,

--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -190,6 +190,7 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
       if (!confirmed) return;
       onClose();
       resetForm();
+      updateSelectedCell({ locationId: null, date: null });
     };
 
     const resetFields = fields => {

--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -146,10 +146,7 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
   const { mutateAsync: mutateBooking } = useLocationBookingMutation(
     { isEdit },
     {
-      onSuccess: () => {
-        notifySuccess(<SuccessMessage isEdit={isEdit} />);
-        onClose();
-      },
+      onSuccess: () => notifySuccess(<SuccessMessage isEdit={isEdit} />),
       onError: error => {
         notifyError(
           error.message == 409 ? (
@@ -182,7 +179,12 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
         bookingTypeId,
         clinicianId,
       },
-      { onSuccess: resetForm },
+      {
+        onSuccess: () => {
+          onClose();
+          resetForm();
+        },
+      },
     );
   };
 

--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -172,16 +172,18 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
     { locationId, startTime, endTime, patientId, bookingTypeId, clinicianId },
     { resetForm },
   ) => {
-    mutateBooking({
-      id: initialValues.id, // Undefined when creating new booking
-      locationId,
-      startTime: toDateTimeString(startTime),
-      endTime: toDateTimeString(endTime),
-      patientId,
-      bookingTypeId,
-      clinicianId,
-    });
-    resetForm();
+    mutateBooking(
+      {
+        id: initialValues.id, // Undefined when creating new booking
+        locationId,
+        startTime: toDateTimeString(startTime),
+        endTime: toDateTimeString(endTime),
+        patientId,
+        bookingTypeId,
+        clinicianId,
+      },
+      { onSuccess: resetForm },
+    );
   };
 
   const renderForm = ({ values, resetForm, setFieldValue, dirty }) => {

--- a/packages/web/app/contexts/LocationBookings.jsx
+++ b/packages/web/app/contexts/LocationBookings.jsx
@@ -3,16 +3,16 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { generateIdFromCell } from '../views/scheduling/locationBookings/utils';
 import {
-  firstDisplayedDayId,
-  thisWeekId,
+  FIRST_DISPLAYED_DAY_ID,
+  THIS_WEEK_ID,
 } from '../views/scheduling/locationBookings/LocationBookingsCalendarHeader';
 
 const LocationBookingsContext = createContext(null);
 
 const scrollToThisWeek = () =>
-  document.getElementById(thisWeekId)?.scrollIntoView({ inline: 'start' });
+  document.getElementById(THIS_WEEK_ID)?.scrollIntoView({ inline: 'start' });
 const scrollToBeginning = () =>
-  document.getElementById(firstDisplayedDayId)?.scrollIntoView({ inline: 'start' });
+  document.getElementById(FIRST_DISPLAYED_DAY_ID)?.scrollIntoView({ inline: 'start' });
  const scrollToCell = cell => {
   document.getElementById(generateIdFromCell(cell))?.scrollIntoView({ inline: 'start' });
 };

--- a/packages/web/app/contexts/LocationBookings.jsx
+++ b/packages/web/app/contexts/LocationBookings.jsx
@@ -43,11 +43,24 @@ export const LocationBookingsContextProvider = ({ children }) => {
   };
 
   const updateMonth = date => {
-    setMonthOf(date);
+    setMonthOf(startOfMonth(date));
     (isThisMonth(date) ? scrollToThisWeek : scrollToBeginning)();
   };
 
-  useEffect(() => scrollToCell(selectedCell), [selectedCell]);
+  useEffect(
+    () => {
+      const { date, locationId } = selectedCell;
+      if (date && locationId && isSameMonth(date, monthOf)) {
+        scrollToCell(selectedCell);
+        return;
+      }
+
+      (isThisMonth(monthOf) ? scrollToThisWeek : scrollToBeginning)();
+    },
+    // Don’t fire this useEffect when the month changes while a cell happens to be selected
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedCell],
+  );
 
   return (
     <LocationBookingsContext.Provider

--- a/packages/web/app/contexts/LocationBookings.jsx
+++ b/packages/web/app/contexts/LocationBookings.jsx
@@ -25,7 +25,7 @@ export const LocationBookingsContextProvider = ({ children }) => {
   useEffect(
     () => {
       if (isSameMonth(selectedCell.date, monthOf)) {
-        scrollToCell(selectedCell);
+        scrollToCell(selectedCell, { behavior: 'instant' });
       } else {
         (isThisMonth(monthOf) ? scrollToThisWeek : scrollToBeginning)({ behavior: 'instant' });
       }

--- a/packages/web/app/contexts/LocationBookings.jsx
+++ b/packages/web/app/contexts/LocationBookings.jsx
@@ -1,21 +1,14 @@
-import { isThisMonth, startOfToday } from 'date-fns';
+import { isSameMonth, isThisMonth, startOfMonth, startOfToday } from 'date-fns';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-import { generateIdFromCell } from '../views/scheduling/locationBookings/utils';
 import {
   FIRST_DISPLAYED_DAY_ID,
   THIS_WEEK_ID,
 } from '../views/scheduling/locationBookings/LocationBookingsCalendarHeader';
+import { generateIdFromCell } from '../views/scheduling/locationBookings/utils';
+import { LOCATION_BOOKINGS_CALENDAR_ID } from '../views/scheduling/locationBookings/LocationBookingsView';
 
 const LocationBookingsContext = createContext(null);
-
-const scrollToThisWeek = () =>
-  document.getElementById(THIS_WEEK_ID)?.scrollIntoView({ inline: 'start' });
-const scrollToBeginning = () =>
-  document.getElementById(FIRST_DISPLAYED_DAY_ID)?.scrollIntoView({ inline: 'start' });
- const scrollToCell = cell => {
-  document.getElementById(generateIdFromCell(cell))?.scrollIntoView({ inline: 'start' });
-};
 
 export const LocationBookingsContextProvider = ({ children }) => {
   const [filters, setFilters] = useState({
@@ -43,24 +36,8 @@ export const LocationBookingsContextProvider = ({ children }) => {
   };
 
   const updateMonth = date => {
-    setMonthOf(startOfMonth(date));
-    (isThisMonth(date) ? scrollToThisWeek : scrollToBeginning)();
+    setMonthOf(date);
   };
-
-  useEffect(
-    () => {
-      const { date, locationId } = selectedCell;
-      if (date && locationId && isSameMonth(date, monthOf)) {
-        scrollToCell(selectedCell);
-        return;
-      }
-
-      (isThisMonth(monthOf) ? scrollToThisWeek : scrollToBeginning)();
-    },
-    // Don’t fire this useEffect when the month changes while a cell happens to be selected
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedCell],
-  );
 
   return (
     <LocationBookingsContext.Provider

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -88,8 +88,6 @@ export const LocationBookingsCalendar = ({
   openCancelModal,
   ...props
 }) => {
-  useEffect(scrollToThisWeek, []);
-
   const { monthOf, setMonthOf } = useLocationBookingsContext();
 
   const displayedDates = getDisplayableDates(monthOf);

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -3,8 +3,6 @@ import {
   endOfDay,
   endOfMonth,
   endOfWeek,
-  isSameMonth,
-  isThisMonth,
   startOfMonth,
   startOfWeek,
 } from 'date-fns';
@@ -20,9 +18,8 @@ import { Colors } from '../../../constants';
 import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
 import { LocationBookingsCalendarBody } from './LocationBookingsCalendarBody';
-import { LocationBookingsCalendarHeader, THIS_WEEK_ID } from './LocationBookingsCalendarHeader';
-import { LOCATION_BOOKINGS_CALENDAR_ID } from './LocationBookingsView';
-import { generateIdFromCell, partitionAppointmentsByLocation } from './utils';
+import { LocationBookingsCalendarHeader } from './LocationBookingsCalendarHeader';
+import { partitionAppointmentsByLocation, scrollToThisWeek } from './utils';
 
 const getDisplayableDates = date => {
   const start = startOfWeek(startOfMonth(date), { weekStartsOn: 1 });
@@ -85,30 +82,15 @@ const emptyStateMessage = (
   </EmptyState>
 );
 
-const scrollToThisWeek = () =>
-  document.getElementById(THIS_WEEK_ID)?.scrollIntoView({ inline: 'start' });
-const scrollToBeginning = () =>
-  document.getElementById(LOCATION_BOOKINGS_CALENDAR_ID)?.scroll({ left: 0 });
-const scrollToCell = cell =>
-  document.getElementById(generateIdFromCell(cell))?.scrollIntoView({ inline: 'start' });
-
 export const LocationBookingsCalendar = ({
   locationsQuery,
   openBookingForm,
   openCancelModal,
   ...props
 }) => {
-  const { monthOf, updateMonth, selectedCell } = useLocationBookingsContext();
+  useEffect(scrollToThisWeek, []);
 
-  useEffect(() => {
-    const { date, locationId } = selectedCell;
-    if (date && locationId && isSameMonth(date, monthOf)) {
-      scrollToCell(selectedCell);
-      return;
-    }
-
-    (isThisMonth(monthOf) ? scrollToThisWeek : scrollToBeginning)();
-  }, [monthOf, selectedCell]);
+  const { monthOf, setMonthOf } = useLocationBookingsContext();
 
   const displayedDates = getDisplayableDates(monthOf);
 
@@ -141,7 +123,7 @@ export const LocationBookingsCalendar = ({
         <CarouselGrid.Root $dayCount={displayedDates.length}>
           <LocationBookingsCalendarHeader
             monthOf={monthOf}
-            updateMonth={updateMonth}
+            setMonthOf={setMonthOf}
             displayedDates={displayedDates}
           />
           <LocationBookingsCalendarBody

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -21,7 +21,7 @@ const StyledFirstHeaderCell = styled(CarouselGrid.FirstHeaderCell)`
   align-items: center;
 `;
 
-const StyledButton = styled(Button).attrs({ variant: 'text' })`
+const GoToThisWeekButton = styled(Button).attrs({ variant: 'text' })`
   font-size: 0.75rem;
   font-weight: 400;
   min-inline-size: 4rem; // Prevent hover effect from affecting layout
@@ -103,18 +103,20 @@ export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedD
     }
   }, [location.search, setMonthOf]);
 
+  const goToThisWeek = () => {
+    if (isThisMonth(monthOf)) {
+      scrollToThisWeek();
+    } else {
+      setMonthOf(startOfToday());
+      // In this case, useEffect in LocationBookings context handles auto-scroll
+    }
+  };
+
   return (
     <CarouselGrid.HeaderRow>
       <StyledFirstHeaderCell>
         <MonthPicker value={monthOf} onChange={setMonthOf} />
-        <StyledButton
-          onClick={() => {
-            if (isThisMonth(monthOf)) scrollToThisWeek();
-            else setMonthOf(startOfToday());
-          }}
-        >
-          This week
-        </StyledButton>
+        <GoToThisWeekButton onClick={goToThisWeek}>This week</GoToThisWeekButton>
       </StyledFirstHeaderCell>
       {displayedDates.map(d => {
         const id = isStartOfThisWeek(d)

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -10,8 +10,8 @@ import { Button, MonthYearInput, formatShort, formatWeekdayShort } from '../../.
 import { Colors } from '../../../constants';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
 
-export const thisWeekId = 'location-bookings-calendar__this-week';
-export const firstDisplayedDayId = 'location-bookings-calendar__beginning';
+export const THIS_WEEK_ID = 'location-bookings-calendar__this-week';
+export const FIRST_DISPLAYED_DAY_ID = 'location-bookings-calendar__beginning';
 
 const StyledFirstHeaderCell = styled(CarouselGrid.FirstHeaderCell)`
   display: grid;
@@ -105,17 +105,14 @@ export const LocationBookingsCalendarHeader = ({ monthOf, updateMonth, displayed
   return (
     <CarouselGrid.HeaderRow>
       <StyledFirstHeaderCell>
-        <MonthPicker
-          value={monthOf}
-          onChange={updateMonth}
-        />
+        <MonthPicker value={monthOf} onChange={updateMonth} />
         <StyledButton onClick={() => updateMonth(startOfToday())}>This week</StyledButton>
       </StyledFirstHeaderCell>
       {displayedDates.map(d => {
         const id = isStartOfThisWeek(d)
-          ? thisWeekId
+          ? THIS_WEEK_ID
           : isFirstDisplayedDate(d)
-          ? firstDisplayedDayId
+          ? FIRST_DISPLAYED_DAY_ID
           : null;
         return <DayHeaderCell date={d} dim={!isSameMonth(d, monthOf)} id={id} key={d.valueOf()} />;
       })}

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { useLocation } from 'react-router-dom';
-import { formatISO, isSameDay, isSameMonth, parseISO, startOfToday } from 'date-fns';
+import { formatISO, isSameDay, isSameMonth, isThisMonth, parseISO, startOfToday } from 'date-fns';
 import queryString from 'query-string';
 
 import { isStartOfThisWeek } from '@tamanu/shared/utils/dateTime';
@@ -9,6 +9,7 @@ import { isStartOfThisWeek } from '@tamanu/shared/utils/dateTime';
 import { Button, MonthYearInput, formatShort, formatWeekdayShort } from '../../../components';
 import { Colors } from '../../../constants';
 import { CarouselComponents as CarouselGrid } from './CarouselComponents';
+import { scrollToThisWeek } from './utils';
 
 export const THIS_WEEK_ID = 'location-bookings-calendar__this-week';
 export const FIRST_DISPLAYED_DAY_ID = 'location-bookings-calendar__beginning';
@@ -90,7 +91,7 @@ const MonthPicker = styled(MonthYearInput)`
   }
 `;
 
-export const LocationBookingsCalendarHeader = ({ monthOf, updateMonth, displayedDates }) => {
+export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedDates }) => {
   const isFirstDisplayedDate = date => isSameDay(date, displayedDates[0]);
 
   const location = useLocation();
@@ -98,15 +99,22 @@ export const LocationBookingsCalendarHeader = ({ monthOf, updateMonth, displayed
     const { date } = queryString.parse(location.search);
     if (date) {
       const parsedDate = parseISO(date);
-      updateMonth(parsedDate);
+      setMonthOf(parsedDate);
     }
-  }, [location.search, updateMonth]);
+  }, [location.search, setMonthOf]);
 
   return (
     <CarouselGrid.HeaderRow>
       <StyledFirstHeaderCell>
-        <MonthPicker value={monthOf} onChange={updateMonth} />
-        <StyledButton onClick={() => updateMonth(startOfToday())}>This week</StyledButton>
+        <MonthPicker value={monthOf} onChange={setMonthOf} />
+        <StyledButton
+          onClick={() => {
+            if (isThisMonth(monthOf)) scrollToThisWeek();
+            else setMonthOf(startOfToday());
+          }}
+        >
+          This week
+        </StyledButton>
       </StyledFirstHeaderCell>
       {displayedDates.map(d => {
         const id = isStartOfThisWeek(d)

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -81,8 +81,11 @@ export const LocationBookingsView = () => {
   };
 
   const openBookingForm = async appointment => {
+    // “Useless” await seems to ensure locationGroupId and locationId fields are
+    // correctly cleared upon resetForm()
+    await setSelectedAppointment(appointment);
+
     const { locationId, startTime } = appointment;
-    setSelectedAppointment(appointment);
     if (locationId && startTime) {
       updateSelectedCell({ locationId, date: parseISO(startTime) });
     }
@@ -95,7 +98,9 @@ export const LocationBookingsView = () => {
   };
 
   const handleNewBooking = async () => {
-    setSelectedAppointment(null);
+    // “Useless” await seems to ensure locationGroupId and locationId fields are
+    // correctly cleared upon resetForm()
+    await setSelectedAppointment(null);
     openBookingForm({});
   };
 

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -17,6 +17,8 @@ import { LocationBookingsCalendar } from './LocationBookingsCalendar';
 import { appointmentToFormValues } from './utils';
 import { parseISO } from 'date-fns';
 
+export const LOCATION_BOOKINGS_CALENDAR_ID = 'location-bookings-calendar';
+
 const PlusIcon = styled(AddRounded)`
   && {
     margin-inline-end: 0.1875rem;
@@ -127,6 +129,7 @@ export const LocationBookingsView = () => {
         </EmptyStateLabel>
       ) : (
         <LocationBookingsCalendar
+          id={LOCATION_BOOKINGS_CALENDAR_ID}
           locationsQuery={locationsQuery}
           openBookingForm={openBookingForm}
           openCancelModal={openCancelModal}

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -80,7 +80,7 @@ export const LocationBookingsView = () => {
 
   const openBookingForm = async appointment => {
     const { locationId, startTime } = appointment;
-    await setSelectedAppointment(appointment);
+    setSelectedAppointment(appointment);
     if (locationId && startTime) {
       updateSelectedCell({ locationId, date: parseISO(startTime) });
     }
@@ -93,7 +93,7 @@ export const LocationBookingsView = () => {
   };
 
   const handleNewBooking = async () => {
-    await setSelectedAppointment(null);
+    setSelectedAppointment(null);
     openBookingForm({});
   };
 

--- a/packages/web/app/views/scheduling/locationBookings/utils.js
+++ b/packages/web/app/views/scheduling/locationBookings/utils.js
@@ -2,6 +2,9 @@ import { eachDayOfInterval, isSameDay, isValid, parseISO, startOfDay } from 'dat
 
 import { toDateString } from '@tamanu/shared/utils/dateTime';
 
+import { THIS_WEEK_ID } from './LocationBookingsCalendarHeader';
+import { LOCATION_BOOKINGS_CALENDAR_ID } from './LocationBookingsView';
+
 export const appointmentToFormValues = appointment => {
   if (!appointment) return {};
 
@@ -57,4 +60,17 @@ export const partitionAppointmentsByDate = appointments =>
     return acc;
   }, {});
 
-export const generateIdFromCell = cell => `${cell.locationId}.${new Date(cell.date).valueOf()}`;
+export const generateIdFromCell = cell => `${cell.locationId}.${cell.date.valueOf()}`;
+
+export const scrollToThisWeek = scrollIntoViewOptions =>
+  document
+    .getElementById(THIS_WEEK_ID)
+    ?.scrollIntoView({ inline: 'start', ...scrollIntoViewOptions });
+
+export const scrollToBeginning = scrollToOptions =>
+  document.getElementById(LOCATION_BOOKINGS_CALENDAR_ID)?.scroll({ left: 0, ...scrollToOptions });
+
+export const scrollToCell = (cell, scrollIntoViewOptions) =>
+  document
+    .getElementById(generateIdFromCell(cell))
+    ?.scrollIntoView({ inline: 'start', ...scrollIntoViewOptions });


### PR DESCRIPTION
### Changes

- Restores behaviour where location bookings calendar initially loads to the current week, instead of the first week of the current month
- Also makes the auto-scroll instant in certain circumstances. Specifically:
  - on initial load, and
  - when the month changes

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
