### PR TITLE
tweak: no-issue: Clean up references to record_sync_tick in changes table

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -800,8 +800,8 @@ describe('CentralSyncManager', () => {
             recordId: patientProgramRegistration.id,
             recordData: expect.objectContaining({
               date: '2025-04-23 00:00:00',
+              updated_at_sync_tick: AFTER_BOUNDARY_SYNC_TICK,
             }),
-            recordSyncTick: AFTER_BOUNDARY_SYNC_TICK.toString(),
           }),
         ]),
       );

--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -17,7 +17,6 @@ export class ChangeLog extends Model {
   declare recordCreatedAt: Date;
   declare recordUpdatedAt: Date;
   declare recordDeletedAt: Date | null;
-  declare recordSyncTick: number;
   declare recordData: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
@@ -72,7 +71,7 @@ export class ChangeLog extends Model {
         tableName: 'changes',
         syncDirection: SYNC_DIRECTIONS.DO_NOT_SYNC,
         schema: 'logs',
-        timestamps: false
+        timestamps: false,
       },
     );
   }

--- a/packages/fake-data/src/fake/fake.ts
+++ b/packages/fake-data/src/fake/fake.ts
@@ -427,7 +427,6 @@ const MODEL_SPECIFIC_OVERRIDES = {
     loggedAt: fakeDateTimeString(),
     recordCreatedAt: fakeDateTimeString(),
     recordUpdatedAt: fakeDateTimeString(),
-    recordSyncTick: chance.integer({ min: 1, max: 10000 }),
     updatedByUserId: fakeUUID(),
     recordUpdate: true,
   }),


### PR DESCRIPTION
### Changes

Pretty sure this is correct, since we no longer have that column on the `changes` table.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
