### PR TITLE
tweak(alerts): Update sync notifications and create new alert

### DIFF
--- a/alerts/sync-errors.yml
+++ b/alerts/sync-errors.yml
@@ -7,7 +7,7 @@ sql: |
     (completed_at - created_at)::text AS duration
   FROM sync_sessions
   WHERE
-    updated_at > now() - interval '1 minute' -- Lookback window
+    updated_at > now() - interval '2 minutes' -- Lookback window
   AND errors IS NOT NULL
   AND (
     (

--- a/alerts/time-demo.yml
+++ b/alerts/time-demo.yml
@@ -1,0 +1,14 @@
+sql: |
+  SELECT now() as current_time_demo;
+
+send:
+  - target: external
+    id: default
+    subject: '[Tamanu Alert] Certificate notification error ({{ hostname }})'
+    template: |
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      {% for row in rows | slice(end=5) %}
+      - Current time is: **{{ row.current_time_demo }}**
+      {% endfor %}


### PR DESCRIPTION
### Changes

Update the sync errors alert to be the last 2 minutes instead the last 1 minute.
Create a new alert to get the time.

Demonstrate how to update and create alerts

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
