### PR TITLE
fix(sync): SAV-983: Ensure records updated by a sync have a unique sync tick on the central-server

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -154,6 +154,7 @@ describe('CentralSyncManager', () => {
   beforeEach(async () => {
     await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, DEFAULT_CURRENT_SYNC_TIME_VALUE);
     await models.SyncLookupTick.truncate({ force: true });
+    await models.SyncDeviceTick.truncate({ force: true });
     await models.Facility.truncate({ cascade: true, force: true });
     await models.Program.truncate({ cascade: true, force: true });
     await models.Survey.truncate({ cascade: true, force: true });
@@ -1995,6 +1996,151 @@ describe('CentralSyncManager', () => {
           }),
         ]),
       );
+    });
+  });
+
+  describe('syncDeviceTick', () => {
+    beforeEach(async () => {
+      jest.resetModules();
+    });
+
+    it('correctly sets the sync device tick for a sync', async () => {
+      const INITIAL_SYNC_TICK = '16';
+      await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, INITIAL_SYNC_TICK);
+      const facility = await models.Facility.create(fake(models.Facility));
+
+      // Existing patient
+      const patient = await models.Patient.create({
+        ...fake(models.Patient),
+        displayId: 'DEF',
+      });
+
+      expect(patient.updatedAtSyncTick).toBe(INITIAL_SYNC_TICK);
+
+      // Patient data for pushing (not inserted yet)
+      const updatedPatientData = {
+        ...patient.dataValues,
+        firstName: 'Changed',
+      };
+
+      const changes = [
+        {
+          direction: SYNC_SESSION_DIRECTION.OUTGOING,
+          isDeleted: false,
+          recordType: 'patients',
+          recordId: updatedPatientData.id,
+          data: updatedPatientData,
+        },
+      ];
+
+      const centralSyncManager = initializeCentralSyncManager();
+      const { sessionId } = await centralSyncManager.startSession({ deviceId: facility.id });
+      await waitForSession(centralSyncManager, sessionId);
+
+      // Push the change
+      await centralSyncManager.addIncomingChanges(sessionId, changes);
+      await centralSyncManager.completePush(sessionId, facility.id);
+      await waitForPushCompleted(centralSyncManager, sessionId);
+
+      await patient.reload();
+
+      // Check if patient updated and sync device tick is created and is unique
+      expect(patient.displayId).toBe(updatedPatientData.displayId);
+      expect(Number.parseInt(patient.updatedAtSyncTick, 10)).toBeGreaterThan(
+        Number.parseInt(INITIAL_SYNC_TICK, 10),
+      );
+      expect(Number.parseInt(patient.updatedAtSyncTick, 10)).toBeLessThan(
+        Number.parseInt(await models.LocalSystemFact.get(FACT_CURRENT_SYNC_TICK), 10),
+      );
+      const syncDeviceTick = await models.SyncDeviceTick.findByPk(patient.updatedAtSyncTick);
+      expect(syncDeviceTick.deviceId).toBe(facility.id);
+    });
+
+    it('prevents concurrent edits from sharing the same sync tick as the device sync tick', async () => {
+      let tickTock;
+      let unblockTickTock;
+      const blockTickTockPromise = new Promise((resolve) => {
+        unblockTickTock = resolve;
+      });
+
+      let flagTickTockBlocked;
+      const isTickTockBlockedPromise = new Promise((resolve) => {
+        flagTickTockBlocked = resolve;
+      });
+
+      const blockTickTock = () => {
+        sequelize.transaction(async () => {
+          await tickTock();
+          await blockTickTockPromise;
+        });
+        flagTickTockBlocked();
+      };
+      const originalUpdateSnapshotRecords =
+        jest.requireActual('@tamanu/database/sync').updateSnapshotRecords;
+      const mockUpdateSnapshotRecords = jest.fn().mockImplementation(async (...args) => {
+        // Block tickTock before completing the persist transaction so that we can test if concurrent edits share the same sync tick
+        blockTickTock();
+        return originalUpdateSnapshotRecords(...args);
+      });
+
+      jest.doMock('@tamanu/database/sync', () => ({
+        ...jest.requireActual('@tamanu/database/sync'),
+        updateSnapshotRecords: mockUpdateSnapshotRecords,
+      }));
+
+      const INITIAL_SYNC_TICK = '16';
+      await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, INITIAL_SYNC_TICK);
+      const facility = await models.Facility.create(fake(models.Facility));
+
+      // Existing patient
+      const patient = await models.Patient.create({
+        ...fake(models.Patient),
+        displayId: 'DEF',
+      });
+
+      expect(patient.updatedAtSyncTick).toBe(INITIAL_SYNC_TICK);
+
+      // Patient data for pushing (not inserted yet)
+      const updatedPatientData = {
+        ...patient.dataValues,
+        firstName: 'Changed',
+      };
+
+      const changes = [
+        {
+          direction: SYNC_SESSION_DIRECTION.OUTGOING,
+          isDeleted: false,
+          recordType: 'patients',
+          recordId: updatedPatientData.id,
+          data: updatedPatientData,
+        },
+      ];
+
+      const centralSyncManager = initializeCentralSyncManager();
+      tickTock = centralSyncManager.tickTockGlobalClock.bind(centralSyncManager);
+      const { sessionId } = await centralSyncManager.startSession({ deviceId: facility.id });
+      await waitForSession(centralSyncManager, sessionId);
+
+      // Push the change
+      await centralSyncManager.addIncomingChanges(sessionId, changes);
+      centralSyncManager.completePush(sessionId, facility.id);
+
+      // Mid push, make a concurrent edit to see if it shares the same sync tick as the device sync tick
+      await isTickTockBlockedPromise;
+      const concurrentEdit = await models.Patient.create({
+        ...fake(models.Patient),
+        displayId: 'GHI',
+      });
+      unblockTickTock();
+      await waitForPushCompleted(centralSyncManager, sessionId);
+
+      await patient.reload();
+
+      // Check if patient updated and the concurrent edit has a different sync tick
+      expect(patient.displayId).toBe(updatedPatientData.displayId);
+      expect(patient.updatedAtSyncTick).not.toBe(concurrentEdit.updatedAtSyncTick);
+      const syncDeviceTick = await models.SyncDeviceTick.findByPk(patient.updatedAtSyncTick);
+      expect(syncDeviceTick.deviceId).toBe(facility.id);
     });
   });
 

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -649,6 +649,11 @@ export class CentralSyncManager {
           { direction: SYNC_SESSION_DIRECTION.INCOMING },
         );
 
+        // Tick tock once more to ensure that no records that are subsequently modified will share the same sync tick as the incoming changes
+        // notably so that if records are modified by adjustDataPostSyncPush(), they will be picked up for pulling in the same session
+        // (specifically won't be removed by removeEchoedChanges())
+        await this.tickTockGlobalClock();
+
         return tock;
       });
 
@@ -656,9 +661,6 @@ export class CentralSyncManager {
         deviceId,
         persistedAtSyncTick,
       });
-      // tick tock global clock so that if records are modified by adjustDataPostSyncPush(),
-      // they will be picked up for pulling in the same session (specifically won't be removed by removeEchoedChanges())
-      await this.tickTockGlobalClock();
       await adjustDataPostSyncPush(sequelize, modelsToInclude, sessionId);
 
       // mark for repull any records that were modified by an incoming sync hook


### PR DESCRIPTION
### Changes

Bit of a sneaky issue here. It was possible that edits made to the central database while a sync was persisting would share a `updated_at_sync_tick` with the records from that sync. The problem is that when we build the `sync_lookup` table, we rely on the `synx_device_ticks` table to tell us which records were pushed by which device. If records are incorrectly treated as part of a sync, they won't sync down to the facility.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sync behavior to ensure records modified during sync have distinct sync ticks, preventing issues with record visibility during pull operations.

- **Tests**
  - Added new test cases to verify correct handling of sync ticks during device synchronization and concurrent edits.
  - Enhanced test setup to ensure a clean state before each test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->