### PR TITLE
fix(mobile): Unblock sync for deleted records

### DIFF
--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, OneToMany } from 'typeorm';
+import { Column, Entity, Index, OneToMany, In } from 'typeorm';
 import { getUniqueId } from 'react-native-device-info';
 import { addHours, parseISO, startOfDay, subYears } from 'date-fns';
 import { groupBy } from 'lodash';
@@ -86,12 +86,11 @@ export class Patient extends BaseModel implements IPatient {
     const patientIds: string[] = JSON.parse(await readConfig('recentlyViewedPatients', '[]'));
     if (patientIds.length === 0) return [];
 
-    const list = await this.getRepository().findByIds(patientIds);
+    const list = await this.getRepository().find({ where: { id: In(patientIds) } });
 
     return (
       patientIds
         // map is needed to make sure that patients are in the same order as in recentlyViewedPatients
-        // (typeorm findByIds doesn't guarantee return order)
         .map((storedId) => list.find(({ id }) => id === storedId))
         // filter removes patients who couldn't be found (which occurs when a patient was deleted)
         .filter((patient) => !!patient)

--- a/packages/mobile/App/services/sync/utils/executeCrud.ts
+++ b/packages/mobile/App/services/sync/utils/executeCrud.ts
@@ -1,4 +1,5 @@
 import { chunk, cloneDeep } from 'lodash';
+import { In } from 'typeorm';
 
 import { DataToPersist } from '../types';
 import { chunkRows, SQLITE_MAX_PARAMETERS } from '../../../infra/db/helpers';
@@ -85,7 +86,7 @@ export const executeDeletes = async (
   const rowIds = recordsForDelete.map(({ id }) => id);
   for (const batchOfIds of chunk(rowIds, SQLITE_MAX_PARAMETERS)) {
     try {
-      const entities = await model.findByIds(batchOfIds);
+      const entities = await model.find({ where: { id: In(batchOfIds) } });
       await model.softRemove(entities);
     } catch (e) {
       // try records individually, some may succeed and we want to capture the

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.spec.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.spec.ts
@@ -9,10 +9,10 @@ jest.mock('./buildFromSyncRecord', () => {
     }),
   };
 });
-// Mock dependencies like `model.findByIds`
-const findByIds = jest.fn();
+// Mock dependencies like `model.find`
+const find = jest.fn();
 const getModel = jest.fn(() => ({
-  findByIds,
+  find,
   sanitizePulledRecordData: jest.fn().mockImplementation(d => d),
 }));
 const Model = getModel() as any;
@@ -22,7 +22,7 @@ const generateExistingRecord = (id, data = {}) => ({
   ...data,
 });
 const mockExistingRecords = records => {
-  findByIds.mockImplementation(() => records);
+  find.mockImplementation(() => records);
 };
 
 describe('saveChangesForModel', () => {

--- a/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
+++ b/packages/mobile/App/services/sync/utils/saveIncomingChanges.ts
@@ -1,5 +1,6 @@
 import RNFS from 'react-native-fs';
 import { chunk } from 'lodash';
+import { In } from 'typeorm';
 
 import { SyncRecord } from '../types';
 import { sortInDependencyOrder } from './sortInDependencyOrder';
@@ -36,7 +37,8 @@ export const saveChangesForModel = async (
     const batchOfIds = incomingRecords.map(r => r.id);
     // add all records that already exist in the db to the list to be updated
     // even if they are being deleted or restored, we should also run an update query to keep the data in sync
-    const batchOfExisting = await model.findByIds(batchOfIds, {
+    const batchOfExisting = await model.find({
+      where: { id: In(batchOfIds) },
       select: ['id', 'deletedAt'],
       withDeleted: true,
     });


### PR DESCRIPTION
### Changes

So we upgraded typeorm version on v2.26 - in this version the findByIds method does not accept options so we didn't get soft deleted records... Meaning that didn't realize they needed to be updated instead of created!

See: https://github.com/typeorm/typeorm/blame/master/src/repository/Repository.ts#L588-L589

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
