### PR TITLE
fix(programRegistry): SAV-962: Fix  mobile update tables for full resync request

### DIFF
--- a/packages/mobile/App/migrations/1743640327000-addPatientProgramRegistrationId.ts
+++ b/packages/mobile/App/migrations/1743640327000-addPatientProgramRegistrationId.ts
@@ -1,48 +1,23 @@
 import { MigrationInterface, QueryRunner, TableForeignKey, TableColumn } from 'typeorm';
 
-const updateTablesForFullResync = async (
+const setPatientProgramRegistrationsAndConditionsForFullResync = async (
   queryRunner: QueryRunner,
-  newTables: string[],
 ): Promise<void> => {
-  // First, check if the record exists
-  const existingRecord = await queryRunner.query(
-    `SELECT id, value FROM local_system_facts WHERE key = 'tablesForFullResync'`,
-  );
+  await queryRunner.query('DELETE FROM patient_program_registration_conditions');
+  await queryRunner.query('DELETE FROM patient_program_registrations');
 
-  if (existingRecord && existingRecord.length > 0) {
-    // Record exists, update it by appending the new tables
-    const currentValue = existingRecord[0].value;
-    const currentTables = currentValue.split(',');
-
-    // Combine current tables with new tables, removing duplicates
-    const allTables = [...new Set([...currentTables, ...newTables])];
-    const newValue = allTables.join(',');
-
-    await queryRunner.query(
-      `UPDATE local_system_facts
-       SET value = ?
-       WHERE id = ?`,
-      [newValue, existingRecord[0].id],
-    );
-  } else {
-    // Record doesn't exist, create a new one
-
-    // uuid generation based on
-    // https://stackoverflow.com/questions/66625085/sqlite-generate-guid-uuid-on-select-into-statement
-    await queryRunner.query(
-      `
+  // uuid generation based on
+  // https://stackoverflow.com/questions/66625085/sqlite-generate-guid-uuid-on-select-into-statement
+  await queryRunner.query(`
       INSERT INTO local_system_facts (id, key, value)
       VALUES (lower(
         hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-' || '4' ||
-        substr(hex(randomblob(2)), 2) || '-' ||
+        substr(hex( randomblob(2)), 2) || '-' ||
         substr('AB89', 1 + (abs(random()) % 4) , 1)  ||
         substr(hex(randomblob(2)), 2) || '-' ||
         hex(randomblob(6))
-      ), 'tablesForFullResync', ?)
-    `,
-      [newTables.join(',')],
-    );
-  }
+      ), 'tablesForFullResync', 'patient_program_registration_conditions,patient_program_registrations')
+    `);
 };
 
 export class addPatientProgramRegistrationId1743640327000 implements MigrationInterface {
@@ -70,15 +45,8 @@ export class addPatientProgramRegistrationId1743640327000 implements MigrationIn
     await queryRunner.dropColumn('patient_program_registration_conditions', 'patientId');
     await queryRunner.dropColumn('patient_program_registration_conditions', 'programRegistryId');
 
-    await queryRunner.query('DELETE FROM patient_program_registration_conditions');
-    await queryRunner.query('DELETE FROM patient_program_registrations');
-
     // Fully resync the patient_program_registration_conditions table so as not to repeat the complex logic from central server migration
-    await updateTablesForFullResync(queryRunner, [
-      'patient_program_registrations',
-      'patient_program_registration_conditions',
-      'patient_additional_data',
-    ]);
+    await setPatientProgramRegistrationsAndConditionsForFullResync(queryRunner);
 
     // Add patientProgramRegistrationId column
     await queryRunner.addColumn(

--- a/packages/mobile/App/models/PatientProgramRegistrationCondition.ts
+++ b/packages/mobile/App/models/PatientProgramRegistrationCondition.ts
@@ -41,11 +41,7 @@ export class PatientProgramRegistrationCondition
   @RelationId(({ patientProgramRegistration }) => patientProgramRegistration)
   patientProgramRegistrationId: ID;
 
-  @ManyToOne(
-    () => ProgramRegistryCondition,
-    ({ patientProgramRegistrationConditions }) => patientProgramRegistrationConditions,
-    { nullable: true },
-  )
+  @ManyToOne(() => ProgramRegistryCondition, ({ conditions }) => conditions, { nullable: true })
   programRegistryCondition?: IProgramRegistryCondition;
 
   @RelationId(({ programRegistryCondition }) => programRegistryCondition)

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -298,7 +298,7 @@ export class MobileSyncManager {
       STAGE_MAX_PROGRESS[this.syncStage - 1],
       'Pausing at 33% while server prepares for pull, please wait...',
     );
-    const tablesForFullResyncRecords = await this.models.LocalSystemFact.findAll({
+    const tablesForFullResyncRecords = await this.models.LocalSystemFact.find({
       where: { key: 'tablesForFullResync' },
     });
 
@@ -331,9 +331,7 @@ export class MobileSyncManager {
       }
 
       if (tablesForFullResync.length > 0) {
-        await this.models.LocalSystemFact.destroy({
-          where: { key: 'tablesForFullResync' },
-        });
+        await this.models.LocalSystemFact.delete({ key: 'tablesForFullResync' });
       }
 
       // update the last successful sync in the same save transaction,

--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -106,7 +106,7 @@ export class MobileSyncManager {
    */
   async waitForCurrentSyncToEnd(): Promise<void> {
     if (this.isSyncing) {
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         const done = (): void => {
           resolve();
           this.emitter.off(SYNC_EVENT_ACTIONS.SYNC_ENDED, done);
@@ -298,9 +298,14 @@ export class MobileSyncManager {
       STAGE_MAX_PROGRESS[this.syncStage - 1],
       'Pausing at 33% while server prepares for pull, please wait...',
     );
-    const tablesForFullResync = await this.models.LocalSystemFact.findOne({
+    const tablesForFullResyncRecords = await this.models.LocalSystemFact.findAll({
       where: { key: 'tablesForFullResync' },
     });
+
+    // Extract values from each record and combine them into a single array
+    const tablesForFullResync = tablesForFullResyncRecords
+      .flatMap((record) => record.value.split(','))
+      .filter(Boolean); // Filter out any empty strings
 
     const incomingModels = getModelsForDirection(this.models, SYNC_DIRECTIONS.PULL_FROM_CENTRAL);
 
@@ -308,8 +313,8 @@ export class MobileSyncManager {
       this.centralServer,
       sessionId,
       pullSince,
-      Object.values(incomingModels).map(m => m.getTableName()),
-      tablesForFullResync?.value.split(','),
+      Object.values(incomingModels).map((m) => m.getTableName()),
+      tablesForFullResync,
       (total, downloadedChangesTotal) =>
         this.updateProgress(total, downloadedChangesTotal, 'Pulling all new changes...'),
     );
@@ -325,8 +330,10 @@ export class MobileSyncManager {
         await saveIncomingChanges(sessionId, totalPulled, incomingModels, this.updateProgress);
       }
 
-      if (tablesForFullResync) {
-        await tablesForFullResync.remove();
+      if (tablesForFullResync.length > 0) {
+        await this.models.LocalSystemFact.destroy({
+          where: { key: 'tablesForFullResync' },
+        });
       }
 
       // update the last successful sync in the same save transaction,


### PR DESCRIPTION
### Changes

Fix issue where we are not handling the possibility of more than one fullResync record existing.


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
