### PR TITLE
tweak(audit): use uuid primary key for changelog table

### DIFF
--- a/packages/database/src/migrations/1739968205114-createChangelogsTable.ts
+++ b/packages/database/src/migrations/1739968205114-createChangelogsTable.ts
@@ -5,10 +5,10 @@ const TABLE = { schema: 'logs', tableName: 'changes' };
 export async function up(query: QueryInterface): Promise<void> {
   await query.createTable(TABLE, {
     id: {
-      type: DataTypes.BIGINT,
+      type: DataTypes.UUID,
       allowNull: false,
       primaryKey: true,
-      autoIncrement: true,
+      defaultValue: Sequelize.fn('gen_random_uuid'),
     },
     table_oid: {
       type: DataTypes.INTEGER,


### PR DESCRIPTION
### Changes

Thinking more about this, we really need a UUID primary key to be able to sync the table without collisions.

Ran the formatter so you probably want to review with whitespace changes omitted.
