### PR TITLE
fix: Fix program registry conditions query caching

### DIFF
--- a/packages/web/app/api/queries/usePatientProgramRegistryConditionsQuery.js
+++ b/packages/web/app/api/queries/usePatientProgramRegistryConditionsQuery.js
@@ -19,12 +19,17 @@ export const usePatientProgramRegistryConditionsQuery = (
 
 export const useProgramRegistryConditionsQuery = programRegistryId => {
   const api = useApi();
-  return useQuery(['programRegistryConditions', programRegistryId], () =>
-    api
-      .get(`programRegistry/${programRegistryId}/conditions`, {
-        orderBy: 'name',
-        order: 'ASC',
-      })
-      .then(response => response.data),
+  return useQuery(
+    ['programRegistryConditions', programRegistryId],
+    () =>
+      api
+        .get(`programRegistry/${programRegistryId}/conditions`, {
+          orderBy: 'name',
+          order: 'ASC',
+        })
+        .then(response => response.data),
+    {
+      enabled: Boolean(programRegistryId),
+    },
   );
 };

--- a/packages/web/app/views/programRegistry/PatientProgramRegistryForm.jsx
+++ b/packages/web/app/views/programRegistry/PatientProgramRegistryForm.jsx
@@ -27,6 +27,7 @@ import { useAuth } from '../../contexts/Auth';
 import { useApi } from '../../api/useApi';
 import { useTranslation } from '../../contexts/Translation';
 import { FORM_TYPES } from '../../constants';
+import { useProgramRegistryConditionsQuery } from '../../api/queries/usePatientProgramRegistryConditionsQuery';
 
 export const PatientProgramRegistryForm = ({ onCancel, onSubmit, editedObject }) => {
   const api = useApi();
@@ -38,17 +39,7 @@ export const PatientProgramRegistryForm = ({ onCancel, onSubmit, editedObject })
   const { data: program } = useQuery(['programRegistry', selectedProgramRegistryId], () =>
     selectedProgramRegistryId ? api.get(`programRegistry/${selectedProgramRegistryId}`) : null,
   );
-  const { data: { data: conditions } = {} } = useQuery(
-    ['programRegistryConditions', selectedProgramRegistryId],
-    () =>
-      api.get(`programRegistry/${selectedProgramRegistryId}/conditions`, {
-        orderBy: 'name',
-        order: 'ASC',
-      }),
-    {
-      enabled: !!selectedProgramRegistryId,
-    },
-  );
+  const { data: conditions = [] } = useProgramRegistryConditionsQuery(selectedProgramRegistryId);
   const programRegistrySuggester = useSuggester('programRegistry', {
     baseQueryParameters: { patientId: patient.id },
   });


### PR DESCRIPTION
### Changes

Program registry conditions were being incorrectly cached as the same query key was being used in two places. Fixed by re-using the same query util in both places

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
