### PR TITLE
feat: EPI-1148: Add short label for Units

### DIFF
--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -74,6 +74,41 @@ export const DRUG_UNIT_LABELS = Object.values(DRUG_UNITS).reduce((prev, curr) =>
   return prev;
 }, {} as any);
 
+export const DRUG_UNIT_SHORT_LABELS = {
+  [DRUG_UNITS.percentage]: '%',
+  [DRUG_UNITS.capsule]: 'Cap',
+  [DRUG_UNITS.disc]: 'Disc',
+  [DRUG_UNITS.douche]: 'Dche',
+  [DRUG_UNITS.drop]: 'Drop',
+  [DRUG_UNITS.ffu]: 'FFU',
+  [DRUG_UNITS.g]: 'g',
+  [DRUG_UNITS.iu]: 'IU',
+  [DRUG_UNITS.l]: 'L',
+  [DRUG_UNITS.lozenge]: 'Loz',
+  [DRUG_UNITS.mg]: 'mg',
+  [DRUG_UNITS.mcg]: 'mcg',
+  [DRUG_UNITS.ml]: 'mL',
+  [DRUG_UNITS.mmol]: 'mmol',
+  [DRUG_UNITS.mol]: 'mol',
+  [DRUG_UNITS.patch]: 'Patch',
+  [DRUG_UNITS.pellet]: 'Pellet',
+  [DRUG_UNITS.pouch]: 'Pouch',
+  [DRUG_UNITS.puff]: 'Puff',
+  [DRUG_UNITS.ring]: 'Ring',
+  [DRUG_UNITS.smear]: 'Smear',
+  [DRUG_UNITS.spray]: 'Spray',
+  [DRUG_UNITS.stick]: 'Stick',
+  [DRUG_UNITS.strip]: 'Strip',
+  [DRUG_UNITS.suppository]: 'Supp',
+  [DRUG_UNITS.swab]: 'Swab',
+  [DRUG_UNITS.tablet]: 'Tab',
+  [DRUG_UNITS.tbsp]: 'tbsp',
+  [DRUG_UNITS.tsp]: 'tsp',
+  [DRUG_UNITS.u]: 'U',
+  [DRUG_UNITS.vial]: 'Vial',
+  [DRUG_UNITS.wafer]: 'Wafer',
+};
+
 const MAX_REPEATS = 12;
 export const REPEATS_LABELS = Array.from({ length: MAX_REPEATS + 1 }, (_, i) => i);
 

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -1,4 +1,4 @@
-import { ADMINISTRATION_FREQUENCY_SYNONYMS, DRUG_UNIT_LABELS } from '@tamanu/constants';
+import { ADMINISTRATION_FREQUENCY_SYNONYMS, DRUG_UNIT_SHORT_LABELS } from '@tamanu/constants';
 import { camelCase } from 'lodash';
 import { formatTime } from '../components';
 
@@ -34,7 +34,7 @@ export const getDose = (medication, getTranslation, getEnumTranslation) => {
   let { doseAmount, units, isVariableDose } = medication;
   if (!units) return '';
   if (isVariableDose) doseAmount = getTranslation('medication.table.variable', 'Variable');
-  return `${doseAmount} ${getEnumTranslation(DRUG_UNIT_LABELS, units)}`;
+  return `${doseAmount} ${getEnumTranslation(DRUG_UNIT_SHORT_LABELS, units)}`;
 };
 
 export const formatTimeSlot = time => {


### PR DESCRIPTION
### Changes

- Introduced DRUG_UNIT_SHORT_LABELS to provide abbreviated representations for various drug units.
- Updated the medications utility to utilize the new short labels for dose formatting.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
