### PR TITLE
feat(ci): Improve model error logging

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -159,11 +159,6 @@ describe('Sync Lookup data', () => {
       data: Buffer.from('test'),
     });
     const referenceData = await ReferenceData.create(fake(ReferenceData));
-
-    const referenceDataBaseObject = fake(ReferenceData, { id: 'reference-data-base-object' });
-    await ReferenceData.create(referenceDataBaseObject);
-    await ReferenceData.create(referenceDataBaseObject);
-
     await ReferenceDataRelation.create(fake(ReferenceDataRelation));
     const category = await PatientFieldDefinitionCategory.create(
       fake(PatientFieldDefinitionCategory),

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -159,6 +159,11 @@ describe('Sync Lookup data', () => {
       data: Buffer.from('test'),
     });
     const referenceData = await ReferenceData.create(fake(ReferenceData));
+
+    const referenceDataBaseObject = fake(ReferenceData, { id: 'reference-data-base-object' });
+    await ReferenceData.create(referenceDataBaseObject);
+    await ReferenceData.create(referenceDataBaseObject);
+
     await ReferenceDataRelation.create(fake(ReferenceDataRelation));
     const category = await PatientFieldDefinitionCategory.create(
       fake(PatientFieldDefinitionCategory),

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -144,7 +144,7 @@ async function connectToDatabase(dbOptions) {
           return await super.run(sql, options);
         } catch (error) {
           log.error(error);
-          throw new Error('Error in query, see logs for more details');
+          throw error;
         }
       }
     }

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -143,8 +143,8 @@ async function connectToDatabase(dbOptions) {
         try {
           return await super.run(sql, options);
         } catch (error) {
-          console.error(error);
-          return null;
+          log.error(error);
+          throw new Error('Error in query, see logs for more details');
         }
       }
     }

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -140,7 +140,12 @@ async function connectToDatabase(dbOptions) {
             'SELECT public.set_session_config($1, $2)',
             [AUDIT_USERID_KEY, userid],
           );
-        return super.run(sql, options);
+        try {
+          return await super.run(sql, options);
+        } catch (error) {
+          console.error(error);
+          return null;
+        }
       }
     }
     sequelize.dialect.Query = QueryWithAuditConfig;


### PR DESCRIPTION
### Changes

With the addition of auditability, whenever we have an error caused by a database model it spews a very unhelpful message and also doesn't point you to the place where the error occurred. With this change, we still get the same unhelpful message but we are now logging the error, which is helpful to speed things up.

Note that I modified a test file to trigger the error by trying to insert two rows with the same `id`. See commit one to check that logic. After getting the two CI runs with previous and current error messages to grab the links for showcase I rolled it back.

Example of unhelpful error message: https://github.com/beyondessential/tamanu/actions/runs/15510032179/job/43669812882?pr=7791

```
      141 |             [AUDIT_USERID_KEY, userid],
      142 |           );
    > 143 |         return super.run(sql, options);
          |                      ^
      144 |       }
      145 |     }
      146 |     sequelize.dialect.Query = QueryWithAuditConfig;

      at QueryWithAuditConfig.run (../../node_modules/sequelize/src/dialects/postgres/query.js:76:25)
      at QueryWithAuditConfig.run (../database/src/services/database.js:143:22)
      at ../../node_modules/sequelize/src/sequelize.js:650:28
      at PostgresQueryInterface.insert (../../node_modules/sequelize/src/dialects/abstract/query-interface.js:795:21)
      at ReferenceData.save (../../node_modules/sequelize/src/model.js:4154:35)
      at Function.create (../../node_modules/sequelize/src/model.js:2305:12)
      at prepareData (__tests__/sync/CentralSyncManager.syncLookup.test.js:165:5)
      at Object.<anonymous> (__tests__/sync/CentralSyncManager.syncLookup.test.js:605:5)
```

Example with change applied: https://github.com/beyondessential/tamanu/actions/runs/15510408792/job/43670710419?pr=7791

```
142 |           );
      143 |         try {
    > 144 |           return await super.run(sql, options);
          |                              ^
      [145](https://github.com/beyondessential/tamanu/actions/runs/15510408792/job/43670710419?pr=7791#step:9:146) |         } catch (error) {
      [146](https://github.com/beyondessential/tamanu/actions/runs/15510408792/job/43670710419?pr=7791#step:9:147) |           log.error(error);
      147 |           throw error;

      at QueryWithAuditConfig.run (../../node_modules/sequelize/src/dialects/postgres/query.js:76:25)
      at QueryWithAuditConfig.run (../database/src/services/database.js:144:30)
      at ../../node_modules/sequelize/src/sequelize.js:650:28
      at PostgresQueryInterface.insert (../../node_modules/sequelize/src/dialects/abstract/query-interface.js:795:21)
      at ReferenceData.save (../../node_modules/sequelize/src/model.js:4[154](https://github.com/beyondessential/tamanu/actions/runs/15510408792/job/43670710419?pr=7791#step:9:155):35)
      at Function.create (../../node_modules/sequelize/src/model.js:2305:12)
      at prepareData (__tests__/sync/CentralSyncManager.syncLookup.test.js:165:5)
      at Object.<anonymous> (__tests__/sync/CentralSyncManager.syncLookup.test.js:605:5)
```

Unhelpful as well, but we get this logged, too:

```
FAIL __disttests__/sync/CentralSyncManager.syncLookup.test.js (37.168 s)
  ● Console

    console.log
      error: undefined name=SequelizeUniqueConstraintError errors=[object Object] parent=error: duplicate key value violates unique constraint "reference_data_pkey" original=error: duplicate key value violates unique constraint "reference_data_pkey" fields=[object Object] sql=INSERT INTO "reference_data" ("id","code","type","name","visibility_status","created_at","updated_at") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id","code","type","name","visibility_status","updated_at_sync_tick","created_at","updated_at","deleted_at";

      at Console.log (../../node_modules/winston/lib/winston/transports/console.js:87:23)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during database queries to enhance stability and provide clearer error messages.

- **Tests**
  - Updated test data setup for more consistent and reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->