### PR TITLE
feat(appointments): NASS-1423 Cancel repeating appointments

### DIFF
--- a/packages/database/src/models/Appointment.ts
+++ b/packages/database/src/models/Appointment.ts
@@ -66,6 +66,7 @@ export class Appointment extends Model {
       'appointmentType',
       'bookingType',
       'encounter',
+      'schedule',
     ];
   }
 

--- a/packages/database/src/models/AppointmentSchedule.ts
+++ b/packages/database/src/models/AppointmentSchedule.ts
@@ -1,8 +1,9 @@
 import { isNumber } from 'lodash';
-import { DataTypes, type HasManyGetAssociationsMixin } from 'sequelize';
+import { DataTypes, Op, type HasManyGetAssociationsMixin } from 'sequelize';
 import { parseISO, add, set, isAfter, endOfDay } from 'date-fns';
 
 import {
+  APPOINTMENT_STATUSES,
   DAYS_OF_WEEK,
   REPEAT_FREQUENCY,
   REPEAT_FREQUENCY_UNIT_PLURAL_LABELS,
@@ -161,6 +162,29 @@ export class AppointmentSchedule extends Model {
         LEFT JOIN locations ON appointments.location_id = locations.id
       `,
     };
+  }
+
+  async endAtAppointment(appointment: Appointment) {
+    const { models } = this.sequelize;
+    if (!this.sequelize.isInsideTransaction()) {
+      throw new Error('AppointmentSchedule.endAtAppointment must always run inside a transaction');
+    }
+    await models.Appointment.update(
+      {
+        status: APPOINTMENT_STATUSES.CANCELLED,
+      },
+      {
+        where: {
+          startTime: { [Op.gte]: appointment.startTime },
+          scheduleId: this.id,
+        },
+      },
+    );
+    await this.update({
+      isFullyGenerated: true,
+      untilDate: appointment.startTime,
+      occurrenceCount: null,
+    });
   }
 
   /**

--- a/packages/database/src/models/AppointmentSchedule.ts
+++ b/packages/database/src/models/AppointmentSchedule.ts
@@ -180,9 +180,18 @@ export class AppointmentSchedule extends Model {
         },
       },
     );
+    const [previousAppointment] = await this.getAppointments({
+      order: [['startTime', 'DESC']],
+      limit: 1,
+      where: {
+        status: {
+          [Op.not]: APPOINTMENT_STATUSES.CANCELLED,
+        },
+      },
+    });
     await this.update({
       isFullyGenerated: true,
-      untilDate: appointment.startTime,
+      untilDate: previousAppointment ? previousAppointment.startTime : appointment.startTime,
       occurrenceCount: null,
     });
   }

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -278,10 +278,10 @@ appointments.put('/:id', async (req, res) => {
   } = req;
   req.checkPermission('write', 'Appointment');
 
-  const result = await req.db.transaction(async () => {
-    const appointment = await Appointment.findByPk(params.id);
-    if (!appointment) throw new NotFoundError();
+  const appointment = await Appointment.findByPk(params.id);
+  if (!appointment) throw new NotFoundError();
 
+  const result = await req.db.transaction(async () => {
     await appointment.update(req.body);
 
     if (status === APPOINTMENT_STATUSES.CANCELLED && schedule.id) {

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -278,13 +278,17 @@ appointments.put('/:id', async (req, res) => {
     models: { Appointment, AppointmentSchedule },
     params,
   } = req;
+  console.log('HITTING THE PUT ENDPOINT');
   req.checkPermission('read', 'Appointment');
   const appointment = await Appointment.findByPk(params.id);
   if (!appointment) throw new NotFoundError();
   req.checkPermission('write', 'Appointment');
 
-  if (req.body.status === APPOINTMENT_STATUSES.CANCELLED && appointment.scheduleId) {
-    const appointmentSchedule = await AppointmentSchedule.findByPk(appointment.scheduleId);
+  console.log('body', req.body);
+
+  if (req.body.status === APPOINTMENT_STATUSES.CANCELLED && req.body.schedule.id) {
+    const appointmentSchedule = await AppointmentSchedule.findByPk(req.body.schedule.id);
+    console.log('appointmentSchedule to destroy', appointmentSchedule);
     await appointmentSchedule.destroy();
     await Appointment.update(
       { status: APPOINTMENT_STATUSES.CANCELLED },

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -275,17 +275,13 @@ appointments.put('/:id', async (req, res) => {
     models: { Appointment, AppointmentSchedule },
     params,
   } = req;
-  console.log('HITTING THE PUT ENDPOINT');
   req.checkPermission('read', 'Appointment');
   const appointment = await Appointment.findByPk(params.id);
   if (!appointment) throw new NotFoundError();
   req.checkPermission('write', 'Appointment');
 
-  console.log('body', req.body);
-
   if (req.body.status === APPOINTMENT_STATUSES.CANCELLED && req.body.schedule.id) {
     const appointmentSchedule = await AppointmentSchedule.findByPk(req.body.schedule.id);
-    console.log('appointmentSchedule to destroy', appointmentSchedule);
     await appointmentSchedule.destroy();
     await Appointment.update(
       { status: APPOINTMENT_STATUSES.CANCELLED },

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -274,7 +274,7 @@ appointments.put('/:id', async (req, res) => {
   const {
     models: { Appointment, AppointmentSchedule },
     params,
-    body: { status, schedule },
+    body: { status, schedule = {} },
   } = req;
   req.checkPermission('write', 'Appointment');
 

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -10,7 +10,6 @@ import {
   PATIENT_COMMUNICATION_TYPES,
 } from '@tamanu/constants';
 import { NotFoundError, ResourceConflictError } from '@tamanu/shared/errors';
-import { simplePut } from '@tamanu/shared/utils/crudHelpers';
 import { replaceInTemplate } from '@tamanu/utils/replaceInTemplate';
 
 import { escapePatternWildcard } from '../../utils/query';
@@ -129,8 +128,6 @@ appointments.post(
     res.status(200).send(response);
   }),
 );
-
-appointments.put('/:id', simplePut('Appointment'));
 
 const isStringOrArray = (obj) => typeof obj === 'string' || Array.isArray(obj);
 

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -292,9 +292,10 @@ appointments.put('/:id', async (req, res) => {
       {
         where: {
           scheduleId: appointment.scheduleId,
-          appointmentDate: {
-            [Op.gte]: appointment.startDate,
-          },
+          // TODO: delete all ones in the future of this appointment
+          // startTime: {
+          //   [Op.gte]: appointment.startTime,
+          // },
         },
       },
     );

--- a/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/BaseModalComponents.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box from '@mui/material/Box'
+import Box from '@mui/material/Box';
 import styled from '@mui/system/styled';
 import { Colors } from '../../../constants';
 import { ConfirmCancelRow } from '../../ButtonRow';
@@ -37,6 +37,13 @@ const AppointmentDetailsContainer = styled(FlexRow)`
   padding-block: 1.5rem;
 `;
 
+const OptionsContainer = styled(FlexCol)`
+  font-size: 0.875rem;
+  background-color: ${Colors.white};
+  border: 1px solid ${Colors.outline};
+  padding: 1.5rem;
+`;
+
 const AppointmentDetailsColumn = styled(FlexCol)`
   padding-inline: 1.5rem;
   gap: 1.25rem;
@@ -70,4 +77,5 @@ export {
   BottomModalContainer,
   StyledConfirmCancelRow,
   BodyContainer,
+  OptionsContainer,
 };

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -184,7 +184,7 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
             if (deletionType === CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT) {
               mutateAppointment({
                 // TODO: possibly too hacky
-                ...omit(appointment, 'schedule'),
+                ...omit(appointment, 'schedule', 'scheduleId'),
                 status: APPOINTMENT_STATUSES.CANCELLED,
               });
             }

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -30,6 +30,15 @@ const StyledBodyText = styled(BodyText)`
   margin-bottom: 20px;
 `;
 
+const StyledRadioInput = styled(RadioInput)`
+  flex-direction: column;
+  .MuiFormControlLabel-root {
+    justify-content: flex-start;
+    border: none;
+    // TODO: last bit of padding here
+  }
+`;
+
 const AppointmentDetailsDisplay = ({ appointment }) => {
   const {
     patient,
@@ -138,7 +147,7 @@ const RepeatingAppointmentOptions = ({ deletionType, setDeletionType }) => {
         This is a repeating appointment. Would you like to cancel this appointment only or this
         appointment and all future appointments as well?
       </StyledBodyText>
-      <RadioInput
+      <StyledRadioInput
         value={deletionType}
         onChange={e => setDeletionType(e.target.value)}
         options={[
@@ -170,6 +179,11 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
   const [deletionType, setDeletionType] = useState(
     CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT,
   );
+
+  const handleCloseModal = () => {
+    setDeletionType(CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT);
+    onClose();
+  };
 
   const { mutateAsync: mutateAppointment } = useAppointmentMutation(appointment.id, {
     onSuccess: () => {
@@ -219,11 +233,11 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
               mutateAppointment({ ...appointment, status: APPOINTMENT_STATUSES.CANCELLED });
             }
           }}
-          onClose={onClose}
+          onClose={handleCloseModal}
         />
       }
       open={open}
-      onClose={onClose}
+      onClose={handleCloseModal}
     >
       <BodyContainer>
         <TranslatedText

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -127,13 +127,13 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
             value={
               schedule.untilDate ? (
                 <TranslatedText
-                  stringId="appointment.duration.endsOn"
+                  stringId="appointment.duration.endsOnDate"
                   fallback="Ends on :date"
                   replacements={{ date: formatShort(schedule.untilDate) }}
                 />
               ) : (
                 <TranslatedText
-                  stringId="appointment.duration.endsOn"
+                  stringId="appointment.duration.endsAfterOccurrences"
                   fallback="Ends after :numberOfOccurrences occurrences"
                   replacements={{ numberOfOccurrences: schedule.occurrenceCount }}
                 />

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -147,16 +147,32 @@ const RepeatingAppointmentOptions = ({ deletionType, setDeletionType }) => {
   return (
     <OptionsContainer>
       <StyledBodyText>
-        This is a repeating appointment. Would you like to cancel this appointment only or this
-        appointment and all future appointments as well?
+        <TranslatedText
+          stringId="appointment.cancelRepeating.message"
+          fallback="This is a repeating appointment. Would you like to cancel this appointment only or this
+        appointment and all future appointments as well?"
+        />
       </StyledBodyText>
       <StyledRadioInput
         value={deletionType}
         onChange={e => setDeletionType(e.target.value)}
         options={[
-          { label: 'This appointment', value: CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT },
           {
-            label: 'This and future appointments',
+            label: (
+              <TranslatedText
+                stringId="appointment.modify.option.thisAppointment"
+                fallback="This appointment"
+              />
+            ),
+            value: CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT,
+          },
+          {
+            label: (
+              <TranslatedText
+                stringId="appointment.modify.option.thisAndFutureAppointments"
+                fallback="This and future appointments"
+              />
+            ),
             value: CANCEL_REPEATING_APPOINTMENT_MODE.THIS_AND_FUTURE_APPOINTMENTS,
           },
         ]}

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -134,8 +134,8 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
               ) : (
                 <TranslatedText
                   stringId="appointment.duration.endsOn"
-                  fallback="Ends after :numberOfOccurences occurrences"
-                  replacements={{ numberOfOccurences: schedule.occurrenceCount }}
+                  fallback="Ends after :numberOfOccurrences occurrences"
+                  replacements={{ numberOfOccurrences: schedule.occurrenceCount }}
                 />
               )
             }

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -35,7 +35,10 @@ const StyledRadioInput = styled(RadioInput)`
   .MuiFormControlLabel-root {
     justify-content: flex-start;
     border: none;
-    // TODO: last bit of padding here
+    padding-left: 0;
+    .MuiButtonBase-root {
+      margin-left: 0;
+    }
   }
 `;
 
@@ -238,6 +241,7 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
       }
       open={open}
       onClose={handleCloseModal}
+      width="md"
     >
       <BodyContainer>
         <TranslatedText

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -6,7 +6,7 @@ import { omit } from 'lodash';
 import { APPOINTMENT_STATUSES, OTHER_REFERENCE_TYPES } from '@tamanu/constants';
 
 import { useAppointmentMutation } from '../../../api/mutations';
-import { formatDateTimeRange } from '../../../utils/dateTime';
+import { formatDateTimeRange, formatShort } from '../../../utils/dateTime';
 import { BaseModal } from '../../BaseModal';
 import { PatientNameDisplay } from '../../PatientNameDisplay';
 import { TranslatedReferenceData, TranslatedText } from '../../Translation';
@@ -23,6 +23,8 @@ import {
 import { RadioInput } from '../../Field';
 import { BodyText } from '../../Typography';
 import styled from 'styled-components';
+import { RepeatCharacteristicsDescription } from '../OutpatientsBookingForm/RepeatCharacteristicsDescription';
+import { parseISO } from 'date-fns';
 
 const StyledBodyText = styled(BodyText)`
   margin-bottom: 20px;
@@ -68,8 +70,13 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
         {schedule.id && (
           <DetailDisplay
             label={<TranslatedText stringId="appointment.repeating.label" fallback="Repeating" />}
-            // TODO: translations + formatting + all variations
-            value={`${schedule.frequency} on ${schedule.daysOfWeek}`}
+            value={
+              <RepeatCharacteristicsDescription
+                startTimeDate={parseISO(startTime)}
+                frequency={schedule.frequency}
+                interval={schedule.interval}
+              />
+            }
           />
         )}
       </AppointmentDetailsColumnLeft>
@@ -105,8 +112,13 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
         {schedule.id && (
           <DetailDisplay
             label={<TranslatedText stringId="appointment.duration.label" fallback="Duration" />}
-            // TODO: translations + formatting + all variations
-            value={`Ends on ${schedule.untilDate}`}
+            value={
+              <TranslatedText
+                stringId="appointment.duration.endsOn"
+                fallback="Ends on :date"
+                replacements={{ date: formatShort(schedule.untilDate) }}
+              />
+            }
           />
         )}
       </AppointmentDetailsColumn>
@@ -114,7 +126,7 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
   );
 };
 
-export const CANCEL_REPEATING_APPOINTMENT_MODE = {
+const CANCEL_REPEATING_APPOINTMENT_MODE = {
   THIS_APPOINTMENT: 'thisAppointment',
   THIS_AND_FUTURE_APPOINTMENTS: 'thisAndFutureAppointments',
 };

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -125,11 +125,19 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
           <DetailDisplay
             label={<TranslatedText stringId="appointment.duration.label" fallback="Duration" />}
             value={
-              <TranslatedText
-                stringId="appointment.duration.endsOn"
-                fallback="Ends on :date"
-                replacements={{ date: formatShort(schedule.untilDate) }}
-              />
+              schedule.untilDate ? (
+                <TranslatedText
+                  stringId="appointment.duration.endsOn"
+                  fallback="Ends on :date"
+                  replacements={{ date: formatShort(schedule.untilDate) }}
+                />
+              ) : (
+                <TranslatedText
+                  stringId="appointment.duration.endsOn"
+                  fallback="Ends after :numberOfOccurences occurrences"
+                  replacements={{ numberOfOccurences: schedule.occurrenceCount }}
+                />
+              )
             }
           />
         )}

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -155,12 +155,22 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
 
   const { mutateAsync: mutateAppointment } = useAppointmentMutation(appointment.id, {
     onSuccess: () => {
-      toast.success(
-        <TranslatedText
-          stringId="appointment.success.cancelAppointment"
-          fallback="Appointment cancelled successfully"
-        />,
-      );
+      if (deletionType === CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT) {
+        toast.success(
+          <TranslatedText
+            stringId="appointment.success.cancelAppointment"
+            fallback="Appointment cancelled successfully"
+          />,
+        );
+      }
+      if (deletionType === CANCEL_REPEATING_APPOINTMENT_MODE.THIS_AND_FUTURE_APPOINTMENTS) {
+        toast.success(
+          <TranslatedText
+            stringId="appointment.success.cancelRepeatingAppointment"
+            fallback="This and future appointments cancelled successfully"
+          />,
+        );
+      }
       queryClient.invalidateQueries('appointments');
       onClose();
     },
@@ -183,7 +193,6 @@ export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
           cancelBooking={() => {
             if (deletionType === CANCEL_REPEATING_APPOINTMENT_MODE.THIS_APPOINTMENT) {
               mutateAppointment({
-                // TODO: possibly too hacky
                 ...omit(appointment, 'schedule', 'scheduleId'),
                 status: APPOINTMENT_STATUSES.CANCELLED,
               });

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -20,7 +20,15 @@ import {
 } from './BaseModalComponents';
 
 const AppointmentDetailsDisplay = ({ appointment }) => {
-  const { patient, startTime, endTime, locationGroup, clinician, appointmentType } = appointment;
+  const {
+    patient,
+    startTime,
+    endTime,
+    locationGroup,
+    clinician,
+    appointmentType,
+    schedule = {},
+  } = appointment;
 
   return (
     <AppointmentDetailsContainer>
@@ -48,6 +56,13 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
             />
           }
         />
+        {schedule.id && (
+          <DetailDisplay
+            label={<TranslatedText stringId="appointment.repeating.label" fallback="Repeating" />}
+            // TODO: translations
+            value={`${schedule.frequency} on ${schedule.daysOfWeek}`}
+          />
+        )}
       </AppointmentDetailsColumnLeft>
       <AppointmentDetailsColumn>
         <DetailDisplay
@@ -78,6 +93,13 @@ const AppointmentDetailsDisplay = ({ appointment }) => {
             />
           }
         />
+        {schedule.id && (
+          <DetailDisplay
+            label={<TranslatedText stringId="appointment.duration.label" fallback="Duration" />}
+            // TODO: translations
+            value={`Ends on ${schedule.untilDate}`}
+          />
+        )}
       </AppointmentDetailsColumn>
     </AppointmentDetailsContainer>
   );
@@ -97,29 +119,26 @@ const BottomModalContent = ({ cancelBooking, onClose }) => (
 export const CancelAppointmentModal = ({ open, onClose, appointment }) => {
   const queryClient = useQueryClient();
 
-  const { mutateAsync: mutateAppointment } = useAppointmentMutation(
-    appointment.id,
-    {
-      onSuccess: () => {
-        toast.success(
-          <TranslatedText
-            stringId="appointment.success.cancelAppointment"
-            fallback="Appointment cancelled successfully"
-          />,
-        );
-        queryClient.invalidateQueries('appointments');
-        onClose();
-      },
-      onError: () => {
-        toast.error(
-          <TranslatedText
-            stringId="appointment.error.cancelAppointment"
-            fallback="Error cancelling appointment"
-          />,
-        );
-      },
+  const { mutateAsync: mutateAppointment } = useAppointmentMutation(appointment.id, {
+    onSuccess: () => {
+      toast.success(
+        <TranslatedText
+          stringId="appointment.success.cancelAppointment"
+          fallback="Appointment cancelled successfully"
+        />,
+      );
+      queryClient.invalidateQueries('appointments');
+      onClose();
     },
-  );
+    onError: () => {
+      toast.error(
+        <TranslatedText
+          stringId="appointment.error.cancelAppointment"
+          fallback="Error cancelling appointment"
+        />,
+      );
+    },
+  });
 
   return (
     <BaseModal

--- a/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
+++ b/packages/web/app/components/Appointments/CancelModal/CancelAppointmentModal.jsx
@@ -18,9 +18,15 @@ import {
   BottomModalContainer,
   DetailDisplay,
   StyledConfirmCancelRow,
+  OptionsContainer,
 } from './BaseModalComponents';
 import { RadioInput } from '../../Field';
 import { BodyText } from '../../Typography';
+import styled from 'styled-components';
+
+const StyledBodyText = styled(BodyText)`
+  margin-bottom: 20px;
+`;
 
 const AppointmentDetailsDisplay = ({ appointment }) => {
   const {
@@ -115,11 +121,11 @@ export const CANCEL_REPEATING_APPOINTMENT_MODE = {
 
 const RepeatingAppointmentOptions = ({ deletionType, setDeletionType }) => {
   return (
-    <AppointmentDetailsContainer>
-      <BodyText>
+    <OptionsContainer>
+      <StyledBodyText>
         This is a repeating appointment. Would you like to cancel this appointment only or this
         appointment and all future appointments as well?
-      </BodyText>
+      </StyledBodyText>
       <RadioInput
         value={deletionType}
         onChange={e => setDeletionType(e.target.value)}
@@ -131,7 +137,7 @@ const RepeatingAppointmentOptions = ({ deletionType, setDeletionType }) => {
           },
         ]}
       />
-    </AppointmentDetailsContainer>
+    </OptionsContainer>
   );
 };
 


### PR DESCRIPTION
Logic for cancelling repeating appointments.

The basic flow is:
- When opening cancelling modal for appointment, if the appointment has a schedule linked, we display the special repeating appointments modal.
- You will have the option to delete either just this appointment or this and all future appointments
	- Selecting this appointment will cancel as normal
	- Selecting this and all future appointments will set them all to cancelled and end the linked appointment schedule using model method

Daniel and I have discussed possibly separating this out into a delete endpoint if it gets to complicated with the modify logic but we have been a bit on the fence. We may end up doing this later but have decided this is fine for now

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
