### PR TITLE
fix(web): session restore logic and spurious network request failed error

### DIFF
--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { TamanuApi as ApiClient, AuthExpiredError } from '@tamanu/api-client';
 import { ENGLISH_LANGUAGE_CODE, SERVER_TYPES } from '@tamanu/constants';
-import { buildAbilityForUser } from '@tamanu/shared/permissions/buildAbility';
 
 import { LOCAL_STORAGE_KEYS } from '../constants';
 import { getDeviceId, notifyError } from '../utils';

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -50,7 +50,6 @@ function restoreFromLocalStorage() {
 }
 
 function saveToLocalStorage({
-  token,
   localisation,
   server,
   availableFacilities,
@@ -59,9 +58,6 @@ function saveToLocalStorage({
   role,
   settings,
 }) {
-  if (token) {
-    localStorage.setItem(TOKEN, token);
-  }
   if (facilityId) {
     localStorage.setItem(FACILITY_ID, facilityId);
   }
@@ -135,6 +131,11 @@ export class TamanuApi extends ApiClient {
     });
   }
 
+  setToken(token, refreshToken) {
+    localStorage.setItem(TOKEN, refreshToken);
+    return super.setToken(token, refreshToken);
+  }
+
   async restoreSession() {
     const {
       token,
@@ -149,10 +150,11 @@ export class TamanuApi extends ApiClient {
     if (!token) {
       throw new Error('No stored session found.');
     }
-    this.setToken(token);
-    const user = await this.get('user/me');
-    this.user = user;
-    const ability = buildAbilityForUser(user, permissions);
+
+    this.setToken(null, token);
+    const config = { showUnknownErrorToast: false };
+    await this.refreshToken(config);
+    const { user, ability } = await this.fetchUserData(permissions, config);
 
     return {
       user,
@@ -169,9 +171,8 @@ export class TamanuApi extends ApiClient {
 
   async login(email, password) {
     const output = await super.login(email, password);
-    const { token, localisation, server, availableFacilities, permissions, role } = output;
+    const { localisation, server, availableFacilities, permissions, role } = output;
     saveToLocalStorage({
-      token,
       localisation,
       server,
       availableFacilities,
@@ -182,14 +183,12 @@ export class TamanuApi extends ApiClient {
   }
 
   async setFacility(facilityId) {
-    const { token, settings } = await this.post('setFacility', { facilityId });
-    this.setToken(token);
+    const { settings } = await this.post('setFacility', { facilityId });
     saveToLocalStorage({
-      token,
       facilityId,
       settings,
     });
-    return { settings, token };
+    return { settings };
   }
 
   async fetch(endpoint, query, config) {

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -131,7 +131,11 @@ export class TamanuApi extends ApiClient {
   }
 
   setToken(token, refreshToken) {
-    localStorage.setItem(TOKEN, refreshToken);
+    if (refreshToken) {
+      localStorage.setItem(TOKEN, refreshToken);
+    } else {
+      localStorage.removeItem(TOKEN);
+    }
     return super.setToken(token, refreshToken);
   }
 


### PR DESCRIPTION
### Changes

Turns out this is the same thing: we store the session token but we really wanted to store the refresh token, and also we weren't disabling the error output when trying to restore the session (and failing due to outdated session token).

### Testing

Go to the deploy, and login once.

Refresh, and you should:
- be logged in without having to enter credentials again
- not see a network error toast

Then logout, and refresh. You should:
- not be logged in, and have to enter creds
- still not see a network error toast

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
