### PR TITLE
fix(translations): Release fix v2.34: Typo in note replacement object

### DIFF
--- a/packages/web/app/components/NoteTable.jsx
+++ b/packages/web/app/components/NoteTable.jsx
@@ -255,7 +255,7 @@ const NoteContent = ({
             <TranslatedText
               stringId="note.table.onBehalfOfText"
               fallback="on behalf of :changeOnBehalfOfName"
-              replacements={{ noteOnBehalfOfName }}
+              replacements={{ changeOnBehalfOfName: noteOnBehalfOfName }}
               data-testid="translatedtext-9x5v"
             />
           </NoteFooterTextElement>


### PR DESCRIPTION
### Changes

Replacements had the wrong object key. Updated to `changeOnBehalfOfName` to follow the same pattern as the other 
"behalf of" text usages

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
