### PR TITLE
fix(export): no-issue: Fix display and column name of 'allowedFacilities' in User export

### DIFF
--- a/packages/central-server/app/admin/exporter/modelExporters/UserExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/UserExporter.js
@@ -7,14 +7,14 @@ export class UserExporter extends ModelExporter {
       include: this.models.User.getFullReferenceAssociations(),
     });
 
-    return users.map(user => ({
+    return users.map((user) => ({
       ...user.dataValues,
-      designations: user.designations.map(it => it.referenceData.id).join(', '),
+      designations: user.designations.map((it) => it.referenceData.id).join(', '),
       allowedFacilities: user.facilities.map(({ id }) => id).join(','),
     }));
   }
 
   customHiddenColumns() {
-    return ['type', 'allowedFacilities'];
+    return ['type', 'facilities'];
   }
 }


### PR DESCRIPTION
### Changes

Just a little fix, I think this might've been a typo in the original implementation to filter out the `facilities` column

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
