### PR TITLE
fix(tests): no-issue: Fix intermittent test failures due to invalid fake AppointmentSchedule fields

### DIFF
--- a/packages/fake-data/src/fake/fake.ts
+++ b/packages/fake-data/src/fake/fake.ts
@@ -409,6 +409,7 @@ const MODEL_SPECIFIC_OVERRIDES = {
     const frequency = chance.pickone(REPEAT_FREQUENCY_VALUES);
     const endsMode = chance.pickone(['on', 'after']);
     return {
+      frequency,
       daysOfWeek: [chance.pickone(DAYS_OF_WEEK)],
       nthWeekday:
         frequency === REPEAT_FREQUENCY.MONTHLY ? chance.integer({ min: -1, max: 4 }) : null,


### PR DESCRIPTION
### Changes

Started noticing intermittent failures with this test. I think we've been initialising fake appointment schedules in a way that might not always be valid.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that generated fake data for appointment schedules now explicitly includes the frequency field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->