### PR TITLE
fix(mobile): 2.24 fix: Error when writing character `(` in select filter

### DIFF
--- a/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/MultipleSelect/index.tsx
@@ -438,23 +438,28 @@ export class MultiSelect extends Component {
     }
   };
 
-  _filterItemsPartial = searchTerm => {
+  _filterItemsPartial = (searchTerm) => {
     const { items, displayKey } = this.props;
     const filteredItems = [];
-    items.forEach(item => {
-      const parts = searchTerm.trim().split(/[ \-:]+/);
-      const regex = new RegExp(`(${parts.join('|')})`, 'ig');
-      if (regex.test(get(item, displayKey))) {
+    const parts = searchTerm.trim().split(/[ \-:]+/);
+
+    items.forEach((item) => {
+      const displayValue = get(item, displayKey);
+      const isMatch = parts.every((part) =>
+        displayValue.toLowerCase().includes(part.toLowerCase())
+      );
+      if (isMatch) {
         filteredItems.push(item);
       }
     });
+
     return filteredItems;
   };
 
-  _filterItemsFull = searchTerm => {
+  _filterItemsFull = (searchTerm) => {
     const { items, displayKey } = this.props;
     const filteredItems = [];
-    items.forEach(item => {
+    items.forEach((item) => {
       if (item[displayKey].toLowerCase().indexOf(searchTerm.trim().toLowerCase()) >= 0) {
         filteredItems.push(item);
       }


### PR DESCRIPTION
This lead to an unterminated capture group.
- This version removes the templated regex to do case insensitve comparison - it does the same thing as far as I could visualize and test but really keen for second option
- Alternative solution to this is to sanitise the search input before templating into regex
`text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');` Mabye lower touch? I just thought it looks bit ick

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
