### PR TITLE
fix(migrations): Exclude SequelizeMeta from logs

### DIFF
--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -31,6 +31,9 @@ export const NON_LOGGED_TABLES = [
   'public.sync_device_ticks',
   'public.sync_lookup_ticks',
 
+  // internal migration tables
+  'public.SequelizeMeta',
+
   // caches
   'public.user_localisation_caches',
   'public.user_recently_viewed_patients',


### PR DESCRIPTION
### Changes

Thanks to Daniel which is the one who actually suggested the change!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal handling to better group migration-related tables, with no impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->