### PR TITLE
fix(patients): TAMOC-276: Deceased patient not showing as grey in recently viewed patients

### DIFF
--- a/packages/facility-server/app/routes/apiv1/user.js
+++ b/packages/facility-server/app/routes/apiv1/user.js
@@ -70,6 +70,7 @@ user.get(
         patients.last_name,
         patients.sex,
         patients.date_of_birth,
+        patients.date_of_death,
         encounters.id AS encounter_id,
         encounters.encounter_type,
         user_recently_viewed_patients.updated_at AS last_accessed_on

--- a/packages/web/app/components/RecentlyViewedPatientsList.jsx
+++ b/packages/web/app/components/RecentlyViewedPatientsList.jsx
@@ -21,7 +21,11 @@ const colorFromEncounterType = {
   default: Colors.blue,
 };
 
-function getColorForEncounter({ $encounterType }) {
+function getPatientStatusColor({ $encounterType, $isDeceased }) {
+  if ($isDeceased) {
+    return Colors.midText;
+  }
+
   return colorFromEncounterType[$encounterType || 'default'] || colorFromEncounterType.default;
 }
 
@@ -91,7 +95,7 @@ const CardListContainer = styled.div`
 const CardTitle = styled(Typography)`
   font-weight: bold;
   font-size: 14px;
-  color: ${getColorForEncounter};
+  color: ${getPatientStatusColor};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -105,13 +109,13 @@ const CapitalizedCardText = styled(CardText)`
   text-transform: capitalize;
 `;
 
-const EncounterTypeIndicator = styled.div`
+const PatientStatusIndicator = styled.div`
   height: 75%;
   border-radius: 10px;
   width: 4px;
   min-width: 4px;
   margin-right: 5px;
-  background-color: ${getColorForEncounter};
+  background-color: ${getPatientStatusColor};
 `;
 
 const Container = styled(ListItem)`
@@ -157,16 +161,22 @@ const SectionTitle = styled.div`
 const PATIENTS_PER_PAGE = 6;
 
 const Card = ({ patient, handleClick, patientPerPage, isDashboard }) => {
+  const isDeceased = Boolean(patient.dateOfDeath);
+
   return (
     <CardComponent
       onClick={() => handleClick(patient.id)}
       patientPerPage={patientPerPage}
       $isDashboard={isDashboard}
     >
-      <EncounterTypeIndicator $encounterType={patient.encounter_type} />
+      <PatientStatusIndicator $encounterType={patient.encounter_type} $isDeceased={isDeceased} />
       <CardComponentContent>
         <ThemedTooltip title={`${patient.firstName || ''} ${patient.lastName || ''}`}>
-          <CardTitle $encounterType={patient.encounter_type} $isDashboard={isDashboard}>
+          <CardTitle
+            $encounterType={patient.encounter_type}
+            $isDeceased={isDeceased}
+            $isDashboard={isDashboard}
+          >
             {patient.firstName} {patient.lastName}
           </CardTitle>
         </ThemedTooltip>

--- a/packages/web/app/components/RecentlyViewedPatientsList.jsx
+++ b/packages/web/app/components/RecentlyViewedPatientsList.jsx
@@ -21,8 +21,8 @@ const colorFromEncounterType = {
   default: Colors.blue,
 };
 
-function getPatientStatusColor({ $encounterType, $isDeceased }) {
-  if ($isDeceased) {
+function getPatientStatusColor({ $encounterType, $isPatientDeceased }) {
+  if ($isPatientDeceased) {
     return Colors.midText;
   }
 
@@ -161,7 +161,7 @@ const SectionTitle = styled.div`
 const PATIENTS_PER_PAGE = 6;
 
 const Card = ({ patient, handleClick, patientPerPage, isDashboard }) => {
-  const isDeceased = Boolean(patient.dateOfDeath);
+  const isPatientDeceased = Boolean(patient.dateOfDeath);
 
   return (
     <CardComponent
@@ -169,12 +169,15 @@ const Card = ({ patient, handleClick, patientPerPage, isDashboard }) => {
       patientPerPage={patientPerPage}
       $isDashboard={isDashboard}
     >
-      <PatientStatusIndicator $encounterType={patient.encounter_type} $isDeceased={isDeceased} />
+      <PatientStatusIndicator
+        $encounterType={patient.encounter_type}
+        $isPatientDeceased={isPatientDeceased}
+      />
       <CardComponentContent>
         <ThemedTooltip title={`${patient.firstName || ''} ${patient.lastName || ''}`}>
           <CardTitle
             $encounterType={patient.encounter_type}
-            $isDeceased={isDeceased}
+            $isPatientDeceased={isPatientDeceased}
             $isDashboard={isDashboard}
           >
             {patient.firstName} {patient.lastName}


### PR DESCRIPTION
### Changes
- Fix Deceased patient not showing as grey in recently viewed patients

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
