### PR TITLE
ci: use ops node version (#8022) [Backport to 2.32]

### DIFF
--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -28,10 +28,18 @@ runs:
       shell: bash
       run: rm -rf ops/.git
 
-    - name: Install Node.js
+    - name: Install Node.js for ops
+      if: inputs.ops-ssh-key
       uses: actions/setup-node@v4
       with:
-        node-version-file: '.nvmrc'
+        node-version-file: ops/.node-version
+        cache: npm
+
+    - name: Install Node.js for us
+      if: '!inputs.ops-ssh-key'
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .nvmrc
         cache: npm
 
     - name: Prepare pulumi


### PR DESCRIPTION
Backport of commit be90d7aef0 (ci: use ops node version #8022) to release/2.32.