### PR TITLE
feat(translations): SAV-910: Program registry enum translations

### DIFF
--- a/packages/constants/src/enumRegistry.ts
+++ b/packages/constants/src/enumRegistry.ts
@@ -19,7 +19,11 @@ import {
   APPOINTMENT_STATUSES,
   IMAGING_REQUEST_STATUS_LABELS,
 } from './statuses.js';
-import { VACCINE_STATUS_LABELS, INJECTION_SITE_LABELS, VACCINE_CATEGORY_LABELS } from './vaccines.js';
+import {
+  VACCINE_STATUS_LABELS,
+  INJECTION_SITE_LABELS,
+  VACCINE_CATEGORY_LABELS,
+} from './vaccines.js';
 import {
   ATTENDANT_OF_BIRTH_LABELS,
   BIRTH_DELIVERY_TYPE_LABELS,
@@ -46,9 +50,10 @@ import {
   REPEAT_FREQUENCY_UNIT_LABELS,
   REPEAT_FREQUENCY_UNIT_PLURAL_LABELS,
 } from './appointments.js';
+import { PROGRAM_REGISTRATION_STATUS_LABELS } from './programRegistry.js';
 
 type EnumKeys = keyof typeof registeredEnums;
-type EnumValues = typeof registeredEnums[EnumKeys];
+type EnumValues = (typeof registeredEnums)[EnumKeys];
 type EnumEntries = [EnumKeys, EnumValues][];
 
 /**
@@ -82,6 +87,7 @@ export const registeredEnums = {
   PATIENT_ISSUE_LABELS,
   PLACE_OF_BIRTH_LABELS,
   PLACE_OF_DEATHS,
+  PROGRAM_REGISTRATION_STATUS_LABELS,
   REFERRAL_STATUS_LABELS,
   REPEATS_LABELS,
   REPEAT_FREQUENCY_LABELS,
@@ -132,6 +138,7 @@ export const translationPrefixes: Record<EnumKeys, string> = {
   PATIENT_ISSUE_LABELS: 'patient.property.issue',
   PLACE_OF_BIRTH_LABELS: 'birth.property.placeOfBirth',
   PLACE_OF_DEATHS: 'death.property.placeOfDeath',
+  PROGRAM_REGISTRATION_STATUS_LABELS: 'programRegistry.property.registrationStatus',
   REFERRAL_STATUS_LABELS: 'referral.property.status',
   REPEATS_LABELS: 'medication.property.repeats',
   REPEAT_FREQUENCY_LABELS: 'scheduling.property.repeatFrequency',
@@ -161,13 +168,12 @@ export const prefixMap = new Map(
 );
 
 /** The list of all translatable enums string id and fallback */
-export const enumTranslations = (Object.entries(
-  registeredEnums,
-) as EnumEntries).flatMap(([key, value]) =>
-  Object.entries(value).map(([enumKey, enumValue]) => [
-    `${translationPrefixes[key]}.${enumKey
-      .toLowerCase()
-      .replace(/[^a-zA-Z0-9]+(.)/g, (_, char) => char.toUpperCase())}`,
-    enumValue,
-  ]),
+export const enumTranslations = (Object.entries(registeredEnums) as EnumEntries).flatMap(
+  ([key, value]) =>
+    Object.entries(value).map(([enumKey, enumValue]) => [
+      `${translationPrefixes[key]}.${enumKey
+        .toLowerCase()
+        .replace(/[^a-zA-Z0-9]+(.)/g, (_, char) => char.toUpperCase())}`,
+      enumValue,
+    ]),
 );

--- a/packages/constants/src/programRegistry.ts
+++ b/packages/constants/src/programRegistry.ts
@@ -11,6 +11,13 @@ export const REGISTRATION_STATUSES = {
   RECORDED_IN_ERROR: 'recordedInError',
 };
 
+// Please keep in sync with packages/mobile/App/constants/programRegistries.ts
+export const PROGRAM_REGISTRATION_STATUS_LABELS = {
+  [REGISTRATION_STATUSES.ACTIVE]: 'Active',
+  [REGISTRATION_STATUSES.INACTIVE]: 'Removed',
+  [REGISTRATION_STATUSES.RECORDED_IN_ERROR]: 'Delete',
+};
+
 export const STATUS_COLOR = {
   purple: COLORS.purple,
   pink: COLORS.pink,

--- a/packages/web/app/constants/index.js
+++ b/packages/web/app/constants/index.js
@@ -7,6 +7,5 @@ export * from './invoices.js';
 export * from './misc.js';
 export * from './notes.js';
 export * from './patient.js';
-export * from './programRegistries.js';
 export * from './styles.js';
 export * from './table.js';

--- a/packages/web/app/constants/programRegistries.js
+++ b/packages/web/app/constants/programRegistries.js
@@ -1,8 +1,0 @@
-import { REGISTRATION_STATUSES } from '@tamanu/constants';
-
-// Please keep in sync with packages/mobile/App/constants/programRegistries.ts
-export const PROGRAM_REGISTRATION_STATUS_LABEL = {
-  [REGISTRATION_STATUSES.ACTIVE]: 'Active',
-  [REGISTRATION_STATUSES.INACTIVE]: 'Removed',
-  [REGISTRATION_STATUSES.RECORDED_IN_ERROR]: 'Delete',
-};

--- a/packages/web/app/views/programRegistry/RegistrationStatusIndicator.jsx
+++ b/packages/web/app/views/programRegistry/RegistrationStatusIndicator.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import { REGISTRATION_STATUSES } from '@tamanu/constants';
-import { Colors, PROGRAM_REGISTRATION_STATUS_LABEL } from '../../constants';
+import { REGISTRATION_STATUSES, PROGRAM_REGISTRATION_STATUS_LABELS } from '@tamanu/constants';
+import { Colors } from '../../constants';
+import { TranslatedEnum } from '../../components';
 import { ThemedTooltip } from '../../components/Tooltip';
 
 const StatusDiv = styled.div`
@@ -28,7 +29,12 @@ const StatusInactiveDot = styled.div`
 export const RegistrationStatusIndicator = ({ patientProgramRegistration, hideText, style }) => {
   return (
     <ThemedTooltip
-      title={PROGRAM_REGISTRATION_STATUS_LABEL[patientProgramRegistration.registrationStatus]}
+      title={
+        <TranslatedEnum
+          value={patientProgramRegistration.registrationStatus}
+          enumValues={PROGRAM_REGISTRATION_STATUS_LABELS}
+        />
+      }
     >
       <StatusDiv>
         {patientProgramRegistration.registrationStatus === REGISTRATION_STATUSES.ACTIVE ? (
@@ -37,7 +43,12 @@ export const RegistrationStatusIndicator = ({ patientProgramRegistration, hideTe
           <StatusInactiveDot style={style} />
         )}
         {!hideText && (
-          <b>{PROGRAM_REGISTRATION_STATUS_LABEL[patientProgramRegistration.registrationStatus]}</b>
+          <b>
+            <TranslatedEnum
+              value={patientProgramRegistration.registrationStatus}
+              enumValues={PROGRAM_REGISTRATION_STATUS_LABELS}
+            />
+          </b>
         )}
       </StatusDiv>
     </ThemedTooltip>


### PR DESCRIPTION
### Changes

These changes are for Program registry enum translations. There is only PROGRAM_REGISTRATION_STATUS_LABELS

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
