### PR TITLE
tweak(testing): no-issue: Make e2e test environment configurable

### DIFF
--- a/packages/e2e-tests/.env.example
+++ b/packages/e2e-tests/.env.example
@@ -1,0 +1,10 @@
+# The URL of the facility frontend
+# e.g. 'https://facility-2.release-2-26.internal.tamanu.io/' or 'http://localhost:5173' etc
+FACILITY_FRONTEND_URL='http://localhost:5173'
+
+# The URL of the admin panel frontend
+# e.g. 'https://central.release-2-26.internal.tamanu.io/' or 'http://localhost:5174' etc
+ADMIN_FRONTEND_URL='http://localhost:5174'
+
+# If true, local servers will be launched automatically as defined in playwright.config.ts
+LAUNCH_LOCAL_SERVERS_WHEN_RUNNING_TESTS=true

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,12 +1,17 @@
 import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+import dotenv from 'dotenv';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+dotenv.config({ path: resolve(__dirname, '.env') });
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -25,9 +30,6 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
-
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
@@ -70,28 +72,37 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: [
-    {
-      command: 'npm run start-dev --workspace=@tamanu/central-server',
-      port: 3000,
-      reuseExistingServer: !process.env.CI,
-      timeout: 240 * 1000,
-      stdout: 'pipe',
-    },
-    {
-      command: 'npm run start-dev --workspace=@tamanu/facility-server',
-      port: 4000,
-      reuseExistingServer: !process.env.CI,
-      timeout: 240 * 1000,
-      stdout: 'pipe',
-    },
-    {
-      command: 'npm run client-start-dev --workspace=@tamanu/web-frontend',
-      port: 5173,
-      reuseExistingServer: !process.env.CI,
-      timeout: 240 * 1000,
-      stdout: 'pipe',
-    },
-  ],
+  /* Automatically run your local servers and frontends before starting the tests if running tests against local environment */
+  ...(process.env.LAUNCH_LOCAL_SERVERS_WHEN_RUNNING_TESTS === 'true' ? {
+    webServer: [
+      {
+        command: 'npm run start-dev --workspace=@tamanu/central-server',
+        port: 3000,
+        reuseExistingServer: !process.env.CI,
+        timeout: 240 * 1000,
+        stdout: 'pipe',
+      },
+      {
+        command: 'npm run start-dev --workspace=@tamanu/facility-server',
+        port: 4000,
+        reuseExistingServer: !process.env.CI,
+        timeout: 240 * 1000,
+        stdout: 'pipe',
+      },
+      {
+        command: 'npm run client-start-dev --workspace=@tamanu/web-frontend',
+        port: 5173,
+        reuseExistingServer: !process.env.CI,
+        timeout: 240 * 1000,
+        stdout: 'pipe',
+      },
+      {
+        command: 'npm run admin-start-dev --workspace @tamanu/web-frontend',
+        port: 5174,
+        reuseExistingServer: !process.env.CI,
+        timeout: 240 * 1000,
+        stdout: 'pipe',
+      },
+    ],
+  } : {}),
 });

--- a/packages/e2e-tests/tests/page.spec.ts
+++ b/packages/e2e-tests/tests/page.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { goToFacilityFrontend } from '../utils/urls';
 
 test('homepage has expected title', async ({ page }) => {
-  await page.goto('/');
+  await goToFacilityFrontend(page);
   await expect(page).toHaveTitle(/Tamanu/);
 });

--- a/packages/e2e-tests/utils/urls.ts
+++ b/packages/e2e-tests/utils/urls.ts
@@ -1,0 +1,12 @@
+import 'dotenv/config';
+
+const facilityFrontend = process.env.FACILITY_FRONTEND_URL;
+const adminFrontend = process.env.ADMIN_FRONTEND_URL;
+
+export const goToFacilityFrontend = async (page: any) => {
+  await page.goto(facilityFrontend);
+};
+
+export const goToAdminFrontend = async (page: any) => {
+  await page.goto(adminFrontend);
+}; 


### PR DESCRIPTION
### Changes

- Introduces a `.env` file to allow developers to run tests locally or against an external deployed environment
- Removes `baseURL` from `playwright.config.ts` so tests can be run against either the facility frontend or admin frontend
- If the `LAUNCH_LOCAL_SERVERS_WHEN_RUNNING_TESTS` environment variable is set to `true` then Playwright will automatically start your local environments for you when the tests are run
- The admin panel frontend has been added to the list of environments to run locally so tests can be built against it

This is my first PR to Tamanu so if there are any best practices I've missed or any corrections at all that you'd recommend please let me know 🙏 If my entire approach here is wrong, please let me know that too 😅 
