### PR TITLE
ci: use public arm64 runners

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -160,9 +160,9 @@ jobs:
       matrix:
         platform:
           - arch: amd64
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04
           - arch: arm64
-            runs-on: Linux-ARM64-Ubuntu-24.04
+            runs-on: ubuntu-24.04-arm
         package:
           - name: central
             path: central-server


### PR DESCRIPTION
### Changes

Now we're open source, we can use the brand new public ARM64 runners: https://github.com/orgs/community/discussions/148648

Let's see if they work...

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->
