### PR TITLE
tweak(scheduling): Datepicker behaviour tweaks

### DIFF
--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -127,8 +127,7 @@ export const MonthPicker = ({
   const [open, setOpen] = useState(false);
 
   const handleMonthChange = monthString => {
-    // Dont attempt change if placeholder month present
-    if (monthString.includes('MMMM')) return;
+    if (monthString.includes('MMMM')) return; // MUI workaround: Dont attempt change if placeholder month present
     const newMonth = new Date(monthString);
     if (isValid(newMonth)) onChange(newMonth);
   };

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -128,7 +128,7 @@ export const MonthPicker = ({
 
   const handleMonthChange = monthString => {
     const parsedDateString = parse(monthString, 'MMMM yyyy', new Date());
-    if (isValid(parsedDateString)) onChange(parsedDateString);
+    if (isValid(parsedDateString)) onChange?.(parsedDateString);
   };
 
   return (
@@ -156,7 +156,7 @@ export const MonthPicker = ({
         },
       }}
       onAccept={date => {
-        if (isValid(date)) onChange(date);
+        if (isValid(date)) onChange?.(date);
       }}
       minDate={minDate}
       maxDate={maxDate}

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -1,6 +1,6 @@
 import Popper from '@mui/material/Popper';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { add, endOfYear, isValid, startOfToday, startOfYear } from 'date-fns';
+import { add, endOfYear, isValid, parse, startOfToday, startOfYear } from 'date-fns';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
@@ -127,9 +127,8 @@ export const MonthPicker = ({
   const [open, setOpen] = useState(false);
 
   const handleMonthChange = monthString => {
-    if (monthString.includes('MMMM')) return; // MUI workaround: Dont attempt change if placeholder month present
-    const newMonth = new Date(monthString);
-    if (isValid(newMonth)) onChange(newMonth);
+    const parsedDateString = parse(monthString, 'MMMM yyyy', new Date());
+    if (isValid(parsedDateString)) onChange(parsedDateString);
   };
 
   return (

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -126,10 +126,10 @@ export const MonthPicker = ({
 }) => {
   const [open, setOpen] = useState(false);
 
-  const handleMonthChange = dateString => {
-    // Check valid date string first
-    if (dateString.substring(0, 4) === 'MMMM') return;
-    const newMonth = new Date(dateString);
+  const handleMonthChange = monthString => {
+    // Dont parse string if placeholder month present
+    if (monthString.includes('MMMM')) return;
+    const newMonth = new Date(monthString);
     if (isValid(newMonth)) onChange(newMonth);
   };
 

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -128,6 +128,7 @@ export const MonthPicker = ({
 
   return (
     <StyledDatePicker
+      key={value.valueOf()}
       onOpen={() => setOpen(true)}
       onClose={() => setOpen(false)}
       yearsPerRow={4}

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -127,7 +127,7 @@ export const MonthPicker = ({
   const [open, setOpen] = useState(false);
 
   const handleMonthChange = monthString => {
-    // Dont parse string if placeholder month present
+    // Dont attempt change if placeholder month present
     if (monthString.includes('MMMM')) return;
     const newMonth = new Date(monthString);
     if (isValid(newMonth)) onChange(newMonth);

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -152,7 +152,9 @@ export const MonthPicker = ({
           ...props,
         },
       }}
-      onAccept={date => onChange?.(date)}
+      onAccept={date => {
+        if (isValid(date)) onChange?.(date);
+      }}
       minDate={minDate}
       maxDate={maxDate}
       value={value}

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -154,7 +154,7 @@ export const MonthPicker = ({
         },
       }}
       onAccept={date => {
-        if (isValid(date)) onChange?.(date);
+        if (isValid(date)) onChange(date);
       }}
       minDate={minDate}
       maxDate={maxDate}

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -126,6 +126,13 @@ export const MonthPicker = ({
 }) => {
   const [open, setOpen] = useState(false);
 
+  const handleMonthChange = dateString => {
+    // Check valid date string first
+    if (dateString.substring(0, 4) === 'MMMM') return;
+    const newMonth = new Date(dateString);
+    if (isValid(newMonth)) onChange(newMonth);
+  };
+
   return (
     <StyledDatePicker
       onOpen={() => setOpen(true)}
@@ -141,13 +148,11 @@ export const MonthPicker = ({
       }}
       slotProps={{
         textField: {
-          onBlur: e => {
-            const newMonth = new Date(e.target.value);
-            if (isValid(newMonth)) onChange(newMonth);
-          },
+          onBlur: e => handleMonthChange(e.target.value),
           onKeyDown: e => {
-            const newMonth = new Date(e.target.value);
-            if (e.key === 'Enter' && isValid(newMonth)) onChange(newMonth);
+            if (e.key === 'Enter') {
+              handleMonthChange(e.target.value);
+            }
           },
           ...props,
         },

--- a/packages/web/app/components/Field/MonthPicker.jsx
+++ b/packages/web/app/components/Field/MonthPicker.jsx
@@ -128,7 +128,6 @@ export const MonthPicker = ({
 
   return (
     <StyledDatePicker
-      key={value.valueOf()}
       onOpen={() => setOpen(true)}
       onClose={() => setOpen(false)}
       yearsPerRow={4}

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -93,7 +93,7 @@ const StyledMonthPicker = styled(MonthPicker)`
 
 export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedDates }) => {
   const isFirstDisplayedDate = date => isSameDay(date, displayedDates[0]);
-  const [forcedRefreshCount, setForcedRefreshCount] = useState(0);
+  const [monthPickerRefreshKey, setMonthPickerRefreshKey] = useState(Date.now());
 
   const location = useLocation();
   useEffect(() => {
@@ -107,7 +107,7 @@ export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedD
   const goToThisWeek = () => {
     if (isThisMonth(monthOf)) {
       scrollToThisWeek();
-      setForcedRefreshCount(prev => prev + 1);
+      setMonthPickerRefreshKey(Date.now()); // We need to trigger a refresh of picker state here to repopulate date
     } else {
       setMonthOf(startOfToday());
       // In this case, useEffect in LocationBookings context handles auto-scroll
@@ -117,7 +117,7 @@ export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedD
   return (
     <CarouselGrid.HeaderRow>
       <StyledFirstHeaderCell>
-        <StyledMonthPicker key={forcedRefreshCount} value={monthOf} onChange={setMonthOf} />
+        <StyledMonthPicker key={monthPickerRefreshKey} value={monthOf} onChange={setMonthOf} />
         <GoToThisWeekButton onClick={goToThisWeek}>This week</GoToThisWeekButton>
       </StyledFirstHeaderCell>
       {displayedDates.map(d => {

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useLocation } from 'react-router-dom';
 import { formatISO, isSameDay, isSameMonth, isThisMonth, parseISO, startOfToday } from 'date-fns';
@@ -93,6 +93,7 @@ const StyledMonthPicker = styled(MonthPicker)`
 
 export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedDates }) => {
   const isFirstDisplayedDate = date => isSameDay(date, displayedDates[0]);
+  const [forcedRefreshCount, setForcedRefreshCount] = useState(0);
 
   const location = useLocation();
   useEffect(() => {
@@ -106,6 +107,7 @@ export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedD
   const goToThisWeek = () => {
     if (isThisMonth(monthOf)) {
       scrollToThisWeek();
+      setForcedRefreshCount(prev => prev + 1);
     } else {
       setMonthOf(startOfToday());
       // In this case, useEffect in LocationBookings context handles auto-scroll
@@ -115,7 +117,7 @@ export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedD
   return (
     <CarouselGrid.HeaderRow>
       <StyledFirstHeaderCell>
-        <StyledMonthPicker value={monthOf} onChange={setMonthOf} />
+        <StyledMonthPicker key={forcedRefreshCount} value={monthOf} onChange={setMonthOf} />
         <GoToThisWeekButton onClick={goToThisWeek}>This week</GoToThisWeekButton>
       </StyledFirstHeaderCell>
       {displayedDates.map(d => {

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -171,7 +171,7 @@ export const DateSelector = ({ value, onChange }) => {
     setViewedDays(getMonthInterval(day));
   };
 
-  const handleChangeToday = () => handleChange(startOfToday());
+  const handleChangeToday = () => handleChange(new Date());
 
   const handleMonthYearChange = newDate => {
     if (isThisMonth(newDate)) {
@@ -197,7 +197,11 @@ export const DateSelector = ({ value, onChange }) => {
 
   return (
     <Wrapper onKeyDown={handleOnKeyDown}>
-      <StyledMonthPicker value={viewedDays[0]} onChange={handleMonthYearChange} />
+      <StyledMonthPicker
+        key={value.valueOf()}
+        value={viewedDays[0]}
+        onChange={handleMonthYearChange}
+      />
       <TodayButton onClick={handleChangeToday}>Today</TodayButton>
       <StepperWrapper>
         <StepperButton onClick={handleDecrement}>

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -16,7 +16,6 @@ import {
   isToday,
   isWeekend,
   startOfMonth,
-  startOfToday,
   subDays,
   subMonths,
 } from 'date-fns';

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -197,7 +197,11 @@ export const DateSelector = ({ value, onChange }) => {
 
   return (
     <Wrapper onKeyDown={handleOnKeyDown}>
-      <StyledMonthPicker value={viewedDays[0]} onChange={handleMonthYearChange} />
+      <StyledMonthPicker
+        key={value.valueOf()}
+        value={viewedDays[0]}
+        onChange={handleMonthYearChange}
+      />
       <TodayButton onClick={handleChangeToday}>Today</TodayButton>
       <StepperWrapper>
         <StepperButton onClick={handleDecrement}>

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -197,11 +197,7 @@ export const DateSelector = ({ value, onChange }) => {
 
   return (
     <Wrapper onKeyDown={handleOnKeyDown}>
-      <StyledMonthPicker
-        key={value.valueOf()}
-        value={viewedDays[0]}
-        onChange={handleMonthYearChange}
-      />
+      <StyledMonthPicker value={viewedDays[0]} onChange={handleMonthYearChange} />
       <TodayButton onClick={handleChangeToday}>Today</TodayButton>
       <StepperWrapper>
         <StepperButton onClick={handleDecrement}>

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { pick } from 'lodash';
-import { startOfDay } from 'date-fns';
+import { isValid, startOfDay } from 'date-fns';
 import styled from 'styled-components';
 import Box from '@mui/material/Box';
 import AddIcon from '@mui/icons-material/Add';
@@ -104,6 +104,7 @@ export const OutpatientAppointmentsView = () => {
   }, [location.search]);
 
   const handleChangeDate = event => {
+    if (!isValid(event.target.value)) return;
     setSelectedDate(event.target.value);
   };
 

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { pick } from 'lodash';
-import { isValid, startOfDay } from 'date-fns';
+import { startOfDay } from 'date-fns';
 import styled from 'styled-components';
 import Box from '@mui/material/Box';
 import AddIcon from '@mui/icons-material/Add';

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -104,7 +104,6 @@ export const OutpatientAppointmentsView = () => {
   }, [location.search]);
 
   const handleChangeDate = event => {
-    if (!isValid(event.target.value)) return;
     setSelectedDate(event.target.value);
   };
 


### PR DESCRIPTION
### Changes

This pr does two things
- Prevent parsing of dateString in format `MMMM 2024` from being parsed to `Jan 1st 2024`. Instead just dont trigger onchange and show built in error state of datepicker
- Re-render the date selector whenever the selected date changes. This allows pressing the "Today" or "This Week" button to repopulate the field and also repopulates when navigating through the same month

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
