### PR TITLE
fix(patientListing): fix-2.24: Hide merged patient from recently viewed list

### DIFF
--- a/packages/facility-server/app/routes/apiv1/user.js
+++ b/packages/facility-server/app/routes/apiv1/user.js
@@ -56,6 +56,7 @@ user.get(
       makeFilter(true, `user_recently_viewed_patients.user_id = :userId`, () => ({
         userId: currentUser.id,
       })),
+      makeFilter(true, `patients.merged_into_id IS NULL`),
     ];
 
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(filters);
@@ -169,28 +170,17 @@ const clinicianTasksQuerySchema = z.object({
     .enum(['dueTime', 'location', 'patientName', 'encounter.patient.displayId', 'name'])
     .optional()
     .default('dueTime'),
-  order: z
-    .enum(['asc', 'desc'])
-    .optional()
-    .default('asc'),
+  order: z.enum(['asc', 'desc']).optional().default('asc'),
   designationId: z.string().optional(),
   locationGroupId: z.string().optional(),
   locationId: z.string().array().optional(),
   highPriority: z
     .enum(['true', 'false'])
-    .transform(value => value === 'true')
+    .transform((value) => value === 'true')
     .optional()
     .default('false'),
-  page: z.coerce
-    .number()
-    .optional()
-    .default(0),
-  rowsPerPage: z.coerce
-    .number()
-    .max(50)
-    .min(10)
-    .optional()
-    .default(25),
+  page: z.coerce.number().optional().default(0),
+  rowsPerPage: z.coerce.number().max(50).min(10).optional().default(25),
   facilityId: z.string(),
 });
 user.get(


### PR DESCRIPTION
### Changes

Some changes were made to merge logic and during regression testing Da noticed some strange behaviour when clicking into a patient in the `Recently Viewed Patient list`. This really shouldnt be showing up at all and is end of release process so this pr just adds a clause to the list query to not grab patients that are merged into others.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
