### PR TITLE
feat(vitals): NASS-1483: Sticky vitals table header

### DIFF
--- a/packages/web/app/components/Table/DynamicColumnTable.jsx
+++ b/packages/web/app/components/Table/DynamicColumnTable.jsx
@@ -6,7 +6,8 @@ import { Colors } from '../../constants';
 
 const StyledTable = styled(Table)`
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: ${props => (props.isBodyScrollable ? 'scroll' : 'hidden')};
+  ${props => props.isBodyScrollable && `max-height: 62vh;`}
   table {
     position: relative;
     thead tr th:first-child,
@@ -31,6 +32,15 @@ const StyledTable = styled(Table)`
       position: sticky;
       left: 16px;
     }
+    ${props =>
+      props.isBodyScrollable &&
+      `
+      thead  {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+      }
+    `}
   }
 `;
 
@@ -38,7 +48,7 @@ const StyledTable = styled(Table)`
 export const DynamicColumnTable = React.memo(({ showFooterLegend, ...props }) => {
   return (
     <>
-      <StyledTable { ...props } />
+      <StyledTable {...props} />
       {showFooterLegend && (
         <Box textAlign="end" marginTop="8px" fontSize="9px" color={Colors.softText}>
           *Changed record

--- a/packages/web/app/components/Table/DynamicColumnTable.jsx
+++ b/packages/web/app/components/Table/DynamicColumnTable.jsx
@@ -6,8 +6,7 @@ import { Colors } from '../../constants';
 
 const StyledTable = styled(Table)`
   overflow-x: auto;
-  overflow-y: ${props => (props.isBodyScrollable ? 'scroll' : 'hidden')};
-  ${props => props.isBodyScrollable && `max-height: 62vh;`}
+  overflow-y: hidden;
   table {
     position: relative;
     thead tr th:first-child,

--- a/packages/web/app/components/VitalsTable.jsx
+++ b/packages/web/app/components/VitalsTable.jsx
@@ -44,6 +44,7 @@ export const VitalsTable = React.memo(() => {
         count={data.length}
         allowExport
         showFooterLegend={showFooterLegend}
+        isBodyScrollable
       />
     </>
   );

--- a/packages/web/app/components/VitalsTable.jsx
+++ b/packages/web/app/components/VitalsTable.jsx
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
 import { DynamicColumnTable } from './Table';
 import { useEncounter } from '../contexts/Encounter';
 import { useVitalsQuery } from '../api/queries/useVitalsQuery';
 import { EditVitalCellModal } from './EditVitalCellModal';
 import { getVitalsTableColumns } from './VitalsAndChartsTableColumns';
 import { useSettings } from '../contexts/Settings';
+
+const StyledDynamicColumnTable = styled(DynamicColumnTable)`
+  overflow-y: scroll;
+  max-height: 62vh; /* Matches generic Table height */
+`;
 
 export const VitalsTable = React.memo(() => {
   const patient = useSelector(state => state.patient);
@@ -35,7 +42,7 @@ export const VitalsTable = React.memo(() => {
           setOpenEditModal(false);
         }}
       />
-      <DynamicColumnTable
+      <StyledDynamicColumnTable
         columns={columns}
         data={data}
         elevated={false}


### PR DESCRIPTION
### Changes

Makes the Vitals table header sticky so that it stays on screen when scrolling the table 

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
