### PR TITLE
fix: EPI-1102: Correctly handling first MAR and once a month frequency logic

### DIFF
--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -67,7 +67,7 @@ export class MedicationAdministrationRecord extends Model {
           dueAt: prescription.startDate,
         });
       }
-      return; 
+      return;
     }
 
     let firstAdministrationDate: Date | undefined;
@@ -107,16 +107,20 @@ export class MedicationAdministrationRecord extends Model {
     while (lastDueDate < endDate) {
       for (const idealTime of prescription.idealTimes || []) {
         const [hours, minutes] = idealTime.split(':').map(Number);
-        const nextDueDate = set(startOfDay(lastDueDate), { hours, minutes, seconds: 0 });
-
-        const actualLastRecordedDueDate = lastMedicationAdministrationRecord
-          ? new Date(lastMedicationAdministrationRecord.dueAt)
-          : new Date(0);
+        const nextDueDate = new Date(
+          lastDueDate.getFullYear(),
+          lastDueDate.getMonth(),
+          lastDueDate.getDate(),
+          hours,
+          minutes,
+          0,
+        );
 
         if (
           nextDueDate < new Date(prescription.startDate) ||
           nextDueDate > endDate ||
-          (lastMedicationAdministrationRecord && nextDueDate < actualLastRecordedDueDate) ||
+          (lastMedicationAdministrationRecord &&
+            nextDueDate < new Date(lastMedicationAdministrationRecord.dueAt)) ||
           (prescription.discontinuedDate && nextDueDate >= new Date(prescription.discontinuedDate))
         ) {
           continue;

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -7,6 +7,7 @@ import {
   endOfDay,
   getDate,
   isValid,
+  set,
   setDate,
   startOfDay,
 } from 'date-fns';
@@ -69,6 +70,14 @@ export class MedicationAdministrationRecord extends Model {
       return;
     }
 
+    let firstAdministrationDate: Date | undefined;
+    if (prescription.idealTimes && prescription.idealTimes.length > 0) {
+      firstAdministrationDate = getFirstAdministrationDate(
+        new Date(prescription.startDate),
+        prescription.idealTimes,
+      );
+    }
+
     const upcomingRecordsShouldBeGeneratedTimeFrame =
       config?.medicationAdministrationRecord?.upcomingRecordsShouldBeGeneratedTimeFrame || 72;
 
@@ -79,35 +88,28 @@ export class MedicationAdministrationRecord extends Model {
       endDate = new Date(prescription.endDate);
     }
 
-    const firstAdministrationDate =
-      prescription.idealTimes && prescription.idealTimes.length > 0
-        ? getFirstAdministrationDate(new Date(prescription.startDate), prescription.idealTimes)
-        : prescription.startDate;
-
-    let lastDueDate = lastMedicationAdministrationRecord
-      ? new Date(lastMedicationAdministrationRecord.dueAt)
-      : firstAdministrationDate;
-
-    const lastRecordedDueDate = lastMedicationAdministrationRecord
-      ? new Date(lastMedicationAdministrationRecord.dueAt)
-      : new Date(0);
+    let lastDueDate: Date;
+    if (lastMedicationAdministrationRecord) {
+      lastDueDate = new Date(lastMedicationAdministrationRecord.dueAt);
+    } else if (firstAdministrationDate) {
+      lastDueDate = firstAdministrationDate;
+    } else {
+      lastDueDate = new Date(prescription.startDate);
+    }
 
     while (lastDueDate < endDate) {
       for (const idealTime of prescription.idealTimes || []) {
         const [hours, minutes] = idealTime.split(':').map(Number);
-        const nextDueDate = new Date(
-          lastDueDate.getFullYear(),
-          lastDueDate.getMonth(),
-          lastDueDate.getDate(),
-          hours,
-          minutes,
-          0,
-        );
+        const nextDueDate = set(startOfDay(lastDueDate), { hours, minutes, seconds: 0 });
+
+        const actualLastRecordedDueDate = lastMedicationAdministrationRecord
+          ? new Date(lastMedicationAdministrationRecord.dueAt)
+          : new Date(0);
 
         if (
           nextDueDate < new Date(prescription.startDate) ||
           nextDueDate > endDate ||
-          (lastMedicationAdministrationRecord && nextDueDate < lastRecordedDueDate) ||
+          (lastMedicationAdministrationRecord && nextDueDate < actualLastRecordedDueDate) ||
           (prescription.discontinuedDate && nextDueDate >= new Date(prescription.discontinuedDate))
         ) {
           continue;

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -116,16 +116,21 @@ export class MedicationAdministrationRecord extends Model {
         if (prescription.frequency === ADMINISTRATION_FREQUENCIES.ONCE_A_MONTH) {
           const originalDay = getDate(firstAdministrationDate);
           if (originalDay === getDate(lastDueDate)) {
-            await this.create({
-              prescriptionId: prescription.id,
-              dueAt: nextDueDate,
-            });
-          // Handle once a month frequency when the administration date is the last day of the month
+            if (isValid(nextDueDate)) {
+              await this.create({
+                prescriptionId: prescription.id,
+                dueAt: nextDueDate,
+              });
+            }
+            // Handle once a month frequency when the administration date is the last day of the month
           } else if (isLastDayOfMonth(nextDueDate) && getDate(nextDueDate) < originalDay) {
-            await this.create({
-              prescriptionId: prescription.id,
-              dueAt: setDate(addMonths(nextDueDate, 1), 1),
-            });
+            const nextMonthDueDate = setDate(addMonths(nextDueDate, 1), 1);
+            if (isValid(nextMonthDueDate)) {
+              await this.create({
+                prescriptionId: prescription.id,
+                dueAt: nextMonthDueDate,
+              });
+            }
           }
         } else {
           // Skip if administration date is not valid (required to pass unit tests)

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -56,10 +56,9 @@ export class MedicationAdministrationRecord extends Model {
       order: [['dueAt', 'DESC']],
     });
 
-    const firstAdministrationDate = getFirstAdministrationDate(
-      new Date(prescription.startDate),
-      prescription.idealTimes,
-    );
+    const firstAdministrationDate = prescription.idealTimes
+      ? getFirstAdministrationDate(new Date(prescription.startDate), prescription.idealTimes)
+      : prescription.startDate;
 
     if (
       prescription.frequency === ADMINISTRATION_FREQUENCIES.IMMEDIATELY ||

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -7,7 +7,6 @@ import {
   endOfDay,
   getDate,
   isValid,
-  set,
   setDate,
   startOfDay,
 } from 'date-fns';

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -67,7 +67,7 @@ export class MedicationAdministrationRecord extends Model {
           dueAt: prescription.startDate,
         });
       }
-      return;
+      return; 
     }
 
     let firstAdministrationDate: Date | undefined;

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -70,21 +70,6 @@ export class MedicationAdministrationRecord extends Model {
       return;
     }
 
-    let firstAdministrationDate: Date | undefined;
-    if (prescription.idealTimes && prescription.idealTimes.length > 0) {
-      try {
-        firstAdministrationDate = getFirstAdministrationDate(
-          new Date(prescription.startDate),
-          prescription.idealTimes,
-        );
-      } catch (error) {
-        console.error(
-          `Error calculating first administration date for prescription ${prescription.id}:`,
-          error,
-        );
-      }
-    }
-
     const upcomingRecordsShouldBeGeneratedTimeFrame =
       config?.medicationAdministrationRecord?.upcomingRecordsShouldBeGeneratedTimeFrame || 72;
 
@@ -95,14 +80,18 @@ export class MedicationAdministrationRecord extends Model {
       endDate = new Date(prescription.endDate);
     }
 
-    let lastDueDate: Date;
-    if (lastMedicationAdministrationRecord) {
-      lastDueDate = new Date(lastMedicationAdministrationRecord.dueAt);
-    } else if (firstAdministrationDate) {
-      lastDueDate = firstAdministrationDate;
-    } else {
-      lastDueDate = new Date(prescription.startDate); 
-    }
+    const firstAdministrationDate =
+      prescription.idealTimes && prescription.idealTimes.length > 0
+        ? getFirstAdministrationDate(new Date(prescription.startDate), prescription.idealTimes)
+        : prescription.startDate;
+
+    let lastDueDate = lastMedicationAdministrationRecord
+      ? new Date(lastMedicationAdministrationRecord.dueAt)
+      : firstAdministrationDate;
+
+    const lastRecordedDueDate = lastMedicationAdministrationRecord
+      ? new Date(lastMedicationAdministrationRecord.dueAt)
+      : new Date(0);
 
     while (lastDueDate < endDate) {
       for (const idealTime of prescription.idealTimes || []) {
@@ -110,15 +99,10 @@ export class MedicationAdministrationRecord extends Model {
         const currentDay = startOfDay(lastDueDate);
         const nextDueDate = set(currentDay, { hours, minutes });
 
-        const actualLastRecordedDueDate = lastMedicationAdministrationRecord
-          ? new Date(lastMedicationAdministrationRecord.dueAt)
-          : new Date(0);
-
         if (
           nextDueDate < new Date(prescription.startDate) ||
           nextDueDate > endDate ||
-          (lastMedicationAdministrationRecord && nextDueDate <= actualLastRecordedDueDate) ||
-          (!lastMedicationAdministrationRecord && nextDueDate < new Date(prescription.startDate)) ||
+          (lastMedicationAdministrationRecord && nextDueDate < lastRecordedDueDate) ||
           (prescription.discontinuedDate && nextDueDate >= new Date(prescription.discontinuedDate))
         ) {
           continue;

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -72,10 +72,17 @@ export class MedicationAdministrationRecord extends Model {
 
     let firstAdministrationDate: Date | undefined;
     if (prescription.idealTimes && prescription.idealTimes.length > 0) {
-      firstAdministrationDate = getFirstAdministrationDate(
-        new Date(prescription.startDate),
-        prescription.idealTimes,
-      );
+      try {
+        firstAdministrationDate = getFirstAdministrationDate(
+          new Date(prescription.startDate),
+          prescription.idealTimes,
+        );
+      } catch (error) {
+        console.error(
+          `Error calculating first administration date for prescription ${prescription.id}:`,
+          error,
+        );
+      }
     }
 
     const upcomingRecordsShouldBeGeneratedTimeFrame =

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -101,7 +101,7 @@ export class MedicationAdministrationRecord extends Model {
     } else if (firstAdministrationDate) {
       lastDueDate = firstAdministrationDate;
     } else {
-      lastDueDate = new Date(prescription.startDate);
+      lastDueDate = new Date(prescription.startDate); 
     }
 
     while (lastDueDate < endDate) {

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -68,7 +68,7 @@ export class MedicationAdministrationRecord extends Model {
       if (!lastMedicationAdministrationRecord) {
         await this.create({
           prescriptionId: prescription.id,
-          dueAt: firstAdministrationDate,
+          dueAt: prescription.startDate,
         });
       }
       return;
@@ -103,7 +103,8 @@ export class MedicationAdministrationRecord extends Model {
         if (
           nextDueDate < new Date(prescription.startDate) ||
           nextDueDate > endDate ||
-          nextDueDate < lastDueDate ||
+          (lastMedicationAdministrationRecord &&
+            nextDueDate <= new Date(lastMedicationAdministrationRecord.dueAt)) ||
           (prescription.discontinuedDate && nextDueDate >= new Date(prescription.discontinuedDate))
         ) {
           continue;

--- a/packages/shared/src/utils/medication.js
+++ b/packages/shared/src/utils/medication.js
@@ -38,7 +38,7 @@ export const getFirstAdministrationDate = (startDate, idealTimes) => {
         getDateFromTimeString(idealTime, addDays(startDate, 1)),
       ),
     )
-    .filter((idealTime) => idealTime > startDate.getTime())
+    .filter((idealTime) => idealTime.getTime() > startDate.getTime())
     .sort((a, b) => a - b)[0];
 
   return firstStartTime;

--- a/packages/shared/src/utils/medication.js
+++ b/packages/shared/src/utils/medication.js
@@ -1,5 +1,5 @@
 import { MEDICATION_ADMINISTRATION_TIME_SLOTS } from '@tamanu/constants';
-import { format, set } from 'date-fns';
+import { addDays, format, set } from 'date-fns';
 
 export const findAdministrationTimeSlotFromIdealTime = (idealTime) => {
   const index = MEDICATION_ADMINISTRATION_TIME_SLOTS.findIndex((slot) => {
@@ -28,4 +28,18 @@ export const getDateFromTimeString = (time, initialDate = new Date()) => {
   const hour = parseInt(parsedTime[0]);
   const minute = parseInt(parsedTime[1]) || 0;
   return set(initialDate, { hours: hour, minutes: minute, seconds: 0 });
+};
+
+export const getFirstAdministrationDate = (startDate, idealTimes) => {
+  const firstStartTime = idealTimes
+    .map((idealTime) => getDateFromTimeString(idealTime, startDate))
+    .concat(
+      idealTimes.map((idealTime) =>
+        getDateFromTimeString(idealTime, addDays(startDate, 1)),
+      ),
+    )
+    .filter((idealTime) => idealTime > startDate.getTime())
+    .sort((a, b) => a - b)[0];
+
+  return firstStartTime;
 };

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -15,13 +15,14 @@ import {
 import {
   findAdministrationTimeSlotFromIdealTime,
   getDateFromTimeString,
+  getFirstAdministrationDate,
 } from '@tamanu/shared/utils/medication';
 import {
   formatShort,
   getCurrentDateString,
   getCurrentDateTimeString,
 } from '@tamanu/utils/dateTime';
-import { addDays, format, subSeconds } from 'date-fns';
+import { format, subSeconds } from 'date-fns';
 import { useFormikContext } from 'formik';
 
 import { foreignKey } from '../utils/validation';
@@ -254,13 +255,10 @@ const MedicationAdministrationForm = () => {
 
     const startDate = new Date(values.startDate);
 
-    const firstStartTime = selectedTimeSlots
-      .map(s => getDateFromTimeString(s.value, startDate).getTime())
-      .concat(
-        selectedTimeSlots.map(s => getDateFromTimeString(s.value, addDays(startDate, 1)).getTime()),
-      )
-      .filter(s => s > startDate.getTime())
-      .sort((a, b) => a - b)[0];
+    const firstStartTime = getFirstAdministrationDate(
+      startDate,
+      selectedTimeSlots.map(s => s.value),
+    ).getTime();
 
     const firstSlot = findAdministrationTimeSlotFromIdealTime(firstStartTime).timeSlot;
 


### PR DESCRIPTION
### Changes

- Fix incorrect MAR schudule when frequency is "Once a month"
- Fix MAR is not recorded when due time is 00:00

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
