### PR TITLE
style(charting): SAV-694: Make charting table body scrollable like vitals table

### DIFF
--- a/packages/web/app/components/Charting/ChartDropdown.jsx
+++ b/packages/web/app/components/Charting/ChartDropdown.jsx
@@ -6,6 +6,7 @@ import { SelectField } from '../Field';
 
 const StyledTranslatedSelectField = styled(SelectField)`
   width: 300px;
+  z-index: 3;
 `;
 
 export const ChartDropdown = ({ selectedChartTypeId, setSelectedChartTypeId, chartTypes }) => {

--- a/packages/web/app/components/ChartsTable.jsx
+++ b/packages/web/app/components/ChartsTable.jsx
@@ -1,15 +1,20 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { DynamicColumnTable, Table } from './Table';
-
 import { Box } from '@material-ui/core';
+import styled from 'styled-components';
 
 import { Colors } from '../constants';
+import { DynamicColumnTable, Table } from './Table';
 import { useEncounter } from '../contexts/Encounter';
 import { useEncounterChartsQuery } from '../api/queries/useEncounterChartsQuery';
 import { EditVitalCellModal } from './EditVitalCellModal';
 import { getChartsTableColumns } from './VitalsAndChartsTableColumns';
 import { LoadingIndicator } from './LoadingIndicator';
+
+const StyledDynamicColumnTable = styled(DynamicColumnTable)`
+  overflow-y: scroll;
+  max-height: 62vh; /* Matches generic Table height */
+`;
 
 export const EmptyChartsTable = ({ noDataMessage, isLoading = false }) => (
   <Table
@@ -78,7 +83,7 @@ export const ChartsTable = React.memo(({ selectedSurveyId, noDataMessage }) => {
         }}
         data-testid="editvitalcellmodal-2jqx"
       />
-      <DynamicColumnTable
+      <StyledDynamicColumnTable
         columns={columns}
         data={data}
         elevated={false}
@@ -87,6 +92,7 @@ export const ChartsTable = React.memo(({ selectedSurveyId, noDataMessage }) => {
         allowExport
         showFooterLegend={showFooterLegend}
         data-testid="dynamiccolumntable-ddeu"
+        isBodyScrollable
       />
     </>
   );


### PR DESCRIPTION
### Changes
- Then have to bump the ChartSelector so it doesn't fall behind sticky header
<img width="833" alt="Screenshot 2025-06-05 at 1 22 23 PM" src="https://github.com/user-attachments/assets/63334341-2ef4-431d-91e0-9e3ed41dc257" />

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dropdown layering to ensure it displays correctly above other elements.
  - Enhanced table appearance with scrollable content and a maximum height for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->