### PR TITLE
fix(Scheduling): Release 2.24: Field population bug for repeating appointments

### DIFF
--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -241,7 +241,8 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
                             fallback="New appointment"
                           />
                         ),
-                        action: () => onOpenDrawer(omit(a, ['id', 'startTime', 'endTime'])),
+                        action: () =>
+                          onOpenDrawer(omit(a, ['id', 'startTime', 'endTime', 'schedule'])),
                       },
                       {
                         label: (


### PR DESCRIPTION
### Changes

Discovered in regression a small bug where an undefined value gets supplied to the RepeatingAppointmentFields when pressing "New appointment" from popper. We dont want to ever repopulate the repeating appointment behaviour so I just removed the key altogether from the object sent to the form which stops the initial render of the fields and therefore the bug.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
