### PR TITLE
feat(programRegistry): SAV-912: Translated enum in mobile

### DIFF
--- a/packages/mobile/App/constants/programRegistries.ts
+++ b/packages/mobile/App/constants/programRegistries.ts
@@ -10,7 +10,7 @@ export enum RegistrationStatus {
 }
 
 // Please keep in sync with packages/web/app/constants/index.js
-export const PROGRAM_REGISTRATION_STATUS_LABEL = {
+export const PROGRAM_REGISTRATION_STATUS_LABELS = {
   [RegistrationStatus.Active]: 'Active',
   [RegistrationStatus.Inactive]: 'Removed',
   [RegistrationStatus.RecordedInError]: 'Delete',

--- a/packages/mobile/App/ui/components/Translations/TranslatedEnum.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedEnum.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { TranslatedText } from './TranslatedText';
+import { TranslatedTextProps } from '~/ui/contexts/TranslationContext';
+import { getEnumPrefix } from './enumRegistry';
+
+interface TranslatedEnumProps extends Partial<TranslatedTextProps>{
+  value: string;
+  enumValues: any;
+  prefix?: string;
+  enumFallback?: string;
+}
+
+export const TranslatedEnum = ({
+  value,
+  enumValues,
+  enumFallback = 'Unknown',
+  ...restProps
+}: TranslatedEnumProps) => {
+  const prefix = getEnumPrefix(enumValues);
+  if (!enumValues[value]) {
+    return (
+      <TranslatedText stringId="general.fallback.unknown" fallback={enumFallback} {...restProps} />
+    );
+  }
+
+  const fallback = enumValues[value];
+  const stringId = `${prefix}.${value}`;
+  return <TranslatedText stringId={stringId} fallback={fallback} {...restProps} />;
+};

--- a/packages/mobile/App/ui/components/Translations/enumRegistry.ts
+++ b/packages/mobile/App/ui/components/Translations/enumRegistry.ts
@@ -1,0 +1,26 @@
+import { PROGRAM_REGISTRATION_STATUS_LABEL } from '~/constants/programRegistries';
+
+type EnumKeys = keyof typeof registeredEnums;
+type EnumValues = (typeof registeredEnums)[EnumKeys];
+type EnumEntries = [EnumKeys, EnumValues][];
+
+
+// These are all taken from constants and shared packages.
+// Whenever adding a new supported enum ensure that the mobile
+// version matches 100% the constants package version.
+const registeredEnums = {
+  PROGRAM_REGISTRATION_STATUS_LABEL,
+};
+
+const translationPrefixes: Record<EnumKeys, string> = {
+  PROGRAM_REGISTRATION_STATUS_LABEL: 'programRegistry.property.registrationStatus',
+};
+
+const prefixMap = new Map(
+  (Object.entries(registeredEnums) as EnumEntries).map(([key, enumValue]) => [
+    enumValue,
+    translationPrefixes[key],
+  ]),
+);
+
+export const getEnumPrefix = enumValues => prefixMap.get(enumValues);

--- a/packages/mobile/App/ui/components/Translations/enumRegistry.ts
+++ b/packages/mobile/App/ui/components/Translations/enumRegistry.ts
@@ -1,4 +1,4 @@
-import { PROGRAM_REGISTRATION_STATUS_LABEL } from '~/constants/programRegistries';
+import { PROGRAM_REGISTRATION_STATUS_LABELS } from '~/constants/programRegistries';
 
 type EnumKeys = keyof typeof registeredEnums;
 type EnumValues = (typeof registeredEnums)[EnumKeys];
@@ -9,11 +9,11 @@ type EnumEntries = [EnumKeys, EnumValues][];
 // Whenever adding a new supported enum ensure that the mobile
 // version matches 100% the constants package version.
 const registeredEnums = {
-  PROGRAM_REGISTRATION_STATUS_LABEL,
+  PROGRAM_REGISTRATION_STATUS_LABELS,
 };
 
 const translationPrefixes: Record<EnumKeys, string> = {
-  PROGRAM_REGISTRATION_STATUS_LABEL: 'programRegistry.property.registrationStatus',
+  PROGRAM_REGISTRATION_STATUS_LABELS: 'programRegistry.property.registrationStatus',
 };
 
 const prefixMap = new Map(

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistryRegistrationStatus.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistryRegistrationStatus.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import { PROGRAM_REGISTRATION_STATUS_LABEL } from '~/constants/programRegistries';
+import { TranslatedEnum } from '~/ui/components/Translations/TranslatedEnum';
 import { StyledText, StyledView } from '~/ui/styled/common';
 import { theme } from '~/ui/styled/theme';
 
@@ -13,7 +14,6 @@ export const StatusContainer = styled.View`
 `;
 
 export const PatientProgramRegistryRegistrationStatus = ({ registrationStatus }) => {
-  const registrationStatusLabel = PROGRAM_REGISTRATION_STATUS_LABEL[registrationStatus]; // TBD: Enum
   return (
     <StatusContainer>
       <StyledView
@@ -27,7 +27,10 @@ export const PatientProgramRegistryRegistrationStatus = ({ registrationStatus })
         marginRight={15}
       />
       <StyledText fontSize={16} fontWeight={500}>
-        {registrationStatusLabel}
+        <TranslatedEnum
+          value={registrationStatus}
+          enumValues={PROGRAM_REGISTRATION_STATUS_LABEL}
+        />
       </StyledText>
     </StatusContainer>
   );

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistryRegistrationStatus.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/PatientProgramRegistryRegistrationStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import { PROGRAM_REGISTRATION_STATUS_LABEL } from '~/constants/programRegistries';
+import { PROGRAM_REGISTRATION_STATUS_LABELS } from '~/constants/programRegistries';
 import { TranslatedEnum } from '~/ui/components/Translations/TranslatedEnum';
 import { StyledText, StyledView } from '~/ui/styled/common';
 import { theme } from '~/ui/styled/theme';
@@ -29,7 +29,7 @@ export const PatientProgramRegistryRegistrationStatus = ({ registrationStatus })
       <StyledText fontSize={16} fontWeight={500}>
         <TranslatedEnum
           value={registrationStatus}
-          enumValues={PROGRAM_REGISTRATION_STATUS_LABEL}
+          enumValues={PROGRAM_REGISTRATION_STATUS_LABELS}
         />
       </StyledText>
     </StatusContainer>

--- a/packages/web/app/components/Translation/TranslatedEnum.jsx
+++ b/packages/web/app/components/Translation/TranslatedEnum.jsx
@@ -22,7 +22,6 @@ export const TranslatedEnum = ({ value, enumValues, enumFallback = 'Unknown', ..
 };
 
 TranslatedEnum.propTypes = {
-  prefix: PropTypes.string,
   value: PropTypes.string.isRequired,
   enumValues: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
### Changes

Welp

So doing a full feature on this seems unfeasible with the time we have at hand. Translated enums do not exist on mobile and reconciliating everything within the two packages is overkill. Also a lot of these enums aren't really part of mobile at all and the ones that are used are called differently so yeah hard to find. I think we will have to start adding them case by case instead of all in one go