### PR TITLE
tweak: remove false-positive typo

### DIFF
--- a/packages/central-server/app/integrations/VdsNc/Document.js
+++ b/packages/central-server/app/integrations/VdsNc/Document.js
@@ -17,7 +17,7 @@ export class VdsNcDocument {
     this.messageData = messageData;
     this.uniqueProofId = uniqueProofId;
 
-    if (!Object.values(ICAO_DOCUMENT_TYPES).some(typ => this.type === typ.JSON)) {
+    if (!Object.values(ICAO_DOCUMENT_TYPES).some(({ JSON }) => this.type === JSON)) {
       throw new Error('A VDS-NC document must have a valid type.');
     }
   }


### PR DESCRIPTION
```
error: `typ` should be `typo`
  --> ./packages/central-server/app/integrations/VdsNc/Document.js:20:50
   |
20 |     if (!Object.values(ICAO_DOCUMENT_TYPES).some(typ => this.type === typ.JSON)) {
   |                                                  ^^^
   |
error: `typ` should be `typo`
  --> ./packages/central-server/app/integrations/VdsNc/Document.js:20:71
   |
20 |     if (!Object.values(ICAO_DOCUMENT_TYPES).some(typ => this.type === typ.JSON)) {
   |                                                                       ^^^
   |
```
