### PR TITLE
tweak(outpatientAppointments): 2.24 fix: Remove ability to create new appointment from existing repeating appointment

### DIFF
--- a/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
+++ b/packages/web/app/views/scheduling/outpatientBookings/OutpatientBookingCalendar.jsx
@@ -232,30 +232,31 @@ export const OutpatientBookingCalendar = ({ groupBy, selectedDate, onOpenDrawer,
             <HeadCell title={title} count={appointments?.length || 0} />
             <AppointmentColumnWrapper>
               {appointments.map(a => {
-                const actions = canCreateAppointment
-                  ? [
-                      {
-                        label: (
-                          <TranslatedText
-                            stringId="appointments.action.newAppointment"
-                            fallback="New appointment"
-                          />
-                        ),
-                        action: () =>
-                          onOpenDrawer(omit(a, ['id', 'startTime', 'endTime', 'schedule'])),
-                      },
-                      {
-                        label: (
-                          <TranslatedText
-                            stringId="appointments.action.emailAppointment"
-                            fallback="Email appointment"
-                          />
-                        ),
-                        action: () =>
-                          setEmailModalState({ appointmentId: a.id, email: a.patient?.email }),
-                      },
-                    ]
-                  : [];
+                const actions = [];
+                if (canCreateAppointment) {
+                  // Only show the new appointment action if not a repeating appointment
+                  if (!a.schedule) {
+                    actions.push({
+                      label: (
+                        <TranslatedText
+                          stringId="appointments.action.newAppointment"
+                          fallback="New appointment"
+                        />
+                      ),
+                      action: () => onOpenDrawer(omit(a, ['id', 'startTime', 'endTime'])),
+                    });
+                  }
+                  actions.push({
+                    label: (
+                      <TranslatedText
+                        stringId="appointments.action.emailAppointment"
+                        fallback="Email appointment"
+                      />
+                    ),
+                    action: () =>
+                      setEmailModalState({ appointmentId: a.id, email: a.patient?.email }),
+                  });
+                }
                 return (
                   <AppointmentTile
                     key={a.id}


### PR DESCRIPTION
In the case of an appointment with schedule the popout menu will look like this
<img width="371" alt="Screenshot 2025-02-04 at 10 12 01 AM" src="https://github.com/user-attachments/assets/26ee7fc3-d3b9-42cf-ad32-a2b6b5a487d5" />

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
