### PR TITLE
fix: EPI-1001: Today's bookings and appointments not filtered by facility

### DIFF
--- a/packages/web/app/views/dashboard/components/TodayAppointmentsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayAppointmentsPane.jsx
@@ -104,7 +104,7 @@ const NoDataContainer = styled.div`
 
 export const TodayAppointmentsPane = ({ showTasks }) => {
   const history = useHistory();
-  const { currentUser } = useAuth();
+  const { currentUser, facilityId } = useAuth();
   const appointments =
     useAutoUpdatingQuery(
       'appointments',
@@ -114,6 +114,7 @@ export const TodayAppointmentsPane = ({ showTasks }) => {
         before: toDateTimeString(endOfDay(new Date())),
         clinicianId: currentUser?.id,
         all: true,
+        facilityId,
       },
       `${WS_EVENTS.DATABASE_TABLE_CHANGED}:appointments`,
     ).data?.data ?? [];

--- a/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
@@ -208,7 +208,7 @@ const BookingsTimelineItem = ({ appointment }) => {
 };
 
 export const TodayBookingsPane = ({ showTasks }) => {
-  const { currentUser } = useAuth();
+  const { currentUser, facilityId } = useAuth();
   const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation();
   const appointments =
     useAutoUpdatingQuery(
@@ -219,6 +219,7 @@ export const TodayBookingsPane = ({ showTasks }) => {
         after: toDateTimeString(startOfDay(new Date())),
         before: toDateTimeString(endOfDay(new Date())),
         clinicianId: currentUser?.id,
+        facilityId,
       },
       `${WS_EVENTS.DATABASE_TABLE_CHANGED}:appointments`,
     ).data?.data ?? [];


### PR DESCRIPTION
### Changes

Today's bookings and appointments in dashboard not filtered by facility

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
