### PR TITLE
tweak(invoice): fix invoice suggester endpoint to be singular

### DIFF
--- a/packages/constants/src/suggesters.ts
+++ b/packages/constants/src/suggesters.ts
@@ -13,7 +13,7 @@ export const SUGGESTER_ENDPOINTS = [
   'facility',
   'facilityLocationGroup',
   'bookableLocationGroup',
-  'invoiceProducts',
+  'invoiceProduct',
   'location',
   'multiReferenceData',
   'patient',

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -917,7 +917,7 @@ describe('Suggestions', () => {
     expect(result.body).toHaveLength(30);
   });
 
-  it('should handle complex includes in invoiceProducts suggester', async () => {
+  it('should handle complex includes in invoiceProduct suggester', async () => {
     const referenceData = await models.ReferenceData.create({
       id: 'test-ref-data-id',
       code: 'TEST_PRODUCT',
@@ -934,7 +934,7 @@ describe('Suggestions', () => {
       visibilityStatus: 'current',
     });
 
-    const result = await userApp.get('/api/suggestions/invoiceProducts?q=test&language=en');
+    const result = await userApp.get('/api/suggestions/invoiceProduct?q=test&language=en');
     expect(result).toHaveSucceeded();
 
     const { body } = result;

--- a/packages/facility-server/app/routes/apiv1/suggestions.js
+++ b/packages/facility-server/app/routes/apiv1/suggestions.js
@@ -26,7 +26,7 @@ const ENDPOINT_TO_DATA_TYPE = {
   ['bookableLocationGroup']: OTHER_REFERENCE_TYPES.LOCATION_GROUP,
   ['patientLabTestCategories']: REFERENCE_TYPES.LAB_TEST_CATEGORY,
   ['patientLabTestPanelTypes']: OTHER_REFERENCE_TYPES.LAB_TEST_PANEL,
-  ['invoiceProducts']: OTHER_REFERENCE_TYPES.INVOICE_PRODUCT,
+  ['invoiceProduct']: OTHER_REFERENCE_TYPES.INVOICE_PRODUCT,
 };
 const getDataType = (endpoint) => ENDPOINT_TO_DATA_TYPE[endpoint] || endpoint;
 // The string_id for the translated_strings table is a concatenation of this prefix
@@ -36,8 +36,8 @@ const getTranslationPrefix = (endpoint) =>
 
 // Helper function to generate the translation subquery
 const getTranslationSubquery = (endpoint, modelName) => `(
-  SELECT "text" 
-  FROM "translated_strings" 
+  SELECT "text"
+  FROM "translated_strings"
   WHERE "language" = $language
   AND "string_id" = '${getTranslationPrefix(endpoint)}' || "${modelName}"."id"
   LIMIT 1
@@ -507,7 +507,7 @@ createNameSuggester('survey', 'Survey', ({ search, query: { programId } }) => ({
 }));
 
 createSuggester(
-  'invoiceProducts',
+  'invoiceProduct',
   'InvoiceProduct',
   ({ endpoint, modelName }) => ({
     ...DEFAULT_WHERE_BUILDER({ endpoint, modelName }),

--- a/packages/web/app/components/Invoice/EditInvoiceModal/InvoiceItem.jsx
+++ b/packages/web/app/components/Invoice/EditInvoiceModal/InvoiceItem.jsx
@@ -126,7 +126,7 @@ export const InvoiceItemRow = ({
     !item?.productId?.startsWith(REFERENCE_TYPES.ADDITIONAL_INVOICE_PRODUCT) ||
     !editable;
 
-  const invoiceProductsSuggester = useSuggester('invoiceProducts', {
+  const invoiceProductsSuggester = useSuggester('invoiceProduct', {
     formatter: ({ name, id, ...others }) => ({
       ...others,
       productName: name,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the naming of the invoice product suggester endpoint from plural to singular for consistency across the application.
  - Updated related test cases and component usage to match the revised endpoint name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->