### PR TITLE
tweak(programRegistry): 2.35 fix: Use autocomplete for conditions on program registry forms

### DIFF
--- a/packages/web/app/features/ProgramRegistry/PatientProgramRegistryActivateModal.jsx
+++ b/packages/web/app/features/ProgramRegistry/PatientProgramRegistryActivateModal.jsx
@@ -33,6 +33,9 @@ export const PatientProgramRegistryActivateModal = ({
   const programRegistryStatusSuggester = useSuggester('programRegistryClinicalStatus', {
     baseQueryParameters: { programRegistryId: patientProgramRegistration.programRegistryId },
   });
+  const patientProgramRegistryConditionSuggester = useSuggester('programRegistryCondition', {
+    baseQueryParameters: { programRegistryId: patientProgramRegistration.programRegistryId },
+  });
   const registeredBySuggester = useSuggester('practitioner');
   const registeringFacilitySuggester = useSuggester('facility');
 

--- a/packages/web/app/features/ProgramRegistry/PatientProgramRegistryActivateModal.jsx
+++ b/packages/web/app/features/ProgramRegistry/PatientProgramRegistryActivateModal.jsx
@@ -33,9 +33,6 @@ export const PatientProgramRegistryActivateModal = ({
   const programRegistryStatusSuggester = useSuggester('programRegistryClinicalStatus', {
     baseQueryParameters: { programRegistryId: patientProgramRegistration.programRegistryId },
   });
-  const patientProgramRegistryConditionSuggester = useSuggester('programRegistryCondition', {
-    baseQueryParameters: { programRegistryId: patientProgramRegistration.programRegistryId },
-  });
   const registeredBySuggester = useSuggester('practitioner');
   const registeringFacilitySuggester = useSuggester('facility');
 

--- a/packages/web/app/features/ProgramRegistry/ProgramRegistryConditionField.jsx
+++ b/packages/web/app/features/ProgramRegistry/ProgramRegistryConditionField.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { useTranslation } from '../../contexts/Translation';
 import { useProgramRegistryConditionsQuery } from '../../api/queries';
 import {
-  BaseSelectField,
+  AutocompleteField,
   FieldWithTooltip,
   getReferenceDataStringId,
-  TranslatedReferenceData,
 } from '../../components';
 
 export const ProgramRegistryConditionField = ({
@@ -20,17 +19,12 @@ export const ProgramRegistryConditionField = ({
   const { data: conditions } = useProgramRegistryConditionsQuery(programRegistryId);
   const options = conditions?.filter(optionsFilter).map?.(condition => ({
     label: (
-      <TranslatedReferenceData
-        fallback={condition.name}
-        value={condition.id}
-        category="programRegistryCondition"
-      />
+      getTranslation(
+        getReferenceDataStringId(condition.id, 'programRegistryCondition'),
+        condition.name,
+      )
     ),
     value: condition.id,
-    searchString: getTranslation(
-      getReferenceDataStringId(condition.id, 'programRegistryCondition'),
-      condition.name,
-    ),
   }));
 
   const onChange = event => {
@@ -57,7 +51,7 @@ export const ProgramRegistryConditionField = ({
       name={name}
       label={label}
       placeholder={getTranslation('general.placeholder.select', 'Select')}
-      component={BaseSelectField}
+      component={AutocompleteField}
       options={options}
       disabled={!conditions || conditions.length === 0}
       aria-labelledby={ariaLabelledby}


### PR DESCRIPTION
### Changes
- Looking at it search string is for multi select only, so I removed that too
- Its complicated for that particular field so I opted for using a Autcomplete with an options array and not a sugggester

**Now**: 

<img width="598" alt="Screenshot 2025-07-07 at 3 08 45 PM" src="https://github.com/user-attachments/assets/ff8cbe14-e70e-4cdc-a266-02db7401ec3d" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
