### PR TITLE
repo(devContainer): use npm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   // "forwardPorts": [ 5432],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "corepack enable yarn && yes | yarn install",
+  "postCreateCommand": "npm install",
 
   // Configure tool-specific properties.
   // "customizations": {},


### PR DESCRIPTION
### Changes

Yarn no longer! 🧶💣 

[Docs for containerised monorepo setup](https://beyond-essential.slab.com/posts/tamanu-monorepo-setup-containerised-qejggubf) also updated to use npm