### PR TITLE
feat(pharmacyOrders): TAN-2522: Add checkbox for to flag if an order is a discharge prescription

### DIFF
--- a/database/model/fhir/medication_requests.md
+++ b/database/model/fhir/medication_requests.md
@@ -55,3 +55,7 @@ Information about the dosage and instructions for taking the medication.
 {% docs fhir__medication_requests__dispense_request %}
 Information about the quantity of the medication to be dispensed and the number of repeats.
 {% enddocs %}
+
+{% docs fhir__medication_requests__category %}
+The type of medication usage. Currently will only be present as 'discharge' if its a discharge prescription.
+{% enddocs %}

--- a/database/model/fhir/medication_requests.yml
+++ b/database/model/fhir/medication_requests.yml
@@ -87,3 +87,6 @@ sources:
             description: "{{ doc('fhir__generic__is_live') }} in medication_requests."
             data_tests:
               - not_null
+          - name: category
+            data_type: jsonb
+            description: "{{ doc('fhir__medication_requests__category') }}"

--- a/database/model/public/pharmacy_orders.md
+++ b/database/model/public/pharmacy_orders.md
@@ -13,3 +13,7 @@ Reference to the [encounter](#!/source/source.tamanu.tamanu.encounters) for the 
 {% docs pharmacy_orders__comments %}
 Comments provided by the clinician when placing the order.
 {% enddocs %}
+
+{% docs pharmacy_orders__is_discharge_prescription %}
+If the patient is being discharged with this prescription.
+{% enddocs %}

--- a/database/model/public/pharmacy_orders.yml
+++ b/database/model/public/pharmacy_orders.yml
@@ -56,3 +56,8 @@ sources:
             description: "{{ doc('generic__updated_at_sync_tick') }} in pharmacy_orders."
             data_tests:
               - not_null
+          - name: is_discharge_prescription
+            data_type: boolean
+            description: "{{ doc('pharmacy_orders__is_discharge_prescription') }}"
+            data_tests:
+              - not_null

--- a/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
@@ -131,6 +131,7 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
           encounterId: resources.encounter.id,
           orderingClinicianId: resources.practitioner.id,
           comments: 'Test comments',
+          isDischargePrescription: true,
         }),
       );
       const pharmacyOrderPrescription = await PharmacyOrderPrescription.create(
@@ -243,6 +244,9 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
         note: [
           {
             text: pharmacyOrder.comments,
+          },
+          {
+            text: 'discharge_prescription',
           },
         ],
       });

--- a/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
@@ -163,6 +163,14 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
             value: pharmacyOrderPrescription.id,
           },
         ],
+        category: {
+          coding: [
+            {
+              system: 'https://hl7.org/fhir/R4B/codesystem-medicationrequest-category.html',
+              code: 'discharge',
+            },
+          ],
+        },
         groupIdentifier: [
           {
             system: 'http://data-dictionary.tamanu.org/tamanu-mrid-pharmacyorder.html',
@@ -244,9 +252,6 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
         note: [
           {
             text: pharmacyOrder.comments,
-          },
-          {
-            text: 'discharge_prescription',
           },
         ],
       });

--- a/packages/database/src/migrations/1754028251662-AddIsDischargePrescriptionColumnToPharmacyOrderTable.ts
+++ b/packages/database/src/migrations/1754028251662-AddIsDischargePrescriptionColumnToPharmacyOrderTable.ts
@@ -1,0 +1,13 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('pharmacy_orders', 'is_discharge_prescription', {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn('pharmacy_orders', 'is_discharge_prescription');
+}

--- a/packages/database/src/migrations/1754352456587-AddCategoryColumnToFhirMedicationRequestTable.ts
+++ b/packages/database/src/migrations/1754352456587-AddCategoryColumnToFhirMedicationRequestTable.ts
@@ -1,0 +1,12 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn({ schema: 'fhir', tableName: 'medication_requests' }, 'category', {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn({ schema: 'fhir', tableName: 'medication_requests' }, 'category');
+}

--- a/packages/database/src/models/PharmacyOrder.ts
+++ b/packages/database/src/models/PharmacyOrder.ts
@@ -9,12 +9,14 @@ export class PharmacyOrder extends Model {
   declare orderingClinicianId: string;
   declare encounterId: string;
   declare comments?: string;
+  declare isDischargePrescription: boolean;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
       {
         id: primaryKey,
         comments: DataTypes.TEXT,
+        isDischargePrescription: DataTypes.BOOLEAN,
       },
       {
         ...options,

--- a/packages/database/src/models/fhir/FhirMedicationRequest.ts
+++ b/packages/database/src/models/fhir/FhirMedicationRequest.ts
@@ -11,6 +11,7 @@ export class FhirMedicationRequest extends FhirResource {
   declare status: string;
   declare intent: string;
   declare groupIdentifier?: Record<string, any>;
+  declare category?: Record<string, any>;
   declare subject?: Record<string, any>;
   declare encounter?: Record<string, any>;
   declare medication?: Record<string, any>;
@@ -34,6 +35,7 @@ export class FhirMedicationRequest extends FhirResource {
           allowNull: false,
         },
         groupIdentifier: DataTypes.JSONB,
+        category: DataTypes.JSONB,
         subject: DataTypes.JSONB,
         encounter: DataTypes.JSONB,
         medication: DataTypes.JSONB,

--- a/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
+++ b/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
@@ -53,14 +53,7 @@ export async function getValues(upstream: PharmacyOrderPrescription, models: Mod
     requester,
     subject,
     encounter,
-    note: pharmacyOrder.comments
-      ? [
-          new FhirAnnotation({
-            author: recorder,
-            text: pharmacyOrder.comments,
-          }),
-        ]
-      : null,
+    note: note(pharmacyOrder, recorder),
     resolved:
       requester.isResolved() &&
       recorder.isResolved() &&
@@ -208,4 +201,25 @@ function getFrequencyPeriodUnit(prescription: Prescription) {
     default:
       throw new Error(`Unmapped frequency: ${prescription.frequency}`);
   }
+}
+
+function note(pharmacyOrder: PharmacyOrder, recorder: FhirReference) {
+  const notes = [];
+  if (pharmacyOrder.comments) {
+    notes.push(
+      new FhirAnnotation({
+        author: recorder,
+        text: pharmacyOrder.comments,
+      }),
+    );
+  }
+  if (pharmacyOrder.isDischargePrescription) {
+    notes.push(
+      new FhirAnnotation({
+        author: recorder,
+        text: 'discharge_prescription',
+      }),
+    );
+  }
+  return notes.length > 0 ? notes : null;
 }

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -963,6 +963,7 @@ describe('Encounter', () => {
           .send({
             orderingClinicianId: app.user.id,
             comments,
+            isDischargePrescription: true,
             pharmacyOrderPrescriptions: [
               {
                 prescriptionId: testPrescription.id,
@@ -974,6 +975,7 @@ describe('Encounter', () => {
         expect(result).toHaveSucceeded();
         expect(result.body.id).toBeTruthy();
         expect(result.body.comments).toBe(comments);
+        expect(result.body.isDischargePrescription).toBe(true);
         expect(result.body.orderingClinicianId).toBe(app.user.id);
         const pharmacyOrderId = result.body.id;
         const pharmacyOrderPrescriptions = await models.PharmacyOrderPrescription.findAll({

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -209,13 +209,15 @@ encounter.post(
     const encounterObject = await models.Encounter.findByPk(id);
     if (!encounterObject) throw new NotFoundError();
 
-    const { orderingClinicianId, comments, pharmacyOrderPrescriptions } = body;
+    const { orderingClinicianId, comments, isDischargePrescription, pharmacyOrderPrescriptions } =
+      body;
 
     const result = await db.transaction(async () => {
       const pharmacyOrder = await models.PharmacyOrder.create({
         orderingClinicianId,
-        comments,
         encounterId: id,
+        comments,
+        isDischargePrescription,
       });
 
       await models.PharmacyOrderPrescription.bulkCreate(

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -116,7 +116,7 @@ const AlreadyOrderedMedicationsWrapper = styled.div`
 `;
 
 export const PharmacyOrderModal = React.memo(({ encounter, open, onClose, onSubmit }) => {
-  const [orderingClinicianId, setOrderingClinicianId] = useState(null);
+  const [orderingClinicianId, setOrderingClinicianId] = useState('');
   const [isDischargePrescription, setIsDischargePrescription] = useState(false);
   const [comments, setComments] = useState('');
   const [showSuccess, setShowSuccess] = useState(false);
@@ -279,14 +279,10 @@ export const PharmacyOrderModal = React.memo(({ encounter, open, onClose, onSubm
   }, [validateForm, handleSendOrder, getAlreadyOrderedPrescriptions]);
 
   const handleClose = useCallback(() => {
-    onClose();
     setTimeout(() => {
-      setShowSuccess(false);
-      setShowAlreadyOrderedConfirmation(false);
-      setComments('');
-      setPrescriptions(initialPrescriptions);
+      onClose();
     }, 200);
-  }, [initialPrescriptions, onClose]);
+  }, [onClose]);
 
   const isFormValid = validateForm();
 

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { Box } from '@material-ui/core';
+import { Box, Divider } from '@material-ui/core';
 
-import { AutocompleteInput, TextField } from '../Field';
+import { AutocompleteInput, CheckInput, TextField } from '../Field';
 import { ConfirmCancelBackRow, ConfirmCancelRow } from '../ButtonRow';
 import { useApi, useSuggester } from '../../api';
 import { useAuth } from '../../contexts/Auth';
@@ -44,9 +44,18 @@ const OrderingClinicianWrapper = styled.div`
   margin-top: 20px;
 `;
 
+const HorizontalDivider = styled(Divider)`
+  margin: 15px 0;
+`;
+
 const CommentsWrapper = styled.div`
-  margin-bottom: 20px;
   margin-top: 20px;
+`;
+
+const DischargePrescriptionWrapper = styled.div`
+  margin-top: 20px;
+  margin-bottom: 40px;
+  font-size: 14px;
 `;
 
 const DialogPrimaryText = styled.div`
@@ -58,6 +67,17 @@ const DialogPrimaryText = styled.div`
 
 const AlreadyOrderedPrimaryText = styled(DialogPrimaryText)`
   text-align: left;
+`;
+
+const DischargePrescriptionMessage = styled.div`
+  font-weight: 500;
+  color: ${Colors.textSecondary};
+  margin-bottom: 6px;
+`;
+
+const DischargePrescriptionLabel = styled.div`
+  font-size: 14px;
+  color: ${Colors.textSecondary};
 `;
 
 const DialogSecondaryText = styled.div`
@@ -97,6 +117,7 @@ const AlreadyOrderedMedicationsWrapper = styled.div`
 
 export const PharmacyOrderModal = React.memo(({ encounter, open, onClose, onSubmit }) => {
   const [orderingClinicianId, setOrderingClinicianId] = useState(null);
+  const [isDischargePrescription, setIsDischargePrescription] = useState(false);
   const [comments, setComments] = useState('');
   const [showSuccess, setShowSuccess] = useState(false);
   const [showAlreadyOrderedConfirmation, setShowAlreadyOrderedConfirmation] = useState(false);
@@ -217,6 +238,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, open, onClose, onSubm
         encounterId: encounter.id,
         orderingClinicianId,
         comments,
+        isDischargePrescription,
         pharmacyOrderPrescriptions: selectedPrescriptions.map(prescription => ({
           prescriptionId: prescription.id,
           quantity: prescription.quantity,
@@ -238,6 +260,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, open, onClose, onSubm
     encounter.id,
     orderingClinicianId,
     comments,
+    isDischargePrescription,
     prescriptions,
     api,
     refetchEncounterMedications,
@@ -442,6 +465,30 @@ export const PharmacyOrderModal = React.memo(({ encounter, open, onClose, onSubm
           data-testid="textfield-comments"
         />
       </CommentsWrapper>
+
+      <HorizontalDivider color={Colors.outline} />
+
+      <DischargePrescriptionWrapper>
+        <DischargePrescriptionMessage>
+          <TranslatedText
+            stringId="pharmacyOrder.dischargePrescription.message"
+            fallback="Check the box below if this is a discharge prescription"
+          />
+        </DischargePrescriptionMessage>
+        <CheckInput
+          name="isDischargePrescription"
+          value={isDischargePrescription}
+          onChange={e => setIsDischargePrescription(e.target.checked)}
+          label={
+            <DischargePrescriptionLabel>
+              <TranslatedText
+                stringId="pharmacyOrder.dischargePrescription.label"
+                fallback="Discharge prescription"
+              />
+            </DischargePrescriptionLabel>
+          }
+        />
+      </DischargePrescriptionWrapper>
 
       <SubmitButtonsWrapper>
         <ConfirmCancelRow

--- a/packages/web/app/views/patients/panes/EncounterMedicationPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterMedicationPane.jsx
@@ -157,6 +157,7 @@ export const EncounterMedicationPane = React.memo(({ encounter, readonly }) => {
           data-testid="medicationmodal-s2hv"
         />
         <PharmacyOrderModal
+          key={pharmacyOrderModalOpen}
           encounter={encounter}
           open={pharmacyOrderModalOpen}
           onClose={() => setPharmacyOrderModalOpen(false)}


### PR DESCRIPTION
### Changes

Just a boolean tracked on the pharmacy_order. We materialise it as a note in the FHIR MedicationRequest resource for now, as there's no clear concept in FHIR that maps to this, tho I might discuss with Megs to get a better idea of the _why_ behind this flag.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
