### PR TITLE
fix(upcomingVaccinations): TAMOC-298: hotfix 2.24: toggle upcoming vaccinations patient level

### DIFF
--- a/packages/database/src/demoData/diagnoses.js
+++ b/packages/database/src/demoData/diagnoses.js
@@ -4963,7 +4963,7 @@ export const DIAGNOSES = splitIds(`
   Sternoclavicular joint dislocation	S43.2
   Steroids abuse	F55
   Stevens johnson syndrome	L51.1
-  Stich abscess	T81.4
+  Stitch abscess	T81.4
   Stiff joint	M25.6
   Stillbirth	na
   Stone in kidney	N20.0

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -115,6 +115,11 @@ export const globalSettings = {
           type: yup.boolean(),
           defaultValue: true,
         },
+        hideUpcomingVaccines: {
+          description: 'Hide upcoming vaccines behind a button from the patient details page',
+          type: yup.boolean(),
+          defaultValue: false,
+        },
         enablePatientDeaths: {
           description: 'Enable death module',
           type: yup.boolean(),

--- a/packages/web/app/views/patients/panes/VaccinesPane.jsx
+++ b/packages/web/app/views/patients/panes/VaccinesPane.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../../components/PatientPrinting';
 import { ImmunisationsTable, ImmunisationScheduleTable } from '../../../features';
 import { useAdministeredVaccinesQuery } from '../../../api/queries';
+import { useSettings } from '../../../contexts/Settings';
 
 const CovidCertificateButton = styled(Button)`
   margin-left: 0;
@@ -36,6 +37,10 @@ const TableWrapper = styled.div`
 `;
 
 export const VaccinesPane = React.memo(({ patient, readonly }) => {
+  const { getSetting } = useSettings();
+  const [hideUpcomingVaccines, setHideUpcomingVaccines] = useState(
+    getSetting('features.hideUpcomingVaccines'),
+  );
   const [isAdministerModalOpen, setIsAdministerModalOpen] = useState(false);
   const [isCovidCertificateModalOpen, setIsCovidCertificateModalOpen] = useState(false);
   const [isCertificateModalOpen, setIsCertificateModalOpen] = useState(false);
@@ -43,6 +48,10 @@ export const VaccinesPane = React.memo(({ patient, readonly }) => {
   const [isEditAdministeredModalOpen, setIsEditAdministeredModalOpen] = useState(false);
   const [isDeleteAdministeredModalOpen, setIsDeleteAdministeredModalOpen] = useState(false);
   const [vaccineData, setVaccineData] = useState();
+
+  const handleShowUpcomingVaccines = useCallback(() => {
+    setHideUpcomingVaccines(false);
+  }, []);
 
   const handleOpenDeleteModal = useCallback(async row => {
     setIsDeleteAdministeredModalOpen(true);
@@ -138,10 +147,19 @@ export const VaccinesPane = React.memo(({ patient, readonly }) => {
           </ButtonWithPermissionCheck>
         </TableButtonRow>
         <TableWrapper>
-          <ImmunisationScheduleTable
-            patient={patient}
-            onItemEdit={id => handleOpenRecordModal(id)}
-          />
+          {hideUpcomingVaccines ? (
+              <Button onClick={handleShowUpcomingVaccines}>
+                <TranslatedText
+                  stringId="vaccine.action.showUpcomingVaccines"
+                  fallback="Show upcoming vaccines"
+                />
+              </Button>
+            ) : (
+              <ImmunisationScheduleTable
+                patient={patient}
+                onItemEdit={id => handleOpenRecordModal(id)}
+              />
+          )}
         </TableWrapper>
         <ImmunisationsTable
           patient={patient}


### PR DESCRIPTION

### Changes

Samoa is facing major facility server load due to historical data entry on vaccinations patient page.
Each load and each submittion of creation will re query the upcoming_vaccinations view at great expense due to the number of vaccines on the server.
This pr adds a new setting that will hide the info and is only shown if a button is pressed.

<img width="1141" alt="Screenshot 2025-06-20 at 2 08 14 PM" src="https://github.com/user-attachments/assets/1f8c33dd-f1bd-4c9c-a7a4-1c7c1110cf49" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
