### PR TITLE
fix(scheduling): Release fix 2.24: Fix padding on patient view tables

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingsTable.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingsTable.jsx
@@ -124,9 +124,7 @@ const StyledTable = styled(Table)`
     }
   }
   .MuiTableCell-body {
-    padding: 6px;
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding: 11px 6px;
     &:first-child {
       position: relative;
       padding-left: 10px;
@@ -154,6 +152,8 @@ const StyledTable = styled(Table)`
       }
       position: relative;
       border-bottom: none;
+      padding-top: 0;
+      padding-bottom: 0;
       &:before {
         content: '';
         position: absolute;
@@ -293,13 +293,12 @@ export const LocationBookingsTable = ({ patient }) => {
     initialSortDirection: 'asc',
   });
 
-  const allAppointments = useLocationBookingsQuery(
-    {
+  const allAppointments =
+    useLocationBookingsQuery({
       all: true,
       patientId: patient?.id,
       after: '1970-01-01 00:00',
-    },
-  ).data?.data ?? [];
+    }).data?.data ?? [];
 
   const { data, isLoading } = useLocationBookingsQuery(
     {

--- a/packages/web/app/components/Appointments/OutpatientAppointmentsTable.jsx
+++ b/packages/web/app/components/Appointments/OutpatientAppointmentsTable.jsx
@@ -110,9 +110,7 @@ const StyledTable = styled(Table)`
     }
   }
   .MuiTableCell-body {
-    padding: 6px;
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding: 11px 6px;
     &:first-child {
       position: relative;
       padding-left: 10px;
@@ -140,6 +138,8 @@ const StyledTable = styled(Table)`
       }
       position: relative;
       border-bottom: none;
+      padding-top: 0;
+      padding-bottom: 0;
       &:before {
         content: '';
         position: absolute;
@@ -307,13 +307,12 @@ export const OutpatientAppointmentsTable = ({ patient }) => {
     initialSortDirection: 'asc',
   });
 
-  const allAppointments = useOutpatientAppointmentsQuery(
-    {
+  const allAppointments =
+    useOutpatientAppointmentsQuery({
       all: true,
       patientId: patient?.id,
       after: '1970-01-01 00:00',
-    },
-  ).data?.data ?? [];
+    }).data?.data ?? [];
 
   const { data, isLoading } = useOutpatientAppointmentsQuery(
     {


### PR DESCRIPTION
### Changes

We discovered while permission testing some weird behaviour with the patient view table. The padding for each row was actually defined by the menu button in the last column. This meant that when we dont have permission to use these buttons, the table rows become very thin. I have essentially just removed the padding from that button and added it to the base row styling. I think these table styles could be cleaned up quite a bit and also possibly combined but out of scope for a release fix like this

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
