### PR TITLE
fix(mobile): hotfix 2.35: TAMOC-313: Null updatedAt on prescription migration

### DIFF
--- a/packages/mobile/App/migrations/1739698276000-changeMedicationsDBSchema.ts
+++ b/packages/mobile/App/migrations/1739698276000-changeMedicationsDBSchema.ts
@@ -140,8 +140,20 @@ export class changeMedicationsDBSchema1739698276000 implements MigrationInterfac
     await queryRunner.createTable(Prescriptions, true);
     await queryRunner.query(
       `INSERT INTO prescriptions
-      SELECT id, date, endDate, note, indication, route, quantity, medicationId, createdAt, updatedAt, updatedAtSyncTick, deletedAt
-      FROM encounter_medications;`,
+        SELECT 
+          id,
+          date,
+          endDate,
+          note,
+          indication,
+          route,
+          quantity,
+          medicationId,
+          createdAt,
+          COALESCE(updatedAt, createdAt) as updatedAt,
+          updatedAtSyncTick,
+          deletedAt
+        FROM encounter_medications;`,
     );
 
     await queryRunner.createTable(EncounterPrescriptions, true);


### PR DESCRIPTION
### Changes
Some historical null updatedAt causing broken migrations.
<img width="767" height="397" alt="Screenshot 2025-07-24 at 1 58 44 PM" src="https://github.com/user-attachments/assets/1ca2646c-d1a8-4145-805f-6104025d53f1" />

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
