### PR TITLE
fix: NASS-1576: Improve datetime input typing UX

### DIFF
--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/DateTimeFieldWithSameDayWarning.jsx
@@ -40,7 +40,6 @@ export const DateTimeFieldWithSameDayWarning = ({ isEdit, onChange }) => {
         onChange(e);
         if (!e.target.value) setFieldValue('endTime', undefined);
       }}
-      save
       helperText={
         showSameDayWarning && (
           <TranslatedText

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -75,6 +75,7 @@ export const DateInput = ({
         // field and interrupt their edit
         // instead, simply return early, which will mean the last valid date will be kept
         // (conveniently, this is also what the html date input will display)
+        // however, we -do- still want to change the text colour from the placeholder colour
         return;
       }
 
@@ -111,6 +112,10 @@ export const DateInput = ({
     if (event.key === 'Backspace') {
       setCurrentText('');
       setIsPlaceholder(true);
+    }
+    // if the user has started typing a date, turn off placeholder styling
+    if (event.key.length === 1) {
+      setIsPlaceholder(false);
     }
   };
 

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -107,6 +107,13 @@ export const DateInput = ({
     [onChange, format, name, saveDateAsString, type],
   );
 
+  const onKeyDown = event => {
+    if (event.key === 'Backspace') {
+      setCurrentText('');
+      setIsPlaceholder(true);
+    }
+  };
+
   const onArrowChange = addDaysAmount => {
     const date = parse(currentText, format, new Date());
     const newDate = formatDate(addDays(date, addDaysAmount), format);
@@ -151,6 +158,7 @@ export const DateInput = ({
       type={type}
       value={currentText}
       onChange={onValueChange}
+      onKeyDown={onKeyDown}
       onBlur={handleBlur}
       InputProps={{
         // Set max property on HTML input element to force 4-digit year value (max year being 9999)

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -104,7 +104,7 @@ export const DateInput = ({
 
       onChange({ target: { value: outputValue, name } });
     },
-    [onChange, format, name, min, max, saveDateAsString, type],
+    [onChange, format, name, saveDateAsString, type],
   );
 
   const onArrowChange = addDaysAmount => {

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -126,7 +126,7 @@ export const DateInput = ({
       clearValue();
     }
     // if the user has started typing a date, turn off placeholder styling
-    if (event.key.length === 1) {
+    if (event.key.length === 1 && isPlaceholder) {
       setIsPlaceholder(false);
     }
   };
@@ -197,7 +197,7 @@ export const DateInput = ({
 
   const remountingDateField = (
     <CustomIconTextInput
-      key={'remounting'}
+      key="remounting"
       type={type}
       InputProps={{
         inputProps,

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -65,6 +65,7 @@ export const DateInput = ({
 
   const [currentText, setCurrentText] = useState(fromRFC3339(value, format));
   const [isPlaceholder, setIsPlaceholder] = useState(!value);
+  const [isRemounting, setIsRemounting] = useState(false);
 
   const onValueChange = useCallback(
     event => {
@@ -126,7 +127,14 @@ export const DateInput = ({
     onValueChange({ target: { value: newDate } });
   };
 
-  const handleBlur = () => {
+  const handleBlur = e => {
+    // if the final input is invalid, clear the component value
+    if (!e.target.value) {
+      onChange({ target: { value: '', name } });
+      setCurrentText('');
+      return;
+    }
+
     const date = parse(currentText, format, new Date());
 
     if (max && !keepIncorrectValue) {
@@ -157,6 +165,20 @@ export const DateInput = ({
       setIsPlaceholder(true);
     };
   }, [value, format]);
+
+  // If the value is cleared, we need to remount the component to reset the input field
+  // because the html date input doesn't know the difference between an empty string and an invalid
+  // date, so if the value is cleared while the user has partially typed a date, the input will
+  // still show the partially typed date
+  useEffect(() => {
+    if (value === '') {
+      setIsRemounting(true);
+      setTimeout(() => setIsRemounting(false), 0);
+    }
+  }, [value]);
+  if (isRemounting) {
+    return;
+  }
 
   const defaultDateField = (
     <CustomIconTextInput

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -68,7 +68,7 @@ export const DateInput = ({
 
   const onValueChange = useCallback(
     event => {
-      if (event.target.validity.valid === false) {
+      if (event.target.validity.badInput) {
         // if the user starts editing the field by typing e.g. a '0' in the month field, until they
         // type another digit the resulting string is an invalid date
         // in this case we don't want to save the value to the form, as it would clear the whole

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -111,7 +111,7 @@ export const DateInput = ({
 
   const onKeyDown = event => {
     if (event.key === 'Backspace') {
-      setCurrentText('');
+      onChange({ target: { value: '', name } });
       setIsPlaceholder(true);
     }
     // if the user has started typing a date, turn off placeholder styling

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -68,6 +68,16 @@ export const DateInput = ({
 
   const onValueChange = useCallback(
     event => {
+      if (event.target.validity.valid === false) {
+        // if the user starts editing the field by typing e.g. a '0' in the month field, until they
+        // type another digit the resulting string is an invalid date
+        // in this case we don't want to save the value to the form, as it would clear the whole
+        // field and interrupt their edit
+        // instead, simply return early, which will mean the last valid date will be kept
+        // (conveniently, this is also what the html date input will display)
+        return;
+      }
+
       const formattedValue = event.target.value;
       if (!formattedValue) {
         onChange({ target: { value: '', name } });


### PR DESCRIPTION
### Changes

When typing into the datetime input, if you started with a number that would create an invalid date (e.g. `0`), it would clear the whole field. This fixes that issue.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
