### PR TITLE
fix(sync): TAMOC-296: Fix child records get soft deleted notes when patient merge HOTFIX 2.30

### DIFF
--- a/packages/central-server/__tests__/sync/PatientMergeSync.test.js
+++ b/packages/central-server/__tests__/sync/PatientMergeSync.test.js
@@ -4,7 +4,7 @@ import { makeTwoPatients } from '../admin/patientMerge/makeTwoPatients';
 import { mergePatient } from '../../app/admin/patientMerge/mergePatient';
 import { createTestContext } from '../utilities';
 
-describe('Patient Merge Sync', () => {
+describe('Sync Patient Merge', () => {
   let ctx;
   let models;
   let keep, merge, facility, mergeEnc, mergeEnc2;
@@ -107,7 +107,7 @@ describe('Patient Merge Sync', () => {
     await models.User.truncate({ cascade: true, force: true });
   });
 
-  it('should refresh notes of encounters for sync', async () => {
+  it('pulls child records (notes) of merged encounters after merging patients', async () => {
     const { LocalSystemFact } = models;
 
     await setupMergeData();
@@ -152,7 +152,7 @@ describe('Patient Merge Sync', () => {
     expect(notes.map((n) => n.recordId).sort()).toEqual([note.id, note2.id].sort());
   });
 
-  it('should refresh notes of patient_care_plans for sync', async () => {
+  it('pulls child records (notes) of merged patient_care_plans after merging patients', async () => {
     const { LocalSystemFact } = models;
 
     await setupMergeData();
@@ -202,7 +202,7 @@ describe('Patient Merge Sync', () => {
     expect(notes.map((n) => n.recordId).sort()).toEqual([note.id, note2.id].sort());
   });
 
-  it('should refresh contributing_death_causes of patient_death_data for sync', async () => {
+  it('pulls child records (contributing_death_causes) of merged patient_death_data after merging patients', async () => {
     const { LocalSystemFact, User, ReferenceData } = models;
 
     await setupMergeData();

--- a/packages/central-server/__tests__/sync/PatientMergeSync.test.js
+++ b/packages/central-server/__tests__/sync/PatientMergeSync.test.js
@@ -1,0 +1,256 @@
+import { FACT_CURRENT_SYNC_TICK, NOTE_RECORD_TYPES } from '@tamanu/constants';
+import { fake, fakeUser } from '@tamanu/fake-data/fake';
+import { makeTwoPatients } from '../admin/patientMerge/makeTwoPatients';
+import { mergePatient } from '../../app/admin/patientMerge/mergePatient';
+import { createTestContext } from '../utilities';
+
+describe('Patient Merge Sync', () => {
+  let ctx;
+  let models;
+  let keep, merge, facility, mergeEnc, mergeEnc2;
+
+  const DEFAULT_CONFIG = {
+    sync: {
+      lookupTable: {
+        enabled: false,
+      },
+      maxRecordsPerSnapshotChunk: 1000000000,
+    },
+  };
+
+  const initializeCentralSyncManager = (config) => {
+    // Have to load test function within test scope so that we can mock dependencies per test case
+    const {
+      CentralSyncManager: TestCentralSyncManager,
+    } = require('../../dist/sync/CentralSyncManager');
+
+    TestCentralSyncManager.overrideConfig(config || DEFAULT_CONFIG);
+
+    return new TestCentralSyncManager(ctx);
+  };
+
+  const setupMergeData = async () => {
+    const { Encounter, Facility, Department, Location, User, PatientFacility, LocalSystemFact } =
+      models;
+    const OLD_SYNC_TICK = '1';
+    await LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, OLD_SYNC_TICK);
+
+    [keep, merge] = await makeTwoPatients(models);
+
+    facility = await Facility.create({
+      ...fake(Facility),
+      name: 'Utopia HQ',
+    });
+
+    const location = await Location.create({
+      ...fake(Location),
+      facilityId: facility.id,
+    });
+
+    const department = await Department.create({
+      ...fake(Department),
+      facilityId: facility.id,
+    });
+
+    const examiner = await User.create(fakeUser());
+
+    const baseEncounter = {
+      locationId: location.id,
+      departmentId: department.id,
+      examinerId: examiner.id,
+    };
+
+    mergeEnc = await models.Encounter.create({
+      ...fake(Encounter),
+      ...baseEncounter,
+      patientId: merge.id,
+    });
+    mergeEnc2 = await models.Encounter.create({
+      ...fake(Encounter),
+      ...baseEncounter,
+      patientId: merge.id,
+    });
+    await models.Encounter.create({
+      ...fake(Encounter),
+      ...baseEncounter,
+      patientId: keep.id, // keep encounter
+    });
+
+    await PatientFacility.upsert({
+      id: PatientFacility.generateId(),
+      patientId: keep.id,
+      facilityId: facility.id,
+    });
+    await PatientFacility.upsert({
+      id: PatientFacility.generateId(),
+      patientId: merge.id,
+      facilityId: facility.id,
+    });
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models } = ctx.store);
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.Facility.truncate({ cascade: true, force: true });
+    await models.PatientFacility.truncate({ cascade: true, force: true });
+    await models.Encounter.truncate({ cascade: true, force: true });
+    await models.Note.truncate({ cascade: true, force: true });
+    await models.Patient.truncate({ cascade: true, force: true });
+    await models.LocalSystemFact.truncate({ cascade: true, force: true });
+    await models.Department.truncate({ cascade: true, force: true });
+    await models.Location.truncate({ cascade: true, force: true });
+    await models.User.truncate({ cascade: true, force: true });
+  });
+
+  it('should refresh notes of encounters for sync', async () => {
+    const { LocalSystemFact } = models;
+
+    await setupMergeData();
+
+    const note = await models.Note.create({
+      ...fake(models.Note),
+      recordId: mergeEnc.id,
+      recordType: NOTE_RECORD_TYPES.ENCOUNTER,
+    });
+    const note2 = await models.Note.create({
+      ...fake(models.Note),
+      recordId: mergeEnc2.id,
+      recordType: NOTE_RECORD_TYPES.ENCOUNTER,
+    });
+
+    const NEW_SYNC_TICK = '4';
+    await LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, NEW_SYNC_TICK);
+
+    await mergePatient(models, keep.id, merge.id);
+
+    const centralSyncManager = initializeCentralSyncManager();
+    const { sessionId } = await centralSyncManager.startSession();
+
+    await centralSyncManager.updateLookupTable();
+
+    // Start the snapshot for pull process
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: NEW_SYNC_TICK - 1, // get all changes since the last sync tick
+        facilityIds: [facility.id],
+        deviceId: facility.id,
+      },
+      () => true,
+    );
+
+    const changes = await centralSyncManager.getOutgoingChanges(sessionId, {
+      limit: 10,
+    });
+    const notes = changes.filter((c) => c.recordType === 'notes');
+    expect(notes).toHaveLength(2);
+    expect(notes.map((n) => n.recordId).sort()).toEqual([note.id, note2.id].sort());
+  });
+
+  it('should refresh notes of patient_care_plans for sync', async () => {
+    const { LocalSystemFact } = models;
+
+    await setupMergeData();
+
+    const patientCarePlan = await models.PatientCarePlan.create({
+      ...fake(models.PatientCarePlan),
+      patientId: merge.id,
+    });
+
+    const note = await models.Note.create({
+      ...fake(models.Note),
+      recordId: patientCarePlan.id,
+      recordType: NOTE_RECORD_TYPES.PATIENT_CARE_PLAN,
+    });
+    const note2 = await models.Note.create({
+      ...fake(models.Note),
+      recordId: patientCarePlan.id,
+      recordType: NOTE_RECORD_TYPES.PATIENT_CARE_PLAN,
+    });
+
+    const NEW_SYNC_TICK = '4';
+    await LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, NEW_SYNC_TICK);
+
+    await mergePatient(models, keep.id, merge.id);
+
+    const centralSyncManager = initializeCentralSyncManager();
+    const { sessionId } = await centralSyncManager.startSession();
+
+    await centralSyncManager.updateLookupTable();
+
+    // Start the snapshot for pull process
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: NEW_SYNC_TICK - 1, // get all changes since the last sync tick
+        facilityIds: [facility.id],
+        deviceId: facility.id,
+      },
+      () => true,
+    );
+
+    const changes = await centralSyncManager.getOutgoingChanges(sessionId, {
+      limit: 10,
+    });
+    const notes = changes.filter((c) => c.recordType === 'notes');
+    expect(notes).toHaveLength(2);
+    expect(notes.map((n) => n.recordId).sort()).toEqual([note.id, note2.id].sort());
+  });
+
+  it('should refresh contributing_death_causes of patient_death_data for sync', async () => {
+    const { LocalSystemFact, User, ReferenceData } = models;
+
+    await setupMergeData();
+
+    const clinician = await User.create(fakeUser());
+
+    const patientDeathData = await models.PatientDeathData.create({
+      ...fake(models.PatientDeathData),
+      clinicianId: clinician.id,
+      patientId: merge.id,
+    });
+
+    const referenceData = await ReferenceData.create(fake(ReferenceData));
+
+    const contributingDeathCause = await models.ContributingDeathCause.create({
+      ...fake(models.ContributingDeathCause),
+      patientDeathDataId: patientDeathData.id,
+      conditionId: referenceData.id,
+    });
+
+    const NEW_SYNC_TICK = '4';
+    await LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, NEW_SYNC_TICK);
+
+    await mergePatient(models, keep.id, merge.id);
+
+    const centralSyncManager = initializeCentralSyncManager();
+    const { sessionId } = await centralSyncManager.startSession();
+
+    await centralSyncManager.updateLookupTable();
+
+    // Start the snapshot for pull process
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: NEW_SYNC_TICK - 1, // get all changes since the last sync tick
+        facilityIds: [facility.id],
+        deviceId: facility.id,
+      },
+      () => true,
+    );
+
+    const changes = await centralSyncManager.getOutgoingChanges(sessionId, {
+      limit: 10,
+    });
+    const contributingDeathCauses = changes.filter(
+      (c) => c.recordType === 'contributing_death_causes',
+    );
+    expect(contributingDeathCauses).toHaveLength(1);
+    expect(contributingDeathCauses[0].recordId).toEqual(contributingDeathCause.id);
+  });
+});

--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -14,7 +14,7 @@ const BULK_CREATE_BATCH_SIZE = 100;
 
 // IMPORTANT: Any models here that have child records, please add the logic to handle them
 // in:
-// - updateDependentRecordsForResync function in this file AND PatientMergeMaintainer.js.
+// - updateDependentRecordsForResync function in this file
 export const simpleUpdateModels = [
   'Encounter',
   'PatientAllergy',
@@ -41,7 +41,7 @@ export const simpleUpdateModels = [
 
 // IMPORTANT: Any models here that have child records, please add the logic to handle them
 // in:
-// - updateDependentRecordsForResync function in this file AND PatientMergeMaintainer.js.
+// - updateDependentRecordsForResync function in this file
 export const specificUpdateModels = [
   'Patient',
   'PatientAdditionalData',

--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -376,7 +376,7 @@ async function updateDependentRecordsForResync(models, unwantedPatientId) {
   await refreshMultiChildRecordsForSync(models.Encounter, encounters);
 
   // Patient Care Plans
-  const patientCarePlans = await models.PatientCarePlan.findOne({
+  const patientCarePlans = await models.PatientCarePlan.findAll({
     where: { patientId: unwantedPatientId },
     attributes: ['id'],
   });

--- a/packages/central-server/app/sync/registerSyncLookupUpdateListener.js
+++ b/packages/central-server/app/sync/registerSyncLookupUpdateListener.js
@@ -1,46 +1,6 @@
-import { snakeCase } from 'lodash';
 
 import { NOTIFY_CHANNELS } from '@tamanu/constants';
-import { getDependentAssociations } from '@tamanu/database';
-
-/**
- * Update child records by setting updated_at_sync_tick = 1
- * so that they are refreshed in the sync_lookup table
- * @param {*} model
- * @param {*} instanceId
- */
-export async function updateChildRecordsForSyncLookup(model, instanceId) {
-  const dependantAssociations = getDependentAssociations(model);
-
-  for (const association of dependantAssociations) {
-    const { target, foreignKey } = association;
-
-    // We need to go via a raw query as Model.update({}) performs validation on the
-    // whole record, so we'll be rejected for failing to include required fields -
-    // even though we only want to update updated_at_sync_tick!
-    const [updatedRows] = await model.sequelize.query(
-      `
-      UPDATE ${target.tableName}
-      SET updated_at_sync_tick = 1
-      WHERE ${snakeCase(foreignKey)} = :instanceId
-      RETURNING id;
-    `,
-      {
-        replacements: {
-          instanceId,
-        },
-      },
-    );
-
-    // If there are any child records, also recursively update them
-    // so that they are also updated in the sync_lookup table
-    // eg: if survey_response is updated, we must also updated survey_response_answers
-    for (const updatedRow of updatedRows) {
-      await updateChildRecordsForSyncLookup(target, updatedRow.id);
-    }
-  }
-}
-
+import { refreshChildRecordsForSync } from '@tamanu/shared/utils/refreshChildRecordsForSync';
 
 /**
  * Register a listener when a record is updated and the change includes patient_id
@@ -52,7 +12,7 @@ export const registerSyncLookupUpdateListener = async (models, dbNotifier) => {
   onTableChanged(async payload => {
     if (payload.event === 'UPDATE' && payload.changedColumns?.includes('patient_id')) {
       const model = Object.values(models).find(model => model.tableName === payload.table);
-      await updateChildRecordsForSyncLookup(model, payload.newId);
+      await refreshChildRecordsForSync(model, payload.newId);
     }
   });
 };

--- a/packages/central-server/app/tasks/PatientMergeMaintainer.js
+++ b/packages/central-server/app/tasks/PatientMergeMaintainer.js
@@ -14,6 +14,7 @@ import {
   mergePatientFieldValues,
   mergePatientProgramRegistrationConditions,
   mergePatientProgramRegistrations,
+  refreshMultiChildRecordsForSync,
   reconcilePatientFacilities,
   simpleUpdateModels,
   specificUpdateModels,
@@ -33,6 +34,7 @@ export class PatientMergeMaintainer extends ScheduledTask {
     super(schedule, log, jitterTime, enabled);
     this.config = conf;
     this.models = context.store.models;
+    this.sequelize = context.store.sequelize;
   }
 
   checkModelsMissingSpecificUpdateCoverage() {
@@ -61,7 +63,7 @@ export class PatientMergeMaintainer extends ScheduledTask {
         patients.id = ${tableName}.${patientFieldName} 
         AND patients.merged_into_id IS NOT NULL
         ${additionalWhere}
-      RETURNING patients.id, patients.merged_into_id;
+      RETURNING ${tableName}.id;
     `);
     return result.rows;
   }
@@ -86,33 +88,58 @@ export class PatientMergeMaintainer extends ScheduledTask {
     );
   }
 
+  async updateDependentRecordsForResync(merges) {
+    const encounters = merges['Encounter'] || [];
+    await refreshMultiChildRecordsForSync(this.models.Encounter, encounters);
+
+    // Patient Care Plans
+    const patientCarePlans = merges['PatientCarePlan'] || [];
+    await refreshMultiChildRecordsForSync(this.models.PatientCarePlan, patientCarePlans);
+
+    // Patient Death Data
+    const patientDeathDataRecords = merges['PatientDeathData'] || [];
+    await refreshMultiChildRecordsForSync(this.models.PatientDeathData, patientDeathDataRecords);
+  }
+
   async remergePatientRecords() {
-    // set up an object for counting affected records
-    const counts = {};
-    const updateCounts = (name, records) => {
-      const len = records && records.length;
-      if (len) {
-        counts[name] = len;
-      }
-    };
+    return this.sequelize.transaction(async () => {
+      // set up an object for counting affected records
+      const counts = {};
+      const merges = {};
+      const updateCounts = (name, records) => {
+        const len = records && records.length;
+        if (len) {
+          counts[name] = len;
+        }
+      };
+      const updateMerges = (name, records) => {
+        if (records?.length) {
+          merges[name] = records;
+        }
+      };
 
-    // do all the simple model updates
-    for (const modelName of simpleUpdateModels) {
-      const model = this.models[modelName];
-      const records = await this.mergeAllRecordsForModel(model);
-      updateCounts(modelName, records);
-    }
-
-    // then the model updates that need specific updates:
-    for (const modelName of specificUpdateModels) {
-      const method = this[`specificUpdate_${modelName}`];
-      if (method) {
-        const records = await method.call(this);
+      // do all the simple model updates
+      for (const modelName of simpleUpdateModels) {
+        const model = this.models[modelName];
+        const records = await this.mergeAllRecordsForModel(model);
         updateCounts(modelName, records);
+        updateMerges(modelName, records);
       }
-    }
 
-    return counts;
+      // then the model updates that need specific updates:
+      for (const modelName of specificUpdateModels) {
+        const method = this[`specificUpdate_${modelName}`];
+        if (method) {
+          const records = await method.call(this);
+          updateCounts(modelName, records);
+          updateMerges(modelName, records);
+        }
+      }
+
+      await this.updateDependentRecordsForResync(merges);
+
+      return counts;
+    });
   }
 
   async specificUpdate_Patient() {
@@ -168,8 +195,8 @@ export class PatientMergeMaintainer extends ScheduledTask {
         keepPatientId,
         mergedPatientId,
       );
-      if (mergedPatientDeathData) {
-        records.push(mergedPatientDeathData);
+      if (mergedPatientDeathData?.length) {
+        records.push(...mergedPatientDeathData);
       }
     }
     return records;

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -65,6 +65,9 @@
     // paste your bugsnag API key here
     apiKey: '',
   },
+  patientMerge:{
+    updateDependentRecordsForResyncEnabled: true
+  },
   "sync": {
     "maxConcurrentSessions": 4,
     "persistedCacheBatchSize": 20000,

--- a/packages/shared/src/utils/index.js
+++ b/packages/shared/src/utils/index.js
@@ -17,3 +17,4 @@ export * from './getLabTestsFromLabRequests';
 export * from './numeralTranslation';
 export * from './enumRegistry';
 export * from './invoice';
+export * from './refreshChildRecordsForSync';

--- a/packages/shared/src/utils/refreshChildRecordsForSync.js
+++ b/packages/shared/src/utils/refreshChildRecordsForSync.js
@@ -1,0 +1,42 @@
+import { snakeCase } from 'lodash';
+
+import { getDependentAssociations } from '@tamanu/database';
+
+/**
+ * Update child records by setting updated_at_sync_tick = 1
+ * so that they are refreshed in the sync_lookup table,
+ * and also pulled down to the clients
+ * @param {*} model
+ * @param {*} instanceId
+ */
+export async function refreshChildRecordsForSync(model, instanceId) {
+  const dependantAssociations = getDependentAssociations(model);
+
+  for (const association of dependantAssociations) {
+    const { target, foreignKey } = association;
+
+    // We need to go via a raw query as Model.update({}) performs validation on the
+    // whole record, so we'll be rejected for failing to include required fields -
+    // even though we only want to update updated_at_sync_tick!
+    const [updatedRows] = await model.sequelize.query(
+      `
+        UPDATE ${target.tableName}
+        SET updated_at_sync_tick = 1
+        WHERE ${snakeCase(foreignKey)} = :instanceId
+        RETURNING id;
+      `,
+      {
+        replacements: {
+          instanceId,
+        },
+      },
+    );
+
+    // If there are any child records, also recursively update them
+    // so that they are also updated in the sync_lookup table
+    // eg: if survey_response is updated, we must also updated survey_response_answers
+    for (const updatedRow of updatedRows) {
+      await refreshChildRecordsForSync(target, updatedRow.id);
+    }
+  }
+}


### PR DESCRIPTION
### Changes
- TAMOC-296: Fix child records get soft deleted notes when patient merge

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning modal when prescribing medications that are already part of ongoing prescriptions, both in medication sets and individual prescriptions.
  - Introduced a new interface to review and confirm actions when overlapping prescriptions are detected, displaying relevant details for user decision-making.

- **Enhancements**
  - Medication summary components now support custom styling via an optional class name prop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
