### PR TITLE
tweak(logs): omit timestamps when running as a systemd service

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -42,7 +42,8 @@
   "log": {
     "path": "",
     "consoleLevel": "http",
-    "color": true
+    "color": true,
+    "timeless": false,
   },
   "honeycomb": {
     "apiKey": "",

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -6,7 +6,8 @@
     "path": "",
     "consoleLevel": "http",
     "color": true,
-    "enableAuditLog": false
+    "enableAuditLog": false,
+    "timeless": false,
   },
   "honeycomb": {
     "apiKey": "",

--- a/packages/shared/src/services/logging/console.js
+++ b/packages/shared/src/services/logging/console.js
@@ -20,13 +20,14 @@ const additionalDataFormatter = (obj = {}) => {
 // formatter for all logging:
 // 2022-03-25T06:52:30.003Z info: My console message! additionalItem=additionalValue
 const logFormat = winston.format.printf(({ level, message, childLabel, timestamp, ...rest }) => {
-  const restString = additionalDataFormatter(rest);
-  if (restString === '') {
-    return `${COLORS.grey(timestamp)} ${level}: ${childLabel ? `${childLabel} - ` : ''}${message}`;
-  }
-
   const isSystemd =  (Boolean(process.env.JOURNAL_STREAM) && !process.stderr.isTTY) || Boolean(process.env.DEBUG_INVOCATION);
   const timefield = (isSystemd || timeless) ? '' : `${COLORS.grey(timestamp)} `;
+
+  const restString = additionalDataFormatter(rest);
+  if (restString === '') {
+    return `${timefield}${level}: ${childLabel ? `${childLabel} - ` : ''}${message}`;
+  }
+
   return `${timefield}${level}: ${message} ${COLORS.grey(restString)}`;
 });
 

--- a/packages/shared/src/services/logging/console.js
+++ b/packages/shared/src/services/logging/console.js
@@ -6,6 +6,9 @@ import { COLORS } from './color';
 // defensive destructure to allow for testing shared directly
 const { consoleLevel, timeless = false } = config?.log || {};
 
+// detect whether we're running as a systemd service
+const isSystemd =  (Boolean(process.env.JOURNAL_STREAM) && !process.stderr.isTTY) || Boolean(process.env.DEBUG_INVOCATION);
+
 // additional parameters to log.info etc will be serialised and logged using this formatter
 const additionalDataFormatter = (obj = {}) => {
   if (typeof obj !== 'object') {
@@ -20,7 +23,6 @@ const additionalDataFormatter = (obj = {}) => {
 // formatter for all logging:
 // 2022-03-25T06:52:30.003Z info: My console message! additionalItem=additionalValue
 const logFormat = winston.format.printf(({ level, message, childLabel, timestamp, ...rest }) => {
-  const isSystemd =  (Boolean(process.env.JOURNAL_STREAM) && !process.stderr.isTTY) || Boolean(process.env.DEBUG_INVOCATION);
   const timefield = (isSystemd || timeless) ? '' : `${COLORS.grey(timestamp)} `;
 
   const restString = additionalDataFormatter(rest);

--- a/packages/shared/src/services/logging/console.js
+++ b/packages/shared/src/services/logging/console.js
@@ -7,7 +7,7 @@ import { COLORS } from './color';
 const { consoleLevel, timeless = false } = config?.log || {};
 
 // detect whether we're running as a systemd service
-const isSystemd =  (Boolean(process.env.JOURNAL_STREAM) && !process.stderr.isTTY) || Boolean(process.env.DEBUG_INVOCATION);
+const isSystemd = (Boolean(process.env.JOURNAL_STREAM) && !process.stderr.isTTY) || Boolean(process.env.DEBUG_INVOCATION);
 
 // additional parameters to log.info etc will be serialised and logged using this formatter
 const additionalDataFormatter = (obj = {}) => {

--- a/packages/shared/src/services/logging/console.js
+++ b/packages/shared/src/services/logging/console.js
@@ -4,7 +4,7 @@ import config from 'config';
 import { COLORS } from './color';
 
 // defensive destructure to allow for testing shared directly
-const { consoleLevel } = config?.log || {};
+const { consoleLevel, timeless = false } = config?.log || {};
 
 // additional parameters to log.info etc will be serialised and logged using this formatter
 const additionalDataFormatter = (obj = {}) => {
@@ -25,7 +25,9 @@ const logFormat = winston.format.printf(({ level, message, childLabel, timestamp
     return `${COLORS.grey(timestamp)} ${level}: ${childLabel ? `${childLabel} - ` : ''}${message}`;
   }
 
-  return `${COLORS.grey(timestamp)} ${level}: ${message} ${COLORS.grey(restString)}`;
+  const isSystemd =  (Boolean(process.env.JOURNAL_STREAM) && !process.stderr.isTTY) || Boolean(process.env.DEBUG_INVOCATION);
+  const timefield = (isSystemd || timeless) ? '' : `${COLORS.grey(timestamp)} `;
+  return `${timefield}${level}: ${message} ${COLORS.grey(restString)}`;
 });
 
 export const localTransport = new winston.transports.Console({


### PR DESCRIPTION
### Changes

When running as a systemd service (e.g. in Linux), the logs have two timestamps:

```
Mar 13 07:48:54 facility.example.tamanu.app systemd-tamanu-facility[71159]: 2025-03-12T22:48:54.953Z info: Sync:
```

This PR adds a `log.timeless` config boolean, and also auto-detects systemd and switches on timeless mode accordingly.
