### PR TITLE
feat(programRegistry): SAV-963: Patient program registration inactive state

### DIFF
--- a/database/model/public/patient_program_registrations.md
+++ b/database/model/public/patient_program_registrations.md
@@ -52,3 +52,11 @@ registration is from.
 Reference to the [Reference Data](#!/source/source.tamanu.tamanu.reference_data)
 (`type=village`) this program registration is from.
 {% enddocs %}
+
+{% docs patient_program_registrations__deactivated_clinician_id %}
+The clinician that removed the patient from the program registry.
+{% enddocs %}
+
+{% docs patient_program_registrations__deactivated_date %}
+The date that the patient from the program registry.
+{% enddocs %}

--- a/database/model/public/patient_program_registrations.yml
+++ b/database/model/public/patient_program_registrations.yml
@@ -101,3 +101,10 @@ sources:
               patient_program_registrations."
             data_tests:
               - not_null
+          - name: deactivated_clinician_id
+            data_type: character varying(255)
+            description: "{{ doc('patient_program_registrations__deactivated_clinician_id')
+              }}"
+          - name: deactivated_date
+            data_type: character varying(255)
+            description: "{{ doc('patient_program_registrations__deactivated_date') }}"

--- a/database/model/public/sync_lookup_ticks.md
+++ b/database/model/public/sync_lookup_ticks.md
@@ -1,0 +1,11 @@
+{% docs table__sync_lookup_ticks %}
+Stores range of sync lookup ticks per sync.
+{% enddocs %}
+
+{% docs sync_lookup_ticks__source_start_tick %}
+Represents the previous lookup up to tick.
+{% enddocs %}
+
+{% docs sync_lookup_ticks__lookup_end_tick %}
+Represents the new sync tick at time of updating lookup pending records.
+{% enddocs %}

--- a/database/model/public/sync_lookup_ticks.md
+++ b/database/model/public/sync_lookup_ticks.md
@@ -7,5 +7,5 @@ Represents the previous lookup up to tick.
 {% enddocs %}
 
 {% docs sync_lookup_ticks__lookup_end_tick %}
-Represents the new sync tick at time of updating lookup pending records.
+Represents the new sync tick at time of updating lookup-pending records.
 {% enddocs %}

--- a/database/model/public/sync_lookup_ticks.yml
+++ b/database/model/public/sync_lookup_ticks.yml
@@ -1,0 +1,24 @@
+version: 2
+sources:
+  - name: tamanu
+    schema: public
+    description: "{{ doc('generic__schema') }}"
+    tables:
+      - name: sync_lookup_ticks
+        description: '{{ doc("table__sync_lookup_ticks") }}'
+        tags: []
+        columns:
+          - name: id
+            data_type: bigint
+            description: "{{ doc('generic__id') }} in sync_lookup_ticks."
+          - name: source_start_tick
+            data_type: bigint
+            description: "{{ doc('sync_lookup_ticks__source_start_tick') }}"
+            data_tests:
+              - not_null
+          - name: lookup_end_tick
+            data_type: bigint
+            description: "{{ doc('sync_lookup_ticks__lookup_end_tick') }}"
+            data_tests:
+              - unique
+              - not_null

--- a/packages/database/src/migrations/1744234388449-addPatientProgramRegistrationInactiveFields.ts
+++ b/packages/database/src/migrations/1744234388449-addPatientProgramRegistrationInactiveFields.ts
@@ -1,0 +1,61 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Step 1: Add new columns
+  await query.addColumn('patient_program_registrations', 'deactivated_clinician_id', {
+    type: DataTypes.STRING,
+    allowNull: true,
+    references: {
+      model: 'users',
+      key: 'id',
+    },
+  });
+
+  await query.addColumn('patient_program_registrations', 'deactivated_date', {
+    type: DataTypes.STRING,
+    allowNull: true,
+  });
+
+  // Step 2: Update deactivation fields for inactive most recent registrations
+  await query.sequelize.query(`
+    UPDATE patient_program_registrations current
+    SET
+      deactivated_date = current.date,
+      deactivated_clinician_id = current.clinician_id
+    WHERE
+      registration_status = 'inactive'
+      AND is_most_recent = TRUE;
+  `);
+
+  // Step 3: Update date and clinician_id to earliest registration for inactive registrations
+  await query.sequelize.query(`
+    WITH earliest_registrations AS (
+      SELECT DISTINCT ON (patient_id, program_registry_id)
+        id,
+        date,
+        clinician_id,
+        patient_id,
+        program_registry_id
+      FROM patient_program_registrations
+      ORDER BY
+        patient_id,
+        program_registry_id,
+        date ASC
+    )
+    UPDATE patient_program_registrations current
+    SET
+      date = er.date,
+      clinician_id = er.clinician_id
+    FROM earliest_registrations er
+    WHERE
+      current.patient_id = er.patient_id
+      AND current.program_registry_id = er.program_registry_id
+      AND current.registration_status = 'inactive'
+      AND is_most_recent = TRUE;
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn('patient_program_registrations', 'deactivated_clinician_id');
+  await query.removeColumn('patient_program_registrations', 'deactivated_date');
+}

--- a/packages/database/src/models/PatientProgramRegistration.ts
+++ b/packages/database/src/models/PatientProgramRegistration.ts
@@ -15,6 +15,8 @@ export class PatientProgramRegistration extends Model {
   declare registeringFacilityId?: string;
   declare facilityId?: string;
   declare villageId?: string;
+  declare deactivatedClinicianId?: string;
+  declare deactivatedDate?: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -29,6 +31,9 @@ export class PatientProgramRegistration extends Model {
           type: DataTypes.TEXT,
           defaultValue: REGISTRATION_STATUSES.ACTIVE,
         },
+        deactivatedDate: dateTimeType('deactivatedDate', {
+          allowNull: true,
+        }),
       },
       {
         ...options,
@@ -42,6 +47,7 @@ export class PatientProgramRegistration extends Model {
       'programRegistry',
       'clinicalStatus',
       'clinician',
+      'deactivatedClinician',
       'registeringFacility',
       'facility',
       'village',
@@ -49,7 +55,7 @@ export class PatientProgramRegistration extends Model {
   }
 
   static getListReferenceAssociations() {
-    return ['clinicalStatus', 'clinician'];
+    return ['clinicalStatus', 'clinician', 'deactivatedClinician'];
   }
 
   static initRelations(models: Models) {
@@ -71,6 +77,11 @@ export class PatientProgramRegistration extends Model {
     this.belongsTo(models.User, {
       foreignKey: { name: 'clinicianId', allowNull: false },
       as: 'clinician',
+    });
+
+    this.belongsTo(models.User, {
+      foreignKey: 'deactivatedClinicianId',
+      as: 'deactivatedClinician',
     });
 
     this.belongsTo(models.Facility, {
@@ -102,7 +113,7 @@ export class PatientProgramRegistration extends Model {
         registrationStatus: { [Op.ne]: REGISTRATION_STATUSES.RECORDED_IN_ERROR },
         patientId,
       },
-      include: ['clinicalStatus', 'programRegistry'],
+      include: ['clinicalStatus', 'programRegistry', 'deactivatedClinician'],
       order: [
         // "active" > "removed"
         ['registrationStatus', 'ASC'],

--- a/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -946,6 +946,12 @@ describe('PatientProgramRegistration', () => {
             name: 'Test Status',
           }),
         );
+        const clinicalStatus2 = await models.ProgramRegistryClinicalStatus.create(
+          fake(models.ProgramRegistryClinicalStatus, {
+            programRegistryId: programRegistry.id,
+            name: 'Test Status 2',
+          }),
+        );
 
         // Create initial registration
         const registration = await models.PatientProgramRegistration.create(
@@ -961,7 +967,7 @@ describe('PatientProgramRegistration', () => {
 
         // Update registration
         await registration.update({
-          registrationStatus: REGISTRATION_STATUSES.INACTIVE,
+          clinicalStatusId: clinicalStatus2.id,
           date: TEST_DATE_LATE,
         });
 
@@ -987,8 +993,7 @@ describe('PatientProgramRegistration', () => {
 
         // Check the first entry (most recent)
         const latestEntry = history[0];
-        expect(latestEntry).toHaveProperty('registrationStatus', REGISTRATION_STATUSES.INACTIVE);
-        expect(latestEntry).toHaveProperty('clinicalStatusId', clinicalStatus.id);
+        expect(latestEntry).toHaveProperty('clinicalStatusId', clinicalStatus2.id);
         expect(latestEntry).toHaveProperty('registrationDate', TEST_DATE_LATE);
       });
     });

--- a/packages/mobile/App/migrations/1744234389088-addPatientProgramRegistrationInactiveFields.ts
+++ b/packages/mobile/App/migrations/1744234389088-addPatientProgramRegistrationInactiveFields.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+const TABLE_NAME = 'patient_program_registrations';
+
+export class addPatientProgramRegistrationInactiveFields1744234389088
+  implements MigrationInterface
+{
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const tableObject = await getTable(queryRunner, TABLE_NAME);
+
+    // Add deactivatedClinicianId column
+    await queryRunner.addColumn(
+      tableObject,
+      new TableColumn({
+        name: 'deactivatedClinicianId',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+
+    // Add foreign key for deactivatedClinicianId
+    await queryRunner.createForeignKey(
+      TABLE_NAME,
+      new TableForeignKey({
+        columnNames: ['deactivatedClinicianId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'SET NULL',
+      }),
+    );
+
+    // Add deactivatedDate column
+    await queryRunner.addColumn(
+      tableObject,
+      new TableColumn({
+        name: 'deactivatedDate',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop foreign key for deactivatedClinicianId
+    const table = await getTable(queryRunner, TABLE_NAME);
+    const foreignKey = table.foreignKeys.find(
+      (fk) => fk.columnNames.indexOf('deactivatedClinicianId') !== -1,
+    );
+    if (foreignKey) {
+      await queryRunner.dropForeignKey(TABLE_NAME, foreignKey);
+    }
+
+    // Drop columns
+    await queryRunner.dropColumn(TABLE_NAME, 'deactivatedClinician_id');
+    await queryRunner.dropColumn(TABLE_NAME, 'deactivatedDate');
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -63,6 +63,7 @@ import { addPatientProgramRegistrationConditionCategoryColumn1739395962000 } fro
 import { addPatientProgramRegistrationReasonForChange1740342611000 } from './1740342611000-addPatientProgramRegistrationReasonForChange';
 import { addPatientProgramRegistrationId1743640327000 } from './1743640327000-addPatientProgramRegistrationId';
 import { removeIsMostRecentFromPatientProgramRegistrations1744754327000 } from './1744754327000-removeIsMostRecentFromPatientProgramRegistrations';
+import { addPatientProgramRegistrationInactiveFields1747346950000 } from './1744234389088-addPatientProgramRegistrationInactiveFields';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -129,4 +130,5 @@ export const migrationList = [
   addPatientProgramRegistrationReasonForChange1740342611000,
   addPatientProgramRegistrationId1743640327000,
   removeIsMostRecentFromPatientProgramRegistrations1744754327000,
+  addPatientProgramRegistrationInactiveFields1747346950000,
 ];

--- a/packages/mobile/App/models/PatientProgramRegistration.ts
+++ b/packages/mobile/App/models/PatientProgramRegistration.ts
@@ -85,15 +85,19 @@ export class PatientProgramRegistration extends BaseModel implements IPatientPro
   @RelationId(({ clinician }) => clinician)
   clinicianId: ID;
 
+  @ManyToOne(() => User, undefined, { nullable: true })
+  deactivatedClinician?: IUser;
+  @RelationId(({ deactivatedClinician }) => deactivatedClinician)
+  deactivatedClinicianId?: ID;
+
+  @Column({ type: 'varchar', nullable: true })
+  deactivatedDate?: DateTimeString;
+
   @OneToMany<PatientProgramRegistrationCondition>(
     () => PatientProgramRegistrationCondition,
     ({ patientProgramRegistration }) => patientProgramRegistration,
   )
   conditions: IPatientProgramRegistrationCondition[];
-
-  // dateRemoved: DateTimeString;
-  // removedBy?: IUser;
-  // removedById?: ID;
 
   @BeforeInsert()
   async markPatientForSync(): Promise<void> {

--- a/packages/mobile/App/types/IPatientProgramRegistration.ts
+++ b/packages/mobile/App/types/IPatientProgramRegistration.ts
@@ -33,5 +33,10 @@ export interface IPatientProgramRegistration {
   villageId?: ID;
   village?: IReferenceData;
 
+  deactivatedClinicianId?: ID;
+  deactivatedClinician?: IUser;
+
+  deactivatedDate?: DateTimeString;
+
   conditions: IPatientProgramRegistrationCondition[];
 }

--- a/packages/web/app/features/ProgramRegistry/ConditionHistoryModal.jsx
+++ b/packages/web/app/features/ProgramRegistry/ConditionHistoryModal.jsx
@@ -21,6 +21,13 @@ const StyledFormTable = styled(FormTable)`
 
   table tr td {
     border: none;
+
+    // This table doesn't have form fields so don't need to move the spans and buttons down for alignment
+    > span,
+    > button {
+      position: static;
+      top: 0;
+    }
   }
 `;
 

--- a/packages/web/app/views/programRegistry/RemoveProgramRegistryFormModal.jsx
+++ b/packages/web/app/views/programRegistry/RemoveProgramRegistryFormModal.jsx
@@ -11,6 +11,7 @@ import {
 import { Colors } from '../../constants';
 import { TranslatedReferenceData } from '../../components/Translation';
 import { useUpdateProgramRegistryMutation } from '../../api/mutations';
+import { useAuth } from '../../contexts/Auth';
 
 const WarningDiv = styled.div`
   display: flex;
@@ -63,12 +64,14 @@ const Value = styled.div`
 
 export const RemoveProgramRegistryFormModal = ({ patientProgramRegistration, onClose, open }) => {
   const { patientId, id } = patientProgramRegistration;
+  const { currentUser } = useAuth();
   const { mutateAsync } = useUpdateProgramRegistryMutation(patientId, id);
 
   if (!patientProgramRegistration) return <></>;
 
   const remove = async () => {
     await mutateAsync({
+      clinicianId: currentUser?.id,
       registrationStatus: REGISTRATION_STATUSES.INACTIVE,
     });
     onClose();


### PR DESCRIPTION
### Changes

- Add new deactivated_clinician_id and deactivated_date fields to patient program registrations table to track de activated state which used to be in registrations history table
- Populate current inactive registrations from historical records
- Update models with new fields
- Update api to use new fields

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
