### PR TITLE
fix: EPI-1067: release 2.23: Fix encounter history table display issue on 1 line row

### DIFF
--- a/packages/web/app/components/PatientHistory.jsx
+++ b/packages/web/app/components/PatientHistory.jsx
@@ -25,6 +25,9 @@ import { ThemedTooltip } from './Tooltip.jsx';
 const DateWrapper = styled.div`
   position: relative;
   min-width: 90px;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
 `;
 
 const FacilityWrapper = styled.div`
@@ -159,14 +162,16 @@ const getDate = ({ startDate, endDate, encounterType }) => {
   const patientStatus = getPatientStatus(encounterType);
   return (
     <DateWrapper>
-      <StatusIndicator patientStatus={patientStatus} />
-      <DateDisplay date={startDate} />
-      &nbsp;&ndash;{' '}
-      {endDate ? (
-        <DateDisplay date={endDate} />
-      ) : (
-        <TranslatedText stringId="general.date.current" fallback="Current" />
-      )}
+      <div>
+        <StatusIndicator patientStatus={patientStatus} />
+        <DateDisplay date={startDate} />
+        &nbsp;&ndash;{' '}
+        {endDate ? (
+          <DateDisplay date={endDate} />
+        ) : (
+          <TranslatedText stringId="general.date.current" fallback="Current" />
+        )}
+      </div>
     </DateWrapper>
   );
 };


### PR DESCRIPTION
### Changes

- Tweak to make encounter history table rows always have 2-line height

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
