### PR TITLE
feat(programRegistry): SAV-868: Fix creating clinical statuses on program registry import

### DIFF
--- a/packages/central-server/__tests__/importers/normaliser.test.js
+++ b/packages/central-server/__tests__/importers/normaliser.test.js
@@ -52,8 +52,14 @@ describe('Sheet name normaliser', () => {
       expect(normaliseSheetName(input)).toEqual('scheduledVaccine');
     }
   });
+
   it('should normalise special case for procedureTypes', () => {
     const name = normaliseSheetName('Procedures');
     expect(name).toEqual('procedureType');
+  });
+
+  it('should normalise special case for programRegistryClinicalStatus', () => {
+    const name = normaliseSheetName('Registry', 'ProgramRegistryClinicalStatus');
+    expect(name).toEqual('programRegistryClinicalStatus');
   });
 });

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -246,7 +246,7 @@ export async function importRows(
         updateStat(stats, statkey(model, sheetName), 'created');
       }
 
-      const dataType = normaliseSheetName(sheetName);
+      const dataType = normaliseSheetName(sheetName, model);
       const isValidTable = model === 'ReferenceData' || camelCase(model) === dataType; // All records in the reference data table are translatable // This prevents join tables from being translated - unsure about this
       const isTranslatable = TRANSLATABLE_REFERENCE_TYPES.includes(dataType);
       if (isTranslatable && isValidTable) {


### PR DESCRIPTION
### Changes

Fix creating clinical statuses on program registry import. Looks like this was lost in a merge conflict resolution.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
