### PR TITLE
fix(lint): eslint config and migration template

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,15 +76,6 @@ export default [
     // mobile rule exclusions (as warnings, until we fix them)
     files: [`packages/mobile/**/*.${TS_EXTS}`],
     rules: {
-      'no-unused-vars': 'off',
-      "@typescript-eslint/no-unused-vars": [
-        'error',
-        {
-          "argsIgnorePattern": "^_",
-          "varsIgnorePattern": "^_",
-          "caughtErrorsIgnorePattern": "^_",
-        },
-      ],
       'no-constructor-return': 'warn',
       'no-promise-executor-return': 'warn',
       'require-atomic-updates': 'warn',
@@ -97,6 +88,17 @@ export default [
     rules: {
       // Disable rules that are incompatible with or better handled by TypeScript
       ...typescriptPlugin.configs['eslint-recommended'].overrides[0].rules,
+      'no-unused-vars': 'off',
+
+      // support _unusedVar pattern
+      "@typescript-eslint/no-unused-vars": [
+        'error',
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_",
+        },
+      ],
 
       // for ts multiple dispatch
       'no-dupe-class-members': 'off',
@@ -139,25 +141,26 @@ export default [
     },
   },
   {
-    files: [`packages/web/**/*.${EXTS}`],
-    languageOptions: {
-      globals: {
-        __VERSION__: 'readonly',
-      },
-    },
-  },
-  {
-    files: [`packages/web/**/*.${JS_EXTS}`, 'packages/qr-tester/www/**/*.js'],
+    files: [
+      `packages/web/!({.storybook,stories})/**/*.${EXTS}`,
+      `packages/web/*.${EXTS}`,
+    ],
     languageOptions: {
       globals: {
         ...globals.browser,
-        CryptoKeyPair: 'readonly',
+        __VERSION__: 'readonly',
+        module: 'readonly',
+
+        // polyfilled by vite
+        Buffer: 'readonly',
+        process: 'readonly',
       },
     },
   },
   {
     files: [
-      `packages/!({web,qr-tester})/**/*.${JS_EXTS}`,
+      `packages/!(web)/**/*.${JS_EXTS}`,
+      `packages/web/{.storybook,stories}/**/*.${JS_EXTS}`,
       `scripts/**/*.${JS_EXTS}`,
       `**/*.config.${JS_EXTS}`,
     ],
@@ -165,15 +168,6 @@ export default [
       globals: {
         ...globals.node,
         CryptoKeyPair: 'readonly',
-      },
-    },
-  },
-  {
-    files: ['packages/qr-tester/www/js/**/*.js'],
-    languageOptions: {
-      globals: {
-        X509: 'readonly',
-        KEYUTIL: 'readonly',
       },
     },
   },
@@ -203,6 +197,7 @@ export default [
 
       // templates
       '**/.migrationTemplate.ts',
+      '**/serverMigrationTemplate.ts',
 
       // local config
       '**/config/local.*',

--- a/scripts/resources/serverMigrationTemplate.ts
+++ b/scripts/resources/serverMigrationTemplate.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-unused-vars */
-// remove the above line
-
 import { DataTypes, QueryInterface } from 'sequelize';
 
 export async function up(query: QueryInterface): Promise<void> {


### PR DESCRIPTION
### Changes

This came from the audit epic but is better applied to main directly.

We deliberately exclude the migration template for mobile from linting... this also excludes the server one, and thus gets rid of the "delete this line" instruction.

Exclude the eslint no-unused-vars from all TS files, instead relying on the TS rule; this prevents invalid "errors" like this where eslint doesn't understand TS function signatures:

```typescript
interface Foo {
  bar: (qux: string) => Promise<void>;
//      ^^^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ qux isn't used
}
```

Move support for the `_underscorePrefixed` allowed unused vars to apply to all typescript, not just mobile, especially now that we have mobile merged into the workspace and want to start sharing code more effectively.

Removed mentions of the gone package `qr-tester`.

Fixes for the web package and its storybook files... that I'm not sure how they ever worked. I think something in the cascade of rules made it so the web package was considered both node and browser, when that wasn't really the intent.

Still, as we've used a couple node-ish things that are polyfilled by Vite, include those explicitly (this should discourage relying on more polyfills).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
