### PR TITLE
fix(web): hotfix 2.34: Fix note modal height.

### DIFF
--- a/packages/web/app/components/NoteModal/NoteModal.jsx
+++ b/packages/web/app/components/NoteModal/NoteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import { useHistory, matchPath } from 'react-router-dom';
 import styled from 'styled-components';
 import MuiDialog from '@material-ui/core/Dialog';
@@ -16,6 +16,24 @@ import { withModalFloating } from '../withModalFloating';
 import { useNoteModal } from '../../contexts/NoteModal';
 import { NoteModalDialogTitle } from './NoteModalCommonComponents';
 import { useMediaQuery } from '@material-ui/core';
+
+const NOTE_MODAL_DIMENSIONS = {
+  BREAKPOINTS: {
+    HEIGHT: 850, // px
+  },
+  WIDTH: {
+    BASE: 500,
+    MIN: 400,
+    MAX: 500,
+  },
+  HEIGHT: {
+    BASE: 500,
+    MIN_DEFAULT: 450,
+    MIN_TREATMENT_PLAN: 500,
+    MAX_DEFAULT: 500,
+    MAX_TALL: 775,
+  },
+};
 
 const StyledMuiDialog = styled(MuiDialog)`
   /* Make the form take up full height */
@@ -55,20 +73,6 @@ const getOnBehalfOfId = (noteFormMode, currentUserId, newData, note) => {
     : undefined;
 };
 
-const getMinConstraints = (noteFormMode, note) => {
-  if (noteFormMode === NOTE_FORM_MODES.EDIT_NOTE && note.noteType === NOTE_TYPES.TREATMENT_PLAN) {
-    return [400, 500];
-  }
-  return [400, 450];
-};
-
-const getMaxConstraints = isHeightBreakpoint => {
-  if (isHeightBreakpoint) {
-    return [500, 775];
-  }
-  return [500, 500];
-};
-
 const MemoizedNoteModalContents = React.memo(
   ({
     open,
@@ -81,16 +85,32 @@ const MemoizedNoteModalContents = React.memo(
     cancelText,
     handleCreateOrEditNewNote,
   }) => {
-    const isHeightBreakpoint = useMediaQuery('(min-height: 850px)');
+    const { BREAKPOINTS, WIDTH, HEIGHT } = NOTE_MODAL_DIMENSIONS;
+
+    const isHeightBreakpoint = useMediaQuery(`(min-height: ${BREAKPOINTS.HEIGHT}px)`);
+    const isTreatmentPlanEdit =
+      noteFormMode === NOTE_FORM_MODES.EDIT_NOTE && note.noteType === NOTE_TYPES.TREATMENT_PLAN;
+
+    const minConstraints = useMemo(() => {
+      if (isTreatmentPlanEdit) {
+        return [WIDTH.MIN, HEIGHT.MIN_TREATMENT_PLAN];
+      }
+      return [WIDTH.MIN, HEIGHT.MIN_DEFAULT];
+    }, [isTreatmentPlanEdit, WIDTH, HEIGHT]);
+
+    const maxConstraints = useMemo(() => {
+      const height = isHeightBreakpoint ? HEIGHT.MAX_TALL : HEIGHT.MAX_DEFAULT;
+      return [WIDTH.MAX, height];
+    }, [isHeightBreakpoint, WIDTH, HEIGHT]);
 
     return (
       <FloatingMuiDialog
         open={open}
         onClose={onClose}
-        baseWidth={500}
-        baseHeight={isHeightBreakpoint ? 775 : 500}
-        minConstraints={getMinConstraints(noteFormMode, note)}
-        maxConstraints={getMaxConstraints(isHeightBreakpoint)}
+        baseWidth={WIDTH.BASE}
+        baseHeight={isHeightBreakpoint ? HEIGHT.MAX_TALL : HEIGHT.BASE}
+        minConstraints={minConstraints}
+        maxConstraints={maxConstraints}
       >
         <NoteModalDialogTitle title={title} onClose={onClose} />
         <NoteForm

--- a/packages/web/app/components/NoteModal/NoteModal.jsx
+++ b/packages/web/app/components/NoteModal/NoteModal.jsx
@@ -15,6 +15,7 @@ import { TranslatedText } from '../Translation/TranslatedText';
 import { withModalFloating } from '../withModalFloating';
 import { useNoteModal } from '../../contexts/NoteModal';
 import { NoteModalDialogTitle } from './NoteModalCommonComponents';
+import { useMediaQuery } from '@material-ui/core';
 
 const StyledMuiDialog = styled(MuiDialog)`
   /* Make the form take up full height */
@@ -61,6 +62,13 @@ const getMinConstraints = (noteFormMode, note) => {
   return [400, 450];
 };
 
+const getMaxConstraints = isHeightBreakpoint => {
+  if (isHeightBreakpoint) {
+    return [500, 775];
+  }
+  return [500, 500];
+};
+
 const MemoizedNoteModalContents = React.memo(
   ({
     open,
@@ -73,14 +81,16 @@ const MemoizedNoteModalContents = React.memo(
     cancelText,
     handleCreateOrEditNewNote,
   }) => {
+    const isHeightBreakpoint = useMediaQuery('(min-height: 850px)');
+
     return (
       <FloatingMuiDialog
         open={open}
         onClose={onClose}
         baseWidth={500}
-        baseHeight={775}
+        baseHeight={isHeightBreakpoint ? 775 : 500}
         minConstraints={getMinConstraints(noteFormMode, note)}
-        maxConstraints={[500, 775]}
+        maxConstraints={getMaxConstraints(isHeightBreakpoint)}
       >
         <NoteModalDialogTitle title={title} onClose={onClose} />
         <NoteForm


### PR DESCRIPTION
### Changes

Fixed note modal height on smaller screens using MUI media query.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
