### PR TITLE
fix(translations): Allow translated text import to handle a number like in repeats

### DIFF
--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -102,7 +102,7 @@ export function administeredVaccineLoader(item) {
 export function translatedStringLoader(item) {
   const { stringId, ...languages } = stripNotes(item);
   return Object.entries(languages)
-    .filter(([, text]) => text.trim())
+    .filter(([, text]) => `${text}`.trim())
     .map(([language, text]) => ({
       model: 'TranslatedString',
       values: {


### PR DESCRIPTION
### Changes
Just noticed this when trying to import scraped translations It would fail on `medication.property.repeats.0` - `medication.property.repeats.12` 

See spreadsheet that now imports correctly
[problematic-translations.xlsx](https://github.com/user-attachments/files/19155037/problematic-translations.xlsx)

XLSX package must have read them as numbers and so they would error on trim, cooerce into string works great

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
