### PR TITLE
tweak(prettier): No-issue: Add global avoid parenthesis setting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 100,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
### Changes

We noticed some strange behaviour in recent PRs where sometimes parenthesis were being added or removed by the prettier. We narrowed down that it was adding them for JS and removing them for JSX. 

While I am not certain, I am pretty sure this is a result of the move to cursor for some devs where we lost the "avoid parenthesis" setting that was manually set for prettier.  To resolve this I have added a global rule (it seems we dont have any rule and we are falling back to default/user settings)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated code formatting to omit parentheses around single arrow function parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->