### PR TITLE
fix(exporter): sort role columns for permissions export

### DIFF
--- a/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
+++ b/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
@@ -741,13 +741,13 @@ describe('Permission and Roles exporter', () => {
       [
         {
           data: [
-            ['verb', 'noun', 'objectId', 'reception', 'admin'],
+            ['verb', 'noun', 'objectId', 'admin', 'reception'],
             ['list', 'User', null, 'y', 'y'],
             ['list', 'ReferenceData', null, 'y', 'y'],
-            ['read', 'ReferenceData', null, 'n', ''],
-            ['write', 'User', null, '', 'y'],
-            ['write', 'ReferenceData', null, '', 'y'],
-            ['read', 'Report', 'new-patients', '', 'y'],
+            ['read', 'ReferenceData', null, '', 'n'],
+            ['write', 'User', null, 'y', ''],
+            ['write', 'ReferenceData', null, 'y', ''],
+            ['read', 'Report', 'new-patients', 'y', ''],
           ],
           name: 'Permission',
         },

--- a/packages/central-server/app/admin/exporter/modelExporters/PermissionExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/PermissionExporter.js
@@ -33,6 +33,9 @@ export class PermissionExporter extends ModelExporter {
   }
 
   getHeadersFromData(data) {
-    return Object.keys(data[0]);
+    const heads = ['verb', 'noun', 'objectId'];
+    const cols = Object.keys(data[0]).filter((col) => !heads.includes(col));
+    cols.sort();
+    return heads.concat(cols);
   }
 }


### PR DESCRIPTION
### Changes

Specifically for the permissions exporter, sort the role columns in lexical order, so it's easier to compare two deployments.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->
