### PR TITLE
feat(desktopCharting): SAV-698: Disable graphs for complex charts

### DIFF
--- a/packages/web/app/utils/getVisualisationConfig.js
+++ b/packages/web/app/utils/getVisualisationConfig.js
@@ -8,7 +8,7 @@ export const getVisualisationConfig = (patientData, surveyData, restOfQuery) => 
 
   // Complex charts should not have graphs enabled yet, this will be done later
   if (surveyData.surveyType === SURVEY_TYPES.COMPLEX_CHART) {
-    return { data: { visualisationConfigs, allGraphedChartKeys: [] }, ...restOfQuery };
+    return { ...restOfQuery, data: { visualisationConfigs, allGraphedChartKeys: [] } };
   }
 
   if (isSuccess) {
@@ -51,5 +51,5 @@ export const getVisualisationConfig = (patientData, surveyData, restOfQuery) => 
     .filter(({ hasVitalChart, key }) => hasVitalChart && key !== VITALS_DATA_ELEMENT_IDS.dbp) // Only show one blood pressure chart on multi vital charts
     .map(({ key }) => key);
 
-  return { data: { visualisationConfigs, allGraphedChartKeys }, ...restOfQuery };
+  return { ...restOfQuery, data: { visualisationConfigs, allGraphedChartKeys } };
 };

--- a/packages/web/app/utils/getVisualisationConfig.js
+++ b/packages/web/app/utils/getVisualisationConfig.js
@@ -1,10 +1,15 @@
-import { VITALS_DATA_ELEMENT_IDS } from '@tamanu/constants/surveys';
+import { SURVEY_TYPES, VITALS_DATA_ELEMENT_IDS } from '@tamanu/constants/surveys';
 import { BLOOD_PRESSURE, bloodPressureChartKeys, LINE } from '../components/Charts/constants';
 import { getConfigObject, getGraphRangeByAge, getNormalRangeByAge } from './survey';
 
 export const getVisualisationConfig = (patientData, surveyData, restOfQuery) => {
   const { isSuccess } = restOfQuery;
   let visualisationConfigs = [];
+
+  // Complex charts should not have graphs enabled yet, this will be done later
+  if (surveyData.surveyType === SURVEY_TYPES.COMPLEX_CHART) {
+    return { data: { visualisationConfigs, allGraphedChartKeys: [] }, ...restOfQuery };
+  }
 
   if (isSuccess) {
     visualisationConfigs = surveyData.components.map(


### PR DESCRIPTION
### Changes

Just a small thing I missed. There is work planned ahead to support complex charts, so instead of blocking it everywhere, I decided to just return an empty state for visualisation configs, allowing us to remove it in the future pretty easily