### PR TITLE
fix(sync): Don't lock sync_sessions to write debug info 2.31 hotfix 

### DIFF
--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -353,9 +353,10 @@ export class CentralSyncManager {
         { where: { id: sessionId } },
       );
 
-      await models.SyncSession.addDebugInfo(sessionId, {
+      await models.SyncSession.setParameters(sessionId, {
         isMobile,
         tablesForFullResync,
+        useSyncLookup: this.constructor.config.sync.lookupTable.enabled,
       });
 
       const modelsToInclude = tablesToInclude

--- a/packages/central-server/app/sync/snapshotOutgoingChanges.js
+++ b/packages/central-server/app/sync/snapshotOutgoingChanges.js
@@ -341,13 +341,7 @@ export const snapshotOutgoingChanges = withConfig(
     sessionConfig,
     config,
   ) => {
-    const useSyncLookup = config.sync.lookupTable.enabled;
-
-    if (useSyncLookup) {
-      await store.models.SyncSession.addDebugInfo(sessionId, { useSyncLookup: true });
-    }
-
-    return useSyncLookup
+    return config.sync.lookupTable.enabled
       ? snapshotOutgoingChangesFromSyncLookup(
           store,
           outgoingModels,

--- a/packages/database/src/models/SyncSession.ts
+++ b/packages/database/src/models/SyncSession.ts
@@ -1,5 +1,6 @@
 import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { log } from '@tamanu/shared/services/logging';
 import { Model } from './Model';
 import { type InitOptions } from '../types/model';
 
@@ -40,8 +41,34 @@ export class SyncSession extends Model {
     );
   }
 
+  /**
+   * Set business-logic parameters to the sync session.
+   * As this writes to the table, it may contend locks.
+   * For debugging information, use addDebugInfo() instead.
+   */
+  static async setParameters(id: string, params: object) {
+    await this.sequelize.query(
+      `
+      UPDATE "sync_sessions"
+      SET "debug_info" = (COALESCE("debug_info"::jsonb, '{}'::jsonb) || $data::jsonb)::json
+      WHERE "id" = $id
+      `,
+      { bind: { id, data: JSON.stringify(params) } },
+    );
+  }
+
+  /**
+   * Add information useful for debugging sync to the session.
+   * To avoid contending locks, this will drop the data if it
+   * can't obtain the write. For business-logic parameters, use
+   * setParameters() instead.
+   */
   static async addDebugInfo(id: string, info: object) {
-    const session = await this.findOne({ where: { id } });
+    // the SKIP LOCKED means we don't lock the sync_sessions table's row
+    // if it's already contended. but that also means that we might lose
+    // some debug info in some cases. so let's debug log it as well.
+    log.debug('Sync session debug', { id, ...info });
+    const session = await this.findOne({ where: { id }, skipLocked: true });
     await session?.update({
       debugInfo: { ...session.debugInfo, ...info },
     });


### PR DESCRIPTION
### Changes

Unsure if we'll ever use this version but might as well. This is an important port missing from v2.16 (https://github.com/beyondessential/tamanu/pull/7702)

Note that storybook was already broken, this one didn't do it: https://github.com/beyondessential/tamanu/actions/runs/14984449660/job/42096204393