### PR TITLE
fix: EPI-1084: Fix encounter medications table order and tooltip displaying issue

### DIFF
--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -130,7 +130,7 @@ export class MedicationAdministrationRecord extends Model {
     await models.MedicationAdministrationRecord.destroy({
       where: {
         administeredAt: {
-          [Op.gte]: encounter.endDate,
+          [Op.gt]: encounter.endDate,
         },
         prescriptionId: {
           [Op.in]: encounterPrescriptions.map(

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -247,7 +247,7 @@ encounterRelations.get(
             ],
           },
           {
-            [Op.or]: [{ endDate: { [Op.is]: null } }, { endDate: { [Op.gte]: startOfMarDate } }],
+            [Op.or]: [{ endDate: null }, { endDate: { [Op.gte]: startOfMarDate } }],
           },
         ],
       };

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -185,7 +185,12 @@ encounterRelations.get(
     const associations = Prescription.getListReferenceAssociations() || [];
 
     const baseQueryOptions = {
-      order: orderBy ? [[...orderBy.split('.'), order.toUpperCase()]] : undefined,
+      order: orderBy
+        ? [
+            [...orderBy.split('.'), order.toUpperCase()],
+            ['date', order.toUpperCase()],
+          ]
+        : undefined,
       include: [
         ...associations,
         {
@@ -239,15 +244,12 @@ encounterRelations.get(
             [Op.or]: [
               { discontinuedDate: { [Op.is]: null } },
               { discontinuedDate: { [Op.gte]: startOfMarDate } },
-            ]
+            ],
           },
           {
-            [Op.or]: [
-              { endDate: { [Op.is]: null } },
-              { endDate: { [Op.gte]: startOfMarDate } }
-            ]
-          }
-        ]
+            [Op.or]: [{ endDate: { [Op.is]: null } }, { endDate: { [Op.gte]: startOfMarDate } }],
+          },
+        ],
       };
     }
 

--- a/packages/web/app/components/FormattedTableCell.jsx
+++ b/packages/web/app/components/FormattedTableCell.jsx
@@ -108,7 +108,13 @@ const LimitedLinesCellWrapper = styled.div`
   ${({ maxWidth }) => maxWidth && `max-width: ${maxWidth};`};
 `;
 
-export const LimitedLinesCell = ({ value, maxWidth, maxLines = 2, isOneLine = false }) => {
+export const LimitedLinesCell = ({
+  value,
+  maxWidth,
+  maxLines = 2,
+  isOneLine = false,
+  disableTooltip = false,
+}) => {
   const contentRef = useRef(null);
   const [isClamped, setClamped] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(false);
@@ -126,13 +132,8 @@ export const LimitedLinesCell = ({ value, maxWidth, maxLines = 2, isOneLine = fa
     return () => window.removeEventListener('resize', handleResize);
   });
 
-  return (
-    <TableTooltip
-      title={value ?? ''}
-      open={isClamped && tooltipOpen}
-      onOpen={() => setTooltipOpen(true)}
-      onClose={() => setTooltipOpen(false)}
-    >
+  const renderLimitedLinesCellWrapper = () => {
+    return (
       <LimitedLinesCellWrapper
         ref={contentRef}
         maxLines={maxLines}
@@ -141,6 +142,21 @@ export const LimitedLinesCell = ({ value, maxWidth, maxLines = 2, isOneLine = fa
       >
         {value}
       </LimitedLinesCellWrapper>
+    );
+  };
+
+  if (disableTooltip) {
+    return renderLimitedLinesCellWrapper();
+  }
+
+  return (
+    <TableTooltip
+      title={value ?? ''}
+      open={isClamped && tooltipOpen}
+      onOpen={() => setTooltipOpen(true)}
+      onClose={() => setTooltipOpen(false)}
+    >
+      {renderLimitedLinesCellWrapper()}
     </TableTooltip>
   );
 };
@@ -175,10 +191,11 @@ export const RangeValidatedCell = React.memo(
     const float = round(parseFloat(value), config);
     const isEditedSuffix = isEdited ? '*' : '';
     const formattedValue = `${formatValue(value, config)}${isEditedSuffix}`;
-    const { tooltip, severity } = useMemo(
-      () => getTooltip(float, config, validationCriteria),
-      [float, config, validationCriteria],
-    );
+    const { tooltip, severity } = useMemo(() => getTooltip(float, config, validationCriteria), [
+      float,
+      config,
+      validationCriteria,
+    ]);
 
     const cell = (
       <CellContainer onClick={onClick} severity={severity} {...props}>

--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { format } from 'date-fns';
 import { Box } from '@material-ui/core';
-import { DRUG_ROUTE_LABELS, MEDICATION_PAUSE_DURATION_UNITS_LABELS } from '@tamanu/constants';
+import { DRUG_ROUTE_LABELS, MEDICATION_DURATION_UNITS_LABELS } from '@tamanu/constants';
 import { useLocation } from 'react-router-dom';
 
 import { DataFetchingTable } from '../Table';
@@ -99,7 +99,7 @@ const getMedicationName = (
           (<TranslatedText stringId="medication.table.pausing" fallback="Paused" />,{' '}
           {pauseData.pauseDuration}{' '}
           {singularize(
-            getEnumTranslation(MEDICATION_PAUSE_DURATION_UNITS_LABELS, pauseData.pauseTimeUnit),
+            getEnumTranslation(MEDICATION_DURATION_UNITS_LABELS, pauseData.pauseTimeUnit),
             pauseData.pauseDuration,
           ).toLowerCase()}{' '}
           - <TranslatedText stringId="medication.table.until" fallback="until" />{' '}
@@ -124,12 +124,17 @@ const getFrequency = ({ frequency, encounterPrescription, discontinued }, getTra
   );
 };
 
-const MEDICATION_COLUMNS = (getTranslation, getEnumTranslation) => [
+const MEDICATION_COLUMNS = (getTranslation, getEnumTranslation, disableTooltip) => [
   {
     key: 'medication.name',
     title: <TranslatedText stringId="medication.table.column.medication" fallback="Medication" />,
     accessor: data => getMedicationName(data, getEnumTranslation),
-    CellComponent: LimitedLinesCell,
+    CellComponent: props => (
+      <LimitedLinesCell 
+        {...props}
+        disableTooltip={disableTooltip}
+      />
+    ),
   },
   {
     key: 'dose',
@@ -266,7 +271,7 @@ export const EncounterMedicationTable = React.memo(({ encounterId }) => {
         />
       )}
       <StyledDataFetchingTable
-        columns={MEDICATION_COLUMNS(getTranslation, getEnumTranslation)}
+        columns={MEDICATION_COLUMNS(getTranslation, getEnumTranslation, !!selectedMedication)}
         endpoint={`encounter/${encounterId}/medications`}
         rowStyle={rowStyle}
         elevated={false}


### PR DESCRIPTION
- Added 'date' to the ordering options in the encounter query.
- Refactored LimitedLinesCell component to conditionally disable tooltips.
- Updated MedicationTable to pass disableTooltip prop to LimitedLinesCell.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
