### PR TITLE
feat(web): EPI-1237: Disable drag-and-drop from Notepad to Notes section

### DIFF
--- a/packages/web/app/components/Field/TextField.jsx
+++ b/packages/web/app/components/Field/TextField.jsx
@@ -112,12 +112,37 @@ export const TextInput = ({
       return false;
     }
   };
+
+  const onDrop = (e) => {
+    if (!enablePasting && disableInputPasting) {
+      e.preventDefault();
+      return false;
+    }
+  };
+
+  const onDragOver = (e) => {
+    if (!enablePasting && disableInputPasting) {
+      e.preventDefault();
+      return false;
+    }
+  };
+
+  const onDragEnter = (e) => {
+    if (!enablePasting && disableInputPasting) {
+      e.preventDefault();
+      return false;
+    }
+  };
+
   return (
     <OuterLabelFieldWrapper label={label} {...props}>
       <StyledTextField
         value={value}
         variant="outlined"
         onPaste={onPaste}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragEnter={onDragEnter}
         inputProps={{
           ...props.inputProps,
           'data-testid': `${dataTestId}-input`,


### PR DESCRIPTION
### Changes

- Added onDrop, onDragOver, and onDragEnter event handlers to prevent pasting when disabled.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
