### PR TITLE
fix(desktop): Properly display custom grab cursor

### DIFF
--- a/packages/web/app/components/TabDisplayDraggable.jsx
+++ b/packages/web/app/components/TabDisplayDraggable.jsx
@@ -4,7 +4,7 @@ import { Box, Tabs } from '@material-ui/core';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import cn from 'classnames';
 import { Colors } from '../constants';
-import grabCursor from '../assets/images/grab_cursor.svg';
+import grabCursor from '../assets/images/grab_cursor.svg?url';
 
 const TabBar = styled.div`
   display: flex;
@@ -20,7 +20,7 @@ const TabContainer = styled(Tabs)`
     background-color: ${Colors.primary};
   }
   * {
-    cursor: url('${grabCursor}'), auto !important;
+    cursor: url("${grabCursor}"), auto !important;
   }
 `;
 


### PR DESCRIPTION
### Changes

Yeah very weird issue, the custom cursor grab SVG we were using stopped appearing. Given it only happens on production builds I get the feeling we probably changed the way we did auto deploys in some way, or a ghost dependency is resolving differently so when it packs the production build, something funky goes on with the CSS and it just shows an empty class, with no rule whatsoever declared.

We could also solve this by embedding the SVG directly in the CSS as a data URL, but this seemed unideal, instead I went with this, [see Vite docs](https://vite.dev/guide/assets#explicit-url-imports) for more info on that. Anyway this approach work, and every other similar SVG/CSS/URL combo we have doesn't really have a problem so it's something way too specific to keep looking IMO.