### PR TITLE
fix(suggester): Hotfix 2.30: Update translated suggester logic

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -714,6 +714,8 @@ describe('Suggestions', () => {
       expect(result3.body.length).toEqual(1);
       expect(result3.body[0].name).toEqual('banana');
     });
+
+    it.todo('translated ordering');
   });
 
   it('should respect visibility status', async () => {

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -718,6 +718,10 @@ describe('Suggestions', () => {
     it.todo('translated ordering');
   });
 
+  describe('Location hierarchy', () => {
+    it.todo('should get suggestions for a location with a parentId');
+  });
+
   it('should respect visibility status', async () => {
     const visible = await models.ReferenceData.create({
       type: 'allergy',

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -411,9 +411,9 @@ const createNameSuggester = (
   options,
 ) =>
   createSuggester(endpoint, modelName, whereBuilderFn, {
-    mapper: ({ id, name }) => ({
+    mapper: ({ dataValues: { translation } = {}, name, id }) => ({
+      name: translation || name,
       id,
-      name,
     }),
     ...options,
   });

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -389,7 +389,12 @@ REFERENCE_TYPE_VALUES.forEach((typeName) => {
 });
 
 createSuggester('labTestType', 'LabTestType', () => VISIBILITY_CRITERIA, {
-  mapper: ({ name, code, id, labTestCategoryId }) => ({ name, code, id, labTestCategoryId }),
+  mapper: ({ dataValues: { translation } = {}, name, code, id, labTestCategoryId }) => ({
+    name: translation || name,
+    code,
+    id,
+    labTestCategoryId,
+  }),
 });
 
 const filterByFacilityWhereBuilder = ({ query, modelName, endpoint }) => {
@@ -448,12 +453,19 @@ createSuggester(
   {
     mapper: async (location) => {
       const availability = await location.getAvailability();
-      const { name, code, id, maxOccupancy, facilityId } = location;
+      const {
+        dataValues: { translation } = {},
+        name,
+        code,
+        id,
+        maxOccupancy,
+        facilityId,
+      } = location;
 
       const lg = await location.getLocationGroup();
       const locationGroup = lg && { name: lg.name, code: lg.code, id: lg.id };
       return {
-        name,
+        name: translation || name,
         code,
         maxOccupancy,
         id,
@@ -504,6 +516,7 @@ createSuggester(
   {
     mapper: (product) => {
       product.addVirtualFields();
+      product.dataValues.name = product.dataValues.translation || product.name;
       return product;
     },
     includeBuilder: (req) => {

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -39,7 +39,7 @@ const getTranslationAttributes = (endpoint, modelName) => {
           SELECT "text" 
           FROM "translated_strings" 
           WHERE "language" = $language
-          AND "string_id" = ${translationPrefix} || "${modelName}"."id"
+          AND "string_id" = '${translationPrefix}' || "${modelName}"."id"
           LIMIT 1
       )`),
         'translation',
@@ -199,7 +199,7 @@ const getTranslationWhereLiteral = (endpoint, modelName, searchColumn) => {
       (SELECT "text" 
         FROM "translated_strings" 
         WHERE "language" = $language
-        AND "string_id" = ${translationPrefix} || "${modelName}"."id"
+        AND "string_id" = '${translationPrefix}' || "${modelName}"."id"
         LIMIT 1),
       "${modelName}"."${searchColumn}"
     ) ILIKE $searchQuery`);

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -71,6 +71,8 @@ function createSuggesterRoute(
         `POSITION(LOWER($positionMatch) in LOWER(${`"${modelName}"."${searchColumn}"`})) > 1`,
       );
 
+      // We supply the searchQuery to both the whereBuilder and the bind so that we can
+      // either use the bind key in SQL or in the whereBuilder directly using sequelize
       const where = whereBuilder({
         search: `%${searchQuery}%`,
         query,

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -132,14 +132,11 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper }) {
       } = req;
       req.checkPermission('list', modelName);
 
-      const dataType = getDataType(endpoint);
-      const translationPrefix = `${REFERENCE_DATA_TRANSLATION_PREFIX}.${dataType}.`;
-
       const record = await models[modelName].findOne({
         where: { id: params.id },
         replacements: {
           language,
-          translationPrefix,
+          translationPrefix: `${REFERENCE_DATA_TRANSLATION_PREFIX}.${getDataType(endpoint)}.`,
         },
         attributes: getTranslationAttributes(modelName),
       });
@@ -165,11 +162,7 @@ function createAllRecordsRoute(
       const { language = DEFAULT_LANGUAGE_CODE } = query;
 
       const model = models[modelName];
-
       const where = whereBuilder({ search: '%', query, req, modelName, searchColumn });
-
-      const dataType = getDataType(endpoint);
-      const translationPrefix = `${REFERENCE_DATA_TRANSLATION_PREFIX}.${dataType}.`;
 
       const results = await model.findAll({
         where,
@@ -177,7 +170,7 @@ function createAllRecordsRoute(
         attributes: getTranslationAttributes(modelName),
         replacements: {
           language,
-          translationPrefix,
+          translationPrefix: `${REFERENCE_DATA_TRANSLATION_PREFIX}.${getDataType(endpoint)}.`,
           searchQuery: '%',
           ...extraReplacementsBuilder(query),
         },

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -96,13 +96,18 @@ function createSuggesterRoute(
 
       const where =
         isTranslatable && hasTranslations
-          ? Sequelize.literal(`EXISTS (
-            SELECT 1 
-            FROM translated_strings 
-            WHERE language = :language
-            AND string_id = '${translationPrefix}' || "${modelName}"."id"
-            AND text ILIKE :searchQuery
-          )`)
+          ? {
+              [Op.and]: [
+                Sequelize.literal(`EXISTS (
+                  SELECT 1 
+                  FROM translated_strings 
+                  WHERE language = :language
+                  AND string_id = '${translationPrefix}' || "${modelName}"."id"
+                  AND text ILIKE :searchQuery
+                )`),
+                VISIBILITY_CRITERIA,
+              ],
+            }
           : whereBuilder(`%${searchQuery}%`, query, req);
 
       if (endpoint === 'location' && query.locationGroupId) {

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -389,8 +389,8 @@ createSuggester('labTestType', 'LabTestType', () => VISIBILITY_CRITERIA, {
   mapper: ({ name, code, id, labTestCategoryId }) => ({ name, code, id, labTestCategoryId }),
 });
 
-const filterByFacilityWhereBuilder = ({ search, query }) => {
-  const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+const filterByFacilityWhereBuilder = ({ search, query, modelName }) => {
+  const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName });
   // Parameters are passed as strings, so we need to check for 'true'
   const shouldFilterByFacility =
     query.filterByFacility === 'true' || query.filterByFacility === true;
@@ -427,7 +427,7 @@ createSuggester(
   'Location',
   // Allow filtering by parent location group
   ({ search, query }) => {
-    const baseWhere = filterByFacilityWhereBuilder({ search, query });
+    const baseWhere = filterByFacilityWhereBuilder({ search, modelName: 'Location', query });
 
     const { ...filters } = query;
     delete filters.q;
@@ -466,12 +466,20 @@ createNameSuggester('locationGroup', 'LocationGroup', filterByFacilityWhereBuild
 
 // Location groups filtered by facility. Used in the survey form autocomplete
 createNameSuggester('facilityLocationGroup', 'LocationGroup', ({ search, query }) =>
-  filterByFacilityWhereBuilder({ search, query: { ...query, filterByFacility: true } }),
+  filterByFacilityWhereBuilder({
+    search,
+    modelName: 'LocationGroup',
+    query: { ...query, filterByFacility: true },
+  }),
 );
 
 // Location groups filtered by isBookable. Used in location bookings view
 createNameSuggester('bookableLocationGroup', 'LocationGroup', ({ search, query }) => ({
-  ...filterByFacilityWhereBuilder({ search, query: { ...query, filterByFacility: true } }),
+  ...filterByFacilityWhereBuilder({
+    search,
+    modelName: 'LocationGroup',
+    query: { ...query, filterByFacility: true },
+  }),
   isBookable: true,
 }));
 
@@ -564,7 +572,7 @@ createSuggester(
 );
 
 createSuggester('nonSensitiveLabTestCategory', 'ReferenceData', ({ search }) => {
-  const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+  const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'ReferenceData' });
   return {
     ...baseWhere,
     type: REFERENCE_TYPES.LAB_TEST_CATEGORY,
@@ -581,7 +589,7 @@ createSuggester('nonSensitiveLabTestCategory', 'ReferenceData', ({ search }) => 
 });
 
 createSuggester('sensitiveLabTestCategory', 'ReferenceData', ({ search }) => {
-  const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+  const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'ReferenceData' });
   return {
     ...baseWhere,
     type: REFERENCE_TYPES.LAB_TEST_CATEGORY,
@@ -602,7 +610,7 @@ createSuggester(
   'patientLabTestCategories',
   'ReferenceData',
   ({ search, query, req }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+    const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'ReferenceData' });
 
     if (!query.patientId) {
       return { ...baseWhere, type: REFERENCE_TYPES.LAB_TEST_CATEGORY };
@@ -662,7 +670,7 @@ createSuggester(
   'patientLabTestPanelTypes',
   'LabTestPanel',
   ({ search, query }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+    const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'LabTestPanel' });
 
     if (!query.patientId) {
       return baseWhere;
@@ -704,7 +712,7 @@ createNameSuggester(
   'programRegistryClinicalStatus',
   'ProgramRegistryClinicalStatus',
   ({ search, query: { programRegistryId } }) => ({
-    ...DEFAULT_WHERE_BUILDER({ search }),
+    ...DEFAULT_WHERE_BUILDER({ search, modelName: 'ProgramRegistryClinicalStatus' }),
     ...(programRegistryId ? { programRegistryId } : {}),
   }),
 );
@@ -713,7 +721,7 @@ createSuggester(
   'programRegistry',
   'ProgramRegistry',
   ({ search, query }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+    const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'ProgramRegistry' });
     if (!query.patientId) {
       return baseWhere;
     }
@@ -748,7 +756,7 @@ createNameSuggester(
   'programRegistryClinicalStatus',
   'ProgramRegistryClinicalStatus',
   ({ search, query: { programRegistryId } }) => ({
-    ...DEFAULT_WHERE_BUILDER({ search }),
+    ...DEFAULT_WHERE_BUILDER({ search, modelName: 'ProgramRegistryClinicalStatus' }),
     ...(programRegistryId ? { programRegistryId } : {}),
   }),
 );
@@ -757,7 +765,7 @@ createNameSuggester(
   'programRegistryCondition',
   'ProgramRegistryCondition',
   ({ search, query: { programRegistryId } }) => ({
-    ...DEFAULT_WHERE_BUILDER({ search }),
+    ...DEFAULT_WHERE_BUILDER({ search, modelName: 'ProgramRegistryCondition' }),
     ...(programRegistryId ? { programRegistryId } : {}),
   }),
 );
@@ -766,7 +774,7 @@ createNameSuggester(
   'programRegistry',
   'ProgramRegistry',
   ({ search, query }) => {
-    const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+    const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'ProgramRegistry' });
     if (!query.patientId) {
       return baseWhere;
     }
@@ -801,7 +809,7 @@ createNameSuggester(
 createNameSuggester('labTestPanel', 'LabTestPanel');
 
 createNameSuggester('template', 'Template', ({ search, query }) => {
-  const baseWhere = DEFAULT_WHERE_BUILDER({ search });
+  const baseWhere = DEFAULT_WHERE_BUILDER({ search, modelName: 'Template' });
   const { type } = query;
 
   if (!type) {

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -12,6 +12,7 @@ import {
   REGISTRATION_STATUSES,
   SUGGESTER_ENDPOINTS,
   SURVEY_TYPES,
+  TRANSLATABLE_REFERENCE_TYPES,
   VISIBILITY_STATUSES,
   OTHER_REFERENCE_TYPES,
   DEFAULT_LANGUAGE_CODE,
@@ -23,11 +24,7 @@ export const suggestions = express.Router();
 
 const defaultLimit = 25;
 
-const defaultMapper = ({ entity_display_label, code, id }) => ({
-  name: entity_display_label,
-  code,
-  id,
-});
+const defaultMapper = ({ entity_display_label, code, id }) => ({ entity_display_label, code, id });
 
 const ENDPOINT_TO_DATA_TYPE = {
   // Special cases where the endpoint name doesn't match the dataType
@@ -79,6 +76,8 @@ function createSuggesterRoute(
       const positionQuery = literal(
         `POSITION(LOWER(:positionMatch) in LOWER(${`"${modelName}"."${searchColumn}"`})) > 1`,
       );
+      const dataType = getDataType(endpoint);
+      const isTranslatable = TRANSLATABLE_REFERENCE_TYPES.includes(dataType);
 
       const where = whereBuilder(`%${searchQuery}%`, query, req);
 

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -355,7 +355,7 @@ REFERENCE_TYPE_VALUES.forEach((typeName) => {
   createSuggester(
     typeName,
     'ReferenceData',
-    ({ modelName, endpoint }) => ({
+    ({ endpoint, modelName }) => ({
       ...DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
       type: typeName,
     }),

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -195,14 +195,14 @@ function createSuggesterCreateRoute(
 // Search against the translation if it exists, otherwise search against the searchColumn
 const getTranslationWhereLiteral = (endpoint, modelName, searchColumn) => {
   const translationPrefix = `${REFERENCE_DATA_TRANSLATION_PREFIX}.${getDataType(endpoint)}.`;
-  return Sequelize.literal(`COALESCE(
+  return Sequelize.literal(`LOWER(COALESCE(
       (SELECT "text" 
         FROM "translated_strings" 
         WHERE "language" = $language
         AND "string_id" = '${translationPrefix}' || "${modelName}"."id"
         LIMIT 1),
       "${modelName}"."${searchColumn}"
-    ) ILIKE $searchQuery`);
+    )) LIKE LOWER($searchQuery)`);
 };
 
 const DEFAULT_WHERE_BUILDER = ({ endpoint, modelName, searchColumn = 'name' }) => ({

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -19,8 +19,6 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { customAlphabet } from 'nanoid';
 
-export const suggestions = express.Router();
-
 const DEFAULT_LIMIT = 25;
 const ENDPOINT_TO_DATA_TYPE = {
   // Special cases where the endpoint name doesn't match the dataType
@@ -59,6 +57,8 @@ const getTranslationWhereLiteral = (modelName, searchColumn) =>
         LIMIT 1),
       "${modelName}"."${searchColumn}"
     ) ILIKE :searchQuery`);
+
+export const suggestions = express.Router();
 
 function createSuggesterRoute(
   endpoint,
@@ -279,7 +279,7 @@ createSuggester(
   'multiReferenceData',
   'ReferenceData',
   ({ search, query: { types } }) => ({
-    ...DEFAULT_WHERE_BUILDER({ search, modelName: 'ReferenceData', isTranslated: false }),
+    ...DEFAULT_WHERE_BUILDER({ search, modelName: 'ReferenceData' }),
     type: { [Op.in]: types },
   }),
   {

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -49,6 +49,7 @@ const getTranslationAttributes = (modelName) => {
   };
 };
 
+// Search against the translation if it exists, otherwise search against the searchColumn
 const getTranslationWhereLiteral = (modelName, searchColumn) =>
   Sequelize.literal(`COALESCE(
       (SELECT "text" 
@@ -166,7 +167,7 @@ function createAllRecordsRoute(
 
       const results = await model.findAll({
         where,
-        order: [[Sequelize.literal(`"${modelName}"."${searchColumn}"`), 'ASC']],
+        order: [[Sequelize.literal(searchColumn), 'ASC']],
         attributes: getTranslationAttributes(modelName),
         replacements: {
           language,

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -12,7 +12,6 @@ import {
   REGISTRATION_STATUSES,
   SUGGESTER_ENDPOINTS,
   SURVEY_TYPES,
-  TRANSLATABLE_REFERENCE_TYPES,
   VISIBILITY_STATUSES,
   OTHER_REFERENCE_TYPES,
   DEFAULT_LANGUAGE_CODE,
@@ -24,7 +23,11 @@ export const suggestions = express.Router();
 
 const defaultLimit = 25;
 
-const defaultMapper = ({ entity_display_label, code, id }) => ({ entity_display_label, code, id });
+const defaultMapper = ({ entity_display_label, code, id }) => ({
+  name: entity_display_label,
+  code,
+  id,
+});
 
 const ENDPOINT_TO_DATA_TYPE = {
   // Special cases where the endpoint name doesn't match the dataType
@@ -76,8 +79,6 @@ function createSuggesterRoute(
       const positionQuery = literal(
         `POSITION(LOWER(:positionMatch) in LOWER(${`"${modelName}"."${searchColumn}"`})) > 1`,
       );
-      const dataType = getDataType(endpoint);
-      const isTranslatable = TRANSLATABLE_REFERENCE_TYPES.includes(dataType);
 
       const where = whereBuilder(`%${searchQuery}%`, query, req);
 

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -99,9 +99,15 @@ function createSuggesterRoute(
         include,
         attributes: getTranslationAttributes(endpoint, modelName, searchColumn),
         order: [
+          // TODO: This is a hack to avoid ambiguous column references when we have includes
+          // need to either fix this or enforce custom orderBuilder
           ...(order ? [order] : []),
-          positionQuery,
-          [getTranslationOrderLiteral(endpoint, modelName, searchColumn), 'ASC'],
+          ...(include
+            ? []
+            : [
+                positionQuery,
+                [getTranslationOrderLiteral(endpoint, modelName, searchColumn), 'ASC'],
+              ]),
         ],
         bind: {
           positionMatch: searchQuery,
@@ -120,7 +126,7 @@ function createSuggesterRoute(
 // this exists so a control can look up the associated information of a given suggester endpoint
 // when it's already been given an id so that it's guaranteed to have the same structure as the
 // options endpoint
-function createSuggesterLookupRoute(endpoint, modelName, { mapper }) {
+function createSuggesterLookupRoute(endpoint, modelName, { mapper, searchColumn }) {
   suggestions.get(
     `/${endpoint}/:id`,
     asyncHandler(async (req, res) => {
@@ -136,7 +142,7 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper }) {
         bind: {
           language,
         },
-        attributes: getTranslationAttributes(endpoint, modelName),
+        attributes: getTranslationAttributes(endpoint, modelName, searchColumn),
       });
 
       if (!record) throw new NotFoundError();

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -195,14 +195,14 @@ function createSuggesterCreateRoute(
 // Search against the translation if it exists, otherwise search against the searchColumn
 const getTranslationWhereLiteral = (endpoint, modelName, searchColumn) => {
   const translationPrefix = `${REFERENCE_DATA_TRANSLATION_PREFIX}.${getDataType(endpoint)}.`;
-  return Sequelize.literal(`LOWER(COALESCE(
+  return Sequelize.literal(`COALESCE(
       (SELECT "text" 
         FROM "translated_strings" 
         WHERE "language" = $language
         AND "string_id" = '${translationPrefix}' || "${modelName}"."id"
         LIMIT 1),
       "${modelName}"."${searchColumn}"
-    )) LIKE LOWER($searchQuery)`);
+    ) ILIKE $searchQuery`);
 };
 
 const DEFAULT_WHERE_BUILDER = ({ endpoint, modelName, searchColumn = 'name' }) => ({


### PR DESCRIPTION
### Changes

During my devoncall shift I did a hotfix that changed the way translations work with suggesters in order to fix a bug and improve performance. Unfortunately in the rush I missed both the consideration of visibilityStatus and I was completely overriding the `whereBuilder` for anything translated meaning all custom `whereBuilder` logic broke 🤦 

In this new fix I have taken a step back and updated the suggester logic with 2 main things.
- A subquery that adds a `translation` attribute to returned records with the relevant translated text is then assigned to the name property if it exists through the mapper to display on the front end
- A subquery within the `whereBuilder` that checks the `searchQuery` against the translated text if it exists and if not searches against the original `searchColumn` for the record

Note: I am a bit concerned about the performance of these subqueries so please flag if this looks alarming and I need to take another look!

It might seem like a lot of lines changed for a hotfix so let me know if I should trim it down or do the refactors separately. But I feel the changes I made (parameterising `whereBuilder` and its usages) are low risk and worth it

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
