### PR TITLE
fix(patients): TAMOC-276: Hide deceased patients from recently viewed (HOTFIX 2.25)

### DIFF
--- a/packages/facility-server/app/routes/apiv1/user.js
+++ b/packages/facility-server/app/routes/apiv1/user.js
@@ -57,6 +57,7 @@ user.get(
         userId: currentUser.id,
       })),
       makeFilter(true, `patients.merged_into_id IS NULL`),
+      makeFilter(true, `patients.date_of_death IS NULL`),
     ];
 
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(filters);


### PR DESCRIPTION
### Changes
- Hide deceased patients from recently viewed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
