### PR TITLE
feat(pdf): EPI-1059: Form printing bug when result includes ≤ or ≥

### DIFF
--- a/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/SurveyResponsesPrintout.jsx
@@ -59,6 +59,9 @@ const pageStyles = StyleSheet.create({
     border: '0.5px solid black',
     gap: 5,
   },
+  robotoFont: {
+    fontFamily: "Roboto"
+  },
 });
 
 const SectionSpacing = ({ height }) => <View style={{ paddingBottom: height ?? '10px' }} />;
@@ -66,7 +69,7 @@ const SectionSpacing = ({ height }) => <View style={{ paddingBottom: height ?? '
 const ResultBox = ({ resultText, resultName }) => (
   <View style={pageStyles.resultBox}>
     <Text>{resultName}</Text>
-    <Text style={[pageStyles.itemText, pageStyles.boldText]}>{resultText}</Text>
+    <Text style={[pageStyles.itemText, pageStyles.robotoFont]}>{resultText}</Text>
   </View>
 );
 

--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -31,6 +31,12 @@ Font.register({
   src: path.join(baseDir, 'Moul-Regular.ttf'),
 });
 
+// title font
+Font.register({
+  family: 'Roboto',
+  src: 'https://cdnjs.cloudflare.com/ajax/libs/ink/3.1.10/fonts/Roboto/roboto-bold-webfont.ttf',
+});
+
 const boldFont = ['Helvetica-BoldOblique', 'Helvetica-Bold'];
 
 const LanguageContext = createContext({});


### PR DESCRIPTION
### Changes

- Add a new font family for pdf to make it be able to show special characters

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
