### PR TITLE
fix(desktopCharting): SAV-699: Reload chart instance on submit

### DIFF
--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -262,12 +262,13 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
       responseData.metadata = {
         chartInstanceResponseId: currentComplexChartInstance.chartInstanceId,
       };
-    } else if (chartSurveyToSubmit.surveyType === SURVEY_TYPES.COMPLEX_CHART_CORE) {
-      reloadChartInstances();
     }
 
     await api.post('surveyResponse', responseData);
     queryClient.invalidateQueries(['encounterCharts', encounter.id, survey.id]);
+    if (chartSurveyToSubmit.surveyType === SURVEY_TYPES.COMPLEX_CHART_CORE) {
+      reloadChartInstances();
+    }
     handleCloseModal();
   };
 


### PR DESCRIPTION
### Changes

A bit of an intermittent issue. This should make it so that we always get new data as we are `await`ing that post.