### PR TITLE
fix(dateTime): Release fix 2.23: Use user time for the triage system note

### DIFF
--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -463,8 +463,7 @@ export class Encounter extends Model {
   }
 
   async addTriageScoreNote(
-    triageRecord: { score: any },
-    submittedTime: string,
+    triageRecord: { score: any; triageTime: string },
     user: ModelProperties<User>,
   ) {
     const department = await this.sequelize.models.Department.findOne({
@@ -479,7 +478,7 @@ export class Encounter extends Model {
 
     await this.addSystemNote(
       `${department.name} triage score: ${triageRecord.score}`,
-      submittedTime,
+      triageRecord.triageTime,
       user,
     );
   }

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -51,7 +51,7 @@ triage.post(
     const triageRecord = await models.Triage.create({ ...body, departmentId, actorId: user.id });
 
     if (vitals) {
-      const getDefaultId = async type =>
+      const getDefaultId = async (type) =>
         models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
       const updatedBody = {
         locationId: vitals.locationId || (await getDefaultId('location')),
@@ -78,7 +78,7 @@ triage.post(
     const encounter = await models.Encounter.findOne({
       where: { id: triageRecord.encounterId },
     });
-    await encounter.addTriageScoreNote(triageRecord, Date.now(), user);
+    await encounter.addTriageScoreNote(triageRecord, user);
 
     res.send(triageRecord);
   }),
@@ -175,7 +175,7 @@ triage.get(
         },
       },
     );
-    const forResponse = result.map(x => renameObjectKeys(x.forResponse()));
+    const forResponse = result.map((x) => renameObjectKeys(x.forResponse()));
 
     res.send({
       data: forResponse,


### PR DESCRIPTION
Use the triage time set from user computer time rather than the facility server time on note creation

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
