### PR TITLE
ci: use ops node version

### DIFF
--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -28,10 +28,18 @@ runs:
       shell: bash
       run: rm -rf ops/.git
 
-    - name: Install Node.js
+    - name: Install Node.js for ops
+      if: inputs.ops-ssh-key
       uses: actions/setup-node@v4
       with:
         node-version-file: ops/.node-version
+        cache: npm
+
+    - name: Install Node.js for us
+      if: '!inputs.ops-ssh-key'
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .nvmrc
         cache: npm
 
     - name: Prepare pulumi

--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version-file: '.nvmrc'
+        node-version-file: ops/.node-version
         cache: npm
 
     - name: Prepare pulumi


### PR DESCRIPTION
### Changes

The ops repo (for pulumi and thus auto deploys) changed its node version to 24. To avoid further issues, use the ops repo's .node-version file.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
