### PR TITLE
tweak(upgrade): alias migrate to upgrade

### DIFF
--- a/packages/central-server/app/subCommands/migrate.js
+++ b/packages/central-server/app/subCommands/migrate.js
@@ -8,4 +8,4 @@ async function migrate(direction) {
   process.exit(0);
 }
 
-export const migrateCommand = createMigrateCommand(Command, migrate);
+export const migrateCommand = createMigrateCommand(Command, migrate, 'just-migrate');

--- a/packages/central-server/app/subCommands/upgrade.js
+++ b/packages/central-server/app/subCommands/upgrade.js
@@ -4,6 +4,7 @@ import { initDatabase } from '../database';
 import { VERSION } from '../middleware/versionCompatibility';
 
 export const upgradeCommand = new Command('upgrade')
+  .alias('migrate')
   .description('Upgrade Tamanu installation')
   .action(async () => {
     const { sequelize, models } = await initDatabase({ testMode: false });

--- a/packages/database/src/services/migrations/migrations.js
+++ b/packages/database/src/services/migrations/migrations.js
@@ -139,10 +139,8 @@ export async function migrate(log, sequelize, direction) {
   throw new Error(`Unrecognised migrate direction: ${direction}`);
 }
 
-export function createMigrateCommand(Command, migrateCallback) {
-  const migrateCommand = new Command('migrate').description(
-    'Apply or roll back database migrations',
-  );
+export function createMigrateCommand(Command, migrateCallback, name = 'migrate') {
+  const migrateCommand = new Command(name).description('Apply or roll back database migrations');
 
   migrateCommand
     .command('up', { isDefault: true })

--- a/packages/facility-server/app/subCommands/migrate.js
+++ b/packages/facility-server/app/subCommands/migrate.js
@@ -8,4 +8,4 @@ async function migrate(direction) {
   process.exit(0);
 }
 
-export const migrateCommand = createMigrateCommand(Command, migrate);
+export const migrateCommand = createMigrateCommand(Command, migrate, 'just-migrate');

--- a/packages/facility-server/app/subCommands/upgrade.js
+++ b/packages/facility-server/app/subCommands/upgrade.js
@@ -4,6 +4,7 @@ import { initDatabase } from '../database';
 import { VERSION } from '../middleware/versionCompatibility';
 
 export const upgradeCommand = new Command('upgrade')
+  .alias('migrate')
   .description('Upgrade Tamanu installation')
   .action(async () => {
     const { sequelize, models } = await initDatabase();

--- a/scripts/apply_and_revert_server_migrations.sh
+++ b/scripts/apply_and_revert_server_migrations.sh
@@ -4,4 +4,4 @@ set -euxo pipefail
 server="${1:?Missing package}"
 npm run --workspace @tamanu/$server build
 npm run --workspace @tamanu/$server start upgrade
-npm run --workspace @tamanu/$server start migrate downToLastReversibleMigration
+npm run --workspace @tamanu/$server start just-migrate downToLastReversibleMigration


### PR DESCRIPTION
### Changes

The `migrate` subcommand becomes an alias to the `upgrade` command, and the "raw" migrate subcommand is renamed to `just-migrate`.

This means that deployment processes (including for auto-deploys) don't need to change to use the new upgrade process, and we still have the ability to do rollbacks and such.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
