### PR TITLE
ci: fix toolbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,8 @@ FROM rust AS build-bestool
 RUN cargo install bestool --no-default-features \
   -F completions \
   -F crypto \
+  -F file \
   -F tamanu \
-  -F walg
 
 FROM ubuntu AS toolbox
 RUN apt update && apt install -y --no-install-recommends \


### PR DESCRIPTION
### Changes

The walg subcommand was removed from bestool; we also want to add the new `file` subcommand.
