### PR TITLE
style(notes): 2.35 fix note modal input overflowing text area

### DIFF
--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -185,6 +185,7 @@ const textareaSx = {
   minHeight: 0,
   overflow: 'auto',
   width: '100%',
+  boxSizing: 'border-box',  
 };
 
 export const NoteContentField = ({


### PR DESCRIPTION
### Changes
Fix note modal contents overflowing text area
<img width="501" alt="Screenshot 2025-07-03 at 9 17 22 AM" src="https://github.com/user-attachments/assets/004fd7f4-fabf-4c83-849e-42d92d807c1f" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
