### PR TITLE
fix(medication): release 2.34: EPI-1084: Sort medications by chronological order instead of reverse chronological order

### DIFF
--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -310,7 +310,6 @@ export const EncounterMedicationTable = ({
       <StyledDataFetchingTable
         columns={MEDICATION_COLUMNS(getTranslation, getEnumTranslation, !!selectedMedication)}
         endpoint={`encounter/${encounter.id}/medications`}
-        initialSort={{ orderBy: 'date', order: 'desc' }}
         rowStyle={rowStyle}
         elevated={false}
         allowExport={false}


### PR DESCRIPTION
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
