### PR TITLE
fix(medication): Improve monthly administration date handling in MAR

### DIFF
--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -105,9 +105,26 @@ export class MedicationAdministrationRecord extends Model {
         case ADMINISTRATION_FREQUENCIES.ONCE_A_WEEK:
           lastStartDate = startOfDay(addDays(lastStartDate, 7));
           break;
-        case ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH:
-          lastStartDate = startOfDay(addDays(lastStartDate, 30));
+        case ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH: {
+          // Get the day of the month from the last administration date
+          const dayOfMonth = lastStartDate.getDate();
+
+          // Create next month's date
+          const nextMonthDate = new Date(lastStartDate);
+          nextMonthDate.setMonth(nextMonthDate.getMonth() + 1);
+
+          // If the day is 29th, 30th, or 31st, set to 1st of next month
+          if (dayOfMonth >= 29) {
+            nextMonthDate.setMonth(nextMonthDate.getMonth() + 1);
+            nextMonthDate.setDate(1);
+          } else {
+            // Keep the same day of month
+            nextMonthDate.setDate(dayOfMonth);
+          }
+
+          lastStartDate = startOfDay(nextMonthDate);
           break;
+        }
         default:
           lastStartDate = startOfDay(addDays(lastStartDate, 1));
           break;

--- a/packages/web/app/components/Medication/Mar/MarTableRow.jsx
+++ b/packages/web/app/components/Medication/Mar/MarTableRow.jsx
@@ -89,7 +89,7 @@ export const MarTableRow = ({ medication, selectedDate }) => {
           )}
         </Box>
       </MarRowContainer>
-      {mapRecordsToWindows(medicationAdministrationRecords).map((record, index) => {
+      {mapRecordsToWindows(medicationAdministrationRecords).map((record, index, array) => {
         return (
           <MarStatus
             key={record?.id || index}
@@ -97,8 +97,8 @@ export const MarTableRow = ({ medication, selectedDate }) => {
             timeSlot={MEDICATION_ADMINISTRATION_TIME_SLOTS[index]}
             medication={medication}
             marInfo={record}
-            previousMarInfo={medicationAdministrationRecords[index - 1]}
-            nextMarInfo={medicationAdministrationRecords[index + 1]}
+            previousMarInfo={array[index - 1]}
+            nextMarInfo={array[index + 1]}
             pauseRecords={pauseRecords}
           />
         );

--- a/packages/web/app/components/Medication/Mar/MarTableRow.jsx
+++ b/packages/web/app/components/Medication/Mar/MarTableRow.jsx
@@ -76,7 +76,7 @@ export const MarTableRow = ({ medication, selectedDate }) => {
           {getTranslatedFrequency(frequency, getTranslation)},{' '}
           {<TranslatedEnum value={route} enumValues={DRUG_ROUTE_LABELS} />}
         </Box>
-        <Box color={Colors.midText}>
+        <Box color={!isPausing ? Colors.midText : undefined}>
           <span>{notes}</span>
           {displayPharmacyNotesInMar && pharmacyNotes && (
             <span>

--- a/packages/web/app/components/Medication/MarStatus.jsx
+++ b/packages/web/app/components/Medication/MarStatus.jsx
@@ -151,6 +151,17 @@ const getIsPaused = ({ pauseRecords, timeSlot, selectedDate, isRecordedStatus })
   });
 };
 
+const getIsPausedThenDiscontinued = ({
+  isPreviouslyPaused,
+  isDiscontinued,
+  timeSlot,
+  selectedDate,
+  discontinuedDate,
+}) => {
+  const startDateOfSlot = getDateFromTimeString(timeSlot.startTime, selectedDate);
+  return isPreviouslyPaused && isDiscontinued && new Date(discontinuedDate) >= startDateOfSlot;
+};
+
 export const MarStatus = ({
   isAlert = false,
   isEdited = false,
@@ -198,7 +209,13 @@ export const MarStatus = ({
       selectedDate,
     });
 
-  const isPausedThenDiscontinued = isPreviouslyPaused && isDiscontinued;
+  const isPausedThenDiscontinued = getIsPausedThenDiscontinued({
+    isPreviouslyPaused,
+    isDiscontinued,
+    timeSlot,
+    selectedDate,
+    discontinuedDate,
+  });
 
   const { getTranslation, getEnumTranslation } = useTranslation();
 


### PR DESCRIPTION
- Improve monthly administration date handling in MedicationAdministrationRecord
- Enhanced logic for calculating the next administration date for medications scheduled once a month, ensuring correct handling of end-of-month scenarios.
- Updated MarTableRow to utilize the correct previous and next medication administration records for improved context in rendering.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
