### PR TITLE
feat(api): SAV-938: Allow any client name in the X-Tamanu-Client header

### DIFF
--- a/packages/central-server/__tests__/middleware/versionCompatibility.test.js
+++ b/packages/central-server/__tests__/middleware/versionCompatibility.test.js
@@ -2,10 +2,10 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { SERVER_TYPES, VERSION_COMPATIBILITY_ERRORS } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
-import { SUPPORTED_CLIENT_VERSIONS } from '../../dist/middleware/versionCompatibility';
+import { VERSION_CONTROLLED_CLIENTS } from '../../dist/middleware/versionCompatibility';
 
-const MIN_MOBILE_VERSION = SUPPORTED_CLIENT_VERSIONS[SERVER_TYPES.MOBILE].min;
-const MIN_FACILITY_VERSION = SUPPORTED_CLIENT_VERSIONS[SERVER_TYPES.FACILITY].min;
+const MIN_MOBILE_VERSION = VERSION_CONTROLLED_CLIENTS[SERVER_TYPES.MOBILE].min;
+const MIN_FACILITY_VERSION = VERSION_CONTROLLED_CLIENTS[SERVER_TYPES.FACILITY].min;
 
 describe('Version compatibility', () => {
   let baseApp;

--- a/packages/central-server/__tests__/middleware/versionCompatibility.test.js
+++ b/packages/central-server/__tests__/middleware/versionCompatibility.test.js
@@ -92,26 +92,24 @@ describe('Version compatibility', () => {
   describe('Other client version checking', () => {
     it.each(['0.0.1', '1.0.0', '1.0.9', '999.999.999'])(
       'Should allow version %s of an unspecified client (so that tests work)',
-      async version => {
-        const response = await app
-          .get('/')
-          .unset('X-Tamanu-Client')
-          .set({
-            'X-Version': version,
-          });
+      async (version) => {
+        const response = await app.get('/').unset('X-Tamanu-Client').set({
+          'X-Version': version,
+        });
         expect(response).toHaveSucceeded();
         expect(response.body).toHaveProperty('index', true);
       },
     );
 
     it.each(['0.0.1', '1.0.0', '1.0.9', '999.999.999'])(
-      'Should deny version %s of an an unknown client type of any version',
-      async version => {
+      'Should allow version %s of an an unknown client type of any version',
+      async (version) => {
         const response = await app.get('/').set({
           'X-Tamanu-Client': 'Unknown Client',
           'X-Version': version,
         });
-        expect(response).not.toHaveSucceeded();
+        expect(response).toHaveSucceeded();
+        expect(response.body).toHaveProperty('index', true);
       },
     );
   });
@@ -128,7 +126,7 @@ describe('Version compatibility', () => {
         'packages/scripts/package.json',
       ];
       versions = await Promise.all(
-        packageFiles.map(async filePath => {
+        packageFiles.map(async (filePath) => {
           const relativePath = `../../../../${filePath}`.split('/');
           const normalisedPath = path.resolve(__dirname, ...relativePath);
           const content = await fs.readFile(normalisedPath);
@@ -139,13 +137,15 @@ describe('Version compatibility', () => {
 
     it('Should have the same version across all packages', async () => {
       const [firstVersion, ...rest] = versions.map(([, v]) => v);
-      rest.forEach(subsequentVersion => {
+      rest.forEach((subsequentVersion) => {
         expect(subsequentVersion).toEqual(firstVersion);
       });
     });
 
     it('Should support the current version of the Facility server', async () => {
-      const facilityVersion = versions.find(([filePath]) => filePath === 'packages/facility-server/package.json')[1];
+      const facilityVersion = versions.find(
+        ([filePath]) => filePath === 'packages/facility-server/package.json',
+      )[1];
       const response = await app.get('/').set({
         'X-Tamanu-Client': SERVER_TYPES.FACILITY,
         'X-Version': facilityVersion,

--- a/packages/central-server/app/middleware/versionCompatibility.js
+++ b/packages/central-server/app/middleware/versionCompatibility.js
@@ -25,7 +25,7 @@ export const MIN_CLIENT_VERSION = MIN_CLIENT_OVERRIDE ?? `${major}.${minor}.0`;
 export const MAX_CLIENT_VERSION = `${major}.${minor}.999`;
 // Note that .999 is only for clarity; higher patch versions will always be allowed
 
-export const SUPPORTED_CLIENT_VERSIONS = {
+export const VERSION_CONTROLLED_CLIENTS = {
   [SERVER_TYPES.FACILITY]: {
     min: MIN_CLIENT_VERSION,
     max: MAX_CLIENT_VERSION,
@@ -49,10 +49,14 @@ export const versionCompatibility = (req, res, next) => {
     return;
   }
 
-  // Default to no version checking if the client type is unrecognised
-  const clientInfo = SUPPORTED_CLIENT_VERSIONS[clientType] || { min: null, max: null };
-  const { min, max } = clientInfo;
+  const clientInfo = VERSION_CONTROLLED_CLIENTS[clientType];
+  if (!clientInfo) {
+    // a non version controlled client; ignore version checking
+    next();
+    return;
+  }
 
+  const { min, max } = clientInfo;
   const runCheck = buildVersionCompatibilityCheck(min, max);
   runCheck(req, res, next);
 };

--- a/packages/central-server/app/middleware/versionCompatibility.js
+++ b/packages/central-server/app/middleware/versionCompatibility.js
@@ -3,7 +3,6 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { parse } from 'semver';
 import { buildVersionCompatibilityCheck } from '@tamanu/shared/utils';
-import { InvalidClientHeadersError } from '@tamanu/shared/errors';
 import { SERVER_TYPES } from '@tamanu/constants';
 
 const pkgpath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
@@ -39,26 +38,6 @@ export const SUPPORTED_CLIENT_VERSIONS = {
     min: MIN_CLIENT_VERSION,
     max: MAX_CLIENT_VERSION,
   },
-  'fiji-vps': {
-    min: null,
-    max: null,
-  },
-  'fiji-vrs': {
-    min: null,
-    max: null,
-  },
-  medici: {
-    min: null,
-    max: null,
-  },
-  mSupply: {
-    min: null,
-    max: null,
-  },
-  FHIR: {
-    min: null,
-    max: null,
-  },
 };
 
 export const versionCompatibility = (req, res, next) => {
@@ -70,17 +49,8 @@ export const versionCompatibility = (req, res, next) => {
     return;
   }
 
-  const clientTypes = Object.keys(SUPPORTED_CLIENT_VERSIONS);
-  if (!clientTypes.includes(clientType)) {
-    next(
-      new InvalidClientHeadersError(
-        `The only supported X-Tamanu-Client values are ${clientTypes.join(', ')}`,
-      ),
-    );
-    return;
-  }
-
-  const clientInfo = SUPPORTED_CLIENT_VERSIONS[clientType];
+  // Default to no version checking if the client type is unrecognised
+  const clientInfo = SUPPORTED_CLIENT_VERSIONS[clientType] || { min: null, max: null };
   const { min, max } = clientInfo;
 
   const runCheck = buildVersionCompatibilityCheck(min, max);

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -113,7 +113,7 @@ All you have to do is download the tools and open them while running while devel
 
 We use a modified version of semver. The major and minor act as usual, but the patch increments forever, rather than getting reset to 0 every minor bump. This gives us a monotonic "build number" we can use as the Google Play Store version.
 
-To bump the version, edit it in `package.json`, and remember to increment the patch monotonically no matter what other changes are made. Any minor bump should have an accompanying release of the central server, with a matching bump to `SUPPORTED_CLIENT_VERSIONS`
+To bump the version, edit it in `package.json`, and remember to increment the patch monotonically no matter what other changes are made. Any minor bump should have an accompanying release of the central server, with a matching bump to `VERSION_CONTROLLED_CLIENTS`
 
 #### Internal distribution
 


### PR DESCRIPTION
### Changes

Opting to just remove the check to ensure that the `X-Tamanu-Client` is a known client globally. The reasoning for doing this is that it's never been a secure mechanism and we notify clients what the supported names were anyway.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated version compatibility checks to allow unrecognized client types to proceed without version constraints, instead of returning an error.
  - Removed support for several legacy client types.
- **Documentation**
  - Updated mobile app README to reflect the renamed version control constant for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->