### PR TITLE
fix: EPI-1001: release 2.23: Fix no response when clicking onto the location bookings link

### DIFF
--- a/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayBookingsPane.jsx
@@ -6,7 +6,7 @@ import TimelineSeparator from '@material-ui/lab/TimelineSeparator';
 import TimelineConnector from '@material-ui/lab/TimelineConnector';
 import TimelineContent from '@material-ui/lab/TimelineContent';
 import TimelineDot from '@material-ui/lab/TimelineDot';
-import { WS_EVENTS } from '@tamanu/constants';
+import { USER_PREFERENCES_KEYS, WS_EVENTS } from '@tamanu/constants';
 import { useHistory } from 'react-router-dom';
 import { endOfDay, startOfDay } from 'date-fns';
 import { formatTime, toDateTimeString } from '@tamanu/utils/dateTime';
@@ -228,7 +228,10 @@ export const TodayBookingsPane = ({ showTasks }) => {
   };
 
   const onLocationBookingsClick = async () => {
-    await mutateUserPreferences({ locationBookingFilters: {} });
+    await mutateUserPreferences({
+      key: USER_PREFERENCES_KEYS.LOCATION_BOOKING_FILTERS,
+      value: { [facilityId]: {} },
+    });
     history.push(`/appointments/locations`);
   };
 


### PR DESCRIPTION
### Changes

- Send correct payload according to UserPreference model change

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
