### PR TITLE
fix: release-v2.22: EPI-1063: Properly filter diagnosis by status in the invoice printout

### DIFF
--- a/packages/shared/src/utils/patientCertificates/printComponents/InvoiceEncounterDetails.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/InvoiceEncounterDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from '@react-pdf/renderer';
+import { DIAGNOSIS_CERTAINTY } from '@tamanu/constants';
 import { DataSection } from './DataSection';
 import { DataItem } from './DataItem';
 import { getLocationName } from '../../patientAccessors';
@@ -9,17 +10,25 @@ import { useLanguageContext } from '../../pdf/languageContext';
 import { formatShort } from '../../dateTime';
 import { P } from '../Typography';
 
+const ALLOWED_DIAGNOSIS_CERTAINTY = [
+  DIAGNOSIS_CERTAINTY.CONFIRMED,
+  DIAGNOSIS_CERTAINTY.EMERGENCY,
+  DIAGNOSIS_CERTAINTY.SUSPECTED,
+];
+
 export const InvoiceEncounterDetails = ({ encounter }) => {
   const { location, department, startDate, endDate, diagnoses } = encounter || {};
   const { getTranslation } = useLanguageContext();
 
-  const primaryDiagnoses = diagnoses
-    .filter(diagnosis => diagnosis.isPrimary)
-    .sort((a, b) => a.diagnosis.name.localeCompare(b.diagnosis.name));
+  const filterAndSortDiagnoses = isPrimary =>
+    diagnoses
+      .filter(diagnosis => diagnosis.isPrimary === isPrimary)
+      .filter(({ certainty }) => ALLOWED_DIAGNOSIS_CERTAINTY.includes(certainty))
+      .sort((a, b) => a.diagnosis.name.localeCompare(b.diagnosis.name));
 
-  const secondaryDiagnoses = diagnoses
-    .filter(diagnosis => !diagnosis.isPrimary)
-    .sort((a, b) => a.diagnosis.name.localeCompare(b.diagnosis.name));
+  const primaryDiagnoses = filterAndSortDiagnoses(true);
+  const secondaryDiagnoses = filterAndSortDiagnoses(false);
+
   return (
     <>
       <DataSection

--- a/packages/shared/src/utils/patientCertificates/printComponents/InvoiceEncounterDetails.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/InvoiceEncounterDetails.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from '@react-pdf/renderer';
-import { DIAGNOSIS_CERTAINTY } from '@tamanu/constants';
+import { DIAGNOSIS_CERTAINTIES_TO_HIDE } from '@tamanu/constants';
 import { DataSection } from './DataSection';
 import { DataItem } from './DataItem';
 import { getLocationName } from '../../patientAccessors';
@@ -10,12 +10,6 @@ import { useLanguageContext } from '../../pdf/languageContext';
 import { formatShort } from '../../dateTime';
 import { P } from '../Typography';
 
-const ALLOWED_DIAGNOSIS_CERTAINTY = [
-  DIAGNOSIS_CERTAINTY.CONFIRMED,
-  DIAGNOSIS_CERTAINTY.EMERGENCY,
-  DIAGNOSIS_CERTAINTY.SUSPECTED,
-];
-
 export const InvoiceEncounterDetails = ({ encounter }) => {
   const { location, department, startDate, endDate, diagnoses } = encounter || {};
   const { getTranslation } = useLanguageContext();
@@ -23,7 +17,7 @@ export const InvoiceEncounterDetails = ({ encounter }) => {
   const filterAndSortDiagnoses = isPrimary =>
     diagnoses
       .filter(diagnosis => diagnosis.isPrimary === isPrimary)
-      .filter(({ certainty }) => ALLOWED_DIAGNOSIS_CERTAINTY.includes(certainty))
+      .filter(({ certainty }) => !DIAGNOSIS_CERTAINTIES_TO_HIDE.includes(certainty))
       .sort((a, b) => a.diagnosis.name.localeCompare(b.diagnosis.name));
 
   const primaryDiagnoses = filterAndSortDiagnoses(true);


### PR DESCRIPTION
### Changes

Properly filter diagnosis by status in the invoice printout

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
