### PR TITLE
fix(ci): SAV-987: Migration determinism test update

### DIFF
--- a/packages/scripts/src/testDeterminism.ts
+++ b/packages/scripts/src/testDeterminism.ts
@@ -143,7 +143,7 @@ async function areMigrationsAvailable(dbConfig: any): Promise<boolean> {
 async function migrate(dbConfig: any): Promise<void> {
   const script = `
     (async () => {
-      const { version } = require('./package.json');
+      const { version } = require('../package.json');
       const { initDatabase } = require('@tamanu/database/services/database');
       const { upgrade } = require('@tamanu/upgrade');
 


### PR DESCRIPTION
### Changes

This was added recently, it's blocking merges against main if you have your branch updated. Seems like it was just a small path issue.

The proof was obtained in https://github.com/beyondessential/tamanu/pull/7869 where the first commit is just there to trigger the migration determinism step (otherwise it will pass) and the second commit fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the path used to retrieve version information during the migration upgrade process to ensure accurate version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->