### PR TITLE
tweak(fhir): no-issue: Bump default fhir _count parameter settings to more reasonable values

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -348,8 +348,8 @@
       },
       "parameters": {
         "_count": {
-          "default": 20,
-          "max": 20
+          "default": 100,
+          "max": 1000
         }
       },
       "extensions": {


### PR DESCRIPTION
### Changes

20 is such a low max by default, has caught me out a few times.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
