### PR TITLE
refactor(locationBookings): clean up `TimeSlotPicker` change logic

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -68,9 +68,9 @@ export const TimeSlotPicker = ({
   date,
   disabled = false,
   /**
-   * If true, this instance a picker for the end time slot of an overnight booking where the start
-   * time has been modified to a time such that there is a conflicting booking between the start
-   * time and this `date`. Any state this instance had is now invalid, and
+   * If true, this instance is a picker for the end time slot of an overnight booking where the
+   * start time has been modified to a time such that there is a conflicting booking between the
+   * start time and this `date`. Any state this instance had is now invalid, and
    * hasNoLegalSelection={true} indicates that this component should render with fresh state.
    */
   hasNoLegalSelection = false,

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/TimeSlotPicker.jsx
@@ -300,10 +300,6 @@ export const TimeSlotPicker = ({
    * Treating the `startTime` and `endTime` string values from the Formik context as the source of
    * truth, synchronise this {@link TimeSlotPicker}’s selection of {@link ToggleButton}s with the
    * currently selected start and end times.
-   *
-   * The `appointments.bookingSlots` configuration may have changed since the last time a given
-   * appointment was updated. This `useEffect` hook realigns an appointment’s start and end times
-   * with the currently available slots.
    */
   useEffect(() => {
     if (hasNoLegalSelection) {


### PR DESCRIPTION
### Changes

Updates `<TimeSlotPicker>` to improve readability by treating `startTime` and `endTime` as the one source of truth. Now uses `useEffect` to synchronise these values (if they exist) to the visible status of the rendered component, rather than updating the underlying data and the component state in parallel

This results in (at least) one more render cycle each time a start/end time is updated, and—as with so many `useEffect` hooks—can be prone to infinite render cycles. Despite these, I find this to be more readable/maintainable—particularly when looking down the barrel of NASS 1522 where we will attempt to preserve the start time when switching a booking overnight and non-overnight

(I previously attempted NASS 1522 using only `onChange` handlers, but it spread the logic out into too many different places, and ran into problems with infinite render loops anyway 🤷)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
