### PR TITLE
fix(userPreferences): 2.24 fix: User preferences getting overriden by entity data returned from mutation

### DIFF
--- a/packages/web/app/api/mutations/useUserPreferencesMutation.js
+++ b/packages/web/app/api/mutations/useUserPreferencesMutation.js
@@ -12,8 +12,6 @@ export const useUserPreferencesMutation = facilityId => {
   return useMutation({
     mutationKey: ['userPreferences'],
     mutationFn: ({ key, value }) => api.post('user/userPreferences', { facilityId, key, value }),
-    onSuccess: data => {
-      queryClient.setQueriesData(['userPreferences', currentUser.id], data);
-    },
+    onSuccess: () => queryClient.invalidateQueries(['userPreferences', currentUser.id]),
   });
 };


### PR DESCRIPTION
So on initial load userPreferences data it is a nested obejct of settings
But after mutation it becomes just the updated data of the user_preferences row so it stopped applying
 
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
