### PR TITLE
feat(desktopCharting): SAV-695: Add ability to edit complex charts core data

### DIFF
--- a/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
@@ -351,10 +351,24 @@ describe('SurveyResponse', () => {
       const newValue1 = 'New answer 1';
       const newValue2 = 'New answer 2';
 
+      // Also create a missing answer
+      const newAnswerDataElement = await ProgramDataElement.create({
+        ...fake(ProgramDataElement),
+        type: PROGRAM_DATA_ELEMENT_TYPES.TEXT,
+      });
+      await SurveyScreenComponent.create({
+        ...fake(SurveyScreenComponent),
+        dataElementId: newAnswerDataElement.id,
+        surveyId: response.surveyId,
+        calculation: '',
+      });
+      const newAnswerValue = 'New answer value';
+
       const result = await app.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
         answers: {
           [answer1.dataElementId]: newValue1,
           [answer2.dataElementId]: newValue2,
+          [newAnswerDataElement.id]: newAnswerValue,
         },
       });
       await answer1.reload();

--- a/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponse.test.js
@@ -1,5 +1,6 @@
 import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
 import { fake } from '@tamanu/fake-data/fake';
+import { PROGRAM_DATA_ELEMENT_TYPES, SURVEY_TYPES } from '@tamanu/constants';
 
 import { createTestContext } from '../utilities';
 
@@ -80,6 +81,71 @@ describe('SurveyResponse', () => {
     });
 
     return { answer, response };
+  };
+
+  const setupComplexChartSurvey = async () => {
+    const {
+      Facility,
+      Location,
+      Department,
+      Patient,
+      User,
+      Encounter,
+      Program,
+      Survey,
+      SurveyResponse,
+      SurveyScreenComponent,
+      ProgramDataElement,
+      SurveyResponseAnswer,
+    } = models;
+
+    const facility = await Facility.create(fake(Facility));
+    const location = await Location.create({
+      ...fake(Location),
+      facilityId: facility.id,
+    });
+    const department = await Department.create({
+      ...fake(Department),
+      facilityId: facility.id,
+    });
+    const examiner = await User.create(fake(User));
+    const patient = await Patient.create(fake(Patient));
+    const encounter = await Encounter.create({
+      ...fake(Encounter),
+      patientId: patient.id,
+      departmentId: department.id,
+      locationId: location.id,
+      examinerId: examiner.id,
+    });
+    const program = await Program.create(fake(Program));
+    const survey = await Survey.create({
+      ...fake(Survey),
+      surveyType: SURVEY_TYPES.COMPLEX_CHART_CORE,
+      programId: program.id,
+    });
+    const response = await SurveyResponse.create({
+      ...fake(SurveyResponse),
+      surveyId: survey.id,
+      encounterId: encounter.id,
+    });
+    const dataElement = await ProgramDataElement.create({
+      ...fake(ProgramDataElement),
+      type: PROGRAM_DATA_ELEMENT_TYPES.TEXT,
+    });
+    await SurveyScreenComponent.create({
+      ...fake(SurveyScreenComponent),
+      dataElementId: dataElement.id,
+      surveyId: survey.id,
+      calculation: '',
+    });
+    const answer = await SurveyResponseAnswer.create({
+      ...fake(SurveyResponseAnswer),
+      dataElementId: dataElement.id,
+      responseId: response.id,
+      body: 'Initial answer',
+    });
+
+    return { answer, response, dataElement, survey };
   };
 
   describe('autocomplete', () => {
@@ -193,6 +259,152 @@ describe('SurveyResponse', () => {
           message: `Selected answer ReferenceData[${facility.id}] not found (check that the surveyquestion's source isn't ReferenceData for a Location, Facility, or Department)`,
         },
       });
+    });
+  });
+
+  describe('complexChartInstance', () => {
+    it('should update existing answers', async () => {
+      const { answer, response } = await setupComplexChartSurvey();
+      const oldValue = answer.body;
+      const newValue = 'Updated answer';
+
+      const result = await app.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
+        answers: {
+          [answer.dataElementId]: newValue,
+        },
+      });
+      await answer.reload();
+
+      expect(result).toHaveSucceeded();
+      expect(answer.body).toEqual(newValue);
+      expect(answer.body).not.toEqual(oldValue);
+    });
+
+    it('should create new answers for data elements not previously answered', async () => {
+      const { ProgramDataElement, SurveyScreenComponent } = models;
+      const { response } = await setupComplexChartSurvey();
+      const newDataElement = await ProgramDataElement.create({
+        ...fake(ProgramDataElement),
+        type: PROGRAM_DATA_ELEMENT_TYPES.TEXT,
+      });
+      await SurveyScreenComponent.create({
+        ...fake(SurveyScreenComponent),
+        dataElementId: newDataElement.id,
+        surveyId: response.surveyId,
+        calculation: '',
+      });
+      const newValue = 'New answer value';
+
+      const result = await app.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
+        answers: {
+          [newDataElement.id]: newValue,
+        },
+      });
+      const newAnswer = await models.SurveyResponseAnswer.findOne({
+        where: {
+          responseId: response.id,
+          dataElementId: newDataElement.id,
+        },
+      });
+
+      expect(result).toHaveSucceeded();
+      expect(newAnswer).toBeTruthy();
+      expect(newAnswer.body).toEqual(newValue);
+    });
+
+    it('should ignore null values in answers', async () => {
+      const { answer, response } = await setupComplexChartSurvey();
+      const originalValue = answer.body;
+
+      const result = await app.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
+        answers: {
+          [answer.dataElementId]: null,
+        },
+      });
+      await answer.reload();
+
+      expect(result).toHaveSucceeded();
+      expect(answer.body).toEqual(originalValue);
+    });
+
+    it('should update multiple answers in a single request', async () => {
+      const { ProgramDataElement, SurveyScreenComponent, SurveyResponseAnswer } = models;
+      const { answer: answer1, response } = await setupComplexChartSurvey();
+      const newDataElement = await ProgramDataElement.create({
+        ...fake(ProgramDataElement),
+        type: PROGRAM_DATA_ELEMENT_TYPES.TEXT,
+      });
+      await SurveyScreenComponent.create({
+        ...fake(SurveyScreenComponent),
+        dataElementId: newDataElement.id,
+        surveyId: response.surveyId,
+        calculation: '',
+      });
+      const answer2 = await models.SurveyResponseAnswer.create({
+        ...fake(SurveyResponseAnswer),
+        dataElementId: newDataElement.id,
+        responseId: response.id,
+        body: 'Initial answer',
+      });
+      const oldValue1 = answer1.body;
+      const oldValue2 = answer2.body;
+      const newValue1 = 'New answer 1';
+      const newValue2 = 'New answer 2';
+
+      const result = await app.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
+        answers: {
+          [answer1.dataElementId]: newValue1,
+          [answer2.dataElementId]: newValue2,
+        },
+      });
+      await answer1.reload();
+      await answer2.reload();
+
+      expect(result).toHaveSucceeded();
+      expect(answer1.body).toEqual(newValue1);
+      expect(answer1.body).not.toEqual(oldValue1);
+      expect(answer2.body).toEqual(newValue2);
+      expect(answer2.body).not.toEqual(oldValue2);
+    });
+
+    it('should return 404 when survey response not found', async () => {
+      const nonExistentId = 'non-existent-id';
+
+      const result = await app.put(`/api/surveyResponse/complexChartInstance/${nonExistentId}`).send({
+        answers: {
+          'some-data-element-id': 'some value',
+        },
+      });
+
+      expect(result).not.toHaveSucceeded();
+      expect(result.status).toBe(404);
+    });
+
+    it('should return error when survey type is not COMPLEX_CHART_CORE', async () => {
+      const { survey, response } = await setupComplexChartSurvey();
+      await survey.update({ surveyType: SURVEY_TYPES.PROGRAMS });
+
+      const result = await app.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
+        answers: {
+          'some-data-element-id': 'some value',
+        },
+      });
+
+      expect(result).not.toHaveSucceeded();
+      expect(result.status).toBe(422);
+    });
+
+    it('should require charting write permission', async () => {
+      const { answer, response } = await setupComplexChartSurvey();
+      const unauthorizedApp = await baseApp.asRole('reception');
+
+      const result = await unauthorizedApp.put(`/api/surveyResponse/complexChartInstance/${response.id}`).send({
+        answers: {
+          [answer.dataElementId]: 'some value',
+        },
+      });
+
+      expect(result).toBeForbidden();
     });
   });
 

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -96,10 +96,11 @@ surveyResponse.put(
     } = req;
 
     const responseRecord = await models.SurveyResponse.findByPk(params.id);
-    req.checkPermission('write', subject('Charting', { id: responseRecord?.surveyId }));
     if (!responseRecord) {
       throw new NotFoundError('Response record not found');
     }
+
+    req.checkPermission('write', subject('Charting', { id: responseRecord.surveyId }));
 
     const survey = await responseRecord.getSurvey();
     if (survey.surveyType !== SURVEY_TYPES.COMPLEX_CHART_CORE) {

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import { subject } from '@casl/ability';
 
 import { transformAnswers } from '@tamanu/shared/reports/utilities/transformAnswers';
 import { SURVEY_TYPES } from '@tamanu/constants';
@@ -93,12 +94,13 @@ surveyResponse.put(
       params,
       db,
     } = req;
-    req.checkPermission('write', 'Charting');
 
     const responseRecord = await models.SurveyResponse.findByPk(params.id);
     if (!responseRecord) {
       throw new NotFoundError('Response record not found');
     }
+
+    req.checkPermission('write', subject('Charting', { id: responseRecord.surveyId }));
 
     const survey = await responseRecord.getSurvey();
     if (survey.surveyType !== SURVEY_TYPES.COMPLEX_CHART_CORE) {

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -106,14 +106,15 @@ surveyResponse.put(
       throw new InvalidOperationError('Cannot edit survey responses');
     }
 
+    const components = await models.SurveyScreenComponent.getComponentsForSurvey(survey.id);
     const responseAnswers = await models.SurveyResponseAnswer.findAll({
       where: { responseId: params.id },
     });
 
     await db.transaction(async () => {
       for (const [dataElementId, value] of Object.entries(body.answers)) {
-        // Ignore null values as they are not valid answers
-        if (value === null) {
+        // Ignore null values or components that are not in the survey
+        if (value === null || !components.some((c) => c.dataElementId === dataElementId)) {
           continue;
         }
 

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -96,11 +96,10 @@ surveyResponse.put(
     } = req;
 
     const responseRecord = await models.SurveyResponse.findByPk(params.id);
+    req.checkPermission('write', subject('Charting', { id: responseRecord?.surveyId }));
     if (!responseRecord) {
       throw new NotFoundError('Response record not found');
     }
-
-    req.checkPermission('write', subject('Charting', { id: responseRecord.surveyId }));
 
     const survey = await responseRecord.getSurvey();
     if (survey.surveyType !== SURVEY_TYPES.COMPLEX_CHART_CORE) {

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -2,9 +2,8 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { transformAnswers } from '@tamanu/shared/reports/utilities/transformAnswers';
-import { NotFoundError } from '@tamanu/api-client';
 import { SURVEY_TYPES } from '@tamanu/constants';
-import { InvalidOperationError } from '@tamanu/shared/errors';
+import { InvalidOperationError, NotFoundError } from '@tamanu/shared/errors';
 
 export const surveyResponse = express.Router();
 

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -113,8 +113,12 @@ surveyResponse.put(
 
     await db.transaction(async () => {
       for (const [dataElementId, value] of Object.entries(body.answers)) {
-        // Ignore null values or components that are not in the survey
-        if (value === null || !components.some((c) => c.dataElementId === dataElementId)) {
+        if (!components.some((c) => c.dataElementId === dataElementId)) {
+          throw new InvalidOperationError('Some components are missing from the survey');
+        }
+
+        // Ignore null values
+        if (value === null) {
           continue;
         }
 

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -6,6 +6,8 @@ import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constant
 import { InfoCard, InfoCardItem } from '../InfoCard';
 import { TranslatedText } from '../Translation';
 import { Colors } from '../../constants';
+import { FormModal } from '../FormModal';
+import { ChartForm } from '../../forms/ChartForm';
 
 const StyledInfoCard = styled(InfoCard)`
   border-radius: 0;
@@ -30,91 +32,111 @@ const StyledEditIcon = styled(EditIcon)`
   color: ${Colors.primary};
 `;
 
-export const ChartInstanceInfoSection = ({ complexChartInstance = {}, fieldVisibility }) => {
-  const { chartInstanceName, chartDate, chartType, chartSubtype } = complexChartInstance;
+export const ChartInstanceInfoSection = ({
+  complexChartInstance = {},
+  fieldVisibility,
+  patient,
+}) => {
+  const {
+    chartInstanceName,
+    chartDate,
+    chartType,
+    chartSubtype,
+    chartSurveyId,
+  } = complexChartInstance;
   const isTypeVisible =
     fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartType] === VISIBILITY_STATUSES.CURRENT;
   const isSubtypeVisible =
     fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartSubtype] === VISIBILITY_STATUSES.CURRENT;
   return (
-    <StyledInfoCard
-      gridRowGap={10}
-      elevated={false}
-      contentMarginBottom={20}
-      headerContent={
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="flex-end"
-          marginTop="-1rem"
-          marginRight="-1rem"
-        >
-          <StyledIconButton
-            onClick={() => {
-              console.log('edit');
-            }}
-            data-testid="stylediconbutton-edit-fkzu"
+    <>
+      <FormModal open={true} onClose={() => {console.log('close')}}>
+        <ChartForm
+          onClose={() => {console.log('close')}}
+          onSubmit={() => {console.log('submit')}}
+          patient={patient}
+          chartSurveyId={chartSurveyId}
+        />
+      </FormModal>
+      <StyledInfoCard
+        gridRowGap={10}
+        elevated={false}
+        contentMarginBottom={20}
+        headerContent={
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="flex-end"
+            marginTop="-1rem"
+            marginRight="-1rem"
           >
-            <StyledEditIcon />
-          </StyledIconButton>
-        </Box>
-      }
-      data-testid="styledinfocard-vd5f"
-    >
-      <InfoCardItem
-        fontSize={14}
-        label={
-          <ChartInstanceInfoLabel
-            stringId="complexChartInstance.location"
-            fallback="Location:"
-            data-testid="chartinstanceinfolabel-2vmu"
-          />
+            <StyledIconButton
+              onClick={() => {
+                console.log('edit');
+              }}
+              data-testid="stylediconbutton-edit-fkzu"
+            >
+              <StyledEditIcon />
+            </StyledIconButton>
+          </Box>
         }
-        value={chartInstanceName}
-        data-testid="infocarditem-1nxo"
-      />
-      <InfoCardItem
-        fontSize={14}
-        label={
-          <ChartInstanceInfoLabel
-            stringId="complexChartInstance.date"
-            fallback="Date & time of onset:"
-            data-testid="chartinstanceinfolabel-xn1c"
-          />
-        }
-        value={chartDate || '-'}
-        data-testid="infocarditem-czi0"
-      />
-
-      {isTypeVisible ? (
+        data-testid="styledinfocard-vd5f"
+      >
         <InfoCardItem
           fontSize={14}
           label={
             <ChartInstanceInfoLabel
-              stringId="complexChartInstance.type"
-              fallback="Type:"
-              data-testid="chartinstanceinfolabel-m3or"
+              stringId="complexChartInstance.location"
+              fallback="Location:"
+              data-testid="chartinstanceinfolabel-2vmu"
             />
           }
-          value={chartType || '-'}
-          data-testid="infocarditem-ql06"
+          value={chartInstanceName}
+          data-testid="infocarditem-1nxo"
         />
-      ) : null}
-
-      {isSubtypeVisible ? (
         <InfoCardItem
           fontSize={14}
           label={
             <ChartInstanceInfoLabel
-              stringId="complexChartInstance.subtype"
-              fallback="Sub type:"
-              data-testid="chartinstanceinfolabel-p5wn"
+              stringId="complexChartInstance.date"
+              fallback="Date & time of onset:"
+              data-testid="chartinstanceinfolabel-xn1c"
             />
           }
-          value={chartSubtype || '-'}
-          data-testid="infocarditem-8nk8"
+          value={chartDate || '-'}
+          data-testid="infocarditem-czi0"
         />
-      ) : null}
-    </StyledInfoCard>
+
+        {isTypeVisible ? (
+          <InfoCardItem
+            fontSize={14}
+            label={
+              <ChartInstanceInfoLabel
+                stringId="complexChartInstance.type"
+                fallback="Type:"
+                data-testid="chartinstanceinfolabel-m3or"
+              />
+            }
+            value={chartType || '-'}
+            data-testid="infocarditem-ql06"
+          />
+        ) : null}
+
+        {isSubtypeVisible ? (
+          <InfoCardItem
+            fontSize={14}
+            label={
+              <ChartInstanceInfoLabel
+                stringId="complexChartInstance.subtype"
+                fallback="Sub type:"
+                data-testid="chartinstanceinfolabel-p5wn"
+              />
+            }
+            value={chartSubtype || '-'}
+            data-testid="infocarditem-8nk8"
+          />
+        ) : null}
+      </StyledInfoCard>
+    </>
   );
 };

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -32,6 +32,13 @@ const StyledEditIcon = styled(EditIcon)`
   color: ${Colors.primary};
 `;
 
+const isVisible = (fieldVisibility, fieldValue, isType) => {
+  const fieldId = isType
+    ? CHARTING_DATA_ELEMENT_IDS.complexChartType
+    : CHARTING_DATA_ELEMENT_IDS.complexChartSubtype;
+  return !!fieldValue || fieldVisibility[fieldId] === VISIBILITY_STATUSES.CURRENT;
+};
+
 export const ChartInstanceInfoSection = ({
   complexChartInstance = {},
   fieldVisibility,
@@ -44,10 +51,8 @@ export const ChartInstanceInfoSection = ({
     chartSubtype,
     chartSurveyId,
   } = complexChartInstance;
-  const isTypeVisible =
-    fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartType] === VISIBILITY_STATUSES.CURRENT;
-  const isSubtypeVisible =
-    fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartSubtype] === VISIBILITY_STATUSES.CURRENT;
+  const isTypeVisible = isVisible(fieldVisibility, chartType, true);
+  const isSubtypeVisible = isVisible(fieldVisibility, chartSubtype, false);
   return (
     <>
       <FormModal open={true} onClose={() => {console.log('close')}}>

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -73,7 +73,6 @@ export const ChartInstanceInfoSection = ({
     };
 
     await api.put(`surveyResponse/complexChartInstance/${chartInstanceId}`, responseData);
-    //queryClient.invalidateQueries(['encounterCharts', encounter.id, chartSurveyId]);
     queryClient.invalidateQueries(['encounterComplexChartInstances', encounter.id, chartSurveyId]);
     setIsEditModalOpen(false);
   };

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
+import EditIcon from '@material-ui/icons/Edit';
+import { Box, IconButton } from '@material-ui/core';
 import { InfoCard, InfoCardItem } from '../InfoCard';
 import { TranslatedText } from '../Translation';
+import { Colors } from '../../constants';
 
 const StyledInfoCard = styled(InfoCard)`
   border-radius: 0;
@@ -13,6 +16,17 @@ const StyledInfoCard = styled(InfoCard)`
 
 const ChartInstanceInfoLabel = styled(TranslatedText)`
   font-weight: 500;
+`;
+
+const StyledIconButton = styled(IconButton)`
+  padding: 0;
+`;
+
+const StyledEditIcon = styled(EditIcon)`
+  float: right;
+  width: 1rem;
+  height: 1rem;
+  color: ${Colors.primary};
 `;
 
 export const ChartInstanceInfoSection = ({
@@ -27,6 +41,24 @@ export const ChartInstanceInfoSection = ({
     gridRowGap={10}
     elevated={false}
     contentMarginBottom={20}
+    headerContent={
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="flex-end"
+        marginTop="-1rem"
+        marginRight="-1rem"
+      >
+        <StyledIconButton
+          onClick={() => {
+            console.log('edit');
+          }}
+          data-testid="stylediconbutton-edit-fkzu"
+        >
+          <StyledEditIcon />
+        </StyledIconButton>
+      </Box>
+    }
     data-testid="styledinfocard-vd5f"
   >
     <InfoCardItem

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import EditIcon from '@material-ui/icons/Edit';
 import { Box, IconButton } from '@material-ui/core';
+import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { InfoCard, InfoCardItem } from '../InfoCard';
 import { TranslatedText } from '../Translation';
 import { Colors } from '../../constants';
@@ -29,91 +30,91 @@ const StyledEditIcon = styled(EditIcon)`
   color: ${Colors.primary};
 `;
 
-export const ChartInstanceInfoSection = ({
-  location,
-  date,
-  type,
-  subtype,
-  isTypeVisible = true,
-  isSubtypeVisible = true,
-}) => (
-  <StyledInfoCard
-    gridRowGap={10}
-    elevated={false}
-    contentMarginBottom={20}
-    headerContent={
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="flex-end"
-        marginTop="-1rem"
-        marginRight="-1rem"
-      >
-        <StyledIconButton
-          onClick={() => {
-            console.log('edit');
-          }}
-          data-testid="stylediconbutton-edit-fkzu"
+export const ChartInstanceInfoSection = ({ complexChartInstance = {}, fieldVisibility }) => {
+  const { chartInstanceName, chartDate, chartType, chartSubtype } = complexChartInstance;
+  const isTypeVisible =
+    fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartType] === VISIBILITY_STATUSES.CURRENT;
+  const isSubtypeVisible =
+    fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartSubtype] === VISIBILITY_STATUSES.CURRENT;
+  return (
+    <StyledInfoCard
+      gridRowGap={10}
+      elevated={false}
+      contentMarginBottom={20}
+      headerContent={
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="flex-end"
+          marginTop="-1rem"
+          marginRight="-1rem"
         >
-          <StyledEditIcon />
-        </StyledIconButton>
-      </Box>
-    }
-    data-testid="styledinfocard-vd5f"
-  >
-    <InfoCardItem
-      fontSize={14}
-      label={
-        <ChartInstanceInfoLabel
-          stringId="complexChartInstance.location"
-          fallback="Location:"
-          data-testid="chartinstanceinfolabel-2vmu"
-        />
+          <StyledIconButton
+            onClick={() => {
+              console.log('edit');
+            }}
+            data-testid="stylediconbutton-edit-fkzu"
+          >
+            <StyledEditIcon />
+          </StyledIconButton>
+        </Box>
       }
-      value={location}
-      data-testid="infocarditem-1nxo"
-    />
-    <InfoCardItem
-      fontSize={14}
-      label={
-        <ChartInstanceInfoLabel
-          stringId="complexChartInstance.date"
-          fallback="Date & time of onset:"
-          data-testid="chartinstanceinfolabel-xn1c"
-        />
-      }
-      value={date || '-'}
-      data-testid="infocarditem-czi0"
-    />
-
-    {isTypeVisible ? (
+      data-testid="styledinfocard-vd5f"
+    >
       <InfoCardItem
         fontSize={14}
         label={
           <ChartInstanceInfoLabel
-            stringId="complexChartInstance.type"
-            fallback="Type:"
-            data-testid="chartinstanceinfolabel-m3or"
+            stringId="complexChartInstance.location"
+            fallback="Location:"
+            data-testid="chartinstanceinfolabel-2vmu"
           />
         }
-        value={type || '-'}
-        data-testid="infocarditem-ql06"
+        value={chartInstanceName}
+        data-testid="infocarditem-1nxo"
       />
-    ) : null}
-
-    {isSubtypeVisible ? (
       <InfoCardItem
         fontSize={14}
         label={
           <ChartInstanceInfoLabel
-            stringId="complexChartInstance.subtype"
-            fallback="Sub type:"
-            data-testid="chartinstanceinfolabel-p5wn"
+            stringId="complexChartInstance.date"
+            fallback="Date & time of onset:"
+            data-testid="chartinstanceinfolabel-xn1c"
           />
         }
-        value={subtype || '-'}
-        data-testid="infocarditem-8nk8"
+        value={chartDate || '-'}
+        data-testid="infocarditem-czi0"
       />
-    ) : null}
-  </StyledInfoCard>
-);
+
+      {isTypeVisible ? (
+        <InfoCardItem
+          fontSize={14}
+          label={
+            <ChartInstanceInfoLabel
+              stringId="complexChartInstance.type"
+              fallback="Type:"
+              data-testid="chartinstanceinfolabel-m3or"
+            />
+          }
+          value={chartType || '-'}
+          data-testid="infocarditem-ql06"
+        />
+      ) : null}
+
+      {isSubtypeVisible ? (
+        <InfoCardItem
+          fontSize={14}
+          label={
+            <ChartInstanceInfoLabel
+              stringId="complexChartInstance.subtype"
+              fallback="Sub type:"
+              data-testid="chartinstanceinfolabel-p5wn"
+            />
+          }
+          value={chartSubtype || '-'}
+          data-testid="infocarditem-8nk8"
+        />
+      ) : null}
+    </StyledInfoCard>
+  );
+};

--- a/packages/web/app/components/ComplexChartModal.jsx
+++ b/packages/web/app/components/ComplexChartModal.jsx
@@ -21,6 +21,7 @@ export const ComplexChartModal = ({
   complexChartInstance,
   complexChartFormMode,
   fieldVisibility,
+  selectedChartSurveyName,
 }) => {
   return (
     <FormModal title={title} open={open} onClose={onClose} data-testid="formmodal-mbvq">
@@ -29,6 +30,7 @@ export const ComplexChartModal = ({
           complexChartInstance={complexChartInstance}
           fieldVisibility={fieldVisibility}
           patient={patient}
+          selectedChartSurveyName={selectedChartSurveyName}
         />
       ) : null}
       <ChartForm

--- a/packages/web/app/components/ComplexChartModal.jsx
+++ b/packages/web/app/components/ComplexChartModal.jsx
@@ -28,7 +28,7 @@ export const ComplexChartModal = ({
         <StyledChartInstanceInfoSection
           complexChartInstance={complexChartInstance}
           fieldVisibility={fieldVisibility}
-          data-testid="styledchartinstanceinfosection-y5ji"
+          patient={patient}
         />
       ) : null}
       <ChartForm

--- a/packages/web/app/components/ComplexChartModal.jsx
+++ b/packages/web/app/components/ComplexChartModal.jsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { FormModal } from './FormModal';
 import { ChartForm } from '../forms/ChartForm';
 import { ChartInstanceInfoSection } from './Charting/ChartInstanceInfoSection';
-import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { COMPLEX_CHART_FORM_MODES } from './Charting/constants';
 
 const StyledChartInstanceInfoSection = styled(ChartInstanceInfoSection)`
@@ -23,22 +22,12 @@ export const ComplexChartModal = ({
   complexChartFormMode,
   fieldVisibility,
 }) => {
-  const { chartInstanceName, chartDate, chartType, chartSubtype } = complexChartInstance || {};
-  const isTypeVisible =
-    fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartType] === VISIBILITY_STATUSES.CURRENT;
-  const isSubtypeVisible =
-    fieldVisibility[CHARTING_DATA_ELEMENT_IDS.complexChartSubtype] === VISIBILITY_STATUSES.CURRENT;
-
   return (
     <FormModal title={title} open={open} onClose={onClose} data-testid="formmodal-mbvq">
       {complexChartFormMode === COMPLEX_CHART_FORM_MODES.RECORD_CHART_ENTRY ? (
         <StyledChartInstanceInfoSection
-          location={chartInstanceName}
-          date={chartDate}
-          type={chartType}
-          subtype={chartSubtype}
-          isTypeVisible={isTypeVisible}
-          isSubtypeVisible={isSubtypeVisible}
+          complexChartInstance={complexChartInstance}
+          fieldVisibility={fieldVisibility}
           data-testid="styledchartinstanceinfosection-y5ji"
         />
       ) : null}

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -339,6 +339,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
         {isComplexChart ? (
           <ComplexChartModal
             {...baseChartModalProps}
+            selectedChartSurveyName={selectedChartSurveyName}
             complexChartInstance={currentComplexChartInstance}
             complexChartFormMode={complexChartFormMode}
             fieldVisibility={fieldVisibility}


### PR DESCRIPTION
### Changes

Pretty much what the title says. This workflow is... different. So I created a specific endpoint to avoid being able to edit other survey responses, which are usually very involved to create. Because the complex chart core is a very simple survey with text fields only (and 1 datetimestring), plus, it shouldn't have any complex actions like calculations or write to patient data, etc., we can be confident on updating the answers this way.