### PR TITLE
feat(translations): NASS-1635: Prepend language name to scraped translations

### DIFF
--- a/.github/scripts/scrape-translations.sh
+++ b/.github/scripts/scrape-translations.sh
@@ -29,4 +29,4 @@ if [ -z "$data" ]; then
 fi
 
 # Append csv header and print data
-printf "stringId,en\n"languageName","English"\n%s" "$data"
+printf "stringId,en\n"languageName","English"\n"countryCode","gb"\n%s" "$data"

--- a/.github/scripts/scrape-translations.sh
+++ b/.github/scripts/scrape-translations.sh
@@ -29,4 +29,4 @@ if [ -z "$data" ]; then
 fi
 
 # Append csv header and print data
-printf "stringId,fallback\n%s" "$data"
+printf "stringId,en\n"languageName","English"\n%s" "$data"


### PR DESCRIPTION
### Changes
- Just want the scraped translations to be as close to final xlsx as possible
- Changed fallback row to en
- Prepend language name & country code

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
