### PR TITLE
fix(fhir): SAV-945: Handle undefined upstreamIds when building FHIR References (hotfix for v2.26)

### DIFF
--- a/packages/database/src/models/fhir/Resource.ts
+++ b/packages/database/src/models/fhir/Resource.ts
@@ -200,7 +200,20 @@ export class FhirResource extends Model {
     });
 
     for (const unresolvedResource of unresolvedResources) {
-      await this.materialiseFromUpstream(unresolvedResource.upstreamId);
+      try {
+        await this.materialiseFromUpstream(unresolvedResource.upstreamId);
+      } catch (error) {
+        if (error instanceof Error) {
+          // Rethrowing like this to preserve stacktrace while logging which resource failed to resolve
+          const rethrownError = new Error(
+            `Error resolving upstreams for ${this.fhirName}/${unresolvedResource.id}: ${error.stack ?? error.message ?? error.toString() ?? ''}`,
+          );
+          rethrownError.stack = error.stack;
+          throw rethrownError;
+        } else {
+          throw error;
+        }
+      }
     }
   }
 
@@ -229,9 +242,9 @@ export class FhirResource extends Model {
   asFhir() {
     const fields: Record<string, any> = {};
     for (const name of Object.keys((this.constructor as typeof FhirResource).getAttributes())) {
-      if (['id', 'versionId', 'upstreamId', 'lastUpdated', 'isLive', 'resolved'].includes(name)) continue;
+      if (['id', 'versionId', 'upstreamId', 'lastUpdated', 'isLive', 'resolved'].includes(name))
+        continue;
       fields[name] = this.get(name) as any;
-
     }
 
     return {

--- a/packages/database/src/models/fhir/Resource.ts
+++ b/packages/database/src/models/fhir/Resource.ts
@@ -205,10 +205,9 @@ export class FhirResource extends Model {
       } catch (error) {
         if (error instanceof Error) {
           // Rethrowing like this to preserve stacktrace while logging which resource failed to resolve
-          const rethrownError = new Error(
-            `Error resolving upstreams for ${this.fhirName}/${unresolvedResource.id}: ${error.stack ?? error.message ?? error.toString() ?? ''}`,
-          );
-          rethrownError.stack = error.stack;
+          const errorMessage = `Error resolving upstreams for ${this.fhirName}/${unresolvedResource.id}: ${error.message ?? error.toString() ?? ''}`;
+          const rethrownError = new Error(errorMessage);
+          rethrownError.stack = `${errorMessage}\n${error.stack}`;
           throw rethrownError;
         } else {
           throw error;

--- a/packages/shared/__tests__/services/fhirTypes/reference.test.js
+++ b/packages/shared/__tests__/services/fhirTypes/reference.test.js
@@ -1,0 +1,78 @@
+import { FhirReference } from '../../../src/services/fhirTypes';
+
+class FakeFhirResourceModel {
+  get fhirName() {
+    return 'FakeFhirResource';
+  }
+
+  constructor() {
+    this.resources = [];
+  }
+
+  add(resource) {
+    this.resources.push(resource);
+  }
+
+  clear() {
+    this.resources = [];
+  }
+
+  async findOne({ where }) {
+    const { upstreamId } = where;
+    if (!upstreamId) {
+      throw new Error(`Must provide an upstreamId in the where clause of findOne`);
+    }
+
+    return this.resources.find((resource) => resource.upstreamId === upstreamId);
+  }
+}
+
+const resourceModel = new FakeFhirResourceModel();
+describe('FhirReference', () => {
+  beforeEach(() => {
+    resourceModel.clear();
+  });
+
+  describe('to', () => {
+    it('should return a resolved reference if that resource exists', async () => {
+      resourceModel.add({ upstreamId: '1234', id: '5678', resolved: true });
+
+      const reference = await FhirReference.to(resourceModel, '1234', { display: 'Test' });
+      expect(reference.reference).toBe('FakeFhirResource/5678');
+      expect(reference.type).toBe('FakeFhirResource');
+      expect(reference.display).toBe('Test');
+    });
+
+    it('should return an unresolved reference if that resource does not exist', async () => {
+      const reference = await FhirReference.to(resourceModel, '1234', { display: 'Test' });
+      expect(reference.reference).toBe('1234');
+      expect(reference.type).toBe('upstream://fake_fhir_resource');
+      expect(reference.display).toBe('Test');
+    });
+
+    it('should return an unresolved reference if that resource is not resolved', async () => {
+      resourceModel.add({ upstreamId: '1234', id: '5678', resolved: false });
+
+      const reference = await FhirReference.to(resourceModel, '1234', { display: 'Test' });
+      expect(reference.reference).toBe('1234');
+      expect(reference.type).toBe('upstream://fake_fhir_resource');
+      expect(reference.display).toBe('Test');
+    });
+
+    it('should return an unresolved reference for a null/undefined upstreamId', async () => {
+      const undefinedReference = await FhirReference.to(resourceModel, undefined, {
+        display: 'Test',
+      });
+      expect(undefinedReference.reference).toBe(null);
+      expect(undefinedReference.type).toBe('upstream://fake_fhir_resource');
+      expect(undefinedReference.display).toBe('Test');
+
+      const nullReference = await FhirReference.to(resourceModel, null, {
+        display: 'Test',
+      });
+      expect(nullReference.reference).toBe(null);
+      expect(nullReference.type).toBe('upstream://fake_fhir_resource');
+      expect(nullReference.display).toBe('Test');
+    });
+  });
+});


### PR DESCRIPTION
### Changes

This fix won't change the underlying issue of why we're seeing `undefined` upstreamIds in Nauru. However since that's the only deployment where this issue is occurring I'd like to just change the code to log and ignore `undefined` upstreamIds and not block the resolver task. Then we can investigate further which resources seem to cause this behaviour.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
