### PR TITLE
fix(translations): NASS-1704: Translate custom patient fields

### DIFF
--- a/packages/central-server/app/admin/importer/translationHandler.js
+++ b/packages/central-server/app/admin/importer/translationHandler.js
@@ -1,0 +1,62 @@
+import { camelCase } from 'lodash';
+import {
+  TRANSLATABLE_REFERENCE_TYPES,
+  REFERENCE_DATA_TRANSLATION_PREFIX,
+  DEFAULT_LANGUAGE_CODE,
+} from '@tamanu/constants';
+import { normaliseSheetName } from './importerEndpoint';
+
+function extractRecordName(values, dataType) {
+  if (dataType === 'scheduledVaccine') return values.label;
+  return values.name;
+}
+
+export function collectTranslationData(model, sheetName, values) {
+  const translationData = [];
+
+  const dataType = normaliseSheetName(sheetName, model);
+  const isValidTable = model === 'ReferenceData' || camelCase(model) === dataType;
+  const isTranslatable = TRANSLATABLE_REFERENCE_TYPES.includes(dataType);
+
+  if (isTranslatable && isValidTable) {
+    translationData.push([
+      `${REFERENCE_DATA_TRANSLATION_PREFIX}.${dataType}.${values.id}`,
+      extractRecordName(values, dataType) ?? '',
+      DEFAULT_LANGUAGE_CODE,
+    ]);
+
+    // Create translations for reference data record options if they exist
+    // This includes patient_field_definition options
+    if (values.options && values.options.length > 0) {
+      // Handle either an array or a comma-separated string of options
+      const optionArray = Array.isArray(values.options)
+        ? values.options
+        : values.options.split(/\s*,\s*/).filter((x) => x);
+      for (const option of optionArray) {
+        translationData.push([
+          `${REFERENCE_DATA_TRANSLATION_PREFIX}.${dataType}.${values.id}.option.${camelCase(option)}`,
+          option,
+          DEFAULT_LANGUAGE_CODE,
+        ]);
+      }
+    }
+  }
+
+  return translationData;
+}
+
+export async function bulkUpsertTranslationDefaults(models, translationData) {
+  if (translationData.length === 0) return;
+
+  await models.TranslatedString.sequelize.query(
+    `
+      INSERT INTO translated_strings (string_id, text, language)
+      VALUES ${translationData.map(() => '(?)').join(',')}
+        ON CONFLICT (string_id, language) DO UPDATE SET text = excluded.text;
+    `,
+    {
+      replacements: translationData,
+      type: models.TranslatedString.sequelize.QueryTypes.INSERT,
+    },
+  );
+}

--- a/packages/facility-server/app/routes/apiv1/patient/patientRelations.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientRelations.js
@@ -357,6 +357,8 @@ patientRelations.get(
       `SELECT
     reference_data.name AS test_category,
     lab_test_types.name AS test_type,
+    lab_test_types.options AS test_options,
+    lab_test_types.id AS test_type_id,
     FIRST(lab_test_types.unit) AS unit,
     JSONB_BUILD_OBJECT(
       'male', JSONB_BUILD_OBJECT(
@@ -416,7 +418,7 @@ patientRelations.get(
       : ''
   }
   GROUP BY
-    test_category, test_type
+    test_category, test_type, test_options, test_type_id
   ORDER BY
     test_category`,
       {

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -126,7 +126,7 @@ export class TamanuApi extends ApiClient {
       deviceId: getDeviceId(),
     });
 
-    this.interceptors.request.use((config) => {
+    this.interceptors.request.use(config => {
       const language = localStorage.getItem(LANGUAGE);
       config.headers['language'] = language;
       return config;
@@ -205,26 +205,39 @@ export class TamanuApi extends ApiClient {
       if (err instanceof AuthExpiredError) {
         clearLocalStorage();
       } else if (showUnknownErrorToast && isErrorUnknown(err)) {
-        notifyError([
-          <b key="general.api.notification.requestFailed">
+        // TODO: this is a hack to get the language from the browser
+        const language = localStorage.getItem(LANGUAGE);
+        if (language === 'en') {
+          notifyError([
+            <b key="general.api.notification.requestFailed">
+              <TranslatedText
+                stringId="general.api.notification.requestFailed"
+                fallback="Network request failed"
+              />
+            </b>,
             <TranslatedText
-              stringId="general.api.notification.requestFailed"
-              fallback="Network request failed"
-            />
-          </b>,
-          <TranslatedText
-            key="general.api.notification.path"
-            stringId="general.api.notification.path"
-            fallback={`Path: ${err.path ?? endpoint}`}
-            replacements={{ path: err.path ?? endpoint }}
-          />,
-          <TranslatedText
-            key="general.api.notification.message"
-            stringId="general.api.notification.message"
-            fallback={`Message: ${message}`}
-            replacements={{ message }}
-          />,
-        ]);
+              key="general.api.notification.path"
+              stringId="general.api.notification.path"
+              fallback="Path: :path"
+              replacements={{ path: err.path ?? endpoint }}
+            />,
+            <TranslatedText
+              key="general.api.notification.message"
+              stringId="general.api.notification.message"
+              fallback="Message: :message"
+              replacements={{ message }}
+            />,
+          ]);
+        } else {
+          notifyError([
+            <b key="general.api.notification.requestFailed">
+              <TranslatedText
+                stringId="general.api.notification.requestFailed"
+                fallback="Network request failed"
+              />
+            </b>,
+          ]);
+        }
       }
 
       throw new Error(message);

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -230,10 +230,10 @@ export class TamanuApi extends ApiClient {
           ]);
         } else {
           notifyError([
-            <b key="general.api.notification.requestFailed">
+            <b key="general.api.notification.requestFailed.generic">
               <TranslatedText
-                stringId="general.api.notification.requestFailed"
-                fallback="Network request failed"
+                stringId="general.api.notification.requestFailed.generic"
+                fallback="Network request failed. Please contact your administrator."
               />
             </b>,
           ]);

--- a/packages/web/app/components/Translation/TranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/TranslatedOptions.jsx
@@ -1,0 +1,40 @@
+import React, { useMemo } from 'react';
+
+import { getReferenceDataOptionStringId } from './TranslatedReferenceData';
+import { useTranslation } from '../../contexts/Translation';
+import { SelectField } from '../Field/SelectField';
+import { TranslatedText } from './TranslatedText';
+
+export const TranslatedOptionSelectField = ({
+  options,
+  referenceDataId,
+  referenceDataCategory,
+  ...props
+}) => {
+  const { getTranslation } = useTranslation();
+  const translatedOptions = useMemo(
+    () =>
+      options.map(option => {
+        const stringId = getReferenceDataOptionStringId(
+          referenceDataId,
+          referenceDataCategory,
+          option,
+        );
+        return {
+          label: getTranslation(stringId, option),
+          value: option,
+        };
+      }),
+    [options, referenceDataId, referenceDataCategory, getTranslation],
+  );
+  return <SelectField options={translatedOptions} {...props} />;
+};
+
+export const TranslatedOption = ({
+  value,
+  referenceDataId,
+  referenceDataCategory,
+}) => {
+  const stringId = getReferenceDataOptionStringId(referenceDataId, referenceDataCategory, value);
+  return <TranslatedText stringId={stringId} fallback={value} />;
+};

--- a/packages/web/app/components/Translation/TranslatedReferenceData.jsx
+++ b/packages/web/app/components/Translation/TranslatedReferenceData.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TranslatedText } from './TranslatedText';
+import { camelCase } from 'lodash';
+
 import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
+
+import { TranslatedText } from './TranslatedText';
 
 export const getReferenceDataStringId = (value, category) => {
   return `${REFERENCE_DATA_TRANSLATION_PREFIX}.${category}.${value}`;
+};
+
+export const getReferenceDataOptionStringId = (value, category, option) => {
+  return `${getReferenceDataStringId(value, category)}.option.${camelCase(option)}`;
 };
 
 export const TranslatedReferenceData = ({ category, value, fallback, placeholder }) => {

--- a/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
@@ -3,7 +3,6 @@ import {
   Field,
   FormGrid,
   NumberField,
-  SelectField,
   TextField,
   TranslatedReferenceData,
   TranslatedText,
@@ -12,6 +11,7 @@ import { PATIENT_FIELD_DEFINITION_TYPES } from '@tamanu/constants';
 import { groupBy } from 'lodash';
 import styled from 'styled-components';
 import { Colors } from '../../constants';
+import { TranslatedOptionSelectField } from '../../components/Translation/TranslatedOptions';
 
 const StyledHeading = styled.div`
   font-weight: 500;
@@ -38,14 +38,15 @@ export const PatientField = ({ definition: { definitionId, name, fieldType, opti
   );
   const fieldName = `patientFields.${definitionId}`;
   if (fieldType === PATIENT_FIELD_DEFINITION_TYPES.SELECT) {
-    const fieldOptions = options.map(o => ({ label: o, value: o }));
     return (
       <Field
         name={fieldName}
-        component={SelectField}
+        component={TranslatedOptionSelectField}
+        referenceDataId={definitionId}
+        referenceDataCategory="patientFieldDefinition"
         label={label}
-        options={fieldOptions}
-        data-testid="field-32ps"
+        options={options}
+        data-testid={`custom-patient-field-${definitionId}`}
       />
     );
   }
@@ -56,7 +57,7 @@ export const PatientField = ({ definition: { definitionId, name, fieldType, opti
         component={TextField}
         label={label}
         enablePasting
-        data-testid="field-gcal"
+        data-testid={`custom-patient-field-${definitionId}`}
       />
     );
   }

--- a/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
@@ -24,6 +24,7 @@ const StyledFormGrid = styled(FormGrid)`
   margin-bottom: 70px;
 `;
 
+// TODO: options not translatable in current implementation
 export const PatientField = ({ definition: { definitionId, name, fieldType, options } }) => {
   // TODO: temporary placeholder component
   // the plan is to reuse the survey question components for these fields

--- a/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientFields.jsx
@@ -1,5 +1,13 @@
 import React, { Fragment } from 'react';
-import { Field, FormGrid, NumberField, SelectField, TextField } from '../../components';
+import {
+  Field,
+  FormGrid,
+  NumberField,
+  SelectField,
+  TextField,
+  TranslatedReferenceData,
+  TranslatedText,
+} from '../../components';
 import { PATIENT_FIELD_DEFINITION_TYPES } from '@tamanu/constants';
 import { groupBy } from 'lodash';
 import styled from 'styled-components';
@@ -19,14 +27,22 @@ const StyledFormGrid = styled(FormGrid)`
 export const PatientField = ({ definition: { definitionId, name, fieldType, options } }) => {
   // TODO: temporary placeholder component
   // the plan is to reuse the survey question components for these fields
+
+  const label = (
+    <TranslatedReferenceData
+      category="patientFieldDefinition"
+      value={definitionId}
+      fallback={name}
+    />
+  );
   const fieldName = `patientFields.${definitionId}`;
   if (fieldType === PATIENT_FIELD_DEFINITION_TYPES.SELECT) {
-    const fieldOptions = options.map((o) => ({ label: o, value: o }));
+    const fieldOptions = options.map(o => ({ label: o, value: o }));
     return (
       <Field
         name={fieldName}
         component={SelectField}
-        label={name}
+        label={label}
         options={fieldOptions}
         data-testid="field-32ps"
       />
@@ -37,7 +53,7 @@ export const PatientField = ({ definition: { definitionId, name, fieldType, opti
       <Field
         name={fieldName}
         component={TextField}
-        label={name}
+        label={label}
         enablePasting
         data-testid="field-gcal"
       />
@@ -46,18 +62,33 @@ export const PatientField = ({ definition: { definitionId, name, fieldType, opti
   if (fieldType === PATIENT_FIELD_DEFINITION_TYPES.NUMBER) {
     return <Field name={fieldName} component={NumberField} label={name} data-testid="field-4rs2" />;
   }
-  return <p>Unknown field type: {fieldType}</p>;
+  return (
+    <p>
+      <TranslatedText
+        stringId="patientFields.error.unknownFieldType"
+        fallback="Unknown field type: :fieldType"
+        replacements={{ fieldType }}
+        data-testid="translatedtext-unknown-field-type"
+      />
+    </p>
+  );
 };
 
 export const PatientFieldsGroup = ({ fieldDefinitions, fieldValues }) => {
-  const groupedFieldDefs = Object.entries(groupBy(fieldDefinitions, 'category'));
+  const groupedFieldDefs = Object.entries(groupBy(fieldDefinitions, 'categoryId'));
   return (
     <div>
-      {groupedFieldDefs.map(([category, defs]) => (
-        <Fragment key={category} data-testid="fragment-e981">
-          <StyledHeading data-testid="styledheading-5shc">{category}</StyledHeading>
+      {groupedFieldDefs.map(([categoryId, defs]) => (
+        <Fragment key={categoryId} data-testid="fragment-e981">
+          <StyledHeading data-testid="styledheading-5shc">
+            <TranslatedReferenceData
+              category="patientFieldDefinitionCategory"
+              value={categoryId}
+              fallback={defs[0].category}
+            />
+          </StyledHeading>
           <StyledFormGrid data-testid="styledformgrid-kotn">
-            {defs.map((f) => (
+            {defs.map(f => (
               <PatientField
                 key={f.definitionId}
                 definition={f}

--- a/packages/web/app/utils/lab.jsx
+++ b/packages/web/app/utils/lab.jsx
@@ -43,7 +43,7 @@ export const getMethod = ({ labTestMethod }) =>
 
 export const getRequestedBy = ({ requestedBy }) =>
   (requestedBy || {})?.displayName || requestedBy || 'Unknown';
-export const getPatientName = (row) => <PatientNameDisplay patient={row} />;
+export const getPatientName = row => <PatientNameDisplay patient={row} />;
 export const getPatientDisplayId = ({ patientDisplayId }) => patientDisplayId || 'Unknown';
 export const getStatus = ({ status }) => <StatusDisplay status={status} />;
 export const getPanelType = ({ labTestPanelId, labTestPanelName }) => (
@@ -74,16 +74,17 @@ export const getRequestType = ({ categoryName, categoryId, category }) => {
   }
   return <TranslatedText stringId="general.fallback.unknown" fallback="Unknown" />;
 };
-export const getPriority = ({ priorityName, priority }) =>
-  priorityName ||
-  (priority && (
+export const getPriority = ({ priorityName, priorityId, priority }) =>
+  priorityName || priority ? (
     <TranslatedReferenceData
-      fallback={priority.name}
-      value={priority.id}
-      category={priority.type}
+      fallback={priorityName || priority.name}
+      value={priorityId || priority.id}
+      category="labTestPriority"
     />
-  )) ||
-  'Unknown';
+  ) : (
+    <TranslatedText stringId="general.fallback.unknown" fallback="Unknown" />
+  );
+
 export const getDateWithTimeTooltip = ({ requestedDate }) => (
   <DateDisplay date={requestedDate} timeOnlyTooltip />
 );

--- a/packages/web/app/views/patients/PatientLabTestsTable.jsx
+++ b/packages/web/app/views/patients/PatientLabTestsTable.jsx
@@ -6,8 +6,9 @@ import { Table } from '../../components/Table';
 import { DateHeadCell, RangeValidatedCell } from '../../components/FormattedTableCell';
 import { Colors } from '../../constants';
 import { LabTestResultModal } from './LabTestResultModal';
-import { BodyText, DateDisplay } from '../../components';
+import { BodyText, DateDisplay, TranslatedReferenceData } from '../../components';
 import { TranslatedText } from '../../components/Translation/TranslatedText';
+import { TranslatedOption } from '../../components/Translation/TranslatedOptions';
 
 const COLUMN_WIDTHS = [150, 120, 120];
 
@@ -17,19 +18,19 @@ const StyledTable = styled(Table)`
     position: relative;
     width: initial;
 
-    thead tr th:nth-child(-n + ${(props) => props.$stickyColumns}),
-    tbody tr td:nth-child(-n + ${(props) => props.$stickyColumns}) {
+    thead tr th:nth-child(-n + ${props => props.$stickyColumns}),
+    tbody tr td:nth-child(-n + ${props => props.$stickyColumns}) {
       position: sticky;
       z-index: 1;
       border-right: 1px solid ${Colors.outline};
     }
 
-    thead tr th:nth-child(${(props) => props.$stickyColumns}),
-    tbody tr td:nth-child(${(props) => props.$stickyColumns}) {
+    thead tr th:nth-child(${props => props.$stickyColumns}),
+    tbody tr td:nth-child(${props => props.$stickyColumns}) {
       border-right: 2px solid ${Colors.outline};
     }
 
-    ${(props) =>
+    ${props =>
       COLUMN_WIDTHS.slice(0, props.$stickyColumns)
         .map(
           (width, index) => `
@@ -59,7 +60,7 @@ const StyledTable = styled(Table)`
     }
 
     thead tr th {
-      color: ${(props) => props.theme.palette.text.secondary};
+      color: ${props => props.theme.palette.text.secondary};
       background: ${Colors.background};
       white-space: break-spaces;
     }
@@ -105,7 +106,7 @@ const StyledButton = styled(Button)`
   }
 `;
 
-const getTitle = (value) => {
+const getTitle = value => {
   const date = DateDisplay.stringFormat(value);
   const timeWithSeconds = DateDisplay.stringFormat(value, formatTimeWithSeconds);
   return `${date} ${timeWithSeconds}`;
@@ -115,7 +116,7 @@ export const PatientLabTestsTable = React.memo(
   ({ patient, labTests = [], count, isLoading, searchParameters }) => {
     const [modalLabTestId, setModalLabTestId] = useState();
     const [modalOpen, setModalOpen] = useState(false);
-    const openModal = (id) => {
+    const openModal = id => {
       if (id) {
         setModalLabTestId(id);
         setModalOpen(true);
@@ -124,7 +125,7 @@ export const PatientLabTestsTable = React.memo(
 
     const allDates = isLoading
       ? []
-      : Object.keys(Object.assign({}, ...labTests.map((x) => x.results)));
+      : Object.keys(Object.assign({}, ...labTests.map(x => x.results)));
 
     const stickyColumns = [
       // Only include category column if not filtering by category
@@ -139,7 +140,7 @@ export const PatientLabTestsTable = React.memo(
                   data-testid="translatedtext-0dpy"
                 />
               ),
-              accessor: (row) => (
+              accessor: row => (
                 <CategoryCell data-testid="categorycell-8dsz">{row.testCategory}</CategoryCell>
               ),
               sortable: false,
@@ -155,9 +156,14 @@ export const PatientLabTestsTable = React.memo(
             data-testid="translatedtext-hrn5"
           />
         ),
-        accessor: (row) => (
+        accessor: row => (
           <CategoryCell data-testid="categorycell-7aet">
-            {row.testType}
+         <TranslatedReferenceData
+        fallback={row.testType}
+        value={row.testTypeId}
+        category="labTestType"
+        data-testid="translatedreferencedata-kplb"
+      />
             <br />
             <BodyText color="textTertiary" data-testid="bodytext-zxuk">
               {row.unit ? `(${row.unit})` : null}
@@ -175,7 +181,7 @@ export const PatientLabTestsTable = React.memo(
             data-testid="translatedtext-v8jk"
           />
         ),
-        accessor: (row) => {
+        accessor: row => {
           const range = row.normalRanges[patient?.sex];
           const value = !range.min
             ? '—' // em dash
@@ -194,7 +200,7 @@ export const PatientLabTestsTable = React.memo(
           title: <DateHeadCell value={date} data-testid={`dateheadcell-qvnq-${index}`} />,
           sortable: false,
           key: date,
-          accessor: (row) => {
+          accessor: row => {
             const normalRange = row.normalRanges[patient?.sex];
             const cellData = row.results[date];
             if (cellData) {
@@ -203,12 +209,20 @@ export const PatientLabTestsTable = React.memo(
                   onClick={() => openModal(cellData.id)}
                   data-testid={`styledbutton-d5us-${index}`}
                 >
-                  <RangeValidatedCell
-                    value={cellData.result}
-                    config={{ unit: row.unit, rounding: null }}
-                    validationCriteria={{ normalRange: normalRange?.min ? normalRange : null }}
-                    data-testid={`rangevalidatedcell-ebuf-${index}`}
-                  />
+                  {row.testOptions ? (
+                    <TranslatedOption
+                      value={cellData.result}
+                      referenceDataId={row.testTypeId}
+                      referenceDataCategory="labTestType"
+                    />
+                  ) : (
+                    <RangeValidatedCell
+                      value={cellData.result}
+                      config={{ unit: row.unit, rounding: null }}
+                      validationCriteria={{ normalRange: normalRange?.min ? normalRange : null }}
+                      data-testid={`rangevalidatedcell-ebuf-${index}`}
+                    />
+                  )}
                 </StyledButton>
               );
             }
@@ -221,7 +235,7 @@ export const PatientLabTestsTable = React.memo(
           },
           exportOverrides: {
             title: `${getTitle(date)}`,
-            accessor: (row) => row.results[date]?.result || '—', // em dash
+            accessor: row => row.results[date]?.result || '—', // em dash
           },
         })),
     ];

--- a/packages/web/app/views/patients/components/AccessorField.jsx
+++ b/packages/web/app/views/patients/components/AccessorField.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { capitalize } from 'lodash';
-import { LAB_TEST_RESULT_TYPES } from '@tamanu/constants';
 import styled from 'styled-components';
-import { Field, NumberField, BaseSelectField, TextField } from '../../../components/Field';
+
+import { LAB_TEST_RESULT_TYPES } from '@tamanu/constants';
+
+import { Field, NumberField, TextField } from '../../../components/Field';
 import { Colors } from '../../../constants';
+import { TranslatedOptionSelectField } from '../../../components/Translation/TranslatedOptions';
 
 const StyledField = styled(Field)`
   .Mui-disabled {
@@ -15,7 +17,7 @@ const StyledField = styled(Field)`
 `;
 
 function getResultComponent(resultType, options) {
-  if (options && options.length) return BaseSelectField;
+  if (options && options.length) return TranslatedOptionSelectField;
   if (resultType === LAB_TEST_RESULT_TYPES.FREE_TEXT) return TextField;
   return NumberField;
 }
@@ -27,10 +29,6 @@ function getResultOptions(options) {
   return trimmed
     .split(/\s*,\s*/)
     .filter((x) => x)
-    .map((value) => ({
-      value,
-      label: capitalize(value),
-    }));
 }
 
 export const AccessorField = ({ id, name, tabIndex, ...props }) => (
@@ -42,11 +40,12 @@ export const AccessorField = ({ id, name, tabIndex, ...props }) => (
   />
 );
 
-export const LabResultAccessorField = ({ resultType, options, ...props }) => (
+export const LabResultAccessorField = ({ resultType, options, labTestTypeId, ...props }) => (
   <AccessorField
     component={getResultComponent(resultType, options)}
     options={getResultOptions(options)}
+    referenceDataId={labTestTypeId}
+    referenceDataCategory='labTestType'
     {...props}
-    data-testid="accessorfield-mcjl"
   />
 );

--- a/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
+++ b/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
@@ -4,6 +4,7 @@ import { DataFetchingTable } from '../../../components';
 
 import { getCompletedDate, getMethod } from '../../../utils/lab';
 import { TranslatedText, TranslatedReferenceData } from '../../../components/Translation';
+import { TranslatedOption } from '../../../components/Translation/TranslatedOptions';
 
 const StyledDataFetchingTable = styled(DataFetchingTable)`
   table tbody tr:last-child td {
@@ -58,7 +59,17 @@ const columns = (sex) => [
       />
     ),
     key: 'result',
-    accessor: ({ result }) => result ?? '',
+    accessor: ({labTestType, result}) => {
+      const { options, id: labTestTypeId } = labTestType;
+      if (options && options.length > 0) {
+        return <TranslatedOption
+          value={result}
+          referenceDataId={labTestTypeId}
+          referenceDataCategory="labTestType"
+        />
+      }
+      return result ?? '';
+    },
   },
   {
     title: (

--- a/packages/web/app/views/patients/components/LabTestResultsModal.jsx
+++ b/packages/web/app/views/patients/components/LabTestResultsModal.jsx
@@ -96,7 +96,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
         />
       ),
       accessor: (row, i) => {
-        const { resultType, options } = row.labTestType;
+        const { resultType, options, id: labTestTypeId } = row.labTestType;
         return (
           <LabResultAccessorField
             resultType={resultType}
@@ -105,6 +105,7 @@ const getColumns = (count, onChangeResult, areLabTestResultsReadOnly) => {
             name={LAB_TEST_PROPERTIES.RESULT}
             onChange={(e) => onChangeResult(e.target.value, row.id)}
             id={row.id}
+            labTestTypeId={labTestTypeId}
             tabIndex={tabIndex(0, i)}
             data-testid="labresultaccessorfield-1r9h"
           />


### PR DESCRIPTION
### Changes

Custom patient fields translations are being created correctly on import but the logic to display on the front-end was never implemented. Just doing that here

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced internationalization support for patient field labels and group headings, enabling translation of these elements throughout the form.
  - Enhanced error notifications with language-sensitive messaging to improve clarity based on user language settings.
  - Added translation support for selectable options in lab test results and patient-related fields, improving localization consistency.
  
- **Refactor**
  - Updated field grouping to use improved identifiers for more accurate categorization.
  - Centralized translation data handling and bulk update processes for reference data imports, simplifying translation management.
  - Refined lab test result and priority display components to leverage translation-aware elements for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->