### PR TITLE
fix(migrations): no-issue: Fix logic that detects if a trigger is installed during migrations

### DIFF
--- a/packages/database/__tests__/services/migrations/migrationHooks.test.ts
+++ b/packages/database/__tests__/services/migrations/migrationHooks.test.ts
@@ -1,0 +1,216 @@
+/* eslint-disable no-param-reassign,no-return-assign */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { closeDatabase, initDatabase } from '../../utilities';
+import {
+  runPostMigration,
+  runPreMigration,
+  tablesWithTrigger,
+  tablesWithoutTrigger,
+} from '../../../src/services/migrations/migrationHooks';
+import { createMigrationInterface } from '../../../src/services/migrations/migrations';
+import { log } from '@tamanu/shared/services/logging/log';
+import { Umzug } from 'umzug';
+import { GLOBAL_EXCLUDE_TABLES } from '../../../src/services/migrations/constants';
+
+const randomSelection = <T>(array: T[]) => array.filter(() => Math.random() > 0.5);
+
+const sortTables = (a: { schema: string; table: string }, b: { schema: string; table: string }) => {
+  if (a.schema === b.schema) {
+    return a.table.localeCompare(b.table);
+  }
+  return a.schema.localeCompare(b.schema);
+};
+
+const addTrigger = async (
+  sequelize: any,
+  table: { schema: string; table: string },
+  prefix: string,
+  suffix: string,
+) => {
+  await removeTrigger(sequelize, table, prefix, suffix);
+  return sequelize.query(
+    `CREATE TRIGGER ${prefix}${table.table}${suffix} BEFORE INSERT OR UPDATE ON ${table.schema}.${table.table} FOR EACH ROW EXECUTE FUNCTION fake_trigger_function();`,
+  );
+};
+
+const removeTrigger = (
+  sequelize: any,
+  table: { schema: string; table: string },
+  prefix: string,
+  suffix: string,
+) => {
+  return sequelize.query(
+    `DROP TRIGGER IF EXISTS ${prefix}${table.table}${suffix} ON ${table.schema}.${table.table};`,
+  );
+};
+
+const addFakeTriggerFunction = (sequelize: any) => {
+  return sequelize.query(
+    `CREATE OR REPLACE FUNCTION fake_trigger_function() RETURNS TRIGGER AS $$ BEGIN RETURN NEW; END; $$ LANGUAGE plpgsql;`,
+  );
+};
+
+const removeFakeTriggerFunction = (sequelize: any) => {
+  return sequelize.query(`DROP FUNCTION IF EXISTS fake_trigger_function;`);
+};
+
+describe('migrationHooks', () => {
+  let database: any;
+  let umzug: Umzug;
+  let allTables: { schema: string; table: string }[];
+
+  beforeEach(async () => {
+    database = await initDatabase();
+    umzug = createMigrationInterface(log, database.sequelize);
+    await runPreMigration(log, database.sequelize);
+    await umzug.up();
+    await runPostMigration(log, database.sequelize);
+    await addFakeTriggerFunction(database.sequelize);
+    allTables = (
+      await database.sequelize.query(
+        "SELECT table_schema as schema, table_name as table FROM information_schema.tables where table_schema IN ('public', 'logs') and table_type != 'VIEW'",
+      )
+    )[0].filter(({ schema, table }) => !GLOBAL_EXCLUDE_TABLES.includes(`${schema}.${table}`));
+  });
+
+  afterEach(async () => {
+    await removeFakeTriggerFunction(database.sequelize);
+    await closeDatabase();
+  });
+
+  describe('tablesWithTrigger', () => {
+    it('should return no tables for non-existing trigger', async () => {
+      const tables = await tablesWithTrigger(database.sequelize, 'banana_', '_chocolate', []);
+      expect(tables).toEqual([]);
+    });
+
+    it('should return tables that have a trigger', async () => {
+      const prefix = 'cat_';
+      const suffix = '_dog';
+      const triggeredTables = randomSelection(allTables);
+      for (const table of triggeredTables) {
+        await addTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const tables = await tablesWithTrigger(database.sequelize, prefix, suffix, []);
+
+      for (const table of triggeredTables) {
+        await removeTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      expect(tables.sort(sortTables)).toEqual(triggeredTables.sort(sortTables));
+    });
+
+    it('should return tables that have a trigger even if it exceeds trigger character limit', async () => {
+      const prefix = 'super_duper_long_trigger_name_';
+      const suffix = '_really_silly_ridiculous_crazy_long_suffix';
+      const triggeredTables = randomSelection(allTables);
+      for (const table of triggeredTables) {
+        await addTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const tables = await tablesWithTrigger(database.sequelize, prefix, suffix, []);
+
+      for (const table of triggeredTables) {
+        await removeTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      expect(tables.sort(sortTables)).toEqual(triggeredTables.sort(sortTables));
+    });
+
+    it('should not return tables that are flagged in the exclude list', async () => {
+      const prefix = 'bird_';
+      const suffix = '_bat';
+      const triggeredTables = randomSelection(allTables);
+      for (const table of triggeredTables) {
+        await addTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const excludeTables = randomSelection(allTables);
+      const tables = await tablesWithTrigger(
+        database.sequelize,
+        prefix,
+        suffix,
+        excludeTables.map(({ schema, table }) => `${schema}.${table}`),
+      );
+
+      for (const table of triggeredTables) {
+        await removeTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      expect(tables.sort(sortTables)).toEqual(
+        triggeredTables.filter(table => !excludeTables.includes(table)).sort(sortTables),
+      );
+    });
+  });
+
+  describe('tablesWithoutTrigger', () => {
+    it('should return all tables for non-existing trigger', async () => {
+      const tables = await tablesWithoutTrigger(database.sequelize, 'banana_', '_chocolate', []);
+      expect(tables.sort(sortTables)).toEqual(allTables.sort(sortTables));
+    });
+
+    it('should return tables that do not have a trigger', async () => {
+      const prefix = 'cat_';
+      const suffix = '_dog';
+      const triggeredTables = randomSelection(allTables);
+      for (const table of triggeredTables) {
+        await addTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const tables = await tablesWithoutTrigger(database.sequelize, prefix, suffix, []);
+
+      for (const table of triggeredTables) {
+        await removeTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const expectedTables = allTables.filter(table => !triggeredTables.includes(table));
+      expect(tables.sort(sortTables)).toEqual(expectedTables.sort(sortTables));
+    });
+
+    it('should return tables that do not have a trigger even if it exceeds trigger character limit', async () => {
+      const prefix = 'super_duper_long_trigger_name_';
+      const suffix = '_really_silly_ridiculous_crazy_long_suffix';
+      const triggeredTables = randomSelection(allTables);
+      for (const table of triggeredTables) {
+        await addTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const tables = await tablesWithoutTrigger(database.sequelize, prefix, suffix, []);
+
+      for (const table of triggeredTables) {
+        await removeTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const expectedTables = allTables.filter(table => !triggeredTables.includes(table));
+      expect(tables.sort(sortTables)).toEqual(expectedTables.sort(sortTables));
+    });
+
+    it('should not return tables that are flagged in the exclude list', async () => {
+      const prefix = 'bird_';
+      const suffix = '_bat';
+      const triggeredTables = randomSelection(allTables);
+      for (const table of triggeredTables) {
+        await addTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const excludeTables = randomSelection(allTables);
+      const tables = await tablesWithoutTrigger(
+        database.sequelize,
+        prefix,
+        suffix,
+        excludeTables.map(({ schema, table }) => `${schema}.${table}`),
+      );
+
+      for (const table of triggeredTables) {
+        await removeTrigger(database.sequelize, table, prefix, suffix);
+      }
+
+      const expectedTables = allTables.filter(table => !triggeredTables.includes(table));
+      expect(tables.sort(sortTables)).toEqual(
+        expectedTables.filter(table => !excludeTables.includes(table)).sort(sortTables),
+      );
+    });
+  });
+});

--- a/packages/database/__tests__/sync/migrations.test.ts
+++ b/packages/database/__tests__/sync/migrations.test.ts
@@ -1,4 +1,4 @@
-import { closeDatabase, initDatabase } from './utilities';
+import { closeDatabase, initDatabase } from '../utilities';
 import { runPostMigration, runPreMigration } from '../../src/services/migrations/migrationHooks';
 import { createMigrationInterface } from '../../src/services/migrations/migrations';
 import { fake } from '@tamanu/fake-data/fake';
@@ -13,7 +13,7 @@ describe('migrations', () => {
       database = await initDatabase();
       models = database.models;
       umzug = createMigrationInterface(log, database.sequelize);
-      await runPreMigration(log, database.sequelize)
+      await runPreMigration(log, database.sequelize);
       await umzug.up();
       await runPostMigration(log, database.sequelize);
       await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 1);

--- a/packages/database/__tests__/sync/saveChangesForModel.test.ts
+++ b/packages/database/__tests__/sync/saveChangesForModel.test.ts
@@ -1,7 +1,7 @@
 import { log } from '@tamanu/shared/services/logging/log';
 import { saveChangesForModel } from '../../src/sync';
 import * as saveChangeModules from '../../src/sync/saveChanges';
-import { closeDatabase, createTestDatabase } from './utilities';
+import { closeDatabase, createTestDatabase } from '../utilities';
 import { describe, expect, it, vitest, beforeAll, afterEach, afterAll } from 'vitest';
 
 vitest.mock('../../src/sync/saveChanges', async () => ({

--- a/packages/database/__tests__/utilities.js
+++ b/packages/database/__tests__/utilities.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import { closeAllDatabases, openDatabase } from '../../src/services/database';
+import { closeAllDatabases, openDatabase } from '../src/services/database';
 import { fakeUUID } from '@tamanu/utils/generateId';
 
 const getOrCreateConnection = async (configOverrides, key = 'main') => {

--- a/packages/database/__tests__/utils/audit/extractChangelogFromSnapshotRecords.test.ts
+++ b/packages/database/__tests__/utils/audit/extractChangelogFromSnapshotRecords.test.ts
@@ -5,7 +5,7 @@ import { fake } from '@tamanu/fake-data/fake';
 import { extractChangelogFromSnapshotRecords } from '../../../src/utils/audit/extractChangelogFromSnapshotRecords';
 import type { SyncSnapshotAttributesWithChangelog } from '../../../src/types/sync';
 import { Attributes } from 'sequelize';
-import { createTestDatabase } from '../../sync/utilities';
+import { createTestDatabase } from '../../utilities';
 
 describe('extractChangelogFromSnapshotRecords', () => {
   let models;

--- a/packages/database/__tests__/utils/getDependentAssociations.test.ts
+++ b/packages/database/__tests__/utils/getDependentAssociations.test.ts
@@ -1,5 +1,5 @@
 import { getDependentAssociations } from '../../src/utils/getDependentAssociations';
-import { createTestDatabase, closeDatabase } from '../sync/utilities';
+import { createTestDatabase, closeDatabase } from '../utilities';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 
 describe('getDependentAssociations', () => {

--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -1,3 +1,8 @@
+export const GLOBAL_EXCLUDE_TABLES = [
+  // internal migration tables
+  'public.SequelizeMeta',
+];
+
 export const NON_SYNCING_TABLES = [
   'logs.debug_logs',
   'logs.fhir_writes',
@@ -6,7 +11,6 @@ export const NON_SYNCING_TABLES = [
   'public.one_time_logins',
   'public.patient_vrs_data',
   'public.refresh_tokens',
-  'public.SequelizeMeta',
   'public.signers',
   'public.sync_device_ticks',
   'public.sync_lookup_ticks',
@@ -22,7 +26,7 @@ export const NON_LOGGED_TABLES = [
   'logs.changes',
   'logs.accesses',
   'logs.debug_logs',
-  
+
   // internal authentication tables
   'public.one_time_logins',
   'public.refresh_tokens',
@@ -33,9 +37,6 @@ export const NON_LOGGED_TABLES = [
   'public.sync_lookup',
   'public.sync_device_ticks',
   'public.sync_lookup_ticks',
-
-  // internal migration tables
-  'public.SequelizeMeta',
 
   // caches
   'public.user_localisation_caches',


### PR DESCRIPTION
### Changes

This was a hotfix originally reviewed here: https://github.com/beyondessential/tamanu/pull/7970

However, have made some changes to the underlying logic as well as adding unit tests so would appreciate a fresh review if possible.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
