### PR TITLE
feat(pharmacyOrders): TAN-2520: Add models for PharmacyOrders tables

### DIFF
--- a/database/model/public/pharmacy_order_prescriptions.md
+++ b/database/model/public/pharmacy_order_prescriptions.md
@@ -1,0 +1,19 @@
+{% docs table__pharmacy_order_prescriptions %}
+Individual prescriptions that are included in a [pharmacy_order](#!/source/source.tamanu.tamanu.pharmacy_orders).
+{% enddocs %}
+
+{% docs pharmacy_order_prescriptions__pharmacy_order_id %}
+Reference to the [pharmacy_order](#!/source/source.tamanu.tamanu.pharmacy_orders).
+{% enddocs %}
+
+{% docs pharmacy_order_prescriptions__prescription_id %}
+Reference to the [prescription](#!/source/source.tamanu.tamanu.prescriptions).
+{% enddocs %}
+
+{% docs pharmacy_order_prescriptions__quantity %}
+Quantity of medication ordered.
+{% enddocs %}
+
+{% docs pharmacy_order_prescriptions__repeats %}
+Number of repeats for the prescription.
+{% enddocs %}

--- a/database/model/public/pharmacy_order_prescriptions.yml
+++ b/database/model/public/pharmacy_order_prescriptions.yml
@@ -1,0 +1,53 @@
+version: 2
+sources:
+  - name: tamanu
+    schema: public
+    description: "{{ doc('generic__schema') }}"
+    tables:
+      - name: pharmacy_order_prescriptions
+        description: '{{ doc("table__pharmacy_order_prescriptions") }}'
+        config:
+          tags: []
+        columns:
+          - name: id
+            data_type: uuid
+            description: "{{ doc('generic__id') }} in pharmacy_order_prescriptions."
+            data_tests:
+              - unique
+              - not_null
+          - name: pharmacy_order_id
+            data_type: uuid
+            description: "{{ doc('pharmacy_order_prescriptions__pharmacy_order_id') }}"
+            data_tests:
+              - not_null
+          - name: prescription_id
+            data_type: text
+            description: "{{ doc('pharmacy_order_prescriptions__prescription_id') }}"
+            data_tests:
+              - not_null
+          - name: quantity
+            data_type: integer
+            description: "{{ doc('pharmacy_order_prescriptions__quantity') }}"
+            data_tests:
+              - not_null
+          - name: repeats
+            data_type: integer
+            description: "{{ doc('pharmacy_order_prescriptions__repeats') }}"
+          - name: created_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__created_at') }} in pharmacy_order_prescriptions."
+            data_tests:
+              - not_null
+          - name: updated_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__updated_at') }} in pharmacy_order_prescriptions."
+            data_tests:
+              - not_null
+          - name: deleted_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__deleted_at') }} in pharmacy_order_prescriptions."
+          - name: updated_at_sync_tick
+            data_type: bigint
+            description: "{{ doc('generic__updated_at_sync_tick') }} in pharmacy_order_prescriptions."
+            data_tests:
+              - not_null

--- a/database/model/public/pharmacy_orders.md
+++ b/database/model/public/pharmacy_orders.md
@@ -1,0 +1,15 @@
+{% docs table__pharmacy_orders %}
+An order for prescriptions placed by Tamanu to a Pharmacy
+{% enddocs %}
+
+{% docs pharmacy_orders__ordering_clinician_id %}
+Reference to the [clinician](#!/source/source.tamanu.tamanu.users) who placed the order.
+{% enddocs %}
+
+{% docs pharmacy_orders__encounter_id %}
+Reference to the [encounter](#!/source/source.tamanu.tamanu.encounters) for the order.
+{% enddocs %}
+
+{% docs pharmacy_orders__comments %}
+Comments provided by the clinician when placing the order.
+{% enddocs %}

--- a/database/model/public/pharmacy_orders.yml
+++ b/database/model/public/pharmacy_orders.yml
@@ -1,0 +1,48 @@
+version: 2
+sources:
+  - name: tamanu
+    schema: public
+    description: "{{ doc('generic__schema') }}"
+    tables:
+      - name: pharmacy_orders
+        description: '{{ doc("table__pharmacy_orders") }}'
+        config:
+          tags: []
+        columns:
+          - name: id
+            data_type: uuid
+            description: "{{ doc('generic__id') }} in pharmacy_orders."
+            data_tests:
+              - unique
+              - not_null
+          - name: ordering_clinician_id
+            data_type: text
+            description: "{{ doc('pharmacy_orders__ordering_clinician_id') }}"
+            data_tests:
+              - not_null
+          - name: encounter_id
+            data_type: text
+            description: "{{ doc('pharmacy_orders__encounter_id') }}"
+            data_tests:
+              - not_null
+          - name: comments
+            data_type: text
+            description: "{{ doc('pharmacy_orders__comments') }}"
+          - name: created_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__created_at') }} in pharmacy_orders."
+            data_tests:
+              - not_null
+          - name: updated_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__updated_at') }} in pharmacy_orders."
+            data_tests:
+              - not_null
+          - name: deleted_at
+            data_type: timestamp with time zone
+            description: "{{ doc('generic__deleted_at') }} in pharmacy_orders."
+          - name: updated_at_sync_tick
+            data_type: bigint
+            description: "{{ doc('generic__updated_at_sync_tick') }} in pharmacy_orders."
+            data_tests:
+              - not_null

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -124,6 +124,8 @@ describe('Sync Lookup data', () => {
       EncounterHistory,
       EncounterPrescription,
       PatientOngoingPrescription,
+      PharmacyOrder,
+      PharmacyOrderPrescription,
       Prescription,
       ImagingRequest,
       ImagingRequestArea,
@@ -308,6 +310,21 @@ describe('Sync Lookup data', () => {
         prescriptionId: prescription.id,
       }),
     );
+
+    const pharmacyOrder = await PharmacyOrder.create(
+      fake(PharmacyOrder, {
+        encounterId: encounter1.id,
+        orderingClinicianId: examiner.id,
+      }),
+    );
+
+    await PharmacyOrderPrescription.create(
+      fake(PharmacyOrderPrescription, {
+        pharmacyOrderId: pharmacyOrder.id,
+        prescriptionId: prescription.id,
+      }),
+    );
+
     const imagingRequest = await ImagingRequest.create(
       fake(ImagingRequest, {
         encounterId: encounter1.id,
@@ -703,7 +720,7 @@ describe('Sync Lookup data', () => {
 
     for (const model of Object.values(patientLinkedModels)) {
       const syncLookupRecord = syncLookupData.find(
-        (d) => d.dataValues.recordType === model.tableName,
+        d => d.dataValues.recordType === model.tableName,
       );
 
       if (!syncLookupRecord) {
@@ -736,7 +753,7 @@ describe('Sync Lookup data', () => {
 
     for (const model of Object.values(patientLinkedModels)) {
       const outgoingSnapshotRecord = outgoingSnapshotRecords.find(
-        (r) => r.recordType === model.tableName,
+        r => r.recordType === model.tableName,
       );
 
       if (!outgoingSnapshotRecord) {
@@ -796,7 +813,7 @@ describe('Sync Lookup data', () => {
 
     for (const model of Object.values(nonPatientLinkedModels)) {
       const outgoingSnapshotRecord = outgoingSnapshotRecords.find(
-        (r) => r.recordType === model.tableName,
+        r => r.recordType === model.tableName,
       );
 
       if (outgoingSnapshotRecord) {
@@ -925,7 +942,7 @@ describe('Sync Lookup data', () => {
           SYNC_SESSION_DIRECTION.OUTGOING,
         );
 
-        expect(outgoingSnapshotRecords.find((r) => r.recordId === setting.id)).toBeDefined();
+        expect(outgoingSnapshotRecords.find(r => r.recordId === setting.id)).toBeDefined();
       });
 
       it('Does not snapshot settings linked to a facility other than the current facility', async () => {
@@ -974,7 +991,7 @@ describe('Sync Lookup data', () => {
           SYNC_SESSION_DIRECTION.OUTGOING,
         );
 
-        expect(outgoingSnapshotRecords.find((r) => r.recordId === setting.id)).not.toBeDefined();
+        expect(outgoingSnapshotRecords.find(r => r.recordId === setting.id)).not.toBeDefined();
       });
 
       it('Snapshots settings with global scope', async () => {
@@ -1022,7 +1039,7 @@ describe('Sync Lookup data', () => {
           SYNC_SESSION_DIRECTION.OUTGOING,
         );
 
-        expect(outgoingSnapshotRecords.find((r) => r.recordId === setting.id)).toBeDefined();
+        expect(outgoingSnapshotRecords.find(r => r.recordId === setting.id)).toBeDefined();
       });
     });
   });
@@ -1082,9 +1099,7 @@ describe('Sync Lookup data', () => {
       SYNC_SESSION_DIRECTION.OUTGOING,
     );
 
-    expect(
-      outgoingSnapshotRecords.find((r) => r.recordId === patientFacility.id),
-    ).not.toBeDefined();
+    expect(outgoingSnapshotRecords.find(r => r.recordId === patientFacility.id)).not.toBeDefined();
   });
 
   describe('syncAllLabRequest', () => {
@@ -1199,7 +1214,7 @@ describe('Sync Lookup data', () => {
 
       for (const model of Object.values(labRequestModels)) {
         const syncLookupRecord = syncLookupData.find(
-          (d) => d.dataValues.recordType === model.tableName,
+          d => d.dataValues.recordType === model.tableName,
         );
 
         if (!syncLookupRecord) {
@@ -1223,23 +1238,23 @@ describe('Sync Lookup data', () => {
       );
 
       const labEncounterIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'encounters')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'encounters')
+        .map(r => r.recordId);
       const labRequestIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_requests')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_requests')
+        .map(r => r.recordId);
       const labRequestAttachmentIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_request_attachments')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_request_attachments')
+        .map(r => r.recordId);
       const labRequestLogIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_request_logs')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_request_logs')
+        .map(r => r.recordId);
       const labTestIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_tests')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_tests')
+        .map(r => r.recordId);
       const labTestPanelRequests = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_test_panel_requests')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_test_panel_requests')
+        .map(r => r.recordId);
 
       expect(labEncounterIds.sort()).toEqual([encounter1.id, encounter2.id].sort());
       expect(labRequestIds.sort()).toEqual([labRequest1.id, labRequest2.id].sort());
@@ -1285,7 +1300,7 @@ describe('Sync Lookup data', () => {
       const syncLookupData = await models.SyncLookup.findAll({});
       for (const model of Object.values(labRequestModels)) {
         const syncLookupRecord = syncLookupData.find(
-          (d) => d.dataValues.recordType === model.tableName,
+          d => d.dataValues.recordType === model.tableName,
         );
 
         if (!syncLookupRecord) {
@@ -1309,23 +1324,23 @@ describe('Sync Lookup data', () => {
       );
 
       const labEncounterIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'encounters')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'encounters')
+        .map(r => r.recordId);
       const labRequestIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_requests')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_requests')
+        .map(r => r.recordId);
       const labRequestAttachmentIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_request_attachments')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_request_attachments')
+        .map(r => r.recordId);
       const labRequestLogIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_request_logs')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_request_logs')
+        .map(r => r.recordId);
       const labTestIds = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_tests')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_tests')
+        .map(r => r.recordId);
       const labTestPanelRequests = outgoingSnapshotRecords
-        .filter((r) => r.recordType === 'lab_test_panel_requests')
-        .map((r) => r.recordId);
+        .filter(r => r.recordType === 'lab_test_panel_requests')
+        .map(r => r.recordId);
 
       expect(labEncounterIds).toEqual([encounter1.id]);
       expect(labRequestIds).toEqual([labRequest1.id]);
@@ -1379,7 +1394,7 @@ describe('Sync Lookup data', () => {
   });
 
   describe('avoidRepull', () => {
-    const snapshotOutgoingRecordsForFacility = async (avoidRepull) => {
+    const snapshotOutgoingRecordsForFacility = async avoidRepull => {
       const deviceId = 'facility-a';
       await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 4);
       const pushedPatientFromCurrentFacility = await models.Patient.create(fake(models.Patient));
@@ -1458,10 +1473,10 @@ describe('Sync Lookup data', () => {
         patientFromAnotherFacility,
       } = await snapshotOutgoingRecordsForFacility(true);
       const snapshotPushedPatientFromCurrentFacility = outgoingSnapshotRecords.find(
-        (r) => r.recordId === pushedPatientFromCurrentFacility.id,
+        r => r.recordId === pushedPatientFromCurrentFacility.id,
       );
       const snapshotPatientFromAnotherFacility = outgoingSnapshotRecords.find(
-        (r) => r.recordId === patientFromAnotherFacility.id,
+        r => r.recordId === patientFromAnotherFacility.id,
       );
 
       expect(snapshotPushedPatientFromCurrentFacility).not.toBeDefined();
@@ -1475,10 +1490,10 @@ describe('Sync Lookup data', () => {
         patientFromAnotherFacility,
       } = await snapshotOutgoingRecordsForFacility(false);
       const snapshotPushedPatientFromCurrentFacility = outgoingSnapshotRecords.find(
-        (r) => r.recordId === pushedPatientFromCurrentFacility.id,
+        r => r.recordId === pushedPatientFromCurrentFacility.id,
       );
       const snapshotPatientFromAnotherFacility = outgoingSnapshotRecords.find(
-        (r) => r.recordId === patientFromAnotherFacility.id,
+        r => r.recordId === patientFromAnotherFacility.id,
       );
 
       expect(snapshotPushedPatientFromCurrentFacility).toBeDefined();

--- a/packages/database/src/migrations/1748555633926-createPharmacyOrdersTables.ts
+++ b/packages/database/src/migrations/1748555633926-createPharmacyOrdersTables.ts
@@ -69,7 +69,7 @@ export async function up(query: QueryInterface): Promise<void> {
     },
     quantity: {
       type: DataTypes.INTEGER,
-      allowNull: true,
+      allowNull: false,
     },
     repeats: {
       type: DataTypes.INTEGER,

--- a/packages/database/src/migrations/1748555633926-createPharmacyOrdersTables.ts
+++ b/packages/database/src/migrations/1748555633926-createPharmacyOrdersTables.ts
@@ -1,0 +1,98 @@
+import { DataTypes, QueryInterface, Sequelize } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Create pharmacy_orders table
+  await query.createTable('pharmacy_orders', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('gen_random_uuid'),
+    },
+    ordering_clinician_id: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id',
+      },
+    },
+    encounter_id: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      references: {
+        model: 'encounters',
+        key: 'id',
+      },
+    },
+    comments: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now'),
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now'),
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  });
+
+  // Create pharmacy_order_prescriptions table
+  await query.createTable('pharmacy_order_prescriptions', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: Sequelize.fn('gen_random_uuid'),
+    },
+    pharmacy_order_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'pharmacy_orders',
+        key: 'id',
+      },
+    },
+    prescription_id: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      references: {
+        model: 'prescriptions',
+        key: 'id',
+      },
+    },
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    repeats: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now'),
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now'),
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.dropTable('pharmacy_order_prescriptions');
+  await query.dropTable('pharmacy_orders');
+}

--- a/packages/database/src/models/PharmacyOrder.ts
+++ b/packages/database/src/models/PharmacyOrder.ts
@@ -14,16 +14,6 @@ export class PharmacyOrder extends Model {
     super.init(
       {
         id: primaryKey,
-        orderingClinicianId: {
-          type: DataTypes.TEXT,
-          allowNull: false,
-          field: 'ordering_clinician_id',
-        },
-        encounterId: {
-          type: DataTypes.TEXT,
-          allowNull: false,
-          field: 'encounter_id',
-        },
         comments: DataTypes.TEXT,
       },
       {

--- a/packages/database/src/models/PharmacyOrder.ts
+++ b/packages/database/src/models/PharmacyOrder.ts
@@ -15,12 +15,12 @@ export class PharmacyOrder extends Model {
       {
         id: primaryKey,
         orderingClinicianId: {
-          type: DataTypes.UUID,
+          type: DataTypes.TEXT,
           allowNull: false,
           field: 'ordering_clinician_id',
         },
         encounterId: {
-          type: DataTypes.UUID,
+          type: DataTypes.TEXT,
           allowNull: false,
           field: 'encounter_id',
         },

--- a/packages/database/src/models/PharmacyOrder.ts
+++ b/packages/database/src/models/PharmacyOrder.ts
@@ -1,0 +1,70 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { Model } from './Model';
+import type { InitOptions, Models } from '../types/model';
+import { buildEncounterLinkedLookupFilter, buildEncounterLinkedSyncFilter } from '../sync';
+
+export class PharmacyOrder extends Model {
+  declare id: string;
+  declare orderingClinicianId: string;
+  declare encounterId: string;
+  declare comments?: string;
+
+  static initModel({ primaryKey, ...options }: InitOptions) {
+    super.init(
+      {
+        id: primaryKey,
+        orderingClinicianId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          field: 'ordering_clinician_id',
+        },
+        encounterId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          field: 'encounter_id',
+        },
+        comments: DataTypes.TEXT,
+      },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
+      },
+    );
+  }
+
+  static initRelations(models: Models) {
+    this.belongsTo(models.User, {
+      foreignKey: 'orderingClinicianId',
+      as: 'orderingClinician',
+    });
+
+    this.belongsTo(models.Encounter, {
+      foreignKey: 'encounterId',
+      as: 'encounter',
+    });
+
+    this.hasMany(models.PharmacyOrderPrescription, {
+      foreignKey: 'pharmacyOrderId',
+      as: 'pharmacyOrderPrescriptions',
+    });
+  }
+
+  static getListReferenceAssociations() {
+    return ['orderingClinician', 'encounter'];
+  }
+
+  static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return buildEncounterLinkedSyncFilter(
+      [this.tableName, 'encounters'],
+      markedForSyncPatientsTable,
+    );
+  }
+
+  static buildSyncLookupQueryDetails() {
+    return buildEncounterLinkedLookupFilter(this);
+  }
+}

--- a/packages/database/src/models/PharmacyOrderPrescription.ts
+++ b/packages/database/src/models/PharmacyOrderPrescription.ts
@@ -25,13 +25,13 @@ export class PharmacyOrderPrescription extends Model {
           field: 'pharmacy_order_id',
         },
         prescriptionId: {
-          type: DataTypes.UUID,
+          type: DataTypes.TEXT,
           allowNull: false,
           field: 'prescription_id',
         },
         quantity: {
           type: DataTypes.INTEGER,
-          allowNull: true,
+          allowNull: false,
         },
         repeats: {
           type: DataTypes.INTEGER,

--- a/packages/database/src/models/PharmacyOrderPrescription.ts
+++ b/packages/database/src/models/PharmacyOrderPrescription.ts
@@ -19,16 +19,6 @@ export class PharmacyOrderPrescription extends Model {
     super.init(
       {
         id: primaryKey,
-        pharmacyOrderId: {
-          type: DataTypes.UUID,
-          allowNull: false,
-          field: 'pharmacy_order_id',
-        },
-        prescriptionId: {
-          type: DataTypes.TEXT,
-          allowNull: false,
-          field: 'prescription_id',
-        },
         quantity: {
           type: DataTypes.INTEGER,
           allowNull: false,

--- a/packages/database/src/models/PharmacyOrderPrescription.ts
+++ b/packages/database/src/models/PharmacyOrderPrescription.ts
@@ -1,0 +1,80 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
+import { Model } from './Model';
+import type { InitOptions, Models } from '../types/model';
+import {
+  buildEncounterPatientIdSelect,
+  buildEncounterLinkedSyncFilter,
+  buildEncounterLinkedSyncFilterJoins,
+} from '../sync';
+
+export class PharmacyOrderPrescription extends Model {
+  declare id: string;
+  declare pharmacyOrderId: string;
+  declare prescriptionId: string;
+  declare quantity?: number;
+  declare repeats?: number;
+
+  static initModel({ primaryKey, ...options }: InitOptions) {
+    super.init(
+      {
+        id: primaryKey,
+        pharmacyOrderId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          field: 'pharmacy_order_id',
+        },
+        prescriptionId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          field: 'prescription_id',
+        },
+        quantity: {
+          type: DataTypes.INTEGER,
+          allowNull: true,
+        },
+        repeats: {
+          type: DataTypes.INTEGER,
+          allowNull: true,
+        },
+      },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
+      },
+    );
+  }
+
+  static initRelations(models: Models) {
+    this.belongsTo(models.PharmacyOrder, {
+      foreignKey: 'pharmacyOrderId',
+      as: 'pharmacyOrder',
+    });
+
+    this.belongsTo(models.Prescription, {
+      foreignKey: 'prescriptionId',
+      as: 'prescription',
+    });
+  }
+
+  static getListReferenceAssociations() {
+    return ['pharmacyOrder', 'prescription'];
+  }
+
+  static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return buildEncounterLinkedSyncFilter(
+      [this.tableName, 'pharmacy_orders', 'encounters'],
+      markedForSyncPatientsTable,
+    );
+  }
+
+  static buildSyncLookupQueryDetails() {
+    return {
+      select: buildEncounterPatientIdSelect(this),
+      joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'pharmacy_orders', 'encounters']),
+    };
+  }
+}

--- a/packages/database/src/models/index.ts
+++ b/packages/database/src/models/index.ts
@@ -116,6 +116,9 @@ export * from './MedicationAdministrationRecord';
 export * from './MedicationAdministrationRecordDose';
 export * from './ReferenceMedicationTemplate';
 
+export * from './PharmacyOrder';
+export * from './PharmacyOrderPrescription';
+
 export * from './Notification';
 
 export * from './Signer';


### PR DESCRIPTION
### Changes

pharmacy_orders are linked to an encounter.
pharmacy_order_prescriptions are linked to prescriptions (which in turn are linked to encounters via encounter_prescriptions)
There's a little bit of an awkward circular relation there but I think it's okay. Might need to double check it doesn't break the sync model ordering logic 

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for pharmacy orders and associated prescriptions, enabling management of orders linked to clinicians, encounters, and prescriptions.
- **Chores**
  - Added new data structures and database tables to support pharmacy order workflows in the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->