### PR TITLE
tweak(security): KAM-404: add helmet library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41422,6 +41422,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.8.0.tgz",
@@ -73165,6 +73174,7 @@
         "express-validator": "^6.5.0",
         "follow": "^1.1.0",
         "form-data": "^4.0.0",
+        "helmet": "^8.1.0",
         "inflection": "^1.13.2",
         "jose": "^5.1.1",
         "json-canonicalize": "^1.0.4",
@@ -73799,6 +73809,7 @@
         "express-session": "^1.18.1",
         "express-validator": "^6.5.0",
         "follow": "^1.1.0",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.5",
         "mathjs": "^9.3.0",

--- a/packages/central-server/app/createApi.js
+++ b/packages/central-server/app/createApi.js
@@ -3,6 +3,7 @@ import compression from 'compression';
 import config from 'config';
 import defineExpress from 'express';
 import asyncHandler from 'express-async-handler';
+import helmet from 'helmet';
 
 import { getLoggingMiddleware, log } from '@tamanu/shared/services/logging';
 import { constructPermission } from '@tamanu/shared/permissions/middleware';
@@ -71,6 +72,12 @@ export async function createApi(ctx) {
     }
   }
 
+  express.use(
+    helmet({
+      crossOriginEmbedderPolicy: true,
+      strictTransportSecurity: false,
+    }),
+  );
   express.use(loadshedder());
   express.use(compression());
   express.use(bodyParser.json({ verify: rawBodySaver, limit: '50mb' }));

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -81,6 +81,7 @@
     "express-validator": "^6.5.0",
     "follow": "^1.1.0",
     "form-data": "^4.0.0",
+    "helmet": "^8.1.0",
     "inflection": "^1.13.2",
     "jose": "^5.1.1",
     "json-canonicalize": "^1.0.4",

--- a/packages/facility-server/app/createApiApp.js
+++ b/packages/facility-server/app/createApiApp.js
@@ -1,5 +1,6 @@
 import config from 'config';
 import defineExpress from 'express';
+import helmet from 'helmet';
 
 import { settingsReaderMiddleware } from '@tamanu/settings/middleware';
 import { defineDbNotifier } from '@tamanu/shared/services/dbNotifier';
@@ -35,6 +36,12 @@ export async function createApiApp({
   const websocketService = defineWebsocketService({ httpServer: server, dbNotifier, models });
   const websocketClientService = defineWebsocketClientService({ config, websocketService, models });
 
+  express.use(
+    helmet({
+      crossOriginEmbedderPolicy: true,
+      strictTransportSecurity: false,
+    }),
+  );
   const { errorMiddleware } = addFacilityMiddleware(express);
 
   // Release the connection back to the pool when the server is closed

--- a/packages/facility-server/app/createSyncApp.js
+++ b/packages/facility-server/app/createSyncApp.js
@@ -1,4 +1,5 @@
 import defineExpress from 'express';
+import helmet from 'helmet';
 
 import errorHandler from './middleware/errorHandler';
 import { createServer } from 'http';
@@ -9,6 +10,12 @@ export async function createSyncApp({ sequelize, syncManager, models, deviceId }
   const express = defineExpress();
   const server = createServer(express);
 
+  express.use(
+    helmet({
+      crossOriginEmbedderPolicy: true,
+      strictTransportSecurity: false,
+    }),
+  );
   const { errorMiddleware } = addFacilityMiddleware(express);
 
   express.use((req, res, next) => {

--- a/packages/facility-server/package.json
+++ b/packages/facility-server/package.json
@@ -62,6 +62,7 @@
     "express-session": "^1.18.1",
     "express-validator": "^6.5.0",
     "follow": "^1.1.0",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.5",
     "mathjs": "^9.3.0",


### PR DESCRIPTION
### Changes

Went through https://helmetjs.github.io/#reference to tweak the options. HSTS is disabled because in various setups (e.g. Itis) we use plain HTTP, and if we want HSTS we can set that within caddy.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced server security by adding improved HTTP header protections.
- **Chores**
  - Updated dependencies to include the latest security middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->