### PR TITLE
fix: fix session restore

### DIFF
--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -80,7 +80,7 @@ export class TamanuApi {
     this.setToken(token);
 
     const { user, ability } = await this.fetchUserData(permissions);
-    return { user, token, localisation, server, availableFacilities, ability, role };
+    return { user, token, localisation, server, availableFacilities, ability, role, permissions };
   }
 
   async fetchUserData(permissions) {
@@ -219,7 +219,7 @@ export class TamanuApi {
 
     // Handle resource conflict
     if (response.status === 409) {
-      throw new ResourceConflictError(message)
+      throw new ResourceConflictError(message);
     }
 
     throw new ServerResponseError(`Server error response: ${message}`);

--- a/packages/web/app/index.js
+++ b/packages/web/app/index.js
@@ -74,4 +74,4 @@ async function start() {
   });
 }
 
-await start();
+start();

--- a/packages/web/app/index.js
+++ b/packages/web/app/index.js
@@ -34,7 +34,7 @@ function initPersistor(api, store) {
   return persistor;
 }
 
-function start() {
+async function start() {
   registerYup();
 
   if (BUGSNAG_API_KEY) {
@@ -50,8 +50,10 @@ function start() {
   // const api = new TamanuApi(version);
   const { store, history } = initStore(API);
 
+  const persistor = initPersistor(API, store);
+
   // attempt to restore session from local storage
-  store.dispatch(restoreSession());
+  await store.dispatch(restoreSession());
 
   API.setAuthFailureHandler(() => {
     store.dispatch(authFailure());
@@ -60,8 +62,6 @@ function start() {
   API.setVersionIncompatibleHandler((isTooLow, minVersion, maxVersion) => {
     store.dispatch(versionIncompatible(isTooLow, minVersion, maxVersion));
   });
-
-  const persistor = initPersistor(API, store);
 
   const container = document.getElementById('root');
 
@@ -74,4 +74,4 @@ function start() {
   });
 }
 
-start();
+await start();


### PR DESCRIPTION
### Changes
Fix the restore session functionality that is used to keep a user logged in during local dev. The issue was that the `ability` method was unintentionally getting set from persisted redux state rather than from the session restore function.

Example of bug before fix:

<img width="1440" alt="Screenshot 2025-03-13 at 12 23 41 PM" src="https://github.com/user-attachments/assets/471500d2-44b8-4229-b388-7bddb460c3ea" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
