### PR TITLE
fix(ci): Solve intermittent fail on WriteLog unit test

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -60,7 +60,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
-      await sleepAsync(1);
+      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
@@ -93,7 +93,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
-      await sleepAsync(1);
+      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
@@ -120,7 +120,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/fhir+json; fhirVersion=4.0')
         .send(body);
-      await sleepAsync(1);
+      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({
@@ -194,7 +194,7 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FuchBaz`).send(body);
-      await sleepAsync(1);
+      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
       const flog = await FhirWriteLog.findOne({

--- a/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/WriteLog.test.js
@@ -1,6 +1,5 @@
 import { Op } from 'sequelize';
 
-import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { showError } from '@tamanu/shared/test-helpers';
 import { SCRUBBED_DATA_MESSAGE } from '@tamanu/constants';
 
@@ -21,6 +20,17 @@ jest.mock('@tamanu/constants', () => {
     },
   };
 });
+
+const attemptFlogRetrieval = async (FhirWriteLog, options) => {
+  let flog;
+  for (let i = 0; i < 10; i++) {
+    flog = await FhirWriteLog.findOne(options);
+    if (flog) {
+      break;
+    }
+  }
+  return flog;
+};
 
 describe(`Materialised FHIR - WriteLog`, () => {
   let ctx;
@@ -60,10 +70,9 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
-      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
-      const flog = await FhirWriteLog.findOne({
+      const flog = await attemptFlogRetrieval(FhirWriteLog, {
         where: { url: { [Op.like]: '%FooBarBaz%' } },
       });
       expect(flog).toBeTruthy();
@@ -93,10 +102,9 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FooBarBaz`).send(body);
-      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
-      const flog = await FhirWriteLog.findOne({
+      const flog = await attemptFlogRetrieval(FhirWriteLog, {
         where: { url: { [Op.like]: '%FooBarBaz%' } },
       });
       expect(flog).toBeTruthy();
@@ -120,10 +128,9 @@ describe(`Materialised FHIR - WriteLog`, () => {
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/fhir+json; fhirVersion=4.0')
         .send(body);
-      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
-      const flog = await FhirWriteLog.findOne({
+      const flog = await attemptFlogRetrieval(FhirWriteLog, {
         where: { url: { [Op.like]: '%HeadMeOff%' } },
       });
       expect(flog).toBeTruthy();
@@ -194,10 +201,9 @@ describe(`Materialised FHIR - WriteLog`, () => {
         ],
       };
       const response = await app.post(`/api/integration/${INTEGRATION_ROUTE}/FuchBaz`).send(body);
-      await sleepAsync(10);
 
       expect(response.status).not.toBe(201);
-      const flog = await FhirWriteLog.findOne({
+      const flog = await attemptFlogRetrieval(FhirWriteLog, {
         where: { url: { [Op.like]: '%FuchBaz%' } },
       });
       expect(flog.verb).toEqual('POST');


### PR DESCRIPTION
### Changes

This issue has been there for quite a while. I attempted to resolve it a long time ago by adding a 1ms sleep, the reasoning being that we had to yield control for the log to be created. While it did work and improve things, it didn't get rid of the error completely.

I'm just giving it a little extra push, in all the runs I've done, with this timeout it doesn't fail. I have the feeling it will eventually fail, but it should at least be odd and not the norm.

PS: I did think about having a couple of retries, but that might be overkill 🤔 though code rabbit also considers that should be the way. I guess that it depends, having an ~8min step fail and having to retry it is definitely more costlier than having a retry mechanism that checks, say, 10 times and waits 5ms (~50ms+ overhead vs having to retry at all cause it's more robust?)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by implementing a smarter polling mechanism to verify logging behavior for FHIR resources and headers, replacing fixed wait times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->