### PR TITLE
fix(medication): EPI-1164: ability to navigate back to encounter medications table from mar

### DIFF
--- a/packages/web/app/components/PatientBreadcrumbs.jsx
+++ b/packages/web/app/components/PatientBreadcrumbs.jsx
@@ -58,7 +58,6 @@ export const PatientBreadcrumbs = ({ patientRoutes }) => {
   const params = useParams();
 
   const handleCategoryClick = () => navigateToCategory(params.category);
-
   // Navigates down the patientRoutes tree to get the active route hierarchy
   // and outputs a list of links and titles for these routes.
   const getPatientCrumbs = (routeList, crumbs = []) => {
@@ -69,8 +68,13 @@ export const PatientBreadcrumbs = ({ patientRoutes }) => {
         path: routeConfig.path,
       });
       if (matched) {
+        let subCrumbs = [];
+        if (routeConfig?.subPaths?.length) {
+          subCrumbs = routeConfig.subPaths.map(subPath => getBreadcrumbFromRoute(subPath));
+        }
         return getPatientCrumbs(routeConfig.routes, [
           ...crumbs,
+          ...subCrumbs,
           getBreadcrumbFromRoute(routeConfig),
         ]);
       }

--- a/packages/web/app/components/PatientNavigation.jsx
+++ b/packages/web/app/components/PatientNavigation.jsx
@@ -1,13 +1,10 @@
-import { goBack, push } from 'connected-react-router';
+import { goBack } from 'connected-react-router';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { Colors } from '../constants';
 import { BackButton } from './Button';
 import { PatientBreadcrumbs } from './PatientBreadcrumbs';
-import { matchPath, useLocation } from 'react-router-dom';
-import { PATIENT_PATHS } from '../constants/patientPaths';
-import { ENCOUNTER_TAB_NAMES } from '../constants/encounterTabNames';
 import { NoteModalActionBlocker } from './NoteModalActionBlocker';
 
 export const NAVIGATION_CONTAINER_HEIGHT = '50px';
@@ -35,24 +32,8 @@ const VerticalDivider = styled.div`
 `;
 
 export const PatientNavigation = ({ patientRoutes }) => {
-  const location = useLocation();
   const dispatch = useDispatch();
-  const navigateBack = () => {
-    const match = matchPath(location.pathname, {
-      path: `${PATIENT_PATHS.MAR}/view`,
-    });
-    if (match.isExact) {
-      const params = match.params;
-      dispatch(
-        push(
-          `/patients/${params.category}/${params.patientId}/encounter/${params.encounterId}?tab=${ENCOUNTER_TAB_NAMES.MEDICATION}`,
-        ),
-      );
-    } else {
-      dispatch(goBack());
-    }
-  };
-
+  const navigateBack = () => dispatch(goBack());
   return (
     <StickyContainer data-testid="stickycontainer-ju8w">
       <NoteModalActionBlocker isNavigationBlock>

--- a/packages/web/app/routes/PatientRoutes.jsx
+++ b/packages/web/app/routes/PatientRoutes.jsx
@@ -29,6 +29,7 @@ import { MarView } from '../views/patients/medication/MarView';
 import { Colors } from '../constants';
 import { useAuth } from '../contexts/Auth';
 import { NoteModal } from '../components/NoteModal/NoteModal';
+import { ENCOUNTER_TAB_NAMES } from '../constants/encounterTabNames';
 
 // This component gets the programRegistryId and uses it to render the title of the program registry
 // in the breadcrumbs. It is the only place where breadcrumbs use url params to render the title.
@@ -107,6 +108,21 @@ export const usePatientRoutes = () => {
                         fallback="Medication Admin Record"
                       />
                     ),
+                    subPaths: [
+                      {
+                        path: `${PATIENT_PATHS.ENCOUNTER}?tab=${ENCOUNTER_TAB_NAMES.MEDICATION}`,
+                        title: (
+                          <TranslatedText
+                            stringId="encounter.medication.title"
+                            fallback="Medication"
+                          />
+                        ),
+                        navigateTo: () =>
+                          navigateToEncounter(encounter.id, {
+                            tab: ENCOUNTER_TAB_NAMES.MEDICATION,
+                          }),
+                      },
+                    ],
                   },
                 ]
               : []),

--- a/packages/web/app/utils/usePatientNavigation.js
+++ b/packages/web/app/utils/usePatientNavigation.js
@@ -1,4 +1,4 @@
-import { push } from 'connected-react-router';
+import { push, replace } from 'connected-react-router';
 import { useDispatch } from 'react-redux';
 import { generatePath, matchPath, useLocation, useParams } from 'react-router-dom';
 import { PATIENT_CATEGORIES, PATIENT_PATHS } from '../constants/patientPaths';
@@ -8,16 +8,16 @@ export const usePatientNavigation = () => {
   const params = useParams();
   const location = useLocation();
 
-  const navigate = (url) => dispatch(push(url));
+  const navigate = url => dispatch(push(url));
 
-  const getParams = (path) =>
+  const getParams = path =>
     matchPath(location.pathname, {
       path,
       exact: false,
       strict: false,
     })?.params ?? {};
 
-  const navigateToCategory = (category) => {
+  const navigateToCategory = category => {
     navigate(
       generatePath(PATIENT_PATHS.CATEGORY, {
         category,
@@ -35,13 +35,17 @@ export const usePatientNavigation = () => {
     navigate(`${patientRoute}${search ? `?${new URLSearchParams(search)}` : ''}`);
   };
 
-  const navigateToEncounter = (encounterId, search) => {
+  const navigateToEncounter = (encounterId, search, replaceInHistory = false) => {
     const existingParams = getParams(PATIENT_PATHS.PATIENT);
     const encounterRoute = generatePath(PATIENT_PATHS.ENCOUNTER, {
       ...existingParams,
       encounterId,
     });
-    navigate(`${encounterRoute}${search ? `?${new URLSearchParams(search)}` : ''}`);
+    if (replaceInHistory) {
+      dispatch(replace(`${encounterRoute}${search ? `?${new URLSearchParams(search)}` : ''}`));
+    } else {
+      navigate(`${encounterRoute}${search ? `?${new URLSearchParams(search)}` : ''}`);
+    }
   };
 
   const navigateToSummary = () => {
@@ -82,7 +86,7 @@ export const usePatientNavigation = () => {
     );
   };
 
-  const navigateToProgramRegistry = (programRegistryId) => {
+  const navigateToProgramRegistry = programRegistryId => {
     if (programRegistryId) {
       const programRegistryRoute = generatePath(PATIENT_PATHS.PROGRAM_REGISTRY, {
         ...params,

--- a/packages/web/app/views/patients/panes/EncounterMedicationPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterMedicationPane.jsx
@@ -25,6 +25,7 @@ import { MedicationImportModal } from '../../../components/Medication/Medication
 import { useEncounterMedicationQuery } from '../../../api/queries/useEncounterMedicationQuery';
 import { useSuggestionsQuery } from '../../../api/queries/useSuggestionsQuery';
 import { useAuth } from '../../../contexts/Auth';
+import { ENCOUNTER_TAB_NAMES } from '../../../constants/encounterTabNames';
 
 const TableButtonRow = styled.div`
   display: flex;
@@ -70,7 +71,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
   const [printMedicationModalOpen, setPrintMedicationModalOpen] = useState(false);
   const [medicationImportModalOpen, setMedicationImportModalOpen] = useState(false);
   const [refreshEncounterMedications, setRefreshEncounterMedications] = useState(0);
-  const { navigateToMar } = usePatientNavigation();
+  const { navigateToMar, navigateToEncounter } = usePatientNavigation();
   const [prescriptionTypeModalOpen, setPrescriptionTypeModalOpen] = useState(false);
   const [prescriptionType, setPrescriptionType] = useState(null);
 
@@ -105,6 +106,12 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
   const canImportOngoingPrescriptions =
     !!importableOngoingPrescriptions?.length && !encounter.endDate;
   const canAccessMar = ability.can('read', 'MedicationAdministration');
+
+  const handleNavigateToMar = () => {
+    // Navigate to the medication tab first to ensure it will be back to the same tab after navigating to the MAR
+    navigateToEncounter(encounter.id, { tab: ENCOUNTER_TAB_NAMES.MEDICATION }, true);
+    navigateToMar();
+  };
 
   return (
     <TabPane data-testid="tabpane-u787">
@@ -208,7 +215,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
                 disabled={readonly}
                 variant="outlined"
                 color="primary"
-                onClick={navigateToMar}
+                onClick={handleNavigateToMar}
               >
                 <TranslatedText
                   stringId="medication.action.medicationAdminRecord"


### PR DESCRIPTION
### Changes

- Add one more breadcrumb item in mar view page (special case)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Breadcrumb navigation now displays additional links for sub-paths, providing more detailed navigation within patient-related routes.
	- Added a breadcrumb link for direct access to the Medication tab within an encounter, improving navigation to specific patient information.
- **Bug Fixes**
	- Simplified back navigation behavior to provide a consistent user experience when returning from patient views.
- **Improvements**
	- Enhanced navigation flow for the Medication Administration Record button to ensure the medication tab is active before proceeding.
	- Added option to replace browser history entries during encounter navigation for smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->