### PR TITLE
fix(fhir): TAN-2514: Fix Lab Requests not being immediately sent to SENAITE

### DIFF
--- a/packages/central-server/__tests__/tasks/fhir/resolver.test.js
+++ b/packages/central-server/__tests__/tasks/fhir/resolver.test.js
@@ -1,0 +1,35 @@
+import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
+import { sortResourcesInDependencyOrder } from '../../../dist/tasks/fhir/resolver';
+import { createTestContext } from '../../utilities';
+import { FHIR_INTERACTIONS } from '@tamanu/constants';
+
+describe('sortResourcesInDependencyOrder', () => {
+  let ctx;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+  });
+
+  afterAll(() => ctx.close());
+
+  it('should sort resources in dependency order', () => {
+    const materialisableResources = resourcesThatCanDo(
+      models,
+      FHIR_INTERACTIONS.INTERNAL.MATERIALISE,
+    );
+    const sorted = sortResourcesInDependencyOrder(materialisableResources);
+
+    expect(sorted.map(r => r.name)).toEqual([
+      'FhirOrganization',
+      'FhirPatient',
+      'FhirPractitioner',
+      'FhirSpecimen',
+      'MediciReport',
+      'FhirEncounter',
+      'FhirImmunization',
+      'FhirServiceRequest',
+    ]);
+  });
+});

--- a/packages/central-server/app/tasks/fhir/resolver.js
+++ b/packages/central-server/app/tasks/fhir/resolver.js
@@ -8,7 +8,7 @@ const buildDependencyMap = resources =>
     return acc;
   }, {});
 
-const sortResourcesInDependencyOrder = resources => {
+export const sortResourcesInDependencyOrder = resources => {
   const dependencyMap = buildDependencyMap(resources);
 
   const sorted = [];

--- a/packages/central-server/app/tasks/fhir/resolver.js
+++ b/packages/central-server/app/tasks/fhir/resolver.js
@@ -1,6 +1,43 @@
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
+import { isEqual, keyBy } from 'lodash';
+
+const buildDependencyMap = resources =>
+  resources.reduce((acc, resource) => {
+    acc[resource.name] = resource.referencedResources.map(r => r.name);
+    return acc;
+  }, {});
+
+const sortResourcesInDependencyOrder = resources => {
+  const dependencyMap = buildDependencyMap(resources);
+
+  const sorted = [];
+  const stillToSort = keyBy(resources, 'name');
+  let previousPass = { ...stillToSort }; // Used to detect if we've made any changes in this pass
+
+  while (Object.keys(stillToSort).length > 0) {
+    Object.values(stillToSort).forEach(model => {
+      const modelName = model.name;
+      const dependsOn = dependencyMap[modelName] || [];
+      const dependenciesStillToSort = dependsOn.filter(d => !!stillToSort[d]);
+
+      if (dependenciesStillToSort.length === 0) {
+        sorted.push(model);
+        delete stillToSort[modelName];
+      }
+    });
+
+    if (isEqual(previousPass, stillToSort)) {
+      // If nothing changes in a pass, we're stuck in a loop
+      throw new Error(`Circular dependency detected: ${Object.keys(stillToSort).join(', ')}`);
+    }
+
+    previousPass = { ...stillToSort };
+  }
+
+  return sorted;
+};
 
 export async function resolver(_, { log, sequelize, models }) {
   await sleepAsync(3000); // sleep for 3 seconds to allow materialisation jobs to complete
@@ -12,8 +49,9 @@ export async function resolver(_, { log, sequelize, models }) {
 
   log.debug('Starting resolve');
   await sequelize.transaction(async () => {
-    for (const Resource of materialisableResources) {
-      await Resource.resolveUpstreams();
+    const sortedResources = sortResourcesInDependencyOrder(materialisableResources);
+    for (const resource of sortedResources) {
+      await resource.resolveUpstreams();
     }
   });
 

--- a/packages/central-server/config/test.json5
+++ b/packages/central-server/config/test.json5
@@ -108,7 +108,7 @@
           "Encounter": true,
           "Immunization": true,
           "Practitioner": true,
-          "MediciReport": false,
+          "MediciReport": true,
           "Specimen": true,
           "Organization": true
         }

--- a/packages/database/src/models/fhir/FhirEncounter.ts
+++ b/packages/database/src/models/fhir/FhirEncounter.ts
@@ -2,9 +2,7 @@ import { DataTypes } from 'sequelize';
 
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
 import { FhirResource } from './Resource';
-import {
-  FhirReference,
-} from '@tamanu/shared/services/fhirTypes';
+import { FhirReference } from '@tamanu/shared/services/fhirTypes';
 import {
   getQueryOptions,
   getValues,
@@ -46,6 +44,7 @@ export class FhirEncounter extends FhirResource {
       models.Location,
       models.LocationGroup,
     ];
+    this.referencedResources = [models.FhirPatient, models.FhirOrganization];
   }
 
   static CAN_DO = new Set([

--- a/packages/database/src/models/fhir/FhirImmunization.ts
+++ b/packages/database/src/models/fhir/FhirImmunization.ts
@@ -58,6 +58,7 @@ export class FhirImmunization extends FhirResource {
       models.ScheduledVaccine,
       models.User,
     ];
+    this.referencedResources = [models.FhirPatient, models.FhirEncounter, models.FhirPractitioner];
   }
 
   static CAN_DO = new Set([

--- a/packages/database/src/models/fhir/FhirPatient.ts
+++ b/packages/database/src/models/fhir/FhirPatient.ts
@@ -1,9 +1,7 @@
 import { DataTypes, type InitOptions } from 'sequelize';
 
 import { FHIR_INTERACTIONS } from '@tamanu/constants';
-import {
-  FhirReference,
-} from '@tamanu/shared/services/fhirTypes';
+import { FhirReference } from '@tamanu/shared/services/fhirTypes';
 import { FhirResource } from './Resource';
 import type { Models } from '../../types/model';
 import {
@@ -52,6 +50,9 @@ export class FhirPatient extends FhirResource {
 
     this.UpstreamModels = [models.Patient];
     this.upstreams = [models.Patient, models.PatientAdditionalData];
+    this.referencedResources = [
+      // FhirPatients can reference eachother, but not flagging here to avoid a circular dependency
+    ];
   }
 
   static CAN_DO = new Set([
@@ -71,7 +72,7 @@ export class FhirPatient extends FhirResource {
     const mergedUp = await upstream?.getMergedUp();
     const mergedDown = await upstream?.getMergedDown();
 
-    return [...(mergedUp?.map((u) => u.id) || []), ...(mergedDown?.map((u) => u.id) || [])];
+    return [...(mergedUp?.map(u => u.id) || []), ...(mergedDown?.map(u => u.id) || [])];
   }
 
   static async queryToFindUpstreamIdsFromTable(
@@ -99,7 +100,8 @@ export class FhirPatient extends FhirResource {
     // Although that should not really happen, but it's better to be safe and not
     // expose the upstream link data.
     resource.link = resource.link.filter(
-      (link: Record<string, any>) => link.other.type !== FhirReference.unresolvedReferenceType(FhirPatient),
+      (link: Record<string, any>) =>
+        link.other.type !== FhirReference.unresolvedReferenceType(FhirPatient),
     );
     return resource;
   }

--- a/packages/database/src/models/fhir/FhirServiceRequest.ts
+++ b/packages/database/src/models/fhir/FhirServiceRequest.ts
@@ -78,6 +78,12 @@ export class FhirServiceRequest extends FhirResource {
       models.LabTestPanel,
       models.Note,
     ];
+    this.referencedResources = [
+      models.FhirPatient,
+      models.FhirEncounter,
+      models.FhirPractitioner,
+      models.FhirSpecimen,
+    ];
   }
 
   static CAN_DO = new Set([

--- a/packages/database/src/models/fhir/FhirSpecimen.ts
+++ b/packages/database/src/models/fhir/FhirSpecimen.ts
@@ -28,6 +28,10 @@ export class FhirSpecimen extends FhirResource {
 
     this.UpstreamModels = [models.LabRequest];
     this.upstreams = [models.LabRequest];
+    this.referencedResources = [
+      models.FhirPractitioner,
+      // FhirServiceRequest is also referenced by Specimen, but not flagging here to avoid a circular dependency
+    ];
   }
 
   static CAN_DO = new Set([

--- a/packages/database/src/models/fhir/Resource.ts
+++ b/packages/database/src/models/fhir/Resource.ts
@@ -90,6 +90,9 @@ export class FhirResource extends Model {
   // list of Tamanu models that are used to materialise this resource
   static upstreams: (typeof Model)[] = [];
 
+  // list of FHIR resources that are referenced by this resource
+  static referencedResources: (typeof Model)[] = [];
+
   // switch to true if the upstream's ID is the UUID pg type
   static UPSTREAM_UUID = false;
 

--- a/packages/database/src/utils/fhir/ServiceRequest/getValues.ts
+++ b/packages/database/src/utils/fhir/ServiceRequest/getValues.ts
@@ -39,10 +39,10 @@ async function getValuesFromImagingRequest(upstream: ImagingRequest, models: Mod
     (
       await ImagingAreaExternalCode.findAll({
         where: {
-          areaId: upstream.areas.map((area) => area.id),
+          areaId: upstream.areas.map(area => area.id),
         },
       })
-    ).map((ext) => [
+    ).map(ext => [
       ext.areaId,
       { code: ext.code, description: ext.description, updatedAt: ext.updatedAt },
     ]),
@@ -143,7 +143,7 @@ async function getValuesFromLabRequest(upstream: LabRequest, models: Models) {
     ],
     priority: validatePriority(upstream.priority?.name),
     code: labCode(upstream),
-    orderDetail: await labOrderDetails(upstream),
+    orderDetail: labOrderDetails(upstream),
     subject,
     encounter,
     occurrenceDateTime: formatFhirDate(upstream.requestedDate),
@@ -307,7 +307,7 @@ function labOrderDetails({ tests }: LabRequest) {
 }
 
 function labAnnotations(upstream: LabRequest) {
-  return upstream.notes.map((note) => {
+  return upstream.notes.map(note => {
     return new FhirAnnotation({
       time: formatFhirDate(note.date),
       text: note.content,


### PR DESCRIPTION
### Changes

The issue previously is that we were resolving resources with no respect to the order that they depend on one another. However, a resource can only be resolved if all of its dependencies have already been resolved. This meant that the resolver may need to run multiple times to resolve a resource.

Now we sort the resources in dependency order before we begin resolving, much like what we do with sync persisting. 

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
