### PR TITLE
feat(db): KAM-325: record data change logs with triggers

### DIFF
--- a/database/model/central-server/logs/changes.md
+++ b/database/model/central-server/logs/changes.md
@@ -15,7 +15,7 @@ been logged.
 {% enddocs %}
 
 {% docs logs__changes__id %}
-The ID of the change log row. This is auto-generated from random.
+The ID of the change log row. This is auto incremented
 {% enddocs %}
 
 {% docs logs__changes__table_oid %}

--- a/database/model/central-server/logs/changes.yml
+++ b/database/model/central-server/logs/changes.yml
@@ -9,7 +9,7 @@ sources:
         tags: []
         columns:
           - name: id
-            data_type: uuid
+            data_type: bigint
             description: "{{ doc('logs__changes__id') }}"
             data_tests:
               - unique

--- a/database/model/facility-server/logs/migrations.md
+++ b/database/model/facility-server/logs/migrations.md
@@ -1,0 +1,23 @@
+{% docs logs__table__migrations %}
+Contains a full log of all migrations made.
+{% enddocs %}
+
+{% docs logs__migrations__id %}
+The ID of the change log row. This is a uuid that is auto-generated
+{% enddocs %}
+
+{% docs logs__migrations__logged_at %}
+The timestamp this change was logged.
+{% enddocs %}
+
+{% docs logs__migrations__current_sync_tick %}
+The current sync tick at time of migrations
+{% enddocs %}
+
+{% docs logs__migrations__direction %}
+The direction of the migration i.e applied (`up`) or reverted (`down`)
+{% enddocs %}
+
+{% docs logs__migrations__migrations %}
+Comma separated list of the applied/reverted migrations
+{% enddocs %}

--- a/database/model/facility-server/logs/migrations.yml
+++ b/database/model/facility-server/logs/migrations.yml
@@ -1,0 +1,36 @@
+version: 2
+sources:
+  - name: logs__tamanu
+    schema: logs
+    description: "{{ doc('logs__generic__schema') }}"
+    tables:
+      - name: migrations
+        description: '{{ doc("logs__table__migrations") }}'
+        tags: []
+        columns:
+          - name: id
+            data_type: uuid
+            description: "{{ doc('logs__migrations__id') }}"
+            data_tests:
+              - unique
+              - not_null
+          - name: logged_at
+            data_type: timestamp with time zone
+            description: "{{ doc('logs__migrations__logged_at') }}"
+            data_tests:
+              - not_null
+          - name: current_sync_tick
+            data_type: bigint
+            description: "{{ doc('logs__migrations__current_sync_tick') }}"
+            data_tests:
+              - not_null
+          - name: direction
+            data_type: text
+            description: "{{ doc('logs__migrations__direction') }}"
+            data_tests:
+              - not_null
+          - name: migrations
+            data_type: text
+            description: "{{ doc('logs__migrations__migrations') }}"
+            data_tests:
+              - not_null

--- a/packages/central-server/__tests__/admin/fhirJobStats.test.js
+++ b/packages/central-server/__tests__/admin/fhirJobStats.test.js
@@ -33,13 +33,13 @@ describe('FHIR job stats', () => {
     expect(response.body.data).toEqual([
       { id: 'topic2,Queued', topic: 'topic2', status: 'Queued', count: '3' },
       { id: 'topic3,Queued', topic: 'topic3', status: 'Queued', count: '2' },
-      { id: 'topic1,Queued', topic: 'topic1', status: 'Queued', count: '1' },
       {
         id: 'fhir.refresh.allFromUpstream,Queued',
         topic: 'fhir.refresh.allFromUpstream',
         status: 'Queued',
-        count: '1',
+        count: '2',
       },
+      { id: 'topic1,Queued', topic: 'topic1', status: 'Queued', count: '1' },
     ]);
     expect(response.body.count).toBe(4);
   });

--- a/packages/central-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
+++ b/packages/central-server/__tests__/subCommands/migrateChangelogNotesToEncounterHistory.test.js
@@ -4,12 +4,10 @@ import { Op } from 'sequelize';
 import { getCurrentDateTimeString, toDateTimeString } from '@tamanu/utils/dateTime';
 import { createDummyEncounter, createDummyPatient } from '@tamanu/database/demoData/patients';
 import { fake } from '@tamanu/shared/test-helpers/fake';
-import { EncounterChangeType, NOTE_RECORD_TYPES, NOTE_TYPES } from '@tamanu/constants';
+import { EncounterChangeType, NOTE_RECORD_TYPES, NOTE_TYPES, SYSTEM_USER_UUID } from '@tamanu/constants';
 
 import { createTestContext } from '../utilities';
 import { migrateDataInBatches } from '../../dist/subCommands/migrateDataInBatches/migrateDataInBatches';
-
-const DEFAULT_USER_ID = 'DEFAULT_USER_ID';
 
 const addSystemNote = async (models, recordId, content, date, user) =>
   models.Note.create({
@@ -18,7 +16,7 @@ const addSystemNote = async (models, recordId, content, date, user) =>
     date,
     noteType: NOTE_TYPES.SYSTEM,
     content,
-    authorId: user?.id || DEFAULT_USER_ID,
+    authorId: user?.id || SYSTEM_USER_UUID,
   });
 
 const addLocationChangeNote = async (
@@ -121,7 +119,6 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
   let patient;
   let facility1;
   let locationGroup1;
-  let defaultUser;
 
   const NOTE_SUB_COMMAND_NAME = 'ChangelogNotesToEncounterHistory';
 
@@ -185,7 +182,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
       force: true,
       where: {
         id: {
-          [Op.not]: DEFAULT_USER_ID,
+          [Op.not]: SYSTEM_USER_UUID,
         },
       },
     });
@@ -194,7 +191,6 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     models = ctx.store.models;
-    defaultUser = await createUser('default user', { id: DEFAULT_USER_ID });
 
     patient = await models.Patient.create(await createDummyPatient(models));
     facility1 = await models.Facility.create({
@@ -272,7 +268,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: clinician.id,
         encounterType: 'admission',
         changeType: EncounterChangeType.Location,
-        actorId: defaultUser.id,
+        actorId: SYSTEM_USER_UUID,
         date: locationChangeNoteDate,
       });
     });
@@ -379,7 +375,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
         changeType: EncounterChangeType.Location,
-        actorId: defaultUser.id,
+        actorId: SYSTEM_USER_UUID,
       });
 
       // Department change history
@@ -390,7 +386,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: oldUser.id,
         encounterType: oldEncounterType,
         changeType: EncounterChangeType.Department,
-        actorId: defaultUser.id,
+        actorId: SYSTEM_USER_UUID,
       });
 
       // Clinician change history
@@ -401,7 +397,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: newUser.id,
         encounterType: oldEncounterType,
         changeType: EncounterChangeType.Examiner,
-        actorId: defaultUser.id,
+        actorId: SYSTEM_USER_UUID,
       });
 
       // Encounter type change history
@@ -412,7 +408,7 @@ describe('migrateChangelogNotesToEncounterHistory', () => {
         examinerId: newUser.id,
         encounterType: newEncounterType,
         changeType: EncounterChangeType.EncounterType,
-        actorId: defaultUser.id,
+        actorId: SYSTEM_USER_UUID,
       });
     });
   });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { Op } from 'sequelize';
 import { endOfDay, parseISO, sub } from 'date-fns';
 
 import {
@@ -18,6 +19,7 @@ import {
   DEBUG_LOG_TYPES,
   APPOINTMENT_STATUSES,
   REPEAT_FREQUENCY,
+  SYSTEM_USER_UUID,
 } from '@tamanu/constants';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { settingsCache } from '@tamanu/settings';
@@ -161,6 +163,12 @@ describe('CentralSyncManager', () => {
     await models.SurveyScreenComponent.truncate({ cascade: true, force: true });
     await models.ReferenceData.truncate({ cascade: true, force: true });
     await models.User.truncate({ cascade: true, force: true });
+    await models.User.create({
+      id: SYSTEM_USER_UUID,
+      email: 'system',
+      displayName: 'System',
+      role: 'system',
+    });
   });
 
   afterAll(() => ctx.close());
@@ -401,7 +409,7 @@ describe('CentralSyncManager', () => {
       const changes = await centralSyncManager.getOutgoingChanges(sessionId, {
         limit: 10,
       });
-      expect(changes.length).toBe(1);
+      expect(changes.filter(({ recordId }) => recordId !== SYSTEM_USER_UUID)).toHaveLength(1);
     });
     it('returns all the outgoing changes with multiple facilities', async () => {
       const facility1 = await models.Facility.create(fake(models.Facility));
@@ -423,7 +431,7 @@ describe('CentralSyncManager', () => {
       const changes = await centralSyncManager.getOutgoingChanges(sessionId, {
         limit: 10,
       });
-      expect(changes.length).toBe(3);
+      expect(changes.filter(({ recordId }) => recordId !== SYSTEM_USER_UUID)).toHaveLength(3);
     });
   });
 
@@ -725,7 +733,9 @@ describe('CentralSyncManager', () => {
 
         // Check if only 3 pre inserted records were snapshotted
         // and not the ones that were inserted in the middle of the snapshot process
-        const outgoingChanges = await centralSyncManager.getOutgoingChanges(sessionId, {});
+        const outgoingChanges = (await centralSyncManager.getOutgoingChanges(sessionId, {})).filter(
+          ({ recordId }) => recordId !== SYSTEM_USER_UUID,
+        );
         expect(outgoingChanges.length).toBe(3);
         expect(outgoingChanges.map((r) => r.recordId).sort()).toEqual(
           [facility, program, survey].map((r) => r.id).sort(),
@@ -777,7 +787,9 @@ describe('CentralSyncManager', () => {
 
         // Check if only 3 pre inserted records were snapshotted
         // and not the ones that were inserted in the middle of the snapshot process
-        const outgoingChanges = await centralSyncManager.getOutgoingChanges(sessionId, {});
+        const outgoingChanges = (await centralSyncManager.getOutgoingChanges(sessionId, {})).filter(
+          ({ recordId }) => recordId !== SYSTEM_USER_UUID,
+        );
         expect(outgoingChanges.length).toBe(3);
         expect(outgoingChanges.map((r) => r.recordId).sort()).toEqual(
           [facility, program, survey].map((r) => r.id).sort(),
@@ -866,7 +878,9 @@ describe('CentralSyncManager', () => {
 
         // Check if only 3 pre inserted records were snapshotted
         // and not the ones that were inserted in the middle of the snapshot process
-        const outgoingChanges = await centralSyncManager.getOutgoingChanges(sessionIdOne, {});
+        const outgoingChanges = (
+          await centralSyncManager.getOutgoingChanges(sessionIdOne, {})
+        ).filter(({ recordId }) => recordId !== SYSTEM_USER_UUID);
 
         expect(outgoingChanges.length).toBe(3);
         expect(outgoingChanges.map((r) => r.recordId).sort()).toEqual(
@@ -897,7 +911,14 @@ describe('CentralSyncManager', () => {
             cascade: true,
             force: true,
           });
-          await models.User.truncate({ cascade: true, force: true });
+          await models.User.destroy({
+            where: {
+              id: {
+                [Op.not]: SYSTEM_USER_UUID,
+              },
+            },
+            force: true,
+          });
           await models.Patient.truncate({ cascade: true, force: true });
           await models.Encounter.truncate({ cascade: true, force: true });
           await models.LabRequest.truncate({ cascade: true, force: true });
@@ -1652,7 +1673,13 @@ describe('CentralSyncManager', () => {
 
       await centralSyncManager.updateLookupTable();
 
-      const lookupData = await models.SyncLookup.findAll({});
+      const lookupData = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       expect(lookupData).toHaveLength(1);
       expect(lookupData[0]).toEqual(
@@ -1696,7 +1723,13 @@ describe('CentralSyncManager', () => {
 
       await centralSyncManager.updateLookupTable();
 
-      const lookupData = await models.SyncLookup.findAll({});
+      const lookupData = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       expect(lookupData).toHaveLength(1);
       expect(lookupData[0]).toEqual(
@@ -1728,7 +1761,13 @@ describe('CentralSyncManager', () => {
       await patient1.save();
 
       await centralSyncManager.updateLookupTable();
-      const lookupData2 = await models.SyncLookup.findAll({});
+      const lookupData2 = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       const newCurrentSyncTime = (await models.LocalSystemFact.get(CURRENT_SYNC_TIME_KEY)) - 1;
 
@@ -1778,7 +1817,13 @@ describe('CentralSyncManager', () => {
 
       await centralSyncManager.updateLookupTable();
 
-      const lookupData = await models.SyncLookup.findAll({});
+      const lookupData = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       expect(lookupData).toHaveLength(2);
       expect(lookupData.find((d) => d.recordType === 'patients')).toEqual(
@@ -1810,7 +1855,13 @@ describe('CentralSyncManager', () => {
       await patient1.save();
 
       await centralSyncManager.updateLookupTable();
-      const lookupData2 = await models.SyncLookup.findAll({});
+      const lookupData2 = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       const newCurrentSyncTime = (await models.LocalSystemFact.get(CURRENT_SYNC_TIME_KEY)) - 1;
 
@@ -1898,7 +1949,13 @@ describe('CentralSyncManager', () => {
 
       await updateLookupTablePromise;
 
-      const lookupData = await models.SyncLookup.findAll({});
+      const lookupData = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       // only expect 3 records as it should not include the 3 records inserted manually
       expect(lookupData).toHaveLength(3);
@@ -1944,7 +2001,13 @@ describe('CentralSyncManager', () => {
 
       await updateLookupTablePromise;
 
-      const lookupData = await models.SyncLookup.findAll({});
+      const lookupData = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
 
       // only expect 3 records as it should not include the 3 records inserted from the importer
       expect(lookupData).toHaveLength(3);
@@ -2018,8 +2081,13 @@ describe('CentralSyncManager', () => {
 
       await updateLookupTablePromise;
 
-      const lookupData = await models.SyncLookup.findAll({});
-
+      const lookupData = await models.SyncLookup.findAll({
+        where: {
+          recordId: {
+            [Op.not]: SYSTEM_USER_UUID,
+          },
+        },
+      });
       // only expect 3 records as it should not include the 3 records inserted from another sync session
       expect(lookupData).toHaveLength(3);
     });

--- a/packages/central-server/__tests__/tasks/FhirMissingResources.test.js
+++ b/packages/central-server/__tests__/tasks/FhirMissingResources.test.js
@@ -7,7 +7,7 @@ import {
   fakeResourcesOfFhirSpecimen,
 } from '../fake/fhir';
 import { FhirMissingResources } from '../../dist/tasks/FhirMissingResources';
-import { JOB_PRIORITIES } from '@tamanu/constants';
+import { JOB_PRIORITIES, SYSTEM_USER_UUID } from '@tamanu/constants';
 
 describe('FhirMissingResources task', () => {
   let ctx;
@@ -50,8 +50,8 @@ describe('FhirMissingResources task', () => {
       },
     });
 
-    expect(count).toEqual(3); // 1 Organization, 1 ServiceRequest, 1 Specimen
-    rows.forEach(job => expect(job.priority).toEqual(JOB_PRIORITIES.LOW));
+    expect(count).toEqual(4); // 1 Organization, 1 ServiceRequest, 1 Specimen, 1 Practitioner
+    rows.forEach((job) => expect(job.priority).toEqual(JOB_PRIORITIES.LOW));
 
     await labRequest.destroy();
   });
@@ -75,7 +75,7 @@ describe('FhirMissingResources task', () => {
     const name = fhirMissingResourcesWorker.getName();
     expect(name).toEqual('FhirMissingResources');
     const countQueue = await fhirMissingResourcesWorker.countQueue();
-    expect(countQueue).toEqual(2); // 1 MediciReport AND 1 ServiceRequest
+    expect(countQueue).toEqual(3); // 1 MediciReport, 1 ServiceRequest, 1 Practitioner
     await fhirMissingResourcesWorker.run();
 
     const fhirJob = await FhirJob.findOne({
@@ -111,7 +111,7 @@ describe('FhirMissingResources task', () => {
     );
 
     const countQueue = await fhirMissingResourcesWorker.countQueue();
-    expect(countQueue).toEqual(1);
+    expect(countQueue).toEqual(2);
     await fhirMissingResourcesWorker.run();
 
     const fhirJob = await FhirJob.findOne({
@@ -125,7 +125,11 @@ describe('FhirMissingResources task', () => {
       },
     });
 
-    expect(fhirJob).toBeNull();
+    expect(fhirJob).toMatchObject({
+      payload: expect.objectContaining({
+        upstreamId: SYSTEM_USER_UUID,
+      }),
+    });
     await encounter.destroy();
   });
 
@@ -155,7 +159,7 @@ describe('FhirMissingResources task', () => {
     });
 
     const countQueue = await fhirMissingResourcesCreatedAfterWorker.countQueue();
-    expect(countQueue).toEqual(3); // 1 Organization, 1 ServiceRequest, 1 Specimen
+    expect(countQueue).toEqual(4); // 1 Organization, 1 ServiceRequest, 1 Specimen, 1 Practitioner
     await fhirMissingResourcesCreatedAfterWorker.run();
 
     const { count, rows } = await FhirJob.findAndCountAll({
@@ -169,8 +173,10 @@ describe('FhirMissingResources task', () => {
       },
     });
 
-    expect(count).toEqual(2);
-    rows.forEach(job => expect(job.payload.upstreamId).toEqual(newLabRequest.id));
+    expect(count).toEqual(3);
+    rows
+      .filter((job) => job.payload.upstreamId !== SYSTEM_USER_UUID)
+      .forEach((job) => expect(job.payload.upstreamId).toEqual(newLabRequest.id));
 
     await oldLabRequest.destroy();
     await newLabRequest.destroy();

--- a/packages/central-server/app/createApi.js
+++ b/packages/central-server/app/createApi.js
@@ -20,11 +20,13 @@ import { translationRoutes } from './translation';
 import { createServer } from 'http';
 
 import { settingsReaderMiddleware } from '@tamanu/settings/middleware';
+import { attachAuditUserToDbSession } from '@tamanu/database/utils/audit';
 
 function api(ctx) {
   const apiRoutes = defineExpress.Router();
   apiRoutes.use('/public', publicRoutes);
   apiRoutes.use(authModule);
+  apiRoutes.use(attachAuditUserToDbSession);
   apiRoutes.use('/translation', translationRoutes);
   apiRoutes.use(constructPermission);
   apiRoutes.use(buildRoutes(ctx));

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -2,7 +2,7 @@ import { trace } from '@opentelemetry/api';
 import { Op, QueryTypes } from 'sequelize';
 import _config from 'config';
 
-import { SYNC_DIRECTIONS, DEBUG_LOG_TYPES, SETTINGS_SCOPES } from '@tamanu/constants';
+import { SYNC_DIRECTIONS, DEBUG_LOG_TYPES, SETTINGS_SCOPES, AUDIT_PAUSE_KEY } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 import {
   adjustDataPostSyncPush,
@@ -581,6 +581,7 @@ export class CentralSyncManager {
     try {
       // commit the changes to the db
       const persistedAtSyncTick = await sequelize.transaction(async () => {
+        await sequelize.setTransactionVar(AUDIT_PAUSE_KEY, true);
         // we tick-tock the global clock to make sure there is a unique tick for these changes
         // n.b. this used to also be used for concurrency control, but that is now handled by
         // shared advisory locks taken using the current sync tick as the id, which are waited on

--- a/packages/constants/src/database.ts
+++ b/packages/constants/src/database.ts
@@ -3,3 +3,10 @@ export const NOTIFY_CHANNELS = {
   MATERIALIZED_VIEW_REFRESHED: 'materialized_view_refreshed',
   TABLE_CHANGED: 'table_changed',
 };
+
+// Session config keys are prefixed with this to avoid conflicts with other settings
+export const SESSION_CONFIG_PREFIX = 'tamanu.'
+
+// Audit session config keys
+export const AUDIT_USERID_KEY = 'audit.userid';
+export const AUDIT_PAUSE_KEY = 'audit.pause';

--- a/packages/database/__tests__/sync/migrations.test.ts
+++ b/packages/database/__tests__/sync/migrations.test.ts
@@ -1,5 +1,5 @@
 import { closeDatabase, initDatabase } from './utilities';
-import { runPostMigration } from '../../src/services/migrations/migrationHooks';
+import { runPostMigration, runPreMigration } from '../../src/services/migrations/migrationHooks';
 import { createMigrationInterface } from '../../src/services/migrations/migrations';
 import { fake } from '@tamanu/shared/test-helpers/fake';
 import { log } from '@tamanu/shared/services/logging/log';
@@ -12,6 +12,7 @@ describe('migrations', () => {
       database = await initDatabase();
       models = database.models;
       umzug = createMigrationInterface(log, database.sequelize);
+      await runPreMigration(log, database.sequelize)
       await umzug.up();
       await runPostMigration(log, database.sequelize);
       await models.LocalSystemFact.set('currentSyncTick', 1);
@@ -33,7 +34,6 @@ describe('migrations', () => {
 
       // act
       await umzug.down({ to: '1692710205000-allowDisablingSyncTrigger' });
-      await models.LocalSystemFact.set('currentSyncTick', 2);
       await umzug.up({ step: 1 });
       await report_definition.reload();
       const tickAfterMigration = await report_definition.updatedAtSyncTick;

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -60,6 +60,11 @@
       "require": "./dist/cjs/utils/fhir/index.js",
       "import": "./dist/esm/utils/fhir/index.js",
       "types": "./dist/esm/utils/fhir/index.d.ts"
+    },
+    "./utils/audit": {
+      "require": "./dist/cjs/utils/audit/index.js",
+      "import": "./dist/esm/utils/audit/index.js",
+      "types": "./dist/esm/utils/audit/index.d.ts"
     }
   },
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",

--- a/packages/database/src/migrations/1739969510355-sessionConfigFunctions.ts
+++ b/packages/database/src/migrations/1739969510355-sessionConfigFunctions.ts
@@ -1,0 +1,30 @@
+import { QueryInterface } from 'sequelize';
+import { SESSION_CONFIG_PREFIX } from '@tamanu/constants/database';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION get_session_config(key TEXT, default_value TEXT)
+    RETURNS text AS $$
+    DECLARE
+      full_key TEXT = '${SESSION_CONFIG_PREFIX}' || key;
+    BEGIN
+      RETURN coalesce(nullif(current_setting(full_key, true), ''), default_value);
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION set_session_config(key TEXT, value TEXT, is_local BOOLEAN DEFAULT FALSE)
+    RETURNS void AS $$
+    DECLARE
+      full_key TEXT = '${SESSION_CONFIG_PREFIX}' || key;
+    BEGIN
+      PERFORM set_config(full_key, value, is_local);
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query('DROP FUNCTION get_session_config');
+  await query.sequelize.query('DROP FUNCTION set_session_config');
+}

--- a/packages/database/src/migrations/1739970132204-ensureSystemUserPresent.ts
+++ b/packages/database/src/migrations/1739970132204-ensureSystemUserPresent.ts
@@ -1,0 +1,20 @@
+import type { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface) {
+  // The previous iteration of that migration, 1685403132663-systemUser, was too
+  // clever and created situations where the system user isn't present in real
+  // deployments and also in tests. As we're increasingly relying on the system
+  // user existing with a Nil UUID, this migration is here to make certain.
+  await query.sequelize.query(`
+    INSERT INTO "users"
+    (id, email, display_name, role)
+    VALUES
+    (uuid_nil(), 'system', 'System', 'system')
+    ON CONFLICT (id) DO NOTHING;
+  `);
+}
+
+export async function down() {
+  // the up migration is idempotent and we also cannot know whether there
+  // existed a system user before, so we can't safely revert anything
+}

--- a/packages/database/src/migrations/1739970132205-addAuditTrigger.ts
+++ b/packages/database/src/migrations/1739970132205-addAuditTrigger.ts
@@ -1,4 +1,5 @@
 import { QueryInterface } from 'sequelize';
+import { AUDIT_USERID_KEY, AUDIT_PAUSE_KEY } from '@tamanu/constants/database';
 
 export async function up(query: QueryInterface): Promise<void> {
   await query.createFunction(
@@ -7,38 +8,44 @@ export async function up(query: QueryInterface): Promise<void> {
     'trigger',
     'plpgsql',
     `
-      INSERT INTO logs.changes (
-        table_oid,
-        table_schema,
-        table_name,
-        logged_at,
-        created_at,
-        updated_at,
-        deleted_at,
-        updated_at_sync_tick,
-        updated_by_user_id,
-        record_id,
-        record_update,
-        record_data
-      ) VALUES (
-        TG_RELID,                 -- table_oid
-        TG_TABLE_SCHEMA,          -- table_schema
-        TG_TABLE_NAME,            -- table_name
-        CURRENT_TIMESTAMP,        -- logged_at
-        NEW.created_at,           -- created_at
-        NEW.updated_at,           -- updated_at
-        NEW.deleted_at,           -- deleted_at
-        NEW.updated_at_sync_tick, -- updated_at_sync_tick
-        NEW.updated_by_user_id,   -- updated_by_user_id
-        NEW.id,                   -- record_id
-        TG_OP = 'UPDATE',         -- record_update
-        to_jsonb(NEW.*)           -- record_data
-      );
-      RETURN NEW;
-    `,
+      BEGIN
+        IF (SELECT get_session_config('${AUDIT_PAUSE_KEY}', 'false')::boolean) THEN
+          RETURN NEW;
+        END IF;
+
+        INSERT INTO logs.changes (
+          table_oid,
+          table_schema,
+          table_name,
+          logged_at,
+          created_at,
+          updated_at,
+          deleted_at,
+          updated_at_sync_tick,
+          updated_by_user_id,
+          record_id,
+          record_update,
+          record_data
+        ) VALUES (
+          TG_RELID,                 -- table_oid
+          TG_TABLE_SCHEMA,          -- table_schema
+          TG_TABLE_NAME,            -- table_name
+          CURRENT_TIMESTAMP,        -- logged_at
+          NEW.created_at,           -- created_at
+          NEW.updated_at,           -- updated_at
+          NEW.deleted_at,           -- deleted_at
+          NEW.updated_at_sync_tick, -- updated_at_sync_tick
+          get_session_config('${AUDIT_USERID_KEY}', uuid_nil()::text), -- updated_by_user_id
+          NEW.id,                   -- record_id
+          TG_OP = 'UPDATE',         -- record_update
+          to_jsonb(NEW.*)           -- record_data
+        );
+        RETURN NEW;
+      END;
+    `
   );
 }
 
 export async function down(query: QueryInterface): Promise<void> {
-  await query.dropFunction('logs.record_change', []);
+  await query.sequelize.query('DROP FUNCTION logs.record_change CASCADE');
 }

--- a/packages/database/src/migrations/1741215641836-createMigrationLogsTable.ts
+++ b/packages/database/src/migrations/1741215641836-createMigrationLogsTable.ts
@@ -1,0 +1,34 @@
+import { DataTypes, QueryInterface, Sequelize } from 'sequelize';
+
+const TABLE = { schema: 'logs', tableName: 'migrations' };
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.createTable(TABLE, {
+    id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('uuid_generate_v4'),
+    },
+    logged_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    current_sync_tick: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    direction: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    migrations: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.dropTable(TABLE);
+}

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -3,7 +3,7 @@ import { Sequelize } from 'sequelize';
 import pg from 'pg';
 import util from 'util';
 
-import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { SYNC_DIRECTIONS, AUDIT_USERID_KEY, SESSION_CONFIG_PREFIX } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 import { serviceContext, serviceName } from '@tamanu/shared/services/logging/context';
 
@@ -14,17 +14,27 @@ import { setupQuote } from '../utils/pgComposite';
 
 createDateTypes();
 
+export const asyncLocalStorage = new AsyncLocalStorage();
 // this allows us to use transaction callbacks without manually managing a transaction handle
 // https://sequelize.org/master/manual/transactions.html#automatically-pass-transactions-to-all-queries
 // done once for all sequelize objects. Instead of cls-hooked we use the built-in AsyncLocalStorage.
-const asyncLocalStorage = new AsyncLocalStorage();
-// eslint-disable-next-line react-hooks/rules-of-hooks
-Sequelize.useCLS({
+export const namespace = {
   bind: () => {}, // compatibility with cls-hooked, not used by sequelize
   get: (id) => asyncLocalStorage.getStore()?.get(id),
   set: (id, value) => asyncLocalStorage.getStore()?.set(id, value),
   run: (callback) => asyncLocalStorage.run(new Map(), callback),
-});
+};
+
+export const setSessionConfigInNamespace = (key, value) => {
+  namespace.run(() => {
+    namespace.set(`${SESSION_CONFIG_PREFIX}${key}`, value);
+  });
+};
+
+export const getSessionConfigInNamespace = (key) => namespace.get(`${SESSION_CONFIG_PREFIX}${key}`);
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+Sequelize.useCLS(namespace);
 
 // this is dangerous and should only be used in test mode
 const unsafeRecreatePgDb = async ({ name, username, password, host, port }) => {
@@ -108,6 +118,26 @@ async function connectToDatabase(dbOptions) {
     logging,
     pool,
   });
+
+  sequelize.setSessionVar = (key, value) =>
+    sequelize.query(`SELECT set_session_config($key, $value)`, {
+      bind: { key, value },
+    });
+
+  sequelize.setTransactionVar = (key, value) =>
+    sequelize.query(`SELECT set_session_config($key, $value, true)`, {
+      bind: { key, value },
+    });
+
+  class QueryWithAditConfig extends sequelize.dialect.Query {
+    async run(sql, options) {
+      const userid = getSessionConfigInNamespace(AUDIT_USERID_KEY);
+      if (userid) await super.run('SELECT set_session_config($1, $2)', [AUDIT_USERID_KEY, userid]);
+      return super.run(sql, options);
+    }
+  }
+  sequelize.dialect.Query = QueryWithAditConfig;
+
   setupQuote(sequelize);
   await sequelize.authenticate();
 

--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -36,4 +36,7 @@ export const NON_LOGGED_TABLES = [
 
   // internal and also signers.privateKey needs to be hard-deletable
   'signers',
+
+  // internal configuration
+  'local_system_facts',
 ];

--- a/packages/database/src/services/migrations/migrationHooks.ts
+++ b/packages/database/src/services/migrations/migrationHooks.ts
@@ -100,9 +100,7 @@ export async function runPreMigration(log: Logger, sequelize: Sequelize) {
 
   // remove changelog trigger before migrations
   // except from SequelizeMeta, so that migrations are recorded in the changelog
-  for (const table of await tablesWithTrigger(sequelize, 'record_', '_changelog', [
-    'SequelizeMeta',
-  ])) {
+  for (const table of await tablesWithTrigger(sequelize, 'record_', '_changelog')) {
     log.info(`Removing changelog trigger from ${table}`);
     await sequelize.query(`DROP TRIGGER record_${table}_changelog ON "${table}"`);
   }

--- a/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
+++ b/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
@@ -1,0 +1,15 @@
+import type { ExpressRequest } from 'types/express';
+import type { NextFunction } from 'express';
+
+import { setSessionConfigInNamespace } from '../../services/database';
+
+import { AUDIT_USERID_KEY } from '@tamanu/constants/database';
+
+export const attachAuditUserToDbSession = async (
+  req: ExpressRequest,
+  _res: Response,
+  next: NextFunction,
+) => {
+  setSessionConfigInNamespace(AUDIT_USERID_KEY, req.user?.id);
+  next();
+};

--- a/packages/database/src/utils/audit/createMigrationAuditLog.ts
+++ b/packages/database/src/utils/audit/createMigrationAuditLog.ts
@@ -1,0 +1,41 @@
+import { QueryTypes, type Sequelize } from 'sequelize';
+import type { Migration } from 'umzug';
+
+import { CURRENT_SYNC_TIME_KEY } from '../../sync/constants';
+
+export const createMigrationAuditLog = async (
+  sequelize: Sequelize,
+  migrations: Migration[],
+  direction: 'up' | 'down',
+) => {
+  const [tableExists] = await sequelize.query(
+    `
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'logs'
+      AND table_name = 'migrations';
+    `,
+    {
+      type: QueryTypes.SELECT,
+    },
+  );
+  if (!tableExists) return;
+  await sequelize.query(
+    `
+      INSERT INTO logs.migrations (logged_at, direction, migrations, current_sync_tick)
+      VALUES (
+        CURRENT_TIMESTAMP,
+        $1,
+        $2,
+        (
+          SELECT value::bigint AS current_sync_tick
+          FROM local_system_facts
+          WHERE key = '${CURRENT_SYNC_TIME_KEY}'
+        )
+      );
+    `,
+    {
+      type: QueryTypes.INSERT,
+      bind: [direction, migrations.map((migration: Migration) => migration.file).join(',')],
+    },
+  );
+};

--- a/packages/database/src/utils/audit/index.ts
+++ b/packages/database/src/utils/audit/index.ts
@@ -1,0 +1,2 @@
+export * from './attachAuditUserToDbSession';
+export * from './createMigrationAuditLog'

--- a/packages/database/src/utils/index.ts
+++ b/packages/database/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './getDependentAssociations';
 export * from './onCreateEncounterMarkPatientForSync';
 export * from './sortInDependencyOrder';
 export * from './fhir';
+export * from './audit';

--- a/packages/facility-server/__tests__/audit/pauseAudit.test.js
+++ b/packages/facility-server/__tests__/audit/pauseAudit.test.js
@@ -1,0 +1,35 @@
+import { AUDIT_PAUSE_KEY } from '@tamanu/constants';
+import { createTestContext } from '../utilities';
+
+describe('pauseAudit', () => {
+  let ctx;
+  let sequelize;
+  let models;
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    sequelize = ctx.sequelize;
+  });
+
+  afterAll(() => ctx.close());
+
+  it('should pause audit for a transaction when pause key is true', async () => {
+    const program1 = await models.Program.create({ code: 'test-1', name: 'Test Program 1' });
+    const program2 = await sequelize.transaction(async () => {
+      await sequelize.setTransactionVar(AUDIT_PAUSE_KEY, true);
+      return models.Program.create({ code: 'test-2', name: 'Test Program 2' });
+    });
+    const changes = await sequelize.query(
+      `SELECT * FROM logs.changes WHERE record_id IN (:programIds);`,
+      {
+        type: sequelize.QueryTypes.SELECT,
+        replacements: {
+          programIds: [program1.id, program2.id],
+        },
+      },
+    );
+    expect(changes.length).toBe(1);
+    // Only the program not created in the paused audit transaction
+    expect(changes[0].record_id).toBe(program1.id);
+  });
+});

--- a/packages/facility-server/__tests__/setupUtilities.js
+++ b/packages/facility-server/__tests__/setupUtilities.js
@@ -1,20 +1,33 @@
 import { Op, Sequelize } from 'sequelize';
 import { FHIR_INTERACTIONS } from '@tamanu/constants/fhir';
+import { SYSTEM_USER_UUID } from '@tamanu/constants/auth';
 import { sortInDependencyOrder } from '@tamanu/database';
 import { FAKE_UUID_PATTERN } from '@tamanu/utils/generateId';
 
 export function deleteAllTestIds({ models }) {
   const sortedModels = sortInDependencyOrder(models).reverse();
   const existingInDb = sortedModels.filter(
-    model => !model.CAN_DO || model.CAN_DO?.has(FHIR_INTERACTIONS.INTERNAL.MATERIALISE),
+    (model) => !model.CAN_DO || model.CAN_DO?.has(FHIR_INTERACTIONS.INTERNAL.MATERIALISE),
   );
-  const deleteTasks = existingInDb.map(Model =>
-    Model.destroy({
-      force: true,
-      where: Sequelize.where(Sequelize.cast(Sequelize.col('id'), 'text'), {
+  const deleteTasks = existingInDb.map((Model) => {
+    const where = [
+      Sequelize.where(Sequelize.cast(Sequelize.col('id'), 'text'), {
         [Op.like]: FAKE_UUID_PATTERN,
       }),
-    }),
-  );
+    ]
+    if (Model.name === 'User') {
+      where.push({
+        id: {
+          [Op.not]: SYSTEM_USER_UUID
+        },
+      });
+    }
+    return Model.destroy({
+      force: true,
+      where: {
+        [Op.and]: where,
+      },
+    });
+  });
   return Promise.all(deleteTasks);
 }

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 
 import { constructPermission } from '@tamanu/shared/permissions/middleware';
 import { settingsCache } from '@tamanu/settings';
+import { attachAuditUserToDbSession } from '@tamanu/database/utils/audit';
 
 import {
   authMiddleware,
@@ -107,6 +108,8 @@ apiv1.get(
 apiv1.use(authMiddleware);
 
 apiv1.use(constructPermission);
+
+apiv1.use(attachAuditUserToDbSession);
 
 apiv1.delete(
   '/admin/settings/cache',

--- a/packages/facility-server/app/sync/FacilitySyncManager.js
+++ b/packages/facility-server/app/sync/FacilitySyncManager.js
@@ -1,6 +1,6 @@
 import _config from 'config';
 import { log } from '@tamanu/shared/services/logging';
-import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { AUDIT_PAUSE_KEY, SYNC_DIRECTIONS } from '@tamanu/constants';
 import {
   createSnapshotTable,
   dropAllSnapshotTables,
@@ -229,6 +229,7 @@ export class FacilitySyncManager {
 
     await this.sequelize.transaction(async () => {
       if (totalPulled > 0) {
+        await this.sequelize.setTransactionVar(AUDIT_PAUSE_KEY, true);
         log.info('FacilitySyncManager.savingChanges', { totalPulled });
         await saveIncomingChanges(
           this.sequelize,


### PR DESCRIPTION
### Changes

- Adds a `logs.changes` table modelled on the data schema we nailed in the `prepper` work
  - Lives in the `logs` schema which is excluded from lean backups but included in full backups
  - Not included in `public` schema so it doesn't get its own triggers
- Adds a trigger to most tables in `public` schema to save their changes in that table
- Changes the trigger system to remove the triggers altogether pre-migrations
- Adds a guard to the trigger auto-adder to only add the triggers when the function is available
- Refactor a little to remove code duplication and use better practices (binds vs string interpolation in queries)