### PR TITLE
fix(scheduling): Release 2.24: Only delete appointments linked to schedule

### DIFF
--- a/packages/database/src/models/AppointmentSchedule.ts
+++ b/packages/database/src/models/AppointmentSchedule.ts
@@ -183,7 +183,7 @@ export class AppointmentSchedule extends Model {
       {
         where: {
           startTime: { [Op.gte]: appointment.startTime },
-          scheduleId: appointment.scheduleId,
+          scheduleId: this.id,
         },
       },
     );

--- a/packages/database/src/models/AppointmentSchedule.ts
+++ b/packages/database/src/models/AppointmentSchedule.ts
@@ -183,6 +183,7 @@ export class AppointmentSchedule extends Model {
       {
         where: {
           startTime: { [Op.gte]: appointment.startTime },
+          scheduleId: appointment.scheduleId,
         },
       },
     );


### PR DESCRIPTION
### Changes

Discovered in testing that when selecting "This and future appointments" when deleting a repeating appointment. It was deleting every appointment in the future rather than only the ones linked to the schedule. Here I just add the schedule id to the where clause

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
