### PR TITLE
fix: EPI-1175: Adjust age displays in the Covid printouts

### DIFF
--- a/packages/shared/src/utils/patientCertificates/CovidPatientDetailsSection.jsx
+++ b/packages/shared/src/utils/patientCertificates/CovidPatientDetailsSection.jsx
@@ -31,7 +31,7 @@ export const CovidPatientDetailsSection = ({
     ({ key }) => !getSetting(`fields.${key}.hidden`),
   );
 
-  const leftWidth = vdsSrc ? 68 : 80;
+  const leftWidth = vdsSrc ? 66 : 88;
   const rightWidth = 100 - leftWidth;
 
   return (


### PR DESCRIPTION
### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
