### PR TITLE
fix(deaths): Release v2.23 fix: Patient death endpoint error

### DIFF
--- a/packages/web/app/components/DiagnosisView.jsx
+++ b/packages/web/app/components/DiagnosisView.jsx
@@ -44,7 +44,7 @@ const AddDiagnosisButton = styled(Button)`
   height: fit-content;
 `;
 
-export const DiagnosisView = React.memo(({ encounter, isTriage, readonly }) => {
+export const DiagnosisView = React.memo(({ encounter, isTriage, readOnly }) => {
   const { diagnoses, id } = encounter;
   const [diagnosis, editDiagnosis] = React.useState(null);
   const { ability } = useAuth();
@@ -55,7 +55,7 @@ export const DiagnosisView = React.memo(({ encounter, isTriage, readonly }) => {
   const DiagnosesDisplay = canListDiagnoses ? (
     <>
       <DiagnosisLabel numberOfDiagnoses={validDiagnoses.length} />
-      <DiagnosisList diagnoses={validDiagnoses} onEditDiagnosis={!readonly && editDiagnosis} />
+      <DiagnosisList diagnoses={validDiagnoses} onEditDiagnosis={!readOnly && editDiagnosis} />
     </>
   ) : (
     <>
@@ -86,7 +86,7 @@ export const DiagnosisView = React.memo(({ encounter, isTriage, readonly }) => {
           onClick={() => editDiagnosis({})}
           variant="outlined"
           color="primary"
-          disabled={readonly}
+          disabled={readOnly}
         >
           <TranslatedText stringId="diagnosis.action.add" fallback="Add diagnosis" />
         </AddDiagnosisButton>

--- a/packages/web/app/components/PatientInfoPane/PatientCoreInfo.jsx
+++ b/packages/web/app/components/PatientInfoPane/PatientCoreInfo.jsx
@@ -77,19 +77,6 @@ const CoreInfoCell = ({ label, children, testId }) => (
   </CoreInfoCellContainer>
 );
 
-const DeceasedText = styled.div`
-  opacity: 0.8;
-`;
-
-const DeceasedIndicator = ({ death }) => (
-  <DeceasedText>
-    <span>
-      <TranslatedText stringId="patient.detailsSidebar.deceasedIndicator" fallback="Deceased" />,
-    </span>
-    <DateDisplay date={death.date} />
-  </DeceasedText>
-);
-
 const HealthIdContainer = styled.div`
   padding: 20px 10px 12px;
 `;
@@ -150,7 +137,6 @@ export const CoreInfoDisplay = memo(({ patient }) => {
             <NameText data-test-id="core-info-patient-last-name">{patient.lastName}</NameText>
           </div>
           <PatientInitialsIcon patient={patient} />
-          {patient.death && <DeceasedIndicator death={patient.death} />}
         </NameContainer>
       </PatientButton>
       <CoreInfoSection>

--- a/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
+++ b/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
@@ -215,7 +215,7 @@ export const PatientInfoPane = () => {
   const { data: deathData, isLoading } = useQuery(
     ['patientDeathSummary', patient.id],
     () => api.get(`patient/${patient.id}/death`, { isErrorUnknown: isErrorUnknownAllow404s }),
-    { enabled: patientDeathsEnabled },
+    { enabled: patientDeathsEnabled && !!patient.dateOfDeath },
   );
 
   const readonly = !!patient.death;

--- a/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
+++ b/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
@@ -218,7 +218,7 @@ export const PatientInfoPane = () => {
     { enabled: patientDeathsEnabled && !!patient.dateOfDeath },
   );
 
-  const readonly = !!patient.death;
+  const readonly = !!patient.dateOfDeath;
   const showRecordDeathActions = !isLoading && patientDeathsEnabled && !deathData?.isFinal;
   const showCauseOfDeathButton = showRecordDeathActions && Boolean(deathData);
 

--- a/packages/web/app/views/patients/EncounterView.jsx
+++ b/packages/web/app/views/patients/EncounterView.jsx
@@ -164,7 +164,7 @@ export const EncounterView = () => {
 
   const [currentTab, setCurrentTab] = useState(query.get('tab'));
   const [tabs, setTabs] = useState(TABS);
-  const disabled = encounter?.endDate || patient.death;
+  const disabled = encounter?.endDate || !!patient.dateOfDeath;
 
   const visibleTabs = tabs.filter(tab => !tab.condition || tab.condition(getSetting));
 
@@ -260,7 +260,7 @@ export const EncounterView = () => {
           )
         }
       />
-      <DiagnosisView encounter={encounter} isTriage={getIsTriage(encounter)} disabled={disabled} />
+      <DiagnosisView encounter={encounter} isTriage={getIsTriage(encounter)} readOnly={disabled} />
       <ContentPane>
         <StyledTabDisplayDraggable
           tabs={visibleTabs}

--- a/packages/web/app/views/patients/PatientView.jsx
+++ b/packages/web/app/views/patients/PatientView.jsx
@@ -123,7 +123,7 @@ export const PatientView = () => {
   const patient = useSelector(state => state.patient);
   const queryTab = query.get('tab');
   const [currentTab, setCurrentTab] = useState(queryTab || PATIENT_TABS.SUMMARY);
-  const disabled = !!patient.death;
+  const disabled = !!patient.dateOfDeath;
   const api = useApi();
   const syncState = useSyncState();
   const isSyncing = syncState.isPatientSyncing(patient.id);


### PR DESCRIPTION
### Changes

Currently we always query the patient death endpoint if it is enabled in settings. This throws an error for every patient without a death record so this just updates to only run the query if the patient record contains a `date_of_death` value

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
