### PR TITLE
fix(sync): SAV-947: Take advisory lock -before- updating sync tick

### DIFF
--- a/packages/database/src/migrations/1744340076240-fixRaceConditionInSettingUpdateSyncTick.ts
+++ b/packages/database/src/migrations/1744340076240-fixRaceConditionInSettingUpdateSyncTick.ts
@@ -1,0 +1,71 @@
+import { QueryInterface } from 'sequelize';
+
+// copied from 1692710205000-allowDisablingSyncTrigger with the order of operations fixed to
+// first get the sync tick, then lock it, then use it
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION set_updated_at_sync_tick()
+      RETURNS trigger
+      LANGUAGE plpgsql AS
+      $func$
+      DECLARE
+        current_tick bigint;
+      BEGIN
+        IF ((SELECT value FROM local_system_facts WHERE key = 'syncTrigger') = 'disabled') THEN
+            RETURN NEW;
+        END IF;
+        -- If setting to "-1" representing "not marked as updated on this client", we actually use
+        -- a different number, "-999", to represent that in the db, so that we can identify the
+        -- difference between explicitly setting it to not marked as updated (when NEW contains -1),
+        -- and having other fields updated without the updated_at_sync_tick being altered (in which
+        -- case NEW will contain -999, easily distinguished from -1)
+        IF NEW.updated_at_sync_tick = -1 THEN
+          NEW.updated_at_sync_tick := -999;
+        ELSE
+          -- First get the current sync tick
+          SELECT value FROM local_system_facts WHERE key = 'currentSyncTick' INTO current_tick;
+
+          -- Then take an advisory lock on that sync tick value (if one doesn't already exist), to
+          -- record that an active transaction is using this sync tick
+          -- see waitForPendingEditsUsingSyncTick for more details
+          PERFORM pg_try_advisory_xact_lock_shared(current_tick);
+
+          -- Finally assign the locked sync tick to the record
+          NEW.updated_at_sync_tick := current_tick;
+        END IF;
+        RETURN NEW;
+      END
+      $func$;
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION set_updated_at_sync_tick()
+      RETURNS trigger
+      LANGUAGE plpgsql AS
+      $func$
+      BEGIN
+        IF ((SELECT value FROM local_system_facts WHERE key = 'syncTrigger') = 'disabled') THEN
+            RETURN NEW;
+        END IF;
+        -- If setting to "-1" representing "not marked as updated on this client", we actually use
+        -- a different number, "-999", to represent that in the db, so that we can identify the
+        -- difference between explicitly setting it to not marked as updated (when NEW contains -1),
+        -- and having other fields updated without the updated_at_sync_tick being altered (in which
+        -- case NEW will contain -999, easily distinguished from -1)
+        IF NEW.updated_at_sync_tick = -1 THEN
+          NEW.updated_at_sync_tick := -999;
+        ELSE
+          SELECT value FROM local_system_facts WHERE key = 'currentSyncTick' INTO NEW.updated_at_sync_tick;
+
+          -- take an advisory lock on the current sync tick (if one doesn't already exist), to
+          -- record that an active transaction is using this sync tick
+          -- see waitForPendingEditsUsingSyncTick for more details
+          PERFORM pg_try_advisory_xact_lock_shared(NEW.updated_at_sync_tick);
+        END IF;
+        RETURN NEW;
+      END
+      $func$;
+  `);
+}


### PR DESCRIPTION
### Changes

See comment inline

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
