### PR TITLE
ci(k8s): add facilityNames option

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,7 +96,7 @@ jobs:
               ...${{ steps.control.outputs.result }},
               ref: process.env.REF,
             });
-            console.log(allDeploys);
+            console.log(JSON.stringify(allDeploys, null, 2));
 
             const matrix = ({ name, control, options }) => ({ name, control, options: JSON.stringify(options) });
             const filter = ({ options: { pause, imagesonly } }) => !pause && !imagesonly;

--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -198,7 +198,7 @@ export function configMap(deployName, imageTag, options) {
       configTemplate: options.config,
       dbStorage: `${options.dbstorage}Gi`,
       facilities: options.facilities,
-      facilityNames: options.facilitynames,
+      facilityNames: options.facilityname && JSON.stringify(options.facilitynames),
       timezone: options.timezone,
       ipAllowList: options.ip,
       nodeEnv: options.env,

--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -198,7 +198,7 @@ export function configMap(deployName, imageTag, options) {
       configTemplate: options.config,
       dbStorage: `${options.dbstorage}Gi`,
       facilities: options.facilities,
-      facilityNames: options.facilityNames,
+      facilityNames: options.facilitynames,
       timezone: options.timezone,
       ipAllowList: options.ip,
       nodeEnv: options.env,

--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -198,7 +198,7 @@ export function configMap(deployName, imageTag, options) {
       configTemplate: options.config,
       dbStorage: `${options.dbstorage}Gi`,
       facilities: options.facilities,
-      facilityNames: options.facilityname && JSON.stringify(options.facilitynames),
+      facilityNames: options.facilitynames && JSON.stringify(options.facilitynames),
       timezone: options.timezone,
       ipAllowList: options.ip,
       nodeEnv: options.env,

--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -141,7 +141,7 @@ const OPTIONS = [
      * Specifies the subdomain names of the Facility servers.
      * Comma-separated.
      */
-    key: 'facilityNames',
+    key: 'facilitynames',
     defaultValue: null,
     parse: input => input.split(','),
   },

--- a/packages/scripts/src/gha-cd-helpers.mjs
+++ b/packages/scripts/src/gha-cd-helpers.mjs
@@ -136,6 +136,15 @@ const OPTIONS = [
     key: 'serviceaccountarn',
     defaultValue: 'arn:aws:iam::143295493206:role/ips-bucket-role-de7b385',
   },
+  {
+    /*
+     * Specifies the subdomain names of the Facility servers.
+     * Comma-separated.
+     */
+    key: 'facilityNames',
+    defaultValue: null,
+    parse: input => input.split(','),
+  },
 ];
 
 function stripPercent(str) {
@@ -189,6 +198,7 @@ export function configMap(deployName, imageTag, options) {
       configTemplate: options.config,
       dbStorage: `${options.dbstorage}Gi`,
       facilities: options.facilities,
+      facilityNames: options.facilityNames,
       timezone: options.timezone,
       ipAllowList: options.ip,
       nodeEnv: options.env,
@@ -208,7 +218,7 @@ export function configMap(deployName, imageTag, options) {
       facilityDbReplicas: options.facilitydbs,
       facilityTasksReplicas: options.facilitytasks,
       facilityWebReplicas: options.facilitydbs,
-    }).map(([key, value]) => [`tamanu-on-k8s:${key}`, { value, secret: false }]),
+    }).map(([key, value]) => [`tamanu-on-k8s:${key}`, { value: value ?? null, secret: false }]),
   );
 }
 


### PR DESCRIPTION
### Changes

Exposes this new option to PR auto-deploy configs.

- ✅ update the [auto-deploy config reference](https://beyond-essential.slab.com/posts/tamanu-auto-deploys-kubernetes-kkovoquc#hld7u-names-of-facilities)