### PR TITLE
fix(vitalCharts): 2.24 fix: x-axis dates showing up as timestamps 

### DIFF
--- a/packages/web/app/components/Charts/components/CustomisedTick.jsx
+++ b/packages/web/app/components/Charts/components/CustomisedTick.jsx
@@ -15,14 +15,15 @@ const Text = styled.text`
 export const CustomisedXAxisTick = props => {
   const { x, y, payload } = props;
   const { value } = payload;
+  const date = new Date(value);
 
   return (
     <g transform={`translate(${x},${y})`}>
       <Text x={0} y={9} textAnchor="middle" fill={Colors.darkText}>
-        {formatShortest(value)}
+        {formatShortest(date)}
       </Text>
       <Text x={0} y={xAxisTickTimeY} textAnchor="middle" fill={Colors.midText}>
-        {formatTime(value)}
+        {formatTime(date)}
       </Text>
     </g>
   );


### PR DESCRIPTION
### Changes
See https://github.com/beyondessential/tamanu/pull/7129
Which is approved ✅ 

the value is a timestamp and needs to be made into a date before formatting is attempted or else it will show those big ol numbers

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
