### PR TITLE
fix(desktopCharting): SAV-686: QA stuff 1601

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -16,8 +16,6 @@ import {
   NOTE_RECORD_TYPES,
   NOTE_TYPES,
   VITALS_DATA_ELEMENT_IDS,
-  CHARTING_DATA_ELEMENT_IDS,
-  SURVEY_TYPES,
 } from '@tamanu/constants';
 import { setupSurveyFromObject } from '@tamanu/database/demoData/surveys';
 import { fake, fakeUser } from '@tamanu/shared/test-helpers/fake';
@@ -472,71 +470,6 @@ describe('Encounter', () => {
       });
       expect(labRequest1.id).toEqual(result.body.data[0].id);
       expect(result.body.data[0].notes[0].content).toEqual(note.content);
-    });
-  });
-
-  describe('GET encounter chart instances', () => {
-    it('should get a list of chart instances of a chart for an encounter', async () => {
-      const encounter = await models.Encounter.create({
-        ...(await createDummyEncounter(models)),
-        patientId: patient.id,
-      });
-      const program = await models.Program.create({ ...fake(models.Program) });
-      const survey = await models.Survey.create({
-        ...fake(models.Survey),
-        code: 'complex-chart-core',
-        programId: program.id,
-        surveyType: SURVEY_TYPES.COMPLEX_CHART_CORE,
-      });
-      const dataElement = await models.ProgramDataElement.create({
-        ...fake(models.ProgramDataElement),
-        id: CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName,
-      });
-      const response1 = await models.SurveyResponse.create({
-        ...fake(models.SurveyResponse),
-        surveyId: survey.id,
-        encounterId: encounter.id,
-      });
-      const response2 = await models.SurveyResponse.create({
-        ...fake(models.SurveyResponse),
-        surveyId: survey.id,
-        encounterId: encounter.id,
-      });
-      const chartInstance1Answer1 = await models.SurveyResponseAnswer.create({
-        ...fake(models.SurveyResponseAnswer),
-        dataElementId: dataElement.id,
-        responseId: response1.id,
-        body: 'Chart 1',
-      });
-      const chartInstance1Answer2 = await models.SurveyResponseAnswer.create({
-        ...fake(models.SurveyResponseAnswer),
-        dataElementId: dataElement.id,
-        responseId: response2.id,
-        body: 'Chart 2',
-      });
-
-      const result = await app.get(
-        `/api/encounter/${encounter.id}/charts/${survey.id}/chartInstances`,
-      );
-      expect(result).toHaveSucceeded();
-      expect(result.body).toMatchObject({
-        count: 2,
-        data: expect.any(Array),
-      });
-      const chartInstance1 = result.body.data.find((x) => x.chartInstanceId === response1.id);
-      const chartInstance2 = result.body.data.find((x) => x.chartInstanceId === response2.id);
-
-      expect(chartInstance1).toMatchObject({
-        chartSurveyId: survey.id,
-        chartInstanceId: response1.id,
-        chartInstanceName: chartInstance1Answer1.body,
-      });
-
-      expect(chartInstance2).toMatchObject({
-        chartSurveyId: survey.id,
-        chartInstanceId: response2.id,
-        chartInstanceName: chartInstance1Answer2.body,
-      });
     });
   });
 
@@ -1356,108 +1289,6 @@ describe('Encounter', () => {
       });
     });
 
-    describe('charting', () => {
-      let chartsEncounter = null;
-      let chartsPatient = null;
-
-      beforeAll(async () => {
-        chartsPatient = await models.Patient.create(await createDummyPatient(models));
-        chartsEncounter = await models.Encounter.create({
-          ...(await createDummyEncounter(models, { endDate: null })),
-          patientId: chartsPatient.id,
-          reasonForEncounter: 'charting test',
-        });
-
-        await setupSurveyFromObject(models, {
-          program: {
-            id: 'charts-program',
-          },
-          survey: {
-            id: 'simple-chart-survey',
-            survey_type: 'simpleChart',
-          },
-          questions: [
-            {
-              name: 'PatientChartingDate',
-              type: 'DateTime',
-            },
-            {
-              name: 'ChartQuestionOne',
-              type: 'Number',
-            },
-            {
-              name: 'ChartQuestionTwo',
-              type: 'Number',
-            },
-          ],
-        });
-      });
-
-      beforeEach(async () => {
-        await models.SurveyResponseAnswer.truncate({});
-        await models.SurveyResponse.truncate({});
-      });
-
-      it('should record a new simple chart reading', async () => {
-        const submissionDate = getCurrentDateTimeString();
-        const result = await app.post('/api/surveyResponse').send({
-          surveyId: 'simple-chart-survey',
-          patientId: chartsPatient.id,
-          startTime: submissionDate,
-          endTime: submissionDate,
-          answers: {
-            [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
-            'pde-ChartQuestionOne': 1234,
-          },
-          facilityId,
-        });
-        expect(result).toHaveSucceeded();
-        const saved = await models.SurveyResponseAnswer.findOne({
-          where: { dataElementId: 'pde-ChartQuestionOne', body: '1234' },
-        });
-        expect(saved).toHaveProperty('body', '1234');
-      });
-
-      it('should get simple chart readings for an encounter', async () => {
-        const surveyId = 'simple-chart-survey';
-        const submissionDate = getCurrentDateTimeString();
-        const answers = {
-          [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
-          'pde-ChartQuestionOne': 123,
-          'pde-ChartQuestionTwo': 456,
-        };
-        await app.post('/api/surveyResponse').send({
-          surveyId,
-          patientId: chartsPatient.id,
-          startTime: submissionDate,
-          endTime: submissionDate,
-          answers,
-          facilityId,
-        });
-        const result = await app.get(`/api/encounter/${chartsEncounter.id}/charts/${surveyId}`);
-        expect(result).toHaveSucceeded();
-        const { body } = result;
-        expect(body).toHaveProperty('count');
-        expect(body.count).toBeGreaterThan(0);
-        expect(body).toHaveProperty('data');
-        expect(body.data).toEqual(
-          expect.arrayContaining(
-            Object.entries(answers).map(([key, value]) =>
-              expect.objectContaining({
-                dataElementId: key,
-                records: {
-                  [submissionDate]: expect.objectContaining({
-                    id: expect.any(String),
-                    body: value.toString(),
-                    logs: null,
-                  }),
-                },
-              }),
-            ),
-          ),
-        );
-      });
-    });
     describe('program responses', () => {
       disableHardcodedPermissionsForSuite();
 

--- a/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
@@ -1,0 +1,198 @@
+import config from 'config';
+import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoData/patients';
+import { CHARTING_DATA_ELEMENT_IDS, SURVEY_TYPES } from '@tamanu/constants';
+import { setupSurveyFromObject } from '@tamanu/database/demoData/surveys';
+import { fake, fakeUser } from '@tamanu/shared/test-helpers/fake';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
+import { createTestContext } from '../utilities';
+
+describe('EncounterCharting', () => {
+  const [facilityId] = selectFacilityIds(config);
+  let patient = null;
+  let user = null;
+  let app = null;
+  let baseApp = null;
+  let models = null;
+  let ctx;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.models;
+    patient = await models.Patient.create(await createDummyPatient(models));
+    user = await models.User.create({ ...fakeUser(), role: 'practitioner' });
+    app = await baseApp.asUser(user);
+  });
+  afterAll(() => ctx.close());
+
+  describe('GET encounter chart instances', () => {
+    it('should get a list of chart instances of a chart for an encounter', async () => {
+      const encounter = await models.Encounter.create({
+        ...(await createDummyEncounter(models)),
+        patientId: patient.id,
+      });
+      const program = await models.Program.create({ ...fake(models.Program) });
+      const survey = await models.Survey.create({
+        ...fake(models.Survey),
+        code: 'complex-chart-core',
+        programId: program.id,
+        surveyType: SURVEY_TYPES.COMPLEX_CHART_CORE,
+      });
+      const dataElement = await models.ProgramDataElement.create({
+        ...fake(models.ProgramDataElement),
+        id: CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName,
+      });
+      const response1 = await models.SurveyResponse.create({
+        ...fake(models.SurveyResponse),
+        surveyId: survey.id,
+        encounterId: encounter.id,
+      });
+      const response2 = await models.SurveyResponse.create({
+        ...fake(models.SurveyResponse),
+        surveyId: survey.id,
+        encounterId: encounter.id,
+      });
+      const chartInstance1Answer1 = await models.SurveyResponseAnswer.create({
+        ...fake(models.SurveyResponseAnswer),
+        dataElementId: dataElement.id,
+        responseId: response1.id,
+        body: 'Chart 1',
+      });
+      const chartInstance1Answer2 = await models.SurveyResponseAnswer.create({
+        ...fake(models.SurveyResponseAnswer),
+        dataElementId: dataElement.id,
+        responseId: response2.id,
+        body: 'Chart 2',
+      });
+
+      const result = await app.get(
+        `/api/encounter/${encounter.id}/charts/${survey.id}/chartInstances`,
+      );
+      expect(result).toHaveSucceeded();
+      expect(result.body).toMatchObject({
+        count: 2,
+        data: expect.any(Array),
+      });
+      const chartInstance1 = result.body.data.find((x) => x.chartInstanceId === response1.id);
+      const chartInstance2 = result.body.data.find((x) => x.chartInstanceId === response2.id);
+
+      expect(chartInstance1).toMatchObject({
+        chartSurveyId: survey.id,
+        chartInstanceId: response1.id,
+        chartInstanceName: chartInstance1Answer1.body,
+      });
+
+      expect(chartInstance2).toMatchObject({
+        chartSurveyId: survey.id,
+        chartInstanceId: response2.id,
+        chartInstanceName: chartInstance1Answer2.body,
+      });
+    });
+  });
+
+  describe('write', () => {
+    describe('charting', () => {
+      let chartsEncounter = null;
+      let chartsPatient = null;
+
+      beforeAll(async () => {
+        chartsPatient = await models.Patient.create(await createDummyPatient(models));
+        chartsEncounter = await models.Encounter.create({
+          ...(await createDummyEncounter(models, { endDate: null })),
+          patientId: chartsPatient.id,
+          reasonForEncounter: 'charting test',
+        });
+
+        await setupSurveyFromObject(models, {
+          program: {
+            id: 'charts-program',
+          },
+          survey: {
+            id: 'simple-chart-survey',
+            survey_type: 'simpleChart',
+          },
+          questions: [
+            {
+              name: 'PatientChartingDate',
+              type: 'DateTime',
+            },
+            {
+              name: 'ChartQuestionOne',
+              type: 'Number',
+            },
+            {
+              name: 'ChartQuestionTwo',
+              type: 'Number',
+            },
+          ],
+        });
+      });
+
+      beforeEach(async () => {
+        await models.SurveyResponseAnswer.truncate({});
+        await models.SurveyResponse.truncate({});
+      });
+
+      it('should record a new simple chart reading', async () => {
+        const submissionDate = getCurrentDateTimeString();
+        const result = await app.post('/api/surveyResponse').send({
+          surveyId: 'simple-chart-survey',
+          patientId: chartsPatient.id,
+          startTime: submissionDate,
+          endTime: submissionDate,
+          answers: {
+            [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
+            'pde-ChartQuestionOne': 1234,
+          },
+          facilityId,
+        });
+        expect(result).toHaveSucceeded();
+        const saved = await models.SurveyResponseAnswer.findOne({
+          where: { dataElementId: 'pde-ChartQuestionOne', body: '1234' },
+        });
+        expect(saved).toHaveProperty('body', '1234');
+      });
+
+      it('should get simple chart readings for an encounter', async () => {
+        const surveyId = 'simple-chart-survey';
+        const submissionDate = getCurrentDateTimeString();
+        const answers = {
+          [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
+          'pde-ChartQuestionOne': 123,
+          'pde-ChartQuestionTwo': 456,
+        };
+        await app.post('/api/surveyResponse').send({
+          surveyId,
+          patientId: chartsPatient.id,
+          startTime: submissionDate,
+          endTime: submissionDate,
+          answers,
+          facilityId,
+        });
+        const result = await app.get(`/api/encounter/${chartsEncounter.id}/charts/${surveyId}`);
+        expect(result).toHaveSucceeded();
+        const { body } = result;
+        expect(body).toHaveProperty('count');
+        expect(body.count).toBeGreaterThan(0);
+        expect(body).toHaveProperty('data');
+        expect(body.data).toEqual(
+          expect.arrayContaining(
+            Object.entries(answers).map(([key, value]) =>
+              expect.objectContaining({
+                dataElementId: key,
+                records: {
+                  [submissionDate]: expect.objectContaining({
+                    id: expect.any(String),
+                    body: value.toString(),
+                    logs: null,
+                  }),
+                },
+              }),
+            ),
+          ),
+        );
+      });
+    });
+  });
+});

--- a/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
@@ -16,7 +16,7 @@ async function createSimpleChartSurvey(models, index) {
     survey: {
       id: `simple-chart-survey-${index}`,
       name: `Survey ${letter}`,
-      survey_type: 'simpleChart',
+      surveyType: SURVEY_TYPES.SIMPLE_CHART,
     },
     questions: [
       {

--- a/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
@@ -243,9 +243,9 @@ describe('EncounterCharting', () => {
         facilityId,
       });
 
-      const result = await app.get(`/api/encounter/${chartsEncounter.id}/charts`);
+      const result = await app.get(`/api/encounter/${chartsEncounter.id}/initialChart`);
       expect(result).toHaveSucceeded();
-      expect(result.body.data[0].survey.name).toBe('Survey B');
+      expect(result.body.data.survey.name).toBe('Survey B');
     });
   });
 });

--- a/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterCharting.test.js
@@ -216,6 +216,36 @@ describe('EncounterCharting', () => {
       );
     });
 
-    it.todo('should return a utility list about chart surveys with responses');
+    it('should return a utility list about chart surveys with responses', async () => {
+      const submissionDate = getCurrentDateTimeString();
+      await app.post('/api/surveyResponse').send({
+        surveyId: 'simple-chart-survey-2',
+        patientId: chartsPatient.id,
+        startTime: submissionDate,
+        endTime: submissionDate,
+        answers: {
+          [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
+          'pde-ChartQuestionOneC': 123,
+          'pde-ChartQuestionTwoC': 456,
+        },
+        facilityId,
+      });
+      await app.post('/api/surveyResponse').send({
+        surveyId: 'simple-chart-survey-1',
+        patientId: chartsPatient.id,
+        startTime: submissionDate,
+        endTime: submissionDate,
+        answers: {
+          [CHARTING_DATA_ELEMENT_IDS.dateRecorded]: submissionDate,
+          'pde-ChartQuestionOneB': 123,
+          'pde-ChartQuestionTwoB': 456,
+        },
+        facilityId,
+      });
+
+      const result = await app.get(`/api/encounter/${chartsEncounter.id}/charts`);
+      expect(result).toHaveSucceeded();
+      expect(result.body.data[0].survey.name).toBe('Survey B');
+    });
   });
 });

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -542,12 +542,12 @@ encounterRelations.get(
 );
 
 encounterRelations.get(
-  '/:id/charts$',
+  '/:id/initialChart$',
   asyncHandler(async (req, res) => {
     req.checkPermission('list', 'Survey');
     const { models, params } = req;
     const { id: encounterId } = params;
-    const rows = await models.SurveyResponse.findAll({
+    const chartSurvey = await models.SurveyResponse.findOne({
       attributes: ['survey.*'],
       where: { encounterId },
       include: [
@@ -561,11 +561,10 @@ encounterRelations.get(
       ],
       order: [['survey', 'name', 'ASC']],
       group: [['survey.id']],
-      limit: 1,
     });
 
     res.send({
-      data: rows,
+      data: chartSurvey,
     });
   }),
 );

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -13,6 +13,7 @@ import {
   CHARTING_DATA_ELEMENT_IDS,
   IMAGING_REQUEST_STATUS_TYPES,
   TASK_STATUSES,
+  SURVEY_TYPES,
 } from '@tamanu/constants';
 import {
   simpleGet,
@@ -536,6 +537,35 @@ encounterRelations.get(
     res.send({
       count: data.length,
       data,
+    });
+  }),
+);
+
+encounterRelations.get(
+  '/:id/charts$',
+  asyncHandler(async (req, res) => {
+    req.checkPermission('list', 'Survey');
+    const { models, params } = req;
+    const { id: encounterId } = params;
+    const rows = await models.SurveyResponse.findAll({
+      attributes: ['survey.*'],
+      where: { encounterId },
+      include: [
+        {
+          attributes: ['id', 'name'],
+          required: true,
+          model: models.Survey,
+          as: 'survey',
+          where: { surveyType: [SURVEY_TYPES.SIMPLE_CHART, SURVEY_TYPES.COMPLEX_CHART] },
+        },
+      ],
+      order: [['survey', 'name', 'ASC']],
+      group: [['survey.id']],
+      limit: 1,
+    });
+
+    res.send({
+      data: rows,
     });
   }),
 );

--- a/packages/web/app/api/queries/useEncounterChartWithResponseQuery.js
+++ b/packages/web/app/api/queries/useEncounterChartWithResponseQuery.js
@@ -5,10 +5,9 @@ import { isErrorUnknownAllow404s, useApi } from '../index';
 export const useEncounterChartWithResponseQuery = encounterId => {
   const api = useApi();
 
-  return useQuery(['encounterChartsList', encounterId], () =>
+  return useQuery(['encounterInitialChart', encounterId], () =>
     api.get(
-      `encounter/${encounterId}/charts`,
-      { rowsPerPage: 50 },
+      `encounter/${encounterId}/initialChart`,
       { isErrorUnknown: isErrorUnknownAllow404s },
       { enabled: Boolean(encounterId) },
     ),

--- a/packages/web/app/api/queries/useEncounterChartWithResponseQuery.js
+++ b/packages/web/app/api/queries/useEncounterChartWithResponseQuery.js
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { isErrorUnknownAllow404s, useApi } from '../index';
+
+// Gets the first alphabetically ordered chart survey that has any answer
+export const useEncounterChartWithResponseQuery = encounterId => {
+  const api = useApi();
+
+  return useQuery(['encounterChartsList', encounterId], () =>
+    api.get(
+      `encounter/${encounterId}/charts`,
+      { rowsPerPage: 50 },
+      { isErrorUnknown: isErrorUnknownAllow404s },
+      { enabled: Boolean(encounterId) },
+    ),
+  );
+};

--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -101,7 +101,7 @@ export const CoreComplexChartData = ({
             </CoreComplexChartSingleInfoWrapper>
           ) : null}
         </CoreComplexChartInfoWrapper>
-        { data.length ? <MenuButton actions={actions} /> : null}
+        { data.length === 0 ? <MenuButton actions={actions} /> : null}
       </CoreComplexChartDataRow>
     </>
   );

--- a/packages/web/app/components/ChartsTable.jsx
+++ b/packages/web/app/components/ChartsTable.jsx
@@ -11,12 +11,13 @@ import { EditVitalCellModal } from './EditVitalCellModal';
 import { getChartsTableColumns } from './VitalsAndChartsTableColumns';
 import { LoadingIndicator } from './LoadingIndicator';
 
-export const EmptyChartsTable = ({ noDataMessage }) => (
+export const EmptyChartsTable = ({ noDataMessage, isLoading = false }) => (
   <Table
     columns={[]}
     data={[]}
     elevated={false}
     noDataBackgroundColor={Colors.background}
+    isLoading={isLoading}
     noDataMessage={
       <Box color={Colors.primary} fontWeight={500}>
         {noDataMessage}

--- a/packages/web/app/components/TabDisplay.jsx
+++ b/packages/web/app/components/TabDisplay.jsx
@@ -38,6 +38,10 @@ const Icon = styled.i`
 export const TabDisplay = React.memo(
   ({ tabs, currentTab, onTabSelect, className, scrollable = true, ...tabProps }) => {
     const currentTabData = tabs.find(t => t.key === currentTab);
+    if (!currentTabData) {
+      return null;
+    }
+
     const buttons = tabs.map(({ key, label, render, icon }) => (
       <StyledTab
         key={key}

--- a/packages/web/app/components/VitalsAndChartsTableColumns.jsx
+++ b/packages/web/app/components/VitalsAndChartsTableColumns.jsx
@@ -28,7 +28,7 @@ const IconButton = styled(IconButtonComponent)`
 `;
 
 const VitalsLimitedLinesCell = ({ value }) => (
-  <LimitedLinesCell value={value} maxWidth="75px" maxLines={1} />
+  <LimitedLinesCell value={value} maxWidth="75px" maxLines={2} />
 );
 
 const MeasureCell = React.memo(({ value, data }) => {

--- a/packages/web/app/contexts/ChartData.jsx
+++ b/packages/web/app/contexts/ChartData.jsx
@@ -24,11 +24,10 @@ export const ChartDataProvider = ({ children }) => {
 
   useEffect(() => {
     if (!isLoading && !isInitiated) {
-      const chartResponseId = chartWithResponse?.[0]?.id;
       // Only set initial type if encounter has chart responses
-      if (chartResponseId) {
+      if (chartWithResponse) {
         // Prioritize user preference, chart with response is only a fallback
-        const initialChart = userPreferences?.selectedChartTypeId ?? chartResponseId;
+        const initialChart = userPreferences?.selectedChartTypeId ?? chartWithResponse.id;
         setSelectedChartTypeId(initialChart);
       }
       setIsInitiated(true);

--- a/packages/web/app/contexts/ChartData.jsx
+++ b/packages/web/app/contexts/ChartData.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useUserPreferencesQuery } from '../api/queries/useUserPreferencesQuery';
 
 const ChartDataContext = createContext({
@@ -9,14 +9,21 @@ const ChartDataContext = createContext({
 export const useChartData = () => useContext(ChartDataContext);
 
 export const ChartDataProvider = ({ children }) => {
-  const { data: userPreferences } = useUserPreferencesQuery();
+  const { data: userPreferences, isLoading } = useUserPreferencesQuery();
   const [selectedChartTypeId, setSelectedChartTypeId] = useState(
     userPreferences?.selectedChartTypeId,
   );
 
+  useEffect(() => {
+    if (userPreferences) {
+      setSelectedChartTypeId(userPreferences?.selectedChartTypeId);
+    }
+  }, [userPreferences]);
+
   return (
     <ChartDataContext.Provider
       value={{
+        isLoading,
         selectedChartTypeId,
         setSelectedChartTypeId,
       }}

--- a/packages/web/app/contexts/ChartData.jsx
+++ b/packages/web/app/contexts/ChartData.jsx
@@ -1,5 +1,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useUserPreferencesQuery } from '../api/queries/useUserPreferencesQuery';
+import { useEncounter } from './Encounter';
+import { useEncounterChartWithResponseQuery } from '../api/queries/useEncounterChartWithResponseQuery';
+import { combineQueries } from '../api';
 
 const ChartDataContext = createContext({
   selectedChartTypeId: null,
@@ -9,21 +12,33 @@ const ChartDataContext = createContext({
 export const useChartData = () => useContext(ChartDataContext);
 
 export const ChartDataProvider = ({ children }) => {
-  const { data: userPreferences, isLoading } = useUserPreferencesQuery();
-  const [selectedChartTypeId, setSelectedChartTypeId] = useState(
-    userPreferences?.selectedChartTypeId,
-  );
+  const { encounter } = useEncounter();
+  const [isInitiated, setIsInitiated] = useState(false);
+  const [selectedChartTypeId, setSelectedChartTypeId] = useState('');
+  const userPreferencesQuery = useUserPreferencesQuery();
+  const chartWithResponseQuery = useEncounterChartWithResponseQuery(encounter?.id);
+  const {
+    data: [userPreferences, chartWithResponse],
+    isLoading,
+  } = combineQueries([userPreferencesQuery, chartWithResponseQuery]);
 
   useEffect(() => {
-    if (userPreferences) {
-      setSelectedChartTypeId(userPreferences?.selectedChartTypeId);
+    if (!isLoading && !isInitiated) {
+      const chartResponseId = chartWithResponse?.[0]?.id;
+      // Only set initial type if encounter has chart responses
+      if (chartResponseId) {
+        // Prioritize user preference, chart with response is only a fallback
+        const initialChart = userPreferences?.selectedChartTypeId ?? chartResponseId;
+        setSelectedChartTypeId(initialChart);
+      }
+      setIsInitiated(true);
     }
-  }, [userPreferences]);
+  }, [userPreferences, chartWithResponse, isInitiated, isLoading]);
 
   return (
     <ChartDataContext.Provider
       value={{
-        isLoading,
+        isLoading: !isInitiated,
         selectedChartTypeId,
         setSelectedChartTypeId,
       }}

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -117,7 +117,11 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
   const queryClient = useQueryClient();
   const { facilityId } = useAuth();
   const { loadEncounter } = useEncounter();
-  const { selectedChartTypeId, setSelectedChartTypeId } = useChartData();
+  const {
+    isLoading: isLoadingChartData,
+    selectedChartTypeId,
+    setSelectedChartTypeId,
+  } = useChartData();
   const {
     data: { chartSurveys = [], complexToCoreSurveysMap = {} } = {},
     isLoading: isLoadingChartSurveys,
@@ -272,11 +276,11 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
     onSubmit: handleSubmitChart,
   };
 
-  if (isLoadingChartSurveys || hasNoCharts) {
+  if (isLoadingChartData || isLoadingChartSurveys || hasNoCharts) {
     return (
       <TabPane>
         <EmptyChartsTable
-          isLoading={isLoadingChartSurveys}
+          isLoading={isLoadingChartData || isLoadingChartSurveys}
           noDataMessage={
             <TranslatedText
               stringId="chart.table.noSelectableCharts"

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -199,12 +199,13 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
     [complexChartInstancesById, currentComplexChartTab],
   );
 
-  // Set default current tab if not set
+  // Sets initial instance tab when selecting a complex chart
   useEffect(() => {
-    if (!currentComplexChartTab && complexChartInstanceTabs?.length) {
+    console.log('running');
+    if (complexChartInstanceTabs?.length) {
       setCurrentComplexChartTab(complexChartInstanceTabs[0].key);
     }
-  }, [complexChartInstanceTabs, currentComplexChartTab]);
+  }, [complexChartInstanceTabs, selectedChartTypeId]);
 
   const handleCloseModal = () => setModalOpen(false);
 

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -262,7 +262,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
   }`;
   const recordButtonEnabled =
     (isComplexChart && !!currentComplexChartInstance) || (!isComplexChart && !!selectedChartTypeId);
-  const hasNoCharts = !isLoadingChartSurveys && !chartTypes?.length;
+  const hasNoCharts = chartTypes.length === 0;
 
   const baseChartModalProps = {
     open: modalOpen,
@@ -272,10 +272,11 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
     onSubmit: handleSubmitChart,
   };
 
-  if (hasNoCharts) {
+  if (isLoadingChartSurveys || hasNoCharts) {
     return (
       <TabPane>
         <EmptyChartsTable
+          isLoading={isLoadingChartSurveys}
           noDataMessage={
             <TranslatedText
               stringId="chart.table.noSelectableCharts"

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -306,13 +306,11 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
         <TableButtonRowWrapper>
           <TableButtonRow variant="small" justifyContent="space-between">
             <StyledButtonGroup>
-              {chartTypes?.length ? (
-                <ChartDropdown
-                  selectedChartTypeId={selectedChartTypeId}
-                  setSelectedChartTypeId={setSelectedChartTypeId}
-                  chartTypes={chartTypes}
-                />
-              ) : null}
+              <ChartDropdown
+                selectedChartTypeId={selectedChartTypeId}
+                setSelectedChartTypeId={setSelectedChartTypeId}
+                chartTypes={chartTypes}
+              />
               {isComplexChart ? (
                 <AddComplexChartButton
                   onClick={() => {

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -120,7 +120,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
   const { selectedChartTypeId, setSelectedChartTypeId } = useChartData();
   const {
     data: { chartSurveys = [], complexToCoreSurveysMap = {} } = {},
-    isLoadingChartSurveys,
+    isLoading: isLoadingChartSurveys,
   } = useChartSurveysQuery();
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -262,6 +262,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
   }`;
   const recordButtonEnabled =
     (isComplexChart && !!currentComplexChartInstance) || (!isComplexChart && !!selectedChartTypeId);
+  const hasNoCharts = !isLoadingChartSurveys && !chartTypes?.length;
 
   const baseChartModalProps = {
     open: modalOpen,
@@ -271,7 +272,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
     onSubmit: handleSubmitChart,
   };
 
-  if (!isLoadingChartSurveys && !chartTypes?.length) {
+  if (hasNoCharts) {
     return (
       <TabPane>
         <EmptyChartsTable

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -201,7 +201,6 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
 
   // Sets initial instance tab when selecting a complex chart
   useEffect(() => {
-    console.log('running');
     if (complexChartInstanceTabs?.length) {
       setCurrentComplexChartTab(complexChartInstanceTabs[0].key);
     }


### PR DESCRIPTION
### Changes

Although it looks like lots of changes, there aren't really that many! Most come from moving tests to their own file plus adding one test to that file.

Refactored a couple of logics that were wrong. Here we make use of the table loading state and avoid flickering until we fetched everything. Also updated the initial chart selection and initial instance selection plus solving a couple of display bugs.
