### PR TITLE
fix(vitals): Release fix 2.37: formatOptionForStringId safety

### DIFF
--- a/packages/shared/src/utils/translation/getReferenceDataStringId.js
+++ b/packages/shared/src/utils/translation/getReferenceDataStringId.js
@@ -7,7 +7,7 @@ import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
  * @example "test.value" → "test_value"
  * @example "hello.world test" → "hello_world_test"
  */
-const formatOptionForStringId = str => str.replace(/[\s.]/g, '_');
+const formatOptionForStringId = str => str?.replace(/[\s.]/g, '_');
 
 /**
  * Returns the stringId for a reference data option.


### PR DESCRIPTION
### Changes

We added in a new function to process special characters for the option stringIds but this has introduced a bug for some places where it the option value loads in and could be null temporarily. Here I just add a bit of defensiveness to the function to stop these new errors. 

Definitely prefer if we know the values are there before we try to render translated strings but feels a bit out of scope of this card

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
