### PR TITLE
fix(pm2): SAV-918: Correctly read config file from pm2.config.cjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ ENV PORT=3000
 EXPOSE 3000
 
 # read configuration from source and from /config
+#
+# NOTE: We also explicitly set this value in central-server/pm2.config.cjs for when running in production
+# but the two values should resolve to the same path
 ENV NODE_CONFIG_DIR=/config:/app/packages/${PACKAGE_PATH}/config
 
 

--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -1,15 +1,20 @@
 const os = require('node:os');
+
+const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
+
+process.env.NODE_CONFIG_DIR = cwd + '/config/';
 const config = require('config');
 
-const totalMemoryMB = Math.round(os.totalmem() / (1024**2));
+const totalMemoryMB = Math.round(os.totalmem() / 1024 ** 2);
 const memory = process.env.TAMANU_MEMORY_ALLOCATION || (totalMemoryMB * 0.6).toFixed(0);
 
 const availableThreads = os.availableParallelism();
 const minimumApiScale = totalMemoryMB > 3000 ? 2 : 1;
 const maximumApiScale = 4; // more requires custom caddy config
-const defaultApiScale = Math.min(maximumApiScale, Math.max(minimumApiScale, Math.floor(availableThreads / 2)));
-
-const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
+const defaultApiScale = Math.min(
+  maximumApiScale,
+  Math.max(minimumApiScale, Math.floor(availableThreads / 2)),
+);
 
 function task(name, args, instances = 1, env = {}) {
   const base = {
@@ -43,7 +48,10 @@ const apps = [
 
 if (config?.integrations?.fhir?.worker?.enabled) {
   apps.push(
-    task('tamanu-fhir-refresh', 'startFhirWorker --topics=fhir.refresh.allFromUpstream,fhir.refresh.entireResource,fhir.refresh.fromUpstream'),
+    task(
+      'tamanu-fhir-refresh',
+      'startFhirWorker --topics=fhir.refresh.allFromUpstream,fhir.refresh.entireResource,fhir.refresh.fromUpstream',
+    ),
     task('tamanu-fhir-resolve', 'startFhirWorker --topics=fhir.resolver'),
   );
 }

--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -2,6 +2,8 @@ const os = require('node:os');
 
 const cwd = '.'; // IMPORTANT: Leave this as-is, for production build
 
+// NOTE: We also explicitly set this value in the Dockerfile for when running in containers
+// but the two values should resolve to the same path
 process.env.NODE_CONFIG_DIR = cwd + '/config/';
 const config = require('config');
 


### PR DESCRIPTION
### Changes

By setting `NODE_CONFIG_DIR` we can ensure that the config is read from the correct directory.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
