### PR TITLE
feat(notifications): EPI-1114: make recentNotificationsTimeFrame configurable

### DIFF
--- a/packages/facility-server/app/routes/apiv1/notifications.js
+++ b/packages/facility-server/app/routes/apiv1/notifications.js
@@ -13,9 +13,12 @@ notifications.get(
   '/',
   asyncHandler(async (req, res) => {
     req.flagPermissionChecked();
-    const { models, user } = req;
+    const { models, user, settings } = req;
+    const { serverFacilityId } = config;
 
-    const recentNotificationsTimeFrame = config.notification?.recentNotificationsTimeFrame || 48;
+    const recentNotificationsTimeFrame =
+      (await settings[serverFacilityId].get('notifications.recentNotificationsTimeFrame')) || 48;
+
     const readNotifications = await models.Notification.findAll({
       where: {
         userId: user.id,

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -133,9 +133,6 @@
   // @see here for a list of available options https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   "countryTimeZone": "Australia/Melbourne",
   "allowMismatchedTimeZones": false,
-  "notification": {
-    "recentNotificationsTimeFrame": 48, // hours
-  },
   "tasking": {
     "upcomingTasksTimeFrame": 8, // hours,
     "upcomingTasksShouldBeGeneratedTimeFrame": 72, // hours

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1285,6 +1285,16 @@ export const globalSettings = {
       type: vitalEditReasonsSchema,
       defaultValue: vitalEditReasonsDefault,
     },
+    notifications: {
+      description: 'Notification settings',
+      properties: {
+        recentNotificationsTimeFrame: {
+          description: '_',
+          type: yup.number(),
+          defaultValue: 48,
+        }
+      }
+    },
   },
 };
 

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1289,7 +1289,7 @@ export const globalSettings = {
       description: 'Notification settings',
       properties: {
         recentNotificationsTimeFrame: {
-          description: '_',
+          description: 'Settings for the time frame of recent notifications',
           type: yup.number(),
           defaultValue: 48,
         }

--- a/packages/web/app/components/Notification/NotificationDrawer.jsx
+++ b/packages/web/app/components/Notification/NotificationDrawer.jsx
@@ -195,7 +195,7 @@ export const NotificationDrawer = ({ open, onClose, notifications, isLoading }) 
   const {
     unreadNotifications = [],
     readNotifications = [],
-    recentNotificationsTimeFrame = 48,
+    recentNotificationsTimeFrame,
   } = notifications;
 
   const onMarkAllAsRead = () => {


### PR DESCRIPTION
### Changes

- Move `recentNotificationsTimeFrame` config to setting

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
