### PR TITLE
fix(e2e): Fix playwright auth context location

### DIFF
--- a/packages/e2e-tests/pages/LoginPage.ts
+++ b/packages/e2e-tests/pages/LoginPage.ts
@@ -12,8 +12,8 @@ export class LoginPage extends BasePage {
   constructor(page: Page) {
     super(page, routes.login);
     this.loginButton = page.getByTestId('loginbutton-gx21');
-    this.emailInput = page.getByTestId('styledfield-dwnl').locator('input');
-    this.passwordInput = page.getByTestId('styledfield-a9k6').locator('input');
+    this.emailInput = page.getByTestId('styledfield-dwnl-input');
+    this.passwordInput = page.getByTestId('styledfield-a9k6-input');
   }
 
   async login(email, password) {

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
     },
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], storageState: '.auth/user.json' },
+      use: { ...devices['Desktop Chrome'], storageState: resolve(__dirname, '.auth/user.json') },
       dependencies: ['setup'],
     },
 

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -1,4 +1,9 @@
 import { test as setup } from '../../fixtures/baseFixture';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 setup('authenticate', async ({ loginPage }) => {
   await loginPage.goto();
@@ -8,5 +13,6 @@ setup('authenticate', async ({ loginPage }) => {
   await loginPage.page.waitForTimeout(1000);
 
   // Save page context
-  await loginPage.page.context().storageState({ path: '.auth/user.json' });
+  const authStatePath = path.join(__dirname, '../../.auth/user.json');
+  await loginPage.page.context().storageState({ path: authStatePath });
 });


### PR DESCRIPTION
### Changes

Running playwright tests via the VS code test runner generated the auth folder / context file at the root of the repo instead of inside the e2e-tests package.
- Swapped to absolute path for the auth context file

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved reliability of authentication state file handling in end-to-end tests by using absolute paths instead of relative paths. This ensures consistent test execution regardless of the working directory.
  - Simplified login form input selectors in end-to-end tests for more straightforward element targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->