### PR TITLE
fix(ci): no-issue: Fix storybook __dirname unresolved errors

### DIFF
--- a/packages/web/.storybook/main.mjs
+++ b/packages/web/.storybook/main.mjs
@@ -1,5 +1,9 @@
+import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
 import { mergeConfig } from 'vite';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 function getAbsolutePath(packageName) {
   return dirname(resolve(__dirname, join('../..', packageName, 'package.json')));

--- a/packages/web/.storybook/main.mjs
+++ b/packages/web/.storybook/main.mjs
@@ -53,11 +53,11 @@ export default {
       },
       resolve: {
         alias: {
-          buffer: resolve(__dirname, './__mocks__/buffer.js'),
-          sequelize: resolve(__dirname, './__mocks__/sequelize.js'),
-          config: resolve(__dirname, './__mocks__/config.js'),
-          yargs: resolve(__dirname, './__mocks__/module.js'),
-          child_process: resolve(__dirname, './__mocks__/module.js'),
+          buffer: resolve(dir, './__mocks__/buffer.js'),
+          sequelize: resolve(dir, './__mocks__/sequelize.js'),
+          config: resolve(dir, './__mocks__/config.js'),
+          yargs: resolve(dir, './__mocks__/module.js'),
+          child_process: resolve(dir, './__mocks__/module.js'),
         },
       },
     });

--- a/packages/web/.storybook/main.mjs
+++ b/packages/web/.storybook/main.mjs
@@ -1,17 +1,29 @@
-import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
 import { mergeConfig } from 'vite';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+// This file needs to support both ESM and CJS, so we can't use `import.meta` or `__dirname` without checking
+let dir;
+try {
+  dir = __dirname;
+} catch (e) {
+  dir = import.meta.dirname;
+}
 
-function getAbsolutePath(packageName) {
-  return dirname(resolve(__dirname, join('../..', packageName, 'package.json')));
+function getNodeModulePath(workspace, packageName) {
+  return dirname(resolve(dir, join(workspace, 'node_modules/', packageName, 'package.json')));
+}
+
+function getRootNodeModulePath(packageName) {
+  return getNodeModulePath('../../../', packageName);
+}
+
+function getWorkspaceNodeModulePath(packageName) {
+  return getNodeModulePath('../', packageName);
 }
 
 /** @type { import('@storybook/react-vite').StorybookConfig } */
 export default {
-  framework: getAbsolutePath('@storybook/react-vite'),
+  framework: getRootNodeModulePath('@storybook/react-vite'),
   stories: ['../**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   typescript: {
     reactDocgen: false,
@@ -21,7 +33,7 @@ export default {
   },
   addons: [
     {
-      name: getAbsolutePath('@storybook/addon-links'),
+      name: getWorkspaceNodeModulePath('@storybook/addon-links'),
       options: { docs: false }, // no mdx
     },
     '@storybook/addon-links',


### PR DESCRIPTION
### Changes

Now that we use modules for this file we need to switch to manually define `__dirname`: https://nodejs.org/docs/latest-v15.x/api/esm.html#esm_no_require_exports_or_module_exports

When I run storybook locally it seems to use cjs, but in CI it uses ESM... not sure what's going on there and perhaps there's a higher order fix that could be done here.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
