### PR TITLE
fix(api): fix duplicate key in `GET /appointment` WHERE clause

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -87,7 +87,7 @@ appointments.get(
   asyncHandler(async (req, res) => {
     req.checkPermission('list', 'Appointment');
     const {
-      models,
+      models: { Appointment },
       query: {
         after = startOfToday(),
         before,
@@ -101,7 +101,6 @@ appointments.get(
         ...queries
       },
     } = req;
-    const { Appointment } = models;
 
     // If only an ‘after’ time is provided, use legacy behaviour and query only by appointment start times
     const shouldQueryByOverlap = !!before;


### PR DESCRIPTION
> [!NOTE]
> This PR replaces #6868 (I updated that one from the wrong branch)

### Changes

Both the `timeQueryWhereClause` and `patientNameOrId` clauses had a key of `[Op.or]`, so the latter overwriting the former when present

This PR updates the `where` clause to explicitly AND together an array of objects instead of implicitly AND-ing properties in an object. More explicitly, it this this:

```js
where: { [Op.and]: [] }
```

…instead of…

```js
where: {}
```

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
