### PR TITLE
fix(pdf): 2.36: Vaccine certificate crash on load

### DIFF
--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -18,8 +18,7 @@ export const withLanguageContext = Component => props => {
   const context = useLanguageContext();
   const { translations, getSetting, settings, ...other } = props;
 
-  const isGlobalFontEnabled =
-    settings?.features?.useGlobalPdfFont ?? getSetting('features.useGlobalPdfFont');
+  const isGlobalFontEnabled = getSetting ? getSetting('features.useGlobalPdfFont') : settings?.features?.useGlobalPdfFont;
   const pdfFont = isGlobalFontEnabled ? 'GlobalPdfFont' : 'Helvetica';
   const pdfFontBold = isGlobalFontEnabled ? 'GlobalPdfFont-Bold' : 'Helvetica-Bold';
 

--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import React, { createContext, useContext, useMemo } from 'react';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, get } from 'lodash';
 import { translationFactory } from '../translation/translationFactory';
 import { getEnumPrefix } from '@tamanu/shared/utils/enumRegistry';
 import { registerFonts } from './registerFonts';
@@ -22,7 +22,7 @@ export const withLanguageContext = Component => props => {
   // and should build a getSetting function from it.
   let { getSetting } = other;
   if (!getSetting && settings) {
-    getSetting = key => settings[key];
+    getSetting = key => get(settings, key);
   }
 
   const isGlobalFontEnabled = getSetting('features.useGlobalPdfFont');

--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -18,7 +18,9 @@ export const withLanguageContext = Component => props => {
   const context = useLanguageContext();
   const { translations, getSetting, settings, ...other } = props;
 
-  const isGlobalFontEnabled = getSetting ? getSetting('features.useGlobalPdfFont') : settings?.features?.useGlobalPdfFont;
+  const isGlobalFontEnabled = getSetting
+    ? getSetting('features.useGlobalPdfFont')
+    : settings?.features?.useGlobalPdfFont;
   const pdfFont = isGlobalFontEnabled ? 'GlobalPdfFont' : 'Helvetica';
   const pdfFontBold = isGlobalFontEnabled ? 'GlobalPdfFont-Bold' : 'Helvetica-Bold';
 

--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -16,11 +16,16 @@ export const useLanguageContext = () => {
 
 export const withLanguageContext = Component => props => {
   const context = useLanguageContext();
-  const { translations, getSetting, settings, ...other } = props;
+  const { translations, settings, ...other } = props;
 
-  const isGlobalFontEnabled = getSetting
-    ? getSetting('features.useGlobalPdfFont')
-    : settings?.features?.useGlobalPdfFont;
+  // If in the pdf.worker context we pass settings an an object not as a function
+  // and should build a getSetting function from it.
+  let { getSetting } = other;
+  if (!getSetting && settings) {
+    getSetting = key => settings[key];
+  }
+
+  const isGlobalFontEnabled = getSetting('features.useGlobalPdfFont');
   const pdfFont = isGlobalFontEnabled ? 'GlobalPdfFont' : 'Helvetica';
   const pdfFontBold = isGlobalFontEnabled ? 'GlobalPdfFont-Bold' : 'Helvetica-Bold';
 

--- a/packages/shared/src/utils/pdf/languageContext.jsx
+++ b/packages/shared/src/utils/pdf/languageContext.jsx
@@ -16,9 +16,10 @@ export const useLanguageContext = () => {
 
 export const withLanguageContext = Component => props => {
   const context = useLanguageContext();
-  const { translations, getSetting, ...other } = props;
+  const { translations, getSetting, settings, ...other } = props;
 
-  const isGlobalFontEnabled = getSetting('features.useGlobalPdfFont');
+  const isGlobalFontEnabled =
+    settings?.features?.useGlobalPdfFont ?? getSetting('features.useGlobalPdfFont');
   const pdfFont = isGlobalFontEnabled ? 'GlobalPdfFont' : 'Helvetica';
   const pdfFontBold = isGlobalFontEnabled ? 'GlobalPdfFont-Bold' : 'Helvetica-Bold';
 

--- a/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/VaccineCertificateModal.jsx
@@ -30,7 +30,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
   const { facilityId } = useAuth();
   const { localisation } = useLocalisation();
   const { translations } = useTranslation();
-  const { getSetting } = useSettings();
+  const { getSetting, settings } = useSettings();
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate({
     footerAssetName: ASSET_NAMES.VACCINATION_CERTIFICATE_FOOTER,
   });
@@ -120,6 +120,7 @@ export const VaccineCertificateModal = React.memo(({ open, onClose, patient }) =
           printedBy={printedBy}
           printedDate={getCurrentDateString()}
           localisation={localisation}
+          settings={settings}
           translations={translations}
           certificateData={{ title, subTitle }}
           healthFacility={healthFacility}

--- a/packages/web/app/contexts/Settings.jsx
+++ b/packages/web/app/contexts/Settings.jsx
@@ -35,6 +35,7 @@ export const SettingsProvider = ({ children }) => {
     <SettingsContext.Provider
       value={{
         getSetting: (path) => get(settings, path),
+        settings,
         isSettingsLoaded,
       }}
     >


### PR DESCRIPTION
### Changes
Vaccine cert uses pdf.worker which cannot be passed function, so we pass settings and build into getSetting.
inside the language context we have to do the same.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
