### PR TITLE
fix(tests): Fix intermittent test failures in translations

### DIFF
--- a/packages/central-server/__tests__/translation.test.js
+++ b/packages/central-server/__tests__/translation.test.js
@@ -1,3 +1,4 @@
+import { sortBy } from 'lodash';
 import { fake } from '@tamanu/fake-data/fake';
 import { createTestContext } from './utilities';
 
@@ -47,11 +48,13 @@ describe('translations', () => {
 
     expect(result.body).toHaveProperty('languageNames');
     expect(result.body.languageNames).toHaveLength(2);
-    expect(result.body.languageNames[0].text).toEqual(LANGUAGE_NAMES[LANGUAGE_CODES.ENGLISH]);
-    expect(result.body.languageNames[1].text).toEqual(LANGUAGE_NAMES[LANGUAGE_CODES.KHMER]);
+    expect(result.body.languageNames.map(({ text }) => text).sort()).toEqual([
+      LANGUAGE_NAMES[LANGUAGE_CODES.ENGLISH],
+      LANGUAGE_NAMES[LANGUAGE_CODES.KHMER],
+    ]);
 
     expect(result.body).toHaveProperty('languagesInDb');
-    expect(result.body.languagesInDb).toEqual([
+    expect(sortBy(result.body.languagesInDb, ['language'])).toEqual([
       { language: LANGUAGE_CODES.ENGLISH },
       { language: LANGUAGE_CODES.KHMER },
     ]);

--- a/packages/facility-server/__tests__/apiv1/TranslatedString.test.js
+++ b/packages/facility-server/__tests__/apiv1/TranslatedString.test.js
@@ -1,4 +1,5 @@
 import { fake } from '@tamanu/fake-data/fake';
+import { sortBy } from 'lodash';
 import Chance from 'chance';
 import { createTestContext } from '../utilities';
 import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
@@ -61,11 +62,13 @@ describe('TranslatedString', () => {
 
       expect(result.body).toHaveProperty('languageNames');
       expect(result.body.languageNames).toHaveLength(2);
-      expect(result.body.languageNames[0].text).toEqual(LANGUAGE_NAMES[LANGUAGE_CODES.ENGLISH]);
-      expect(result.body.languageNames[1].text).toEqual(LANGUAGE_NAMES[LANGUAGE_CODES.KHMER]);
+      expect(result.body.languageNames.map(({ text }) => text).sort()).toEqual([
+        LANGUAGE_NAMES[LANGUAGE_CODES.ENGLISH],
+        LANGUAGE_NAMES[LANGUAGE_CODES.KHMER],
+      ]);
 
       expect(result.body).toHaveProperty('languagesInDb');
-      expect(result.body.languagesInDb).toEqual([
+      expect(sortBy(result.body.languagesInDb, ['language'])).toEqual([
         { language: LANGUAGE_CODES.ENGLISH },
         { language: LANGUAGE_CODES.KHMER },
       ]);


### PR DESCRIPTION
### Changes

Removed expected order of results as `/v1/public/translation/languageOptions` doesn't have an expected order

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
