### PR TITLE
fix(sync): no-issue: Prevent initiating sync pull if the sync lookup table has not yet built

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -230,6 +230,21 @@ describe('CentralSyncManager', () => {
         .finally(() => spyMarkAsStartedAt.mockRestore());
     });
 
+    it('throws an error if the sync lookup table has not yet built', async () => {
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: {
+          lookupTable: {
+            enabled: true,
+          },
+          maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+        },
+      });
+      const { sessionId } = await centralSyncManager.startSession();
+      await expect(waitForSession(centralSyncManager, sessionId)).rejects.toThrow(
+        `Sync session '${sessionId}' encountered an error: Sync lookup table has not yet built. Cannot initiate sync.`,
+      );
+    });
+
     it('throws an error when checking a session is ready if it never assigned a started_at_tick', async () => {
       const fakeMarkAsStartedAt = () => {
         // Do nothing and ensure we error out when the client starts polling
@@ -385,23 +400,6 @@ describe('CentralSyncManager', () => {
 
       await centralSyncManager.endSession(sessionId);
       await expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow();
-    });
-  });
-
-  describe('initiatePull', () => {
-    it('throws an error if the sync lookup table has not yet built', async () => {
-      const centralSyncManager = initializeCentralSyncManager({
-        sync: {
-          lookupTable: {
-            enabled: true,
-          },
-          maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
-        },
-      });
-      const { sessionId } = await centralSyncManager.startSession();
-      await centralSyncManager.initiatePull(sessionId, {});
-      const session = await models.SyncSession.findByPk(sessionId);
-      expect(session.errors).toEqual(['Sync lookup table has not yet built. Cannot initiate pull']);
     });
   });
 
@@ -1717,6 +1715,8 @@ describe('CentralSyncManager', () => {
             maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
           },
         });
+        await centralSyncManager.updateLookupTable();
+
         const { sessionId } = await centralSyncManager.startSession();
         await waitForSession(centralSyncManager, sessionId);
 
@@ -1802,6 +1802,7 @@ describe('CentralSyncManager', () => {
             maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
           },
         });
+        await centralSyncManager.updateLookupTable();
         const { sessionId } = await centralSyncManager.startSession();
         await waitForSession(centralSyncManager, sessionId);
 
@@ -1952,6 +1953,7 @@ describe('CentralSyncManager', () => {
           maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
         },
       });
+      await centralSyncManager.updateLookupTable();
       const { sessionId } = await centralSyncManager.startSession();
       await waitForSession(centralSyncManager, sessionId);
 
@@ -2039,6 +2041,7 @@ describe('CentralSyncManager', () => {
           maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
         },
       });
+      await centralSyncManager.updateLookupTable();
       const { sessionId } = await centralSyncManager.startSession();
       await waitForSession(centralSyncManager, sessionId);
 
@@ -2108,6 +2111,7 @@ describe('CentralSyncManager', () => {
           maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
         },
       });
+      await centralSyncManager.updateLookupTable();
       const { sessionId } = await centralSyncManager.startSession({ isMobile: true });
       await waitForSession(centralSyncManager, sessionId);
 

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -388,6 +388,23 @@ describe('CentralSyncManager', () => {
     });
   });
 
+  describe('initiatePull', () => {
+    it('throws an error if the sync lookup table has not yet built', async () => {
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: {
+          lookupTable: {
+            enabled: true,
+          },
+          maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+        },
+      });
+      const { sessionId } = await centralSyncManager.startSession();
+      await centralSyncManager.initiatePull(sessionId, {});
+      const session = await models.SyncSession.findByPk(sessionId);
+      expect(session.errors).toEqual(['Sync lookup table has not yet built. Cannot initiate pull']);
+    });
+  });
+
   describe('getOutgoingChanges', () => {
     beforeEach(async () => {
       jest.resetModules();

--- a/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
+++ b/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
@@ -32,8 +32,9 @@ describe('SyncQueuedDevice', () => {
   };
 
   beforeAll(async () => {
-    ({ baseApp, ...ctx } = await createTestContext());
-    ({ models } = ctx.store);
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
     app = await baseApp.asRole('admin');
 
     await Promise.all(
@@ -47,8 +48,14 @@ describe('SyncQueuedDevice', () => {
       sync: {
         awaitPreparation: true,
         maxConcurrentSessions: 1,
+        maxRecordsPerSnapshotChunk: 1000000000,
+        lookupTable: {
+          enabled: true,
+        },
       },
     });
+
+    await new CentralSyncManager(ctx).updateLookupTable();
   });
 
   beforeEach(async () => {

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -131,7 +131,6 @@ export class CentralSyncManager {
       // if the sync_lookup table is enabled, don't allow syncs until it has finished its first update run
       const syncLookupUpToTick =
         await this.store.models.LocalSystemFact.get(FACT_LOOKUP_UP_TO_TICK);
-      console.log('syncLookupUpToTick', syncLookupUpToTick);
       if (
         this.constructor.config.sync.lookupTable.enabled &&
         isNaN(parseInt(syncLookupUpToTick, 10))


### PR DESCRIPTION
### Changes

It was a bit confusing, but with the previous logic we'd allow the snapshot to start building even though the sync_lookup table hadn't yet built. This meant that while the facility that was doing the pulling was waiting until the sync_lookup had built, the snapshot ran regardless so there was no data to sync.

Decided to move it to the top of the pull control flow and just error out if the lookup table hadn't finished building.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
