### PR TITLE
tweak(alerts): Create new alert for Palau to detect Unresolvable FHIR Service Requests

### DIFF
--- a/alerts/fhir-unresolvable-service-requests-labs.yml
+++ b/alerts/fhir-unresolvable-service-requests-labs.yml
@@ -1,0 +1,25 @@
+sql: |
+  SELECT
+    lr.display_id as lab_request_id,
+    ROUND(EXTRACT(EPOCH FROM (NOW() - fsr.last_updated)) / 60)::text AS duration_minutes
+  FROM fhir.service_requests fsr
+  JOIN lab_requests lr on fsr.upstream_id = lr.id
+  WHERE fsr.resolved = FALSE
+    AND NOW() - fsr.last_updated > INTERVAL '1 hours';
+
+send:
+  - target: external
+    id: default
+    subject: '[Tamanu Alert] Unresolvable FHIR Service Requests (Lab Requests) detected ({{ hostname }})'
+    template: |
+      <p>Server: {{ hostname }}</p>
+      <p>Alert: {{ filename }}</p>
+      <h1>Unresolvable FHIR Service Requests (Lab Requests) detected</h1>
+      <ul>
+        {% for row in rows | slice(end=5) %}
+        <li><b>{{row.resource}}</> Lab Request ID: <b>{{ row.lab_request_id }}</b> - Unresolved for: <i>{{ row.duration_minutes }} minutes</i></li>
+        {% endfor %}
+         <li>... and {{ rows | length - 5 }} more</li>
+        {% endif %}
+      </ul>
+      <p>For more information, please check the logs.</p>


### PR DESCRIPTION
### Changes

Create a new alert, designed for Palau to detect Unresolvable FHIR Service Requests. 

### Deploys


### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
