### PR TITLE
feat: EPI-1086: Frequency logic

### DIFF
--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -34,3 +34,101 @@ export const DRUG_ROUTE_LABELS = {
 
 const MAX_REPEATS = 12;
 export const REPEATS_LABELS = Array.from({ length: MAX_REPEATS + 1 }, (_, i) => i);
+
+export const ADMINISTRATION_FREQUENCIES = {
+  DAILY_IN_THE_MORNING: 'Daily in the morning',
+  DAILY_AT_MIDDAY: 'Daily at midday',
+  DAILY_AT_NIGHT: 'Daily at night',
+  DAILY: 'Daily',
+  TWO_TIMES_DAILY: 'Two times daily',
+  THREE_TIMES_DAILY: 'Three times daily',
+  FOUR_TIMES_DAILY: 'Four times daily',
+  EVERY_4_HOURS: 'Every 4 hours',
+  EVERY_6_HOURS: 'Every 6 hours',
+  EVERY_8_HOURS: 'Every 8 hours',
+  EVERY_SECOND_DAY: 'Every second day',
+  ONCE_A_WEEK: 'Once a week',
+  ONCE_A_MONTH: 'Once a month',
+  IMMEDIATELY: 'Immediately',
+  WHEN_REQUIRE: 'When required',
+};
+
+export const ADMINISTRATION_FREQUENCY_DETAILS = {
+  en: {
+    [ADMINISTRATION_FREQUENCIES.DAILY_IN_THE_MORNING]: {
+      synonyms: ['mane', 'Morning'],
+      startTimes: ['06:00'],
+      dosesPerDay: 1,
+    },
+    [ADMINISTRATION_FREQUENCIES.DAILY_AT_MIDDAY]: {
+      synonyms: ['midday'],
+      startTimes: ['12:00'],
+      dosesPerDay: 1,
+    },
+    [ADMINISTRATION_FREQUENCIES.DAILY_AT_NIGHT]: {
+      synonyms: ['nocte', 'nightly'],
+      startTimes: ['18:00'],
+      dosesPerDay: 1,
+    },
+    [ADMINISTRATION_FREQUENCIES.DAILY]: {
+      synonyms: ['D', 'Every 24 hours', 'q24h', 'q1d', 'Q.D.', 'QD'],
+      startTimes: ['06:00'],
+      dosesPerDay: 1,
+    },
+    [ADMINISTRATION_FREQUENCIES.TWO_TIMES_DAILY]: {
+      synonyms: ['BD', 'Every 12 hours', 'q12h', 'BID', 'B.D.', 'Twice a day'],
+      startTimes: ['06:00', '18:00'],
+      dosesPerDay: 2,
+    },
+    [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: {
+      synonyms: ['TID', 'TDS', 'T.I.D.'],
+      startTimes: ['06:00', '14:00', '22:00'],
+      dosesPerDay: 3,
+    },
+    [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: {
+      synonyms: ['QID', 'QDS', 'Q.I.D.'],
+      startTimes: ['06:00', '12:00', '18:00', '22:00'],
+      dosesPerDay: 4,
+    },
+    [ADMINISTRATION_FREQUENCIES.EVERY_4_HOURS]: {
+      synonyms: ['q4h', '4h', '4 hourly', '4 hrly'],
+      startTimes: ['02:00', '06:00', '10:00', '14:00', '18:00', '22:00'],
+      dosesPerDay: 6,
+    },
+    [ADMINISTRATION_FREQUENCIES.EVERY_6_HOURS]: {
+      synonyms: ['q6h', '6h', '6 hourly', '6 hrly'],
+      startTimes: ['00:00', '06:00', '12:00', '18:00'],
+      dosesPerDay: 4,
+    },
+    [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: {
+      synonyms: ['q8h', '8h', '8 hourly', '8 hrly'],
+      startTimes: ['00:00', '08:00', '16:00'],
+      dosesPerDay: 3,
+    },
+    [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: {
+      synonyms: ['QOD', 'Q.O.D.', 'Every other day'],
+      startTimes: ['06:00'],
+      dosesPerDay: 0.5,
+    },
+    [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: {
+      synonyms: ['Weekly', 'Once weekly'],
+      startTimes: ['06:00'],
+      dosesPerDay: 1 / 7,
+    },
+    [ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH]: {
+      synonyms: ['Monthly', 'Q.M.', 'QM', 'Once a month', 'Once monthly'],
+      startTimes: ['06:00'],
+      dosesPerDay: 1 / 28,
+    },
+    [ADMINISTRATION_FREQUENCIES.IMMEDIATELY]: {
+      synonyms: ['STAT', 'Immediately'],
+      startTimes: null,
+      dosesPerDay: null,
+    },
+    [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRE]: {
+      synonyms: ['PRN', 'As required', 'No frequency'],
+      startTimes: null,
+      dosesPerDay: null,
+    },
+  },
+};

--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -1,3 +1,5 @@
+import { ENGLISH_LANGUAGE_CODE } from './translations';
+
 export const DRUG_ROUTES = {
   dermal: 'dermal',
   ear: 'ear',
@@ -50,85 +52,101 @@ export const ADMINISTRATION_FREQUENCIES = {
   ONCE_A_WEEK: 'Once a week',
   ONCE_A_MONTH: 'Once a month',
   IMMEDIATELY: 'Immediately',
-  WHEN_REQUIRE: 'When required',
+  WHEN_REQUIRED: 'When required',
+};
+
+export const ADMINISTRATION_FREQUENCY_SYNONYMS = {
+  [ENGLISH_LANGUAGE_CODE]: {
+    [ADMINISTRATION_FREQUENCIES.DAILY_IN_THE_MORNING]: ['mane', 'Morning'],
+    [ADMINISTRATION_FREQUENCIES.DAILY_AT_MIDDAY]: ['midday'],
+    [ADMINISTRATION_FREQUENCIES.DAILY_AT_NIGHT]: ['nocte', 'nightly'],
+    [ADMINISTRATION_FREQUENCIES.DAILY]: ['D', 'Every 24 hours', 'q24h', 'q1d', 'Q.D.', 'QD'],
+    [ADMINISTRATION_FREQUENCIES.TWO_TIMES_DAILY]: [
+      'BD',
+      'Every 12 hours',
+      'q12h',
+      'BID',
+      'B.D.',
+      'Twice a day',
+    ],
+    [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: ['TID', 'TDS', 'T.I.D.'],
+    [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: ['QID', 'QDS', 'Q.I.D.'],
+    [ADMINISTRATION_FREQUENCIES.EVERY_4_HOURS]: ['q4h', '4h', '4 hourly', '4 hrly'],
+    [ADMINISTRATION_FREQUENCIES.EVERY_6_HOURS]: ['q6h', '6h', '6 hourly', '6 hrly'],
+    [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: ['q8h', '8h', '8 hourly', '8 hrly'],
+    [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: ['QOD', 'Q.O.D.', 'Every other day'],
+    [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: ['Weekly', 'Once weekly'],
+    [ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH]: [
+      'Monthly',
+      'Q.M.',
+      'QM',
+      'Once a month',
+      'Once monthly',
+    ],
+    [ADMINISTRATION_FREQUENCIES.IMMEDIATELY]: ['STAT', 'Immediately'],
+    [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRED]: ['PRN', 'As required', 'No frequency'],
+  },
 };
 
 export const ADMINISTRATION_FREQUENCY_DETAILS = {
-  en: {
-    [ADMINISTRATION_FREQUENCIES.DAILY_IN_THE_MORNING]: {
-      synonyms: ['mane', 'Morning'],
-      startTimes: ['06:00'],
-      dosesPerDay: 1,
-    },
-    [ADMINISTRATION_FREQUENCIES.DAILY_AT_MIDDAY]: {
-      synonyms: ['midday'],
-      startTimes: ['12:00'],
-      dosesPerDay: 1,
-    },
-    [ADMINISTRATION_FREQUENCIES.DAILY_AT_NIGHT]: {
-      synonyms: ['nocte', 'nightly'],
-      startTimes: ['18:00'],
-      dosesPerDay: 1,
-    },
-    [ADMINISTRATION_FREQUENCIES.DAILY]: {
-      synonyms: ['D', 'Every 24 hours', 'q24h', 'q1d', 'Q.D.', 'QD'],
-      startTimes: ['06:00'],
-      dosesPerDay: 1,
-    },
-    [ADMINISTRATION_FREQUENCIES.TWO_TIMES_DAILY]: {
-      synonyms: ['BD', 'Every 12 hours', 'q12h', 'BID', 'B.D.', 'Twice a day'],
-      startTimes: ['06:00', '18:00'],
-      dosesPerDay: 2,
-    },
-    [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: {
-      synonyms: ['TID', 'TDS', 'T.I.D.'],
-      startTimes: ['06:00', '12:00', '18:00'],
-      dosesPerDay: 3,
-    },
-    [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: {
-      synonyms: ['QID', 'QDS', 'Q.I.D.'],
-      startTimes: ['06:00', '12:00', '18:00', '22:00'],
-      dosesPerDay: 4,
-    },
-    [ADMINISTRATION_FREQUENCIES.EVERY_4_HOURS]: {
-      synonyms: ['q4h', '4h', '4 hourly', '4 hrly'],
-      startTimes: ['02:00', '06:00', '10:00', '14:00', '18:00', '22:00'],
-      dosesPerDay: 6,
-    },
-    [ADMINISTRATION_FREQUENCIES.EVERY_6_HOURS]: {
-      synonyms: ['q6h', '6h', '6 hourly', '6 hrly'],
-      startTimes: ['00:00', '06:00', '12:00', '18:00'],
-      dosesPerDay: 4,
-    },
-    [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: {
-      synonyms: ['q8h', '8h', '8 hourly', '8 hrly'],
-      startTimes: ['06:00', '14:00', '22:00'],
-      dosesPerDay: 3,
-    },
-    [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: {
-      synonyms: ['QOD', 'Q.O.D.', 'Every other day'],
-      startTimes: ['06:00'],
-      dosesPerDay: 1 / 2,
-    },
-    [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: {
-      synonyms: ['Weekly', 'Once weekly'],
-      startTimes: ['06:00'],
-      dosesPerDay: 1 / 7,
-    },
-    [ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH]: {
-      synonyms: ['Monthly', 'Q.M.', 'QM', 'Once a month', 'Once monthly'],
-      startTimes: ['06:00'],
-      dosesPerDay: 1 / 28,
-    },
-    [ADMINISTRATION_FREQUENCIES.IMMEDIATELY]: {
-      synonyms: ['STAT', 'Immediately'],
-      startTimes: null,
-      dosesPerDay: null,
-    },
-    [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRE]: {
-      synonyms: ['PRN', 'As required', 'No frequency'],
-      startTimes: null,
-      dosesPerDay: null,
-    },
+  [ADMINISTRATION_FREQUENCIES.DAILY_IN_THE_MORNING]: {
+    startTimes: ['06:00'],
+    dosesPerDay: 1,
+  },
+  [ADMINISTRATION_FREQUENCIES.DAILY_AT_MIDDAY]: {
+    startTimes: ['12:00'],
+    dosesPerDay: 1,
+  },
+  [ADMINISTRATION_FREQUENCIES.DAILY_AT_NIGHT]: {
+    startTimes: ['18:00'],
+    dosesPerDay: 1,
+  },
+  [ADMINISTRATION_FREQUENCIES.DAILY]: {
+    startTimes: ['06:00'],
+    dosesPerDay: 1,
+  },
+  [ADMINISTRATION_FREQUENCIES.TWO_TIMES_DAILY]: {
+    startTimes: ['06:00', '18:00'],
+    dosesPerDay: 2,
+  },
+  [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: {
+    startTimes: ['06:00', '12:00', '18:00'],
+    dosesPerDay: 3,
+  },
+  [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: {
+    startTimes: ['06:00', '12:00', '18:00', '22:00'],
+    dosesPerDay: 4,
+  },
+  [ADMINISTRATION_FREQUENCIES.EVERY_4_HOURS]: {
+    startTimes: ['02:00', '06:00', '10:00', '14:00', '18:00', '22:00'],
+    dosesPerDay: 6,
+  },
+  [ADMINISTRATION_FREQUENCIES.EVERY_6_HOURS]: {
+    startTimes: ['00:00', '06:00', '12:00', '18:00'],
+    dosesPerDay: 4,
+  },
+  [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: {
+    startTimes: ['06:00', '14:00', '22:00'],
+    dosesPerDay: 3,
+  },
+  [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: {
+    startTimes: ['06:00'],
+    dosesPerDay: 1 / 2,
+  },
+  [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: {
+    startTimes: ['06:00'],
+    dosesPerDay: 1 / 7,
+  },
+  [ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH]: {
+    startTimes: ['06:00'],
+    dosesPerDay: 1 / 28,
+  },
+  [ADMINISTRATION_FREQUENCIES.IMMEDIATELY]: {
+    startTimes: null,
+    dosesPerDay: null,
+  },
+  [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRED]: {
+    startTimes: null,
+    dosesPerDay: null,
   },
 };

--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -1,5 +1,3 @@
-import { ENGLISH_LANGUAGE_CODE } from './translations';
-
 export const DRUG_ROUTES = {
   dermal: 'dermal',
   ear: 'ear',
@@ -56,36 +54,34 @@ export const ADMINISTRATION_FREQUENCIES = {
 };
 
 export const ADMINISTRATION_FREQUENCY_SYNONYMS = {
-  [ENGLISH_LANGUAGE_CODE]: {
-    [ADMINISTRATION_FREQUENCIES.DAILY_IN_THE_MORNING]: ['mane', 'Morning'],
-    [ADMINISTRATION_FREQUENCIES.DAILY_AT_MIDDAY]: ['midday'],
-    [ADMINISTRATION_FREQUENCIES.DAILY_AT_NIGHT]: ['nocte', 'nightly'],
-    [ADMINISTRATION_FREQUENCIES.DAILY]: ['D', 'Every 24 hours', 'q24h', 'q1d', 'Q.D.', 'QD'],
-    [ADMINISTRATION_FREQUENCIES.TWO_TIMES_DAILY]: [
-      'BD',
-      'Every 12 hours',
-      'q12h',
-      'BID',
-      'B.D.',
-      'Twice a day',
-    ],
-    [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: ['TID', 'TDS', 'T.I.D.'],
-    [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: ['QID', 'QDS', 'Q.I.D.'],
-    [ADMINISTRATION_FREQUENCIES.EVERY_4_HOURS]: ['q4h', '4h', '4 hourly', '4 hrly'],
-    [ADMINISTRATION_FREQUENCIES.EVERY_6_HOURS]: ['q6h', '6h', '6 hourly', '6 hrly'],
-    [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: ['q8h', '8h', '8 hourly', '8 hrly'],
-    [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: ['QOD', 'Q.O.D.', 'Every other day'],
-    [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: ['Weekly', 'Once weekly'],
-    [ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH]: [
-      'Monthly',
-      'Q.M.',
-      'QM',
-      'Once a month',
-      'Once monthly',
-    ],
-    [ADMINISTRATION_FREQUENCIES.IMMEDIATELY]: ['STAT', 'Immediately'],
-    [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRED]: ['PRN', 'As required', 'No frequency'],
-  },
+  [ADMINISTRATION_FREQUENCIES.DAILY_IN_THE_MORNING]: ['mane', 'Morning'],
+  [ADMINISTRATION_FREQUENCIES.DAILY_AT_MIDDAY]: ['midday'],
+  [ADMINISTRATION_FREQUENCIES.DAILY_AT_NIGHT]: ['nocte', 'nightly'],
+  [ADMINISTRATION_FREQUENCIES.DAILY]: ['D', 'Every 24 hours', 'q24h', 'q1d', 'Q.D.', 'QD'],
+  [ADMINISTRATION_FREQUENCIES.TWO_TIMES_DAILY]: [
+    'BD',
+    'Every 12 hours',
+    'q12h',
+    'BID',
+    'B.D.',
+    'Twice a day',
+  ],
+  [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: ['TID', 'TDS', 'T.I.D.'],
+  [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: ['QID', 'QDS', 'Q.I.D.'],
+  [ADMINISTRATION_FREQUENCIES.EVERY_4_HOURS]: ['q4h', '4h', '4 hourly', '4 hrly'],
+  [ADMINISTRATION_FREQUENCIES.EVERY_6_HOURS]: ['q6h', '6h', '6 hourly', '6 hrly'],
+  [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: ['q8h', '8h', '8 hourly', '8 hrly'],
+  [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: ['QOD', 'Q.O.D.', 'Every other day'],
+  [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: ['Weekly', 'Once weekly'],
+  [ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH]: [
+    'Monthly',
+    'Q.M.',
+    'QM',
+    'Once a month',
+    'Once monthly',
+  ],
+  [ADMINISTRATION_FREQUENCIES.IMMEDIATELY]: ['STAT', 'Immediately'],
+  [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRED]: ['PRN', 'As required', 'No frequency'],
 };
 
 export const ADMINISTRATION_FREQUENCY_DETAILS = {

--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -82,7 +82,7 @@ export const ADMINISTRATION_FREQUENCY_DETAILS = {
     },
     [ADMINISTRATION_FREQUENCIES.THREE_TIMES_DAILY]: {
       synonyms: ['TID', 'TDS', 'T.I.D.'],
-      startTimes: ['06:00', '14:00', '22:00'],
+      startTimes: ['06:00', '12:00', '18:00'],
       dosesPerDay: 3,
     },
     [ADMINISTRATION_FREQUENCIES.FOUR_TIMES_DAILY]: {
@@ -102,13 +102,13 @@ export const ADMINISTRATION_FREQUENCY_DETAILS = {
     },
     [ADMINISTRATION_FREQUENCIES.EVERY_8_HOURS]: {
       synonyms: ['q8h', '8h', '8 hourly', '8 hrly'],
-      startTimes: ['00:00', '08:00', '16:00'],
+      startTimes: ['06:00', '14:00', '22:00'],
       dosesPerDay: 3,
     },
     [ADMINISTRATION_FREQUENCIES.EVERY_SECOND_DAY]: {
       synonyms: ['QOD', 'Q.O.D.', 'Every other day'],
       startTimes: ['06:00'],
-      dosesPerDay: 0.5,
+      dosesPerDay: 1 / 2,
     },
     [ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK]: {
       synonyms: ['Weekly', 'Once weekly'],

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1334,8 +1334,8 @@ export const globalSettings = {
               type: yup.boolean(),
               defaultValue: true,
             },
-            [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRE]: {
-              description: ADMINISTRATION_FREQUENCIES.WHEN_REQUIRE,
+            [ADMINISTRATION_FREQUENCIES.WHEN_REQUIRED]: {
+              description: ADMINISTRATION_FREQUENCIES.WHEN_REQUIRED,
               type: yup.boolean(),
               defaultValue: true,
             },

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ADMINISTRATION_FREQUENCY_DETAILS } from "@tamanu/constants";
+import { AutocompleteInput } from "../Field";
+import { FrequencySuggester } from "./frequencySuggester";
+import { TranslatedText } from "../Translation/TranslatedText";
+import { useTranslation } from "../../contexts/Translation";
+
+const getFrequencySuggestions = (details, language) => {
+  return Object.entries(details[language]).map(([key, value]) => ({
+    label: `${key} (${value.synonyms[0]})`,
+    value: key,
+    synonyms: value.synonyms,
+    startTimes: value.startTimes,
+    dosesPerDay: value.dosesPerDay,
+  }));
+};
+
+export const FrequencySearchInput = () => {
+  const { storedLanguage } = useTranslation();
+
+  const frequencySuggestions = getFrequencySuggestions(ADMINISTRATION_FREQUENCY_DETAILS, storedLanguage);
+  const frequencySuggester = new FrequencySuggester(frequencySuggestions);
+
+  return <AutocompleteInput
+    onChange={() => {}}
+    label={<TranslatedText stringId="medication.frequency.label" fallback="Frequency" />}
+    suggester={frequencySuggester}
+  />;
+};

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -1,31 +1,23 @@
 import React from 'react';
-import {
-  ADMINISTRATION_FREQUENCY_DETAILS,
-  ADMINISTRATION_FREQUENCY_SYNONYMS,
-} from '@tamanu/constants';
 import { AutocompleteInput } from '../Field';
 import { FrequencySuggester } from './frequencySuggester';
 import { TranslatedText } from '../Translation/TranslatedText';
 import { useTranslation } from '../../contexts/Translation';
+import { getTranslatedFrequencySynonyms } from '../../utils/medications';
 
-const getFrequencySuggestions = (synonyms, details, language) => {
-  return Object.entries(synonyms[language]).map(([key, value]) => ({
+const getFrequencySuggestions = synonyms => {
+  return Object.entries(synonyms).map(([key, value]) => ({
     label: `${key} (${value[0]})`,
     value: key,
     synonyms: value,
-    startTimes: details[key].startTimes,
-    dosesPerDay: details[key].dosesPerDay,
   }));
 };
 
 export const FrequencySearchInput = ({ onChange }) => {
-  const { storedLanguage } = useTranslation();
+  const { getTranslation } = useTranslation();
+  const translatedFrequencySynonyms = getTranslatedFrequencySynonyms(getTranslation);
 
-  const frequencySuggestions = getFrequencySuggestions(
-    ADMINISTRATION_FREQUENCY_SYNONYMS,
-    ADMINISTRATION_FREQUENCY_DETAILS,
-    storedLanguage,
-  );
+  const frequencySuggestions = getFrequencySuggestions(translatedFrequencySynonyms);
   const frequencySuggester = new FrequencySuggester(frequencySuggestions);
 
   return (

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -1,29 +1,38 @@
-import React from "react";
-import { ADMINISTRATION_FREQUENCY_DETAILS } from "@tamanu/constants";
-import { AutocompleteInput } from "../Field";
-import { FrequencySuggester } from "./frequencySuggester";
-import { TranslatedText } from "../Translation/TranslatedText";
-import { useTranslation } from "../../contexts/Translation";
+import React from 'react';
+import {
+  ADMINISTRATION_FREQUENCY_DETAILS,
+  ADMINISTRATION_FREQUENCY_SYNONYMS,
+} from '@tamanu/constants';
+import { AutocompleteInput } from '../Field';
+import { FrequencySuggester } from './frequencySuggester';
+import { TranslatedText } from '../Translation/TranslatedText';
+import { useTranslation } from '../../contexts/Translation';
 
-const getFrequencySuggestions = (details, language) => {
-  return Object.entries(details[language]).map(([key, value]) => ({
-    label: `${key} (${value.synonyms[0]})`,
+const getFrequencySuggestions = (synonyms, details, language) => {
+  return Object.entries(synonyms[language]).map(([key, value]) => ({
+    label: `${key} (${value[0]})`,
     value: key,
-    synonyms: value.synonyms,
-    startTimes: value.startTimes,
-    dosesPerDay: value.dosesPerDay,
+    synonyms: value,
+    startTimes: details[key].startTimes,
+    dosesPerDay: details[key].dosesPerDay,
   }));
 };
 
-export const FrequencySearchInput = () => {
+export const FrequencySearchInput = ({ onChange }) => {
   const { storedLanguage } = useTranslation();
 
-  const frequencySuggestions = getFrequencySuggestions(ADMINISTRATION_FREQUENCY_DETAILS, storedLanguage);
+  const frequencySuggestions = getFrequencySuggestions(
+    ADMINISTRATION_FREQUENCY_SYNONYMS,
+    ADMINISTRATION_FREQUENCY_DETAILS,
+    storedLanguage,
+  );
   const frequencySuggester = new FrequencySuggester(frequencySuggestions);
 
-  return <AutocompleteInput
-    onChange={() => {}}
-    label={<TranslatedText stringId="medication.frequency.label" fallback="Frequency" />}
-    suggester={frequencySuggester}
-  />;
+  return (
+    <AutocompleteInput
+      onChange={onChange}
+      label={<TranslatedText stringId="medication.frequency.label" fallback="Frequency" />}
+      suggester={frequencySuggester}
+    />
+  );
 };

--- a/packages/web/app/components/Medication/frequencySuggester.js
+++ b/packages/web/app/components/Medication/frequencySuggester.js
@@ -1,0 +1,33 @@
+export class FrequencySuggester {
+  constructor(suggestions) {
+    this.suggestions = suggestions;
+  }
+
+  fetchCurrentOption = async value => {
+    return value;
+  };
+
+  fetchSuggestions = async search => {
+    const searchLower = search.toLowerCase();
+
+    return this.suggestions
+      .filter(
+        ({ label, synonyms }) =>
+          label.toLowerCase().includes(searchLower) ||
+          synonyms.some(syn => syn.toLowerCase().includes(searchLower)),
+      )
+      .sort(({ label: aLabel, synonyms: aSyn }, { label: bLabel, synonyms: bSyn }) => {
+        const aStart = aLabel.toLowerCase().startsWith(searchLower);
+        const bStart = bLabel.toLowerCase().startsWith(searchLower);
+        if (aStart !== bStart) return bStart - aStart;
+
+        const aInclude = aLabel.toLowerCase().includes(searchLower);
+        const bInclude = bLabel.toLowerCase().includes(searchLower);
+        if (aInclude !== bInclude) return bInclude - aInclude;
+
+        const aSynInclude = aSyn.some(syn => syn.toLowerCase().includes(searchLower));
+        const bSynInclude = bSyn.some(syn => syn.toLowerCase().includes(searchLower));
+        return bSynInclude - aSynInclude;
+      });
+  };
+}

--- a/packages/web/app/components/Medication/frequencySuggester.js
+++ b/packages/web/app/components/Medication/frequencySuggester.js
@@ -16,7 +16,7 @@ export class FrequencySuggester {
           label.toLowerCase().includes(searchLower) ||
           synonyms.some(syn => syn.toLowerCase().includes(searchLower)),
       )
-      .sort(({ label: aLabel, synonyms: aSyn }, { label: bLabel, synonyms: bSyn }) => {
+      .sort(({ label: aLabel, synonyms: aSynonym }, { label: bLabel, synonyms: bSynonym }) => {
         const aStart = aLabel.toLowerCase().startsWith(searchLower);
         const bStart = bLabel.toLowerCase().startsWith(searchLower);
         if (aStart !== bStart) return bStart - aStart;
@@ -25,9 +25,13 @@ export class FrequencySuggester {
         const bInclude = bLabel.toLowerCase().includes(searchLower);
         if (aInclude !== bInclude) return bInclude - aInclude;
 
-        const aSynInclude = aSyn.some(syn => syn.toLowerCase().includes(searchLower));
-        const bSynInclude = bSyn.some(syn => syn.toLowerCase().includes(searchLower));
-        return bSynInclude - aSynInclude;
+        const aSynonymInclude = aSynonym.some(synonym =>
+          synonym.toLowerCase().includes(searchLower),
+        );
+        const bSynonymInclude = bSynonym.some(synonym =>
+          synonym.toLowerCase().includes(searchLower),
+        );
+        return bSynonymInclude - aSynonymInclude;
       });
   };
 }

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -1,0 +1,20 @@
+import { ADMINISTRATION_FREQUENCY_SYNONYMS } from '@tamanu/constants';
+import { camelCase } from 'lodash';
+
+export const getTranslatedFrequencySynonyms = getTranslation => {
+  const result = {};
+  Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS).forEach(([frequency, synonyms]) => {
+    const labelKey = getTranslation(
+      `medication.frequency.${camelCase(frequency)}.label`,
+      frequency,
+    );
+
+    const translatedSynonyms = synonyms.map((synonym, index) =>
+      getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, synonym),
+    );
+
+    result[labelKey] = translatedSynonyms;
+  });
+
+  return result;
+};


### PR DESCRIPTION
### Changes

- Add a constant that contains administration frequency details
- Add an autocomplete input and suggester logic for searching frequency

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
