### PR TITLE
fix(certificates): Patient birth certificate not loading

### DIFF
--- a/packages/web/app/api/queries/usePatientAdditionalDataQuery.js
+++ b/packages/web/app/api/queries/usePatientAdditionalDataQuery.js
@@ -2,14 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
 import { useAuth } from '../../contexts/Auth';
 
-export const usePatientAdditionalDataQuery = (patientId, enabled = null) => {
+export const usePatientAdditionalDataQuery = (patientId, fetchOptions) => {
   const api = useApi();
   const { facilityId } = useAuth();
   return useQuery(
     ['additionalData', patientId],
     () => api.get(`patient/${encodeURIComponent(patientId)}/additionalData`, { facilityId }),
     {
-      enabled: enabled !== null ? enabled : !!patientId,
+      enabled: !!patientId,
+      ...fetchOptions,
     },
   );
 };

--- a/packages/web/app/api/queries/usePatientAdditionalDataQuery.js
+++ b/packages/web/app/api/queries/usePatientAdditionalDataQuery.js
@@ -2,14 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../useApi';
 import { useAuth } from '../../contexts/Auth';
 
-export const usePatientAdditionalDataQuery = (patientId) => {
+export const usePatientAdditionalDataQuery = (patientId, enabled = null) => {
   const api = useApi();
   const { facilityId } = useAuth();
   return useQuery(
     ['additionalData', patientId],
     () => api.get(`patient/${encodeURIComponent(patientId)}/additionalData`, { facilityId }),
     {
-      enabled: !!patientId,
+      enabled: enabled !== null ? enabled : !!patientId,
     },
   );
 };

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -22,7 +22,7 @@ const useParent = (api, enabled, parentId) => {
   const {
     data: additionalData,
     isLoading: isAdditionalDataLoading,
-  } = usePatientAdditionalDataQuery(parentId, enabled);
+  } = usePatientAdditionalDataQuery(parentId, { enabled });
 
   const { data: village, isLoading: isVillageLoading } = useQuery(
     ['village', parentData?.villageId],

--- a/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/BirthNotificationCertificateModal.jsx
@@ -22,7 +22,7 @@ const useParent = (api, enabled, parentId) => {
   const {
     data: additionalData,
     isLoading: isAdditionalDataLoading,
-  } = usePatientAdditionalDataQuery(parentId);
+  } = usePatientAdditionalDataQuery(parentId, enabled);
 
   const { data: village, isLoading: isVillageLoading } = useQuery(
     ['village', parentData?.villageId],


### PR DESCRIPTION
### Changes

We recently did a [change in this PR](https://github.com/beyondessential/tamanu/pull/7468/files#diff-7e2162ae0a18d7cb4043d0508018b8aac3b82b7e4ee80feed6f66019b8d58e62L22-R25) that didn't quite match what we were doing, as we previously relied on controlling `useQuery` `enabled` option, without it, the `isLoading` property is always `true` and leaves the certificate loading forever if the patient doesn't have mother and father specified.

I checked the PR and this seems to be the only place where we would change the behavior so yeah this is it. I decided to update the hook to be more generic so we're able to override with any `fetchOptions`. Also went with this name because it seems the most repeated one on the web package (while `queryOptions` and `useQueryOptions` coming second).