### PR TITLE
fix(audit): release 2.33: exclude access from changes

### DIFF
--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -18,8 +18,11 @@ export const NON_SYNCING_TABLES = [
 ];
 
 export const NON_LOGGED_TABLES = [
+  // logs
   'logs.changes',
+  'logs.accesses',
   'logs.debug_logs',
+  
   // internal authentication tables
   'public.one_time_logins',
   'public.refresh_tokens',


### PR DESCRIPTION
### Changes
In preparing audit demo I noticed that if both changes and accesses are enabled, we get a change log entry on accesses which will lead to crazy bloat of table.

This started when I fixed the trigger applications in sync changes pr

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
