### PR TITLE
tweak(scheduling): NASS-1570: Small UI/UX tweaks group 2

### DIFF
--- a/packages/web/app/api/queries/useLocationsQuery.js
+++ b/packages/web/app/api/queries/useLocationsQuery.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
 
-export const useLocationsQuery = options => {
+export const useLocationsQuery = (options, useQueryOptions) => {
   const api = useApi();
-  return useQuery(['locations', options], () => api.get('location', options));
+  return useQuery(['locations', options], () => api.get('location', options), useQueryOptions);
 };

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
@@ -42,7 +42,6 @@ const PrimaryDetails = styled('div')`
 const PatientId = styled('p')`
   color: ${Colors.primary};
   font-weight: 500;
-  letter-spacing: 0.08em;
   font-variant-numeric: lining-nums tabular-nums;
   margin-block: 0.25rem 0;
 `;

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendar.jsx
@@ -100,14 +100,17 @@ export const LocationBookingsCalendar = ({
     clinicianId?.length > 0 || bookingTypeId?.length > 0 || !!patientNameOrId;
   const { data: locations } = locationsQuery;
 
-  const { data: appointmentsData } = useLocationBookingsQuery({
-    after: toDateTimeString(displayedDates[0]),
-    before: toDateTimeString(endOfDay(displayedDates.at(-1))),
-    all: true,
-    clinicianId,
-    bookingTypeId,
-    patientNameOrId,
-  });
+  const { data: appointmentsData } = useLocationBookingsQuery(
+    {
+      after: toDateTimeString(displayedDates[0]),
+      before: toDateTimeString(endOfDay(displayedDates.at(-1))),
+      all: true,
+      clinicianId,
+      bookingTypeId,
+      patientNameOrId,
+    },
+    { keepPreviousData: true },
+  );
   const appointments = appointmentsData?.data ?? [];
   const appointmentsByLocation = partitionAppointmentsByLocation(appointments);
 

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsView.jsx
@@ -94,11 +94,14 @@ export const LocationBookingsView = () => {
     openBookingForm({});
   };
 
-  const locationsQuery = useLocationsQuery({
-    facilityId,
-    bookableOnly: true,
-    locationGroupIds: filters.locationGroupIds,
-  });
+  const locationsQuery = useLocationsQuery(
+    {
+      facilityId,
+      bookableOnly: true,
+      locationGroupIds: filters.locationGroupIds,
+    },
+    { keepPreviousData: true },
+  );
 
   const { data: locations } = locationsQuery;
   const hasNoLocations = locations?.length === 0;

--- a/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/DateSelector.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import ArrowBackIos from '@mui/icons-material/ArrowBackIos';
+import ArrowBackIos from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos';
 import { css, styled } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
 import { omit } from 'lodash';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -20,6 +21,7 @@ import { useSendAppointmentEmail } from '../../../api/mutations';
 import { toast } from 'react-toastify';
 import { useAuth } from '../../../contexts/Auth';
 import { APPOINTMENT_GROUP_BY } from './OutpatientAppointmentsView';
+import { useOutpatientAppointmentsContext } from '../../../contexts/OutpatientAppointments';
 
 export const ColumnWrapper = styled(Box)`
   --column-width: 14rem;
@@ -104,6 +106,18 @@ const ErrorText = styled(StatusText)`
   color: ${Colors.alert};
 `;
 
+const LoadingSkeleton = styled(Skeleton).attrs({
+  animation: 'wave',
+  variant: 'rectangular',
+  width: '100%',
+  height: '100%',
+  sx: { bgcolor: Colors.white },
+})`
+  ::after {
+    animation-duration: 1s !important;
+  }
+`;
+
 export const HeadCell = ({ title, count }) => (
   <>
     <HeadCellWrapper>
@@ -138,6 +152,7 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
   const { ability } = useAuth();
   const {
     data: { headData = [], cellData },
+    isLoading,
     error,
   } = useOutpatientAppointmentsCalendarData({
     groupBy,
@@ -164,6 +179,10 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
         ),
     },
   );
+
+  if (isLoading) {
+    return <LoadingSkeleton />;
+  }
 
   if (error) {
     return (

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -151,7 +151,6 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
   const { ability } = useAuth();
   const {
     data: { headData = [], cellData },
-    isLoading,
     error,
   } = useOutpatientAppointmentsCalendarData({
     groupBy,
@@ -178,10 +177,6 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
         ),
     },
   );
-
-  if (isLoading) {
-    return <LoadingSkeleton />;
-  }
 
   if (error) {
     return (

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -1,5 +1,4 @@
 import Box from '@mui/material/Box';
-import Skeleton from '@mui/material/Skeleton';
 import { omit } from 'lodash';
 import React, { useState } from 'react';
 import styled from 'styled-components';

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -21,7 +21,6 @@ import { useSendAppointmentEmail } from '../../../api/mutations';
 import { toast } from 'react-toastify';
 import { useAuth } from '../../../contexts/Auth';
 import { APPOINTMENT_GROUP_BY } from './OutpatientAppointmentsView';
-import { useOutpatientAppointmentsContext } from '../../../contexts/OutpatientAppointments';
 
 export const ColumnWrapper = styled(Box)`
   --column-width: 14rem;

--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -105,18 +105,6 @@ const ErrorText = styled(StatusText)`
   color: ${Colors.alert};
 `;
 
-const LoadingSkeleton = styled(Skeleton).attrs({
-  animation: 'wave',
-  variant: 'rectangular',
-  width: '100%',
-  height: '100%',
-  sx: { bgcolor: Colors.white },
-})`
-  ::after {
-    animation-duration: 1s !important;
-  }
-`;
-
 export const HeadCell = ({ title, count }) => (
   <>
     <HeadCellWrapper>

--- a/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
+++ b/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
@@ -12,7 +12,7 @@ import { useOutpatientAppointmentsContext } from '../../../contexts/OutpatientAp
 import { APPOINTMENT_GROUP_BY } from './OutpatientAppointmentsView';
 
 export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate }) => {
-  const locationGroupsQuery = useLocationGroupsQuery();
+  const locationGroupsQuery = useLocationGroupsQuery(null, { keepPreviousData: true });
   const { data: locationGroupData } = locationGroupsQuery;
 
   const usersQuery = useUsersQuery(
@@ -20,6 +20,7 @@ export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate })
     {
       // Add an 'unknown' user to the list for appointments that don't have a clinician
       select: ({ data }) => [...data, { id: 'unknown', displayName: 'Unknown' }],
+      keepPreviousData: true,
     },
   );
   const { data: usersData } = usersQuery;
@@ -35,6 +36,7 @@ export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate })
     {
       /** A null `filters` is valid (i.e. when a user has never used this filter before) */
       enabled: filters !== undefined,
+      keepPreviousData: true,
     },
   );
   const { data: appointmentsData } = appointmentsQuery;


### PR DESCRIPTION
### Changes

Fixes contained in this pr
- **Main fix** Stop jumpy filtering on Outpatient appointments + Location bookings 
  - This basically just involves adding `keepPreviousData: true` option for the queries. The loading state still shows on initial load (Im a tad concerned about a bad user experience when on slow connection but thats what we decided in refinement)
- Correct font styling in patient details
- Correct back icon import

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
