### PR TITLE
fix(notification): release-2.23: adjust default recentNotificationsTimeFrame value for notitications

### DIFF
--- a/packages/facility-server/app/routes/apiv1/notifications.js
+++ b/packages/facility-server/app/routes/apiv1/notifications.js
@@ -15,7 +15,7 @@ notifications.get(
     req.flagPermissionChecked();
     const { models, user } = req;
 
-    const recentNotificationsTimeFrame = config.notification?.recentNotificationsTimeFrame || 8;
+    const recentNotificationsTimeFrame = config.notification?.recentNotificationsTimeFrame || 48;
     const readNotifications = await models.Notification.findAll({
       where: {
         userId: user.id,

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -133,6 +133,9 @@
   // @see here for a list of available options https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   "countryTimeZone": "Australia/Melbourne",
   "allowMismatchedTimeZones": false,
+  "notification": {
+    "recentNotificationsTimeFrame": 48, // hours
+  },
   "tasking": {
     "upcomingTasksTimeFrame": 8, // hours,
     "upcomingTasksShouldBeGeneratedTimeFrame": 72, // hours


### PR DESCRIPTION

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
