### PR TITLE
fix(locationBookings): clear end date selection when modifying overnight booking

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangePicker.jsx
@@ -51,7 +51,7 @@ export const DateTimeRangePicker = ({
         key={appointmentId ?? `${locationId}_${dateFieldValue}`}
         label={timePickerLabel}
         required={required}
-        variant="range"
+        variant={TIME_SLOT_PICKER_VARIANTS.RANGE}
       />
     </>
   );

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangePicker.jsx
@@ -6,6 +6,7 @@ import { useLocationBookingsContext } from '../../../../contexts/LocationBooking
 import { DateField, Field } from '../../../Field';
 import { TranslatedText } from '../../../Translation';
 import { TimeSlotPicker } from './TimeSlotPicker';
+import { TIME_SLOT_PICKER_VARIANTS } from './constants';
 
 export const DateTimeRangePicker = ({
   dateFieldHelperText,

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -337,7 +337,7 @@ export const TimeSlotPicker = ({
         error={showError}
         {...props}
       >
-        {isFetchingExistingBookings || isTimeSlotsPending ? (
+        {!date || isFetchingExistingBookings || isTimeSlotsPending ? (
           <PlaceholderTimeSlotToggles />
         ) : (
           timeSlots?.map(timeSlot => {


### PR DESCRIPTION
### Changes

Currently, when modifying an existing overnight booking that bleeds into today:

When you uncheck the `☑️ Overnight stay` checkbox (which should clear the **End date** and **Booking end time** fields), the booking end time slot picker state reflects the time slots the location booking occupies **today** (regardless of what start/end dates are selected)—even though the component is (correctly) disabled.

This is because the disabled end time slot picker, in order to render the correct time slots, uses **today** as an (arbitrary) date under the hood. This PR avoids that.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
