### PR TITLE
fix(procedures): TAMOC-295: Separate suggesters - Main

### DIFF
--- a/packages/web/app/components/ProcedureModal.jsx
+++ b/packages/web/app/components/ProcedureModal.jsx
@@ -32,7 +32,9 @@ export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure 
   const locationSuggester = useSuggester('location', {
     baseQueryParameters: { filterByFacility: true },
   });
-  const practitionerSuggester = useSuggester('practitioner');
+  const physicianSuggester = useSuggester('practitioner');
+  const anaesthetistSuggester = useSuggester('practitioner');
+  const assistantSuggester = useSuggester('practitioner');
   const procedureSuggester = useSuggester('procedureType');
   const anaestheticSuggester = useSuggester('drug');
 
@@ -86,7 +88,9 @@ export const ProcedureModal = ({ onClose, onSaved, encounterId, editedProcedure 
         onCancel={onClose}
         editedObject={editedProcedure}
         locationSuggester={locationSuggester}
-        practitionerSuggester={practitionerSuggester}
+        physicianSuggester={physicianSuggester}
+        anaesthetistSuggester={anaesthetistSuggester}
+        assistantSuggester={assistantSuggester}
         procedureSuggester={procedureSuggester}
         anaestheticSuggester={anaestheticSuggester}
         data-testid="procedureform-euca"

--- a/packages/web/app/forms/ProcedureForm.jsx
+++ b/packages/web/app/forms/ProcedureForm.jsx
@@ -34,7 +34,9 @@ export const ProcedureForm = React.memo(
     editedObject,
     anaestheticSuggester,
     procedureSuggester,
-    practitionerSuggester,
+    physicianSuggester,
+    anaesthetistSuggester,
+    assistantSuggester,
   }) => {
     const { currentUser } = useAuth();
 
@@ -102,7 +104,7 @@ export const ProcedureForm = React.memo(
                     }
                     required
                     component={AutocompleteField}
-                    suggester={practitionerSuggester}
+                    suggester={physicianSuggester}
                     data-testid="field-lit6"
                   />
                   <Field
@@ -180,7 +182,7 @@ export const ProcedureForm = React.memo(
                     />
                   }
                   component={AutocompleteField}
-                  suggester={practitionerSuggester}
+                  suggester={anaesthetistSuggester}
                   data-testid="field-96eg"
                 />
                 <Field
@@ -208,7 +210,7 @@ export const ProcedureForm = React.memo(
                     />
                   }
                   component={AutocompleteField}
-                  suggester={practitionerSuggester}
+                  suggester={assistantSuggester}
                   data-testid="field-f3l4"
                 />
                 <Field
@@ -337,8 +339,9 @@ ProcedureForm.propTypes = {
 
   anaestheticSuggester: suggesterType.isRequired,
   procedureSuggester: suggesterType.isRequired,
-  locationSuggester: suggesterType.isRequired,
-  practitionerSuggester: suggesterType.isRequired,
+  physicianSuggester: suggesterType.isRequired,
+  anaesthetistSuggester: suggesterType.isRequired,
+  assistantSuggester: suggesterType.isRequired,
 };
 
 ProcedureForm.defaultProps = {


### PR DESCRIPTION
Cherry-picked from 2.30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the procedure form to use separate suggesters for physician, anaesthetist, and assistant fields, replacing the previous single practitioner suggester.
  - Adjusted form field inputs and properties to align with the new suggesters for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->