### PR TITLE
fix(userPreferences): Release fix 2.24: Encode facility id in request

### DIFF
--- a/packages/web/app/api/queries/useUserPreferencesQuery.js
+++ b/packages/web/app/api/queries/useUserPreferencesQuery.js
@@ -8,7 +8,7 @@ export const useUserPreferencesQuery = queryOptions => {
 
   return useQuery(
     ['userPreferences', currentUser?.id],
-    () => api.get(`user/userPreferences/${facilityId}`),
+    () => api.get(`user/userPreferences/${encodeURIComponent(facilityId)}`),
     queryOptions,
   );
 };


### PR DESCRIPTION
### Changes

Forgot to encode this so for devs with the facility `ref/facility/ba` we get an error on request because of the `/`. I believe this doesnt actually happen in reality because of import limitations currently but adding for safety incase there are ids of this kind out there and also is the proper thing to do

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
