### PR TITLE
fix(patientEncounter): release-2.25-fix-encounter-summary

### DIFF
--- a/packages/database/src/models/PatientAdditionalData.ts
+++ b/packages/database/src/models/PatientAdditionalData.ts
@@ -147,7 +147,7 @@ export class PatientAdditionalData extends Model {
   }
 
   static getFullReferenceAssociations() {
-    return ['countryOfBirth', 'nationality', 'ethnicity', 'insurer'];
+    return ['countryOfBirth', 'country', 'nationality', 'ethnicity', 'insurer'];
   }
 
   static buildSyncLookupQueryDetails() {


### PR DESCRIPTION
### Changes

The address line is not showing up on the patient encounter summary because the country data is not available in the patient additional data query. I can't find if it was changed but it seems like it was never there.

https://beyondessential.slack.com/archives/C03KJSEPV9A/p1739746333290829

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
