### PR TITLE
ci: try to fix central tests timeout by sharding more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           - { package: "@tamanu/database",                    postgres: 12 }
           - { package: "@tamanu/database",                    postgres: 14 }
           - { package: "@tamanu/database",                    postgres: 16 }
+          - { package: "@tamanu/database",                    postgres: 17 }
           - { package: "@tamanu/shared",                                   }
           - { package: "@tamanu/utils",                                    }
           - { package: "@tamanu/web-frontend" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
       - uses: actions/cache/restore@v3
+        id: cache
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { package: "@tamanu/facility-server", shard: 1/4, postgres: 14 }
-          - { package: "@tamanu/facility-server", shard: 2/4, postgres: 14 }
-          - { package: "@tamanu/facility-server", shard: 3/4, postgres: 14 }
-          - { package: "@tamanu/facility-server", shard: 4/4, postgres: 14 }
-          - { package: "@tamanu/central-server",  shard: 1/4, postgres: 14 }
-          - { package: "@tamanu/central-server",  shard: 2/4, postgres: 14 }
-          - { package: "@tamanu/central-server",  shard: 3/4, postgres: 14 }
-          - { package: "@tamanu/central-server",  shard: 4/4, postgres: 14 }
+          - { package: "@tamanu/facility-server", shard: 1/4, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 2/4, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 3/4, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 4/4, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 1/5, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 2/5, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 3/5, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 4/5, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 4/5, postgres: 16 }
           - { package: "@tamanu/database",                    postgres: 12 }
           - { package: "@tamanu/database",                    postgres: 14 }
           - { package: "@tamanu/database",                    postgres: 16 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ env:
   NODE_MODULES_PATHS: |
     node_modules
     packages/*/node_modules
-    !packages/mobile/node_modules
 
 jobs:
   node_modules_cache:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
       - run: scripts/apply_and_revert_server_migrations.sh ${{ matrix.server }}
 
   test-mobile:
+    needs: node_modules_cache
     name: Test mobile
     runs-on: ubuntu-latest
     steps:
@@ -261,6 +262,7 @@ jobs:
         run: .github/scripts/test-facility-offline.sh facility-start-again
 
   test-package-lock:
+    needs: node_modules_cache
     name: Check package-lock.json is up to date
     runs-on: ubuntu-latest
     steps:
@@ -271,6 +273,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
+      - uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
       - run: npm i
       - run: git diff --exit-code
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,10 @@ jobs:
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
-      - run: npm ci
-      - uses: actions/cache/save@v3
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
@@ -79,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
-      - run: npm ci
+      - run: npm i
       - run: npm run build-shared
       - run: npm run --workspace ${{ matrix.package }} build
 
@@ -114,7 +116,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
-      - run: npm ci
+      - run: npm i
       - run: npm run build
 
   lint:
@@ -133,7 +135,7 @@ jobs:
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
-      - run: npm ci
+      - run: npm i
 
       - name: Lint errors
         run: npm run lint-all -- --quiet
@@ -160,7 +162,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
-      - run: npm ci
+      - run: npm i
       - run: npm run build-shared
       - run: npm run --workspace @tamanu/web-frontend test-storybook
 
@@ -194,7 +196,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
-      - run: npm ci
+      - run: npm i
       - run: npm run build-shared
 
       - name: Install and start postgres ${{ matrix.postgres }}
@@ -217,14 +219,10 @@ jobs:
           cache: npm
       - uses: actions/cache/restore@v3
         with:
-          key: ${{ runner.os }}-npmmobile-${{ hashFiles('mobile/package-lock.json') }}
-          path: mobile/node_modules
-      - run: npm ci
-        working-directory: packages/mobile
-      - uses: actions/cache/save@v3
-        with:
-          key: ${{ runner.os }}-npmmobile-${{ hashFiles('mobile/package-lock.json') }}
-          path: mobile/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+
+      - run: npm i
 
       - run: npm run test
         working-directory: packages/mobile
@@ -245,7 +243,7 @@ jobs:
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
-      - run: npm ci
+      - run: npm i
 
       - name: Install and start postgres
         run: |
@@ -273,7 +271,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - run: npm ci
+      - run: npm i
       - run: git diff --exit-code
 
   dbt-model:
@@ -304,7 +302,7 @@ jobs:
 
       - name: Build
         run: |
-          npm install
+          npm i
           npm run build-shared
           npm run --workspace @tamanu/central-server build
           npm run --workspace @tamanu/facility-server build
@@ -350,7 +348,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
-      - run: npm install
+      - run: npm i
       - run: npm run dbt-check-todos
 
   typos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { package: "@tamanu/facility-server", shard: 1/4, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 2/4, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 3/4, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 4/4, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 1/5, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 2/5, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 3/5, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 4/5, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 4/5, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 1/6, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 2/6, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 3/6, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 4/6, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 5/6, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 6/6, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 1/6, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 2/6, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 3/6, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 4/6, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 5/6, postgres: 16 }
+          - { package: "@tamanu/central-server",  shard: 6/6, postgres: 16 }
           - { package: "@tamanu/database",                    postgres: 12 }
           - { package: "@tamanu/database",                    postgres: 14 }
           - { package: "@tamanu/database",                    postgres: 16 }


### PR DESCRIPTION
### Changes

I had an inkling that maybe central-server was failing and timing out in CI (but not locally!) because of the same kind of contention that led us to shard the tests in the first place. This change... doesn't solve the problem entirely, but does seem to make it less likely. So maybe it's some of this and some of something else, but this still helps a bit.

Additionally:
- also increased the sharding on facility-server tests to lower the overall CI time (now we're OSS and don't pay for minutes, it doesn't matter)
- add postgres 17 to the database tests
- use the node_modules caching better (saves ~1 minute per job)
- skip fetching and saving the node_modules cache if the package-lock.json hasn't changed (saves ~1-2 minutes per run)
- don't save and fetch a separate cache for mobile now that we have that package part of the main workspace

Timings:
- before
  - cold cache: [13m51](https://github.com/beyondessential/tamanu/actions/runs/16159282510?pr=7962)
  - hot cache: [9m20](https://github.com/beyondessential/tamanu/actions/runs/16158464326?pr=7938)
- after
  - cold cache: [11m46](https://github.com/beyondessential/tamanu/actions/runs/16165846389/attempts/1?pr=7971)
  - hot cache: [7m16](https://github.com/beyondessential/tamanu/actions/runs/16165846389/attempts/2?pr=7971)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
