### PR TITLE
fix(dbt): tags go in config now

### DIFF
--- a/packages/scripts/src/dbt/generateModel.js
+++ b/packages/scripts/src/dbt/generateModel.js
@@ -295,7 +295,9 @@ async function generateTableModel(schema, table, genericColNames) {
           {
             name: table.name,
             description: `{{ doc('${docPrefix(schema, 'table')}__${table.name}') }}`,
-            tags: [],
+            config: {
+              tags: [],
+            },
             columns: await Promise.all(
               table.columns.map((c) =>
                 generateColumnModel(schema, table.name, c, genericColNames.includes(c.name)),


### PR DESCRIPTION
### Changes

Via Juliana:

> There's been a change to the schema that tags now sits under config.

This PR only changes the generator, such that new table schema files will be created correctly; but the existing ones need fixing too.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the structure of generated table models so that tags are now organized under a configuration section, improving clarity and consistency. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->