### PR TITLE
fix(referrals): SAV-883: Display referrals in alphabetical order when 'Select a referral' on desktop

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Survey.test.js
+++ b/packages/facility-server/__tests__/apiv1/Survey.test.js
@@ -1,5 +1,6 @@
 import { setupSurveyFromObject } from '@tamanu/database/demoData/surveys';
 import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
+import { SURVEY_TYPES } from '@tamanu/constants';
 
 import { createTestContext } from '../utilities';
 
@@ -16,6 +17,92 @@ describe('Survey', () => {
     app = await baseApp.asRole('practitioner');
   });
   afterAll(() => ctx.close());
+
+  describe('survey list', () => {
+    beforeAll(async () => {
+      await setupSurveyFromObject(models, {
+        program: {
+          id: 'survey-program',
+        },
+        survey: {
+          id: 'program-survey-1',
+          surveyType: 'programs',
+          name: 'B Survey',
+        },
+        questions: [
+          {
+            name: 'Question1',
+            type: 'Number',
+            validationCriteria: JSON.stringify({
+              min: 0,
+              max: 999,
+            }),
+            config: JSON.stringify({
+              unit: 'mm Hg',
+            }),
+          },
+        ],
+      });
+
+      await setupSurveyFromObject(models, {
+        program: {
+          id: 'survey-program',
+        },
+        survey: {
+          id: 'program-survey-2',
+          surveyType: 'programs',
+          name: 'A Survey',
+        },
+        questions: [
+          {
+            name: 'Question2',
+            type: 'Number',
+            validationCriteria: JSON.stringify({
+              min: 0,
+              max: 999,
+            }),
+            config: JSON.stringify({
+              unit: 'mm Hg',
+            }),
+          },
+        ],
+      });
+
+      await setupSurveyFromObject(models, {
+        program: {
+          id: 'survey-program',
+        },
+        survey: {
+          id: 'program-survey-3',
+          surveyType: 'programs',
+          name: 'C Survey',
+        },
+        questions: [
+          {
+            name: 'Question3',
+            type: 'Number',
+            validationCriteria: JSON.stringify({
+              min: 0,
+              max: 999,
+            }),
+            config: JSON.stringify({
+              unit: 'mm Hg',
+            }),
+          },
+        ],
+      });
+    });
+
+    it('sorted alphabetically', async () => {
+      const result = await app.get(`/api/survey?type=${SURVEY_TYPES.PROGRAMS}`);
+      expect(result).toHaveSucceeded();
+
+      expect(result.body.surveys).toHaveLength(3);
+      expect(result.body.surveys[0].name).toBe('A Survey');
+      expect(result.body.surveys[1].name).toBe('B Survey');
+      expect(result.body.surveys[2].name).toBe('C Survey');
+    });
+  });
 
   describe('vitals', () => {
     beforeAll(async () => {

--- a/packages/facility-server/app/routes/apiv1/survey.js
+++ b/packages/facility-server/app/routes/apiv1/survey.js
@@ -75,6 +75,7 @@ survey.get(
         surveyType: req.query.type,
         visibilityStatus: { [Op.ne]: VISIBILITY_STATUSES.HISTORICAL },
       },
+      order: [['name', 'ASC']],
     });
     const filteredSurveys = getFilteredListByPermission(ability, surveys, 'submit');
 


### PR DESCRIPTION
### Changes
- Display referrals in alphabetical order when 'Select a referral' on desktop

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
