### PR TITLE
tweak(syncLookup): no-issue: Enable sync lookup by default

### DIFF
--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -517,6 +517,12 @@ export class CentralSyncManager {
   async checkPullReady(sessionId) {
     await this.connectToSession(sessionId);
 
+    // if the sync_lookup table is enabled, wait until it has finished its first update run
+    const syncLookupUpToTick = await this.store.models.LocalSystemFact.get(FACT_LOOKUP_UP_TO_TICK);
+    if (this.constructor.config.sync.lookupTable.enabled && syncLookupUpToTick === undefined) {
+      return false;
+    }
+
     // if this snapshot still processing, return false to tell the client to keep waiting
     const snapshotIsProcessing = await this.checkSessionIsProcessing(sessionId);
     if (snapshotIsProcessing) {

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -79,7 +79,7 @@
     "syncSessionTimeoutMs": null,
     snapshotTransactionTimeoutMs: null,
     "lookupTable": {
-      "enabled": false,
+      "enabled": true,
       "perModelUpdateTimeoutMs": null,
       "avoidRepull": true
     }


### PR DESCRIPTION
### Changes

Fix written by Edwin. Reason this was defaulted to `false` was because it would break autodeploys. This new line on centralSyncManager fixes that by waiting until the syncSnapshot table has initialised before syncing

edit: passed test on deploy ✅ 

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
