### PR TITLE
tweak(syncLookup): No-issue: Default sync lookup table to false

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -79,7 +79,7 @@
     "syncSessionTimeoutMs": null,
     snapshotTransactionTimeoutMs: null,
     "lookupTable": {
-      "enabled": true,
+      "enabled": false,
       "perModelUpdateTimeoutMs": null,
       "avoidRepull": true
     }


### PR DESCRIPTION
### Changes

As of now this causes a bug on autodeploys where the initial sync will never trigger and the facility will have empty data until a resync is triggered

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
