### PR TITLE
fix(scheduling): Release fix 2.27: Broken start time behaviour for overnight bookings

### DIFF
--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
@@ -18,6 +18,7 @@ const ErrorSpan = styled.span`
 
 const DateTimePicker = ({
   disabled = false,
+  onChange,
   minDate,
   required = false,
   timePickerVariant,
@@ -74,7 +75,10 @@ const DateTimePicker = ({
         label={datePickerLabel}
         min={minDate}
         name={datePickerName}
-        onChange={flushChangeToDateField}
+        onChange={e => {
+          flushChangeToDateField(e);
+          onChange?.(e);
+        }}
         required={required}
         helperText={
           hasConflict && (

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
@@ -31,10 +31,12 @@ const DateTimePicker = ({
   const dateFieldValue = values[datePickerName];
   const isValidDate = isValid(parseISO(dateFieldValue));
 
-  /** Keep startDate synchronised with date field for non-overnight bookings */
-  const flushChangeToDateField = e => {
+  const onChange = e => {
     if (datePickerName === 'startDate') {
+      // Keep startDate synchronised with date field for non-overnight bookings
       setFieldValue('date', e.target.value);
+      // Clear start time for overnight bookings
+      setFieldValue('startTime', null);
     }
   };
 
@@ -74,7 +76,7 @@ const DateTimePicker = ({
         label={datePickerLabel}
         min={minDate}
         name={datePickerName}
-        onChange={flushChangeToDateField}
+        onChange={onChange}
         required={required}
         helperText={
           hasConflict && (

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimePicker.jsx
@@ -31,12 +31,10 @@ const DateTimePicker = ({
   const dateFieldValue = values[datePickerName];
   const isValidDate = isValid(parseISO(dateFieldValue));
 
-  const onChange = e => {
+  /** Keep startDate synchronised with date field for non-overnight bookings */
+  const flushChangeToDateField = e => {
     if (datePickerName === 'startDate') {
-      // Keep startDate synchronised with date field for non-overnight bookings
       setFieldValue('date', e.target.value);
-      // Clear start time for overnight bookings
-      setFieldValue('startTime', null);
     }
   };
 
@@ -76,7 +74,7 @@ const DateTimePicker = ({
         label={datePickerLabel}
         min={minDate}
         name={datePickerName}
-        onChange={onChange}
+        onChange={flushChangeToDateField}
         required={required}
         helperText={
           hasConflict && (

--- a/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangeField.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/DateTimeRangeField/DateTimeRangeField.jsx
@@ -13,7 +13,13 @@ const dayAfter = dateStr => {
   return addDays(date, 1);
 };
 
-export const DateTimeRangeField = ({ disabled, required, separate = false, ...props }) => {
+export const DateTimeRangeField = ({
+  disabled,
+  onChangeStartDate,
+  required,
+  separate = false,
+  ...props
+}) => {
   const {
     values: { locationId, startDate },
   } = useFormikContext();
@@ -22,7 +28,7 @@ export const DateTimeRangeField = ({ disabled, required, separate = false, ...pr
     const isEndPickerDisabled = disabled || !locationId || !startDate;
     return (
       <>
-        <StartDateTimePicker disabled={disabled} required={required} />
+        <StartDateTimePicker disabled={disabled} onChange={onChangeStartDate} required={required} />
         <EndDateTimePicker
           disabled={isEndPickerDisabled}
           minDate={isEndPickerDisabled ? null : toDateString(dayAfter(startDate))}

--- a/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationBookingForm/LocationBookingDrawer.jsx
@@ -280,7 +280,11 @@ export const LocationBookingDrawer = ({ open, onClose, initialValues }) => {
             component={CheckField}
             onChange={() => resetFields(['endDate', 'endTime'])}
           />
-          <DateTimeRangeField required separate={values.overnight} />
+          <DateTimeRangeField
+            onChangeStartDate={() => resetFields(['startTime'])}
+            required
+            separate={values.overnight}
+          />
           <Field
             component={AutocompleteField}
             label={<TranslatedText stringId="general.form.patient.label" fallback="Patient" />}


### PR DESCRIPTION
### Changes

A couple of edge cases were found where the `startTime` wasn't clearing properly when changing `startDate` which lead to confusing behaviour. This pr just clears the `startTime` whenever `startDate` is changed.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
