### PR TITLE
refactor(web): replace non-standard Uint8Array.from usage

### DIFF
--- a/packages/web/app/hooks/useDocumentActions.js
+++ b/packages/web/app/hooks/useDocumentActions.js
@@ -6,10 +6,7 @@ import { notify, notifyError, notifySuccess } from '../utils';
 import { saveFile } from '../utils/fileSystemAccess';
 import { useTranslation } from '../contexts/Translation';
 
-const base64ToUint8Array = base64 => {
-  const binString = atob(base64);
-  return Uint8Array.from(binString, m => m.codePointAt(0));
-};
+const base64ToUint8Array = base64 => Buffer.from(base64, 'base64');
 
 export const useDocumentActions = () => {
   const api = useApi();


### PR DESCRIPTION
### Changes

[As far as I can tell](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), `Uint8Array.from` doesn't exist in the web context. However, it does _technically_ exist in Node.js, because `Uint8Array` is implemented there as a subset of `Buffer`. This doesn't seem like a very solid thing to rely on.

We _could_ replace the usage with Uint8Array natives directly, but the most direct equivalent [is only supported on Firefox at the moment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64)... so as we already use `Buffer` (polyfilled by Vite) elsewhere, using that seemed the best at both satisfying "this is a known API" and "demonstrates intent".
