### PR TITLE
repo: no-issue: ignore .pem files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ lints.md
 .keys
 .tmp
 *.csca
+*.pem
 
 # Docker
 /dockercfg


### PR DESCRIPTION
### Changes

Gotta hide these or else cursor will read them! Feels pretty safe to generically hide them, can't imagine why we'd ever want to track a `.pem` file

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ignored files to exclude all files with the `.pem` extension from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->