### PR TITLE
feat(outpatientAppointments): Email from popout

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -51,6 +51,45 @@ const timeOverlapWhereCondition = (startTime, endTime) => {
   };
 };
 
+const sendAppointmentReminder = async (appointmentId, email, facilityId, models, settings) => {
+  const { Appointment, Facility, PatientCommunication } = models;
+
+  // Fetch appointment relations
+  const [appointment, facility] = await Promise.all([
+    Appointment.findByPk(appointmentId, {
+      include: ['patient', 'clinician', 'locationGroup'],
+    }),
+    Facility.findByPk(facilityId),
+  ]);
+
+  const { patient, locationGroup, clinician } = appointment;
+
+  const appointmentConfirmationTemplate = await settings[facilityId].get(
+    'templates.appointmentConfirmation',
+  );
+
+  const start = new Date(appointment.startTime);
+  const content = replaceInTemplate(appointmentConfirmationTemplate.body, {
+    firstName: patient.firstName,
+    lastName: patient.lastName,
+    facilityName: facility.name,
+    startDate: format(start, 'dd-MM-yyyy'),
+    startTime: format(start, 'hh:mm a'),
+    locationName: locationGroup.name,
+    clinicianName: clinician?.displayName ? `\nClinician: ${clinician.displayName}` : '',
+  });
+
+  await PatientCommunication.create({
+    type: PATIENT_COMMUNICATION_TYPES.APPOINTMENT_CONFIRMATION,
+    channel: PATIENT_COMMUNICATION_CHANNELS.EMAIL,
+    status: COMMUNICATION_STATUSES.QUEUED,
+    destination: email,
+    subject: appointmentConfirmationTemplate.subject,
+    content,
+    patientId: patient.id,
+  });
+};
+
 appointments.post(
   '/$',
   asyncHandler(async (req, res) => {
@@ -61,48 +100,29 @@ appointments.post(
       body: { facilityId, ...body },
       settings,
     } = req;
-    const { Appointment, Facility, PatientCommunication } = models;
+    const { Appointment } = models;
 
     await db.transaction(async () => {
       const result = await Appointment.create(body);
-      // Fetch relations for the new appointment
-      const [appointment, facility] = await Promise.all([
-        Appointment.findByPk(result.id, {
-          include: ['patient', 'clinician', 'locationGroup'],
-        }),
-        Facility.findByPk(facilityId),
-      ]);
-
-      const { patient, locationGroup, clinician } = appointment;
-
       if (body.email) {
-        const appointmentConfirmationTemplate = await settings[facilityId].get(
-          'templates.appointmentConfirmation',
-        );
-
-        const start = new Date(body.startTime);
-        const content = replaceInTemplate(appointmentConfirmationTemplate.body, {
-          firstName: patient.firstName,
-          lastName: patient.lastName,
-          facilityName: facility.name,
-          startDate: format(start, 'dd-MM-yyyy'),
-          startTime: format(start, 'hh:mm a'),
-          locationName: locationGroup.name,
-          clinicianName: clinician?.displayName ? `\nClinician: ${clinician.displayName}` : '',
-        });
-
-        await PatientCommunication.create({
-          type: PATIENT_COMMUNICATION_TYPES.APPOINTMENT_CONFIRMATION,
-          channel: PATIENT_COMMUNICATION_CHANNELS.EMAIL,
-          status: COMMUNICATION_STATUSES.QUEUED,
-          destination: body.email,
-          subject: appointmentConfirmationTemplate.subject,
-          content,
-          patientId: body.patientId,
-        });
+        await sendAppointmentReminder(result.id, body.email, facilityId, models, settings);
       }
       res.status(201).send(result);
     });
+  }),
+);
+
+appointments.post(
+  '/emailReminder',
+  asyncHandler(async (req, res) => {
+    req.checkPermission('read', 'Appointment');
+    const {
+      models,
+      body: { facilityId, id, email },
+      settings,
+    } = req;
+    await sendAppointmentReminder(id, email, facilityId, models, settings);
+    res.status(200).send();
   }),
 );
 

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -51,7 +51,7 @@ const timeOverlapWhereCondition = (startTime, endTime) => {
   };
 };
 
-const sendAppointmentReminder = async (appointmentId, email, facilityId, models, settings) => {
+const sendAppointmentReminder = async ({ appointmentId, email, facilityId, models, settings }) => {
   const { Appointment, Facility, PatientCommunication } = models;
 
   // Fetch appointment relations
@@ -105,7 +105,13 @@ appointments.post(
     await db.transaction(async () => {
       const result = await Appointment.create(body);
       if (body.email) {
-        await sendAppointmentReminder(result.id, body.email, facilityId, models, settings);
+        await sendAppointmentReminder({
+          appointmentId: result.id,
+          email: body.email,
+          facilityId,
+          models,
+          settings,
+        });
       }
       res.status(201).send(result);
     });
@@ -121,7 +127,7 @@ appointments.post(
       body: { facilityId, appointmentId, email },
       settings,
     } = req;
-    await sendAppointmentReminder(appointmentId, email, facilityId, models, settings);
+    await sendAppointmentReminder({ appointmentId, email, facilityId, models, settings });
     res.status(200).send();
   }),
 );

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -118,10 +118,10 @@ appointments.post(
     req.checkPermission('read', 'Appointment');
     const {
       models,
-      body: { facilityId, id, email },
+      body: { facilityId, appointmentId, email },
       settings,
     } = req;
-    await sendAppointmentReminder(id, email, facilityId, models, settings);
+    await sendAppointmentReminder(appointmentId, email, facilityId, models, settings);
     res.status(200).send();
   }),
 );

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -79,7 +79,7 @@ const sendAppointmentReminder = async ({ appointmentId, email, facilityId, model
     clinicianName: clinician?.displayName ? `\nClinician: ${clinician.displayName}` : '',
   });
 
-  await PatientCommunication.create({
+  return await PatientCommunication.create({
     type: PATIENT_COMMUNICATION_TYPES.APPOINTMENT_CONFIRMATION,
     channel: PATIENT_COMMUNICATION_CHANNELS.EMAIL,
     status: COMMUNICATION_STATUSES.QUEUED,
@@ -127,8 +127,14 @@ appointments.post(
       body: { facilityId, appointmentId, email },
       settings,
     } = req;
-    await sendAppointmentReminder({ appointmentId, email, facilityId, models, settings });
-    res.status(200).send();
+    const response = await sendAppointmentReminder({
+      appointmentId,
+      email,
+      facilityId,
+      models,
+      settings,
+    });
+    res.status(200).send(response);
   }),
 );
 

--- a/packages/web/app/api/mutations/index.js
+++ b/packages/web/app/api/mutations/index.js
@@ -1,4 +1,5 @@
 export { useAppointmentMutation } from './useAppointmentMutation';
+export { useSendAppointmentEmail } from './useSendAppointmentEmail';
 export { useImagingRequestMutation } from './useImagingRequestMutation';
 export { useLocationBookingMutation } from './useLocationBookingMutation';
 export * from './usePatientMove';

--- a/packages/web/app/api/mutations/useSendAppointmentEmail.js
+++ b/packages/web/app/api/mutations/useSendAppointmentEmail.js
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useApi } from '../useApi';
+import { useAuth } from '../../contexts/Auth';
+
+export const useSendAppointmentEmail = (appointmentId, useMutationOptions) => {
+  const { facilityId } = useAuth();
+  const api = useApi();
+  return useMutation(
+    email => api.post('appointments/emailReminder', { appointmentId, email, facilityId }),
+    useMutationOptions,
+  );
+};

--- a/packages/web/app/forms/EmailAddressConfirmationForm.jsx
+++ b/packages/web/app/forms/EmailAddressConfirmationForm.jsx
@@ -8,51 +8,49 @@ import { Field, Form, TextField } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 
-export const EmailAddressConfirmationForm = React.memo(
-  ({ onCancel, onSubmit, initialEmailOverride }) => {
-    const { getTranslation } = useTranslation();
-    const patient = useSelector(state => state.patient);
+export const EmailAddressConfirmationForm = React.memo(({ onCancel, onSubmit, emailOverride }) => {
+  const { getTranslation } = useTranslation();
+  const patient = useSelector(state => state.patient);
 
-    return (
-      <Form
-        onSubmit={onSubmit}
-        initialValues={{ email: initialEmailOverride || patient.email }}
-        enableReinitialize
-        validationSchema={Yup.object().shape({
-          email: Yup.string()
-            .email(getTranslation('validation.rule.validEmail', 'Must be a valid email address'))
-            .nullable()
-            .required(),
-          confirmEmail: Yup.string()
-            .oneOf(
-              [Yup.ref('email'), null],
-              getTranslation('validation.rule.emailsMatch', 'Emails must match'),
-            )
-            .required(),
-        })}
-        render={({ submitForm }) => (
-          <FormGrid columns={1}>
-            <Field
-              name="email"
-              label={<TranslatedText stringId="patient.email.label" fallback="Patient email" />}
-              component={TextField}
-              required
-            />
-            <Field
-              name="confirmEmail"
-              label={
-                <TranslatedText
-                  stringId="patient.confirmEmail.label"
-                  fallback="Confirm patient email"
-                />
-              }
-              component={TextField}
-              required
-            />
-            <FormSubmitCancelRow onConfirm={submitForm} onCancel={onCancel} />
-          </FormGrid>
-        )}
-      />
-    );
-  },
-);
+  return (
+    <Form
+      onSubmit={onSubmit}
+      initialValues={{ email: emailOverride || patient.email }}
+      enableReinitialize
+      validationSchema={Yup.object().shape({
+        email: Yup.string()
+          .email(getTranslation('validation.rule.validEmail', 'Must be a valid email address'))
+          .nullable()
+          .required(),
+        confirmEmail: Yup.string()
+          .oneOf(
+            [Yup.ref('email'), null],
+            getTranslation('validation.rule.emailsMatch', 'Emails must match'),
+          )
+          .required(),
+      })}
+      render={({ submitForm }) => (
+        <FormGrid columns={1}>
+          <Field
+            name="email"
+            label={<TranslatedText stringId="patient.email.label" fallback="Patient email" />}
+            component={TextField}
+            required
+          />
+          <Field
+            name="confirmEmail"
+            label={
+              <TranslatedText
+                stringId="patient.confirmEmail.label"
+                fallback="Confirm patient email"
+              />
+            }
+            component={TextField}
+            required
+          />
+          <FormSubmitCancelRow onConfirm={submitForm} onCancel={onCancel} />
+        </FormGrid>
+      )}
+    />
+  );
+});

--- a/packages/web/app/forms/EmailAddressConfirmationForm.jsx
+++ b/packages/web/app/forms/EmailAddressConfirmationForm.jsx
@@ -8,48 +8,51 @@ import { Field, Form, TextField } from '../components/Field';
 import { FormGrid } from '../components/FormGrid';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 
-export const EmailAddressConfirmationForm = React.memo(({ onCancel, onSubmit }) => {
-  const { getTranslation } = useTranslation();
-  const patient = useSelector(state => state.patient);
+export const EmailAddressConfirmationForm = React.memo(
+  ({ onCancel, onSubmit, initialEmailOverride }) => {
+    const { getTranslation } = useTranslation();
+    const patient = useSelector(state => state.patient);
 
-  return (
-    <Form
-      onSubmit={onSubmit}
-      initialValues={{ email: patient.email }}
-      validationSchema={Yup.object().shape({
-        email: Yup.string()
-          .email(getTranslation('validation.rule.validEmail', 'Must be a valid email address'))
-          .nullable()
-          .required(),
-        confirmEmail: Yup.string()
-          .oneOf(
-            [Yup.ref('email'), null],
-            getTranslation('validation.rule.emailsMatch', 'Emails must match'),
-          )
-          .required(),
-      })}
-      render={({ submitForm }) => (
-        <FormGrid columns={1}>
-          <Field
-            name="email"
-            label={<TranslatedText stringId="patient.email.label" fallback="Patient email" />}
-            component={TextField}
-            required
-          />
-          <Field
-            name="confirmEmail"
-            label={
-              <TranslatedText
-                stringId="patient.confirmEmail.label"
-                fallback="Confirm patient email"
-              />
-            }
-            component={TextField}
-            required
-          />
-          <FormSubmitCancelRow onConfirm={submitForm} onCancel={onCancel} />
-        </FormGrid>
-      )}
-    />
-  );
-});
+    return (
+      <Form
+        onSubmit={onSubmit}
+        initialValues={{ email: initialEmailOverride || patient.email }}
+        enableReinitialize
+        validationSchema={Yup.object().shape({
+          email: Yup.string()
+            .email(getTranslation('validation.rule.validEmail', 'Must be a valid email address'))
+            .nullable()
+            .required(),
+          confirmEmail: Yup.string()
+            .oneOf(
+              [Yup.ref('email'), null],
+              getTranslation('validation.rule.emailsMatch', 'Emails must match'),
+            )
+            .required(),
+        })}
+        render={({ submitForm }) => (
+          <FormGrid columns={1}>
+            <Field
+              name="email"
+              label={<TranslatedText stringId="patient.email.label" fallback="Patient email" />}
+              component={TextField}
+              required
+            />
+            <Field
+              name="confirmEmail"
+              label={
+                <TranslatedText
+                  stringId="patient.confirmEmail.label"
+                  fallback="Confirm patient email"
+                />
+              }
+              component={TextField}
+              required
+            />
+            <FormSubmitCancelRow onConfirm={submitForm} onCancel={onCancel} />
+          </FormGrid>
+        )}
+      />
+    );
+  },
+);

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -223,7 +223,6 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
                           fallback="Email appointment"
                         />
                       ),
-                      // TODO: prepopulate with relevant email
                       action: () =>
                         setEmailModalState({ appointmentId: a.id, email: a.patient?.email }),
                     },

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -245,7 +245,7 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
             setEmailModalState(null);
           }}
           onCancel={() => setEmailModalState(null)}
-          initialEmailOverride={emailModalState?.email}
+          emailOverride={emailModalState?.email}
         />
       </FormModal>
     </Box>

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -151,11 +151,11 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
     selectedDate,
   });
 
-  const [emailModalId, setEmailModalId] = useState(null);
+  const [emailModalState, setEmailModalState] = useState(null);
 
   const sendAppointmentEmail = async email => {
     await api.post(`appointments/emailReminder`, {
-      appointmentId: emailModalId,
+      appointmentId: emailModalState.id,
       email,
       facilityId,
     });
@@ -224,7 +224,8 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
                         />
                       ),
                       // TODO: prepopulate with relevant email
-                      action: () => setEmailModalId(a.id),
+                      action: () =>
+                        setEmailModalState({ appointmentId: a.id, email: a.patient?.email }),
                     },
                   ]}
                 />
@@ -235,15 +236,16 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
       })}
       <FormModal
         title={<TranslatedText stringId="patient.email.title" fallback="Enter email address" />}
-        open={!!emailModalId}
-        onClose={() => setEmailModalId(null)}
+        open={!!emailModalState}
+        onClose={() => setEmailModalState(null)}
       >
         <EmailAddressConfirmationForm
           onSubmit={async ({ email }) => {
             sendAppointmentEmail(email);
-            setEmailModalId(null);
+            setEmailModalState(null);
           }}
-          onCancel={() => setEmailModalId(null)}
+          onCancel={() => setEmailModalState(null)}
+          initialEmailOverride={emailModalState?.email}
         />
       </FormModal>
     </Box>

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -11,8 +11,8 @@ import { ThemedTooltip } from '../../../components/Tooltip';
 import { Colors } from '../../../constants';
 import { useOutpatientAppointmentsCalendarData } from './useOutpatientAppointmentsCalendarData';
 import { EmailAddressConfirmationForm } from '../../../forms/EmailAddressConfirmationForm';
-import { useApi } from '../../../api';
-import { useAuth } from '../../../contexts/Auth';
+import { useSendAppointmentEmail } from '../../../api/mutations';
+import { toast } from 'react-toastify';
 
 export const ColumnWrapper = styled(Box)`
   --column-width: 14rem;
@@ -140,8 +140,6 @@ export const HeadCell = ({ title, count }) => (
 );
 
 export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer, onCancel }) => {
-  const api = useApi();
-  const { facilityId } = useAuth();
   const {
     data: { headData = [], cellData, titleKey },
     isLoading,
@@ -152,13 +150,13 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
   });
 
   const [emailModalState, setEmailModalState] = useState(null);
-
-  const sendAppointmentEmail = async email =>
-    api.post(`appointments/emailReminder`, {
-      appointmentId: emailModalState.id,
-      email,
-      facilityId,
-    });
+  const { mutateAsync: sendAppointmentEmail } = useSendAppointmentEmail(
+    emailModalState?.appointmentId,
+    {
+      onSuccess: () => toast.success('Email sent succesfully'),
+      onError: () => toast.error('Error sending email'),
+    },
+  );
 
   if (isLoading) {
     return <LoadingSkeleton />;

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -153,8 +153,20 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
   const { mutateAsync: sendAppointmentEmail } = useSendAppointmentEmail(
     emailModalState?.appointmentId,
     {
-      onSuccess: () => toast.success('Email sent succesfully'),
-      onError: () => toast.error('Error sending email'),
+      onSuccess: () =>
+        toast.success(
+          <TranslatedText
+            stringId="appointments.action.emailReminder.success"
+            fallback="Email successfully sent"
+          />,
+        ),
+      onError: () =>
+        toast.error(
+          <TranslatedText
+            stringId="appointments.action.emailReminder.error"
+            fallback="Error sending email"
+          />,
+        ),
     },
   );
 

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -153,13 +153,12 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
 
   const [emailModalState, setEmailModalState] = useState(null);
 
-  const sendAppointmentEmail = async email => {
-    await api.post(`appointments/emailReminder`, {
+  const sendAppointmentEmail = async email =>
+    api.post(`appointments/emailReminder`, {
       appointmentId: emailModalState.id,
       email,
       facilityId,
     });
-  };
 
   if (isLoading) {
     return <LoadingSkeleton />;

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -240,7 +240,7 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
       >
         <EmailAddressConfirmationForm
           onSubmit={async ({ email }) => {
-            sendAppointmentEmail(email);
+            await sendAppointmentEmail(email);
             setEmailModalState(null);
           }}
           onCancel={() => setEmailModalState(null)}

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -1,15 +1,16 @@
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
 import { omit } from 'lodash';
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import { BodyText, SmallBodyText, TranslatedText } from '../../../components';
+import { BodyText, FormModal, SmallBodyText, TranslatedText } from '../../../components';
 import { APPOINTMENT_CALENDAR_CLASS } from '../../../components/Appointments/AppointmentDetailPopper';
 import { AppointmentTile } from '../../../components/Appointments/AppointmentTile';
 import { ThemedTooltip } from '../../../components/Tooltip';
 import { Colors } from '../../../constants';
 import { useOutpatientAppointmentsCalendarData } from './useOutpatientAppointmentsCalendarData';
+import { EmailAddressConfirmationForm } from '../../../forms/EmailAddressConfirmationForm';
 
 export const ColumnWrapper = styled(Box)`
   --column-width: 14rem;
@@ -146,6 +147,12 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
     selectedDate,
   });
 
+  const [isEmailModalOpen, setIsEmailModalOpen] = useState(false);
+
+  const sendAppointmentEmail = data => {
+    // apo.post(data)
+  };
+
   if (isLoading) {
     return <LoadingSkeleton />;
   }
@@ -201,6 +208,16 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
                       ),
                       action: () => onOpenDrawer(omit(a, ['id', 'startTime', 'endTime'])),
                     },
+                    {
+                      label: (
+                        <TranslatedText
+                          stringId="appointments.action.emailAppointment"
+                          fallback="Email appointment"
+                        />
+                      ),
+                      // TODO: prepopulate with relevant email
+                      action: () => setIsEmailModalOpen(true),
+                    },
                   ]}
                 />
               ))}
@@ -208,6 +225,20 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
           </ColumnWrapper>
         );
       })}
+      <FormModal
+        title={<TranslatedText stringId="patient.email.title" fallback="Enter email address" />}
+        open={isEmailModalOpen}
+        onClose={() => setIsEmailModalOpen(false)}
+      >
+        <EmailAddressConfirmationForm
+          // TODO: send request to new(?) endpoint that triggers patient communication email
+          onSubmit={async data => {
+            sendAppointmentEmail(data);
+            setIsEmailModalOpen(false);
+          }}
+          onCancel={() => setIsEmailModalOpen(false)}
+        />
+      </FormModal>
     </Box>
   );
 };


### PR DESCRIPTION
### Changes

Allow triggering of sending an email from the appointment detail popup actions menu.

This pr:
- Adds new option for "Email appointment" on the appointment popper
- Extract email logic in appointments.js to be a function
- New endpoint that calls the above function
- Slight tweak to existing email modal in order to work outside of redux patient scope


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
