### PR TITLE
fix(deaths): Release fix v2.23: Patient death button display

### DIFF
--- a/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
+++ b/packages/web/app/components/PatientInfoPane/PatientInfoPane.jsx
@@ -212,14 +212,14 @@ export const PatientInfoPane = () => {
   const patient = useSelector(state => state.patient);
   const api = useApi();
   const patientDeathsEnabled = getSetting('features.enablePatientDeaths');
-  const { data: deathData, isLoading } = useQuery(
+  const { data: deathData, isFetching } = useQuery(
     ['patientDeathSummary', patient.id],
     () => api.get(`patient/${patient.id}/death`, { isErrorUnknown: isErrorUnknownAllow404s }),
     { enabled: patientDeathsEnabled && !!patient.dateOfDeath },
   );
 
   const readonly = !!patient.dateOfDeath;
-  const showRecordDeathActions = !isLoading && patientDeathsEnabled && !deathData?.isFinal;
+  const showRecordDeathActions = !isFetching && patientDeathsEnabled && !deathData?.isFinal;
   const showCauseOfDeathButton = showRecordDeathActions && Boolean(deathData);
 
   return (


### PR DESCRIPTION
After my last tweak it stopped showing the "Record death button". This was because after adding in the "enabled" option for react query, `isLoading` is always set to true when enabled option for query is false. I have just replaced `isLoading` with `isFetching`. From looking online this is a common pain point for people and this is often how it is solved

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
