### PR TITLE
fix(mobile): Release fix v2.23: Correct column drop migration for labTest on mobile

### DIFF
--- a/packages/mobile/App/migrations/1734072605000-removeLabTestStatus.ts
+++ b/packages/mobile/App/migrations/1734072605000-removeLabTestStatus.ts
@@ -1,5 +1,5 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
-import { getTable } from './utils/queryRunner.js';
+import { getTable } from './utils/queryRunner';
 
 export class removeLabTestStatus1734072605000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {

--- a/packages/mobile/App/migrations/1734072605000-removeLabTestStatus.ts
+++ b/packages/mobile/App/migrations/1734072605000-removeLabTestStatus.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class removeLabTestStatus1734072605000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE labTest DROP COLUMN status;`);
+    await queryRunner.dropColumn('labTest', 'status');
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/mobile/App/migrations/1734072605000-removeLabTestStatus.ts
+++ b/packages/mobile/App/migrations/1734072605000-removeLabTestStatus.ts
@@ -1,8 +1,10 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { getTable } from './utils/queryRunner.js';
 
 export class removeLabTestStatus1734072605000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropColumn('labTest', 'status');
+    const tableObject = await getTable(queryRunner, 'labTest');
+    await queryRunner.dropColumn(tableObject, 'status');
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
### Changes

ALTER TABLE ... DROP ... is not supported by sqlite from what i can tell. I have just updated this to drop like other migrations

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
