### PR TITLE
fix(outpatientAppointments): 2.24 fix: Update endTime date on startTime change

### DIFF
--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/OutpatientAppointmentDrawer.jsx
@@ -1,13 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { PriorityHigh as HighPriorityIcon } from '@material-ui/icons';
 import { omit, set } from 'lodash';
-import { format, isAfter, parseISO, add } from 'date-fns';
+import {
+  format,
+  isAfter,
+  parseISO,
+  add,
+  set as dateFnsSet,
+  getYear,
+  getDate,
+  getMonth,
+} from 'date-fns';
 import { useFormikContext } from 'formik';
 import styled from 'styled-components';
 import * as yup from 'yup';
 
 import { DAYS_OF_WEEK, REPEAT_FREQUENCY } from '@tamanu/constants';
 import { getWeekdayOrdinalPosition } from '@tamanu/utils/appointmentScheduling';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 
 import { usePatientSuggester, useSuggester } from '../../../api';
 import { useAppointmentMutation } from '../../../api/mutations';
@@ -327,6 +337,23 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
       handleResetRepeatUntilDate(startTimeDate);
     };
 
+    const handleUpdateStartTime = event => {
+      const startTimeDate = parseISO(event.target.value);
+      handleUpdateScheduleToStartTime(startTimeDate);
+      if (!values.endTime) return;
+      // Update the end time to match the new start time date
+      setFieldValue(
+        'endTime',
+        toDateTimeString(
+          dateFnsSet(parseISO(values.endTime), {
+            year: getYear(startTimeDate),
+            date: getDate(startTimeDate),
+            month: getMonth(startTimeDate),
+          }),
+        ),
+      );
+    };
+
     return (
       <Drawer
         open={open}
@@ -394,14 +421,7 @@ export const OutpatientAppointmentDrawer = ({ open, onClose, initialValues = {} 
             component={AutocompleteField}
             suggester={clinicianSuggester}
           />
-          <DateTimeFieldWithSameDayWarning
-            isEdit={isEdit}
-            onChange={e => {
-              const newValue = e.target.value;
-              setFieldValue('startTime', newValue);
-              handleUpdateScheduleToStartTime(parseISO(newValue));
-            }}
-          />
+          <DateTimeFieldWithSameDayWarning isEdit={isEdit} onChange={handleUpdateStartTime} />
           <Field
             name="endTime"
             disabled={!values.startTime}


### PR DESCRIPTION
### Changes
This already happened on end_time change - as the field is a time only field we had to ensure that the calendar date was set from the start_time.
However when changing start_time. the end_date would remain the original calendar date of start_time and not update.

I noticed this when fixing some issues identified in modify repeating ticket but it also applies to 2.24

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
