### PR TITLE
fix(patientListings): 2.24 fix: Area showing as location name in patient listing tables

### DIFF
--- a/packages/web/app/components/LocationCell.jsx
+++ b/packages/web/app/components/LocationCell.jsx
@@ -40,7 +40,7 @@ export const LocationGroupCell = ({
   locationGroupId,
   plannedLocationGroupName,
   plannedLocationGroupId,
-  ...props
+  style,
 }) => {
   return (
     <LocationCell
@@ -49,7 +49,7 @@ export const LocationGroupCell = ({
       plannedLocationName={plannedLocationGroupName}
       plannedLocationId={plannedLocationGroupId}
       category="locationGroup"
-      {...props}
+      style={style}
     />
   );
 };


### PR DESCRIPTION
### Changes

locationId and locationName got overridden by spread props which also contain those props.
this lead to location name showing up in area column.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
