### PR TITLE
fix(medication): EPI-1101: Fix wrong pause and discontinue date when setting different timezone

### DIFF
--- a/packages/web/app/components/Medication/Mar/ChangeStatusModal.jsx
+++ b/packages/web/app/components/Medication/Mar/ChangeStatusModal.jsx
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import { Box, Divider } from '@material-ui/core';
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { format } from 'date-fns';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 import {
   Field,
   Form,
@@ -146,7 +146,7 @@ export const ChangeStatusModal = ({ open, onClose, medication, marInfo, timeSlot
       await updateMarToGiven({
         dose: {
           doseAmount: Number(doseAmount),
-          givenTime: format(givenTime, 'yyyy-MM-dd HH:mm:ss'),
+          givenTime: toDateTimeString(givenTime),
           givenByUserId,
           recordedByUserId,
         },

--- a/packages/web/app/components/Medication/Mar/EditAdministrationRecordModal.jsx
+++ b/packages/web/app/components/Medication/Mar/EditAdministrationRecordModal.jsx
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import { Box, Divider } from '@material-ui/core';
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { format } from 'date-fns';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { Field, Form, TextField, NumberField, AutocompleteField } from '../../Field';
 import { FormGrid } from '../../FormGrid';
 import { ConfirmCancelRow, FormModal, TranslatedText } from '../..';
@@ -139,7 +139,7 @@ export const EditAdministrationRecordModal = ({
       }
       await updateMarDose({
         doseAmount: Number(doseAmount),
-        givenTime: format(givenTime, 'yyyy-MM-dd HH:mm:ss'),
+        givenTime: toDateTimeString(givenTime),
         givenByUserId,
         recordedByUserId,
         reasonForChange,

--- a/packages/web/app/components/Medication/Mar/MarDetails.jsx
+++ b/packages/web/app/components/Medication/Mar/MarDetails.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { getDose } from '@tamanu/shared/utils/medication';
 import * as yup from 'yup';
 import { FieldArray } from 'formik';
-import { format } from 'date-fns';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { Colors, FORM_TYPES } from '../../../constants';
 import { Button, OutlinedButton } from '../../Button';
 import { MarInfoPane } from './MarInfoPane';
@@ -243,7 +243,7 @@ export const MarDetails = ({
       ...data,
       doses: data.doses.map(dose => ({
         ...dose,
-        givenTime: format(dose.givenTime, 'yyyy-MM-dd HH:mm:ss'),
+        givenTime: toDateTimeString(dose.givenTime),
         doseAmount: Number(dose.doseAmount),
       })),
     });

--- a/packages/web/app/components/Medication/Mar/StatusPopper.jsx
+++ b/packages/web/app/components/Medication/Mar/StatusPopper.jsx
@@ -5,7 +5,8 @@ import { Divider, Popper, Paper, ClickAwayListener, Fade, IconButton } from '@ma
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import { getDateFromTimeString } from '@tamanu/shared/utils/medication';
-import { addHours, format, set } from 'date-fns';
+import { addHours, set } from 'date-fns';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 import * as yup from 'yup';
 import { Colors } from '../../../constants';
 import { TranslatedText } from '../../Translation';
@@ -289,11 +290,11 @@ const GivenScreen = ({
     });
     const dueAt = addHours(getDateFromTimeString(timeSlot.startTime, selectedDate), 1);
     await updateMarToGiven({
-      dueAt: format(dueAt, 'yyyy-MM-dd HH:mm:ss'),
+      dueAt: toDateTimeString(dueAt),
       prescriptionId,
       dose: {
         doseAmount,
-        givenTime: format(givenTime, 'yyyy-MM-dd HH:mm:ss'),
+        givenTime: toDateTimeString(givenTime),
       },
     });
   };
@@ -447,7 +448,7 @@ export const StatusPopper = ({
     await updateMarToNotGiven({
       status: ADMINISTRATION_STATUS.NOT_GIVEN,
       reasonNotGivenId,
-      dueAt: format(dueAt, 'yyyy-MM-dd HH:mm:ss'),
+      dueAt: toDateTimeString(dueAt),
       prescriptionId,
     });
 

--- a/packages/web/app/components/Medication/MedicationDiscontinueModal.jsx
+++ b/packages/web/app/components/Medication/MedicationDiscontinueModal.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { Box } from '@mui/material';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { MedicationSummary } from './MedicationSummary';
 import {
   AutocompleteField,
@@ -44,7 +45,10 @@ export const MedicationDiscontinueModal = ({ medication, onDiscontinue, onClose 
   const practitionerSuggester = useSuggester('practitioner');
 
   const onSubmit = async data => {
-    const updatedMedication = await api.post(`medication/${medication.id}/discontinue`, data);
+    const updatedMedication = await api.post(`medication/${medication.id}/discontinue`, {
+      ...data,
+      discontinuingDate: getCurrentDateTimeString(),
+    });
     onDiscontinue(updatedMedication);
     onClose();
   };

--- a/packages/web/app/components/Medication/MedicationPauseModal.jsx
+++ b/packages/web/app/components/Medication/MedicationPauseModal.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { Box } from '@mui/material';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 import {
   BaseModal,
@@ -76,7 +77,10 @@ export const MedicationPauseModal = ({ medication, onPause, onClose }) => {
   const api = useApi();
 
   const onSubmit = async data => {
-    await api.post(`medication/${medication.id}/pause`, data);
+    await api.post(`medication/${medication.id}/pause`, {
+      ...data,
+      pauseStartDate: getCurrentDateTimeString(),
+    });
     onPause();
     onClose();
   };


### PR DESCRIPTION
### Changes

- Added optional fields for discontinuingDate and pauseStartDate in medication schemas.
- Updated API calls in MedicationDiscontinueModal and MedicationPauseModal to include the new date fields.
- Refactored date handling in medication-related components to ensure consistent datetime formatting using toDateTimeString.
- Improved overall data integrity and user experience when managing medication statuses.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
