### PR TITLE
tweak(surveys): Order program surveys endpoint results by name

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Programs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Programs.test.js
@@ -116,11 +116,12 @@ describe('Programs', () => {
     });
 
     testProgram = await createDummyProgram();
-    testSurvey = await createDummySurvey(testProgram, 6);
-    testSurvey2 = await createDummySurvey(testProgram, 10);
-    testSurvey3 = await createDummySurvey(testProgram, 10);
+    testSurvey = await createDummySurvey(testProgram, 6, {name: 'testSurvey-1'});
+    testSurvey2 = await createDummySurvey(testProgram, 10, {name: 'testSurvey-2'});
+    testSurvey3 = await createDummySurvey(testProgram, 10, {name: 'testSurvey-3'});
     testReferralSurvey = await createDummySurvey(testProgram, 10, {
       surveyType: SURVEY_TYPES.REFERRAL,
+      name: 'testSurvey-4',
     });
   });
   afterAll(() => ctx.close());
@@ -140,14 +141,12 @@ describe('Programs', () => {
       const result = await app.get(`/api/program/${testProgram.id}/surveys`);
       expect(result).toHaveSucceeded();
       expect(result.body.count).toEqual(4);
-      expect(result.body.data).toEqual(
-        expect.arrayContaining([
+      expect(result.body.data).toEqual([
           expect.objectContaining({ name: testSurvey.name }),
           expect.objectContaining({ name: testSurvey2.name }),
           expect.objectContaining({ name: testSurvey3.name }),
           expect.objectContaining({ name: testReferralSurvey.name }),
-        ]),
-      );
+        ]);
     });
 
     it('should only suggest relevant surveys', async () => {

--- a/packages/facility-server/__tests__/apiv1/Programs.test.js
+++ b/packages/facility-server/__tests__/apiv1/Programs.test.js
@@ -139,12 +139,15 @@ describe('Programs', () => {
     it('should list surveys within a program', async () => {
       const result = await app.get(`/api/program/${testProgram.id}/surveys`);
       expect(result).toHaveSucceeded();
-
       expect(result.body.count).toEqual(4);
-      expect(result.body.data[0]).toHaveProperty('name', testSurvey.name);
-      expect(result.body.data[1]).toHaveProperty('name', testSurvey2.name);
-      expect(result.body.data[2]).toHaveProperty('name', testSurvey3.name);
-      expect(result.body.data[3]).toHaveProperty('name', testReferralSurvey.name);
+      expect(result.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: testSurvey.name }),
+          expect.objectContaining({ name: testSurvey2.name }),
+          expect.objectContaining({ name: testSurvey3.name }),
+          expect.objectContaining({ name: testReferralSurvey.name }),
+        ]),
+      );
     });
 
     it('should only suggest relevant surveys', async () => {

--- a/packages/facility-server/app/routes/apiv1/program.js
+++ b/packages/facility-server/app/routes/apiv1/program.js
@@ -58,6 +58,7 @@ programRelations.get(
         programId: params.id,
         visibilityStatus: { [Op.ne]: VISIBILITY_STATUSES.HISTORICAL },
       },
+      order: [['name', 'ASC']],
     });
     const filteredRecords = getFilteredListByPermission(ability, records, 'submit');
     const data = filteredRecords.map(x => x.forResponse());


### PR DESCRIPTION
### Changes

- Small thing noted in support request
https://beyondessential.slack.com/archives/C022N48Q3JQ/p1741581318429169

- They mentioned no need for hotfix on this one

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
