### PR TITLE
fix(programRegistry): SAV-861: Ensure determinism in migration

### DIFF
--- a/packages/database/src/migrations/1744234388450-movePatientProgramRegistrationsToAuditTable.ts
+++ b/packages/database/src/migrations/1744234388450-movePatientProgramRegistrationsToAuditTable.ts
@@ -49,6 +49,7 @@ export async function up(query: QueryInterface): Promise<void> {
   // Migrate historical changes to audit table
   await query.sequelize.query(`
     INSERT INTO logs.changes (
+      id,
       table_oid,
       table_schema,
       table_name,
@@ -67,6 +68,7 @@ export async function up(query: QueryInterface): Promise<void> {
       record_data
     )
     SELECT
+      uuid_generate_v5(uuid_generate_v5(uuid_nil(), 'patient_program_registrations'), ppr.id::text),
       ${tableOid},
       'public',
       'patient_program_registrations',


### PR DESCRIPTION
### Changes

Found out about this change when working on another card. However it's weird that CI passed on the PR this migration was created, see #7537. While the last commit didn't run migrations steps, previous ones did and passed. I'm not completely sure as to why this wasn't picked up.

The thing here would be that the migration is going to run on both servers, and if they don't have the same ID, we will have duplicate logs for all inserted records