### PR TITLE
fix(errors): 2.36: Update isErrorUnknown to new TamanuApi error structure

### DIFF
--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -97,15 +97,17 @@ function clearLocalStorage() {
 }
 
 export function isErrorUnknownDefault(error) {
-  if (!error || typeof error.status !== 'number') {
+  const status = error?.response?.status;
+  if (!status || typeof status !== 'number') {
     return true;
   }
   // we don't want to show toast for 403 (no permission) errors
-  return error.status >= 400 && error.status != 403;
+  return status >= 400 && status != 403;
 }
 
 export function isErrorUnknownAllow404s(error) {
-  if (error?.status === 404) {
+  const status = error?.response?.status;
+  if (status === 404) {
     return false;
   }
   return isErrorUnknownDefault(error);


### PR DESCRIPTION
### Changes
- This fixes the config for skipping error toast on requests when the request errors with a 404.
- We do this when we have some kind of supplemental data that causes no issue if it doesn't exist - like death data, profile picture. 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
