### PR TITLE
tweak(tests): 2.24 fix: Update appointment tests post index migration merge

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -553,6 +553,7 @@ describe('Appointments', () => {
                 [Op.not]: APPOINTMENT_STATUSES.CANCELLED,
               },
             },
+            order: [['startTime', 'ASC']],
           },
         ],
       });
@@ -576,6 +577,7 @@ describe('Appointments', () => {
           {
             model: models.Appointment,
             as: 'appointments',
+            order: [['startTime', 'ASC']],
           },
         ],
       });

--- a/packages/facility-server/__tests__/apiv1/Appointments.test.js
+++ b/packages/facility-server/__tests__/apiv1/Appointments.test.js
@@ -540,56 +540,40 @@ describe('Appointments', () => {
       expect(result).toHaveSucceeded();
       expect(result.body.schedule).toBeTruthy();
 
-      const updatedExistingSchedule = await models.AppointmentSchedule.findOne({
+      const updatedExistingSchedule = await models.AppointmentSchedule.findByPk(schedule.id);
+      const updatedExistingScheduleAppointments = await updatedExistingSchedule.getAppointments({
         where: {
-          id: schedule.id,
-        },
-        include: [
-          {
-            model: models.Appointment,
-            as: 'appointments',
-            where: {
-              status: {
-                [Op.not]: APPOINTMENT_STATUSES.CANCELLED,
-              },
-            },
-            order: [['startTime', 'ASC']],
+          status: {
+            [Op.not]: APPOINTMENT_STATUSES.CANCELLED,
           },
-        ],
+        },
+        order: [['startTime', 'ASC']],
       });
 
       expect(updatedExistingSchedule.untilDate).toEqual('2024-10-09');
-      expect(updatedExistingSchedule.appointments.map((a) => a.startTime)).toEqual([
+      expect(updatedExistingScheduleAppointments.map((a) => a.startTime)).toEqual([
         '2024-10-02 12:00:00',
         '2024-10-09 12:00:00',
       ]);
       expect(
-        updatedExistingSchedule.appointments.every(
+        updatedExistingScheduleAppointments.every(
           (a) => a.appointmentTypeId === 'appointmentType-standard',
         ),
       ).toBeTruthy();
 
-      const newSchedule = await models.AppointmentSchedule.findOne({
-        where: {
-          id: result.body.schedule.id,
-        },
-        include: [
-          {
-            model: models.Appointment,
-            as: 'appointments',
-            order: [['startTime', 'ASC']],
-          },
-        ],
+      const newScheduleAppointments = await models.Appointment.findAll({
+        where: { scheduleId: result.body.schedule.id },
+        order: [['startTime', 'ASC']],
       });
 
-      expect(newSchedule.appointments.map((a) => a.startTime)).toEqual([
+      expect(newScheduleAppointments.map((a) => a.startTime)).toEqual([
         '2024-10-16 12:00:00',
         '2024-10-23 12:00:00',
         '2024-10-30 12:00:00',
         '2024-11-06 12:00:00',
       ]);
       expect(
-        newSchedule.appointments.every((a) => a.appointmentTypeId === 'appointmentType-specialist'),
+        newScheduleAppointments.every((a) => a.appointmentTypeId === 'appointmentType-specialist'),
       ).toBeTruthy();
     });
 
@@ -637,24 +621,16 @@ describe('Appointments', () => {
       expect(updatedExistingSchedule.untilDate).toEqual('2024-10-02');
       expect(updatedExistingSchedule.appointments).toHaveLength(0);
 
-      const newSchedule = await models.AppointmentSchedule.findOne({
-        where: {
-          id: result.body.schedule.id,
-        },
-        include: [
-          {
-            model: models.Appointment,
-            as: 'appointments',
-          },
-        ],
+      const newScheduleAppointments = await models.Appointment.findAll({
+        where: { scheduleId: result.body.schedule.id },
+        order: [['startTime', 'ASC']],
       });
-
-      expect(newSchedule.appointments.map((a) => a.startTime)).toEqual([
+      expect(newScheduleAppointments.map((a) => a.startTime)).toEqual([
         '2024-10-02 12:00:00',
         '2024-10-16 12:00:00',
       ]);
       expect(
-        newSchedule.appointments.every((a) => a.appointmentTypeId === 'appointmentType-specialist'),
+        newScheduleAppointments.every((a) => a.appointmentTypeId === 'appointmentType-specialist'),
       ).toBeTruthy();
     });
   });


### PR DESCRIPTION
Tests need to be slightly changed to be explicit about order of schedules joined appointments

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
