### PR TITLE
fix(fhir): SAV-891: Bump lastUpdated of MediciReport when rematerialising

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MediciReport.test.js
@@ -194,15 +194,10 @@ describe(`Materialised - MediciReport`, () => {
   }
 
   it('materialise a Medici report', async () => {
-    const {
-      encounter,
-      encounterDiagnosis,
-      encounterMedication,
-      procedureType,
-      labTestType,
-    } = await makeEncounter({
-      encounterType: 'emergency',
-    });
+    const { encounter, encounterDiagnosis, encounterMedication, procedureType, labTestType } =
+      await makeEncounter({
+        encounterType: 'emergency',
+      });
 
     const { MediciReport } = ctx.store.models;
 
@@ -220,7 +215,7 @@ describe(`Materialised - MediciReport`, () => {
       patientBillingId: null,
       patientBillingType: null,
       encounterId: encounter.id,
-      age: 31,
+      age: expect.any(Number), // age will change every year
       weight: null,
       visitType: 'Emergency short stay',
       episodeEndStatus: null,

--- a/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
+++ b/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
@@ -372,5 +372,8 @@ export const getMaterialisedValues = async (sequelize, upstreamId) => {
     },
   });
 
-  return upstream;
+  return {
+    lastUpdated: new Date(),
+    ...upstream,
+  };
 };


### PR DESCRIPTION
### Changes

We were actually never bumping the last updated previously.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
