### PR TITLE
feat(programRegistry): SAV-982: resync patient_program_registrations

### DIFF
--- a/packages/database/src/migrations/1748555633925-fullyResyncPatientProgramRegistrations.ts
+++ b/packages/database/src/migrations/1748555633925-fullyResyncPatientProgramRegistrations.ts
@@ -1,0 +1,33 @@
+import { QueryInterface } from 'sequelize';
+import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
+import config from 'config';
+
+export async function up(query: QueryInterface): Promise<void> {
+  const isFacility = Boolean(selectFacilityIds(config));
+
+  if (isFacility) {
+    return;
+  }
+  // Update updated_at_sync_tick for patient_program_registrations
+  await query.sequelize.query(`
+    UPDATE patient_program_registrations
+    SET updated_at_sync_tick = (SELECT CAST(value AS bigint) FROM local_system_facts WHERE key = 'currentSyncTick')
+  `);
+
+  // Update updated_at_sync_tick for patient_program_registration_conditions
+  await query.sequelize.query(`
+    UPDATE patient_program_registration_conditions
+    SET updated_at_sync_tick = (SELECT CAST(value AS bigint) FROM local_system_facts WHERE key = 'currentSyncTick')
+  `);
+
+  // Delete records from sync_lookup table
+  await query.sequelize.query(`
+    DELETE FROM sync_lookup
+    WHERE record_type IN ('patient_program_registrations', 'patient_program_registration_conditions')
+  `);
+}
+
+export async function down(): Promise<void> {
+  // Note: This migration cannot be easily reversed as we're updating existing data
+  // and deleting records.
+}

--- a/packages/mobile/App/migrations/1743640327000-addPatientProgramRegistrationId.ts
+++ b/packages/mobile/App/migrations/1743640327000-addPatientProgramRegistrationId.ts
@@ -1,25 +1,5 @@
 import { MigrationInterface, QueryRunner, TableForeignKey, TableColumn } from 'typeorm';
 
-const setPatientProgramRegistrationsAndConditionsForFullResync = async (
-  queryRunner: QueryRunner,
-): Promise<void> => {
-  await queryRunner.query('DELETE FROM patient_program_registration_conditions');
-  await queryRunner.query('DELETE FROM patient_program_registrations');
-
-  // uuid generation based on
-  // https://stackoverflow.com/questions/66625085/sqlite-generate-guid-uuid-on-select-into-statement
-  await queryRunner.query(`
-      INSERT INTO local_system_facts (id, key, value)
-      VALUES (lower(
-        hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-' || '4' ||
-        substr(hex( randomblob(2)), 2) || '-' ||
-        substr('AB89', 1 + (abs(random()) % 4) , 1)  ||
-        substr(hex(randomblob(2)), 2) || '-' ||
-        hex(randomblob(6))
-      ), 'tablesForFullResync', 'patient_program_registration_conditions,patient_program_registrations')
-    `);
-};
-
 export class addPatientProgramRegistrationId1743640327000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
     // Remove old columns
@@ -44,9 +24,6 @@ export class addPatientProgramRegistrationId1743640327000 implements MigrationIn
     }
     await queryRunner.dropColumn('patient_program_registration_conditions', 'patientId');
     await queryRunner.dropColumn('patient_program_registration_conditions', 'programRegistryId');
-
-    // Fully resync the patient_program_registration_conditions table so as not to repeat the complex logic from central server migration
-    await setPatientProgramRegistrationsAndConditionsForFullResync(queryRunner);
 
     // Add patientProgramRegistrationId column
     await queryRunner.addColumn(


### PR DESCRIPTION
### Changes
Make sure that patient_program_registrations and patient_program_registration_conditions tables fully re-sync after migrations to change their schema for program registry phase 2.

Based on conversations in slack [here](https://beyondessential.slack.com/archives/GE9NHB95F/p1748493596574709)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
