### PR TITLE
feat(programRegistry): SAV-871: Hide the history section of program registries if Audit Changes are disabled

### DIFF
--- a/packages/settings/src/reader/ReadSettings.ts
+++ b/packages/settings/src/reader/ReadSettings.ts
@@ -6,6 +6,7 @@ import { settingsCache } from '../cache';
 import { Models } from './readers/SettingsDBReader';
 
 export const KEYS_EXPOSED_TO_FRONT_END = [
+  'audit',
   'appointments',
   'ageDisplayFormat',
   'customisations',

--- a/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
+++ b/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
@@ -25,6 +25,7 @@ import { optionalForeignKey } from '../../utils/validation';
 import { PROGRAM_REGISTRY_CONDITION_CATEGORIES } from '@tamanu/constants';
 import { usePatientProgramRegistryConditionsQuery } from '../../api/queries';
 import { ConditionHistoryModal } from './ConditionHistoryModal';
+import { useSettings } from '../../contexts/Settings';
 
 const StyledFormTable = styled(FormTable)`
   overflow: auto;
@@ -154,9 +155,11 @@ export const RelatedConditionsForm = ({
 }) => {
   const [warningOpen, setWarningOpen] = useState(false);
   const [selectedCondition, setSelectedCondition] = useState(null);
+  const { getSetting } = useSettings();
   const { getTranslation } = useTranslation();
 
   const { id, programRegistryId, clinicalStatusId } = patientProgramRegistration;
+  const areAuditChangesEnabled = getSetting('audit.changes.enabled');
 
   const { data: conditions = [], isLoading } = usePatientProgramRegistryConditionsQuery(id);
 
@@ -425,7 +428,7 @@ export const RelatedConditionsForm = ({
             accessor: (row, groupName, index) => {
               // Check for date as a proxy for whether the row is new
               const initialValue = initialValues.conditions[groupName][index]?.date;
-              if (!initialValue) {
+              if (!initialValue || !areAuditChangesEnabled) {
                 return null;
               }
               return (

--- a/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
+++ b/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
@@ -459,11 +459,13 @@ export const RelatedConditionsForm = ({
                 await handleConfirmedSubmit(values);
               }}
             />
-            <ConditionHistoryModal
-              open={!!selectedCondition}
-              onClose={() => setSelectedCondition(null)}
-              condition={selectedCondition}
-            />
+            {areAuditChangesEnabled && (
+              <ConditionHistoryModal
+                open={!!selectedCondition}
+                onClose={() => setSelectedCondition(null)}
+                condition={selectedCondition}
+              />
+            )}
             <FormActions isDirty={dirty} />
           </>
         );

--- a/packages/web/app/features/ProgramRegistry/UpdateConditionFormModal.jsx
+++ b/packages/web/app/features/ProgramRegistry/UpdateConditionFormModal.jsx
@@ -21,6 +21,7 @@ import { useTranslation } from '../../contexts/Translation';
 import { RecordedInErrorWarningModal } from './RecordedInErrorWarningModal';
 import { ConditionHistoryTable } from './ConditionHistoryTable';
 import Divider from '@material-ui/core/Divider';
+import { useSettings } from '../../contexts/Settings';
 
 const StyledFormTable = styled(FormTable)`
   margin-top: 1rem;
@@ -55,12 +56,15 @@ const useUpdateConditionMutation = (patientProgramRegistrationId, conditionId) =
 
 export const UpdateConditionFormModal = ({ onClose, open, condition = {} }) => {
   const [warningOpen, setWarningOpen] = useState(false);
+  const { getSetting } = useSettings();
   const { getTranslation } = useTranslation();
   const { id: conditionId, patientProgramRegistrationId, conditionCategory } = condition;
   const { mutateAsync: submit, isLoading: isSubmitting } = useUpdateConditionMutation(
     patientProgramRegistrationId,
     conditionId,
   );
+
+  const areAuditChangesEnabled = getSetting('audit.changes.enabled');
 
   const handleConfirmedSubmit = async values => {
     await submit(values);
@@ -164,8 +168,12 @@ export const UpdateConditionFormModal = ({ onClose, open, condition = {} }) => {
           return (
             <>
               <StyledFormTable columns={columns} data={[condition]} />
-              <Divider />
-              <ConditionHistoryTable historyData={condition?.history} />
+              {areAuditChangesEnabled && (
+                <>
+                  <Divider />
+                  <ConditionHistoryTable historyData={condition?.history} />
+                </>
+              )}
               <ModalFormActionRow onCancel={onClose} confirmDisabled={!dirty || isSubmitting} />
               <RecordedInErrorWarningModal
                 open={warningOpen}


### PR DESCRIPTION
### Changes

Hide the history section of program registries if Audit Changes are disabled. This came up in testing as a question below.
https://linear.app/bes/issue/SAV-871/related-condition-history-modal#comment-b05522db

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
