### PR TITLE
perf: switch UUID default to gen_random_uuid

### DIFF
--- a/packages/central-server/app/tasks/VaccinationReminderProcessor.js
+++ b/packages/central-server/app/tasks/VaccinationReminderProcessor.js
@@ -71,7 +71,7 @@ export class VaccinationReminderProcessor extends ScheduledTask {
     )
     insert into patient_communications (id, created_at, updated_at, channel,  patient_id, destination, hash, status, type, subject, content)
     select
-      uuid_generate_v4() id,
+      gen_random_uuid() id,
       NOW() created_at,
       NOW() updated_at,
       r.channel,

--- a/packages/database/src/migrations/1739168538058-pgcryptoExtension.ts
+++ b/packages/database/src/migrations/1739168538058-pgcryptoExtension.ts
@@ -1,9 +1,14 @@
-import { QueryInterface } from 'sequelize';
+import { QueryInterface, QueryTypes } from 'sequelize';
+
 
 export async function up(query: QueryInterface): Promise<void> {
-  await query.sequelize.query('CREATE EXTENSION pgcrypto');
+  // we only need pgcrypto for postgres <13
+  const rows = await query.sequelize.query('show server_version_num', { type: QueryTypes.SELECT });
+  if (((rows?.[0] as { [key: string]: any })?.server_version_num ?? 0) < 13000) {
+    await query.sequelize.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+  }
 }
 
 export async function down(query: QueryInterface): Promise<void> {
-  await query.sequelize.query('DROP EXTENSION pgcrypto');
+  await query.sequelize.query('DROP EXTENSION IF EXISTS pgcrypto');
 }

--- a/packages/database/src/migrations/1739168538058-pgcryptoExtension.ts
+++ b/packages/database/src/migrations/1739168538058-pgcryptoExtension.ts
@@ -1,10 +1,13 @@
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-
 export async function up(query: QueryInterface): Promise<void> {
   // we only need pgcrypto for postgres <13
-  const rows = await query.sequelize.query('show server_version_num', { type: QueryTypes.SELECT });
-  if (((rows?.[0] as { [key: string]: any })?.server_version_num ?? 0) < 13000) {
+  const rows = await query.sequelize.query(
+    'SELECT setting FROM pg_settings WHERE name = $name LIMIT 1',
+    { type: QueryTypes.SELECT, bind: { name: 'server_version_num' } },
+  );
+
+  if (((rows?.[0] as { [key: string]: any })?.setting ?? 0) < 130000) {
     await query.sequelize.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
   }
 }

--- a/packages/database/src/migrations/1739168538058-pgcryptoExtension.ts
+++ b/packages/database/src/migrations/1739168538058-pgcryptoExtension.ts
@@ -1,0 +1,9 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query('CREATE EXTENSION pgcrypto');
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query('DROP EXTENSION pgcrypto');
+}

--- a/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
+++ b/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
@@ -38,6 +38,7 @@ const UUID_OSSP_TABLES: TableNameString[] = [
   'public.invoice_payments',
   'public.invoices',
   'public.lab_test_panel_requests',
+  'public.local_system_facts',
   'public.note_items',
   'public.note_pages',
   'public.notes',

--- a/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
+++ b/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
@@ -38,7 +38,6 @@ const UUID_OSSP_TABLES: TableNameString[] = [
   'public.invoice_payments',
   'public.invoices',
   'public.lab_test_panel_requests',
-  'public.local_system_facts',
   'public.note_items',
   'public.note_pages',
   'public.notes',
@@ -82,6 +81,74 @@ const STRING_OSSP_TABLES: TableNameString[] = [
   'public.vital_logs',
 ];
 
+/*
+select pg_class.relnamespace::regnamespace || '.' || pg_class.relname as t
+from pg_attribute join pg_class on attrelid = pg_class.oid
+where attname = 'id' and atttypid = 'character varying'::regtype::oid and reltype != 0
+order by t;
+-- and then deduplicated with STRING_OSSP_TABLES
+*/
+const STRING_NO_DEFAULT_TABLES: TableNameString[] = [
+  'public.administered_vaccines',
+  'public.appointments',
+  'public.assets',
+  'public.attachments',
+  'public.certifiable_vaccines',
+  'public.certificate_notifications',
+  'public.contributing_death_causes',
+  'public.departments',
+  'public.discharges',
+  'public.document_metadata',
+  'public.encounter_diagnoses',
+  'public.encounter_medications',
+  'public.encounters',
+  'public.facilities',
+  'public.imaging_request_areas',
+  'public.invoice_products',
+  'public.lab_request_logs',
+  'public.lab_requests',
+  'public.lab_test_types',
+  'public.lab_tests',
+  'public.local_system_facts',
+  'public.location_groups',
+  'public.locations',
+  'public.notes_legacy',
+  'public.one_time_logins',
+  'public.patient_allergies',
+  'public.patient_care_plans',
+  'public.patient_communications',
+  'public.patient_conditions',
+  'public.patient_death_data',
+  'public.patient_family_histories',
+  'public.patient_field_definition_categories',
+  'public.patient_field_definitions',
+  'public.patient_issues',
+  'public.patient_secondary_ids',
+  'public.patient_vrs_data',
+  'public.patients',
+  'public.permissions',
+  'public.procedures',
+  'public.program_data_elements',
+  'public.programs',
+  'public.reference_data',
+  'public.referrals',
+  'public.report_definition_versions',
+  'public.report_definitions',
+  'public.report_requests',
+  'public.roles',
+  'public.scheduled_vaccines',
+  'public.signers',
+  'public.survey_response_answers',
+  'public.survey_responses',
+  'public.survey_screen_components',
+  'public.surveys',
+  'public.triages',
+  'public.user_facilities',
+  'public.user_localisation_caches',
+  'public.users',
+  'public.vitals',
+];
+
 function toTableName(table: TableNameString): TableName {
   const [schema, tableName] = table.split('.');
   return { schema, tableName: tableName! };
@@ -89,6 +156,15 @@ function toTableName(table: TableNameString): TableName {
 
 export async function up(query: QueryInterface): Promise<void> {
   for (const table of STRING_OSSP_TABLES) {
+    await query.changeColumn(toTableName(table), 'id', {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('gen_random_uuid'),
+    });
+  }
+
+  for (const table of STRING_NO_DEFAULT_TABLES) {
     await query.changeColumn(toTableName(table), 'id', {
       type: DataTypes.STRING,
       allowNull: false,
@@ -114,20 +190,8 @@ export async function up(query: QueryInterface): Promise<void> {
     });
   }
 
-  await query.changeColumn(toTableName('public.user_localisation_caches'), 'id', {
-    type: DataTypes.TEXT,
-    allowNull: false,
-    defaultValue: Sequelize.fn('gen_random_uuid'),
-  });
-
-  await query.changeColumn(toTableName('public.one_time_logins'), 'id', {
-    type: DataTypes.TEXT,
-    allowNull: false,
-    defaultValue: Sequelize.fn('gen_random_uuid'),
-  });
-
   await query.changeColumn(toTableName('public.imaging_requests'), 'display_id', {
-    type: DataTypes.TEXT,
+    type: DataTypes.STRING,
     allowNull: false,
     defaultValue: Sequelize.fn('gen_random_uuid'),
   });
@@ -149,6 +213,14 @@ export async function down(query: QueryInterface): Promise<void> {
     });
   }
 
+  for (const table of STRING_NO_DEFAULT_TABLES) {
+    await query.changeColumn(toTableName(table), 'id', {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+    });
+  }
+
   for (const table of UUID_OSSP_TABLES) {
     await query.changeColumn(toTableName(table), 'id', {
       type: DataTypes.UUID,
@@ -166,18 +238,8 @@ export async function down(query: QueryInterface): Promise<void> {
     });
   }
 
-  await query.changeColumn(toTableName('public.user_localisation_caches'), 'id', {
-    type: DataTypes.TEXT,
-    allowNull: false,
-  });
-
-  await query.changeColumn(toTableName('public.one_time_logins'), 'id', {
-    type: DataTypes.TEXT,
-    allowNull: false,
-  });
-
   await query.changeColumn(toTableName('public.imaging_requests'), 'display_id', {
-    type: DataTypes.TEXT,
+    type: DataTypes.STRING,
     allowNull: false,
     defaultValue: Sequelize.fn('uuid_generate_v4'),
   });

--- a/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
+++ b/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
@@ -158,15 +158,7 @@ function removeDefaultQuery(table: string, column: string) {
 }
 
 export async function up(query: QueryInterface): Promise<void> {
-  for (const table of STRING_OSSP_TABLES) {
-    await query.sequelize.query(changeDefaultQuery(table, 'id', 'gen_random_uuid'));
-  }
-
-  for (const table of STRING_NO_DEFAULT_TABLES) {
-    await query.sequelize.query(changeDefaultQuery(table, 'id', 'gen_random_uuid'));
-  }
-
-  for (const table of UUID_OSSP_TABLES) {
+  for (const table of STRING_OSSP_TABLES.concat(STRING_NO_DEFAULT_TABLES, UUID_OSSP_TABLES)) {
     await query.sequelize.query(changeDefaultQuery(table, 'id', 'gen_random_uuid'));
   }
 
@@ -179,16 +171,12 @@ export async function up(query: QueryInterface): Promise<void> {
 }
 
 export async function down(query: QueryInterface): Promise<void> {
-  for (const table of STRING_OSSP_TABLES) {
+  for (const table of STRING_OSSP_TABLES.concat(STRING_NO_DEFAULT_TABLES, UUID_OSSP_TABLES)) {
     await query.sequelize.query(changeDefaultQuery(table, 'id', 'uuid_generate_v4'));
   }
 
   for (const table of STRING_NO_DEFAULT_TABLES) {
     await query.sequelize.query(removeDefaultQuery(table, 'id'));
-  }
-
-  for (const table of UUID_OSSP_TABLES) {
-    await query.sequelize.query(changeDefaultQuery(table, 'id', 'uuid_generate_v4'));
   }
 
   for (const table of FHIR_TABLES) {

--- a/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
+++ b/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
@@ -113,6 +113,24 @@ export async function up(query: QueryInterface): Promise<void> {
     });
   }
 
+  await query.changeColumn(toTableName('public.user_localisation_caches'), 'id', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('gen_random_uuid'),
+  });
+
+  await query.changeColumn(toTableName('public.one_time_logins'), 'id', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('gen_random_uuid'),
+  });
+
+  await query.changeColumn(toTableName('public.imaging_requests'), 'display_id', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('gen_random_uuid'),
+  });
+
   await query.changeColumn(toTableName('fhir.jobs'), 'discriminant', {
     type: DataTypes.TEXT,
     allowNull: false,
@@ -146,6 +164,22 @@ export async function down(query: QueryInterface): Promise<void> {
       defaultValue: Sequelize.fn('uuid_generate_v4'),
     });
   }
+
+  await query.changeColumn(toTableName('public.user_localisation_caches'), 'id', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  });
+
+  await query.changeColumn(toTableName('public.one_time_logins'), 'id', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  });
+
+  await query.changeColumn(toTableName('public.imaging_requests'), 'display_id', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('uuid_generate_v4'),
+  });
 
   await query.changeColumn(toTableName('fhir.jobs'), 'discriminant', {
     type: DataTypes.TEXT,

--- a/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
+++ b/packages/database/src/migrations/1739170944565-changeDefaultsToPgcrypto.ts
@@ -1,0 +1,114 @@
+/* eslint-disable no-unused-vars */
+// remove the above line
+
+import { DataTypes, QueryInterface, Sequelize, type TableName } from 'sequelize';
+
+type TableNameString = `${string}.${string}`;
+
+/*
+select pg_class.relnamespace::regnamespace || '.' || pg_class.relname as t
+from pg_attribute join pg_class on attrelid = pg_class.oid
+where attname = 'id' and atttypid = 'uuid'::regtype::oid and reltype != 0
+order by t;
+*/
+const UUID_OSSP_TABLES: TableNameString[] = [
+  'fhir.encounters',
+  'fhir.immunizations',
+  'fhir.job_workers',
+  'fhir.jobs',
+  'fhir.non_fhir_medici_report',
+  'fhir.organizations',
+  'fhir.patients',
+  'fhir.practitioners',
+  'fhir.service_requests',
+  'fhir.specimens',
+  'logs.debug_logs',
+  'logs.fhir_writes',
+  'public.appointment_schedules',
+  'public.death_revert_logs',
+  'public.encounter_diets',
+  'public.encounter_history',
+  'public.imaging_results',
+  'public.invoice_discounts',
+  'public.invoice_insurer_payments',
+  'public.invoice_insurers',
+  'public.invoice_item_discounts',
+  'public.invoice_items',
+  'public.invoice_patient_payments',
+  'public.invoice_payments',
+  'public.invoices',
+  'public.lab_test_panel_requests',
+  'public.note_items',
+  'public.note_pages',
+  'public.notes',
+  'public.notifications',
+  'public.patient_program_registrations',
+  'public.reference_data_relations',
+  'public.refresh_tokens',
+  'public.settings',
+  'public.socket_io_attachments',
+  'public.sync_sessions',
+  'public.task_designations',
+  'public.task_template_designations',
+  'public.task_templates',
+  'public.tasks',
+  'public.templates',
+  'public.user_designations',
+  'public.user_recently_viewed_patients',
+];
+
+const FHIR_TABLES = UUID_OSSP_TABLES.filter(
+  (table) => table.startsWith('fhir.') && !['fhir.jobs', 'fhir.job_workers'].includes(table),
+);
+
+function toTableName(table: TableNameString): TableName {
+  const [schema, tableName] = table.split('.');
+  return { schema, tableName: tableName! };
+}
+
+async function changeUuidColumnDefault(
+  query: QueryInterface,
+  table: TableNameString,
+  column: string,
+  defaultFn: string,
+  primaryKey = false,
+) {
+  await query.changeColumn(toTableName(table), column, {
+    type: DataTypes.UUID,
+    allowNull: false,
+    primaryKey,
+    defaultValue: Sequelize.fn(defaultFn),
+  });
+}
+
+export async function up(query: QueryInterface): Promise<void> {
+  for (const table of UUID_OSSP_TABLES) {
+    await changeUuidColumnDefault(query, table, 'id', 'gen_random_uuid', true);
+  }
+
+  for (const table of FHIR_TABLES) {
+    await changeUuidColumnDefault(query, table, 'version_id', 'gen_random_uuid');
+  }
+
+  await query.changeColumn(toTableName('fhir.jobs'), 'discriminant', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('gen_random_uuid'),
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  for (const table of UUID_OSSP_TABLES) {
+    await changeUuidColumnDefault(query, table, 'id', 'uuid_generate_v4', true);
+  }
+
+  for (const table of FHIR_TABLES) {
+    await changeUuidColumnDefault(query, table, 'version_id', 'uuid_generate_v4');
+  }
+
+  await query.changeColumn(toTableName('fhir.jobs'), 'discriminant', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: Sequelize.fn('uuid_generate_v4'),
+  });
+}

--- a/packages/database/src/models/DeathRevertLog.ts
+++ b/packages/database/src/models/DeathRevertLog.ts
@@ -20,7 +20,7 @@ export class DeathRevertLog extends Model {
           type: DataTypes.UUID,
           allowNull: false,
           primaryKey: true,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
         },
         revertTime: dateTimeType('revertTime', { allowNull: false }),
         deathDataId: { type: DataTypes.STRING, allowNull: false },

--- a/packages/database/src/models/ImagingRequest.ts
+++ b/packages/database/src/models/ImagingRequest.ts
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Sequelize } from 'sequelize';
 import {
   IMAGING_REQUEST_STATUS_TYPES,
   IMAGING_TYPES_VALUES,
@@ -52,12 +52,12 @@ export class ImagingRequest extends Model {
         id: {
           type: DataTypes.STRING,
           allowNull: false,
-          defaultValue: DataTypes.UUIDV4,
+          defaultValue: Sequelize.fn('gen_random_uuid'),
           primaryKey: true,
         },
         displayId: {
           type: DataTypes.STRING,
-          defaultValue: DataTypes.UUIDV4,
+          defaultValue: Sequelize.fn('gen_random_uuid'),
           allowNull: false,
         },
 

--- a/packages/database/src/models/ImagingResult.ts
+++ b/packages/database/src/models/ImagingResult.ts
@@ -28,7 +28,7 @@ export class ImagingResult extends Model {
           type: DataTypes.UUID,
           allowNull: false,
           primaryKey: true,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
         },
         visibilityStatus: {
           type: DataTypes.STRING,

--- a/packages/database/src/models/LocalSystemFact.ts
+++ b/packages/database/src/models/LocalSystemFact.ts
@@ -2,6 +2,7 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import type { InitOptions } from '../types/model';
+import { randomUUID } from 'node:crypto';
 
 // stores data written _by the server_
 // e.g. which host did we last connect to?
@@ -42,7 +43,12 @@ export class LocalSystemFact extends Model {
     if (existing) {
       await this.update({ value }, { where: { key } });
     } else {
-      await this.create({ key, value });
+      // This function is used in the migration code, and in Postgres
+      // version 12 `gen_random_uuid()` is not available in a blank
+      // database, and it's used to default the ID. So instead, create
+      // random UUIDs here in code, so the default isn't invoked. We
+      // use Node's native function so it's just as fast.
+      await this.create({ id: randomUUID(), key, value });
     }
   }
 

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -90,8 +90,8 @@ export class Model<
    * Generates a uuid via the database
    */
   static async generateDbUuid() {
-    const result: any  = await this.sequelize.query(`SELECT uuid_generate_v4();`);
-    return result[0][0].uuid_generate_v4;
+    const result: any  = await this.sequelize.query(`SELECT gen_random_uuid();`);
+    return result[0][0].gen_random_uuid;
   }
 
   static validateSync(timestamps: boolean) {

--- a/packages/database/src/models/OneTimeLogin.ts
+++ b/packages/database/src/models/OneTimeLogin.ts
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Sequelize } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import type { InitOptions, Models } from '../types/model';
@@ -10,10 +10,15 @@ export class OneTimeLogin extends Model {
   declare usedAt?: Date;
   declare userId: string;
 
-  static initModel({ primaryKey, ...options }: InitOptions) {
+  static initModel(options: InitOptions) {
     super.init(
       {
-        id: primaryKey,
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+          defaultValue: Sequelize.fn('gen_random_uuid'),
+        },
         token: { type: DataTypes.STRING, allowNull: false },
         expiresAt: { type: DataTypes.DATE, allowNull: false },
         usedAt: { type: DataTypes.DATE, allowNull: true },

--- a/packages/database/src/models/ReferenceDataRelation.ts
+++ b/packages/database/src/models/ReferenceDataRelation.ts
@@ -18,7 +18,7 @@ export class ReferenceDataRelation extends Model {
           type: DataTypes.UUID,
           allowNull: false,
           primaryKey: true,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
         },
         referenceDataId: {
           type: DataTypes.TEXT,

--- a/packages/database/src/models/UserLocalisationCache.ts
+++ b/packages/database/src/models/UserLocalisationCache.ts
@@ -1,4 +1,4 @@
-import { DataTypes, type NonNullFindOptions } from 'sequelize';
+import { DataTypes, Sequelize, type NonNullFindOptions } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import type { InitOptions, Models } from '../types/model';
@@ -8,10 +8,15 @@ export class UserLocalisationCache extends Model {
   declare localisation: string;
   declare userId?: string;
 
-  static initModel({ primaryKey, ...options }: InitOptions) {
+  static initModel(options: InitOptions) {
     super.init(
       {
-        id: primaryKey,
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+          defaultValue: Sequelize.fn('gen_random_uuid'),
+        },
         localisation: {
           type: DataTypes.STRING,
           allowNull: false,

--- a/packages/database/src/models/fhir/Job.ts
+++ b/packages/database/src/models/fhir/Job.ts
@@ -27,7 +27,7 @@ export class FhirJob extends Model {
         id: {
           ...primaryKey,
           type: DataTypes.UUID,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
         },
 
         // queue
@@ -55,7 +55,7 @@ export class FhirJob extends Model {
         discriminant: {
           type: DataTypes.TEXT,
           allowNull: false,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
           unique: true,
         },
 

--- a/packages/database/src/models/fhir/JobWorker.ts
+++ b/packages/database/src/models/fhir/JobWorker.ts
@@ -13,7 +13,7 @@ export class FhirJobWorker extends Model {
         id: {
           ...primaryKey,
           type: DataTypes.UUID,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
         },
         metadata: {
           type: DataTypes.JSONB,

--- a/packages/database/src/models/fhir/Resource.ts
+++ b/packages/database/src/models/fhir/Resource.ts
@@ -27,13 +27,13 @@ export class FhirResource extends Model {
         id: {
           type: DataTypes.UUID,
           allowNull: false,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
           primaryKey: true,
         },
         versionId: {
           type: DataTypes.UUID,
           allowNull: false,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
         },
         upstreamId: {
           type: this.UPSTREAM_UUID ? DataTypes.UUID : DataTypes.STRING,
@@ -108,8 +108,8 @@ export class FhirResource extends Model {
 
     if (!resource) {
       resource = this.build({
-        id: Sequelize.fn('uuid_generate_v4'),
-        versionId: Sequelize.fn('uuid_generate_v4'),
+        id: Sequelize.fn('gen_random_uuid'),
+        versionId: Sequelize.fn('gen_random_uuid'),
         upstreamId: id,
       });
     }

--- a/packages/database/src/models/fhir/WriteLog.ts
+++ b/packages/database/src/models/fhir/WriteLog.ts
@@ -20,7 +20,7 @@ export class FhirWriteLog extends Model {
         id: {
           type: DataTypes.UUID,
           allowNull: false,
-          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          defaultValue: Sequelize.fn('gen_random_uuid'),
           primaryKey: true,
         },
         createdAt: {

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -130,7 +130,7 @@ export async function initDatabase(dbOptions) {
     makeEveryModelParanoid = true,
     saltRounds = null,
     alwaysCreateConnection = true,
-    primaryKeyDefault = Sequelize.UUIDV4,
+    primaryKeyDefault = Sequelize.fn('gen_random_uuid'),
     hackToSkipEncounterValidation = false, // TODO: remove once mobile implements all relationships
   } = dbOptions;
 

--- a/packages/database/src/services/migrations/migrations.js
+++ b/packages/database/src/services/migrations/migrations.js
@@ -5,7 +5,7 @@ import { runPostMigration } from './runPostMigration';
 import { wrap, chain } from 'lodash';
 
 // before this, we just cut our losses and accept irreversible migrations
-const LAST_REVERSIBLE_MIGRATION = '048_changeNoteRecordTypeColumn.js';
+const LAST_REVERSIBLE_MIGRATION = '1685403132663-systemUser.js';
 const NO_SYNC_MIGRATION_TIMESTAMP = '1692710205000';
 
 export function createMigrationInterface(log, sequelize) {

--- a/packages/facility-server/__tests__/sync/snapshotOutgoingChanges.test.js
+++ b/packages/facility-server/__tests__/sync/snapshotOutgoingChanges.test.js
@@ -349,12 +349,12 @@ describe('snapshotOutgoingChanges', () => {
     await ctx.sequelize.query(`
       INSERT INTO reference_data (id, created_at, updated_at, type, code, name)
       SELECT
-        uuid_generate_v4() as id,
+        gen_random_uuid() as id,
         now() as created_at,
         now() as updated_at,
         'test' as type,
-        uuid_generate_v4() || '-' || generate_series as code,
-        uuid_generate_v4() || '-' || generate_series as name
+        gen_random_uuid() || '-' || generate_series as code,
+        gen_random_uuid() || '-' || generate_series as name
       FROM generate_series(1, ${limit + 100});
     `);
 


### PR DESCRIPTION
### Changes

In #6326, it was found that a low-hanging fruit for sync performance was to change the serial generation from UUID to a bigserial.

Subsequently, [in the slack thread for the PR](https://beyondessential.slack.com/archives/C01RZFLB3DZ/p1724368895597569), we found that the `uuid_generate_v4()` function from the (built-in) extension `uuid-ossp` is **3.5 times slower** than `gen_random_uuid` from the (also built-in) extension `pgcrypto`, _specifically on Windows_. On Linux they're the same (and also performance for that one function is 30% greater on Linux given the same resources).

This PR migrates every single table and model to `gen_random_uuid`. It also adds default values for the `id` to a number of tables which had forgotten to do that (it doesn't touch tables with e.g. generated columns where the omission is intentional).

As we move to Linux this will become less important, but in the meantime this may provide some performance benefit to our Windows deployments.
