### PR TITLE
feat(fhir): TAN-2524: Display village in address line of FHIR Patient if defined

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/Patient.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Patient.test.js
@@ -23,16 +23,23 @@ describe(`Materialised FHIR - Patient`, () => {
 
   describe('full resource checks', () => {
     beforeEach(async () => {
-      const { FhirPatient, Patient, PatientAdditionalData } = ctx.store.models;
+      const { FhirPatient, Patient, PatientAdditionalData, ReferenceData } = ctx.store.models;
       await FhirPatient.truncate();
       await PatientAdditionalData.truncate();
       await Patient.truncate();
+      await ReferenceData.truncate();
     });
 
     it('fetches a patient by materialised ID', async () => {
       // arrange
-      const { FhirPatient, Patient, PatientAdditionalData } = ctx.store.models;
-      const patient = await Patient.create(fake(Patient, { dateOfDeath: getCurrentDateString() }));
+      const { FhirPatient, Patient, PatientAdditionalData, ReferenceData } = ctx.store.models;
+      const village = await ReferenceData.create({
+        ...fake(ReferenceData, { type: 'village' }),
+        id: fakeUUID(),
+      });
+      const patient = await Patient.create(
+        fake(Patient, { dateOfDeath: getCurrentDateString(), villageId: village.id }),
+      );
       const additionalData = await PatientAdditionalData.create({
         ...fake(PatientAdditionalData),
         patientId: patient.id,
@@ -58,7 +65,7 @@ describe(`Materialised FHIR - Patient`, () => {
         address: [
           {
             city: additionalData.cityTown,
-            line: [additionalData.streetVillage],
+            line: [village.name],
             type: 'physical',
             use: 'home',
           },

--- a/packages/database/src/models/Patient.ts
+++ b/packages/database/src/models/Patient.ts
@@ -22,6 +22,7 @@ export class Patient extends Model {
   declare dateOfDeath?: string;
   declare sex: string;
   declare email?: string;
+  declare villageId?: string;
   declare visibilityStatus?: string;
   declare mergedIntoId?: string;
   declare additionalData?: PatientAdditionalData[];


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient records can now reference a village, and addresses will display the village name when available.

* **Bug Fixes**
  * Improved accuracy of patient address information by integrating village reference data into patient records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->