### PR TITLE
fix(scheduling): Release fix 2.24: Add ability to remove saved endTime

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -174,9 +174,6 @@ appointments.put(
           );
         }
       } else {
-        if (!appointmentData.endTime) {
-          appointmentData.endTime = null;
-        }
         await appointment.update(appointmentData);
       }
       return { ok: 'ok' };

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -174,6 +174,9 @@ appointments.put(
           );
         }
       } else {
+        if (!appointmentData.endTime) {
+          appointmentData.endTime = null;
+        }
         await appointment.update(appointmentData);
       }
       return { ok: 'ok' };

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
@@ -17,7 +17,7 @@ export const TimeWithFixedDateField = ({ field, date, ...props }) => {
             month: getMonth(date),
           }),
         )
-      : undefined;
+      : null;
     field.onChange({ target: { value: newValue, name: field.name } });
   };
   return <TimeInput name={field.name} value={field.value} {...props} onChange={handleChange} />;


### PR DESCRIPTION
### Changes

Because end time isnt sent with the body when its been deleted, the endpoint doesn't attempt to update/delete it. Here I manually check and then set the column to null. I do feel like there must be an easier way to do this though 🤔 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
