### PR TITLE
fix(appointments): TAMOC-306: Prevent long patient names from covering appointment edit menu

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/PatientDetailsDisplay.jsx
@@ -21,7 +21,10 @@ const Header = styled('header')`
   }
 `;
 
-const H2 = styled('h2')`
+const PatientNameHeader = styled('h2')`
+  max-width: 80%; /* This is to prevent the name from displaying over the edit menu */
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 0.875rem;
   font-weight: 500;
   margin-block: 0;
@@ -50,7 +53,7 @@ export const PatientDetailsDisplay = ({ patient, onClick, additionalData }) => {
   const { displayId, sex, dateOfBirth } = patient;
   return (
     <Header onClick={onClick} tabIndex={0} data-testid="header-p2x8">
-      <H2 data-testid="h2-9n82">{getPatientNameAsString(patient)}</H2>
+      <PatientNameHeader data-testid="h2-9n82">{getPatientNameAsString(patient)}</PatientNameHeader>
       <PrimaryDetails data-testid="primarydetails-5tdg">
         <InlineDetailsDisplay
           label={


### PR DESCRIPTION
### Changes

Had to manually limit the max-width of the Patient Name heading and add an overflow:hidden css property

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
