### PR TITLE
fix(programRegistry): SAV-992: Get rid of duplicate patient program registrations

### DIFF
--- a/packages/database/src/migrations/1742866911418-removeDuplicatePatientProgramRegistrations.ts
+++ b/packages/database/src/migrations/1742866911418-removeDuplicatePatientProgramRegistrations.ts
@@ -2,14 +2,14 @@ import { QueryInterface } from 'sequelize';
 
 export async function up(query: QueryInterface): Promise<void> {
   // Ensure is_most_recent still exists
-  const [hasIsMostRecent]: any = await query.sequelize.query(`
+  const [isMostRecentResults]: any = await query.sequelize.query(`
     SELECT EXISTS (SELECT TRUE
     FROM information_schema.columns
     WHERE table_schema = 'public' AND table_name = 'patient_program_registrations' AND column_name = 'is_most_recent');
   `);
 
   // Skip migration
-  if (!hasIsMostRecent?.[0]?.exists) {
+  if (!isMostRecentResults?.[0]?.exists) {
     return;
   }
 

--- a/packages/database/src/migrations/1742866911418-removeDuplicatePatientProgramRegistrations.ts
+++ b/packages/database/src/migrations/1742866911418-removeDuplicatePatientProgramRegistrations.ts
@@ -19,6 +19,7 @@ export async function up(query: QueryInterface): Promise<void> {
     WITH duplicate_groups AS (
       SELECT patient_id, program_registry_id
       FROM patient_program_registrations
+      WHERE is_most_recent = true
       GROUP BY patient_id, program_registry_id
       HAVING COUNT(*) > 1
     ),

--- a/packages/database/src/migrations/1742866911418-removeDuplicatePatientProgramRegistrations.ts
+++ b/packages/database/src/migrations/1742866911418-removeDuplicatePatientProgramRegistrations.ts
@@ -1,0 +1,56 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Ensure is_most_recent still exists
+  const [hasIsMostRecent]: any = await query.sequelize.query(`
+    SELECT EXISTS (SELECT TRUE
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'patient_program_registrations' AND column_name = 'is_most_recent');
+  `);
+
+  // Skip migration
+  if (!hasIsMostRecent?.[0]?.exists) {
+    return;
+  }
+
+  // Remove duplicate rows
+  await query.sequelize.query(`
+    -- Get duplicate groups
+    WITH duplicate_groups AS (
+      SELECT patient_id, program_registry_id
+      FROM patient_program_registrations
+      GROUP BY patient_id, program_registry_id
+      HAVING COUNT(*) > 1
+    ),
+    -- Get all patient program registration rows involved and rank them
+    ranked_rows AS (
+      SELECT
+        ppr.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY ppr.patient_id, ppr.program_registry_id
+          ORDER BY
+            -- Priority 1: deleted_at IS NULL (not deleted) gets highest priority
+            CASE WHEN deleted_at IS NULL THEN 0 ELSE 1 END ASC,
+            -- Priority 2: is_most_recent = true gets second highest priority
+            CASE WHEN is_most_recent = true THEN 0 ELSE 1 END ASC,
+            -- Priority 3: earliest date
+            date ASC
+        ) as row_rank
+      FROM patient_program_registrations ppr
+      INNER JOIN duplicate_groups dg
+        ON ppr.patient_id = dg.patient_id
+        AND ppr.program_registry_id = dg.program_registry_id
+    )
+
+    -- Delete duplicate rows
+    DELETE FROM patient_program_registrations
+    WHERE id IN (
+      SELECT id FROM ranked_rows
+      WHERE row_rank > 1
+    );
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No down migration
+}


### PR DESCRIPTION
### Changes

The reason why we need to do this is because otherwise the `logs.changes` table will have "missing records" - while we will be getting rid of these, it's possible that they are updated and create orphan rows at `logs.changes`. If you follow the linear card you'll find more info there and also a slack thread detailing.

Note that the SQL itself was reviewed already by Juliana (although it needed a slight tweak, see second commit) and the migration is inserted to run before `1742866911419-addPatientProgramRegistrationId.ts`.

This needs to be hotfixed to 2.33 and up