### PR TITLE
fix(programRegistry): SAV-974: Fix desktop program registration caching bug

### DIFF
--- a/packages/web/app/features/ProgramRegistry/DeleteProgramRegistryFormModal.jsx
+++ b/packages/web/app/features/ProgramRegistry/DeleteProgramRegistryFormModal.jsx
@@ -31,18 +31,18 @@ const Body = styled.div`
 const useDeletePatientProgramRegistration = (patientProgramRegistration = {}, onSuccess) => {
   const api = useApi();
   const queryClient = useQueryClient();
-  const { id, patientId } = patientProgramRegistration;
+  const { id: registrationId, patientId } = patientProgramRegistration;
 
   return useMutation({
     mutationFn: async () => {
-      return api.delete(`patient/programRegistration/${id}`);
+      return api.delete(`patient/programRegistration/${registrationId}`);
     },
     onSuccess: async () => {
-      onSuccess();
-      await queryClient.invalidateQueries(['patient', patientId]);
+      await queryClient.resetQueries(['patient', patientId]);
       await queryClient.invalidateQueries([
         `infoPaneListItem-${PANE_SECTION_IDS.PROGRAM_REGISTRY}`,
       ]);
+      onSuccess();
     },
   });
 };


### PR DESCRIPTION
### Changes

This change fixes an error where a stale program registration id from the react-query cache is being used as the basis for a subsequent data fetch to get the registration conditions. The stale id no longer exists which results in a 404 error. When invalidating a query in react-query, it will return stale data for a render or 2 until the new data is fetched in the background. In most cases this is fine, but in the case of a deletion this is causing the above problem. I fixed the issue by resetting the relevant query rather than invalidating it which completely clears out the stale data from the cache.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
