### PR TITLE
fix(update): incorrect semver selector for mobile update url default

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -37,7 +37,7 @@
     }
   },
   "updateUrls": {
-    "mobile": "https://meta.tamanu.app/versions/^{minVersion}/mobile",
+    "mobile": "https://meta.tamanu.app/versions/~{minVersion}/mobile",
   },
   "log": {
     "path": "",


### PR DESCRIPTION
### Changes

I made a mistake :( the correct semver selector here is `~` (`~2.25.0` -> `2.25.4`), not `^` (`^2.25.0` -> `^2.27.0`).

I've patched a workaround in the meta server so we don't need to urgently re-patch all the branches, tho.
