### PR TITLE
fix: EPI-1102: Add MAR loader, generate infinite MARs for non-duration medication and hide paused due MARs

### DIFF
--- a/packages/central-server/app/tasks/GenerateMedicationAdministrationRecords.js
+++ b/packages/central-server/app/tasks/GenerateMedicationAdministrationRecords.js
@@ -32,7 +32,7 @@ export class GenerateMedicationAdministrationRecords extends ScheduledTask {
     const { Prescription, MedicationAdministrationRecord } = this.models;
     const baseQueryOptions = {
       where: {
-        endDate: { [Op.gt]: getCurrentDateTimeString() },
+        endDate: { [Op.or]: [{ [Op.gt]: getCurrentDateTimeString() }, { [Op.is]: null }] },
         discontinuedDate: null,
       },
     };

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -151,7 +151,9 @@ export class Encounter extends Model {
           afterUpdate: async (encounter: Encounter, opts) => {
             if (encounter.endDate && !encounter.previous('endDate')) {
               await models.Task.onEncounterDischarged(encounter, opts?.transaction ?? undefined);
-              await models.MedicationAdministrationRecord.onEncounterDischarged(encounter, opts?.transaction ?? undefined);
+              await models.MedicationAdministrationRecord.removeInvalidMedicationAdministrationRecords(
+                opts?.transaction,
+              );
             }
           },
         },

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -94,8 +94,7 @@ export class Prescription extends Model {
               );
             }
             if (prescription.changed('discontinued') && prescription.discontinued) {
-              await models.MedicationAdministrationRecord.onPrescriptionDiscontinued(
-                prescription,
+              await models.MedicationAdministrationRecord.removeInvalidMedicationAdministrationRecords(
                 options.transaction,
               );
             }

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -209,13 +209,6 @@ encounterRelations.get(
       include: [
         ...associations,
         {
-          model: models.Encounter,
-          as: 'encounters',
-          through: { attributes: [] },
-          where: { id: params.id },
-          attributes: ['id'],
-        },
-        {
           model: models.EncounterPrescription,
           as: 'encounterPrescription',
           include: {
@@ -227,8 +220,12 @@ encounterRelations.get(
                 [Op.gt]: getCurrentDateTimeString(),
               },
             },
+            required: false,
           },
-          attributes: ['id'],
+          attributes: ['id', 'encounterId', 'isDischarge'],
+          where: {
+            encounterId: params.id,
+          },
         },
       ],
     };

--- a/packages/web/app/components/Medication/Mar/MarStatus.jsx
+++ b/packages/web/app/components/Medication/Mar/MarStatus.jsx
@@ -330,21 +330,19 @@ export const MarStatus = ({
   };
 
   const renderStatus = () => {
-    if (!marInfo || isDiscontinued || isEnd || (!status && isPaused)) return null;
-    let color = Colors.green;
+    if (!marInfo || isEnd || isDiscontinued || (!status && isPaused)) return null;
     switch (status) {
       case ADMINISTRATION_STATUS.GIVEN:
         return (
-          <IconWrapper $color={color}>
+          <IconWrapper $color={Colors.green}>
             <CheckCircleIcon />
             {isAlert && <StyledPriorityHighIcon />}
             {isEdited && <EditedIcon>*</EditedIcon>}
           </IconWrapper>
         );
       case ADMINISTRATION_STATUS.NOT_GIVEN:
-        color = Colors.alert;
         return (
-          <IconWrapper $color={color}>
+          <IconWrapper $color={Colors.alert}>
             <CancelIcon />
             {isAlert && <StyledPriorityHighIcon />}
             {isEdited && <EditedIcon>*</EditedIcon>}
@@ -352,10 +350,8 @@ export const MarStatus = ({
         );
       default: {
         if (isPast) {
-          if (isPrn) return null;
-          color = Colors.darkOrange;
-          return (
-            <IconWrapper $color={color}>
+          return isPrn ? null : (
+            <IconWrapper $color={Colors.darkOrange}>
               <HelpOutlineIcon />
             </IconWrapper>
           );
@@ -385,8 +381,6 @@ export const MarStatus = ({
   };
 
   const getTooltipText = () => {
-    // Do not show tooltip for past due PRN medication as they are hidden
-    if (isPrn && isPast && !status) return null;
     if (isDiscontinued) {
       return (
         <Box maxWidth={69}>
@@ -472,7 +466,7 @@ export const MarStatus = ({
             );
           }
           if (isPast) {
-            return (
+            return isPrn ? null : (
               <Box maxWidth={69}>
                 <TranslatedText
                   stringId="medication.mar.missed.tooltip"

--- a/packages/web/app/components/Medication/Mar/MarStatus.jsx
+++ b/packages/web/app/components/Medication/Mar/MarStatus.jsx
@@ -330,7 +330,7 @@ export const MarStatus = ({
   };
 
   const renderStatus = () => {
-    if (!marInfo || isDiscontinued || (!status && isPaused)) return null;
+    if (!marInfo || isDiscontinued || isEnd || (!status && isPaused)) return null;
     let color = Colors.green;
     switch (status) {
       case ADMINISTRATION_STATUS.GIVEN:

--- a/packages/web/app/components/Medication/Mar/MarStatus.jsx
+++ b/packages/web/app/components/Medication/Mar/MarStatus.jsx
@@ -330,7 +330,7 @@ export const MarStatus = ({
   };
 
   const renderStatus = () => {
-    if (!marInfo || isDiscontinued) return null;
+    if (!marInfo || isDiscontinued || (!status && isPaused)) return null;
     let color = Colors.green;
     switch (status) {
       case ADMINISTRATION_STATUS.GIVEN:
@@ -402,6 +402,16 @@ export const MarStatus = ({
         <Box maxWidth={105}>
           <TranslatedText stringId="medication.mar.endsOn.tooltip" fallback="Ends on" />
           <div>{format(new Date(endDate), 'dd/MM/yyyy hh:mma').toLowerCase()}</div>
+        </Box>
+      );
+    }
+    if (isPaused && !status) {
+      return (
+        <Box maxWidth={69}>
+          <TranslatedText
+            stringId="medication.mar.medicationPaused.tooltip"
+            fallback="Medication paused"
+          />
         </Box>
       );
     }
@@ -486,16 +496,6 @@ export const MarStatus = ({
             </Box>
           );
       }
-    }
-    if (isPaused) {
-      return (
-        <Box maxWidth={69}>
-          <TranslatedText
-            stringId="medication.mar.medicationPaused.tooltip"
-            fallback="Medication paused"
-          />
-        </Box>
-      );
     }
     return null;
   };

--- a/packages/web/app/components/Medication/Mar/MarTable.jsx
+++ b/packages/web/app/components/Medication/Mar/MarTable.jsx
@@ -142,6 +142,15 @@ const CurrentTimeOverlay = styled.div`
   pointer-events: none;
 `;
 
+const LoadingContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  border-left: 1px solid ${Colors.outline};
+  height: 42px;
+`;
+
 const formatTime = time => {
   return format(time, 'ha').toLowerCase();
 };
@@ -171,9 +180,12 @@ export const MarTable = ({ selectedDate }) => {
   const scrollableContentRef = useRef(null);
   const [overlayHeight, setOverlayHeight] = useState('100%');
 
-  const { data: medicationsData } = useEncounterMedicationQuery(encounter?.id, {
-    marDate: toDateString(selectedDate),
-  });
+  const { data: medicationsData, isLoading: isLoadingMedications } = useEncounterMedicationQuery(
+    encounter?.id,
+    {
+      marDate: toDateString(selectedDate),
+    },
+  );
   const medications = (medicationsData?.data || []).sort((a, b) => {
     if (a.discontinued === b.discontinued) {
       return 0;
@@ -313,24 +325,34 @@ export const MarTable = ({ selectedDate }) => {
                 stringId="medication.mar.scheduledMedication.label"
               />
             </SubHeader>
-            <MedicationGrid>
-              {scheduledMedications.length ? (
-                scheduledMedications.map(medication => (
-                  <MarTableRow
-                    key={medication?.id}
-                    medication={medication}
-                    selectedDate={selectedDate}
-                  />
-                ))
-              ) : (
-                <EmptyMessage>
-                  <TranslatedText
-                    fallback="No scheduled medication to display"
-                    stringId="medication.mar.noScheduledMedication.label"
-                  />
-                </EmptyMessage>
-              )}
-            </MedicationGrid>
+            {isLoadingMedications ? (
+              <LoadingContainer>
+                <TranslatedText
+                  stringId="general.table.loading"
+                  fallback="Loading..."
+                  data-testid="translatedtext-yvlt"
+                />
+              </LoadingContainer>
+            ) : (
+              <MedicationGrid>
+                {scheduledMedications.length ? (
+                  scheduledMedications.map(medication => (
+                    <MarTableRow
+                      key={medication?.id}
+                      medication={medication}
+                      selectedDate={selectedDate}
+                    />
+                  ))
+                ) : (
+                  <EmptyMessage>
+                    <TranslatedText
+                      fallback="No scheduled medication to display"
+                      stringId="medication.mar.noScheduledMedication.label"
+                    />
+                  </EmptyMessage>
+                )}
+              </MedicationGrid>
+            )}
           </div>
 
           {/* PRN medications section */}
@@ -341,24 +363,34 @@ export const MarTable = ({ selectedDate }) => {
                 stringId="medication.mar.prnMedication.label"
               />
             </SubHeader>
-            <MedicationGrid>
-              {prnMedications.length ? (
-                prnMedications.map(medication => (
-                  <MarTableRow
-                    key={medication?.id}
-                    medication={medication}
-                    selectedDate={selectedDate}
-                  />
-                ))
-              ) : (
-                <EmptyMessage>
-                  <TranslatedText
-                    fallback="No PRN medication to display"
-                    stringId="medication.mar.noPrnMedication.label"
-                  />
-                </EmptyMessage>
-              )}
-            </MedicationGrid>
+            {isLoadingMedications ? (
+              <LoadingContainer>
+                <TranslatedText
+                  stringId="general.table.loading"
+                  fallback="Loading..."
+                  data-testid="translatedtext-yvlt"
+                />
+              </LoadingContainer>
+            ) : (
+              <MedicationGrid>
+                {prnMedications.length ? (
+                  prnMedications.map(medication => (
+                    <MarTableRow
+                      key={medication?.id}
+                      medication={medication}
+                      selectedDate={selectedDate}
+                    />
+                  ))
+                ) : (
+                  <EmptyMessage>
+                    <TranslatedText
+                      fallback="No PRN medication to display"
+                      stringId="medication.mar.noPrnMedication.label"
+                    />
+                  </EmptyMessage>
+                )}
+              </MedicationGrid>
+            )}
           </div>
         </ScrollableContent>
       </MedicationContainer>

--- a/packages/web/app/components/Medication/Mar/StatusPopper.jsx
+++ b/packages/web/app/components/Medication/Mar/StatusPopper.jsx
@@ -214,11 +214,16 @@ const MainScreen = ({ onGivenClick, onNotGivenClick }) => {
   );
 };
 
-const ReasonScreen = ({ reasonsNotGiven, onReasonSelect }) => {
+const ReasonScreen = ({ reasonsNotGiven, onReasonSelect, isUpdatingMarToNotGiven }) => {
   return (
     <PopperContent>
       {reasonsNotGiven?.data?.map(reason => (
-        <Button key={reason.id} variant="outlined" onClick={() => onReasonSelect(reason.id)}>
+        <Button
+          key={reason.id}
+          variant="outlined"
+          onClick={() => onReasonSelect(reason.id)}
+          disabled={isUpdatingMarToNotGiven}
+        >
           <TranslatedText stringId={reason.name} fallback={reason.name} />
         </Button>
       ))}
@@ -251,13 +256,16 @@ const GivenScreen = ({
     }
   }, []);
 
-  const { mutateAsync: updateMarToGiven } = useGivenMarMutation(marId, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['encounterMedication', encounter?.id]);
-      queryClient.invalidateQueries(['marDoses', marId]);
-      onClose();
+  const { mutateAsync: updateMarToGiven, isLoading: isUpdatingMarToGiven } = useGivenMarMutation(
+    marId,
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['encounterMedication', encounter?.id]);
+        queryClient.invalidateQueries(['marDoses', marId]);
+        onClose();
+      },
     },
-  });
+  );
   const handleDecreaseDose = (doseAmount, setFieldValue) => {
     if (doseAmount <= 0.25) return;
     setFieldValue('doseAmount', doseAmount - 0.25);
@@ -369,7 +377,8 @@ const GivenScreen = ({
                 onClick={submitForm}
                 variant="outlined"
                 size="small"
-                disabled={!values.doseAmount}
+                disabled={!values.doseAmount || isUpdatingMarToGiven}
+                isSubmitting={isUpdatingMarToGiven}
               >
                 <TranslatedText stringId="general.action.confirm" fallback="Confirm" />
               </ConfirmButton>
@@ -423,7 +432,10 @@ export const StatusPopper = ({
   const [showReasonScreen, setShowReasonScreen] = useState(false);
   const [showGivenScreen, setShowGivenScreen] = useState(false);
 
-  const { mutateAsync: updateMarToNotGiven } = useNotGivenMarMutation(marId, {
+  const {
+    mutateAsync: updateMarToNotGiven,
+    isLoading: isUpdatingMarToNotGiven,
+  } = useNotGivenMarMutation(marId, {
     onSuccess: () => {
       queryClient.invalidateQueries(['encounterMedication', encounter?.id]);
     },
@@ -463,7 +475,13 @@ export const StatusPopper = ({
 
   const getContent = () => {
     if (showReasonScreen) {
-      return <ReasonScreen reasonsNotGiven={reasonsNotGiven} onReasonSelect={handleReasonSelect} />;
+      return (
+        <ReasonScreen
+          reasonsNotGiven={reasonsNotGiven}
+          onReasonSelect={handleReasonSelect}
+          isUpdatingMarToNotGiven={isUpdatingMarToNotGiven}
+        />
+      );
     }
     if (showGivenScreen) {
       return (

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -24,7 +24,7 @@ import {
 } from '@tamanu/utils/dateTime';
 import { format, subSeconds } from 'date-fns';
 import { useFormikContext } from 'formik';
-
+import { toast } from 'react-toastify';
 import { foreignKey } from '../utils/validation';
 import { PrintPrescriptionModal } from '../components/PatientPrinting';
 import {
@@ -528,13 +528,19 @@ export const MedicationForm = ({ encounterId, onCancel, onSaved }) => {
     }
 
     const idealTimes = data.timeSlots.map(slot => slot.value);
-    const medicationSubmission = await api.post('medication', {
-      ...data,
-      doseAmount: data.doseAmount || undefined,
-      durationValue: data.durationValue || undefined,
-      idealTimes,
-      encounterId,
-    });
+    let medicationSubmission;
+    try {
+      medicationSubmission = await api.post('medication', {
+        ...data,
+        doseAmount: data.doseAmount || undefined,
+        durationValue: data.durationValue || undefined,
+        idealTimes,
+        encounterId,
+      });
+    } catch (error) {
+      toast.error(error.message);
+      return Promise.reject(error);
+    }
     // The return from the post doesn't include the joined tables like medication and prescriber
     const newMedication = await api.get(`medication/${medicationSubmission.id}`);
 
@@ -810,7 +816,7 @@ export const MedicationForm = ({ encounterId, onCancel, onSaved }) => {
                       replacements={{ unit: weightUnit }}
                     />
                   }
-                  onChange={(e) => setPatientWeight(e.target.value)}
+                  onChange={e => setPatientWeight(e.target.value)}
                   component={TextField}
                   placeholder={getTranslation('medication.patientWeight.placeholder', 'e.g 2.4')}
                   type="number"


### PR DESCRIPTION
### Changes

- Updated GenerateMedicationAdministrationRecords to include null endDate in query conditions.
- Added loading state handling in MarTable component for better user experience during medication data retrieval.
- Enhanced StatusPopper to disable buttons while updating MAR status, preventing user actions during processing.
- Hide due and missed MARs during the pause period

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
