### PR TITLE
repo: fix license field in settings package

### DIFF
--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/beyondessential/tamanu.git#readme",
   "repository": "git@github.com:beyondessential/tamanu.git",
   "author": "Beyond Essential Systems Pty. Ltd.",
-  "license": "SEE LICENSE IN ../../license",
+  "license": "GPL-3.0-or-later",
   "scripts": {
     "build": "npm run build:src && npm run build:cjs && npm run build:types && dual-pkg dist/mjs dist/cjs",
     "build:src": "swc --delete-dir-on-start --out-dir dist/mjs --copy-files --source-maps true src",


### PR DESCRIPTION
### Changes

It was an old reference to the `../../LICENSE` file which was renamed to `COPYRIGHT` at some point; changed it to be the SPDX identifier for consistency with the other packages.