### PR TITLE
fix(desktop): remove config for notitications

### DIFF
--- a/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
+++ b/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
@@ -64,6 +64,8 @@ describe('Lab test publisher', () => {
     const labTest = await models.LabTest.create({
       labRequestId: labRequest.id,
       labTestTypeId: testType,
+      encounterId: encounter.id,
+      requestedById: examiner.id,
     });
     return { encounter, labRequest, labTest };
   };

--- a/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
+++ b/packages/central-server/__tests__/tasks/automaticLabTestPublisher.test.js
@@ -64,8 +64,6 @@ describe('Lab test publisher', () => {
     const labTest = await models.LabTest.create({
       labRequestId: labRequest.id,
       labTestTypeId: testType,
-      encounterId: encounter.id,
-      requestedById: examiner.id,
     });
     return { encounter, labRequest, labTest };
   };

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -137,8 +137,4 @@
     "upcomingTasksTimeFrame": 8, // hours,
     "upcomingTasksShouldBeGeneratedTimeFrame": 72, // hours
   },
-  "notification": {
-    "enabled": true,
-    "recentNotificationsTimeFrame": 48, // hours
-  },
 }

--- a/packages/shared/src/models/Notification.js
+++ b/packages/shared/src/models/Notification.js
@@ -4,7 +4,6 @@ import { Model } from './Model';
 import { dateTimeType } from './dateTimeTypes';
 import { getCurrentDateTimeString } from '../utils/dateTime';
 import { log } from '../services/logging';
-import config from 'config';
 import { buildPatientSyncFilterViaPatientId } from './buildPatientSyncFilterViaPatientId';
 import { buildPatientLinkedLookupFilter } from './buildPatientLinkedLookupFilter';
 
@@ -79,8 +78,6 @@ export class Notification extends Model {
 
   static async pushNotification(type, metadata) {
     try {
-      if (!config.notification?.enabled) return;
-
       const { models } = this.sequelize;
 
       let patientId;

--- a/packages/shared/src/models/Notification.js
+++ b/packages/shared/src/models/Notification.js
@@ -99,6 +99,10 @@ export class Notification extends Model {
           return;
       }
 
+      if (!patientId || !userId) {
+        return;
+      }
+
       await this.create({
         type,
         metadata,


### PR DESCRIPTION
### Changes

- We should remove this config as it isn't necessary. We can't disable the notifications for a specific facility server cuz the notifications are generated on both facility and central server

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
