### PR TITLE
fix(patientRegistration): 2.24 fix: Allow a table column with title of `''` to hide title and not fallback to key

### DIFF
--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -25,7 +25,7 @@ import { ThemedTooltip } from '../Tooltip';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Paginator } from './Paginator';
 import { TranslatedText } from '../Translation/TranslatedText';
-import { get } from 'lodash';
+import { get, isUndefined } from 'lodash';
 import { useTranslation } from '../../contexts/Translation.jsx';
 
 const preventInputCallback = e => {
@@ -192,7 +192,15 @@ const HeaderContainer = React.memo(({ children, numeric }) => (
   <StyledTableCell align={numeric ? 'right' : 'left'}>{children}</StyledTableCell>
 ));
 
-const getTableRow = ({ children, lazyLoading, rowStyle, onClick, className, onMouseEnter, onMouseLeave }) => (
+const getTableRow = ({
+  children,
+  lazyLoading,
+  rowStyle,
+  onClick,
+  className,
+  onMouseEnter,
+  onMouseLeave,
+}) => (
   <StyledTableRow
     className={className}
     onClick={onClick}
@@ -381,7 +389,7 @@ class TableComponent extends React.Component {
           {title || key}
         </TableSortLabel>
       ) : (
-        <span>{displayTitle || key}</span>
+        <span>{isUndefined(displayTitle) ? key : displayTitle}</span>
       );
 
       const headerElement = titleCellComponent || defaultHeaderElement;
@@ -490,7 +498,16 @@ class TableComponent extends React.Component {
   }
 
   renderFooter() {
-    const { page, lazyLoading, exportName, columns, data, allowExport, count, ExportButton } = this.props;
+    const {
+      page,
+      lazyLoading,
+      exportName,
+      columns,
+      data,
+      allowExport,
+      count,
+      ExportButton,
+    } = this.props;
 
     // Footer is empty, don't render anything
     if (((page === null || lazyLoading) && !allowExport) || count === 0) {
@@ -502,7 +519,12 @@ class TableComponent extends React.Component {
         <StyledTableRow $lazyLoading={lazyLoading}>
           {allowExport ? (
             <TableCell colSpan={page !== null ? 2 : columns.length}>
-              <DownloadDataButton exportName={exportName} columns={columns} data={data} ExportButton={ExportButton} />
+              <DownloadDataButton
+                exportName={exportName}
+                columns={columns}
+                data={data}
+                ExportButton={ExportButton}
+              />
             </TableCell>
           ) : null}
           {page !== null && !lazyLoading && this.renderPaginator()}

--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -192,15 +192,7 @@ const HeaderContainer = React.memo(({ children, numeric }) => (
   <StyledTableCell align={numeric ? 'right' : 'left'}>{children}</StyledTableCell>
 ));
 
-const getTableRow = ({
-  children,
-  lazyLoading,
-  rowStyle,
-  onClick,
-  className,
-  onMouseEnter,
-  onMouseLeave,
-}) => (
+const getTableRow = ({ children, lazyLoading, rowStyle, onClick, className, onMouseEnter, onMouseLeave }) => (
   <StyledTableRow
     className={className}
     onClick={onClick}
@@ -498,16 +490,7 @@ class TableComponent extends React.Component {
   }
 
   renderFooter() {
-    const {
-      page,
-      lazyLoading,
-      exportName,
-      columns,
-      data,
-      allowExport,
-      count,
-      ExportButton,
-    } = this.props;
+    const { page, lazyLoading, exportName, columns, data, allowExport, count, ExportButton } = this.props;
 
     // Footer is empty, don't render anything
     if (((page === null || lazyLoading) && !allowExport) || count === 0) {
@@ -519,12 +502,7 @@ class TableComponent extends React.Component {
         <StyledTableRow $lazyLoading={lazyLoading}>
           {allowExport ? (
             <TableCell colSpan={page !== null ? 2 : columns.length}>
-              <DownloadDataButton
-                exportName={exportName}
-                columns={columns}
-                data={data}
-                ExportButton={ExportButton}
-              />
+              <DownloadDataButton exportName={exportName} columns={columns} data={data} ExportButton={ExportButton} />
             </TableCell>
           ) : null}
           {page !== null && !lazyLoading && this.renderPaginator()}

--- a/packages/web/app/components/Table/Table.jsx
+++ b/packages/web/app/components/Table/Table.jsx
@@ -25,7 +25,7 @@ import { ThemedTooltip } from '../Tooltip';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Paginator } from './Paginator';
 import { TranslatedText } from '../Translation/TranslatedText';
-import { get, isUndefined } from 'lodash';
+import { get } from 'lodash';
 import { useTranslation } from '../../contexts/Translation.jsx';
 
 const preventInputCallback = e => {
@@ -389,7 +389,7 @@ class TableComponent extends React.Component {
           {title || key}
         </TableSortLabel>
       ) : (
-        <span>{isUndefined(displayTitle) ? key : displayTitle}</span>
+        <span>{displayTitle ?? key}</span>
       );
 
       const headerElement = titleCellComponent || defaultHeaderElement;

--- a/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
@@ -24,6 +24,7 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
     return [
       {
         key: 'registrationStatus',
+        title: '',
         accessor: data => (
           <RegistrationStatusIndicator patientProgramRegistration={data} hideText />
         ),
@@ -137,6 +138,7 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
       },
       {
         key: 'actions',
+        title: '',
         accessor: row => {
           const isRemoved = row.registrationStatus === REGISTRATION_STATUSES.INACTIVE;
           const isDeleted = row.registrationStatus === REGISTRATION_STATUSES.RECORDED_IN_ERROR;


### PR DESCRIPTION
### Changes

Previously this was falsy so we always had to set key to "" which is problematic in the case that two titles are hidden (key duplicate error) This fixes it

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
