### PR TITLE
tweak(e2e): Refactor patient sidebar tests to use newPatient fixture

### DIFF
--- a/.github/scripts/e2e-test-setup.sh
+++ b/.github/scripts/e2e-test-setup.sh
@@ -38,11 +38,11 @@ EOF
         },
 
         facilities: {
-            "facility-test": {
-                name: "Facility Test",
-                code: "test",
-                user: "facility-test@tamanu.io",
-                password: "facility-test",
+            "facility-1": {
+                name: "facility-1",
+                code: "facility-1",
+                user: "facility-1@tamanu.io",
+                password: "facility-1",
             },
         },
 

--- a/.github/scripts/e2e-test-setup.sh
+++ b/.github/scripts/e2e-test-setup.sh
@@ -63,10 +63,10 @@ e2e_test_setup_setup_facility() {
 	cat <<- EOF > packages/facility-server/config/local.json5
 	{
 	    "port": "4000",
-	    "serverFacilityIds": ["facility-test"],
+	    "serverFacilityIds": ["facility-1"],
 	    "sync": {
-	        "email": "facility-test@tamanu.io",
-	        "password": "facility-test",
+	        "email": "facility-1@tamanu.io",
+	        "password": "facility-1",
 	        "enabled": true,
 	        "host": "http://localhost:3000"
 	    },

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -205,7 +205,6 @@ export class PatientDetailsPage extends BasePatientPage {
   }
 
   async goToPatient(patient: Patient) {
-    console.log('going to');
     await this.page.goto(constructFacilityUrl(`/#/patients/all/${patient.id}`));
   }
 
@@ -247,6 +246,7 @@ export class PatientDetailsPage extends BasePatientPage {
   async addNewAllergyNotInDropdown(allergyName: string) {
     await this.page.getByRole('menuitem', { name: allergyName }).click();
     await this.dropdownMenuItem.waitFor({ state: 'hidden' });
+    await this.page.waitForTimeout(2000);
     await this.clickAddButtonToConfirm(this.submitNewAllergyAddButton);
   }
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -246,7 +246,7 @@ export class PatientDetailsPage extends BasePatientPage {
   async addNewAllergyNotInDropdown(allergyName: string) {
     await this.page.getByRole('menuitem', { name: allergyName }).click();
     await this.dropdownMenuItem.waitFor({ state: 'hidden' });
-    await this.page.waitForTimeout(2000);
+    await expect(this.allergyNameField).toHaveValue(allergyName);
     await this.clickAddButtonToConfirm(this.submitNewAllergyAddButton);
   }
 

--- a/packages/e2e-tests/tests/patients/patientSideBar.spec.ts
+++ b/packages/e2e-tests/tests/patients/patientSideBar.spec.ts
@@ -1,16 +1,9 @@
 import { test, expect } from '../../fixtures/baseFixture';
-import { createPatientViaApi } from '../../utils/generateNewPatient';
 
 test.describe('Patient Side Bar', () => {
-  test.beforeEach(async ({ patientDetailsPage, allPatientsPage }) => {
-    await allPatientsPage.goto();
-    await createPatientViaApi(allPatientsPage);
-
-    //this is to replicate the workflow of visiting an existing patient
-    const patientData = allPatientsPage.getPatientData();
-    await allPatientsPage.navigateToPatientDetailsPage(patientData.nhn);
+  test.beforeEach(async ({ patientDetailsPage, newPatient }) => {
+    await patientDetailsPage.goToPatient(newPatient);
     await patientDetailsPage.confirmPatientDetailsPageHasLoaded();
-    await expect(patientDetailsPage.patientNHN).toContainText(patientData.nhn);
   });
 
   test('Add ongoing condition with just the required fields', async ({ patientDetailsPage }) => {
@@ -166,10 +159,9 @@ test.describe('Patient Side Bar', () => {
 
   test('Add allergy that is not in dropdown list', async ({
     patientDetailsPage,
-    allPatientsPage,
+    newPatient,
   }) => {
-    const patientData = allPatientsPage.getPatientData();
-    const newAllergy = patientDetailsPage.generateNewAllergy(patientData.nhn);
+    const newAllergy = patientDetailsPage.generateNewAllergy(newPatient.displayId);
 
     await patientDetailsPage.searchNewAllergyNotInDropdown(newAllergy);
 
@@ -280,6 +272,7 @@ test.describe('Patient Side Bar', () => {
   test('Warning appears when navigating to patient with a warning', async ({
     patientDetailsPage,
     allPatientsPage,
+    newPatient,
   }) => {
     await patientDetailsPage.addNewOtherPatientIssueWarning(
       'A warning appears when navigating to a patient with a warning',
@@ -287,8 +280,7 @@ test.describe('Patient Side Bar', () => {
 
     await allPatientsPage.goto();
 
-    const patientData = allPatientsPage.getPatientData();
-    await allPatientsPage.navigateToPatientDetailsPage(patientData.nhn);
+    await allPatientsPage.navigateToPatientDetailsPage(newPatient.displayId);
 
     await expect(
       patientDetailsPage.warningModalTitle.filter({ hasText: 'Patient warnings' }),
@@ -298,7 +290,7 @@ test.describe('Patient Side Bar', () => {
     );
   });
 
-  test('Edit patient warning', async ({ patientDetailsPage, allPatientsPage }) => {
+  test('Edit patient warning', async ({ patientDetailsPage, allPatientsPage, newPatient }) => {
     await patientDetailsPage.addNewOtherPatientIssueWarning('Test warning');
     await patientDetailsPage.warningModalOkayButton.click();
 
@@ -316,8 +308,7 @@ test.describe('Patient Side Bar', () => {
 
     await allPatientsPage.goto();
 
-    const patientData = allPatientsPage.getPatientData();
-    await allPatientsPage.navigateToPatientDetailsPage(patientData.nhn);
+    await allPatientsPage.navigateToPatientDetailsPage(newPatient.displayId);
 
     await expect(
       patientDetailsPage.warningModalTitle.filter({ hasText: 'Patient warnings' }),

--- a/packages/e2e-tests/utils/apiHelpers.ts
+++ b/packages/e2e-tests/utils/apiHelpers.ts
@@ -4,6 +4,7 @@ import { request, Page, APIRequestContext } from '@playwright/test';
 import { constructFacilityUrl } from './navigation';
 import { getItemFromLocalStorage } from './localStorage';
 import { Patient, User } from '@tamanu/database';
+import { generateNHN } from './generateNewPatient';
 
 export const createApiContext = async ({ page }: { page: Page }) => {
   const token = await getItemFromLocalStorage(page, 'apiToken');
@@ -31,7 +32,7 @@ export const createPatient = async (api: APIRequestContext, page: Page): Promise
   const patientData = {
     birthFacilityId: null,
     dateOfBirth: faker.date.birthdate(),
-    displayId: faker.string.uuid(),
+    displayId: generateNHN(),
     facilityId,
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),

--- a/packages/e2e-tests/utils/generateNewPatient.ts
+++ b/packages/e2e-tests/utils/generateNewPatient.ts
@@ -3,7 +3,7 @@ import { AllPatientsPage } from '../pages/patients/AllPatientsPage';
 import { constructFacilityUrl } from './navigation';
 import { testData } from '../utils/testData';
 
-function generateNHN() {
+export function generateNHN() {
   const letters = faker.string.alpha({ length: 4, casing: 'upper' });
   const numbers = faker.string.numeric(6);
   const generatedId = `${letters}${numbers}`;
@@ -24,6 +24,7 @@ function generatePatientData() {
   return { firstName, lastName, gender, formattedDOB, nhn, culturalName, village, id: '' };
 }
 
+//TODO: delete this once all tests that use it are refactored to use the new patient fixture
 export async function createPatientViaApi(allPatientsPage: AllPatientsPage) {
   const patientData = generatePatientData();
   allPatientsPage.setPatientData(patientData);


### PR DESCRIPTION
### Changes

- Refactors the existing patient sidebar tests to use the newPatient fixture
- Fixes some flakiness that was introduced to one of the allergy dropdown tests
- Changes the newPatient fixture to use the correct format for the patient NHN
- Changes Github E2E test setup config to be more consistent

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of allergy addition in patient details by verifying the input field value before confirming.
- **Refactor**
	- Simplified patient sidebar tests to use a new patient fixture, reducing setup complexity and improving test clarity.
- **Chores**
	- Updated internal utilities for patient ID generation to enhance consistency across tests.
	- Renamed facility identifiers and credentials in test environment setup for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->