### PR TITLE
fix: EPI-1085: Apply frequecies enabled setting to front-end

### DIFF
--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -24,6 +24,7 @@ export const KEYS_EXPOSED_TO_FRONT_END = [
   'upcomingVaccinations',
   'vaccinations',
   'vitalEditReasons',
+  'medications',
 ] as const;
 
 export class ReadSettings<Path = SettingPath> {

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -4,6 +4,7 @@ import { FrequencySuggester } from './frequencySuggester';
 import { TranslatedText } from '../Translation/TranslatedText';
 import { useTranslation } from '../../contexts/Translation';
 import { getTranslatedFrequencySynonyms } from '../../utils/medications';
+import { useSettings } from '../../contexts/Settings';
 
 const getFrequencySuggestions = synonyms => {
   return Object.entries(synonyms).map(([key, value]) => ({
@@ -15,7 +16,10 @@ const getFrequencySuggestions = synonyms => {
 
 export const FrequencySearchInput = ({ ...props }) => {
   const { getTranslation } = useTranslation();
-  const translatedFrequencySynonyms = getTranslatedFrequencySynonyms(getTranslation);
+  const { getSetting } = useSettings();
+  const frequenciesEnabled = getSetting(`medications.frequenciesEnabled`);
+
+  const translatedFrequencySynonyms = getTranslatedFrequencySynonyms(frequenciesEnabled, getTranslation);
 
   const frequencySuggestions = getFrequencySuggestions(translatedFrequencySynonyms);
   const frequencySuggester = new FrequencySuggester(frequencySuggestions);

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -1,9 +1,10 @@
 import { ADMINISTRATION_FREQUENCY_SYNONYMS } from '@tamanu/constants';
 import { camelCase } from 'lodash';
 
-export const getTranslatedFrequencySynonyms = getTranslation => {
+export const getTranslatedFrequencySynonyms = (frequenciesEnabled, getTranslation) => {
   const result = {};
   Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS).forEach(([frequency, synonyms]) => {
+    if (!frequenciesEnabled[frequency]) return;
     const labelKey = getTranslation(
       `medication.frequency.${camelCase(frequency)}.label`,
       frequency,


### PR DESCRIPTION
### Changes

Apply frequecies enabled setting to front-end

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
