### PR TITLE
refactor(locationBookings): use string for date prop

### DIFF
--- a/packages/shared/src/utils/dateTime.js
+++ b/packages/shared/src/utils/dateTime.js
@@ -6,9 +6,11 @@ import {
   differenceInYears,
   endOfDay,
   formatISO9075,
+  isBefore,
   isMatch,
   isSameDay,
   isValid,
+  isWithinInterval,
   max,
   min,
   parseISO,
@@ -275,8 +277,17 @@ export const datetimeCustomValidation = z.string().refine(
   },
 );
 
-export const endpointsOfDay = date =>
-  isValid(date) ? [startOfDay(date), endOfDay(date)] : [null, null];
+export const endpointsOfDay = date => [startOfDay(date), endOfDay(date)];
+
+/** Returns `true` if and only if `interval1` is a subset of `interval2`. It need not be a strict subset. */
+export const isIntervalWithinInterval = (interval1, interval2) => {
+  const { start, end } = interval1;
+  return isWithinInterval(start, interval2) && isWithinInterval(end, interval2);
+};
+
+/** Returns `true` if and only if `date` is an element of [`interval.start`, `interval.end`). */
+export const isWithinIntervalExcludingEnd = (date, interval) =>
+  isBefore(date, interval.end) && isWithinInterval(date, interval);
 
 export const maxValidDate = dates => {
   const validDates = dates.filter(isValid);

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
@@ -3,7 +3,7 @@ import { useFormikContext } from 'formik';
 import React from 'react';
 import styled from 'styled-components';
 
-import { toDateString, toDateTimeString } from '@tamanu/shared/utils/dateTime';
+import { toDateTimeString } from '@tamanu/shared/utils/dateTime';
 
 import { useLocationBookingsQuery } from '../../../../api/queries';
 import { Colors } from '../../../../constants';
@@ -29,8 +29,7 @@ const DateTimePicker = ({
 }) => {
   const { values, setFieldValue } = useFormikContext();
   const dateFieldValue = values[datePickerName];
-  const date = dateFieldValue ? startOfDay(parseISO(dateFieldValue)) : null;
-  const isValidDate = isValid(date);
+  const isValidDate = isValid(parseISO(dateFieldValue));
 
   /** Keep synchronised with date field for non-overnight bookings */
   const flushChangeToDateField = e => void setFieldValue('date', e.target.value);
@@ -69,7 +68,7 @@ const DateTimePicker = ({
         component={DateField}
         disabled={disabled}
         label={datePickerLabel}
-        min={isValid(minDate) ? toDateString(minDate) : null}
+        min={minDate}
         name={datePickerName}
         onChange={flushChangeToDateField}
         required={required}
@@ -86,7 +85,7 @@ const DateTimePicker = ({
         saveDateAsString
       />
       <TimeSlotPicker
-        date={isValidDate ? date : null}
+        date={isValidDate ? dateFieldValue : null}
         disabled={disabled || !isValidDate || hasConflict}
         hasNoLegalSelection={hasConflict}
         label={timePickerLabel}

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangeField.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangeField.jsx
@@ -1,10 +1,17 @@
-import { addDays } from 'date-fns';
+import { addDays, parseISO } from 'date-fns';
 import { useFormikContext } from 'formik';
 import React from 'react';
+
+import { toDateString } from '@tamanu/shared/utils/dateTime';
 
 import { TranslatedText } from '../../../Translation';
 import { EndDateTimePicker, StartDateTimePicker } from './DateTimePicker';
 import { DateTimeRangePicker } from './DateTimeRangePicker';
+
+const dayAfter = dateStr => {
+  const date = parseISO(dateStr);
+  return addDays(date, 1);
+};
 
 export const DateTimeRangeField = ({ disabled, required, separate = false, ...props }) => {
   const {
@@ -18,7 +25,7 @@ export const DateTimeRangeField = ({ disabled, required, separate = false, ...pr
         <StartDateTimePicker disabled={disabled} required={required} />
         <EndDateTimePicker
           disabled={isEndPickerDisabled}
-          minDate={!isEndPickerDisabled ? addDays(new Date(startDate), 1) : null}
+          minDate={isEndPickerDisabled ? null : toDateString(dayAfter(startDate))}
           required={required}
         />
       </>

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangePicker.jsx
@@ -1,11 +1,11 @@
-import { isValid, parseISO, startOfDay } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 import { useFormikContext } from 'formik';
 import React from 'react';
 
+import { useLocationBookingsContext } from '../../../../contexts/LocationBookings';
 import { DateField, Field } from '../../../Field';
 import { TranslatedText } from '../../../Translation';
 import { TimeSlotPicker } from './TimeSlotPicker';
-import { useLocationBookingsContext } from '../../../../contexts/LocationBookings';
 
 export const DateTimeRangePicker = ({
   dateFieldHelperText,
@@ -22,8 +22,7 @@ export const DateTimeRangePicker = ({
   const hasSelectedLocation = !!values.locationId;
 
   const dateFieldValue = values[datePickerName];
-  const date = dateFieldValue ? startOfDay(parseISO(dateFieldValue)) : null;
-  const isValidDate = isValid(date);
+  const isValidDate = isValid(parseISO(dateFieldValue));
 
   const { id: appointmentId, locationId } = values;
 
@@ -47,9 +46,9 @@ export const DateTimeRangePicker = ({
         {...props}
       />
       <TimeSlotPicker
-        date={isValidDate ? date : null}
+        date={isValidDate ? dateFieldValue : null}
         disabled={disabled || !hasSelectedLocation || !isValidDate}
-        key={appointmentId ?? `${locationId}_${date?.valueOf()}`}
+        key={appointmentId ?? `${locationId}_${dateFieldValue}`}
         label={timePickerLabel}
         required={required}
         variant="range"

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -153,22 +153,13 @@ export const TimeSlotPicker = ({
 
   const updateSelection = useCallback(
     (newToggleSelection, newInterval) => {
-      const { start, end } = newInterval;
       setSelectedToggles(newToggleSelection);
-      switch (variant) {
-        case TIME_SLOT_PICKER_VARIANTS.RANGE:
-          void setFieldValue('startTime', toDateTimeString(start));
-          void setFieldValue('endTime', toDateTimeString(end));
-          return;
-        case TIME_SLOT_PICKER_VARIANTS.START:
-          void setFieldValue('startTime', toDateTimeString(start));
-          return;
-        case TIME_SLOT_PICKER_VARIANTS.END:
-          void setFieldValue('endTime', toDateTimeString(end));
-          return;
-      }
+
+      const { start, end } = newInterval;
+      if (start !== undefined) void setFieldValue('startTime', toDateTimeString(start));
+      if (end !== undefined) void setFieldValue('endTime', toDateTimeString(end));
     },
-    [setFieldValue, variant],
+    [setFieldValue],
   );
 
   useEffect(() => {

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -320,7 +320,7 @@ export const TimeSlotPicker = ({
       }
 
       /** Returns the would-be time range selection if the provided time slot were to be clicked */
-      const getTargetSelection = timeSlot => {
+      const getTargetSelection = () => {
         switch (variant) {
           case TIME_SLOT_PICKER_VARIANTS.RANGE:
             return {
@@ -339,7 +339,7 @@ export const TimeSlotPicker = ({
             };
         }
       };
-      const targetSelection = getTargetSelection(timeSlot);
+      const targetSelection = getTargetSelection();
 
       return !bookedIntervals.some(interval => areIntervalsOverlapping(targetSelection, interval));
     },

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -114,7 +114,7 @@ export const TimeSlotPicker = ({
     [bookingSlotSettings, dayStart],
   );
 
-  const initialTimeRange = useMemo(
+  const initialInterval = useMemo(
     () => appointmentToInterval({ startTime: initialStart, endTime: initialEnd }),
     [initialStart, initialEnd],
   );
@@ -124,16 +124,16 @@ export const TimeSlotPicker = ({
    * the integer form of its start time.
    */
   const [selectedToggles, setSelectedToggles] = useState(() => {
-    if (!initialTimeRange) return [];
+    if (!initialInterval) return [];
 
     // When modifying a non-overnight booking, don’t prepopulate the overnight variants of this
     // component (and vice versa)
-    const isModifyingOvernightBooking = !isSameDay(initialTimeRange.start, initialTimeRange.end);
+    const isModifyingOvernightBooking = !isSameDay(initialInterval.start, initialInterval.end);
     const isOvernightVariant = variant !== TIME_SLOT_PICKER_VARIANTS.RANGE;
     if (isModifyingOvernightBooking !== isOvernightVariant) return [];
 
     return timeSlots
-      .filter(slot => areIntervalsOverlapping(slot, initialTimeRange))
+      .filter(slot => areIntervalsOverlapping(slot, initialInterval))
       .map(idOfTimeSlot);
   });
   const [hoverRange, setHoverRange] = useState(null);
@@ -152,8 +152,8 @@ export const TimeSlotPicker = ({
   );
 
   const updateSelection = useCallback(
-    (newToggleSelection, newTimeRange) => {
-      const { start, end } = newTimeRange;
+    (newToggleSelection, newInterval) => {
+      const { start, end } = newInterval;
       setSelectedToggles(newToggleSelection);
       switch (variant) {
         case TIME_SLOT_PICKER_VARIANTS.RANGE:
@@ -207,11 +207,11 @@ export const TimeSlotPicker = ({
           const newStart = new Date(newToggles[0]);
           const startOfLatestSlot = new Date(newToggles.at(-1));
           const newEnd = endOfSlotStartingAt(startOfLatestSlot);
-          const newTimeRange = { start: newStart, end: newEnd };
+          const newInterval = { start: newStart, end: newEnd };
           const newSelection = timeSlots
-            .filter(slot => areIntervalsOverlapping(slot, newTimeRange))
+            .filter(slot => areIntervalsOverlapping(slot, newInterval))
             .map(idOfTimeSlot);
-          updateSelection(newSelection, newTimeRange);
+          updateSelection(newSelection, newInterval);
           return;
         }
 
@@ -307,8 +307,8 @@ export const TimeSlotPicker = ({
     () =>
       existingBookings?.data
         .map(appointmentToInterval)
-        .filter(interval => !isEqual(interval, initialTimeRange)) ?? [], // Ignore the booking currently being modified
-    [existingBookings?.data, initialTimeRange],
+        .filter(interval => !isEqual(interval, initialInterval)) ?? [], // Ignore the booking currently being modified
+    [existingBookings?.data, initialInterval],
   );
 
   /** A time slot is selectable if it does not create a selection of time slots that collides with another booking */

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/utils.js
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/utils.js
@@ -23,18 +23,6 @@ export const appointmentToInterval = appointment => {
   return { start, end };
 };
 
-export const isWithinIntervalExcludingEnd = (date, interval) =>
-  isBefore(date, interval.end) && isWithinInterval(date, interval);
-
-/**
- * @param {{start: Date, end: Date}} timeSlot
- * @param {{start: Date, end: Date} | null} range
- */
-export const isTimeSlotWithinRange = (timeSlot, range) => {
-  if (!range) return false;
-  return isWithinInterval(timeSlot.start, range) && isWithinInterval(timeSlot.end, range);
-};
-
 /**
  * @param bookingSlotSettings See @tamanu/settings/src/schema/facility.ts for schema.
  * @param {Date} date

--- a/packages/web/stories/appointments/timeSlotSelector.stories.jsx
+++ b/packages/web/stories/appointments/timeSlotSelector.stories.jsx
@@ -8,7 +8,7 @@ import { TimeSlotPicker } from '../../app/components/Appointments/LocationBookin
 import { MockSettingsProvider } from '../utils/mockSettingsProvider';
 import { MockedApi } from '../utils/mockedApi';
 
-const todaysDate = toDateString(new Date());
+const todaysDate = toDateString(startOfToday());
 
 const mockAppointments = [
   {


### PR DESCRIPTION
> [!TIP]
> I’d suggest reviewing this one [commit-by-commit](https://github.com/beyondessential/tamanu/pull/6974/commits)

### Changes

- Using date object as prop was nice, but component got more complex and now the date needs to be used as dependency to some callback/memo/effect hooks

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
