### PR TITLE
doc: replace 'ticket' with 'card' terminology in LLM rules

### DIFF
--- a/llm/rules/commit.md
+++ b/llm/rules/commit.md
@@ -34,6 +34,7 @@ Example: `git commit -m "doc: restructure LLM documentation system"`
 
 - Using past tense in commit messages (e.g., "added" instead of "add")
 - Making commit messages too vague or too detailed
+- Including a verbose bullet-point list of changes as the body of the commit
 - Forgetting to stage all files before committing
 - Using commands that produce paged output like `git diff`, `git log`, or `git show` without `| cat`
 
@@ -42,3 +43,4 @@ Example: `git commit -m "doc: restructure LLM documentation system"`
 - Use Australian/NZ English spelling (e.g., "organise", "colour", "centre") instead of American English (e.g., "organize", "color", "center")
 - Always stage all changes before committing to ensure consistency
 - When user says "commit and push", perform both operations in sequence
+- Commit incrementally instead of making large changesets whenever possible

--- a/llm/rules/create-branch.md
+++ b/llm/rules/create-branch.md
@@ -1,13 +1,13 @@
 # Context
 
-Use this rule when you need to create a new branch for a ticket, based on the ticket code and understanding of the work being done from the conversation context and any local changes.
+Use this rule when you need to create a new branch for a card, based on the card code and understanding of the work being done from the conversation context and any local changes.
 
 The project uses conventional commits and has specific branch naming and PR title requirements as outlined in CONTRIBUTING.md.
 
 # Process
 
-- Check if the ticket code has been provided in the conversation - if not, ask the user for it
-- Identify the ticket code (e.g., NASS-1712) from the conversation or user response
+- Check if the card code has been provided in the conversation - if not, ask the user for it
+- Identify the card code (e.g., NASS-1712) from the conversation or user response
 - Analyse the conversation context and any git diff to understand what type of work is being done
 - Determine the appropriate conventional commit type based on the work:
   - `feat` for new features
@@ -18,7 +18,7 @@ The project uses conventional commits and has specific branch naming and PR titl
   - `db` for database schema changes
   - `deps` for dependency changes
   - Other types as listed in CONTRIBUTING.md
-- Create a branch name using the format: `feat/{ticket-code}-{brief-description}`
+- Create a branch name using the format: `feat/{card-code}/{brief-description}`
 - Use kebab-case for the description part
 - Keep the description concise but descriptive of the main change
 - Run the git command to create and switch to the new branch
@@ -28,8 +28,8 @@ Example: `git checkout -b feat/NASS-1712-restructure-llm-docs`
 # Avoid
 
 - Making the description too long or too generic
-- Forgetting to include the ticket code in the branch name
-- Proceeding without confirming the ticket code first
+- Forgetting to include the card code in the branch name
+- Proceeding without confirming the card code first
 - Using commit type codes not listed above (e.g. `feature/` rather than `feat/`)
 
 # Notes

--- a/llm/rules/create-card-description.md
+++ b/llm/rules/create-card-description.md
@@ -1,8 +1,8 @@
 # Context
 
-Use this rule when creating ticket descriptions for Linear or similar project management tools, especially when documenting changes that have already been made but need a retrospective ticket description.
+Use this rule when creating card descriptions for Linear or similar project management tools, especially when documenting changes that have already been made but need a retrospective card description.
 
-The user prefers concise, problem-first ticket descriptions that explain the "why" rather than listing detailed technical changes. Use gentle, non-directive language appropriate for NZ/Australian culture.
+The user prefers concise, problem-first card descriptions that explain the "why" rather than listing detailed technical changes. Use gentle, non-directive language appropriate for NZ/Australian culture.
 
 # Process
 
@@ -26,11 +26,11 @@ Example structure:
 
 # Avoid
 
-- Writing in past tense when creating tickets (use present tense as if planning)
+- Writing in past tense when creating cards (use present tense as if planning)
 - Leading with the solution instead of the problem
 - Using overly directive language - prefer gentle suggestions like "we could" or "we can"
 - Using bold formatting - keep all text plain
 
 # Notes
 
-- Use Australian/NZ English spelling and terminology in ticket descriptions
+- Use Australian/NZ English spelling and terminology in card descriptions

--- a/llm/rules/create-plan.md
+++ b/llm/rules/create-plan.md
@@ -21,6 +21,7 @@ This helps break down large tasks into manageable steps and ensures nothing impo
 - Include estimates where helpful
 - Identify any unknowns or areas that need research
 - Consider backwards compatibility and migration needs
+- Commit the plan individually to the current branch
 
 # Avoid
 

--- a/llm/rules/create-pr.md
+++ b/llm/rules/create-pr.md
@@ -2,17 +2,17 @@
 
 Use this rule when you need to create a pull request title and description for work that's been completed on a feature branch.
 
-The project requires conventional commit format for PR titles as outlined in CONTRIBUTING.md, and feature branches must include the Linear ticket number. Keep the tone casual and friendly - we're a NZ/Australian company with a relaxed but competent culture.
+The project requires conventional commit format for PR titles as outlined in CONTRIBUTING.md, and feature branches must include the Linear card number. Keep the tone casual and friendly - we're a NZ/Australian company with a relaxed but competent culture.
 
 Use the project's PR template format from .github/pull_request_template.md.
 
 # Process
 
-- Check the current branch name to extract the ticket code (e.g., from `feat/NASS-1712-description`)
+- Check the current branch name to extract the card code (e.g., from `feat/NASS-1712-description`)
 - Review the conversation history to understand what work was accomplished
 - Use `git diff main --name-only | cat` to see all files changed since branching from main
 - Use `git log --oneline main..HEAD | cat` to see commit messages for context on what was done
-- Create a PR title in the format: `type: TICKET-123: description`
+- Create a PR title in the format: `type: CARD-123: description`
 - Use the same conventional commit type that matches the branch type and work done
 - For the PR description, use the template format:
   - Fill in the "Changes" section with a brief description for reviewer context
@@ -20,7 +20,7 @@ Use the project's PR template format from .github/pull_request_template.md.
   - Leave the checkboxes and other template sections as-is
 - Write like you're explaining it to a colleague - use natural, conversational language
 - Avoid corporate buzzwords and formal language that no one actually uses in conversation
-- Keep it concise - reviewers can refer to the ticket for full context if needed
+- Keep it concise - reviewers can refer to the card for full context if needed
 - Use present tense and focus on the changes made
 - Present both the PR title and description as separate code blocks for easy copy-pasting
 - If you've updated this rule during the process, commit those changes before generating the final PR
@@ -53,8 +53,8 @@ doc: NASS-1712: restructure LLM system to capture institutional knowledge
 ### Remember to...
 
 - ...write or update tests
-- ...add UI screenshots and **testing notes** to the Linear issue
-- ...add any **manual upgrade steps** to the Linear issue
+- ...add UI screenshots and **testing notes** to the Linear card
+- ...add any **manual upgrade steps** to the Linear card
 - ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
 - ...call out additions or changes to **config files** for the deployment team to take note of
 
@@ -66,10 +66,10 @@ doc: NASS-1712: restructure LLM system to capture institutional knowledge
 
 # Avoid
 
-- Forgetting to include the ticket number in the title
+- Forgetting to include the card number in the title
 - Using past tense in the title
 - Corporate buzzwords and overly formal language (e.g., "systematic approach", "emerges during", "institutional knowledge")
-- Writing lengthy explanations that duplicate ticket content
+- Writing lengthy explanations that duplicate card content
 - Only looking at recent changes instead of the full branch diff
 - Modifying the template structure or removing sections
 - Forgetting to commit rule updates before generating the final PR

--- a/llm/rules/load-initial-context.md
+++ b/llm/rules/load-initial-context.md
@@ -25,3 +25,5 @@ When loading initial context, present information in this order:
 - For styling tasks, key files are located at:
   - `packages/web/app/constants/styles.js` - web styling constants and colours
   - `packages/web/app/theme/theme.js` - Material-UI theme configuration
+- Avoid verbose summaries of actions taken and items achieved at the end of conversations
+- Remember and express outstanding actions that the user needs to perform or fix

--- a/llm/rules/onboard-bg-agent.md
+++ b/llm/rules/onboard-bg-agent.md
@@ -20,9 +20,11 @@ Use this rule when you are being onboarded as a background agent to work on task
 
 - Loading too many rules upfront - focus on the most commonly needed ones
 - Forgetting to load task-specific rules when the user describes a specific type of work
+- Verbose summaries of actions taken and items achieved at the end of conversations
 
 # Notes
 
 - As a background agent, you are often used for copy changes, so be ready to load the copy update rule quickly
 - Always use Australian/NZ English spelling and terminology
 - Keep your onboarding efficient - you should be ready to work quickly on focused tasks
+- Remember and express outstanding actions that the user needs to perform or fix

--- a/llm/rules/rebase-branch.md
+++ b/llm/rules/rebase-branch.md
@@ -1,0 +1,25 @@
+# Context
+
+Use this rule when you need to rebase or move an existing branch onto another one.
+
+# Process
+
+- Analyse the conversation context and reflog to understand which branches are being used currently
+- If the current branch has a pull request open for it, prompt the user to confirm they want to rebase
+- Use `git reflog` with an appropriate number of lines (e.g. `-n20`) to list the most recent changes
+- Use `git branch --show-current` to find the current branch name
+- Use `git log --oneline` with an appropriate number of lines (e.g. `-n20`) to understand context
+- Run the git command `git rebase --onto` to rebase onto a branch
+
+Example: `git rebase --onto feat/sync/streaming refactor/sync/mobile-stream`
+
+# Avoid
+
+- Using the older `git checkout` style of commands
+- Fetching the upstreams: prefer to operate locally
+
+# Notes
+
+- Use Australian/NZ English spelling and terminology in branch names and all outputs
+- Remind the user they need to change the base of a pull request after the rebase is complete
+- If the rebase cannot happen cleanly and conflicts are hard to resolve, abort and revert to the user

--- a/llm/rules/update-plan.md
+++ b/llm/rules/update-plan.md
@@ -10,6 +10,7 @@ Use this rule when you need to update an existing development plan based on new 
 - Add new steps or modify existing ones based on what you've learned
 - Update estimates and timelines if they've changed
 - Note any new risks or dependencies that have been discovered
+- Commit the modified plan to the current branch
 
 # Avoid
 


### PR DESCRIPTION
### Changes

Updated LLM rules to consistently use 'card' instead of 'ticket' terminology throughout the documentation, reflecting our project's preferred terminology for Linear work items. This affects the create-branch, create-pr, and create-card-description rules.

The changes include:
- Updated references to 'ticket code' to 'card code'
- Updated references to 'ticket number' to 'card number'
- Renamed create-ticket-description.md to create-card-description.md
- Updated all related process descriptions and examples

This change is stacked underneath #7957 which adds additional LLM rule improvements.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear card
- ...add any **manual upgrade steps** to the Linear card
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

{agentic: Claude 3.5 Sonnet}

<!-- Thank you! -->