### PR TITLE
fix(sync): don't lock sync_sessions to write debug info

### DIFF
--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -356,6 +356,7 @@ export class CentralSyncManager {
       await models.SyncSession.addDebugInfo(sessionId, {
         isMobile,
         tablesForFullResync,
+        useSyncLookup: this.constructor.config.sync.lookupTable.enabled,
       });
 
       const modelsToInclude = tablesToInclude

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -353,7 +353,7 @@ export class CentralSyncManager {
         { where: { id: sessionId } },
       );
 
-      await models.SyncSession.addDebugInfo(sessionId, {
+      await models.SyncSession.setParameters(sessionId, {
         isMobile,
         tablesForFullResync,
         useSyncLookup: this.constructor.config.sync.lookupTable.enabled,

--- a/packages/central-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/central-server/app/sync/snapshotOutgoingChanges.js
@@ -341,13 +341,7 @@ export const snapshotOutgoingChanges = withConfig(
     sessionConfig,
     config,
   ) => {
-    const useSyncLookup = config.sync.lookupTable.enabled;
-
-    if (useSyncLookup) {
-      await store.models.SyncSession.addDebugInfo(sessionId, { useSyncLookup: true });
-    }
-
-    return useSyncLookup
+    return config.sync.lookupTable.enabled
       ? snapshotOutgoingChangesFromSyncLookup(
           store,
           outgoingModels,

--- a/packages/database/src/models/SyncSession.ts
+++ b/packages/database/src/models/SyncSession.ts
@@ -41,7 +41,29 @@ export class SyncSession extends Model {
     );
   }
 
-  static async addDebugInfo(id: string, info: object) {
+  /**
+   * Set business-logic parameters to the sync session.
+   * As this writes to the table, it may contend locks.
+   * For debugging information, use addDebugInfo() instead.
+   */
+  static async setParameters(id: string, params: { [key: string]: any }) {
+    await this.sequelize.query(
+      `
+      UPDATE "sync_sessions"
+      SET "debug_info" = (COALESCE("debug_info"::jsonb, '{}'::jsonb) || $data::jsonb)::json
+      WHERE "id" = $id
+      `,
+      { bind: { id, data: JSON.stringify(params) } },
+    );
+  }
+
+  /**
+   * Add information useful for debugging sync to the session.
+   * To avoid contending locks, this will drop the data if it
+   * can't obtain the write. For business-logic parameters, use
+   * setParameters() instead.
+   */
+  static async addDebugInfo(id: string, info: { [key: string]: any }) {
     // the SKIP LOCKED means we don't lock the sync_sessions table's row
     // if it's already contended. but that also means that we might lose
     // some debug info in some cases. so let's debug log it as well.


### PR DESCRIPTION
### Changes

Fixes for sync database contention encountered on support (BESTA-0016).

When we snapshot, we take a REPEATABLE READ transaction to ensure consistency, but that comes with an implicit contract to never write to shared resources, only read, otherwise locks can be taken and block the rest of the server. In Samoa, we found that a write had slipped through by way of recording the syncLookup toggle to `sync_sessions.debug_info` just before we run the snapshot... which happens within the transaction. In high contention scenarios, this can result in that snapshot transaction blocking one, and via update cascading, ultimately blocking all other updates to the sync_sessions table, which leads to Postgres connection exhaustion.

This PR:
- adds `SKIP LOCKED` to the `addDebugInfo` function, which means that we no longer block on locked session rows just to write some debug data. We log (at debug level) to the console to avoid altogether losing debug data.
- adds a new `setParameters` function which does the same as `addDebugInfo` but explicitly writes data, and is also optimised to a single `UPDATE` statement (which may avoid some locks as the Postgres engine can re-apply the modification via compare-and-swap itself rather than relying on JS logic for the data change).
- moves the specific syncLookup `addDebugInfo` from within the transaction to happen outside of it. Because we're enabling syncLookup permanently anyway soon, it doesn't really matter, but let's still preserve that bit for now. (Also because this fix is going to be backported to 2.16.)
- change that `addDebugInfo` update to a `setParameters` call

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of synchronization sessions by making debug information updates non-blocking, reducing the chance of sync interruptions.
- **Chores**
	- Enhanced debug logging for sync sessions to provide clearer insights during synchronization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->