### PR TITLE
fix(mobile): Update generated id columns

### DIFF
--- a/packages/mobile/App/models/PatientFacility.ts
+++ b/packages/mobile/App/models/PatientFacility.ts
@@ -35,6 +35,6 @@ export class PatientFacility extends BaseModel {
     // to avoid clashes on the joined id
 
     //patient actually stores the patientId in @BeforeInsert
-    this.id = `${this.patient.replace(';', ':')};${this.facility.replace(';', ':')}`;
+    this.id = `${this.patient.replaceAll(';', ':')};${this.facility.replaceAll(';', ':')}`;
   }
 }

--- a/packages/mobile/App/models/PatientFieldValue.ts
+++ b/packages/mobile/App/models/PatientFieldValue.ts
@@ -32,7 +32,7 @@ export class PatientFieldValue extends BaseModel implements IPatientFieldValue {
   async assignIdAsPatientIdDefinitionId(): Promise<void> {
     // N.B. because ';' is used to join the two, we replace any actual occurrence of ';' with ':'
     // to avoid clashes on the joined id
-    this.id = `${this.patient.replace(';', ':')};${this.definition.replace(';', ':')}`;
+    this.id = `${this.patient.replaceAll(';', ':')};${this.definition.replaceAll(';', ':')}`;
   }
 
   static async getForPatientAndDefinition(

--- a/packages/mobile/App/models/PatientFieldValue.ts
+++ b/packages/mobile/App/models/PatientFieldValue.ts
@@ -1,4 +1,4 @@
-import { BeforeInsert, Column, Entity, ManyToOne, RelationId } from 'typeorm';
+import { BeforeInsert, Column, Entity, ManyToOne, PrimaryColumn, RelationId } from 'typeorm';
 
 import { IPatientFieldValue } from '~/types';
 import { Patient } from './Patient';
@@ -9,6 +9,9 @@ import { BaseModel } from './BaseModel';
 @Entity('patient_field_values')
 export class PatientFieldValue extends BaseModel implements IPatientFieldValue {
   static syncDirection = SYNC_DIRECTIONS.BIDIRECTIONAL;
+
+  @PrimaryColumn()
+  id: string;
 
   @Column({ nullable: false })
   value: string;


### PR DESCRIPTION
### Changes

I was working with generated columns recently and noticed that only three (soon four) models with those type of columns exist on mobile. We already had a way to circumvent it in place, however it seemed odd: with just using `replace` we are not really changing all occurrences as we are on SQL using `REPLACE`. This change is to fix that, even though it's probably unlikely either would have more than one semicolon. The other change was just a lint issue complaining that `this.id` doesn't exist on `PatientFieldValue`.

I'll briefly mention that `TranslatedString` does not require either because we have validation against letting `stringId` or `language` have semicolon.

I'll also mention that we might have an argument to update the `UserPreference` model (only exists on server) because it doesn't escape the semicolon in either `user_id`, `key` or `facility_id`, which technically could happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of special characters in generated IDs to prevent potential clashes by ensuring all semicolons are consistently replaced.
- **New Features**
  - Added an explicit unique identifier field for patient field values to enhance data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->