### PR TITLE
fix(fhir): SAV-891: Bump lastUpdated of MediciReport when rematerialising (hotfix 2.18.7)

### DIFF
--- a/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
+++ b/packages/shared/src/models/fhir/MediciReport/getMaterialisedValues.js
@@ -372,5 +372,8 @@ export const getMaterialisedValues = async (sequelize, upstreamId) => {
     },
   });
 
-  return upstream;
+  return {
+    lastUpdated: new Date(),
+    ...upstream,
+  };
 };


### PR DESCRIPTION
* fix(fhir): SAV-891: Bump lastUpdated of MediciReport when rematerialising

---------

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
