### PR TITLE
fix: EPI-1134: Fix wrong dose index and wrong default Given by and Record by user

### DIFF
--- a/packages/web/app/components/Medication/Mar/ChangeStatusModal.jsx
+++ b/packages/web/app/components/Medication/Mar/ChangeStatusModal.jsx
@@ -127,14 +127,6 @@ export const ChangeStatusModal = ({ open, onClose, medication, marInfo, timeSlot
         changingStatusReason,
       });
     } else {
-      if (
-        !showWarningModal &&
-        Number(values.doseAmount) !== Number(medication?.doseAmount) &&
-        !medication?.isVariableDose
-      ) {
-        setShowWarningModal(MAR_WARNING_MODAL.NOT_MATCHING_DOSE);
-        return;
-      }
       const {
         doseAmount,
         givenTime,
@@ -142,6 +134,14 @@ export const ChangeStatusModal = ({ open, onClose, medication, marInfo, timeSlot
         recordedByUserId,
         changingStatusReason,
       } = values;
+      if (
+        !showWarningModal &&
+        Number(doseAmount) !== Number(medication?.doseAmount) &&
+        !medication?.isVariableDose
+      ) {
+        setShowWarningModal(MAR_WARNING_MODAL.NOT_MATCHING_DOSE);
+        return;
+      }
       await updateMarToGiven({
         dose: {
           doseAmount: Number(doseAmount),

--- a/packages/web/app/components/Medication/Mar/EditAdministrationRecordModal.jsx
+++ b/packages/web/app/components/Medication/Mar/EditAdministrationRecordModal.jsx
@@ -99,7 +99,8 @@ export const EditAdministrationRecordModal = ({
   timeSlot,
   showDoseIndex,
 }) => {
-  const practitionerSuggester = useSuggester('practitioner');
+  const recordedBySuggester = useSuggester('practitioner');
+  const givenBySuggester = useSuggester('practitioner');
   const medicationReasonNotGivenSuggester = useSuggester('medicationNotGivenReason');
   const queryClient = useQueryClient();
   const { encounter } = useEncounter();
@@ -200,7 +201,7 @@ export const EditAdministrationRecordModal = ({
           <TranslatedText
             stringId="modal.mar.doseIndex.label"
             fallback="Dose :index"
-            replacements={{ index: doseInfo?.doseIndex }}
+            replacements={{ index: doseInfo?.doseIndex + 1 }}
           />
         </DoseLabel>
       ) : (
@@ -239,7 +240,7 @@ export const EditAdministrationRecordModal = ({
                     name="recordedByUserId"
                     component={AutocompleteField}
                     label="Recorded by"
-                    suggester={practitionerSuggester}
+                    suggester={recordedBySuggester}
                     required
                   />
                   <div style={{ gridColumn: '1 / -1' }}>
@@ -304,14 +305,14 @@ export const EditAdministrationRecordModal = ({
                     name="givenByUserId"
                     component={AutocompleteField}
                     label="Given by"
-                    suggester={practitionerSuggester}
+                    suggester={givenBySuggester}
                     required
                   />
                   <Field
                     name="recordedByUserId"
                     component={AutocompleteField}
                     label="Recorded by"
-                    suggester={practitionerSuggester}
+                    suggester={recordedBySuggester}
                     required
                   />
                   <div style={{ gridColumn: '1 / -1' }}>


### PR DESCRIPTION
### Changes

- Renamed practitionerSuggester to recordedBySuggester and givenBySuggester for clarity.
- Adjusted dose index display to increment by 1 for better user understanding.
- Ensured consistent usage of suggester variables across the modal components.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
