### PR TITLE
fix(web): Fix TamanuApi session restoring

### DIFF
--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -6,24 +6,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 setup('authenticate', async ({ loginPage }) => {
-  // Start waiting for the login response before triggering the action.
-  const loginResponsePromise = loginPage.page.waitForResponse(
-    response => response.url().includes('/login') && response.status() === 200,
-  );
-
   await loginPage.goto();
-  await loginPage.login(process.env.TEST_EMAIL!, process.env.TEST_PASSWORD!);
+  await loginPage.login(process.env.TEST_EMAIL, process.env.TEST_PASSWORD);
 
-  const loginResponse = await loginResponsePromise;
-  const responseBody = await loginResponse.json();
-  const authToken = responseBody.token;
-
-  if (authToken) {
-    // Store the token in localStorage for future test runs
-    await loginPage.page.evaluate(token => {
-      localStorage.setItem('apiToken', token);
-    }, authToken);
-  }
+  // Ensure state is persisted
+  await loginPage.page.waitForTimeout(1000);
 
   // Save page context
   const authStatePath = path.join(__dirname, '../../.auth/user.json');

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -11,6 +11,7 @@ setup('authenticate', async ({ loginPage }) => {
     response => response.url().includes('/login') && response.status() === 200,
   );
 
+  await loginPage.goto();
   await loginPage.login(process.env.TEST_EMAIL!, process.env.TEST_PASSWORD!);
 
   const loginResponse = await loginResponsePromise;

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -6,11 +6,28 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 setup('authenticate', async ({ loginPage }) => {
-  await loginPage.goto();
-  await loginPage.login(process.env.TEST_EMAIL, process.env.TEST_PASSWORD);
+  let authToken: string | null = null;
 
-  // Ensure state is persisted
+  // Listen for the login API response
+  loginPage.page.on('response', async (response) => {
+    if (response.url().includes('/login')) {
+      const responseBody = await response.json();
+      authToken = responseBody.token;
+    }
+  });
+
+  await loginPage.goto();
+  await loginPage.login(process.env.TEST_EMAIL!, process.env.TEST_PASSWORD!);
+
+  // Wait for the response to be captured
   await loginPage.page.waitForTimeout(1000);
+
+  if (authToken) {
+    // Store the token in localStorage for future test runs
+    await loginPage.page.evaluate((token) => {
+      localStorage.setItem('apiToken', token);
+    }, authToken);
+  }
 
   // Save page context
   const authStatePath = path.join(__dirname, '../../.auth/user.json');

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -143,6 +143,9 @@ export class TamanuApi extends ApiClient {
     return super.setToken(token, refreshToken);
   }
 
+  // Overwrite base method to integrate with the facility-server refresh endpoint which just
+  // checks for an apiToken and returns a new one. This should be removed when refresh tokens are
+  // set up in facility-server
   async refreshToken(config = {}) {
     const response = await this.post(
       'refresh',

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -49,7 +49,6 @@ function restoreFromLocalStorage() {
 }
 
 function saveToLocalStorage({
-  token,
   localisation,
   server,
   availableFacilities,
@@ -58,9 +57,6 @@ function saveToLocalStorage({
   role,
   settings,
 }) {
-  if (token) {
-    localStorage.setItem(TOKEN, token);
-  }
   if (facilityId) {
     localStorage.setItem(FACILITY_ID, facilityId);
   }
@@ -192,9 +188,8 @@ export class TamanuApi extends ApiClient {
 
   async login(email, password) {
     const output = await super.login(email, password);
-    const { localisation, server, availableFacilities, permissions, role, token } = output;
+    const { localisation, server, availableFacilities, permissions, role } = output;
     saveToLocalStorage({
-      token,
       localisation,
       server,
       availableFacilities,


### PR DESCRIPTION
### Changes

Fix a regression in a recent PR [here](https://github.com/beyondessential/tamanu/pull/8109) where apiTokens are no longer stored in local storage after login on Tamanu Web. Additionally overwrite the refresh functionality of TamanuApi to integrate with facility-server refresh endpoint.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
