### PR TITLE
tweak(alerts): Add isMobile exclusion to sync-errors alert

### DIFF
--- a/alerts/sync-errors.yml
+++ b/alerts/sync-errors.yml
@@ -10,6 +10,7 @@ sql: |
     updated_at > now() - interval '1 minute' -- Lookback window
   AND errors IS NOT NULL
   AND errors <> ARRAY['could not serialize access due to concurrent update']
+  AND debug_info->>'isMobile' <> 'true'
   ORDER BY created_at DESC
 
 send:


### PR DESCRIPTION
### Changes
Raised a few times recently

Will we follow up with a mobile sync errors alert?

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
