### PR TITLE
tweak(locationBookings): avoid flash of content when loading time slots

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -19,10 +19,11 @@ import { useLocationBookingsQuery } from '../../../../api/queries';
 import { Colors } from '../../../../constants';
 import { useBookingSlots } from '../../../../hooks/useBookingSlots';
 import { OuterLabelFieldWrapper } from '../../../Field';
-import { SkeletonTimeSlotToggles, TimeSlotToggle } from './TimeSlotToggle';
+import { PlaceholderTimeSlotToggles, TimeSlotToggle } from './TimeSlotToggle';
 import { CONFLICT_TOOLTIP_TITLE, TIME_SLOT_PICKER_VARIANTS } from './constants';
 import {
   appointmentToInterval,
+  idOfTimeSlot,
   isSameArrayMinusHead,
   isSameArrayMinusHeadOrTail,
   isSameArrayMinusTail,
@@ -55,8 +56,6 @@ const StyledFormHelperText = styled(FormHelperText)`
     font-weight: 500;
   }
 `;
-
-const idOfTimeSlot = timeSlot => timeSlot.start.valueOf();
 
 /**
  * TimeSlotPicker assumes that it is given a valid `date`, and checks for conflicting
@@ -340,7 +339,7 @@ export const TimeSlotPicker = ({
         {...props}
       >
         {isFetchingExistingBookings || isTimeSlotsPending ? (
-          <SkeletonTimeSlotToggles />
+          <PlaceholderTimeSlotToggles />
         ) : (
           timeSlots?.map(timeSlot => {
             const isBooked = bookedIntervals.some(bookedInterval =>

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotToggle.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotToggle.jsx
@@ -208,6 +208,10 @@ const SkeletonTimeSlotToggles = ({ count = 16 }) => {
   return Array.from({ length: count }).map((_, i) => <StyledSkeleton key={i} />);
 };
 
+/**
+ * @privateRemarks Use of today is arbitrary; we just need a valid date for the time slots to
+ * render. The time slots are the same for each day, so this does just fine as a GUI placeholder.
+ */
 export const PlaceholderTimeSlotToggles = memo(() => {
   const { isPending, slots } = useBookingSlots(startOfToday());
   if (isPending) return <SkeletonTimeSlotToggles />;

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotToggle.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotToggle.jsx
@@ -1,14 +1,17 @@
 import Skeleton, { skeletonClasses } from '@mui/material/Skeleton';
 import ToggleButton, { toggleButtonClasses } from '@mui/material/ToggleButton';
 import { toggleButtonGroupClasses } from '@mui/material/ToggleButtonGroup';
-import React from 'react';
+import { startOfToday } from 'date-fns';
+import React, { memo } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Colors } from '../../../../constants';
+import { useBookingSlots } from '../../../../hooks/useBookingSlots';
 import { TimeRangeDisplay } from '../../../DateDisplay';
 import { ConditionalTooltip, ThemedTooltip } from '../../../Tooltip';
 import { TranslatedText } from '../../../Translation/TranslatedText';
 import { CONFLICT_TOOLTIP_TITLE, TIME_SLOT_PICKER_VARIANTS } from './constants';
+import { idOfTimeSlot } from './utils';
 
 /**
  * @privateRemarks Specificity (0,5,0) to override styles (for all states, including :disabled and
@@ -201,6 +204,12 @@ const StyledSkeleton = styled(Skeleton).attrs({ variant: 'rounded' })`
   }
 `;
 
-export const SkeletonTimeSlotToggles = ({ count = 16 }) => {
+const SkeletonTimeSlotToggles = ({ count = 16 }) => {
   return Array.from({ length: count }).map((_, i) => <StyledSkeleton key={i} />);
 };
+
+export const PlaceholderTimeSlotToggles = memo(() => {
+  const { isPending, slots } = useBookingSlots(startOfToday());
+  if (isPending) return <SkeletonTimeSlotToggles />;
+  return slots?.map(slot => <TimeSlotToggle disabled key={idOfTimeSlot(slot)} timeSlot={slot} />);
+});

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/utils.js
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/utils.js
@@ -23,6 +23,8 @@ export const appointmentToInterval = appointment => {
   return { start, end };
 };
 
+export const idOfTimeSlot = timeSlot => timeSlot.start.valueOf();
+
 export const isWithinIntervalExcludingEnd = (date, interval) =>
   isBefore(date, interval.end) && isWithinInterval(date, interval);
 


### PR DESCRIPTION
### Changes

Current implementation always falls back to skeleton time slot toggles (with the default pulse animation from MUI). When switching dates in the Location Bookings view, this only appears briefly and makes the GUI look janky.

This PR introduces a smarter placeholder which uses an arbitrary day to render placeholder disabled time slot toggles. Under the hood it uses today as that arbitrary day, but the time times of day that make each time slot are guaranteed to be identical.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
