### PR TITLE
fix: EPI-1146: Fix discharge summary printout

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
@@ -171,7 +171,7 @@ const columns = (getTranslation, getEnumTranslation) => [
   },
   {
     key: 'repeats',
-    title: getTranslation('pdf.table.column.repeat', 'Repeat'),
+    title: getTranslation('pdf.table.column.repeats', 'Repeats'),
     accessor: ({ repeats }) => repeats || 0,
   },
 ];
@@ -189,7 +189,9 @@ const DischargeSummaryPrintoutComponent = ({
   const { logo } = certificateData;
   const { diagnoses, procedures, medications } = encounter;
 
-  const visibleMedications = medications.filter((m) => !m.discontinued);
+  const visibleMedications = medications
+    .filter((m) => !m.discontinued)
+    .sort((a, b) => a.medication.name.localeCompare(b.medication.name));
   const visibleDiagnoses = diagnoses.filter(
     ({ certainty }) => !DIAGNOSIS_CERTAINTIES_TO_HIDE.includes(certainty),
   );


### PR DESCRIPTION
### Changes

- Changed the column title for repeats in the discharge summary printout to ensure consistency in terminology.
- Enhanced the medication display by filtering out discontinued medications and sorting the visible medications alphabetically by name, improving readability and organization.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
