### PR TITLE
fix: EPI-1130: Fix MAR popper position, warning modal and unexpected PRN tooltip 

### DIFF
--- a/packages/web/app/components/Medication/Mar/MarStatus.jsx
+++ b/packages/web/app/components/Medication/Mar/MarStatus.jsx
@@ -101,16 +101,22 @@ const DiscontinuedDivider = styled.div`
 `;
 
 const getIsPast = ({ timeSlot, selectedDate }) => {
-  const endDate = getDateFromTimeString(timeSlot.endTime, selectedDate);
-  return new Date() > endDate;
+  const slotEndDate = getDateFromTimeString(timeSlot.endTime, selectedDate);
+  return new Date() > slotEndDate;
+};
+
+const getIsCurrent = ({ timeSlot, selectedDate }) => {
+  const slotStartDate = getDateFromTimeString(timeSlot.startTime, selectedDate);
+  const slotEndDate = getDateFromTimeString(timeSlot.endTime, selectedDate);
+  return new Date() >= slotStartDate && new Date() < slotEndDate;
 };
 
 const getIsDisabled = ({ hasRecord, timeSlot, selectedDate }) => {
-  const startDate = getDateFromTimeString(timeSlot.startTime, selectedDate);
+  const slotStartDate = getDateFromTimeString(timeSlot.startTime, selectedDate);
   if (!hasRecord) {
-    return startDate > new Date();
+    return slotStartDate > new Date();
   }
-  return startDate > addHours(new Date(), 2);
+  return slotStartDate > addHours(new Date(), 2);
 };
 
 const getIsEnd = ({ endDate, hasRecord, timeSlot, selectedDate }) => {
@@ -215,6 +221,7 @@ export const MarStatus = ({
   const isPast = getIsPast({ timeSlot, selectedDate });
   const isDisabled = getIsDisabled({ hasRecord: !!marInfo, timeSlot, selectedDate });
   const isFuture = getDateFromTimeString(timeSlot.startTime, selectedDate) > new Date();
+  const isCurrent = getIsCurrent({ timeSlot, selectedDate });
   const isDiscontinued = getIsDiscontinued({
     discontinuedDate,
     dueAt,
@@ -288,7 +295,7 @@ export const MarStatus = ({
       setShowWarningModal(MAR_WARNING_MODAL.PAST);
       return;
     }
-    if (isFuture) {
+    if (isFuture || (isCurrent && !marInfo?.id)) {
       setShowWarningModal(MAR_WARNING_MODAL.FUTURE);
       return;
     }
@@ -454,6 +461,7 @@ export const MarStatus = ({
             );
           }
           if (isPast) {
+            if (isPrn) return null;
             return (
               <Box maxWidth={69}>
                 <TranslatedText

--- a/packages/web/app/components/Medication/Mar/StatusPopper.jsx
+++ b/packages/web/app/components/Medication/Mar/StatusPopper.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useQueryClient } from '@tanstack/react-query';
 import { Divider, Popper, Paper, ClickAwayListener, Fade, IconButton } from '@material-ui/core';
@@ -30,29 +30,46 @@ const StyledPaper = styled(Paper)`
     content: '';
     position: absolute;
     top: 50%;
-    left: 100%;
     transform: translateY(-50%);
     width: 0;
     height: 0;
     border-top: 8px solid transparent;
     border-bottom: 8px solid transparent;
-    border-left: 8px solid white;
     z-index: 2;
+    ${p =>
+      p.$placement === 'right'
+        ? `
+      right: 100%;
+      border-right: 8px solid white;
+    `
+        : `
+      left: 100%;
+      border-left: 8px solid white;
+    `}
   }
 
   &::after {
     content: '';
     position: absolute;
     top: 50%;
-    left: 100%;
     transform: translateY(-50%);
     width: 0;
     height: 0;
     border-top: 9px solid transparent;
     border-bottom: 9px solid transparent;
-    border-left: 9px solid rgba(0, 0, 0, 0.1);
     z-index: 1;
-    margin-left: 1px;
+    ${p =>
+      p.$placement === 'right'
+        ? `
+      right: 100%;
+      border-right: 9px solid rgba(0, 0, 0, 0.1);
+      margin-right: 1px;
+    `
+        : `
+      left: 100%;
+      border-left: 9px solid rgba(0, 0, 0, 0.1);
+      margin-left: 1px;
+    `}
   }
 `;
 
@@ -462,11 +479,15 @@ export const StatusPopper = ({
     return <MainScreen onGivenClick={handleGivenClick} onNotGivenClick={handleNotGivenClick} />;
   };
 
+  const placement = useMemo(() => {
+    return ['00:00', '02:00', '04:00'].includes(timeSlot.startTime) ? 'right' : 'left';
+  }, [timeSlot]);
+
   return (
     <Popper
       open={open}
       anchorEl={anchorEl}
-      placement="left"
+      placement={placement}
       transition
       modifiers={{
         offset: {
@@ -489,7 +510,7 @@ export const StatusPopper = ({
         <Fade {...TransitionProps} timeout={250}>
           <div>
             <ClickAwayListener onClickAway={handleClose}>
-              <StyledPaper>{getContent()}</StyledPaper>
+              <StyledPaper $placement={placement}>{getContent()}</StyledPaper>
             </ClickAwayListener>
           </div>
         </Fade>


### PR DESCRIPTION
…mproved time slot handling

- Added `getIsCurrent` function to determine if a time slot is currently active based on start and end times.
- Updated `getIsDisabled` logic to use consistent variable naming for clarity.
- Modified `MarStatus` to show warning modal for current time slots without records.
- Refactored `StatusPopper` to dynamically adjust placement based on time slot start time, improving UI responsiveness.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
