### PR TITLE
tweak(mobile): NASS-1596: Parameterize mobile suggester

### DIFF
--- a/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
@@ -44,17 +44,17 @@ export const SurveyQuestionAutocomplete = (props): JSX.Element => {
   const where = useSurveyAutocompleteWhere(props.config);
   const { source } = props.config;
 
-  const suggester = new Suggester(
-    models[source],
-    {
+  const suggester = new Suggester({
+    model: models[source],
+    options: {
       where,
       column: getNameColumnForModel(source),
     },
-    val => ({
+    formatter: (val) => ({
       label: getDisplayNameForModel(source, val),
       value: val.id,
     }),
-  );
+  });
 
   return (
     <AutocompleteModalField

--- a/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
@@ -21,32 +21,44 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
   const [labTestTypes, setLabTestTypes] = useState([]);
   const { models } = useBackend();
 
-  const labRequestCategorySuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.LabTestCategory,
+  const labRequestCategorySuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.LabTestCategory,
+      },
     },
   });
-  const labRequestPrioritySuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.LabTestPriority,
+  const labRequestPrioritySuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.LabTestPriority,
+      },
     },
   });
-  const labSampleSiteSuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.LabSampleSite,
+  const labSampleSiteSuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.LabSampleSite,
+      },
     },
   });
-  const specimenTypeSuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.SpecimenType,
+  const specimenTypeSuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.SpecimenType,
+      },
     },
   });
 
-  const practitionerSuggester = new Suggester(
-    models.User,
-    { column: 'displayName' },
-    (model): OptionType => ({ label: model.displayName, value: model.id }),
-  );
+  const practitionerSuggester = new Suggester({
+    model: models.User,
+    options: { column: 'displayName' },
+    formatter: (model): OptionType => ({ label: model.displayName, value: model.id }),
+  });
 
   const handleLabRequestTypeSelected = useCallback(async (selectedValue) => {
     const where: any = {

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
@@ -16,9 +16,12 @@ export const LocationDetailsSection = (): ReactElement => {
   const { getTranslation } = useTranslation();
   const { getSetting } = useSettings();
 
-  const villageSuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.Village,
+  const villageSuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.Village,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
+++ b/packages/mobile/App/ui/components/Forms/PatientAdditionalDataForm/helpers.ts
@@ -129,9 +129,12 @@ export const getSuggester = (
   models: typeof MODELS_MAP,
   type: string,
 ): Suggester<typeof ReferenceData> =>
-  new Suggester(models.ReferenceData, {
-    where: {
-      type,
+  new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from '~/ui/contexts/TranslationContext';
 const InjectionSiteDropdown = ({ value, label, onChange, selectPlaceholderText }): JSX.Element => (
   <Dropdown
     value={value}
-    options={INJECTION_SITE_OPTIONS.map(o => ({ label: o, value: o }))}
+    options={INJECTION_SITE_OPTIONS.map((o) => ({ label: o, value: o }))}
     onChange={onChange}
     label={label}
     selectPlaceholderText={selectPlaceholderText}
@@ -95,9 +95,12 @@ export const DepartmentField = ({ navigation }: NavigationFieldProps): JSX.Eleme
   const { models } = useBackend();
   const { facilityId } = useFacility();
 
-  const departmentSuggester = new Suggester(models.Department, {
-    where: {
-      facility: facilityId,
+  const departmentSuggester = new Suggester({
+    model: models.Department,
+    options: {
+      where: {
+        facility: facilityId,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/components/HierarchyFieldItem.tsx
+++ b/packages/mobile/App/ui/components/HierarchyFieldItem.tsx
@@ -17,23 +17,22 @@ export const HierarchyFieldItem = ({
   const { models } = useBackend();
   const { setFieldValue, dirty } = useFormikContext();
 
-  const suggesterInstance = new Suggester(
-    models.ReferenceData,
-    {
+  const suggesterInstance = new Suggester({
+    model: models.ReferenceData,
+    options: {
       where: {
         type: referenceType,
       },
       relations: ['parents'],
     },
-    undefined,
-    (item: IReferenceData) => {
+    filter: (item: IReferenceData) => {
       if (isFirstLevel || !parentId) {
         return true;
       }
       const parent = item.parents[0];
       return parent?.referenceDataParentId === parentId && parent?.type === relationType;
     },
-  );
+  });
 
   // Clear the value of the field when the parent field changes
   useEffect(() => {

--- a/packages/mobile/App/ui/components/LocationField.tsx
+++ b/packages/mobile/App/ui/components/LocationField.tsx
@@ -20,16 +20,22 @@ export const LocationField: React.FC<LocationFieldProps> = ({ navigation, requir
   const { models } = useBackend();
   const { facilityId } = useFacility();
 
-  const locationGroupSuggester = new Suggester(models.LocationGroup, {
-    where: {
-      facility: facilityId,
+  const locationGroupSuggester = new Suggester({
+    model: models.LocationGroup,
+    options: {
+      where: {
+        facility: facilityId,
+      },
     },
   });
 
-  const locationSuggester = new Suggester(models.Location, {
-    where: {
-      facility: facilityId,
-      locationGroup: values.locationGroupId,
+  const locationSuggester = new Suggester({
+    model: models.Location,
+    options: {
+      where: {
+        facility: facilityId,
+        locationGroup: values.locationGroupId,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -50,11 +50,6 @@ export interface SuggesterConfig<ModelType> {
   options: SuggesterOptions<ModelType>;
   formatter?: (entity: BaseModel) => OptionType;
   filter?: (entity: BaseModel) => boolean;
-  hierarchyOptions?: {
-    parentId?: string;
-    relationType?: string;
-    isFirstLevel?: boolean;
-  };
 }
 
 export class Suggester<ModelType> {

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -45,8 +45,19 @@ const replaceDataLabelsWithTranslations = ({ data, translations }) => {
     name: translationsByDataId[item.id]?.text ?? item.name,
   }));
 };
+export interface SuggesterConfig<ModelType> {
+  model: ModelType;
+  options: SuggesterOptions<ModelType>;
+  formatter?: (entity: BaseModel) => OptionType;
+  filter?: (entity: BaseModel) => boolean;
+  hierarchyOptions?: {
+    parentId?: string;
+    relationType?: string;
+    isFirstLevel?: boolean;
+  };
+}
 
-export class Suggester<ModelType extends BaseModelSubclass> {
+export class Suggester<ModelType> {
   model: ModelType;
 
   options: SuggesterOptions<ModelType>;
@@ -59,19 +70,14 @@ export class Suggester<ModelType extends BaseModelSubclass> {
 
   cachedData: any;
 
-  constructor(
-    model: ModelType,
-    options,
-    formatter = defaultFormatter,
-    filter?: (entity: BaseModel) => boolean,
-  ) {
-    this.model = model;
-    this.options = options;
+  constructor(config: SuggesterConfig<ModelType>) {
+    this.model = config.model;
+    this.options = config.options;
     // If you don't provide a formatter, this assumes that your model has "name" and "id" fields
-    this.formatter = formatter;
+    this.formatter = config.formatter || defaultFormatter;
     // Frontend filter applied to the data received. Use this to filter by permission
     // by the model id: ({ id }) => ability.can('read', subject('noun', { id })),
-    this.filter = filter;
+    this.filter = config.filter;
     this.lastUpdatedAt = -Infinity;
     this.cachedData = null;
   }

--- a/packages/mobile/App/ui/helpers/suggester.ts
+++ b/packages/mobile/App/ui/helpers/suggester.ts
@@ -52,7 +52,7 @@ export interface SuggesterConfig<ModelType> {
   filter?: (entity: BaseModel) => boolean;
 }
 
-export class Suggester<ModelType> {
+export class Suggester<ModelType extends BaseModelSubclass> {
   model: ModelType;
 
   options: SuggesterOptions<ModelType>;

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
@@ -25,16 +25,15 @@ export const ProgramRegistrySection = (): ReactElement => {
   const { ability } = useAuth();
   const { getTranslation } = useTranslation();
 
-  const ProgramRegistrySuggester = new Suggester(
-    models.ProgramRegistry,
-    {
+  const ProgramRegistrySuggester = new Suggester({
+    model: models.ProgramRegistry,
+    options: {
       where: {
         visibilityStatus: VisibilityStatus.Current,
       },
     },
-    undefined,
-    ({ id }) => ability.can('read', subject('ProgramRegistry', { id })),
-  );
+    formatter: ({ id }) => ability.can('read', subject('ProgramRegistry', { id })),
+  });
 
   const [programRegistries, programRegistryError, isProgramRegistryLoading] = useBackendEffect(
     async ({ models }) => {

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
@@ -32,7 +32,7 @@ export const ProgramRegistrySection = (): ReactElement => {
         visibilityStatus: VisibilityStatus.Current,
       },
     },
-    formatter: ({ id }) => ability.can('read', subject('ProgramRegistry', { id })),
+    filter: ({ id }) => ability.can('read', subject('ProgramRegistry', { id })),
   });
 
   const [programRegistries, programRegistryError, isProgramRegistryLoading] = useBackendEffect(

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
@@ -16,9 +16,12 @@ export const VillageSection = (): ReactElement => {
   const navigation = useNavigation();
   const { models } = useBackend();
 
-  const villageSuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.Village,
+  const villageSuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.Village,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/AddIllnessDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/AddIllnessDetails.tsx
@@ -45,41 +45,45 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
 
   const user = useSelector(authUserSelector);
 
-  const onRecordIllness = useCallback(async ({ diagnosis, certainty, clinicalNote }: any): Promise<
-    any
-  > => {
-    const encounter = await models.Encounter.getOrCreateCurrentEncounter(
-      selectedPatient.id,
-      user.id,
-    );
+  const onRecordIllness = useCallback(
+    async ({ diagnosis, certainty, clinicalNote }: any): Promise<any> => {
+      const encounter = await models.Encounter.getOrCreateCurrentEncounter(
+        selectedPatient.id,
+        user.id,
+      );
 
-    if (diagnosis) {
-      await models.Diagnosis.createAndSaveOne({
-        // TODO: support selecting multiple diagnoses and flagging as primary/non primary
-        isPrimary: true,
-        encounter: encounter.id,
-        date: getCurrentDateTimeString(),
-        diagnosis,
-        certainty,
-      });
-    }
+      if (diagnosis) {
+        await models.Diagnosis.createAndSaveOne({
+          // TODO: support selecting multiple diagnoses and flagging as primary/non primary
+          isPrimary: true,
+          encounter: encounter.id,
+          date: getCurrentDateTimeString(),
+          diagnosis,
+          certainty,
+        });
+      }
 
-    if (clinicalNote) {
-      await models.Note.createForRecord({
-        recordId: encounter.id,
-        recordType: NOTE_RECORD_TYPES.ENCOUNTER,
-        noteType: NOTE_TYPES.CLINICAL_MOBILE,
-        content: clinicalNote,
-        author: user.id,
-      });
-    }
+      if (clinicalNote) {
+        await models.Note.createForRecord({
+          recordId: encounter.id,
+          recordType: NOTE_RECORD_TYPES.ENCOUNTER,
+          noteType: NOTE_TYPES.CLINICAL_MOBILE,
+          content: clinicalNote,
+          author: user.id,
+        });
+      }
 
-    navigateToHistory();
-  }, []);
+      navigateToHistory();
+    },
+    [],
+  );
 
-  const diagnosisSuggester = new Suggester(models.ReferenceData, {
-    where: {
-      type: ReferenceDataType.Diagnosis,
+  const diagnosisSuggester = new Suggester({
+    model: models.ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.Diagnosis,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
@@ -58,9 +58,12 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
     navigateToHistory();
   }, []);
 
-  const medicationSuggester = new Suggester(ReferenceData, {
-    where: {
-      type: ReferenceDataType.Drug,
+  const medicationSuggester = new Suggester({
+    model: ReferenceData,
+    options: {
+      where: {
+        type: ReferenceDataType.Drug,
+      },
     },
   });
 

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
@@ -23,26 +23,35 @@ import { useBackendEffect } from '~/ui/hooks/index';
 import { PatientProgramRegistrationCondition } from '~/models/PatientProgramRegistrationCondition';
 import { Routes } from '~/ui/helpers/routes';
 import { TranslatedText } from '~/ui/components/Translations/TranslatedText';
-import { TranslatedReferenceData, getReferenceDataStringId } from '~/ui/components/Translations/TranslatedReferenceData';
+import {
+  TranslatedReferenceData,
+  getReferenceDataStringId,
+} from '~/ui/components/Translations/TranslatedReferenceData';
 import { useTranslation } from '~/ui/contexts/TranslationContext';
 
 export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: BaseAppProps) => {
   const { programRegistry, editedObject, selectedPatient } = route.params;
   const { getTranslation } = useTranslation();
   const { models } = useBackend();
-  const practitionerSuggester = new Suggester(
-    models.User,
-    { column: 'displayName' },
-    (model): OptionType => ({ label: model.displayName, value: model.id }),
-  );
-  const facilitySuggester = new Suggester(models.Facility, {
-    where: {
-      visibilityStatus: VisibilityStatus.Current,
+  const practitionerSuggester = new Suggester({
+    model: models.User,
+    options: { column: 'displayName' },
+    formatter: (model): OptionType => ({ label: model.displayName, value: model.id }),
+  });
+  const facilitySuggester = new Suggester({
+    model: models.Facility,
+    options: {
+      where: {
+        visibilityStatus: VisibilityStatus.Current,
+      },
     },
   });
-  const conditionSuggester = new Suggester(models.ProgramRegistryCondition, {
-    where: {
-      programRegistry: programRegistry.id,
+  const conditionSuggester = new Suggester({
+    model: models.ProgramRegistryCondition,
+    options: {
+      where: {
+        programRegistry: programRegistry.id,
+      },
     },
   });
 
@@ -55,13 +64,13 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
         },
       });
 
-      return statuses.map(status => {
+      return statuses.map((status) => {
         const translatedName = getTranslation(
           getReferenceDataStringId(status.id, 'programRegistryClinicalStatus'),
           status.name,
         );
         return {
-            ...status,
+          ...status,
           translatedName,
         };
       });
@@ -192,7 +201,10 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
                     component={Dropdown}
                     name="clinicalStatusId"
                     options={
-                      clinicalStatusOptions?.map((x) => ({ label: x.translatedName, value: x.id })) || []
+                      clinicalStatusOptions?.map((x) => ({
+                        label: x.translatedName,
+                        value: x.id,
+                      })) || []
                     }
                   />
                 </StyledView>
@@ -206,20 +218,16 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
                     }
                     labelFontSize={14}
                     component={MultiSelectModalField}
-                    modalTitle={
-                      getTranslation('programRegistry.conditions.label', 'Conditions')
-                    }
+                    modalTitle={getTranslation('programRegistry.conditions.label', 'Conditions')}
                     suggester={conditionSuggester}
                     placeholder={getTranslation('general.placeholder.search', 'Search')}
                     navigation={navigation}
                     name="conditions"
                     value={values.conditions}
-                    searchPlaceholder={
-                      getTranslation(
-                        'programRegistry.search.conditions',
-                        'Search conditions...',
-                      )
-                    }
+                    searchPlaceholder={getTranslation(
+                      'programRegistry.search.conditions',
+                      'Search conditions...',
+                    )}
                   />
                 </StyledView>
                 <Button


### PR DESCRIPTION
### Changes

This has been broken off to simplify a bigger pr (NASS-1596) that introduces location hierarchy to mobile. This suggester class already has too many arguments and we add more in that pr so here I am parameterising to make calling suggesters clearer

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
