### PR TITLE
fix(programRegistry): 2.35: Make program registry table exportable

### DIFF
--- a/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
@@ -104,7 +104,9 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
           />
         ),
         sortable: false,
-        accessor: ({ conditions }) => <ConditionsCell conditions={conditions} getTranslation={getTranslation} />,
+        accessor: ({ conditions }) => (
+          <ConditionsCell conditions={conditions} getTranslation={getTranslation} />
+        ),
         CellComponent: LimitedLinesCell,
         maxWidth: 200,
       },

--- a/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryTable.jsx
@@ -20,8 +20,7 @@ import { TranslatedText } from '../../components/Translation';
 import { useTranslation } from '../../contexts/Translation.jsx';
 import { NoteModalActionBlocker } from '../../components/NoteModalActionBlocker';
 
-const ConditionsCell = ({ conditions }) => {
-  const { getTranslation } = useTranslation();
+const ConditionsCell = ({ conditions, getTranslation }) => {
   return conditions
     ?.map(condition => {
       const { id, name } = condition;
@@ -32,6 +31,7 @@ const ConditionsCell = ({ conditions }) => {
 };
 
 export const ProgramRegistryTable = ({ searchParameters }) => {
+  const { getTranslation, getEnumTranslation } = useTranslation();
   const params = useParams();
   const [openModal, setOpenModal] = useState();
   const [refreshCount, updateRefreshCount] = useRefreshCount();
@@ -43,6 +43,9 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
         accessor: data => (
           <RegistrationStatusIndicator patientProgramRegistration={data} hideText />
         ),
+        exportOverrides: {
+          accessor: data => getEnumTranslation(REGISTRATION_STATUSES, data.registrationStatus),
+        },
         sortable: false,
       },
       {
@@ -101,7 +104,7 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
           />
         ),
         sortable: false,
-        accessor: ConditionsCell,
+        accessor: ({ conditions }) => <ConditionsCell conditions={conditions} getTranslation={getTranslation} />,
         CellComponent: LimitedLinesCell,
         maxWidth: 200,
       },
@@ -135,6 +138,15 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
       {
         key: 'clinicalStatus',
         title: <TranslatedText stringId="programRegistry.clinicalStatus.label" fallback="Status" />,
+        exportOverrides: {
+          accessor: data => {
+            const { id, name } = data.clinicalStatus || {};
+            return getTranslation(
+              getReferenceDataStringId(id, 'programRegistryClinicalStatus'),
+              name,
+            );
+          },
+        },
         accessor: row => {
           return <ClinicalStatusDisplay clinicalStatus={row.clinicalStatus} />;
         },
@@ -143,6 +155,7 @@ export const ProgramRegistryTable = ({ searchParameters }) => {
       {
         key: 'actions',
         title: '',
+        allowExport: false,
         accessor: row => {
           const isRemoved = row.registrationStatus === REGISTRATION_STATUSES.INACTIVE;
           const isDeleted = row.registrationStatus === REGISTRATION_STATUSES.RECORDED_IN_ERROR;


### PR DESCRIPTION
### Changes

- Few missing bits to allow export.
- Had to pass that getTranslation into Cell due to hook error on export otherwise

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
