### PR TITLE
tweak(audit): 2.32 fix: Specify public schema in calls to set_session_config

### DIFF
--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -122,12 +122,12 @@ async function connectToDatabase(dbOptions) {
   });
 
   sequelize.setSessionVar = (key, value) =>
-    sequelize.query(`SELECT set_session_config($key, $value)`, {
+    sequelize.query(`SELECT public.set_session_config($key, $value)`, {
       bind: { key, value },
     });
 
   sequelize.setTransactionVar = (key, value) =>
-    sequelize.query(`SELECT set_session_config($key, $value, true)`, {
+    sequelize.query(`SELECT public.set_session_config($key, $value, true)`, {
       bind: { key, value },
     });
 
@@ -137,7 +137,7 @@ async function connectToDatabase(dbOptions) {
         const userid = getSessionConfigInNamespace(AUDIT_USERID_KEY);
         if (userid)
           await super.run(
-            'SELECT set_session_config($1, $2)',
+            'SELECT public.set_session_config($1, $2)',
             [AUDIT_USERID_KEY, userid],
           );
         return super.run(sql, options);


### PR DESCRIPTION
### Changes
- Will cause issue generating report if using reporting user
- This is because of search_path being set to `reporting`
- It looks for reporting.set_session_config

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
