### PR TITLE
tweak(mobile): NASS-1606: Hotfix 2.26: Bump min sdk version to 31

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -344,7 +344,7 @@ jobs:
     name: Package test Android for ${{ matrix.name }}
     uses: ./.github/workflows/cd-package-android.yml
     with:
-      server: central.${{ matrix.name }}.internal.tamanu.io
+      server: central.${{ matrix.name }}.cd.tamanu.app
       ref: ${{ needs.config.outputs.ref }}
       branding: ${{ fromJson(matrix.options).branding }}
     secrets:

--- a/docs/requests/deletion.http
+++ b/docs/requests/deletion.http
@@ -1,5 +1,5 @@
 @token=fake-token
-@server=https://central.main.internal.tamanu.io
+@server=https://central.main.cd.tamanu.app
 
 ### Delete a survey screen component
 DELETE {{server}}/api/sync/surveyScreenComponent/program-snap-fiji-2%2Fsurvey-snap-fiji-2%2Fcomponent-FijSNAP_18  HTTP/1.1

--- a/docs/requests/reference.http
+++ b/docs/requests/reference.http
@@ -1,6 +1,6 @@
 
 @token=fake-token
-@server=https://central.main.internal.tamanu.io
+@server=https://central.main.cd.tamanu.app
 
 ### Get a list of reference data
 GET {{server}}/api/sync/reference?since=0  HTTP/1.1

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -1,6 +1,6 @@
 {
   "port": 3000,
-  // this should be set to the external address of the server, e.g. "https://central.main.internal.tamanu.io"
+  // this should be set to the external address of the server, e.g. "https://central.main.cd.tamanu.app"
   "canonicalHostName": "http://localhost:3000",
   "db": {
     "name": "tamanu-central",
@@ -476,7 +476,7 @@
   "telegramBot": {
     apiToken: "",
     webhook: {
-      // this should be set to the external address of the server, e.g. "https://central.main.internal.tamanu.io/api/public/telegram-webhook"
+      // this should be set to the external address of the server, e.g. "https://central.main.cd.tamanu.app/api/public/telegram-webhook"
       url: "",
       secret: ""
     }

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -24,7 +24,7 @@
   },
   "sync": {
     "schedule": "*/1 * * * *",
-    "host": "https://central.main.internal.tamanu.io",
+    "host": "https://central.main.cd.tamanu.app",
     "email": "",
     "password": "",
     "timeout": 10000,

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -179,6 +179,8 @@ dependencies {
 
     implementation project(':react-native-config')
 
+    implementation 'org.jetbrains:annotations:16.0.2'
+
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")

--- a/packages/mobile/android/app/src/main/java/com/tamanuapp/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/com/tamanuapp/MainActivity.java
@@ -1,8 +1,14 @@
 package com.tamanuapp;
 
+import android.content.Context;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import org.jetbrains.annotations.Nullable;
 
 public class MainActivity extends ReactActivity {
 
@@ -15,6 +21,14 @@ public class MainActivity extends ReactActivity {
     return "tamanuapp";
   }
 
+  @Override
+  public Intent registerReceiver(@Nullable BroadcastReceiver receiver, IntentFilter filter) {
+    if (Build.VERSION.SDK_INT >= 34 && getApplicationInfo().targetSdkVersion >= 34) {
+      return super.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
+    } else {
+      return super.registerReceiver(receiver, filter);
+    }
+  }
   /**
    * Returns the instance of the {@link ReactActivityDelegate}. There the RootView is created and
    * you can specify the renderer you wish to use - the new renderer (Fabric) or the old renderer

--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "32.0.0"
-        minSdkVersion = 21
-        compileSdkVersion = 32
-        targetSdkVersion = 32
+        buildToolsVersion = "34.0.0"
+        minSdkVersion = 31
+        compileSdkVersion = 34
+        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/packages/mobile/request-examples.http
+++ b/packages/mobile/request-examples.http
@@ -1,4 +1,4 @@
-@server = https://central.main.internal.tamanu.io
+@server = https://central.main.cd.tamanu.app
 @token = {{login.response.body.token}}
 
 ### Login

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -66,15 +66,15 @@ export default async () => {
       host: 'localhost',
       proxy: {
         '/api': {
-          target: process.env.TAMANU_VITE_TARGET ?? 'https://facility-1.main.internal.tamanu.io',
+          target: process.env.TAMANU_VITE_TARGET ?? 'https://facility-1.main.cd.tamanu.app',
           // specify other servers to use as backend by setting the environment variable, e.g.
           // TAMANU_VITE_TARGET=http://localhost:3000
           // TAMANU_VITE_TARGET=http://localhost:4000
-          // TAMANU_VITE_TARGET=https://central.main.internal.tamanu.io
+          // TAMANU_VITE_TARGET=https://central.main.cd.tamanu.app
           changeOrigin: true,
         },
         '/socket.io': {
-          target: process.env.TAMANU_VITE_TARGET ?? 'https://facility-1.main.internal.tamanu.io',
+          target: process.env.TAMANU_VITE_TARGET ?? 'https://facility-1.main.cd.tamanu.app',
           ws: true,
         },
       },


### PR DESCRIPTION
### Changes

Also included in this is a cherry pick of the new auto deploy urls for testing

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
