### PR TITLE
fix(reports): NASS-1481: Default date ranges to use strings and end/start of day fixes

### DIFF
--- a/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
+++ b/packages/central-server/__tests__/admin/reports/reportRoutes.test.js
@@ -96,7 +96,7 @@ describe('reportRoutes', () => {
       const res = await adminApp.get(`/api/admin/reports/${testReport.id}/versions`);
       expect(res).toHaveSucceeded();
       expect(res.body).toHaveLength(2);
-      expect(res.body.map(x => x.id)).toEqual(expect.arrayContaining([v1.id, v2.id]));
+      expect(res.body.map((x) => x.id)).toEqual(expect.arrayContaining([v1.id, v2.id]));
     });
     it('shouldnt return unnecessary metadata', async () => {
       const { ReportDefinitionVersion } = models;
@@ -115,7 +115,7 @@ describe('reportRoutes', () => {
         'active',
         'createdBy',
       ];
-      const additionalKeys = Object.keys(res.body[0]).filter(k => !allowedKeys.includes(k));
+      const additionalKeys = Object.keys(res.body[0]).filter((k) => !allowedKeys.includes(k));
       expect(additionalKeys).toHaveLength(0);
     });
   });
@@ -195,10 +195,7 @@ describe('reportRoutes', () => {
     });
 
     it('should not return unnecessary metadata', async () => {
-      const newVersion = getMockReportVersion(
-        1,
-        'select * from patients limit 1',
-      );
+      const newVersion = getMockReportVersion(1, 'select * from patients limit 1');
       delete newVersion.versionNumber;
 
       const res = await adminApp
@@ -403,7 +400,9 @@ describe('reportRoutes', () => {
     describe('verifyQuery', () => {
       it('should return true if query is valid', async () => {
         const query = 'select * from patients limit 1';
-        await expect(verifyQuery(query, { parameters: [] }, { store: ctx.store })).resolves.not.toThrow();
+        await expect(
+          verifyQuery(query, { parameters: [] }, { store: ctx.store }),
+        ).resolves.not.toThrow();
       });
       it('should return true if query is valid with paramDefinition', async () => {
         const query = 'select * from patients where id = :test limit 1';

--- a/packages/shared/src/reports/reportDefinitions.js
+++ b/packages/shared/src/reports/reportDefinitions.js
@@ -20,14 +20,12 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'PractitionerField' }],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Recent Diagnoses',
     id: 'recent-diagnoses',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'DiagnosisField',
@@ -49,7 +47,6 @@ export const REPORT_DEFINITIONS = [
     id: 'vaccine-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [
       { parameterField: 'VillageField' },
       { parameterField: 'VaccineCategoryField' },
@@ -61,7 +58,6 @@ export const REPORT_DEFINITIONS = [
     id: 'tuvalu-vaccine-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
     parameters: [
       { parameterField: 'VillageField' },
       { parameterField: 'VaccineCategoryField' },
@@ -73,27 +69,23 @@ export const REPORT_DEFINITIONS = [
     id: 'covid-vaccine-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [{ parameterField: 'VillageField' }],
   },
   {
     name: 'COVID vaccine campaign - First dose summary',
     id: 'covid-vaccine-summary-dose1',
-    filterDateRangeAsStrings: true,
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'COVID vaccine campaign - Second dose summary',
     id: 'covid-vaccine-summary-dose2',
-    filterDateRangeAsStrings: true,
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
   },
   {
     name: 'Adverse Event Following Immunization',
     id: 'aefi',
-    filterDateRangeAsStrings: true,
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
@@ -101,7 +93,6 @@ export const REPORT_DEFINITIONS = [
   {
     name: 'Samoa Adverse Event Following Immunisation',
     id: 'samoa-aefi',
-    filterDateRangeAsStrings: true,
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
@@ -128,7 +119,6 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Fiji Traveller COVID-19 Tests - Line list',
@@ -136,21 +126,18 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'LabTestLaboratoryField' }],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Palau COVID-19 Test - Line list',
     id: 'palau-covid-swab-lab-test-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Nauru COVID-19 Test - Line list',
     id: 'nauru-covid-swab-lab-test-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Palau COVID-19 Case Report - Line list',
@@ -158,14 +145,12 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Kiribati COVID-19 Test - Line list',
     id: 'kiribati-covid-swab-lab-test-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Samoa COVID-19 Test - Line list',
@@ -173,14 +158,12 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'COVID-19 Tests - Summary',
     id: 'covid-swab-lab-tests-summary',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [{ parameterField: 'VillageField' }, { parameterField: 'LabTestLaboratoryField' }],
   },
   {
@@ -188,28 +171,24 @@ export const REPORT_DEFINITIONS = [
     id: 'india-assistive-technology-device-line-list',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Iraq assistive technology device - Line list',
     id: 'iraq-assistive-technology-device-line-list',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'PNG assistive technology device - Line list',
     id: 'png-assistive-technology-device-line-list',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Fiji recent attendance - Line list',
     id: 'fiji-recent-attendance-list',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [
       { parameterField: 'VillageField' },
       { parameterField: 'DiagnosisField', name: 'diagnosis', label: 'Diagnosis' },
@@ -220,7 +199,6 @@ export const REPORT_DEFINITIONS = [
     id: 'fiji-ncd-primary-screening-line-list',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterSelectField',
@@ -248,7 +226,6 @@ export const REPORT_DEFINITIONS = [
     id: 'fiji-ncd-primary-screening-pending-referrals-line-list',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterSelectField',
@@ -276,7 +253,6 @@ export const REPORT_DEFINITIONS = [
     id: 'fiji-ncd-primary-screening-summary',
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterMultiselectField',
@@ -323,7 +299,6 @@ export const REPORT_DEFINITIONS = [
     id: 'fiji-statistical-report-for-phis-summary',
     dateRangeLabel: 'Date range (or leave blank for the past 30 days of data)',
     dataSourceOptions: [REPORT_DATA_SOURCES.ALL_FACILITIES],
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterAutocompleteField',
@@ -351,7 +326,6 @@ export const REPORT_DEFINITIONS = [
     id: GENERIC_SURVEY_EXPORT_REPORT_ID,
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [
       { parameterField: 'VillageField' },
       {
@@ -368,7 +342,6 @@ export const REPORT_DEFINITIONS = [
     id: 'appointments-line-list',
     dateRangeLabel: 'Date range (or leave blank for the next 30 days of data)',
     dataSourceOptions: [REPORT_DATA_SOURCES.THIS_FACILITY],
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterAutocompleteField',
@@ -387,7 +360,7 @@ export const REPORT_DEFINITIONS = [
         parameterField: 'ParameterSelectField',
         name: 'appointmentStatus',
         label: 'Appointment Status',
-        options: Object.values(APPOINTMENT_STATUSES).map(status => ({
+        options: Object.values(APPOINTMENT_STATUSES).map((status) => ({
           label: status,
           value: status,
         })),
@@ -399,7 +372,6 @@ export const REPORT_DEFINITIONS = [
     id: 'imaging-requests-line-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterAutocompleteField',
@@ -412,7 +384,7 @@ export const REPORT_DEFINITIONS = [
         parameterField: 'ParameterMultiselectField',
         label: 'Status',
         name: 'statuses',
-        options: Object.values(IMAGING_REQUEST_STATUS_TYPES).map(status => ({
+        options: Object.values(IMAGING_REQUEST_STATUS_TYPES).map((status) => ({
           label: IMAGING_REQUEST_STATUS_CONFIG[status].label,
           value: status,
         })),
@@ -424,7 +396,6 @@ export const REPORT_DEFINITIONS = [
     id: 'deceased-patients-line-list',
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings: true,
     parameters: [
       {
         parameterField: 'ParameterAutocompleteField',
@@ -458,7 +429,6 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: ALL_TIME_DATE_LABEL,
     dataSourceOptions: [REPORT_DATA_SOURCES.THIS_FACILITY],
     parameters: [],
-    filterDateRangeAsStrings: true,
   },
   {
     name: 'Registered births - Line list',
@@ -466,6 +436,5 @@ export const REPORT_DEFINITIONS = [
     dateRangeLabel: LAST_30_DAYS_DATE_LABEL,
     dataSourceOptions: REPORT_DATA_SOURCE_VALUES,
     parameters: [{ parameterField: 'VillageField' }],
-    filterDateRangeAsStrings: true,
   },
 ];

--- a/packages/shared/src/reports/utilities/getAvailableReports.js
+++ b/packages/shared/src/reports/utilities/getAvailableReports.js
@@ -34,7 +34,6 @@ const getDbReports = async (ability, models) => {
       id: version.id,
       name: r.name,
       dataSourceOptions: version.queryOptions.dataSources,
-      filterDateRangeAsStrings: true,
       dateRangeLabel:
         version.queryOptions.dateRangeLabel ||
         REPORT_DATE_RANGE_LABELS[version.queryOptions.defaultDateRange],

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -4,7 +4,7 @@ import { toDateTimeString, getCurrentDateTimeString } from '@tamanu/utils/dateTi
 
 const START_OF_EPOCH = '1970-01-01 00:00:00';
 
-function getStartDate(dateRange, endDate) {
+const getStartDate = (dateRange, endDate) => {
   switch (dateRange) {
     case REPORT_DEFAULT_DATE_RANGES.ALL_TIME:
       return START_OF_EPOCH;
@@ -22,9 +22,9 @@ function getStartDate(dateRange, endDate) {
     default:
       throw new Error('Unknown date range for report generation');
   }
-}
+};
 
-function getEndDate(dateRange, fromDate) {
+const getEndDate = (dateRange, fromDate) => {
   switch (dateRange) {
     case REPORT_DEFAULT_DATE_RANGES.ALL_TIME:
     case REPORT_DEFAULT_DATE_RANGES.EIGHTEEN_YEARS:
@@ -37,7 +37,16 @@ function getEndDate(dateRange, fromDate) {
     default:
       throw new Error('Unknown date range for report generation');
   }
-}
+};
+
+const getQueryDates = (dateRange, { toDate, fromDate }) => ({
+  toDate: toDate
+    ? toDateTimeString(endOfDay(parseISO(toDate)))
+    : getEndDate(dateRange, fromDate || getCurrentDateTimeString()),
+  fromDate: fromDate
+    ? toDateTimeString(startOfDay(parseISO(fromDate)))
+    : getStartDate(dateRange, toDate),
+});
 
 export const getReportQueryReplacements = async (
   paramDefinitions,
@@ -45,19 +54,13 @@ export const getReportQueryReplacements = async (
   params = {},
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
-  const toDate = params.toDate
-    ? toDateTimeString(endOfDay(parseISO(params.toDate)))
-    : getEndDate(dateRange, params.fromDate || getCurrentDateTimeString());
-  const fromDate = params.fromDate
-    ? toDateTimeString(startOfDay(parseISO(params.fromDate)))
-    : getStartDate(dateRange, toDate);
-
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
+  const { toDate, fromDate } = getQueryDates(dateRange, params);
   return {
     ...paramDefaults,
     ...params,
-    currentFacilityId: facilityId,
     fromDate,
     toDate,
+    currentFacilityId: facilityId,
   };
 };

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -55,12 +55,11 @@ export const getReportQueryReplacements = async (
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
-  const { toDate, fromDate } = getQueryDates(dateRange, params);
+  const queryDates = getQueryDates(dateRange, params);
   return {
     ...paramDefaults,
     ...params,
-    fromDate,
-    toDate,
+    ...queryDates,
     currentFacilityId: facilityId,
   };
 };

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -4,7 +4,7 @@ import { toDateTimeString, getCurrentDateTimeString } from '@tamanu/utils/dateTi
 
 const START_OF_EPOCH = '1970-01-01 00:00:00';
 
-const getFromDate = (dateRange, { toDate, fromDate }) => {
+const getFromDate = (dateRange, { toDate = getCurrentDateTimeString(), fromDate }) => {
   if (fromDate) {
     return toDateTimeString(startOfDay(parseISO(fromDate)));
   }
@@ -21,7 +21,7 @@ const getFromDate = (dateRange, { toDate, fromDate }) => {
     case REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS:
       return toDateTimeString(subDays(parseISO(toDate), 1));
     case REPORT_DEFAULT_DATE_RANGES.NEXT_THIRTY_DAYS:
-      return fromDate
+      return toDate
         ? getCurrentDateTimeString()
         : toDateTimeString(startOfDay(addDays(new Date(), 1)));
     default:

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -21,7 +21,9 @@ const getStartDate = (dateRange, { toDate, fromDate }) => {
     case REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS:
       return toDateTimeString(subDays(parseISO(toDate), 1));
     case REPORT_DEFAULT_DATE_RANGES.NEXT_THIRTY_DAYS:
-      return toDateTimeString(startOfDay(addDays(new Date(), 1)));
+      return fromDate
+        ? getCurrentDateTimeString()
+        : toDateTimeString(startOfDay(addDays(new Date(), 1)));
     default:
       throw new Error('Unknown date range for report generation');
   }

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -4,7 +4,7 @@ import { toDateTimeString, getCurrentDateTimeString } from '@tamanu/utils/dateTi
 
 const START_OF_EPOCH = '1970-01-01 00:00:00';
 
-const getStartDate = (dateRange, { toDate, fromDate }) => {
+const getFromDate = (dateRange, { toDate, fromDate }) => {
   if (fromDate) {
     return toDateTimeString(startOfDay(parseISO(fromDate)));
   }
@@ -29,7 +29,7 @@ const getStartDate = (dateRange, { toDate, fromDate }) => {
   }
 };
 
-const getEndDate = (dateRange, { toDate, fromDate }) => {
+const getToDate = (dateRange, { toDate, fromDate }) => {
   if (toDate) {
     return toDateTimeString(endOfDay(parseISO(toDate)));
   }
@@ -56,11 +56,12 @@ export const getReportQueryReplacements = async (
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
+  console.log({ fromDate: getFromDate(dateRange, params), toDate: getToDate(dateRange, params) });
   return {
     ...paramDefaults,
     ...params,
-    fromDate: getStartDate(dateRange, params),
-    toDate: getEndDate(dateRange, params),
+    fromDate: getFromDate(dateRange, params),
+    toDate: getToDate(dateRange, params),
     currentFacilityId: facilityId,
   };
 };

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -54,10 +54,6 @@ export const getReportQueryReplacements = async (
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
-  console.log({
-    fromDate: getStartDate(dateRange, params),
-    toDate: getEndDate(dateRange, params),
-  });
   return {
     ...paramDefaults,
     ...params,

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -22,10 +22,7 @@ const getFromDate = (dateRange, { toDate, fromDate }) => {
     case REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS:
       return toDateTimeString(subDays(parseISO(defaultedToDate), 1));
     case REPORT_DEFAULT_DATE_RANGES.NEXT_THIRTY_DAYS:
-      if (toDate) {
-        return toDateTimeString(startOfDay(subDays(parseISO(toDate), 30)));
-      }
-      return toDateTimeString(startOfDay(addDays(new Date(), 1)));
+      return toDateTimeString(startOfDay(toDate ? subDays(parseISO(toDate), 30) : addDays(new Date(), 1)));
     default:
       throw new Error('Unknown date range for report generation');
   }
@@ -58,7 +55,6 @@ export const getReportQueryReplacements = async (
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
-  console.log({ fromDate: getFromDate(dateRange, params), toDate: getToDate(dateRange, params) });
   return {
     ...paramDefaults,
     ...params,

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -39,7 +39,7 @@ const getEndDate = (dateRange, { toDate, fromDate }) => {
     case REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS:
       return getCurrentDateTimeString();
     case REPORT_DEFAULT_DATE_RANGES.NEXT_THIRTY_DAYS:
-      return toDateTimeString(endOfDay(addDays(parseISO(fromDate) || new Date(), 30)));
+      return toDateTimeString(endOfDay(addDays(fromDate ? parseISO(fromDate) : new Date(), 30)));
     default:
       throw new Error('Unknown date range for report generation');
   }
@@ -52,6 +52,10 @@ export const getReportQueryReplacements = async (
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
+  console.log({
+    fromDate: getStartDate(dateRange, params),
+    toDate: getEndDate(dateRange, params),
+  });
   return {
     ...paramDefaults,
     ...params,

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -4,7 +4,8 @@ import { toDateTimeString, getCurrentDateTimeString } from '@tamanu/utils/dateTi
 
 const START_OF_EPOCH = '1970-01-01 00:00:00';
 
-const getFromDate = (dateRange, { toDate = getCurrentDateTimeString(), fromDate }) => {
+const getFromDate = (dateRange, { toDate, fromDate }) => {
+  const defaultedToDate = toDate || getCurrentDateTimeString();
   if (fromDate) {
     return toDateTimeString(startOfDay(parseISO(fromDate)));
   }
@@ -12,18 +13,19 @@ const getFromDate = (dateRange, { toDate = getCurrentDateTimeString(), fromDate 
     case REPORT_DEFAULT_DATE_RANGES.ALL_TIME:
       return START_OF_EPOCH;
     case REPORT_DEFAULT_DATE_RANGES.EIGHTEEN_YEARS:
-      return toDateTimeString(startOfDay(subYears(parseISO(toDate), 18)));
+      return toDateTimeString(startOfDay(subYears(parseISO(defaultedToDate), 18)));
     case REPORT_DEFAULT_DATE_RANGES.THIRTY_DAYS:
       // If we have a toDate, but no fromDate, run 30 days prior to the toDate
-      return toDateTimeString(startOfDay(subDays(parseISO(toDate), 30)));
+      return toDateTimeString(startOfDay(subDays(parseISO(defaultedToDate), 30)));
     case REPORT_DEFAULT_DATE_RANGES.SEVEN_DAYS:
-      return toDateTimeString(startOfDay(subDays(parseISO(toDate), 7)));
+      return toDateTimeString(startOfDay(subDays(parseISO(defaultedToDate), 7)));
     case REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS:
-      return toDateTimeString(subDays(parseISO(toDate), 1));
+      return toDateTimeString(subDays(parseISO(defaultedToDate), 1));
     case REPORT_DEFAULT_DATE_RANGES.NEXT_THIRTY_DAYS:
-      return toDate
-        ? getCurrentDateTimeString()
-        : toDateTimeString(startOfDay(addDays(new Date(), 1)));
+      if (toDate) {
+        return toDateTimeString(startOfDay(subDays(parseISO(toDate), 30)));
+      }
+      return toDateTimeString(startOfDay(addDays(new Date(), 1)));
     default:
       throw new Error('Unknown date range for report generation');
   }

--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -39,7 +39,9 @@ const getEndDate = (dateRange, { toDate, fromDate }) => {
     case REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS:
       return getCurrentDateTimeString();
     case REPORT_DEFAULT_DATE_RANGES.NEXT_THIRTY_DAYS:
-      return toDateTimeString(endOfDay(addDays(fromDate ? parseISO(fromDate) : new Date(), 30)));
+      return toDateTimeString(
+        endOfDay(addDays(fromDate ? parseISO(fromDate) : addDays(new Date(), 1), 30)),
+      );
     default:
       throw new Error('Unknown date range for report generation');
   }

--- a/packages/web/app/views/reports/ReportGeneratorForm.jsx
+++ b/packages/web/app/views/reports/ReportGeneratorForm.jsx
@@ -149,7 +149,7 @@ export const ReportGeneratorForm = () => {
       <TranslatedText stringId="report.generate.dateRange.label" fallback="Date range" />
     ),
     dataSourceOptions = REPORT_DATA_SOURCE_VALUES,
-    filterDateRangeAsStrings = false,
+    filterDateRangeAsStrings = true,
   } = reportsById[selectedReportId] || {};
 
   const isDataSourceFieldDisabled = dataSourceOptions.length === 1;


### PR DESCRIPTION
### Changes
- Use date_time_strings for default date ranges ( we are comparing with date_time_string fields
- Flip filterDateRangeAsStrings default to true 
- Fix issue with fromDate and toDate not using startOfDay and endOfDay
- Fix next thirty days to start at start of next day and then end of day at 30 days ahead.

Doing some testing with Juliana ✅ given the LGTM

table of all possible behaviors see [comment](https://linear.app/bes/issue/NASS-1481/some-db-reports-dont-pull-data-properly-for-non-default-date-range#comment-6cf36e21)
![Screenshot 2025-02-18 at 2 27 21 PM](https://github.com/user-attachments/assets/43a59594-f313-40bb-8d49-7f7c0263d0c0)


### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
