### PR TITLE
db: better changelog indexes

### DIFF
--- a/packages/database/src/migrations/1753999599109-betterIndexesForLogsChanges.ts
+++ b/packages/database/src/migrations/1753999599109-betterIndexesForLogsChanges.ts
@@ -3,45 +3,73 @@ import { QueryInterface } from 'sequelize';
 const TABLE = { schema: 'logs', tableName: 'changes' };
 
 export async function up(query: QueryInterface): Promise<void> {
-  await query.removeIndex(TABLE, 'changes_device_id');
-  await query.removeIndex(TABLE, 'changes_logged_at');
-  await query.removeIndex(TABLE, 'changes_record_created_at');
-  await query.removeIndex(TABLE, 'changes_record_updated_at');
-  await query.removeIndex(TABLE, 'changes_table_name');
-  await query.removeIndex(TABLE, 'changes_table_oid');
-  await query.removeIndex(TABLE, 'changes_updated_by_user_id');
+  // Drop existing indexes if they exist
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_device_id;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_logged_at;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_record_created_at;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_record_updated_at;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_table_name;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_table_oid;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_updated_by_user_id;`);
 
-  // btree for regular columns
-  await query.addIndex(TABLE, ['device_id']);
-  await query.addIndex(TABLE, ['table_oid']);
-  await query.addIndex(TABLE, ['updated_by_user_id']);
+  // Create btree indexes for regular columns
+  await query.sequelize.query(
+    `CREATE INDEX changes_device_id ON logs.changes USING btree (device_id);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_table_oid ON logs.changes USING btree (table_oid);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_updated_by_user_id ON logs.changes USING btree (updated_by_user_id);`,
+  );
   await query.sequelize.query(
     `CREATE INDEX changes_table_name ON logs.changes USING btree (((table_schema || '.'::text) || table_name));`,
   );
 
-  // brin for time series
-  await query.addIndex(TABLE, ['logged_at'], { using: 'BRIN' });
-  await query.addIndex(TABLE, ['record_created_at'], { using: 'BRIN' });
-  await query.addIndex(TABLE, ['record_updated_at'], { using: 'BRIN' });
+  // Create brin indexes for time series
+  await query.sequelize.query(
+    `CREATE INDEX changes_logged_at ON logs.changes USING brin (logged_at);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_record_created_at ON logs.changes USING brin (record_created_at);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_record_updated_at ON logs.changes USING brin (record_updated_at);`,
+  );
 }
 
 export async function down(query: QueryInterface): Promise<void> {
-  await query.removeIndex(TABLE, 'changes_device_id');
-  await query.removeIndex(TABLE, 'changes_logged_at');
-  await query.removeIndex(TABLE, 'changes_record_created_at');
-  await query.removeIndex(TABLE, 'changes_record_updated_at');
-  await query.removeIndex(TABLE, 'changes_table_name');
-  await query.removeIndex(TABLE, 'changes_table_oid');
-  await query.removeIndex(TABLE, 'changes_updated_by_user_id');
+  // Drop existing indexes if they exist
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_device_id;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_logged_at;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_record_created_at;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_record_updated_at;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_table_name;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_table_oid;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_updated_by_user_id;`);
 
-  await query.addIndex(TABLE, ['device_id'], { using: 'HASH' });
-  await query.addIndex(TABLE, ['table_oid'], { using: 'HASH' });
-  await query.addIndex(TABLE, ['updated_by_user_id'], { using: 'HASH' });
+  // Recreate original hash indexes for regular columns
+  await query.sequelize.query(
+    `CREATE INDEX changes_device_id ON logs.changes USING hash (device_id);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_table_oid ON logs.changes USING hash (table_oid);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_updated_by_user_id ON logs.changes USING hash (updated_by_user_id);`,
+  );
   await query.sequelize.query(
     `CREATE INDEX changes_table_name ON logs.changes USING hash (((table_schema || '.'::text) || table_name));`,
   );
 
-  await query.addIndex(TABLE, ['logged_at'], { using: 'BTREE' });
-  await query.addIndex(TABLE, ['record_created_at'], { using: 'BTREE' });
-  await query.addIndex(TABLE, ['record_updated_at'], { using: 'BTREE' });
+  // Recreate original btree indexes for time series
+  await query.sequelize.query(
+    `CREATE INDEX changes_logged_at ON logs.changes USING btree (logged_at);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_record_created_at ON logs.changes USING btree (record_created_at);`,
+  );
+  await query.sequelize.query(
+    `CREATE INDEX changes_record_updated_at ON logs.changes USING btree (record_updated_at);`,
+  );
 }

--- a/packages/database/src/migrations/1753999599109-betterIndexesForLogsChanges.ts
+++ b/packages/database/src/migrations/1753999599109-betterIndexesForLogsChanges.ts
@@ -1,0 +1,47 @@
+import { QueryInterface } from 'sequelize';
+
+const TABLE = { schema: 'logs', tableName: 'changes' };
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.removeIndex(TABLE, 'changes_device_id');
+  await query.removeIndex(TABLE, 'changes_logged_at');
+  await query.removeIndex(TABLE, 'changes_record_created_at');
+  await query.removeIndex(TABLE, 'changes_record_updated_at');
+  await query.removeIndex(TABLE, 'changes_table_name');
+  await query.removeIndex(TABLE, 'changes_table_oid');
+  await query.removeIndex(TABLE, 'changes_updated_by_user_id');
+
+  // btree for regular columns
+  await query.addIndex(TABLE, ['device_id']);
+  await query.addIndex(TABLE, ['table_oid']);
+  await query.addIndex(TABLE, ['updated_by_user_id']);
+  await query.sequelize.query(
+    `CREATE INDEX changes_table_name ON logs.changes USING btree (((table_schema || '.'::text) || table_name));`,
+  );
+
+  // brin for time series
+  await query.addIndex(TABLE, ['logged_at'], { using: 'BRIN' });
+  await query.addIndex(TABLE, ['record_created_at'], { using: 'BRIN' });
+  await query.addIndex(TABLE, ['record_updated_at'], { using: 'BRIN' });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeIndex(TABLE, 'changes_device_id');
+  await query.removeIndex(TABLE, 'changes_logged_at');
+  await query.removeIndex(TABLE, 'changes_record_created_at');
+  await query.removeIndex(TABLE, 'changes_record_updated_at');
+  await query.removeIndex(TABLE, 'changes_table_name');
+  await query.removeIndex(TABLE, 'changes_table_oid');
+  await query.removeIndex(TABLE, 'changes_updated_by_user_id');
+
+  await query.addIndex(TABLE, ['device_id'], { using: 'HASH' });
+  await query.addIndex(TABLE, ['table_oid'], { using: 'HASH' });
+  await query.addIndex(TABLE, ['updated_by_user_id'], { using: 'HASH' });
+  await query.sequelize.query(
+    `CREATE INDEX changes_table_name ON logs.changes USING hash (((table_schema || '.'::text) || table_name));`,
+  );
+
+  await query.addIndex(TABLE, ['logged_at'], { using: 'BTREE' });
+  await query.addIndex(TABLE, ['record_created_at'], { using: 'BTREE' });
+  await query.addIndex(TABLE, ['record_updated_at'], { using: 'BTREE' });
+}

--- a/packages/database/src/migrations/1753999599109-betterIndexesForLogsChanges.ts
+++ b/packages/database/src/migrations/1753999599109-betterIndexesForLogsChanges.ts
@@ -1,7 +1,5 @@
 import { QueryInterface } from 'sequelize';
 
-const TABLE = { schema: 'logs', tableName: 'changes' };
-
 export async function up(query: QueryInterface): Promise<void> {
   // Drop existing indexes if they exist
   await query.sequelize.query(`DROP INDEX IF EXISTS logs.changes_device_id;`);


### PR DESCRIPTION
### Changes

Follows an investigation into indexing that table when it has real volumes of data. Full details [in slack](https://beyondessential.slack.com/archives/GE9NHB95F/p1753911199521059), summary:

> - hash indexes can be very fast to create/maintain!... if the input data varies a lot. That is, you want to minimise hash/bucket collision. So, record_id, super fast! takes 70 seconds to build. device_id, which is entirely identical in this data set? 6 hours. not a typo.
> - btree indexes are kinda the medium experience. There's no collisions, but they need balancing. OTOH btree is the only index type we have parallel build support for across all our versions (landed in pg 11, parallel BRIN indexes landed in 17, and parallel GIN are landing in 18 next year). The btree on created_at took 1h30.
> - `maintenance_work_mem` is critical! this is a database setting, by default it's set to 64MB. Lifting it to 1GB brings... btrees in 15 seconds, spread out hashes in 40 seconds. It doesn't help for hashes on collided data.
> - BRIN is a fun one. It's a lightweight partitioning index suited especially to time series data, like logged_at... which takes 16 seconds to build (4 seconds on 1GB work_mem), and adds up to 168KB of index data. yes, KB.
> - Now the chonker: the GIN index on record_data. Or is it? That index takes 7 minutes to build. There is a marginal (10%) improvement with a 1GB work_mem. Turns out, not the problem.
> 
> Thus, proposed solution:
> - switch logged_at, record_created_at, and record_updated_at to BRIN
> - keep record_id on hash and record_data on gin
> - move every other hash index to btree
> - set maintenance_work_mem to 1GB (at least for this, but I say we leave it there permanently unless we get a specific memory issue, to help with future migrations)

This delivers a 99.2% reduction in indexing time (19 hours to 10 minutes on the tested dataset).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
