### PR TITLE
refactor(api): bring api-client package up to parity with Facility's

### DIFF
--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -32,7 +32,7 @@ export class TamanuApi {
   user = null;
   logger = console;
 
-  constructor({ endpoint, agentName, agentVersion, deviceId, defaultRequestConfig = {} }) {
+  constructor({ endpoint, agentName, agentVersion, deviceId, defaultRequestConfig = {}, logger }) {
     this.#prefix = endpoint;
     const endpointUrl = new URL(endpoint);
     this.#host = endpointUrl.origin;
@@ -45,6 +45,9 @@ export class TamanuApi {
       request: new InterceptorManager(),
       response: new InterceptorManager(),
     };
+    if (logger) {
+      this.logger = logger;
+    }
   }
 
   getHost() {
@@ -247,7 +250,7 @@ export class TamanuApi {
    * Generally only used internally.
    */
   async extractError(endpoint, response) {
-    const { error } = await getResponseErrorSafely(response);
+    const { error } = await getResponseErrorSafely(response, this.logger);
     const message = error?.message || response.status.toString();
 
     // handle auth invalid

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -31,6 +31,7 @@ export class TamanuApi {
   lastRefreshed = null;
   user = null;
   logger = console;
+  fetchImplementation = fetch;
 
   constructor({ endpoint, agentName, agentVersion, deviceId, defaultRequestConfig = {}, logger }) {
     this.#prefix = endpoint;
@@ -225,7 +226,7 @@ export class TamanuApi {
     }
     const latestConfig = await requestPromise;
 
-    const response = await fetcher(url, latestConfig);
+    const response = await fetcher(url, { fetch: this.fetchImplementation, ...latestConfig });
 
     const responseInterceptorChain = [];
     // response: first in first out

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -225,7 +225,20 @@ export class TamanuApi {
     const { error } = await getResponseErrorSafely(response);
     const message = error?.message || response.status.toString();
 
-    // handle forbidden error and trigger catch all modal
+    // handle auth invalid
+    if (response.status === 401 && endpoint === 'login') {
+      const message =
+        (await response.json().then(
+          json => json.message,
+          () => null,
+        )) ?? 'Failed authentication';
+      if (this.#onAuthFailure) {
+        this.#onAuthFailure(message);
+      }
+      throw new AuthInvalidError(message, response);
+    }
+
+    // handle forbidden error
     if (response.status === 403 && error) {
       throw new ForbiddenError(message, response);
     }

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -167,8 +167,10 @@ export class TamanuApi {
     const url = `${this.#prefix}/${path}`;
     const config = {
       headers: {
-        ...(useAuthToken ? { Authorization: `Bearer ${useAuthToken}` } : {}),
+        Accept: 'application/json',
+        'Content-Type': otherConfig.body ? 'application/json' : undefined,
         ...headers,
+        ...(useAuthToken ? { Authorization: `Bearer ${useAuthToken}` } : {}),
         'X-Tamanu-Client': this.agentName,
         'X-Version': this.agentVersion,
       },

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -122,7 +122,9 @@ export class TamanuApi {
   }
 
   async refreshToken() {
-    if (!this.#refreshToken && !this.#authToken) return;
+    if (!this.#refreshToken) {
+      throw new Error('No refresh token available');
+    }
 
     try {
       const response = await this.post(

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -108,11 +108,13 @@ export class TamanuApi {
   }
 
   async refreshToken() {
+    if (!this.#refreshToken && !this.#authToken) return;
+
     try {
       const response = await this.post(
         'refresh',
         {},
-        { useAuthToken: this.#authToken, waitForAuth: false },
+        { useAuthToken: this.#refreshToken ?? this.#authToken, waitForAuth: false },
       );
       const { token, refreshToken } = response;
       this.setToken(token, refreshToken);

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -62,7 +62,7 @@ export class TamanuApi {
     this.#onVersionIncompatible = handler;
   }
 
-  async login(email, password) {
+  async login(email, password, config = {}) {
     if (this.#ongoingAuth) {
       await this.#ongoingAuth;
     }
@@ -75,7 +75,7 @@ export class TamanuApi {
           password,
           deviceId: this.deviceId,
         },
-        { returnResponse: true, useAuthToken: false, waitForAuth: false },
+        { ...config, returnResponse: true, useAuthToken: false, waitForAuth: false },
       );
       const serverType = response.headers.get('X-Tamanu-Server');
       if (![SERVER_TYPES.FACILITY, SERVER_TYPES.CENTRAL].includes(serverType)) {

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -349,4 +349,21 @@ export class TamanuApi {
   async delete(endpoint, query = {}, config = {}) {
     return this.fetch(endpoint, query, { ...config, method: 'DELETE' });
   }
+
+  async pollUntilOk(...args) {
+    const waitTime = 1000; // retry once per second
+    const maxAttempts = 60 * 60 * 12; // for a maximum of 12 hours
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const response = await this.fetch(...args);
+      if (response) {
+        return response;
+      }
+
+      await new Promise(resolve => {
+        setTimeout(resolve, waitTime);
+      });
+    }
+
+    throw new Error(`Poll of ${args[0]} did not succeed after ${maxAttempts} attempts`);
+  }
 }

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -20,6 +20,7 @@ import { InterceptorManager } from './InterceptorManager';
 export class TamanuApi {
   #host;
   #prefix;
+  #defaultRequestConfig = {};
 
   #onAuthFailure;
   #onVersionIncompatible;
@@ -31,10 +32,11 @@ export class TamanuApi {
   user = null;
   logger = console;
 
-  constructor({ endpoint, agentName, agentVersion, deviceId }) {
+  constructor({ endpoint, agentName, agentVersion, deviceId, defaultRequestConfig = {} }) {
     this.#prefix = endpoint;
     const endpointUrl = new URL(endpoint);
     this.#host = endpointUrl.origin;
+    this.#defaultRequestConfig = defaultRequestConfig;
 
     this.agentName = agentName;
     this.agentVersion = agentVersion;
@@ -137,7 +139,10 @@ export class TamanuApi {
   }
 
   async fetch(endpoint, query = {}, options = {}) {
-    let { useAuthToken = this.#authToken, ...moreConfig } = options;
+    let { useAuthToken = this.#authToken, ...moreConfig } = {
+      ...this.#defaultRequestConfig,
+      ...options,
+    };
     const {
       headers,
       returnResponse = false,

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -60,7 +60,7 @@ export class TamanuApi {
         password,
         deviceId: this.deviceId,
       },
-      { returnResponse: true },
+      { returnResponse: true, useAuthToken: false },
     );
     const serverType = response.headers.get('X-Tamanu-Server');
     if (![SERVER_TYPES.FACILITY, SERVER_TYPES.CENTRAL].includes(serverType)) {

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -129,8 +129,11 @@ export class TamanuApi {
     try {
       const response = await this.post(
         'refresh',
-        {},
-        { useAuthToken: this.#refreshToken ?? this.#authToken, waitForAuth: false },
+        {
+          deviceId: this.deviceId,
+          refreshToken: this.#refreshToken,
+        },
+        { useAuthToken: false, waitForAuth: false },
       );
       const { token, refreshToken } = response;
       this.setToken(token, refreshToken);

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -148,7 +148,7 @@ export class TamanuApi {
     const response = await fetchOrThrowIfUnavailable(url, latestConfig);
 
     const responseInterceptorChain = [];
-    // request: first in first out
+    // response: first in first out
     this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
       responseInterceptorChain.push(interceptor.fulfilled, interceptor.rejected);
     });

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -182,6 +182,14 @@ export class TamanuApi {
       ...otherConfig,
     };
 
+    if (
+      config.body &&
+      config.headers['Content-Type']?.startsWith('application/json') &&
+      !(config.body instanceof Uint8Array) // also covers Buffer
+    ) {
+      config.body = JSON.stringify(config.body);
+    }
+
     const requestInterceptorChain = [];
     // request: first in last out
     this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {

--- a/packages/api-client/src/errors.js
+++ b/packages/api-client/src/errors.js
@@ -1,10 +1,47 @@
 import { VERSION_COMPATIBILITY_ERRORS } from '@tamanu/constants';
 
-export class ServerResponseError extends Error {}
-export class AuthExpiredError extends ServerResponseError {}
-export class VersionIncompatibleError extends ServerResponseError {}
 export class ServerUnavailableError extends Error {}
+export class ServerResponseError extends Error {
+  constructor(message, response) {
+    super(message);
+    this.response = response;
+  }
+}
+export class NotFoundError extends ServerResponseError {}
+export class AuthError extends ServerResponseError {}
+export class AuthInvalidError extends AuthError {}
+export class AuthExpiredError extends AuthError {}
+export class ForbiddenError extends AuthError {}
+export class VersionIncompatibleError extends ServerResponseError {}
 export class ResourceConflictError extends ServerResponseError {}
+
+export function isRecoverable(error) {
+  if (error instanceof ServerUnavailableError) {
+    return true;
+  }
+
+  if (!(error instanceof ServerResponseError)) {
+    return false;
+  }
+
+  if (error instanceof AuthInvalidError || error instanceof VersionIncompatibleError) {
+    return false;
+  }
+
+  if (error.response.status >= 400 && error.response.status < 500) {
+    return false;
+  }
+
+  if (error.message.includes('Insufficient') && error.message.toLowerCase().includes('storage')) {
+    return false;
+  }
+
+  if (error.message.includes('Sync session')) {
+    return false;
+  }
+
+  return true;
+}
 
 export function getVersionIncompatibleMessage(error, response) {
   if (error.message === VERSION_COMPATIBILITY_ERRORS.LOW) {

--- a/packages/api-client/src/fetch.js
+++ b/packages/api-client/src/fetch.js
@@ -23,13 +23,12 @@ export async function fetchOrThrowIfUnavailable(url, { timeout = false, ...confi
   }
 }
 
-export async function getResponseErrorSafely(response) {
+export async function getResponseErrorSafely(response, logger = console) {
   try {
     return await response.json();
   } catch (e) {
     // log json parsing errors, but still return a valid object
-    // eslint-disable-next-line no-console
-    console.warn(`getResponseJsonSafely: Error parsing JSON: ${e}`);
+    logger.warn(`getResponseJsonSafely: Error parsing JSON: ${e}`);
     return {
       error: { name: 'JSONParseError', message: `Error parsing JSON: ${e}` },
     };

--- a/packages/api-client/src/fetch.js
+++ b/packages/api-client/src/fetch.js
@@ -25,7 +25,12 @@ export async function fetchOrThrowIfUnavailable(url, { timeout = false, ...confi
 
 export async function getResponseErrorSafely(response, logger = console) {
   try {
-    return await response.json();
+    const data = await response.text();
+    if (data.length === 0) {
+      return {};
+    }
+
+    return JSON.parse(data);
   } catch (e) {
     // log json parsing errors, but still return a valid object
     logger.warn(`getResponseJsonSafely: Error parsing JSON: ${e}`);

--- a/packages/api-client/src/fetch.js
+++ b/packages/api-client/src/fetch.js
@@ -1,6 +1,6 @@
 import { ServerUnavailableError } from './errors';
 
-export async function fetchOrThrowIfUnavailable(url, { timeout = false, ...config } = {}) {
+export async function fetchOrThrowIfUnavailable(url, { fetch, timeout = false, ...config } = {}) {
   const abort = new AbortController();
   let timer;
   if (timeout && Number.isFinite(timeout) && !config.signal) {

--- a/packages/api-client/src/fetch.js
+++ b/packages/api-client/src/fetch.js
@@ -1,9 +1,16 @@
 import { ServerUnavailableError } from './errors';
 
-export async function fetchOrThrowIfUnavailable(url, config = {}) {
+export async function fetchOrThrowIfUnavailable(url, { timeout = false, ...config } = {}) {
+  const abort = new AbortController();
+  let timer;
+  if (timeout && Number.isFinite(timeout) && !config.signal) {
+    timer = setTimeout(() => abort.abort(), timeout);
+  }
+
   try {
-    const response = await fetch(url, config);
-    return response;
+    return await fetch(url, { signal: abort.signal, ...config }).finally(() => {
+      clearTimeout(timer);
+    });
   } catch (e) {
     if (e instanceof Error && e.message === 'Failed to fetch') {
       // apply more helpful message if the server is not available

--- a/packages/api-client/src/fetchWithRetryBackoff.js
+++ b/packages/api-client/src/fetchWithRetryBackoff.js
@@ -1,0 +1,72 @@
+import { isRecoverable } from './errors';
+import { fetchOrThrowIfUnavailable } from './fetch';
+
+export async function fetchWithRetryBackoff(
+  url,
+  config = {},
+  { log = console, maxAttempts = 15, maxWaitMs = 10000, multiplierMs = 300 } = {},
+) {
+  if (!Number.isFinite(maxAttempts) || maxAttempts < 1) {
+    // developer assert, not a real runtime error
+    throw new Error(`retries: maxAttempts must be a finite integer, instead got ${maxAttempts}`);
+  }
+
+  let lastN = 0;
+  let secondLastN = 0;
+  let attempt = 0;
+  const overallStartMs = Date.now();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    attempt += 1;
+    const attemptStartMs = Date.now();
+    try {
+      log.debug(`retries: started`, { attempt, maxAttempts });
+      const result = await fetchOrThrowIfUnavailable(url, config);
+      const now = Date.now();
+      const attemptMs = now - attemptStartMs;
+      const totalMs = now - overallStartMs;
+      log.debug(`retries: succeeded`, {
+        attempt,
+        maxAttempts,
+        time: `${attemptMs}ms`,
+        totalTime: `${totalMs}ms`,
+      });
+      return result;
+    } catch (e) {
+      // throw if the error is irrecoverable
+      if (!isRecoverable(e)) {
+        log.error(`retries: failed, error was irrecoverable`, {
+          attempt,
+          maxAttempts,
+          stack: e.stack,
+        });
+        throw e;
+      }
+
+      // throw if we've exceeded our maximum retries
+      if (attempt >= maxAttempts) {
+        log.error(`retries: failed, max retries exceeded`, {
+          attempt,
+          maxAttempts,
+          stack: e.stack,
+        });
+        throw e;
+      }
+
+      // otherwise, calculate the next backoff delay
+      [secondLastN, lastN] = [lastN, Math.max(lastN + secondLastN, 1)];
+      const delay = Math.min(lastN * multiplierMs, maxWaitMs);
+      log.warn(`retries: failed, retrying`, {
+        attempt,
+        maxAttempts,
+        retryingIn: `${delay}ms`,
+        stack: e.stack,
+      });
+
+      await new Promise(resolve => {
+        setTimeout(resolve, delay);
+      });
+    }
+  }
+}

--- a/packages/api-client/src/index.js
+++ b/packages/api-client/src/index.js
@@ -1,7 +1,12 @@
 export {
-  AuthExpiredError,
-  ServerResponseError,
   ServerUnavailableError,
+  ServerResponseError,
+  NotFoundError,
+  AuthError,
+  AuthInvalidError,
+  AuthExpiredError,
+  ForbiddenError,
   VersionIncompatibleError,
+  ResourceConflictError,
 } from './errors';
 export { TamanuApi } from './TamanuApi';


### PR DESCRIPTION
### Changes

The purpose is to replace the facility-server and mobile implementations with this package, while keeping it working for web (and in fact improve the web functionality).

Recommend reviewing one commit at a time, they're almost all split to one atomic change each.

This was not a copy-paste of functionality, but rather a feature-by-feature rethink and integration into the package, for consistency and quality, but also because api-client has to work both in the browser (via vite) and in Node.js. There's also some drive-by improvements that weren't in the Facility's implementation.

- f0a938a09d: when the api-client package was made, the info it returned from the login endpoint was everything the endpoint returned. however, things have evolved since, but the api-client didn't follow. this update instead returns everything the endpoint provides, extracting some specific things
- 0561dd7b3c, 21b2b86c78, 709cf0667f, 8c78681dc7, bd7e4cd088: misc improvements and bugfixes to the login and refreshToken routines
- beff3262cc: the `waitForAuth` functionality, on by default, delays api calls until an auth token is available. that means you can call an endpoint and the login in parallel and have the correct ordering.
- e78938a154: include the response object in the error instance when available
- 4b7dd8f148: return a specific error class for invalid credentials responses
- bb2e615220: export all the new (and some existing!) error types in the main package index
- 19e16e1865: if an endpoint returns no content and we're expecting json, return an empty object instead of an error
- 0dc0c25205: use the native fetch api `Headers` object to merge and create headers, instead of a plain object
- bf10ebafcc: allow a custom logger, default it to console, and use the logger in various places
- 90b0484ca4: automatically encode to JSON when the content-type matches and a body is provided that is not a buffer/uint8array
- 1beb4f13a0: in the constructor, allow specifying custom fetch options as defaults for the instance
- c7a134e52c: the `waitUntilOk` (in the facility code, called `waitUntilTrue`) method
- 5e832ce270: add default `accept` and `content-type` headers
- 7b8c93b6b5: the `timeout` option (as a shorthand to doing abortcontroller stuff)
- 73b8e5ef8d: the retry-with-backoff feature (off by default)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication handling with improved token management and support for concurrent login serialization.
  * Added robust request retry logic with exponential backoff for improved reliability.
  * Introduced a polling utility to repeatedly fetch a resource until available or timeout.
  * Expanded error handling with more granular error types and richer error context.
  * Added request timeout support for fetch operations.

* **Bug Fixes**
  * Improved consistency and clarity in error extraction and handling for various HTTP response codes.

* **Chores**
  * Refined and extended error class hierarchy for clearer error categorization and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->