### PR TITLE
fix(web): Set autoFilled autocomplete value correctly for reference data

### DIFF
--- a/packages/web/app/components/Field/AutocompleteField.jsx
+++ b/packages/web/app/components/Field/AutocompleteField.jsx
@@ -255,7 +255,7 @@ export class AutocompleteInput extends Component {
     const autoSelectOption = suggestions[0];
     this.setState({
       selectedOption: {
-        value: autoSelectOption.label,
+        value: autoSelectOption.value,
         tag: autoSelectOption.tag,
       },
     });


### PR DESCRIPTION
https://beyondessential.slack.com/archives/C03KJSEPV9A/p1740451171498229

### Changes

Previously we were setting the intial value of an AutoComplete field to the `label` of the reference data rather than the `value`. This caused a bug when the suggester attempts to fetch the option for that value.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
