### PR TITLE
tweak(translations): 2.35 fix: Remove duplication of string ids for Related conditions label

### DIFF
--- a/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
+++ b/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
@@ -461,7 +461,7 @@ export const RelatedConditionsForm = ({
             <Divider />
             <Heading5 mt={0} mb={1}>
               <TranslatedText
-                stringId="programRegistry.relatedConditions"
+                stringId="programRegistry.relatedConditions.label"
                 fallback="Related conditions"
               />
             </Heading5>

--- a/packages/web/app/views/programRegistry/ConditionSection.jsx
+++ b/packages/web/app/views/programRegistry/ConditionSection.jsx
@@ -133,7 +133,7 @@ export const ConditionSection = ({ registrationId, isInactive }) => {
     <Container>
       <Heading5 mt={0} mb={1}>
         <TranslatedText
-          stringId="programRegistry.relatedConditions.title"
+          stringId="programRegistry.relatedConditions.label"
           fallback="Related conditions"
           data-testid="translatedtext-tezx"
         />


### PR DESCRIPTION
### Changes
Make them use same string id

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
