### PR TITLE
fix(vitalCharts): hotfix 2.23: x-axis dates showing up as timestamps

### DIFF
--- a/packages/web/app/components/Charts/components/CustomisedTick.jsx
+++ b/packages/web/app/components/Charts/components/CustomisedTick.jsx
@@ -15,14 +15,15 @@ const Text = styled.text`
 export const CustomisedXAxisTick = props => {
   const { x, y, payload } = props;
   const { value } = payload;
+  const date = new Date(value);
 
   return (
     <g transform={`translate(${x},${y})`}>
       <Text x={0} y={9} textAnchor="middle" fill={Colors.darkText}>
-        {formatShortest(value)}
+        {formatShortest(date)}
       </Text>
       <Text x={0} y={xAxisTickTimeY} textAnchor="middle" fill={Colors.midText}>
-        {formatTime(value)}
+        {formatTime(date)}
       </Text>
     </g>
   );


### PR DESCRIPTION
### Changes

Hotfix 🔥 
Then I will cherry-pick to 2.24
I think this might be regression associated with shared package refactors 🤔 
But anyways the value is a timestamp and needs to be made into a date before formatting is attempted or else it will show those big ol numbers

#### Before: 
<img width="914" alt="Screenshot 2025-01-30 at 2 09 40 PM" src="https://github.com/user-attachments/assets/c7b3e990-4308-475c-a3d6-05a65f6c5e21" />

#### After
<img width="908" alt="Screenshot 2025-01-30 at 2 09 18 PM" src="https://github.com/user-attachments/assets/9543a951-2353-4026-8013-607eaba2a76c" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
