### PR TITLE
fix(gha): no-issue: Mark 'Publish release to meta' step as failed if curl returns a 400+ error code

### DIFF
--- a/.github/actions/meta-api/action.yml
+++ b/.github/actions/meta-api/action.yml
@@ -28,4 +28,4 @@ runs:
         EOF
 
         set -x
-        curl -v "${{ inputs.url }}${{ inputs.api }}" -E meta.crt --key meta.key ${{ inputs.arg }}
+        curl --fail-with-body -v "${{ inputs.url }}${{ inputs.api }}" -E meta.crt --key meta.key ${{ inputs.arg }}


### PR DESCRIPTION
### Changes

Trying this curl feature: https://curl.se/docs/manpage.html#--fail-with-body

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
