### PR TITLE
feat(audit): SAV-708: Include new column that stores reason for change

### DIFF
--- a/database/model/logs/changes.md
+++ b/database/model/logs/changes.md
@@ -84,3 +84,7 @@ Note that as this is `JSONB`, some type information may be lost. However, row
 data in a Tamanu system is transported using JSON via the sync system anyway, so
 it is expected that all data trivially round-trips via JSON.
 {% enddocs %}
+
+{% docs logs__changes__reason %}
+A string representing the reason for the change.
+{% enddocs %}

--- a/database/model/logs/changes.yml
+++ b/database/model/logs/changes.yml
@@ -88,5 +88,3 @@ sources:
           - name: reason
             data_type: text
             description: "{{ doc('logs__changes__reason') }}"
-            data_tests:
-              - not_null

--- a/database/model/logs/changes.yml
+++ b/database/model/logs/changes.yml
@@ -85,3 +85,8 @@ sources:
             description: "{{ doc('logs__generic__updated_at_sync_tick') }} in changes."
             data_tests:
               - not_null
+          - name: reason
+            data_type: text
+            description: "{{ doc('logs__changes__reason') }}"
+            data_tests:
+              - not_null

--- a/packages/constants/src/database.ts
+++ b/packages/constants/src/database.ts
@@ -11,3 +11,4 @@ export const SESSION_CONFIG_PREFIX = 'tamanu.'
 export const AUDIT_USERID_KEY = 'audit.userid';
 export const AUDIT_ENDPOINT_KEY = 'audit.endpoint';
 export const AUDIT_PAUSE_KEY = 'audit.pause';
+export const AUDIT_REASON_KEY = 'audit.reason';

--- a/packages/database/src/migrations/1752615789878-addNewReasonColumnForChangelogs.ts
+++ b/packages/database/src/migrations/1752615789878-addNewReasonColumnForChangelogs.ts
@@ -14,8 +14,7 @@ const TABLE = {
 export async function up(query: QueryInterface): Promise<void> {
   await query.addColumn(TABLE, 'reason', {
     type: DataTypes.TEXT,
-    allowNull: false,
-    defaultValue: 'unknown',
+    allowNull: true,
   });
 
   await query.sequelize.query(`
@@ -47,7 +46,7 @@ export async function up(query: QueryInterface): Promise<void> {
         NEW.id,                   -- record_id
         local_system_fact('${FACT_DEVICE_ID}', 'unknown'), -- device_id,
         local_system_fact('${FACT_CURRENT_VERSION}', 'unknown'), -- version,
-        get_session_config('${AUDIT_REASON_KEY}', 'unknown'), -- reason,
+        get_session_config('${AUDIT_REASON_KEY}', NULL), -- reason,
         NEW.created_at,           -- created_at
         NEW.updated_at,           -- updated_at
         NEW.deleted_at,           -- deleted_at

--- a/packages/database/src/migrations/1752615789878-addNewReasonColumnForChangelogs.ts
+++ b/packages/database/src/migrations/1752615789878-addNewReasonColumnForChangelogs.ts
@@ -1,0 +1,102 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+import {
+  AUDIT_USERID_KEY,
+  AUDIT_REASON_KEY,
+  FACT_CURRENT_VERSION,
+  FACT_DEVICE_ID,
+} from '@tamanu/constants';
+
+const TABLE = {
+  tableName: 'changes',
+  schema: 'logs',
+}
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn(TABLE, 'reason', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: 'unknown',
+  });
+
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION logs.record_change()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NOT logs.is_audit_changes_enabled() THEN
+        RETURN NEW;
+      END IF;
+
+      INSERT INTO logs.changes (
+        table_oid,
+        table_schema,
+        table_name,
+        updated_by_user_id,
+        record_id,
+        device_id,
+        version,
+        reason,
+        record_created_at,
+        record_updated_at,
+        record_deleted_at,
+        record_data
+      ) VALUES (
+        TG_RELID,                 -- table_oid
+        TG_TABLE_SCHEMA,          -- table_schema
+        TG_TABLE_NAME,            -- table_name
+        get_session_config('${AUDIT_USERID_KEY}', uuid_nil()::text), -- updated_by_user_id
+        NEW.id,                   -- record_id
+        local_system_fact('${FACT_DEVICE_ID}', 'unknown'), -- device_id,
+        local_system_fact('${FACT_CURRENT_VERSION}', 'unknown'), -- version,
+        get_session_config('${AUDIT_REASON_KEY}', 'unknown'), -- reason,
+        NEW.created_at,           -- created_at
+        NEW.updated_at,           -- updated_at
+        NEW.deleted_at,           -- deleted_at
+        to_jsonb(NEW.*)           -- record_data
+      );
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn(TABLE, 'reason');
+
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION logs.record_change()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NOT logs.is_audit_changes_enabled() THEN
+        RETURN NEW;
+      END IF;
+
+      INSERT INTO logs.changes (
+        table_oid,
+        table_schema,
+        table_name,
+        updated_by_user_id,
+        record_id,
+        device_id,
+        version,
+        record_created_at,
+        record_updated_at,
+        record_deleted_at,
+        record_data
+      ) VALUES (
+        TG_RELID,                 -- table_oid
+        TG_TABLE_SCHEMA,          -- table_schema
+        TG_TABLE_NAME,            -- table_name
+        get_session_config('${AUDIT_USERID_KEY}', uuid_nil()::text), -- updated_by_user_id
+        NEW.id,                   -- record_id
+        local_system_fact('${FACT_DEVICE_ID}', 'unknown'), -- device_id,
+        local_system_fact('${FACT_CURRENT_VERSION}', 'unknown'), -- version,
+        NEW.created_at,           -- created_at
+        NEW.updated_at,           -- updated_at
+        NEW.deleted_at,           -- deleted_at
+        to_jsonb(NEW.*)           -- record_data
+      );
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    `);
+}

--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -67,8 +67,7 @@ export class ChangeLog extends Model {
         },
         reason: {
           type: DataTypes.TEXT,
-          allowNull: false,
-          defaultValue: 'unknown',
+          allowNull: true,
         },
       },
 

--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -18,7 +18,7 @@ export class ChangeLog extends Model {
   declare recordUpdatedAt: Date;
   declare recordDeletedAt: Date | null;
   declare recordData: string;
-  declare reason: string;
+  declare reason: string | null;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(

--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -18,6 +18,7 @@ export class ChangeLog extends Model {
   declare recordUpdatedAt: Date;
   declare recordDeletedAt: Date | null;
   declare recordData: string;
+  declare reason: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -63,6 +64,11 @@ export class ChangeLog extends Model {
         recordData: {
           type: DataTypes.JSONB,
           allowNull: false,
+        },
+        reason: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          defaultValue: 'unknown',
         },
       },
 


### PR DESCRIPTION
### Changes

Desktop charting needs the ability to be edited (survey response answers) while keeping track of the edit history. The decision was to reuse the audit work for this. We need to keep track of previous vales, record the user that made the change, the time it was made and the reason for change, all are already part of the `logs.changes` table except the reason for change.

Here, the proposal is to add a new field that tracks the changelog `reason`, which we can set explicitly whenever appropriate, otherwise it will default to `unknown`, which is somewhat adequate (we always know how it was logged, not why).

With the current state of things, the only records that will have a non-default `reason` will be survey response answers and vital logs. The latter which should eventually be removed once we migrate vitals to keep track via audit.