### PR TITLE
tweak(sync): KOR-37: Migration last interacted times fixes

### DIFF
--- a/packages/database/src/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
+++ b/packages/database/src/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
@@ -27,10 +27,9 @@ export async function up(query: QueryInterface): Promise<void> {
 
   // Query uses limited syntax to match mobile sqlite migration query
   // Calculate last interaction time based on:
-  // - Patient facility creation time
-  // - Latest encounter time (if location belongs to same facility)
-  // - Latest program registration time (if for same facility)
-  // If no interaction time is found, use the patient facility creation time
+  // - Encounters in that facility for that patient
+  // - Program registrations in that facility for that patient
+  // - If no interaction time is found, use the patient facility creation time
   await query.sequelize.query(`
     WITH calculated_interaction_times AS (
       SELECT 

--- a/packages/database/src/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
+++ b/packages/database/src/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
@@ -61,7 +61,6 @@ export async function up(query: QueryInterface): Promise<void> {
       LEFT JOIN patient_program_registrations ppr
         ON pf.patient_id = ppr.patient_id
         AND pf.facility_id = ppr.registering_facility_id
-      WHERE (e.id IS NULL OR l.id IS NOT NULL OR ppr.id IS NOT NULL)
       GROUP BY pf.id, pf.created_at
     )
     UPDATE patient_facilities 

--- a/packages/mobile/App/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
+++ b/packages/mobile/App/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
@@ -27,10 +27,9 @@ export class addLastInteractedTimeToPatientFacilities1752709361030 implements Mi
 
     // Query differs from postgres version because of sqlite limitations
     // Calculate last interaction time based on:
-    // - Patient facility creation time
-    // - Latest encounter time (if location belongs to same facility)
-    // - Latest program registration time (if for same facility)
-    // If no interaction time is found, use the patient facility creation time
+    // - Encounters in that facility for that patient
+    // - Program registrations in that facility for that patient
+    // - If no interaction time is found, use the patient facility creation time
     await queryRunner.query(`
       WITH calculated_interaction_times AS (
         SELECT 

--- a/packages/mobile/App/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
+++ b/packages/mobile/App/migrations/1752709361030-addLastInteractedTimeToPatientFacilities.ts
@@ -60,7 +60,6 @@ export class addLastInteractedTimeToPatientFacilities1752709361030 implements Mi
         LEFT JOIN patient_program_registrations ppr
           ON pf.patientId = ppr.patientId
           AND pf.facilityId = ppr.registeringFacilityId
-        WHERE (e.id IS NULL OR l.id IS NOT NULL OR ppr.id IS NOT NULL)
         GROUP BY pf.id, pf.createdAt
       )
       UPDATE patient_facilities 


### PR DESCRIPTION
### Changes
- This was failing in epic to deploy 🤔 with null last_interacted_time
  - This deploys now
- These get checked in the cases
- We want each patient facility to return a date, fallback is patient_facilities created_at

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
