### PR TITLE
fix(upgrade): ditch the idea of "convenient" short step IDs

### DIFF
--- a/packages/upgrade/__tests__/needs.test.ts
+++ b/packages/upgrade/__tests__/needs.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from 'vitest';
+import { needsStep, STEP_PREFIX, needsMigration, MIGRATION_PREFIX } from '../src/step.js';
+
+it('needsStep normal usage', async () => {
+  expect(needsStep('1749079898013-initDeviceKey/0')).toBe(
+    `${STEP_PREFIX}1749079898013-initDeviceKey/0`,
+  );
+});
+
+it('needsStep strips extension', async () => {
+  expect(needsStep('1749079898013-initDeviceKey.ts/0')).toBe(
+    `${STEP_PREFIX}1749079898013-initDeviceKey/0`,
+  );
+});
+
+it('needsStep strips prefix', async () => {
+  expect(needsStep('steps/1749079898013-initDeviceKey/0')).toBe(
+    `${STEP_PREFIX}1749079898013-initDeviceKey/0`,
+  );
+});
+
+it('needsStep throws when index is missing', async () => {
+  expect(() => needsStep('1749079898013-initDeviceKey')).toThrow(
+    'You must provide an index when depending on upgrade steps',
+  );
+});
+
+it('needsStep throws when nothing is passed in', async () => {
+  expect(() => needsStep('')).toThrow('Invalid step name');
+});
+
+it('needsMigration normal usage', async () => {
+  expect(needsMigration('1739968205100-addLSFFunction')).toBe(
+    `${MIGRATION_PREFIX}1739968205100-addLSFFunction`,
+  );
+});
+
+it('needsMigration strips extension', async () => {
+  expect(needsMigration('1739968205100-addLSFFunction.js')).toBe(
+    `${MIGRATION_PREFIX}1739968205100-addLSFFunction`,
+  );
+});
+
+it('needsMigration strips prefix', async () => {
+  expect(needsMigration('steps/1739968205100-addLSFFunction')).toBe(
+    `${MIGRATION_PREFIX}1739968205100-addLSFFunction`,
+  );
+});

--- a/packages/upgrade/__tests__/toposort.test.ts
+++ b/packages/upgrade/__tests__/toposort.test.ts
@@ -42,11 +42,9 @@ it('simple', async () => {
   expect(order).toEqual([
     START,
     'upgrade/foo/0',
-    'upgrade/foo',
     MIGRATIONS_START,
     MIGRATIONS_END,
     'upgrade/bar/0',
-    'upgrade/bar',
     END,
   ]);
 });
@@ -95,9 +93,7 @@ it('multi step file with indexed step dep', async () => {
     'upgrade/foo/0',
     'upgrade/bar/0',
     'upgrade/foo/1',
-    'upgrade/foo',
     MIGRATIONS_START,
-    'upgrade/bar',
     MIGRATIONS_END,
     END,
   ]);
@@ -145,19 +141,16 @@ it('migration dependency', async () => {
   expect(order).toEqual([
     START,
     'upgrade/foo/0',
-    'upgrade/foo',
     MIGRATIONS_START,
     'migration/1744261686398-addEnabledCheckToAuditTrigger',
     'migration/1744602896344-addLookupTicksTable',
     'migration/1745987213057-OptimiseFhirJobGrabFunction',
     'upgrade/baz/0',
-    'upgrade/baz',
     'migration/1747862710346-removeColumnsFromChangelogs',
     'migration/1748216223615-separateSyncSessionParametersFromDebugInfo',
     'migration/1748555633925-fullyResyncPatientProgramRegistrations',
     MIGRATIONS_END,
     'upgrade/bar/0',
-    'upgrade/bar',
     END,
   ]);
 });

--- a/packages/upgrade/src/index.ts
+++ b/packages/upgrade/src/index.ts
@@ -75,7 +75,10 @@ export async function upgrade({
       continue;
     }
 
-    if (id.endsWith(START) || id.endsWith(END)) continue;
+    if (id.endsWith(START) || id.endsWith(END)) {
+      // virtual step, skip
+      continue;
+    }
 
     if (id.startsWith(MIGRATION_PREFIX)) {
       const target = pendingMigrations.find((mig) =>

--- a/packages/upgrade/src/step.ts
+++ b/packages/upgrade/src/step.ts
@@ -8,20 +8,27 @@ export const END: At = ':end:';
 export const MIGRATION_PREFIX = 'migration/';
 export const STEP_PREFIX = 'upgrade/';
 
-export type StepStr = `upgrade/${string}` | `upgrade/${string}/${number}`;
+export type StepStr = `upgrade/${string}/${number}`;
 export type MigrationStr = `migration/${string}`;
 export type Need = StepStr | MigrationStr;
 export type Needs = Need[];
 
-export const needsStep = (step: string) => `upgrade/${basename(step, extname(step))}` as StepStr;
+export const needsStep = (step: string) => {
+  const re = /^(?<file>.+?)(\/(?<index>\d+))?$/;
+  const { file, index } = re.exec(step)?.groups || {};
+  if (!file) throw new Error(`Invalid step name: ${step}`);
+  if (!index) throw new Error('You must provide an index when depending on upgrade steps');
+
+  return `upgrade/${basename(file, extname(file))}/${index}` as StepStr;
+};
 export const needsMigration = (mig: string) =>
   `migration/${basename(mig, extname(mig))}` as MigrationStr;
 export const onlySteps = (needs: Needs): StepStr[] =>
   needs.filter((need: Need) => need.startsWith(STEP_PREFIX)) as StepStr[];
 export const onlyMigrations = (needs: Needs): MigrationStr[] =>
   needs.filter((need: Need) => need.startsWith(MIGRATION_PREFIX)) as MigrationStr[];
-export const stepFile = (str: StepStr) => str.split('/')[1]! + '.js';
-export const migrationFile = (str: MigrationStr) => str.split('/')[1]! + '.js';
+export const stepFile = (str: StepStr) => str.split('/')[1] + '.js';
+export const migrationFile = (str: MigrationStr) => str.split('/')[1] + '.js';
 
 export interface StepArgs {
   sequelize: Sequelize;


### PR DESCRIPTION
### Changes

This is both confusing in the before/after behaviour and also created the conditions for a false-positive warning bug where the "short" IDs weren't properly ignored during the run.

While removing, I also discovered another bug where specifying indexed steps in the needsStep() function would have stripped the actual step name due to the ext-stripping processing.

This commit also adds tests for that functionality.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for step identifiers, ensuring that step dependencies must include an index and providing clearer error messages for invalid input.
- **Tests**
	- Added comprehensive unit tests for step and migration normalization, including error cases.
	- Updated test expectations to reflect changes in step identifier handling.
- **Refactor**
	- Simplified internal logic for step dependency resolution and clarified comments for better maintainability.
- **Documentation**
	- Enhanced comments to clarify requirements for step IDs and relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->