### PR TITLE
fix(appointments): Adjust appointment sync behaviour for location bookings

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -206,7 +206,7 @@ appointments.get(
 
     const facilityIdField = isStringOrArray(queries.locationGroupId)
       ? '$locationGroup.facility_id$'
-      : '$location.facility_id$';
+      : '$location.locationGroup.facility_id$';
     const facilityIdQuery = facilityId ? { [facilityIdField]: facilityId } : null;
 
     const filters = Object.entries(queries).reduce((_filters, [queryField, queryValue]) => {

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -206,7 +206,7 @@ appointments.get(
 
     const facilityIdField = isStringOrArray(queries.locationGroupId)
       ? '$locationGroup.facility_id$'
-      : '$location.locationGroup.facility_id$';
+      : '$location.facility_id$';
     const facilityIdQuery = facilityId ? { [facilityIdField]: facilityId } : null;
 
     const filters = Object.entries(queries).reduce((_filters, [queryField, queryValue]) => {


### PR DESCRIPTION
### Changes
Needed to also check the location_id facility is part of location bookings to sync

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
