### PR TITLE
fix(timesync): Init timesync offset as 0 if disabled and bump timesimp version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73772,7 +73772,7 @@
         "shortid": "^2.2.13",
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
-        "timesimp": "^1.0.2",
+        "timesimp": "^1.0.3",
         "umzug": "^2.3.0",
         "undici": "^7.5.0",
         "uuid": "^11.0.3",
@@ -73816,6 +73816,227 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-android-arm-eabi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-android-arm-eabi/-/timesimp-android-arm-eabi-1.0.3.tgz",
+      "integrity": "sha512-PnWry1AtQ8plLPCSD0/N4rWJPYxzodKUyqocL7tIv+tbQIGwYD+k2DCWyvDBf8Ljwh7/6joFoiaWaNwAWx91BA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-android-arm64/-/timesimp-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-fEjfJHrCRzPHemvuMdBx+nGo8Zd19juBkvXknuaDpAyRr52JjpVHVJ/qX7qI4Lv7hj0hUxrC6yWjtEdE5aDj+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-darwin-arm64/-/timesimp-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-k8juzMAzEisXAifFZ5yIFxRG5C5OJhjrQ32rwXNhBJ71gAFPFvv0c2KZAFu3TETY7/nk2LXQU8Ph6mJc1Y9K/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-darwin-universal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-darwin-universal/-/timesimp-darwin-universal-1.0.3.tgz",
+      "integrity": "sha512-RdFp8QLFeHcv/pdklPnYw3Xwr7l5A48R4TFv/Q9KjAddDNMyTncuUxpQYK4f/gnk3h6/m961O+azjEcSC0t3SQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-darwin-x64/-/timesimp-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-iy1Lnd8AtYMESk29isRps233naYbaIDafI7v7LjWu+7Ezp447y7hGby0SauTsRSA+w7pswKFcRFvQNTOZw2KRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-arm-gnueabihf/-/timesimp-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-NduUGis8ATuycdDWTj9Bnsfh1cI75HQGWWfwWKyYvfg3J4mlb0s1ikpM/e8PpuemLcB4BlKODLaYUdctWQDmsQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-arm-musleabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-arm-musleabihf/-/timesimp-linux-arm-musleabihf-1.0.3.tgz",
+      "integrity": "sha512-PjxEFIRW8fNXN8BmgjIr/hAuFedMizFW82vXq+51TWb3KiI4huYdmNhGbBhWE8hQBEcCH7QU1v5mBYkjGp5Z4w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-arm64-gnu/-/timesimp-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-h2uqek6ZOHtcBE7h3TWa8y1CGIZLqCEBhn/SVM+b3zbnyp4CqVotiLBebrNgTuR5uI6mwMLNFSjdXnFO0xzlWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-arm64-musl/-/timesimp-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-fcpDYS3SOFk7HeHEByzjnOcgOQh/L8xO5eeiAmWMcA70Gjt3wb14iPMwFr2i+ZJBGsaBmQvfaoaNHOVeXS5LEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-riscv64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-riscv64-gnu/-/timesimp-linux-riscv64-gnu-1.0.3.tgz",
+      "integrity": "sha512-O4qoLkj2jugdqT2wlHCI7bz9GTJQzJqcFedGeCD7CGm8E8OHiS1ixSTLQ0zEiNLpzC0tsNC906JcmRkrUsp89A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-x64-gnu/-/timesimp-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5XoEp4qsKttCQACfZiC1a/GBU4u7ayBCdtnfwMxVM7D3D/3paXPoAPwcnbniNUGKMFUPi5Obnb+OQhQtVe/07A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-linux-x64-musl/-/timesimp-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-Y8k78Xhdy8dGCAN65FjQchMR+7LQq5PBFYNELfuUYfvdPr3Cu7byW5GGTXqdZSXnQeQUK9zzRBAc6V3xIL3J7w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-win32-arm64-msvc/-/timesimp-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-mb91nNIz0de3fooKRD/rGJmzbjlQwd+kpurDyJVvBWmcifrbwTGk4vn0nNRawEqJqCpigTY18PjXn3RtphxVmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/facility-server/node_modules/@passcod/timesimp-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@passcod/timesimp-win32-x64-msvc/-/timesimp-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-N+pSpniUiMYa8bDITmlTS0kFwpbcu6HsxcnqUrCYz2K6j2OebSC6JxljQKAbZ95hnd+QO6b/UFRJm4Npkvx8ng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "packages/facility-server/node_modules/cookie": {
@@ -73972,6 +74193,31 @@
       },
       "engines": {
         "node": ">=10.2.0"
+      }
+    },
+    "packages/facility-server/node_modules/timesimp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/timesimp/-/timesimp-1.0.3.tgz",
+      "integrity": "sha512-iDuLkhKhX9Z9AbmXcLZFEb4GwEr4IsjdkfhtfETMrosI92L3xvy4JRUxmEby7FKPI7yY0+heUMsCtD+8ZiWQFw==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "@passcod/timesimp-android-arm-eabi": "1.0.3",
+        "@passcod/timesimp-android-arm64": "1.0.3",
+        "@passcod/timesimp-darwin-arm64": "1.0.3",
+        "@passcod/timesimp-darwin-universal": "1.0.3",
+        "@passcod/timesimp-darwin-x64": "1.0.3",
+        "@passcod/timesimp-linux-arm-gnueabihf": "1.0.3",
+        "@passcod/timesimp-linux-arm-musleabihf": "1.0.3",
+        "@passcod/timesimp-linux-arm64-gnu": "1.0.3",
+        "@passcod/timesimp-linux-arm64-musl": "1.0.3",
+        "@passcod/timesimp-linux-riscv64-gnu": "1.0.3",
+        "@passcod/timesimp-linux-x64-gnu": "1.0.3",
+        "@passcod/timesimp-linux-x64-musl": "1.0.3",
+        "@passcod/timesimp-win32-arm64-msvc": "1.0.3",
+        "@passcod/timesimp-win32-x64-msvc": "1.0.3"
       }
     },
     "packages/facility-server/node_modules/typed-function": {

--- a/packages/facility-server/app/services/initTimesync.js
+++ b/packages/facility-server/app/services/initTimesync.js
@@ -1,9 +1,13 @@
 import { Timesimp } from 'timesimp';
+import config from 'config';
 import { FACT_TIME_OFFSET } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 
 export const initTimesync = async ({ models, url }) => {
   log.info('Initializing timesync', { server: url });
+  if (!config.timesync.enabled) {
+    await models.LocalSystemFact.set(FACT_TIME_OFFSET, '0');
+  }
   return new Timesimp(
     async (err) => {
       if (err) throw err;

--- a/packages/facility-server/package.json
+++ b/packages/facility-server/package.json
@@ -78,7 +78,7 @@
     "shortid": "^2.2.13",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
-    "timesimp": "^1.0.2",
+    "timesimp": "^1.0.3",
     "umzug": "^2.3.0",
     "undici": "^7.5.0",
     "uuid": "^11.0.3",


### PR DESCRIPTION
### Changes

- Upgrade patch version
- Init as 0 on boot if disabled

into changes-sync-audit

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
