### PR TITLE
fix(programRegistries): SAV-882: Order program registries alphabetically in sidebar nav menu

### DIFF
--- a/packages/web/app/api/queries/useProgramRegistryQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryQuery.js
@@ -10,5 +10,7 @@ export const useProgramRegistryQuery = (programRegistryId, fetchOptions) => {
 
 export const useListOfProgramRegistryQuery = () => {
   const api = useApi();
-  return useQuery(['ProgramRegistries'], () => api.get('programRegistry', {}));
+  return useQuery(['ProgramRegistries'], () =>
+    api.get('programRegistry', { orderBy: 'name', order: 'ASC' }),
+  );
 };


### PR DESCRIPTION
### Changes
- Order program registries alphabetically in sidebar nav menu

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
