### PR TITLE
fix(desktopCharting): SAV-700: Translation and visibility

### DIFF
--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -15,6 +15,7 @@ import {
   IMAGING_REQUEST_STATUS_TYPES,
   TASK_STATUSES,
   SURVEY_TYPES,
+  VISIBILITY_STATUSES,
 } from '@tamanu/constants';
 import {
   simpleGet,
@@ -748,7 +749,10 @@ encounterRelations.get(
           required: true,
           model: models.Survey,
           as: 'survey',
-          where: { surveyType: [SURVEY_TYPES.SIMPLE_CHART, SURVEY_TYPES.COMPLEX_CHART] },
+          where: {
+            surveyType: [SURVEY_TYPES.SIMPLE_CHART, SURVEY_TYPES.COMPLEX_CHART],
+            visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+          },
         },
       ],
       order: [['survey', 'name', 'ASC']],

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -49,7 +49,7 @@ export const ChartInstanceInfoSection = ({
   fieldVisibility,
   patient,
   selectedChartSurveyName,
-  coreComplexChartSurvey,
+  coreComplexDataElements,
 }) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const { encounter } = useEncounter();
@@ -78,18 +78,12 @@ export const ChartInstanceInfoSection = ({
     setIsEditModalOpen(false);
   };
 
-  const instanceNameDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName,
-  )?.dataElement;
-  const dateDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartDate,
-  )?.dataElement;
-  const typeDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartType,
-  )?.dataElement;
-  const subtypeDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartSubtype,
-  )?.dataElement;
+  const {
+    instanceNameDataElement,
+    dateDataElement,
+    typeDataElement,
+    subtypeDataElement,
+  } = coreComplexDataElements;
 
   return (
     <>

--- a/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
+++ b/packages/web/app/components/Charting/ChartInstanceInfoSection.jsx
@@ -4,7 +4,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import { Box, IconButton } from '@material-ui/core';
 import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { InfoCard, InfoCardItem } from '../InfoCard';
-import { TranslatedText } from '../Translation';
+import { TranslatedReferenceData } from '../Translation';
 import { Colors } from '../../constants';
 import { FormModal } from '../FormModal';
 import { ChartForm } from '../../forms/ChartForm';
@@ -22,7 +22,7 @@ const StyledInfoCard = styled(InfoCard)`
   }
 `;
 
-const ChartInstanceInfoLabel = styled(TranslatedText)`
+const ChartInstanceInfoLabel = styled(TranslatedReferenceData)`
   font-weight: 500;
 `;
 
@@ -49,6 +49,7 @@ export const ChartInstanceInfoSection = ({
   fieldVisibility,
   patient,
   selectedChartSurveyName,
+  coreComplexChartSurvey,
 }) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const { encounter } = useEncounter();
@@ -76,6 +77,20 @@ export const ChartInstanceInfoSection = ({
     queryClient.invalidateQueries(['encounterComplexChartInstances', encounter.id, chartSurveyId]);
     setIsEditModalOpen(false);
   };
+
+  const instanceNameDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName,
+  )?.dataElement;
+  const dateDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartDate,
+  )?.dataElement;
+  const typeDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartType,
+  )?.dataElement;
+  const subtypeDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartSubtype,
+  )?.dataElement;
+
   return (
     <>
       <FormModal title={title} open={isEditModalOpen} onClose={() => setIsEditModalOpen(false)}>
@@ -112,8 +127,9 @@ export const ChartInstanceInfoSection = ({
           fontSize={14}
           label={
             <ChartInstanceInfoLabel
-              stringId="complexChartInstance.location"
-              fallback="Location:"
+              category="programDataElement"
+              value={instanceNameDataElement?.id}
+              fallback={instanceNameDataElement?.name}
               data-testid="chartinstanceinfolabel-2vmu"
             />
           }
@@ -124,8 +140,9 @@ export const ChartInstanceInfoSection = ({
           fontSize={14}
           label={
             <ChartInstanceInfoLabel
-              stringId="complexChartInstance.date"
-              fallback="Date & time of onset:"
+              category="programDataElement"
+              value={dateDataElement?.id}
+              fallback={dateDataElement?.name}
               data-testid="chartinstanceinfolabel-xn1c"
             />
           }
@@ -138,8 +155,9 @@ export const ChartInstanceInfoSection = ({
             fontSize={14}
             label={
               <ChartInstanceInfoLabel
-                stringId="complexChartInstance.type"
-                fallback="Type:"
+                category="programDataElement"
+                value={typeDataElement?.id}
+                fallback={typeDataElement?.name}
                 data-testid="chartinstanceinfolabel-m3or"
               />
             }
@@ -153,8 +171,9 @@ export const ChartInstanceInfoSection = ({
             fontSize={14}
             label={
               <ChartInstanceInfoLabel
-                stringId="complexChartInstance.subtype"
-                fallback="Sub type:"
+                category="programDataElement"
+                value={subtypeDataElement?.id}
+                fallback={subtypeDataElement?.name}
                 data-testid="chartinstanceinfolabel-p5wn"
               />
             }

--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -44,7 +44,7 @@ export const CoreComplexChartData = ({
   type,
   subtype,
   fieldVisibility,
-  coreComplexChartSurvey,
+  coreComplexDataElements,
 }) => {
   const { ability } = useAuth();
   const [open, setModalOpen] = useState(false);
@@ -75,15 +75,7 @@ export const CoreComplexChartData = ({
   const isSubtypeVisible = isFieldVisible(subtype, CHARTING_DATA_ELEMENT_IDS.complexChartSubtype);
   const showMenuButton = data.length === 0 && actions.length > 0;
 
-  const dateDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartDate,
-  )?.dataElement;
-  const typeDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartType,
-  )?.dataElement;
-  const subtypeDataElement = coreComplexChartSurvey?.components?.find(
-    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartSubtype,
-  )?.dataElement;
+  const { dateDataElement, typeDataElement, subtypeDataElement } = coreComplexDataElements;
 
   return (
     <>

--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -94,7 +94,7 @@ export const CoreComplexChartData = ({
                 value={dateDataElement?.id}
                 fallback={dateDataElement?.name}
                 data-testid="translatedreferencedata-moh0"
-              />{':'}
+              />{dateDataElement ? ':' : null}
             </CoreComplexChartInfoHeader>
             <DateDisplay date={date} showTime data-testid="datedisplay-hnbz" />
           </CoreComplexChartSingleInfoWrapper>
@@ -107,7 +107,7 @@ export const CoreComplexChartData = ({
                   value={typeDataElement?.id}
                   fallback={typeDataElement?.name}
                   data-testid="translatedreferencedata-4z04"
-                />{':'}
+                />{typeDataElement ? ':' : null}
               </CoreComplexChartInfoHeader>
 
               <>{type || '-'}</>
@@ -122,7 +122,7 @@ export const CoreComplexChartData = ({
                   value={subtypeDataElement?.id}
                   fallback={subtypeDataElement?.name}
                   data-testid="translatedreferencedata-9x05"
-                />{':'}
+                />{subtypeDataElement ? ':' : null}
               </CoreComplexChartInfoHeader>
               <>{subtype || '-'}</>
             </CoreComplexChartSingleInfoWrapper>

--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { subject } from '@casl/ability';
 
 import { useAuth } from '../../contexts/Auth';
-import { TranslatedText } from '../Translation';
+import { TranslatedReferenceData, TranslatedText } from '../Translation';
 import { DeleteChartModal } from '../DeleteChartModal';
 import { Colors } from '../../constants';
 import { MenuButton } from '../MenuButton';
@@ -44,6 +44,7 @@ export const CoreComplexChartData = ({
   type,
   subtype,
   fieldVisibility,
+  coreComplexChartSurvey,
 }) => {
   const { ability } = useAuth();
   const [open, setModalOpen] = useState(false);
@@ -74,6 +75,16 @@ export const CoreComplexChartData = ({
   const isSubtypeVisible = isFieldVisible(subtype, CHARTING_DATA_ELEMENT_IDS.complexChartSubtype);
   const showMenuButton = data.length === 0 && actions.length > 0;
 
+  const dateDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartDate,
+  )?.dataElement;
+  const typeDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartType,
+  )?.dataElement;
+  const subtypeDataElement = coreComplexChartSurvey?.components?.find(
+    c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartSubtype,
+  )?.dataElement;
+
   return (
     <>
       <DeleteChartModal
@@ -86,11 +97,12 @@ export const CoreComplexChartData = ({
         <CoreComplexChartInfoWrapper data-testid="corecomplexchartinfowrapper-zn2k">
           <CoreComplexChartSingleInfoWrapper data-testid="corecomplexchartsingleinfowrapper-qen9">
             <CoreComplexChartInfoHeader data-testid="corecomplexchartinfoheader-a7s5">
-              <TranslatedText
-                stringId="complexChartInstance.date"
-                fallback="Date & time of onset:"
-                data-testid="translatedtext-moh0"
-              />
+              <TranslatedReferenceData
+                category="programDataElement"
+                value={dateDataElement?.id}
+                fallback={dateDataElement?.name}
+                data-testid="translatedreferencedata-moh0"
+              />{':'}
             </CoreComplexChartInfoHeader>
             <DateDisplay date={date} showTime data-testid="datedisplay-hnbz" />
           </CoreComplexChartSingleInfoWrapper>
@@ -98,11 +110,12 @@ export const CoreComplexChartData = ({
           {isTypeVisible ? (
             <CoreComplexChartSingleInfoWrapper data-testid="corecomplexchartsingleinfowrapper-2jla">
               <CoreComplexChartInfoHeader data-testid="corecomplexchartinfoheader-4k95">
-                <TranslatedText
-                  stringId="complexChartInstance.type"
-                  fallback="Type:"
-                  data-testid="translatedtext-4z04"
-                />
+                <TranslatedReferenceData
+                  category="programDataElement"
+                  value={typeDataElement?.id}
+                  fallback={typeDataElement?.name}
+                  data-testid="translatedreferencedata-4z04"
+                />{':'}
               </CoreComplexChartInfoHeader>
 
               <>{type || '-'}</>
@@ -112,11 +125,12 @@ export const CoreComplexChartData = ({
           {isSubtypeVisible ? (
             <CoreComplexChartSingleInfoWrapper data-testid="corecomplexchartsingleinfowrapper-h7z6">
               <CoreComplexChartInfoHeader data-testid="corecomplexchartinfoheader-bgio">
-                <TranslatedText
-                  stringId="complexChartInstance.subtype"
-                  fallback="Sub type:"
-                  data-testid="translatedtext-9x05"
-                />
+                <TranslatedReferenceData
+                  category="programDataElement"
+                  value={subtypeDataElement?.id}
+                  fallback={subtypeDataElement?.name}
+                  data-testid="translatedreferencedata-9x05"
+                />{':'}
               </CoreComplexChartInfoHeader>
               <>{subtype || '-'}</>
             </CoreComplexChartSingleInfoWrapper>

--- a/packages/web/app/components/ComplexChartModal.jsx
+++ b/packages/web/app/components/ComplexChartModal.jsx
@@ -22,7 +22,7 @@ export const ComplexChartModal = ({
   complexChartFormMode,
   fieldVisibility,
   selectedChartSurveyName,
-  coreComplexChartSurvey,
+  coreComplexDataElements,
 }) => {
   return (
     <FormModal title={title} open={open} onClose={onClose} data-testid="formmodal-mbvq">
@@ -32,7 +32,7 @@ export const ComplexChartModal = ({
           fieldVisibility={fieldVisibility}
           patient={patient}
           selectedChartSurveyName={selectedChartSurveyName}
-          coreComplexChartSurvey={coreComplexChartSurvey}
+          coreComplexDataElements={coreComplexDataElements}
         />
       ) : null}
       <ChartForm

--- a/packages/web/app/components/ComplexChartModal.jsx
+++ b/packages/web/app/components/ComplexChartModal.jsx
@@ -22,6 +22,7 @@ export const ComplexChartModal = ({
   complexChartFormMode,
   fieldVisibility,
   selectedChartSurveyName,
+  coreComplexChartSurvey,
 }) => {
   return (
     <FormModal title={title} open={open} onClose={onClose} data-testid="formmodal-mbvq">
@@ -31,6 +32,7 @@ export const ComplexChartModal = ({
           fieldVisibility={fieldVisibility}
           patient={patient}
           selectedChartSurveyName={selectedChartSurveyName}
+          coreComplexChartSurvey={coreComplexChartSurvey}
         />
       ) : null}
       <ChartForm

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -197,24 +197,21 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
       ),
     [coreComplexChartSurvey?.components],
   );
+
   const coreComplexDataElements = useMemo(() => {
-    const instanceNameDataElement = coreComplexChartSurvey?.components?.find(
-      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName,
-    )?.dataElement;
-    const dateDataElement = coreComplexChartSurvey?.components?.find(
-      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartDate,
-    )?.dataElement;
-    const typeDataElement = coreComplexChartSurvey?.components?.find(
-      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartType,
-    )?.dataElement;
-    const subtypeDataElement = coreComplexChartSurvey?.components?.find(
-      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartSubtype,
-    )?.dataElement;
+    if (!coreComplexChartSurvey?.components) {
+      return {};
+    }
+    const componentsByDataElementId = keyBy(coreComplexChartSurvey.components, 'dataElementId');
+    const findDataElement = id => componentsByDataElementId[id]?.dataElement;
+
     return {
-      instanceNameDataElement,
-      dateDataElement,
-      typeDataElement,
-      subtypeDataElement,
+      instanceNameDataElement: findDataElement(
+        CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName
+      ),
+      dateDataElement: findDataElement(CHARTING_DATA_ELEMENT_IDS.complexChartDate),
+      typeDataElement: findDataElement(CHARTING_DATA_ELEMENT_IDS.complexChartType),
+      subtypeDataElement: findDataElement(CHARTING_DATA_ELEMENT_IDS.complexChartSubtype)
     };
   }, [coreComplexChartSurvey]);
 

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -345,6 +345,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
             complexChartInstance={currentComplexChartInstance}
             complexChartFormMode={complexChartFormMode}
             fieldVisibility={fieldVisibility}
+            coreComplexChartSurvey={coreComplexChartSurvey}
             data-testid="complexchartmodal-aldg"
           />
         ) : (
@@ -425,6 +426,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
             date={currentComplexChartInstance.chartDate}
             type={currentComplexChartInstance.chartType}
             subtype={currentComplexChartInstance.chartSubtype}
+            coreComplexChartSurvey={coreComplexChartSurvey}
             fieldVisibility={fieldVisibility}
             data-testid="corecomplexchartdata-tepa"
           />

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -188,14 +188,14 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
     selectedChartTypeId,
   ]);
 
-  const { data: fullChartSurvey } = useChartSurveyQuery(coreComplexChartSurveyId);
+  const { data: coreComplexChartSurvey } = useChartSurveyQuery(coreComplexChartSurveyId);
 
   const fieldVisibility = useMemo(
     () =>
       Object.fromEntries(
-        fullChartSurvey?.components.map(c => [c.dataElementId, c.visibilityStatus]) || [],
+        coreComplexChartSurvey?.components.map(c => [c.dataElementId, c.visibilityStatus]) || [],
       ),
-    [fullChartSurvey?.components],
+    [coreComplexChartSurvey?.components],
   );
 
   const isInstancesQueryEnabled = !!coreComplexChartSurveyId;

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify';
 import { subject } from '@casl/ability';
 
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
-import { SURVEY_TYPES } from '@tamanu/constants';
+import { CHARTING_DATA_ELEMENT_IDS, SURVEY_TYPES } from '@tamanu/constants';
 
 import { TabPane } from '../components';
 import { TableButtonRow, ButtonWithPermissionCheck } from '../../../components';
@@ -197,6 +197,26 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
       ),
     [coreComplexChartSurvey?.components],
   );
+  const coreComplexDataElements = useMemo(() => {
+    const instanceNameDataElement = coreComplexChartSurvey?.components?.find(
+      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartInstanceName,
+    )?.dataElement;
+    const dateDataElement = coreComplexChartSurvey?.components?.find(
+      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartDate,
+    )?.dataElement;
+    const typeDataElement = coreComplexChartSurvey?.components?.find(
+      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartType,
+    )?.dataElement;
+    const subtypeDataElement = coreComplexChartSurvey?.components?.find(
+      c => c.dataElementId === CHARTING_DATA_ELEMENT_IDS.complexChartSubtype,
+    )?.dataElement;
+    return {
+      instanceNameDataElement,
+      dateDataElement,
+      typeDataElement,
+      subtypeDataElement,
+    };
+  }, [coreComplexChartSurvey]);
 
   const isInstancesQueryEnabled = !!coreComplexChartSurveyId;
   const {
@@ -345,7 +365,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
             complexChartInstance={currentComplexChartInstance}
             complexChartFormMode={complexChartFormMode}
             fieldVisibility={fieldVisibility}
-            coreComplexChartSurvey={coreComplexChartSurvey}
+            coreComplexDataElements={coreComplexDataElements}
             data-testid="complexchartmodal-aldg"
           />
         ) : (
@@ -426,7 +446,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
             date={currentComplexChartInstance.chartDate}
             type={currentComplexChartInstance.chartType}
             subtype={currentComplexChartInstance.chartSubtype}
-            coreComplexChartSurvey={coreComplexChartSurvey}
+            coreComplexDataElements={coreComplexDataElements}
             fieldVisibility={fieldVisibility}
             data-testid="corecomplexchartdata-tepa"
           />


### PR DESCRIPTION
### Changes

- New requirement we want to display the same field names used in the form
- Small gotcha that happens if the user preference chart is made historical, we shouldn't select that option