### PR TITLE
fix: Fix localised field string ids

### DIFF
--- a/packages/shared/src/utils/handoverNotes/HandoverPatient.jsx
+++ b/packages/shared/src/utils/handoverNotes/HandoverPatient.jsx
@@ -55,8 +55,8 @@ export const HandoverPatient = ({
                     : patient[key]) || '';
                 const label =
                   defaultLabel ||
-                  getTranslation(`general.localisedFields.${key}.label.short`) ||
-                  getTranslation(`general.localisedFields.${key}.label`);
+                  getTranslation(`general.localisedField.${key}.label.short`) ||
+                  getTranslation(`general.localisedField.${key}.label`);
 
                 return (
                   <ValueDisplay

--- a/packages/shared/src/utils/patientCertificates/CovidPatientDetailsSection.jsx
+++ b/packages/shared/src/utils/patientCertificates/CovidPatientDetailsSection.jsx
@@ -42,8 +42,8 @@ export const CovidPatientDetailsSection = ({
             const value =
               accessor?.(patient, { getLocalisation, getTranslation }) ?? (patient[key] || '');
             const label =
-              getTranslation(`general.localisedFields.${key}.label.short`) ||
-              getTranslation(`general.localisedFields.${key}.label`) ||
+              getTranslation(`general.localisedField.${key}.label.short`) ||
+              getTranslation(`general.localisedField.${key}.label`) ||
               defaultLabel;
 
             return (

--- a/packages/shared/src/utils/patientLetters/PatientLetter.jsx
+++ b/packages/shared/src/utils/patientLetters/PatientLetter.jsx
@@ -45,8 +45,8 @@ const DetailsSection = ({ getLocalisation, data }) => {
               const value =
                 (accessor ? accessor(data, { getLocalisation, getTranslation }) : data[key]) || '';
               const label =
-                getTranslation(`general.localisedFields.${key}.label.short`) ||
-                getTranslation(`general.localisedFields.${key}.label`) ||
+                getTranslation(`general.localisedField.${key}.label.short`) ||
+                getTranslation(`general.localisedField.${key}.label`) ||
                 defaultLabel;
 
               return (

--- a/packages/web/app/components/TriageModal.jsx
+++ b/packages/web/app/components/TriageModal.jsx
@@ -65,7 +65,7 @@ export const TriageModal = React.memo(
     ).map(([name, label, accessor]) => (
       <React.Fragment key={name}>
         <DetailLabel>
-          <TranslatedText stringId={`general.localisedFields.${name}.label`} fallback={label} />:
+          <TranslatedText stringId={`general.localisedField.${name}.label`} fallback={label} />:
         </DetailLabel>
         <DetailValue>{accessor ? accessor(patient) : patient[name]}</DetailValue>
       </React.Fragment>


### PR DESCRIPTION
### Changes

- removed the 's' from a few localised field string ids

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
