### PR TITLE
fix(programConditions): 2.35: Two program registry conditions bugs

### DIFF
--- a/packages/web/app/components/Field/SelectField.jsx
+++ b/packages/web/app/components/Field/SelectField.jsx
@@ -182,8 +182,9 @@ export const SelectInput = ({
   if (disabled || isReadonly || !options || options.length === 0) {
     const selectedOptionLabel = ((options || []).find(o => o.value === value) || {}).label || '';
     const valueText =
-      isValidElement(selectedOptionLabel) && selectedOptionLabel.type.name === 'TranslatedText'
-        ? selectedOptionLabel.props.fallback // temporary workaround to stop [object Object] from being displayed
+      isValidElement(selectedOptionLabel) &&
+      ['TranslatedText', 'TranslatedReferenceData'].includes(selectedOptionLabel.type.name)
+        ? selectedOptionLabel.props.fallback // TODO temporary workaround to stop [object Object] from being displayed
         : selectedOptionLabel;
     return (
       <OuterLabelFieldWrapper label={label} {...props}>

--- a/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
+++ b/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
@@ -373,7 +373,7 @@ export const RelatedConditionsForm = ({
                 }
               }
 
-              if (initialValue === 'recordedInError') {
+              if (isRecordedInError(initialValue)) {
                 return (
                   <ProgramRegistryConditionCategoryField
                     name={fieldName}


### PR DESCRIPTION
### Changes

- Fixed issue where disabled category fields in the program registry modal were displaying as '[object Object]' by properly extending a previous "short term fix" for translated data to the TranslatedReferenceData components in the SelectField component
- Fixed issue where "recorded in error" categories were not being properly detected by using `isRecordedInError` helper function instead of direct string comparison. This ensures that condition categories marked as "recorded in error" cannot be changed, making them non-reversible as intended

**Context**
When multiple instances of the same condition were recorded against a program registry with different categories (one being a configured category and another being a hardcoded category like "Resolved" or "Disproven"), the category field was displaying as '[object Object]' in the "Update program registry" modal.

Additionally, conditions marked as "recorded in error" were incorrectly able to be changed, which should not be possible.

**Testing**
1. Create multiple instances of the same condition with different categories:
   - One with a configured category
   - One with "Resolved" or "Disproven"
   - Verify category displays correctly in modal
2. Mark a condition as "recorded in error"
   - Verify it cannot be changed back

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
