### PR TITLE
tweak(central): default the mobile update URLs to the right thing

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -37,7 +37,7 @@
     }
   },
   "updateUrls": {
-    "mobile": ""
+    "mobile": "https://meta.tamanu.app/versions/^{minVersion}/mobile",
   },
   "log": {
     "path": "",

--- a/packages/shared/src/utils/buildVersionCompatibilityCheck.js
+++ b/packages/shared/src/utils/buildVersionCompatibilityCheck.js
@@ -8,13 +8,13 @@ const respondWithError = (res, error) => {
   res.status(400).json({ error });
 };
 
-function getUpdateInformation(req) {
+function getUpdateInformation(req, minVersion) {
   if (!config.updateUrls) return {};
 
   const clientType = req.header('X-Tamanu-Client') || '';
   if (clientType.includes('Tamanu Mobile')) {
     return {
-      updateUrl: config.updateUrls.mobile,
+      updateUrl: config.updateUrls.mobile.replaceAll('{minVersion}', minVersion),
     };
   }
 
@@ -42,7 +42,7 @@ export const buildVersionCompatibilityCheck = (min, max) => (req, res, next) => 
     respondWithError(res, {
       message: VERSION_COMPATIBILITY_ERRORS.LOW,
       name: 'InvalidClientVersion',
-      ...getUpdateInformation(req),
+      ...getUpdateInformation(req, min),
     });
     return;
   }


### PR DESCRIPTION
### Changes

From an idea by @tcodling in [NASS-1266](https://linear.app/bes/issue/NASS-1266/smooth-updates-of-s3-app-builds#comment-153639c1).

We add a placeholder string replacement to the `updateUrls.mobile` with the minimum required version `{minVersion}`, and change the default to be `https://meta.tamanu.app/versions/^{minVersion}/mobile`. Since the meta server supports npm-style version ranges, this then resolves to the latest version in the release branch.

Then a manual release step that's needed is to drop the `updateUrls` block from the config on central (to let the default apply), and 🎉 mobile updates will "just work" from now on, no further config changes needed on upgrade.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
