### PR TITLE
fix(web): TAMOC-318: coerce survey option values to string

### DIFF
--- a/packages/shared/src/utils/translation/getReferenceDataStringId.js
+++ b/packages/shared/src/utils/translation/getReferenceDataStringId.js
@@ -7,7 +7,7 @@ import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
  * @example "test.value" → "test_value"
  * @example "hello.world test" → "hello_world_test"
  */
-const formatOptionForStringId = str => str.toString().replace(/[\s.]/g, '_');
+const formatOptionForStringId = str => String(str).replace(/[\s.]/g, '_');
 
 /**
  * Returns the stringId for a reference data option.

--- a/packages/shared/src/utils/translation/getReferenceDataStringId.js
+++ b/packages/shared/src/utils/translation/getReferenceDataStringId.js
@@ -7,7 +7,7 @@ import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
  * @example "test.value" → "test_value"
  * @example "hello.world test" → "hello_world_test"
  */
-const formatOptionForStringId = str => str.replace(/[\s.]/g, '_');
+const formatOptionForStringId = str => str.toString().replace(/[\s.]/g, '_');
 
 /**
  * Returns the stringId for a reference data option.


### PR DESCRIPTION
### Changes

In #7823 we added more processing to these survey options notably to enable translations. However I think that was only really tested on string options, not on numeric options. Simple fix.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
