### PR TITLE
fix(suggestions): SAV-898: Inability to search by key word

### DIFF
--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -707,21 +707,24 @@ createSuggester(
 
     return {
       ...baseWhere,
-      // Only suggest program registries this patient isn't already part of
-      id: {
-        [Op.notIn]: Sequelize.literal(
-          `(
-          SELECT DISTINCT(pr.id)
-          FROM program_registries pr
-          INNER JOIN patient_program_registrations ppr
-          ON ppr.program_registry_id = pr.id
-          WHERE
-            ppr.patient_id = :patient_id
-          AND
-            ppr.registration_status != '${REGISTRATION_STATUSES.RECORDED_IN_ERROR}'
-        )`,
-        ),
-      },
+      // Wrap inside AND to avoid overwriting the translation ID selection (suggestedIds)
+      [Op.and]: {
+        // Only suggest program registries this patient isn't already part of
+        id: {
+          [Op.notIn]: Sequelize.literal(
+            `(
+            SELECT DISTINCT(pr.id)
+            FROM program_registries pr
+            INNER JOIN patient_program_registrations ppr
+            ON ppr.program_registry_id = pr.id
+            WHERE
+              ppr.patient_id = :patient_id
+            AND
+              ppr.registration_status != '${REGISTRATION_STATUSES.RECORDED_IN_ERROR}'
+          )`,
+          ),
+        },
+      }
     };
   },
   {


### PR DESCRIPTION
### Changes

Sneaky issue because there is a lot of misdirection. However the problem is that we were overwriting the `suggestedIds` query key (`id`) when destructuring the `omit(whereQuery, 'name')` object.

There might be a potential gain to simply check whether that object contains an `id` key, and only then include the `AND` block, at the cost of obfuscating things further. I decided not to do it, but could make a pretty function for it, as I think inline would be too obnoxious to read

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->