### PR TITLE
fix(programRegistry): SAV-868: Program registry exports

### DIFF
--- a/packages/web/app/components/Translation/utils.js
+++ b/packages/web/app/components/Translation/utils.js
@@ -12,8 +12,6 @@ import { ClinicalStatusCell } from '../../views/programRegistry/ClinicalStatusDi
 export const isTranslatedText = element => {
   if (!isValidElement(element)) return false;
 
-  // log out the name of the type of the element
-  console.log(element.type.name);
   return [
     TranslatedText,
     TranslatedReferenceData,

--- a/packages/web/app/components/Translation/utils.js
+++ b/packages/web/app/components/Translation/utils.js
@@ -2,6 +2,7 @@ import { isValidElement } from 'react';
 import { SexCell } from '../../views/patients/columns';
 import { LocationCell } from '../LocationCell';
 import { TranslatedEnum, TranslatedReferenceData, TranslatedSex, TranslatedText } from '.';
+import { ClinicalStatusCell } from '../../views/programRegistry/ClinicalStatusDisplay';
 
 /**
  * Given a valid React element, returns true if and only if that element is a wrapper around
@@ -10,12 +11,17 @@ import { TranslatedEnum, TranslatedReferenceData, TranslatedSex, TranslatedText 
  */
 export const isTranslatedText = element => {
   if (!isValidElement(element)) return false;
+
+  // log out the name of the type of the element
+  console.log(element.type.name);
   return [
     TranslatedText,
     TranslatedReferenceData,
     TranslatedEnum,
     TranslatedSex,
+    // Workaround so that custom table cells that have translations work table export
     LocationCell,
     SexCell,
+    ClinicalStatusCell,
   ].includes(element.type);
 };

--- a/packages/web/app/components/Translation/utils.js
+++ b/packages/web/app/components/Translation/utils.js
@@ -17,7 +17,7 @@ export const isTranslatedText = element => {
     TranslatedReferenceData,
     TranslatedEnum,
     TranslatedSex,
-    // Workaround so that custom table cells that have translations work table export
+    // Workaround so that custom table cells that have translations work with table exports
     LocationCell,
     SexCell,
     ClinicalStatusCell,

--- a/packages/web/app/views/programRegistry/ClinicalStatusDisplay.jsx
+++ b/packages/web/app/views/programRegistry/ClinicalStatusDisplay.jsx
@@ -29,3 +29,7 @@ export const ClinicalStatusDisplay = ({ clinicalStatus }) => {
     </ThemedTooltip>
   );
 };
+
+export const ClinicalStatusCell = ({ value: clinicalStatus }) => {
+  return <ClinicalStatusDisplay clinicalStatus={clinicalStatus} />;
+};

--- a/packages/web/app/views/programRegistry/ProgramRegistryStatusHistory.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryStatusHistory.jsx
@@ -6,7 +6,7 @@ import { DateDisplay } from '../../components/DateDisplay';
 import { Colors } from '../../constants';
 import { Heading5 } from '../../components/Typography';
 import { useProgramRegistryClinicalStatusQuery } from '../../api/queries/useProgramRegistryClinicalStatusQuery';
-import { ClinicalStatusDisplay } from './ClinicalStatusDisplay';
+import { ClinicalStatusCell } from './ClinicalStatusDisplay';
 import { useTableSorting } from '../../components/Table/useTableSorting';
 import { TranslatedText } from '../../components';
 
@@ -50,9 +50,7 @@ export const ProgramRegistryStatusHistory = ({
         key: 'clinicalStatusId',
         title: <TranslatedText stringId="programRegistry.clinicalStatus.label" fallback="Status" />,
         sortable: false,
-        accessor: row => {
-          return <ClinicalStatusDisplay clinicalStatus={row.clinicalStatus} />;
-        },
+        CellComponent: ClinicalStatusCell,
       },
       {
         key: 'clinicianId',

--- a/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
@@ -11,7 +11,7 @@ import { ChangeStatusFormModal } from './ChangeStatusFormModal';
 import { Colors } from '../../constants';
 import { LimitedLinesCell } from '../../components/FormattedTableCell';
 import { RegistrationStatusIndicator } from './RegistrationStatusIndicator';
-import { ClinicalStatusDisplay } from './ClinicalStatusDisplay';
+import { ClinicalStatusCell } from './ClinicalStatusDisplay';
 import { useRefreshCount } from '../../hooks/useRefreshCount';
 import { ActivatePatientProgramRegistry } from './ActivatePatientProgramRegistry';
 import { TranslatedText } from '../../components/Translation';
@@ -125,9 +125,7 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
       {
         key: 'clinicalStatus',
         title: <TranslatedText stringId="programRegistry.clinicalStatus.label" fallback="Status" />,
-        accessor: row => {
-          return <ClinicalStatusDisplay clinicalStatus={row.clinicalStatus} />;
-        },
+        CellComponent: ClinicalStatusCell,
         maxWidth: 200,
       },
       {


### PR DESCRIPTION
### Changes
If a table cell component or accessor references another component and that component has a translation then downloads will break for that table. The core issue is that normalizeRecursively function in DownloadDataButton doesn’t take into account nested components.

This PR just patches the issue for the Program Registry Table but the issue might come up again as more table cells get translated so I've created a ticket to look at a more sustainable fix.

https://linear.app/bes/issue/NOTAM-457/table-cellcomponents-break-datadownload

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
