### PR TITLE
fix(registerPatient): 2.24 fix: Mobile newly registered patients not showing up when searching by dob

### DIFF
--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/index.tsx
@@ -136,7 +136,7 @@ const FormComponent = ({ selectedPatient, setSelectedPatient, isEdit, children }
       const { dateOfBirth, ...otherValues } = values;
       const newPatient = await Patient.createAndSaveOne<Patient>({
         ...otherValues,
-        dateOfBirth: formatISO9075(dateOfBirth),
+        dateOfBirth: formatISO9075(dateOfBirth, { representation: 'date' }),
         displayId: generateId(),
       });
 


### PR DESCRIPTION
### Changes

[See Thread](https://beyondessential.slack.com/archives/C03KJSEPV9A/p1738029544261489)
Low touch solution to this one. 

It was saving them as date times in local sqlite3 db
They where trimmed to size by time they hit central tho so doesn't effect sync or anything

Heres the state after creating 4 patients on mobile
<img width="304" alt="Screenshot 2025-01-28 at 4 09 56 PM" src="https://github.com/user-attachments/assets/0fb71f88-9684-4f2b-806c-e3a5ed2270d7" />

They then do not make a complete match with dob filter.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
