### PR TITLE
ci(dbt): specify python at v3.11 for latest-ubuntu

### DIFF
--- a/.github/workflows/cd-deploy-dbt-docs.yml
+++ b/.github/workflows/cd-deploy-dbt-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 'latest'
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install Python dependencies


### PR DESCRIPTION
### Changes
Should fix dbt deploy
```
Run actions/setup-python@v4 Installed versions Version latest was not found in the local cache Error: The version ‘latest’ with architecture ‘x64’ was not found for Ubuntu 24.04.
```

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
