### PR TITLE
tweak(repeatingAppointments): Fix day offset direction for repeating appointment generation window 

### DIFF
--- a/packages/central-server/app/tasks/GenerateRepeatingAppointments.js
+++ b/packages/central-server/app/tasks/GenerateRepeatingAppointments.js
@@ -39,7 +39,7 @@ export class GenerateRepeatingAppointments extends ScheduledTask {
           ORDER BY appointments.start_time DESC
           LIMIT 1
         ) AS latest_appointment ON true
-        WHERE latest_appointment.start_time::date < NOW() - INTERVAL :offsetDays DAY
+        WHERE latest_appointment.start_time::date < NOW() + INTERVAL :offsetDays DAY
         AND appointment_schedules.is_fully_generated = false
       `,
       {


### PR DESCRIPTION
I had it wrong way round - now it will generate 7 days before start of last appointment. Previously it was doing 7 days after

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
