### PR TITLE
tweak(logs): add progress information to persist sync messages

### DIFF
--- a/packages/database/__tests__/sync/saveChangesForModel.test.ts
+++ b/packages/database/__tests__/sync/saveChangesForModel.test.ts
@@ -1,3 +1,4 @@
+import { log } from '@tamanu/shared/services/logging/log';
 import { saveChangesForModel } from '../../src/sync';
 import * as saveChangeModules from '../../src/sync/saveChanges';
 import { closeDatabase, createTestDatabase } from './utilities';
@@ -37,7 +38,7 @@ describe('saveChangesForModel', () => {
       const isDeleted = false;
       const changes = [{ data: newRecord, isDeleted }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, true);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, true, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(1);
       expect(saveChangeModules.saveCreates).toBeCalledWith(models.SurveyScreenComponent, [
@@ -58,7 +59,7 @@ describe('saveChangesForModel', () => {
       const isDeleted = true;
       const changes = [{ data: newRecord, isDeleted }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, true);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, true, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(1);
       expect(saveChangeModules.saveCreates).toBeCalledWith(models.SurveyScreenComponent, [
@@ -84,7 +85,7 @@ describe('saveChangesForModel', () => {
       const newRecord = { id: existingRecord.id, text: 'current' };
       const changes = [{ data: newRecord, isDeleted: false }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, true);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, true, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(0);
       expect(saveChangeModules.saveUpdates).toBeCalledTimes(1);
@@ -111,7 +112,7 @@ describe('saveChangesForModel', () => {
       const newRecord = { id: existingRecord.id, text: 'current' };
       const changes = [{ data: newRecord, isDeleted: true }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, true);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, true, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(0);
       expect(saveChangeModules.saveUpdates).toBeCalledTimes(1);
@@ -135,7 +136,7 @@ describe('saveChangesForModel', () => {
       const newRecord = { id: existingRecord.id, text: 'current' };
       const changes = [{ data: newRecord, isDeleted: true }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, true);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, true, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(0);
       expect(saveChangeModules.saveUpdates).toBeCalledTimes(1);
@@ -163,7 +164,7 @@ describe('saveChangesForModel', () => {
       const newRecord = { id: existingRecord.id, text: 'current' };
       const changes = [{ data: newRecord, isDeleted: false }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, false);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, false, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(0);
       expect(saveChangeModules.saveUpdates).toBeCalledTimes(1);
@@ -187,7 +188,7 @@ describe('saveChangesForModel', () => {
       const newRecord = { id: existingRecord.id, text: 'current' };
       const changes = [{ data: newRecord, isDeleted: false }];
       // act
-      await saveChangesForModel(models.SurveyScreenComponent, changes, true);
+      await saveChangesForModel(models.SurveyScreenComponent, changes, true, log);
       // assertions
       expect(saveChangeModules.saveCreates).toBeCalledTimes(0);
       expect(saveChangeModules.saveUpdates).toBeCalledTimes(1);

--- a/packages/database/src/sync/saveIncomingChanges.ts
+++ b/packages/database/src/sync/saveIncomingChanges.ts
@@ -1,5 +1,6 @@
 import config from 'config';
 import { Sequelize } from 'sequelize';
+import type { Logger } from 'winston';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { log } from '@tamanu/shared/services/logging/log';
 
@@ -18,6 +19,7 @@ export const saveChangesForModel = async (
   model: typeof Model,
   changes: Awaited<ReturnType<typeof findSyncSnapshotRecords>>,
   isCentralServer: boolean,
+  log: Logger,
 ) => {
   const sanitizeData = (d: ModelSanitizeArgs) =>
     isCentralServer ? model.sanitizeForCentralServer(d) : model.sanitizeForFacilityServer(d);
@@ -86,19 +88,28 @@ export const saveChangesForModel = async (
     });
 
   // run each import process
-  log.debug(`saveIncomingChanges: Creating ${recordsForCreate.length} new records`);
+  log.debug('Sync: saveIncomingChanges: Creating new records', { count: recordsForCreate.length });
   if (recordsForCreate.length > 0) {
     await saveCreates(model, recordsForCreate);
   }
-  log.debug(`saveIncomingChanges: Updating ${recordsForUpdate.length} existing records`);
+
+  log.debug('Sync: saveIncomingChanges: Updating existing records', {
+    count: recordsForUpdate.length,
+  });
   if (recordsForUpdate.length > 0) {
     await saveUpdates(model, recordsForUpdate, idToExistingRecord, isCentralServer);
   }
-  log.debug(`saveIncomingChanges: Soft deleting ${recordsForDelete.length} old records`);
+
+  log.debug('Sync: saveIncomingChanges: Soft deleting old records', {
+    count: recordsForDelete.length,
+  });
   if (recordsForDelete.length > 0) {
     await saveDeletes(model, recordsForDelete);
   }
-  log.debug(`saveIncomingChanges: Restoring ${recordsForRestore.length} deleted records`);
+
+  log.debug('Sync: saveIncomingChanges: Restoring deleted records', {
+    count: recordsForRestore.length,
+  });
   if (recordsForRestore.length > 0) {
     await saveRestores(model, recordsForRestore);
   }
@@ -110,6 +121,7 @@ const saveChangesForModelInBatches = async (
   sessionId: string,
   recordType: RecordType,
   isCentralServer: boolean,
+  log: Logger,
 ) => {
   const syncRecordsCount = await countSyncSnapshotRecords(
     sequelize,
@@ -117,11 +129,15 @@ const saveChangesForModelInBatches = async (
     SYNC_SESSION_DIRECTION.INCOMING,
     model.tableName,
   );
-  log.debug(`saveIncomingChanges: Saving ${syncRecordsCount} changes for ${model.tableName}`);
 
   const batchCount = Math.ceil(syncRecordsCount / persistedCacheBatchSize);
-  let fromId;
+  log.debug('Sync: saveIncomingChanges', {
+    total: syncRecordsCount,
+    batch: batchCount,
+    pauseMs: pauseBetweenPersistedCacheBatchesInMilliseconds,
+  });
 
+  let fromId;
   for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
     const batchRecords = await findSyncSnapshotRecords(
       sequelize,
@@ -135,15 +151,15 @@ const saveChangesForModelInBatches = async (
 
     try {
       log.info('Sync: Persisting cache to table', {
-        table: model.tableName,
         count: batchRecords.length,
+        total: syncRecordsCount,
       });
 
-      await saveChangesForModel(model, batchRecords, isCentralServer);
+      await saveChangesForModel(model, batchRecords, isCentralServer, log);
 
       await sleepAsync(pauseBetweenPersistedCacheBatchesInMilliseconds);
     } catch (error) {
-      log.error(`Failed to save changes for ${model.name}`);
+      log.error('Failed to save changes');
       throw error;
     }
   }
@@ -157,13 +173,18 @@ export const saveIncomingChanges = async (
 ) => {
   const sortedModels = sortInDependencyOrder(pulledModels);
 
-  for (const model of sortedModels) {
+  for (const [i, model] of sortedModels.entries()) {
     await saveChangesForModelInBatches(
       model,
       sequelize,
       sessionId,
       model.tableName,
       isCentralServer,
+      log.child({
+        sessionId,
+        table: model.tableName,
+        nthTable: `${i}/${sortedModels.length}`,
+      }),
     );
   }
 };

--- a/packages/database/src/sync/saveIncomingChanges.ts
+++ b/packages/database/src/sync/saveIncomingChanges.ts
@@ -183,7 +183,7 @@ export const saveIncomingChanges = async (
       log.child({
         sessionId,
         table: model.tableName,
-        nthTable: `${i}/${sortedModels.length}`,
+        nthTable: `${i + 1}/${sortedModels.length}`,
       }),
     );
   }

--- a/packages/database/src/utils/sortInDependencyOrder.ts
+++ b/packages/database/src/utils/sortInDependencyOrder.ts
@@ -1,6 +1,6 @@
 import type { Models } from '../types/model';
 
-export function sortInDependencyOrder(models: Models) {
+export function sortInDependencyOrder(models: Models): Array<Models[keyof Models]> {
   const sorted: Array<Models[keyof Models]> = [];
   const stillToSort = new Map(Object.entries(models).sort((a, b) => a[0].localeCompare(b[0])));
 


### PR DESCRIPTION
### Changes

Before:

```
info: Sync: Persisting cache to table table=lab_tests count=10000
```

After:

```
info: Sync: Persisting cache to table table=lab_tests nthTable=20/99 count=10000 total=102382
```

Also:

```
tweak(logs): add sessionId to persist sync messages
tweak(logs): make logs more parametric for grepping
```
