### PR TITLE
fix(alerts): sync alerts need to use facilityIds now

### DIFF
--- a/alerts/fhir-queued-job-long.yml
+++ b/alerts/fhir-queued-job-long.yml
@@ -1,11 +1,13 @@
 sql: |
   SELECT
     id,
+    topic,
     payload->>'resource' AS resource,
     ROUND(EXTRACT(EPOCH FROM (NOW() - created_at)) / 60)::text AS duration_minutes
   FROM fhir.jobs
   WHERE status = 'Queued'
-    AND NOW() - created_at > INTERVAL '15 minutes';
+    AND NOW() - created_at > INTERVAL '15 minutes'
+    AND topic != 'fhir.resolver'
 
 send:
   - target: external
@@ -17,7 +19,7 @@ send:
       <h1>Long queued FHIR jobs detected</h1>
       <ul>
         {% for row in rows | slice(end=5) %}
-        <li><b>{{row.resource}}</> ID: <b>{{ row.id }}</b> - Duration: <i>{{ row.duration_minutes }} minutes</i></li>
+        <li><b>{{ row.topic }} {{row.resource}}</> ID: <b>{{ row.id }}</b> - Duration: <i>{{ row.duration_minutes }} minutes</i></li>
         {% endfor %}
         {% if rows | length > 5 %}
         <li>... and {{ rows | length - 5 }} more</li>

--- a/alerts/sync-errors.yml
+++ b/alerts/sync-errors.yml
@@ -2,7 +2,7 @@ sql: |
   SELECT
     id,
     errors::text,
-    debug_info->>'facilityId' AS facility_id,
+    json_array_elements_text(debug_info->'facilityIds') AS facility_id,
     created_at::text AS created,
     (completed_at - created_at)::text AS duration
   FROM sync_sessions

--- a/alerts/sync-facility-not-syncing.yml
+++ b/alerts/sync-facility-not-syncing.yml
@@ -1,9 +1,17 @@
 sql: |
-  select facility_id from patient_facilities group by facility_id
+  with sync_sessions_with_facility_id as (
+    select
+        created_at,
+        completed_at,
+        json_array_elements_text(debug_info->'facilityIds') as facility_id
+    from sync_sessions
+  )
+  select distinct facility_id from sync_sessions_with_facility_id
+  where created_at > current_timestamp - '48 hours'::interval
   except
-  select debug_info->>'facilityId' as facility_id from sync_sessions
-  where completed_at > now() - '30 minutes'::interval
-  group by debug_info->>'facilityId';
+  select facility_id from sync_sessions_with_facility_id
+  where completed_at > current_timestamp - '30 minutes'::interval
+  group by facility_id;
 
 send:
   - target: external
@@ -12,7 +20,12 @@ send:
     template: |
       <p>Server: {{ hostname }}</p>
       <p>Alert: {{ filename }}</p>
-      <h1>There hasn't been a completed sync session for the following facilit{% if rows | length > 1 %}ies{% else %}y{% endif %} in the past 30 minutes:</h1>
+      <p>
+        From the facilities that synced in the last two days...
+        there hasn't been a completed sync session for the following
+        facilit{% if rows | length > 1 %}ies{% else %}y{% endif %}
+        in the past 30 minutes:
+      </p>
       <ul>
         {% for row in rows %}
         <li><b>{{ row.facility_id }}</b></li>

--- a/alerts/sync-long.yml
+++ b/alerts/sync-long.yml
@@ -1,11 +1,11 @@
 sql: |
   select
     id, errors::text,
-    debug_info->>'facilityId' AS facility_id,
+    json_array_elements_text(debug_info->'facilityIds') AS facility_id,
     created_at::text AS created,
     (completed_at - created_at)::text AS duration
   from sync_sessions
-  where created_at > $1
+  where (current_timestamp - created_at) < '60 minutes'::interval
   and completed_at IS NULL
   and (pull_until is null or pull_since is null or pull_until - pull_since < 1000)
   and (updated_at - created_at) > '20 minutes'::interval;


### PR DESCRIPTION
### Changes

- Sync: When we switched to putting `facilityIds` in `debug_info` in the `sync_sessions` table it broke the sync alerts. Unfortunately it did so silently such that the sync alerts always return zero rows == no errors.

- FHIR: The job `fhir.resolver` just tends to sit there all the time even if FHIR is disabled, and that's causing a spurious alert.