### PR TITLE
fix(audit): TAMOC-299: Exclude SequelizeMeta from logs as it generates an error HOTFIX 2.33

### DIFF
--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -34,6 +34,9 @@ export const NON_LOGGED_TABLES = [
   'public.sync_device_ticks',
   'public.sync_lookup_ticks',
 
+  // internal migration tables
+  'public.SequelizeMeta',
+
   // caches
   'public.user_localisation_caches',
   'public.user_recently_viewed_patients',


### PR DESCRIPTION
Cherry-picked from 2.34