### PR TITLE
fix(ui): refresh appointment booking drawer when expected

### DIFF
--- a/packages/web/app/components/Drawer.jsx
+++ b/packages/web/app/components/Drawer.jsx
@@ -67,9 +67,6 @@ export const Drawer = ({
   orientation = 'horizontal',
   ...props
 }) => {
-  const drawerBodyRef = useRef(null);
-  useEffect(() => drawerBodyRef.current.scrollTo(0, 0), [open]);
-
   return (
     <StyledCollapse in={open} orientation={orientation} {...props}>
       <Wrapper>
@@ -79,7 +76,7 @@ export const Drawer = ({
             <CloseDrawerIcon />
           </IconButton>
         </Header>
-        <DrawerBody ref={drawerBodyRef}>
+        <DrawerBody>
           {description && <Description>{description}</Description>}
           {children}
         </DrawerBody>

--- a/packages/web/app/components/Drawer.jsx
+++ b/packages/web/app/components/Drawer.jsx
@@ -1,6 +1,6 @@
 import Collapse, { collapseClasses } from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Colors } from '../constants';

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -1,5 +1,6 @@
 import { Typography } from '@material-ui/core';
 import { AddRounded } from '@material-ui/icons';
+import { parseISO } from 'date-fns';
 import { omit } from 'lodash';
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
@@ -12,10 +13,9 @@ import { LocationBookingDrawer } from '../../../components/Appointments/Location
 import { Colors } from '../../../constants';
 import { useAuth } from '../../../contexts/Auth';
 import { useLocationBookingsContext } from '../../../contexts/LocationBookings';
-import { LocationBookingsFilter } from './LocationBookingsFilter';
 import { LocationBookingsCalendar } from './LocationBookingsCalendar';
+import { LocationBookingsFilter } from './LocationBookingsFilter';
 import { appointmentToFormValues } from './utils';
-import { parseISO } from 'date-fns';
 
 export const LOCATION_BOOKINGS_CALENDAR_ID = 'location-bookings-calendar';
 
@@ -148,6 +148,10 @@ export const LocationBookingsView = () => {
       {selectedAppointment && (
         <LocationBookingDrawer
           initialValues={appointmentToFormValues(selectedAppointment)}
+          key={
+            selectedAppointment.id ??
+            `${selectedAppointment.locationId}_${selectedAppointment.startTime}`
+          }
           open={isDrawerOpen}
           onClose={closeBookingForm}
         />

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientAppointmentsView.jsx
@@ -140,6 +140,7 @@ export const OutpatientAppointmentsView = () => {
             />
             <OutpatientAppointmentDrawer
               initialValues={selectedAppointment}
+              key={selectedAppointment.id}
               onClose={handleCloseDrawer}
               open={drawerOpen}
             />


### PR DESCRIPTION
### Changes

Previously we listened for whether the drawer was `open` and used a `useEffect` to scroll the drawer back up to the top. This PR actually tells React when we need a fresh instance of the drawer.

Still a bit hacky, but less hacky and has better “coverage”. (Previous version had a few blind spots)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
