### PR TITLE
fix(patientView): release fix v2.23: Patient view reload bug

### DIFF
--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -1,4 +1,14 @@
-import { add, differenceInDays, differenceInMonths, differenceInWeeks, differenceInYears, formatDuration, intervalToDuration, startOfDay, type Duration } from 'date-fns';
+import {
+  add,
+  differenceInDays,
+  differenceInMonths,
+  differenceInWeeks,
+  differenceInYears,
+  formatDuration,
+  intervalToDuration,
+  startOfDay,
+  type Duration,
+} from 'date-fns';
 import { isISOString, parseDate } from './dateTime';
 
 export const getAgeDurationFromDate = (date: string | Date | null | undefined) => {
@@ -26,21 +36,26 @@ const getDifferenceFnByUnit = {
 };
 
 // eslint-disable-next-line no-unused-vars
-const comparators: Record<string, (left: Date| number, right: Date| number) => boolean> = {
+const comparators: Record<string, (left: Date | number, right: Date | number) => boolean> = {
   '>': (left, right) => left > right,
   '<': (left, right) => left < right,
   '>=': (left, right) => left >= right,
   '<=': (left, right) => left <= right,
 };
 
-const compareDate = (leftDate: Date| number, operator: string, rightDate: Date| number, exclusive: boolean = false) => {
+const compareDate = (
+  leftDate: Date | number,
+  operator: string,
+  rightDate: Date | number,
+  exclusive: boolean = false,
+) => {
   let comparator = operator;
   if (!exclusive) comparator += '=';
 
   const comparatorFn = comparators[comparator];
 
   return comparatorFn?.(leftDate, rightDate) ?? false;
-}
+};
 
 type AgeRange = {
   min?: {
@@ -51,7 +66,7 @@ type AgeRange = {
     duration: Duration;
     exclusive?: boolean;
   };
-}
+};
 const ageIsWithinRange = (birthDate: Date, range: AgeRange) => {
   const { duration: minDuration, exclusive: minExclusive } = range.min ?? {};
   const { duration: maxDuration, exclusive: maxExclusive } = range.max ?? {};
@@ -62,14 +77,17 @@ const ageIsWithinRange = (birthDate: Date, range: AgeRange) => {
     (!minDate || compareDate(minDate, '<', now, minExclusive)) &&
     (!maxDate || compareDate(now, '<', maxDate, maxExclusive))
   );
-}
+};
 
 export type AgeDisplayFormat = {
   as: 'days' | 'weeks' | 'months' | 'years';
   range: AgeRange;
 };
-export const getDisplayAge = (dateOfBirth: string, ageDisplayFormat: AgeDisplayFormat[] | null | undefined) => {
-  if (!ageDisplayFormat || !isISOString(dateOfBirth)) {
+export const getDisplayAge = (
+  dateOfBirth: string,
+  ageDisplayFormat: AgeDisplayFormat[] | null | undefined,
+) => {
+  if (!ageDisplayFormat || !dateOfBirth || !isISOString(dateOfBirth)) {
     return '';
   }
 
@@ -89,4 +107,4 @@ export const getDisplayAge = (dateOfBirth: string, ageDisplayFormat: AgeDisplayF
   }
 
   return formatDuration(ageDuration, { format: ['years'] });
-}
+};


### PR DESCRIPTION
Simple fix for stopping the full screen error when patient screen has no patient in context. 

This is a weird fix because it returns to the 2.22 behaviour but also exposed an exisiting bug that the patient refresh is broken. Previously you were able to refresh on the patient without issue but now it logs you out and when you log back in the patient screen will be loaded but without a patient in context.

I had a quick look into reimplementing the proper behaviour but it wasn't obvious and this is a release fix so just going to make a card for now.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
