### PR TITLE
fix(patientDetails): TAMOC-310: Separate suggesters for mother and father fields

### DIFF
--- a/packages/web/app/forms/PatientDetailsForm/layouts/generic/patientFields/GenericPersonalFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/layouts/generic/patientFields/GenericPersonalFields.jsx
@@ -25,7 +25,8 @@ export const GenericPersonalFields = ({ patientRegistryType, filterByMandatory, 
   const nationalitySuggester = useSuggester('nationality');
   const occupationSuggester = useSuggester('occupation');
   const religionSuggester = useSuggester('religion');
-  const patientSuggester = usePatientSuggester();
+  const motherSuggester = usePatientSuggester();
+  const fatherSuggester = usePatientSuggester();
 
   const PERSONAL_FIELDS = {
     title: {
@@ -165,7 +166,7 @@ export const GenericPersonalFields = ({ patientRegistryType, filterByMandatory, 
     },
     motherId: {
       component: AutocompleteField,
-      suggester: patientSuggester,
+      suggester: motherSuggester,
       label: (
         <TranslatedText
           stringId="general.localisedField.motherId.label"
@@ -176,7 +177,7 @@ export const GenericPersonalFields = ({ patientRegistryType, filterByMandatory, 
     },
     fatherId: {
       component: AutocompleteField,
-      suggester: patientSuggester,
+      suggester: fatherSuggester,
       label: (
         <TranslatedText
           stringId="general.localisedField.fatherId.label"


### PR DESCRIPTION
### Changes
Previously it would save to one or the other.
We have seen a few issues like this.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
