### PR TITLE
feat(patientListing): 2.24 fix: Add filter to exclude soft deleted patients in patient endpoint 

### DIFF
--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -4,7 +4,7 @@ import { ENCOUNTER_TYPES } from '@tamanu/constants';
 
 import { makeDeletedAtIsNullFilter, makeFilter } from './query';
 
-export const createPatientFilters = filterParams => {
+export const createPatientFilters = (filterParams) => {
   const filters = [
     makeFilter(
       filterParams.displayId,
@@ -82,7 +82,8 @@ export const createPatientFilters = filterParams => {
       }),
     ),
     makeDeletedAtIsNullFilter('encounters'),
-  ].filter(f => f);
+    makeDeletedAtIsNullFilter('patients'),
+  ].filter((f) => f);
 
   return filters;
 };

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -4,7 +4,7 @@ import { ENCOUNTER_TYPES } from '@tamanu/constants';
 
 import { makeDeletedAtIsNullFilter, makeFilter } from './query';
 
-export const createPatientFilters = (filterParams) => {
+export const createPatientFilters = filterParams => {
   const filters = [
     makeFilter(
       filterParams.displayId,
@@ -83,7 +83,7 @@ export const createPatientFilters = (filterParams) => {
     ),
     makeDeletedAtIsNullFilter('encounters'),
     makeDeletedAtIsNullFilter('patients'),
-  ].filter((f) => f);
+  ].filter(f => f);
 
   return filters;
 };


### PR DESCRIPTION
Exclude soft deleted patients from patient endpoint. this is used on the Patient listing views and bed managment and few other places.
I can't think that we would ever want to return in patient endpoint right?

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
