### PR TITLE
tweak(alerts): convert to markdown

### DIFF
--- a/alerts/certificate-notification-error.yml
+++ b/alerts/certificate-notification-error.yml
@@ -2,22 +2,21 @@ sql: |
   SELECT *
   FROM certificate_notifications
   WHERE status = 'Error'
-  AND created_at > $1;
+  AND created_at > $1
+  ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] Certificate notification error ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <h1>Patient notifications errored</h1>
-      <p>There are {{ rows | length }} certificate notifications that have failed to process.</p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.id }}</b>: {{ row.type }} - <i>{{ row.error }}</i></li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      There are {{ rows | length }} certificate notifications that have failed to process:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.type }} ({{ row.id }})**: {{ row.error }}
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/fhir-error.yml
+++ b/alerts/fhir-error.yml
@@ -2,22 +2,21 @@ sql: |
   SELECT *
   FROM fhir.jobs
   WHERE error IS NOT NULL
-  AND created_at > $1;
+  AND created_at > $1
+  ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] FHIR job error ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <h1>FHIR jobs errored</h1>
-      <p>There are {{ rows | length }} FHIR jobs that have failed to process.</p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.created_at }}</b>: {{ row.topic }} - <i>{{ row.error }}</i></li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      There are {{ rows | length }} FHIR jobs that have failed to process:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.topic }} ({{ row.created_at }})**: {{ row.error }}
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/fhir-queue-incredibly-large.yml
+++ b/alerts/fhir-queue-incredibly-large.yml
@@ -3,14 +3,14 @@ sql: |
     COUNT(*) AS job_count
   FROM fhir.jobs
   WHERE status = 'Queued'
-  HAVING COUNT(*) > 1000;
+  HAVING COUNT(*) > 1000
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] FHIR job queue abnormally large ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <p>Alert: {{ filename }}</p>
-      <h1>FHIR queued jobs count is abnormally high</h1>
-      <p>Currently queued jobs: {{ rows[0].job_count }}</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      Currently queued jobs: {{ rows[0].job_count }}

--- a/alerts/fhir-queued-job-long.yml
+++ b/alerts/fhir-queued-job-long.yml
@@ -3,26 +3,24 @@ sql: |
     id,
     topic,
     payload->>'resource' AS resource,
-    ROUND(EXTRACT(EPOCH FROM (NOW() - created_at)) / 60)::text AS duration_minutes
+    ROUND(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - created_at)) / 60)::text AS duration_minutes
   FROM fhir.jobs
   WHERE status = 'Queued'
-    AND NOW() - created_at > INTERVAL '15 minutes'
+    AND CURRENT_TIMESTAMP - created_at > INTERVAL '15 minutes'
     AND topic != 'fhir.resolver'
+  ORDER BY created_at ASC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] Long queued FHIR jobs ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <p>Alert: {{ filename }}</p>
-      <h1>Long queued FHIR jobs detected</h1>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.topic }} {{row.resource}}</> ID: <b>{{ row.id }}</b> - Duration: <i>{{ row.duration_minutes }} minutes</i></li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.topic }}** {{row.resource}} ({{ row.id }}) for {{ row.duration_minutes }} minutes
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/fhir-running-job-long.yml
+++ b/alerts/fhir-running-job-long.yml
@@ -2,23 +2,22 @@ sql: |
   SELECT
     id,
     payload->>'resource' AS resource,
-    ROUND(EXTRACT(EPOCH FROM (NOW() - started_at)) / 60)::text AS duration_minutes
+    ROUND(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - started_at)) / 60)::text AS duration_minutes
   FROM fhir.jobs
   WHERE status = 'Started'
-    AND NOW() - started_at > INTERVAL '15 minutes';
+    AND CURRENT_TIMESTAMP - started_at > INTERVAL '15 minutes'
+  ORDER BY started_at ASC
+
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] Long running FHIR jobs ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <p>Alert: {{ filename }}</p>
-      <h1>Long running FHIR jobs detected</h1>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{row.resource}}</> ID: <b>{{ row.id }}</b> - Duration: <i>{{ row.duration_minutes }} minutes</i></li>
-        {% endfor %}
-         <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      {% for row in rows | slice(end=5) %}
+      - **{{row.resource}}** {{ row.id }} for {{ row.duration_minutes }} minutes
+      {% endfor %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/ips-error.yml
+++ b/alerts/ips-error.yml
@@ -2,22 +2,21 @@ sql: |
   SELECT *
   FROM ips_requests
   WHERE status = 'Error'
-  AND created_at > $1;
+  AND created_at > $1
+  ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] IPS request error ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <h1>IPS request errored</h1>
-      <p>There are {{ rows | length }} IPS requests that have failed.</p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.id }}</b> - <i>{{ row.error }}</i></li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      There are {{ rows | length }} IPS requests that have failed:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: {{ row.error }}
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/patient-communications-error.yml
+++ b/alerts/patient-communications-error.yml
@@ -2,22 +2,21 @@ sql: |
   SELECT *
   FROM patient_communications
   WHERE status = 'Error'
-  AND created_at > $1;
+  AND created_at > $1
+  ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] Patient communication error ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <h1>Patient communication errored</h1>
-      <p>There are {{ rows | length }} Patient communications that have failed to process.</p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.id }}</b>: {{ row.type }} - <i>{{ row.error }}</i></li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      There are {{ rows | length }} patient communications that have failed to process:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: (*{{ row.type }}*) {{ row.error }}
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/report-error.yml
+++ b/alerts/report-error.yml
@@ -2,22 +2,21 @@ sql: |
   SELECT *
   FROM report_requests
   WHERE status = 'Error'
-  AND created_at > $1;
+  AND created_at > $1
+  ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] Report request error ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <h1>Report request errored</h1>
-      <p>There are {{ rows | length }} report requests that have failed.</p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.id }}</b> - <i>{{ row.error }}</i></li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      There are {{ rows | length }} report requests that have failed:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: {{ row.error }}
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/sync-errors.yml
+++ b/alerts/sync-errors.yml
@@ -9,23 +9,23 @@ sql: |
   WHERE
     updated_at > now() - interval '1 minute' -- Lookback window
   AND errors IS NOT NULL
-  AND errors <> ARRAY['could not serialize access due to concurrent update'];
+  AND errors <> ARRAY['could not serialize access due to concurrent update']
+  ORDER BY created_at DESC
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] Sync session error ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <p>Alert: {{ filename }}</p>
-      <h1>Sync sessions with an error in the last minute</h1>
-      <p><b>Report this immediately to support.</b></p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.id }}</b>: <i>{{ row.errors }}</i> ({{ row.facility_id }},  duration {{ row.duration }}, start {{ row.created }})</li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      **Report this immediately to support.**
+
+      Sync sessions with an error in the last minute:
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: _{{ row.errors }}_ ({{ row.facility_id }},  duration {{ row.duration }}, start {{ row.created }})
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}

--- a/alerts/sync-facility-not-syncing.yml
+++ b/alerts/sync-facility-not-syncing.yml
@@ -22,6 +22,8 @@ send:
       - Server: {{ hostname }}
       - Alert: {{ filename }}
 
+      **Report this immediately to support.**
+
       From the facilities that synced in the last two days...
       there hasn't been a completed sync session for the following
       facilit{% if rows | length > 1 %}ies{% else %}y{% endif %}
@@ -30,6 +32,3 @@ send:
       {% for row in rows %}
       - **{{ row.facility_id }}**
       {% endfor %}
-      </ul>
-
-      **Report this immediately to support.**

--- a/alerts/sync-facility-not-syncing.yml
+++ b/alerts/sync-facility-not-syncing.yml
@@ -11,24 +11,25 @@ sql: |
   except
   select facility_id from sync_sessions_with_facility_id
   where completed_at > current_timestamp - '30 minutes'::interval
-  group by facility_id;
+  group by facility_id
+  order by facility_id
 
 send:
   - target: external
     id: default
     subject: '[Tamanu Alert] No complete sync for at least one facility in the past 30 minutes'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <p>Alert: {{ filename }}</p>
-      <p>
-        From the facilities that synced in the last two days...
-        there hasn't been a completed sync session for the following
-        facilit{% if rows | length > 1 %}ies{% else %}y{% endif %}
-        in the past 30 minutes:
-      </p>
-      <ul>
-        {% for row in rows %}
-        <li><b>{{ row.facility_id }}</b></li>
-        {% endfor %}
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      From the facilities that synced in the last two days...
+      there hasn't been a completed sync session for the following
+      facilit{% if rows | length > 1 %}ies{% else %}y{% endif %}
+      in the past 30 minutes:
+
+      {% for row in rows %}
+      - **{{ row.facility_id }}**
+      {% endfor %}
       </ul>
-      <p><b>Report this immediately to support.</b></p>
+
+      **Report this immediately to support.**

--- a/alerts/sync-long.yml
+++ b/alerts/sync-long.yml
@@ -8,23 +8,22 @@ sql: |
   where (current_timestamp - created_at) < '60 minutes'::interval
   and completed_at IS NULL
   and (pull_until is null or pull_since is null or pull_until - pull_since < 1000)
-  and (updated_at - created_at) > '20 minutes'::interval;
+  and (updated_at - created_at) > '20 minutes'::interval
+  order by created_at desc
 
 send:
   - target: external
     id: default
     subject: '[Tamanu alert] Sync sessions longer than 20 minutes ({{ hostname }})'
     template: |
-      <p>Server: {{ hostname }}</p>
-      <p>Alert: {{ filename }}</p>
-      <h1>Sync sessions lasting longer than 21 minutes in the last {{ interval }}</h1>
-      <p><b>Report this immediately to support.</b></p>
-      <ul>
-        {% for row in rows | slice(end=5) %}
-        <li><b>{{ row.id }}</b>: <i>{{ row.errors }}</i> ({{ row.facility_id }},  duration {{ row.duration }}, start {{ row.created }})</li>
-        {% endfor %}
-        {% if rows | length > 5 %}
-        <li>... and {{ rows | length - 5 }} more</li>
-        {% endif %}
-      </ul>
-      <p>For more information, please check the logs.</p>
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      **Report this immediately to support.**
+
+      {% for row in rows | slice(end=5) %}
+      - **{{ row.id }}**: _{{ row.errors }}_ ({{ row.facility_id }},  duration {{ row.duration }}, start {{ row.created }})
+      {% endfor %}
+      {% if rows | length > 5 %}
+      - ... and {{ rows | length - 5 }} more
+      {% endif %}


### PR DESCRIPTION
### Changes

bestool 0.26.0 adds markdown support for the alerts, which means that slack alerts no longer need to have all the ugly HTML, but emails will still look beautiful. This PR converts all the standard alerts to markdown.

It also does a few tweaks to the text and queries:
- adds `ORDER BY` clauses in places to stabilise the message and highlight e.g. the longest running FHIR jobs first
- removes redundant info from the template (e.g. when that's present in the subject)
- removes the implied "Please see the logs"
- removes the unnecessary `;` from the end of queries
