### PR TITLE
fix(translations): Hotfix 2.36: formatOptionForStringId safety

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamanu",
-  "version": "2.36.2",
+  "version": "2.36.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamanu",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-and-later AND BUSL-1.1",
       "dependencies": {
         "@rnx-kit/metro-resolver-symlinks": "^0.1.36",
@@ -73247,7 +73247,7 @@
     },
     "packages/api-client": {
       "name": "@tamanu/api-client",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73261,7 +73261,7 @@
     },
     "packages/build-tooling": {
       "name": "@tamanu/build-tooling",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@swc/cli": "^0.1.63",
@@ -73301,7 +73301,7 @@
     },
     "packages/central-server": {
       "name": "@tamanu/central-server",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
@@ -73636,7 +73636,7 @@
     },
     "packages/constants": {
       "name": "@tamanu/constants",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/date-fns": "^2.6.3",
@@ -73689,7 +73689,7 @@
     },
     "packages/database": {
       "name": "@tamanu/database",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73778,7 +73778,7 @@
     },
     "packages/e2e-tests": {
       "name": "@tamanu/e2e-tests",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "devDependencies": {
         "@faker-js/faker": "^9.8.0",
         "@playwright/test": "^1.42.1",
@@ -73805,7 +73805,7 @@
     },
     "packages/facility-server": {
       "name": "@tamanu/facility-server",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^7.22.4",
@@ -74344,7 +74344,7 @@
     },
     "packages/fake-data": {
       "name": "@tamanu/fake-data",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -74391,7 +74391,7 @@
     },
     "packages/mobile": {
       "name": "@tamanu/mobile",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "hasInstallScript": true,
       "dependencies": {
         "@casl/ability": "^4.1.0",
@@ -76242,7 +76242,7 @@
       }
     },
     "packages/scripts": {
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -76280,7 +76280,7 @@
     },
     "packages/settings": {
       "name": "@tamanu/settings",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -76549,7 +76549,7 @@
     },
     "packages/shared": {
       "name": "@tamanu/shared",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@casl/ability": "^6.7.1",
@@ -78598,7 +78598,7 @@
     },
     "packages/upgrade": {
       "name": "@tamanu/upgrade",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -78649,7 +78649,7 @@
     },
     "packages/utils": {
       "name": "@tamanu/utils",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "date-fns": "^4.1.0",
@@ -78724,7 +78724,7 @@
     },
     "packages/web": {
       "name": "@tamanu/web-frontend",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",

--- a/packages/shared/src/utils/translation/getReferenceDataStringId.js
+++ b/packages/shared/src/utils/translation/getReferenceDataStringId.js
@@ -7,7 +7,7 @@ import { REFERENCE_DATA_TRANSLATION_PREFIX } from '@tamanu/constants';
  * @example "test.value" → "test_value"
  * @example "hello.world test" → "hello_world_test"
  */
-const formatOptionForStringId = str => str.replace(/[\s.]/g, '_');
+const formatOptionForStringId = str => str?.replace(/[\s.]/g, '_');
 
 /**
  * Returns the stringId for a reference data option.


### PR DESCRIPTION
### Changes

Found in release 2.37 and fixed there. Porting this fix back to 2.36 where it was introduced

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
