### PR TITLE
fix(upload): Allow browser to set content-type & add boundary to uploads

### DIFF
--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -202,18 +202,18 @@ export class TamanuApi {
       ...otherConfig,
     };
 
+    // For fetch we have to explicitly remove the content-type header
+    // to allow the browser to add the boundary value
+    if (config.body instanceof FormData) {
+      config.headers.delete('content-type');
+    }
+
     if (
       config.body &&
       config.headers.get('content-type')?.startsWith('application/json') &&
       !(config.body instanceof Uint8Array) // also covers Buffer
     ) {
       config.body = JSON.stringify(config.body);
-    }
-
-    // For fetch we have to explicitly remove the content-type header
-    // to allow the browser to add the boundary value
-    if (config.body instanceof FormData) {
-      config.headers.delete('content-type');
     }
 
     const requestInterceptorChain = [];

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -341,7 +341,6 @@ export class TamanuApi {
     return this.fetch(endpoint, undefined, {
       method: 'POST',
       body: formData,
-      headers: {},
       ...options,
     });
   }

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -210,8 +210,8 @@ export class TamanuApi {
       config.body = JSON.stringify(config.body);
     }
 
-    // Explicitly let the browser set the content-type header
-    // and add boundary value
+    // For fetch we have to explicitly remove the content-type header
+    // to allow the browser to add the boundary value
     if (config.body instanceof FormData) {
       config.headers.delete('content-type');
     }
@@ -341,7 +341,7 @@ export class TamanuApi {
     return this.fetch(endpoint, undefined, {
       method: 'POST',
       body: formData,
-      headers: {}, // Explicitly let the browser set the content-type header
+      headers: {},
       ...options,
     });
   }

--- a/packages/api-client/src/TamanuApi.js
+++ b/packages/api-client/src/TamanuApi.js
@@ -210,6 +210,12 @@ export class TamanuApi {
       config.body = JSON.stringify(config.body);
     }
 
+    // Explicitly let the browser set the content-type header
+    // and add boundary value
+    if (config.body instanceof FormData) {
+      config.headers.delete('content-type');
+    }
+
     const requestInterceptorChain = [];
     // request: first in last out
     this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
@@ -335,9 +341,7 @@ export class TamanuApi {
     return this.fetch(endpoint, undefined, {
       method: 'POST',
       body: formData,
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
+      headers: {}, // Explicitly let the browser set the content-type header
       ...options,
     });
   }


### PR DESCRIPTION
### Changes
Make sure no content-type set on form data upload

See https://stackoverflow.com/questions/39280438/fetch-missing-boundary-in-multipart-form-data-post
And here for more information on boundary https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
