### PR TITLE
tweak(mobile): NASS-1606: Hotfix 2.26: Revert the min sdk bump

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -179,8 +179,6 @@ dependencies {
 
     implementation project(':react-native-config')
 
-    implementation 'org.jetbrains:annotations:16.0.2'
-
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")

--- a/packages/mobile/android/app/src/main/java/com/tamanuapp/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/com/tamanuapp/MainActivity.java
@@ -1,14 +1,8 @@
 package com.tamanuapp;
 
-import android.content.Context;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
-import android.content.BroadcastReceiver;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.os.Build;
-import org.jetbrains.annotations.Nullable;
 
 public class MainActivity extends ReactActivity {
 
@@ -21,14 +15,6 @@ public class MainActivity extends ReactActivity {
     return "tamanuapp";
   }
 
-  @Override
-  public Intent registerReceiver(@Nullable BroadcastReceiver receiver, IntentFilter filter) {
-    if (Build.VERSION.SDK_INT >= 34 && getApplicationInfo().targetSdkVersion >= 34) {
-      return super.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
-    } else {
-      return super.registerReceiver(receiver, filter);
-    }
-  }
   /**
    * Returns the instance of the {@link ReactActivityDelegate}. There the RootView is created and
    * you can specify the renderer you wish to use - the new renderer (Fabric) or the old renderer

--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "34.0.0"
-        minSdkVersion = 31
-        compileSdkVersion = 34
-        targetSdkVersion = 34
+        buildToolsVersion = "32.0.0"
+        minSdkVersion = 21
+        compileSdkVersion = 32
+        targetSdkVersion = 32
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
### Changes

We just upgraded this to enforce a new min sdk for android but we need to allow android 11 for now in 2.26 for the Samoa deployment. We have smoke tested it without issue however as it hasn't gone through full regression there may be unexpected mobile bugs in this but we have communicated that to Aislinn

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
