### PR TITLE
ci(release): automatically create RC entry to meta server

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -90,7 +90,6 @@ jobs:
           return JSON.stringify({ name: `RC (${version})`, rank: 'test', host: `https://central.${url}.cd.tamanu.app` });
 
     - name: Post new RC to meta
-      if: startsWith(github.ref, 'refs/tags/v')
       continue-on-error: true
       uses: ./.github/actions/meta-api
       with:

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -76,3 +76,26 @@ jobs:
         version=$(jq -r .version package.json)
         git commit -am "release: Bump version to $version"
         git push
+
+    - name: Compute new RC details
+      uses: actions/github-script@v7
+      id: rc
+      env:
+        NEW_BRANCH_NAME: ${{ steps.branchname.outputs.result }}
+      with:
+        result-encoding: string
+        script: |
+          const version = process.env.NEW_BRANCH_NAME.split('/')[1];
+          const url = process.env.NEW_BRANCH_NAME.replace(/[/.]/g, '-');
+          return JSON.stringify({ name: `RC (${version})`, rank: 'test', host: `https://central.${url}.cd.tamanu.app` });
+
+    - name: Post new RC to meta
+      if: startsWith(github.ref, 'refs/tags/v')
+      continue-on-error: true
+      uses: ./.github/actions/meta-api
+      with:
+        url: ${{ vars.META_URL }}
+        crt: ${{ secrets.META_CERT }}
+        key: ${{ secrets.META_KEY }}
+        api: /servers
+        arg: --data-binary '${{ steps.rc.outputs.result }}'


### PR DESCRIPTION
### Changes

Now that the meta server API takes stable keys, we can finally automate the addition of RCs to the server list.

Noting this requires a small change to the meta server to allow multiple roles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the release workflow to compute and post release candidate details to an external API during version tagging. Workflow continues even if posting fails. No impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->