### PR TITLE
fix(programRegistry): SAV-861: Fix migration value

### DIFF
--- a/packages/database/src/migrations/1744234388450-movePatientProgramRegistrationsToAuditTable.ts
+++ b/packages/database/src/migrations/1744234388450-movePatientProgramRegistrationsToAuditTable.ts
@@ -79,7 +79,7 @@ export async function up(query: QueryInterface): Promise<void> {
       ${changesHasUpdatedAtSyncTick ? updatedAtSyncTickSelect : ''}
       COALESCE(ppr.clinician_id::text, '${SYSTEM_USER_UUID}'),
       ppr.id,
-      registration_summary.is_insert,
+      NOT registration_summary.is_insert,
       ppr.created_at,
       ppr.updated_at,
       ppr.deleted_at,

--- a/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js
@@ -5,7 +5,7 @@ import { subject } from '@casl/ability';
 import { NotFoundError } from '@tamanu/shared/errors';
 import { REGISTRATION_STATUSES } from '@tamanu/constants';
 import { validatePatientProgramRegistrationRequest } from './utils';
-import { Op, Sequelize } from 'sequelize';
+import { Op } from 'sequelize';
 
 export const patientProgramRegistration = express.Router();
 


### PR DESCRIPTION
### Changes

Sneaky. So essentially I got it backwards on the other one. One possible review would be to flip the subquery to be `is_update` instead of `is_insert` and flip the cases, but this feels safer at this point