### PR TITLE
fix(sync): no-issue: Prevent initiating sync pull if the sync lookup table has not yet built

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -230,6 +230,21 @@ describe('CentralSyncManager', () => {
         .finally(() => spyMarkAsStartedAt.mockRestore());
     });
 
+    it('throws an error if the sync lookup table has not yet built', async () => {
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: {
+          lookupTable: {
+            enabled: true,
+          },
+          maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+        },
+      });
+      const { sessionId } = await centralSyncManager.startSession();
+      await expect(waitForSession(centralSyncManager, sessionId)).rejects.toThrow(
+        `Sync session '${sessionId}' encountered an error: Sync lookup table has not yet built. Cannot initiate sync.`,
+      );
+    });
+
     it('throws an error when checking a session is ready if it never assigned a started_at_tick', async () => {
       const fakeMarkAsStartedAt = () => {
         // Do nothing and ensure we error out when the client starts polling
@@ -1700,6 +1715,8 @@ describe('CentralSyncManager', () => {
             maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
           },
         });
+        await centralSyncManager.updateLookupTable();
+
         const { sessionId } = await centralSyncManager.startSession();
         await waitForSession(centralSyncManager, sessionId);
 
@@ -1785,6 +1802,7 @@ describe('CentralSyncManager', () => {
             maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
           },
         });
+        await centralSyncManager.updateLookupTable();
         const { sessionId } = await centralSyncManager.startSession();
         await waitForSession(centralSyncManager, sessionId);
 
@@ -1935,6 +1953,7 @@ describe('CentralSyncManager', () => {
           maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
         },
       });
+      await centralSyncManager.updateLookupTable();
       const { sessionId } = await centralSyncManager.startSession();
       await waitForSession(centralSyncManager, sessionId);
 
@@ -2022,6 +2041,7 @@ describe('CentralSyncManager', () => {
           maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
         },
       });
+      await centralSyncManager.updateLookupTable();
       const { sessionId } = await centralSyncManager.startSession();
       await waitForSession(centralSyncManager, sessionId);
 
@@ -2091,6 +2111,7 @@ describe('CentralSyncManager', () => {
           maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
         },
       });
+      await centralSyncManager.updateLookupTable();
       const { sessionId } = await centralSyncManager.startSession({ isMobile: true });
       await waitForSession(centralSyncManager, sessionId);
 

--- a/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
+++ b/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
@@ -32,8 +32,9 @@ describe('SyncQueuedDevice', () => {
   };
 
   beforeAll(async () => {
-    ({ baseApp, ...ctx } = await createTestContext());
-    ({ models } = ctx.store);
+    ctx = await createTestContext();
+    baseApp = ctx.baseApp;
+    models = ctx.store.models;
     app = await baseApp.asRole('admin');
 
     await Promise.all(
@@ -47,8 +48,14 @@ describe('SyncQueuedDevice', () => {
       sync: {
         awaitPreparation: true,
         maxConcurrentSessions: 1,
+        maxRecordsPerSnapshotChunk: 1000000000,
+        lookupTable: {
+          enabled: true,
+        },
       },
     });
+
+    await new CentralSyncManager(ctx).updateLookupTable();
   });
 
   beforeEach(async () => {

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -1,7 +1,7 @@
 import { trace } from '@opentelemetry/api';
 import { Op, QueryTypes } from 'sequelize';
 import _config from 'config';
-import { isNaN } from 'lodash';
+import { isNil } from 'lodash';
 
 import { DEBUG_LOG_TYPES, SETTINGS_SCOPES } from '@tamanu/constants';
 import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
@@ -131,10 +131,7 @@ export class CentralSyncManager {
       // if the sync_lookup table is enabled, don't allow syncs until it has finished its first update run
       const syncLookupUpToTick =
         await this.store.models.LocalSystemFact.get(FACT_LOOKUP_UP_TO_TICK);
-      if (
-        this.constructor.config.sync.lookupTable.enabled &&
-        isNaN(parseInt(syncLookupUpToTick, 10))
-      ) {
+      if (this.constructor.config.sync.lookupTable.enabled && isNil(syncLookupUpToTick)) {
         throw new Error(`Sync lookup table has not yet built. Cannot initiate sync.`);
       }
 

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -1,6 +1,7 @@
 import { trace } from '@opentelemetry/api';
 import { Op, QueryTypes } from 'sequelize';
 import _config from 'config';
+import { isNaN } from 'lodash';
 
 import { DEBUG_LOG_TYPES, SETTINGS_SCOPES } from '@tamanu/constants';
 import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
@@ -91,7 +92,7 @@ export class CentralSyncManager {
     // as a side effect of starting a new session, cause a tick on the global sync clock
     // this is a convenient way to tick the clock, as it means that no two sync sessions will
     // happen at the same global sync time, meaning there's no ambiguity when resolving conflicts
-    
+
     const sessionId = await this.store.models.SyncSession.generateDbUuid();
     const startTime = new Date();
     const parameters = { deviceId, facilityIds, isMobile };
@@ -127,6 +128,16 @@ export class CentralSyncManager {
 
   async prepareSession(syncSession) {
     try {
+      // if the sync_lookup table is enabled, don't allow syncs until it has finished its first update run
+      const syncLookupUpToTick =
+        await this.store.models.LocalSystemFact.get(FACT_LOOKUP_UP_TO_TICK);
+      if (
+        this.constructor.config.sync.lookupTable.enabled &&
+        isNaN(parseInt(syncLookupUpToTick, 10))
+      ) {
+        throw new Error(`Sync lookup table has not yet built. Cannot initiate sync.`);
+      }
+
       await createSnapshotTable(this.store.sequelize, syncSession.id);
       const { tick } = await this.tickTockGlobalClock();
       await syncSession.markAsStartedAt(tick);
@@ -540,12 +551,6 @@ export class CentralSyncManager {
 
   async checkPullReady(sessionId) {
     await this.connectToSession(sessionId);
-
-    // if the sync_lookup table is enabled, wait until it has finished its first update run
-    const syncLookupUpToTick = await this.store.models.LocalSystemFact.get(FACT_LOOKUP_UP_TO_TICK);
-    if (this.constructor.config.sync.lookupTable.enabled && syncLookupUpToTick === undefined) {
-      return false;
-    }
 
     // if this snapshot still processing, return false to tell the client to keep waiting
     const snapshotIsProcessing = await this.checkSessionIsProcessing(sessionId);


### PR DESCRIPTION
### Changes

Original PR: https://github.com/beyondessential/tamanu/pull/7801

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when starting a sync session with the lookup table feature enabled, ensuring an error is thrown if the lookup table is not yet built.

- **Tests**
	- Added and updated tests to verify correct error handling and ensure the lookup table is built before starting sync sessions in relevant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->