### PR TITLE
tweak(sync): No-issue: Enable lookup table by default

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -74,7 +74,7 @@
     "syncSessionTimeoutMs": null,
     snapshotTransactionTimeoutMs: null,
     "lookupTable": {
-      "enabled": false,
+      "enabled": true,
       "perModelUpdateTimeoutMs": null,
       "avoidRepull": true
     }


### PR DESCRIPTION
### Changes

We use the lookup table everywhere now and have confidence in it. 

There's SAV-925 to remove the switch and old code entirely, but this for now at least means auto deployed environments are using it by default

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
