### PR TITLE
feat(reports): NASS-1605: Add new report parameter fields BookingTypeField and AppointmentTypeField 

### DIFF
--- a/packages/web/app/views/reports/AppointmentTypeField.jsx
+++ b/packages/web/app/views/reports/AppointmentTypeField.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useSuggester } from '../../api';
+import { AutocompleteField, Field } from '../../components';
+
+export const AppointmentTypeField = ({ required, name, label }) => {
+  const appointmentTypeSuggester = useSuggester('appointmentType');
+  return (
+    <Field
+      name={name}
+      label={label}
+      component={AutocompleteField}
+      suggester={appointmentTypeSuggester}
+      required={required}
+    />
+  );
+};

--- a/packages/web/app/views/reports/BookingTypeField.jsx
+++ b/packages/web/app/views/reports/BookingTypeField.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useSuggester } from '../../api';
+import { AutocompleteField, Field } from '../../components';
+
+export const BookingTypeField = ({ required, name, label }) => {
+  const bookingTypeSuggester = useSuggester('bookingType');
+  return (
+    <Field
+      name={name}
+      label={label}
+      component={AutocompleteField}
+      suggester={bookingTypeSuggester}
+      required={required}
+    />
+  );
+};

--- a/packages/web/app/views/reports/ParameterField.jsx
+++ b/packages/web/app/views/reports/ParameterField.jsx
@@ -1,9 +1,13 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
+import { useField } from 'formik';
+
 import {
   SUGGESTER_ENDPOINTS,
   SUGGESTER_ENDPOINTS_SUPPORTING_ALL,
 } from '@tamanu/constants/suggesters';
+
+import { useSuggester } from '../../api';
 import {
   AutocompleteField,
   Field,
@@ -19,11 +23,11 @@ import { LabTestTypeField } from './LabTestTypeField';
 import { LabTestCategoryField } from './LabTestCategoryField';
 import { VaccineCategoryField } from './VaccineCategoryField';
 import { ImagingTypeField } from './ImagingTypeField';
-import { VaccineField } from './VaccineField';
-import { useSuggester } from '../../api';
-import { FacilityField } from './FacilityField';
-import { useField } from 'formik';
 import { LabTestCategorySensitiveField } from './LabTestCategorySensitiveField';
+import { AppointmentTypeField } from './AppointmentTypeField';
+import { BookingTypeField } from './BookingTypeField';
+import { VaccineField } from './VaccineField';
+import { FacilityField } from './FacilityField';
 
 export const FIELD_TYPES_TO_SUGGESTER_OPTIONS = {
   ParameterSuggesterSelectField: SUGGESTER_ENDPOINTS_SUPPORTING_ALL,
@@ -108,6 +112,8 @@ export const PARAMETER_FIELD_COMPONENTS = {
   LabTestCategorySensitiveField,
   ParameterSuggesterSelectField,
   LabTestTypeField,
+  AppointmentTypeField,
+  BookingTypeField,
 };
 
 export const ParameterField = ({

--- a/packages/web/app/views/reports/ParameterField.jsx
+++ b/packages/web/app/views/reports/ParameterField.jsx
@@ -96,24 +96,24 @@ const ParameterMultiselectField = ({ name, ...props }) => (
 const EmptyField = styled.div``;
 
 export const PARAMETER_FIELD_COMPONENTS = {
-  VillageField,
-  LabTestLaboratoryField,
-  PractitionerField,
-  FacilityField,
+  AppointmentTypeField,
+  BookingTypeField,
   DiagnosisField,
-  VaccineCategoryField,
-  VaccineField,
   EmptyField,
-  ParameterAutocompleteField,
-  ParameterSelectField,
-  ParameterMultiselectField,
+  FacilityField,
   ImagingTypeField,
   LabTestCategoryField,
   LabTestCategorySensitiveField,
-  ParameterSuggesterSelectField,
+  LabTestLaboratoryField,
   LabTestTypeField,
-  AppointmentTypeField,
-  BookingTypeField,
+  ParameterAutocompleteField,
+  ParameterMultiselectField,
+  ParameterSelectField,
+  ParameterSuggesterSelectField,
+  PractitionerField,
+  VaccineCategoryField,
+  VaccineField,
+  VillageField,
 };
 
 export const ParameterField = ({


### PR DESCRIPTION
### Changes

- Adds BookingTypeField and AppointmentTypeField

I thought about making a factory type thing for these - but I somewhat appreciate the clearness

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an autocomplete input field for selecting appointment types.
  - Added an autocomplete input field for selecting booking types.
  - Enabled support for appointment type, booking type, and lab test category sensitive fields in report parameter selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->