### PR TITLE
repo: add database/sync to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,18 +13,19 @@
 /packages/facility-server/app/sync/                     @edmofro @chris-bes
 /packages/central-server/app/sync/                      @edmofro @chris-bes
 /packages/mobile/App/services/sync/                     @edmofro @chris-bes
+/packages/database/src/sync/                            @edmofro @chris-bes
 
 #
 # The deployment team are code owner of the default config files to make sure
 # that they're across any changes that might need to be made to any particular
 # server.
 #
-/packages/central-server/config/default.json5  @beyondessential/tamanu-deployment-team
+/packages/central-server/config/default.json5   @beyondessential/tamanu-deployment-team
 /packages/facility-server/config/default.json5  @beyondessential/tamanu-deployment-team
-/packages/settings/schema/facility.ts  @beyondessential/tamanu-deployment-team
-/packages/settings/schema/central.ts  @beyondessential/tamanu-deployment-team
-/packages/settings/schema/global.ts  @beyondessential/tamanu-deployment-team
-/packages/settings/schema/definitions/*/*.ts @beyondessential/tamanu-deployment-team
+/packages/settings/schema/facility.ts           @beyondessential/tamanu-deployment-team
+/packages/settings/schema/central.ts            @beyondessential/tamanu-deployment-team
+/packages/settings/schema/global.ts             @beyondessential/tamanu-deployment-team
+/packages/settings/schema/definitions/*/*.ts    @beyondessential/tamanu-deployment-team
 
 #
 # Kamaka needs to be across changes to the PM2 config files, as they're critical

--- a/packages/web/.storybook/main.mjs
+++ b/packages/web/.storybook/main.mjs
@@ -2,7 +2,7 @@ import { dirname, join, resolve } from 'path';
 import { mergeConfig } from 'vite';
 
 function getAbsolutePath(packageName) {
-  return dirname(require.resolve(join(packageName, 'package.json')));
+  return dirname(resolve(__dirname, join('../..', packageName, 'package.json')));
 }
 
 /** @type { import('@storybook/react-vite').StorybookConfig } */


### PR DESCRIPTION
### Changes

I think this was missed when the database package was broken out, it makes changes to sync machinery possible without codeowner review if it's confined to the database package.