### PR TITLE
tweak(prinout): NASS-1676: Vitals printout styling + more vitals rows rendered per page

### DIFF
--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -89,11 +89,12 @@ const tableStyles = StyleSheet.create({
     flexDirection: 'row',
     borderLeft: borderStyle,
     alignItems: 'flex-start',
-    padding: 7,
+    padding: '5px 5px',
+    fontSize: 8,
   },
   p: {
     fontFamily: 'Helvetica',
-    fontSize: 10,
+    fontSize: 8,
   },
   notesCell: {
     width: '100%',
@@ -123,9 +124,9 @@ const P = ({ style = {}, bold, children }) => (
   </Text>
 );
 
-const Cell = ({ children, style = {} }) => (
+const Cell = ({ children, style = {}, bold = false }) => (
   <View style={[tableStyles.baseCell, style]}>
-    <P>{children}</P>
+    <P bold={bold}>{children}</P>
   </View>
 );
 
@@ -199,8 +200,8 @@ const DataTable = ({ data, columns, title, type }) => {
       <DataTableHeading columns={columns} title={title} width={width} />
       {data.map((row) => (
         <Row key={row.id} wrap={false} width={width}>
-          {columns.map(({ key, accessor, style }) => (
-            <Cell key={key} style={style}>
+          {columns.map(({ key, accessor, style }, index) => (
+            <Cell key={key} style={style} bold={index === 0}>
               {accessor ? accessor(row) : row[key] || ''}
             </Cell>
           ))}

--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -166,15 +166,17 @@ const DataTableHeading = ({ columns, title, width }) => {
     <View fixed>
       <MultipageTableHeading title={title} />
       <Row wrap={false} width={width}>
-        {columns.map(({ key, title, style }) => {
+        {columns.map(({ key, title, style }, index) => {
           if (Array.isArray(title)) {
+            const rotateStyle = index > 0 ? { transform: 'rotate(-90deg)', paddingBottom: 10, paddingTop: 10 } : {};
             return (
-              <View
-                key={key}
-                style={[tableStyles.baseCell, { flexDirection: 'column', padding: 4 }, style]}
-              >
-                <P style={{ fontFamily: 'Helvetica-Bold' }}>{title[0]}</P>
-                <P>{title[1]}</P>
+              <View key={key} style={[tableStyles.baseCell, style]}>
+                <View
+                  style={rotateStyle}
+                >
+                  <P bold style={{ letterSpacing: 0.3 }}>{title[0]}</P>
+                  <P>{title[1]}</P>
+                </View>
               </View>
             );
           }
@@ -341,7 +343,8 @@ const EncounterRecordPrintoutComponent = ({
       {
         key: 'dateMoved',
         title: getTranslation('pdf.encounterRecord.dateAndTimeMoved', 'Date & time moved'),
-        accessor: ({ date }) => (date ? `${formatShort(date)} ${formatTime(date)}` : '--/--/---- --:----'),
+        accessor: ({ date }) =>
+          date ? `${formatShort(date)} ${formatTime(date)}` : '--/--/---- --:----',
         style: { width: '35%' },
       },
     ],
@@ -361,7 +364,8 @@ const EncounterRecordPrintoutComponent = ({
       {
         key: 'dateMoved',
         title: getTranslation('pdf.encounterRecord.dateAndTimeMoved', 'Date & time moved'),
-        accessor: ({ date }) => (date ? `${formatShort(date)} ${formatTime(date)}` : '--/--/---- --:----'),
+        accessor: ({ date }) =>
+          date ? `${formatShort(date)} ${formatTime(date)}` : '--/--/---- --:----',
         style: { width: '35%' },
       },
     ],

--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -203,7 +203,7 @@ const DataTable = ({ data, columns, title, type }) => {
       {data.map((row) => (
         <Row key={row.id} wrap={false} width={width}>
           {columns.map(({ key, accessor, style }, index) => (
-            <Cell key={key} style={style} bold={index === 0}>
+            <Cell key={key} style={style} bold={type === 'vitals' && index === 0}>
               {accessor ? accessor(row) : row[key] || ''}
             </Cell>
           ))}

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -320,7 +320,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
         key: 'measure',
         title: getTranslation('vitals.table.column.measure', 'Measure'),
         accessor: ({ value }) => value,
-        style: { width: 140 },
+        style: { width: 140, alignItems: 'flex-end' },
       },
       ...dateArray
         .sort((a, b) => b.localeCompare(a))
@@ -331,7 +331,7 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
             const { value, config } = cells[date];
             return formatValue(value, config);
           },
-          style: { width: 60 },
+          style: { width: 60, },
         })),
     ];
   };


### PR DESCRIPTION
### Changes
Code rabbit reviews where incorrectly referring react pdf docs with bad suggestions btw so have ignored them

- Can fit way more rows
- Style changes
<img width="390" alt="Screenshot 2025-06-13 at 11 07 38 AM" src="https://github.com/user-attachments/assets/1d90fd58-a517-4e4f-a3b8-c729c0115ec4" />

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
  - Improved table readability in Encounter Record printouts by reducing font sizes and adjusting cell padding.
  - Enhanced header formatting with bold and rotated text for multi-line column titles.
  - Adjusted alignment for the "measure" column in the vitals table to improve content presentation.
  - Added bold styling to first-column cells in vitals tables for clearer data emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->