### PR TITLE
fix: EPI-1084: Fix Medication table pause and discontinued display

### DIFF
--- a/packages/web/app/utils/utils.jsx
+++ b/packages/web/app/utils/utils.jsx
@@ -5,6 +5,7 @@ import { each, isArray, toString } from 'lodash';
 import { toast } from 'react-toastify';
 import deepEqual from 'deep-equal';
 import shortid from 'shortid';
+import { singularize as singularizeFn } from 'inflection';
 
 export const prepareToastMessage = msg => {
   const messages = isArray(msg) ? msg : [msg];
@@ -116,4 +117,8 @@ export const validateDecimalPlaces = (e, expectedDecimalPlaces = 2) => {
       e.target.value = parseFloat(value).toFixed(expectedDecimalPlaces);
     }
   }
+};
+
+export const singularize = (word, count) => {
+  return Number(count) === 1 ? singularizeFn(word) : word;
 };


### PR DESCRIPTION
### Changes

- Added support for displaying medication pause duration with appropriate unit translation.
- Improved initial sorting of the medication table by discontinued status.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
