### PR TITLE
fix(pm2): SAV-935: Correctly set the NODE_CONFIG_DIR env var for the Tamanu app (hotfix for v2.28)

### DIFF
--- a/packages/central-server/pm2.config.cjs
+++ b/packages/central-server/pm2.config.cjs
@@ -29,8 +29,9 @@ function task(name, args, instances = 1, env = {}) {
     exec_mode: 'fork',
     restart_delay: 5000,
     env: {
-      NODE_ENV: 'production',
       ...env,
+      NODE_ENV: 'production',
+      NODE_CONFIG_DIR: 'config/',
     },
   };
 


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
