### PR TITLE
tweak(alerts): Exclude mobile facilities in long sync alerts

### DIFF
--- a/alerts/sync-facility-not-syncing.yml
+++ b/alerts/sync-facility-not-syncing.yml
@@ -5,6 +5,7 @@ sql: |
         completed_at,
         json_array_elements_text(debug_info->'facilityIds') as facility_id
     from sync_sessions
+    where debug_info->>'isMobile' <> 'true'
   )
   select distinct facility_id from sync_sessions_with_facility_id
   where created_at > current_timestamp - '48 hours'::interval


### PR DESCRIPTION
### Changes
- The alert is for checking if sync from a facility is completed every 30 minutes. This should not be applied to facilities that are used by mobiles

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
