### PR TITLE
fix(mobile): Release fix v2.26: Fix missing sync icon

### DIFF
--- a/packages/mobile/App/ui/components/PatientSyncStatus/index.tsx
+++ b/packages/mobile/App/ui/components/PatientSyncStatus/index.tsx
@@ -15,11 +15,13 @@ interface PatientSyncStatusProps {
 export const PatientSyncStatus = ({ selectedPatient }: PatientSyncStatusProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const [refreshCount, updateRefreshCount] = useRefreshCount();
-  const facilityId = readConfig('facilityId', '');
   const [patientFacility, , isLoading] = useBackendEffect(
-    ({ models: m }) =>
+    async ({ models: m }) =>
       m.PatientFacility.findOne({
-        where: { patient: { id: selectedPatient.id }, facility: { id: facilityId } },
+        where: {
+          patient: { id: selectedPatient.id },
+          facility: { id: await readConfig('facilityId', '') },
+        },
       }),
     [refreshCount],
   );

--- a/packages/mobile/App/ui/components/PatientSyncStatus/index.tsx
+++ b/packages/mobile/App/ui/components/PatientSyncStatus/index.tsx
@@ -31,7 +31,6 @@ export const PatientSyncStatus = ({ selectedPatient }: PatientSyncStatusProps): 
   }
 
   const isMarkedForSync = Boolean(patientFacility);
-
   return (
     <>
       <SyncStatusModal


### PR DESCRIPTION
### Changes

Noticed during testing that we weren't awaiting our readConfig for facilityId and so it was never populating. When correcting this logic it works as expected. Not sure how this wasnt already broken though. Maybe it was but wasnt picked up 🤔 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
