### PR TITLE
fix(test): failing front-end unit test

### DIFF
--- a/packages/web/__tests__/components/Table/DownloadDataButton.test.jsx
+++ b/packages/web/__tests__/components/Table/DownloadDataButton.test.jsx
@@ -95,8 +95,9 @@ describe('DownloadDataButton', () => {
   it('when given a custom ExportButton, is rendered with a translated button label', () => {
     const stringId = chance.string();
     const translationFallback = chance.string();
+    const testId = chance.string();
     const ExportButton = props => (
-      <button {...props}>
+      <button data-testid={testId} {...props}>
         <TranslatedText stringId={stringId} fallback={translationFallback} />
       </button>
     );
@@ -110,7 +111,7 @@ describe('DownloadDataButton', () => {
       />,
     );
 
-    const button = screen.getByTestId('download-data-button');
+    const button = screen.getByTestId(testId);
     expect(getTranslationSpy).toHaveBeenCalledTimes(1);
     expect(getTranslationSpy).toHaveBeenCalledWith(
       stringId,

--- a/packages/web/__tests__/components/Table/DownloadDataButton.test.jsx
+++ b/packages/web/__tests__/components/Table/DownloadDataButton.test.jsx
@@ -27,6 +27,7 @@ import {
 } from '../../../app/views/patients/columns';
 import { renderElementWithTranslatedText } from '../../helpers';
 import { randomTestPatient } from '../../helpers/randomTestPatient';
+import { TranslatedText } from '../../../app/components';
 
 /** Stub `saveFile` to prevent `URL.createObjectURL` erroring in test environment */
 vi.mock('../../../app/utils/fileSystemAccess.js', async () => {
@@ -37,7 +38,9 @@ vi.mock('../../../app/utils/fileSystemAccess.js', async () => {
   };
 });
 
-const mockTranslations = { 'general.table.action.export': '🌐 Export 🌐' };
+const chance = new Chance();
+
+const mockTranslations = { 'general.action.download': '🌐 Download 🌐' };
 // eslint-disable-next-line no-unused-vars
 const mockGetTranslation = (stringId, fallback, _replacements, _uppercase, _lowercase) =>
   mockTranslations[stringId] ?? fallback;
@@ -80,18 +83,48 @@ describe('DownloadDataButton', () => {
     const button = screen.getByTestId('download-data-button');
     expect(getTranslationSpy).toHaveBeenCalledTimes(1);
     expect(getTranslationSpy).toHaveBeenCalledWith(
-      'general.table.action.export',
-      'Export',
+      'general.action.download',
+      'Download',
       undefined,
       undefined,
       undefined,
     );
-    expect(button.textContent).toBe('🌐 Export 🌐');
+    expect(button.textContent).toBe('🌐 Download 🌐');
+  });
+
+  it('when given a custom ExportButton, is rendered with a translated button label', () => {
+    const stringId = chance.string();
+    const translationFallback = chance.string();
+    const ExportButton = props => (
+      <button {...props}>
+        <TranslatedText stringId={stringId} fallback={translationFallback} />
+      </button>
+    );
+
+    render(
+      <DownloadDataButton
+        ExportButton={ExportButton}
+        exportName={chance.string()}
+        columns={columns}
+        data={data}
+      />,
+    );
+
+    const button = screen.getByTestId('download-data-button');
+    expect(getTranslationSpy).toHaveBeenCalledTimes(1);
+    expect(getTranslationSpy).toHaveBeenCalledWith(
+      stringId,
+      translationFallback,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(button.textContent).toBe(translationFallback);
   });
 
   it('does attempt to save a spreadsheet', async () => {
     const user = userEvent.setup();
-    const exportName = new Chance().string();
+    const exportName = chance.string();
     render(<DownloadDataButton exportName={exportName} columns={columns} data={data} />);
 
     const button = screen.getByTestId('download-data-button');

--- a/packages/web/app/components/LocationCell.jsx
+++ b/packages/web/app/components/LocationCell.jsx
@@ -40,7 +40,7 @@ export const LocationGroupCell = ({
   locationGroupId,
   plannedLocationGroupName,
   plannedLocationGroupId,
-  style,
+  ...props
 }) => {
   return (
     <LocationCell
@@ -48,8 +48,8 @@ export const LocationGroupCell = ({
       locationId={locationGroupId}
       plannedLocationName={plannedLocationGroupName}
       plannedLocationId={plannedLocationGroupId}
-      style={style}
       category="locationGroup"
+      {...props}
     />
   );
 };

--- a/packages/web/app/components/PatientHistory.jsx
+++ b/packages/web/app/components/PatientHistory.jsx
@@ -156,7 +156,7 @@ const getDate = ({ startDate, endDate, encounterType }) => {
     <DateWrapper>
       <StatusIndicator patientStatus={patientStatus} />
       <DateDisplay date={startDate} />
-      {' - '}
+      &nbsp;&ndash;{' '}
       {endDate ? (
         <DateDisplay date={endDate} />
       ) : (

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -146,11 +146,7 @@ export function DownloadDataButton({ exportName, columns, data, ExportButton }) 
   return (
     <>
       {ExportButton ? (
-        <ExportButton
-          onClick={onDownloadData}
-          data-test-class="download-data-button"
-          data-testid="download-data-button"
-        />
+        <ExportButton onClick={onDownloadData} />
       ) : (
         <GreyOutlinedButton
           onClick={onDownloadData}


### PR DESCRIPTION
### Changes

#6844 introduced a small change to the `<DownloadDataButton>` that wasn’t reflected in its unit test. This:

- updates the test to expect the new (translated) label; and
- adds a new (very similar) unit test for the new branch of code

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
