### PR TITLE
fix(pm2): SAV-935: Correctly set the NODE_CONFIG_DIR env var for the Tamanu app (hotfix for v2.22)

### DIFF
--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -29,8 +29,9 @@ function task(name, args, instances = 1, env = {}) {
     exec_mode: 'fork',
     restart_delay: 5000,
     env: {
-      NODE_ENV: 'production',
       ...env,
+      NODE_ENV: 'production',
+      NODE_CONFIG_DIR: 'config/',
     },
   };
 


### PR DESCRIPTION
### Changes

We were setting the `NODE_CONFIG_DIR` to `packages/central-server/config/` in the `pm2.config.cjs` however this meant when Tamanu launched it was looking in `packages/central-server/packages/central-server/config/`.

Now setting it back to `config/` so that Tamanu looks in the correct directory.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
