### PR TITLE
feat(audit): SAV-985: Correct patient program registrations audit logs

### DIFF
--- a/packages/upgrade/src/steps/1750625211505-bumpProgramRegistrationHistory.ts
+++ b/packages/upgrade/src/steps/1750625211505-bumpProgramRegistrationHistory.ts
@@ -1,0 +1,26 @@
+import { FACT_CURRENT_SYNC_TICK } from '@tamanu/constants';
+import type { Steps, StepArgs } from '../step.ts';
+import { END, needsMigration } from '../step.js';
+
+export const STEPS: Steps = [
+  {
+    at: END,
+    after: [needsMigration('1744234388450-movePatientProgramRegistrationsToAuditTable.ts')],
+    async check({ serverType }: StepArgs) {
+      // Only run in central server
+      return serverType === 'central';
+    },
+    async run({ sequelize }: StepArgs) {
+      // Manually inserted logs.changes records might have updated_at_sync_tick = 0,
+      // so we need to bump them to the current sync tick to avoid them being skipped.
+      // This only happens upgrading from a version before 2.32.0 into 2.33.0 or above.
+      await sequelize.query(`
+        UPDATE logs.changes
+        SET updated_at_sync_tick = (
+          SELECT CAST(value AS bigint) FROM local_system_facts WHERE key = '${FACT_CURRENT_SYNC_TICK}'
+        )
+        WHERE updated_at_sync_tick = 0 AND table_name = 'patient_program_registrations';
+      `);
+    },
+  },
+];

--- a/packages/upgrade/src/steps/1750625211505-bumpProgramRegistrationHistory.ts
+++ b/packages/upgrade/src/steps/1750625211505-bumpProgramRegistrationHistory.ts
@@ -17,10 +17,16 @@ export const STEPS: Steps = [
       await sequelize.query(`
         UPDATE logs.changes
         SET updated_at_sync_tick = (
-          SELECT CAST(value AS bigint) FROM local_system_facts WHERE key = '${FACT_CURRENT_SYNC_TICK}'
+          SELECT CAST(value AS bigint) FROM local_system_facts WHERE key = :currentSyncTick
         )
         WHERE updated_at_sync_tick = 0 AND table_name = 'patient_program_registrations';
-      `);
+      `,
+        {
+          replacements: {
+            currentSyncTick: FACT_CURRENT_SYNC_TICK,
+          },
+        },
+      );
     },
   },
 ];


### PR DESCRIPTION
### Changes

Very involved issue, see slack thread for context. This is a new solution that will only help us from 2.34 and above once it gets hotfixed. For 2.33 we will have to do it manually but that doesn't sound so bad!

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved synchronization reliability by updating outdated sync tick values for certain program registration history records during system upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->