### PR TITLE
fix: EPI-1263: resolve medication set errors

### DIFF
--- a/packages/central-server/app/admin/exporter/modelExporters/MedicationTemplateExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/MedicationTemplateExporter.js
@@ -26,7 +26,7 @@ export class MedicationTemplateExporter extends ReferenceDataExporter {
         medication: medicationId,
         prnMedication: isPrn,
         doseAmount: isVariableDose ? 'variable' : doseAmount,
-        duration: `${durationValue} ${durationUnit}`,
+        duration: durationValue ? `${durationValue} ${durationUnit}` : null,
       };
     });
   }

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -33,16 +33,16 @@ const existingRecordLoaders = {
   PatientAdditionalData: (PAD, { patientId }) => PAD.findByPk(patientId, { paranoid: false }),
   // PatientFieldValue model has a composite PK that uses patientId & definitionId
   PatientFieldValue: (PFV, { patientId, definitionId }) =>
-    PFV.findOne({ where: { patientId, definitionId } }, { paranoid: false }),
+    PFV.findOne({ where: { patientId, definitionId }, paranoid: false }),
   // TranslatedString model has a composite PK that uses stringId & language
   TranslatedString: (TS, { stringId, language }) =>
-    TS.findOne({ where: { stringId, language } }, { paranoid: false }),
+    TS.findOne({ where: { stringId, language }, paranoid: false }),
   ReferenceDataRelation: (RDR, { referenceDataId, referenceDataParentId, type }) =>
-    RDR.findOne({ where: { referenceDataId, referenceDataParentId, type } }, { paranoid: false }),
+    RDR.findOne({ where: { referenceDataId, referenceDataParentId, type }, paranoid: false }),
   TaskTemplateDesignation: (TTD, { taskTemplateId, designationId }) =>
-    TTD.findOne({ where: { taskTemplateId, designationId } }, { paranoid: false }),
+    TTD.findOne({ where: { taskTemplateId, designationId }, paranoid: false }),
   UserDesignation: (UD, { userId, designationId }) =>
-    UD.findOne({ where: { userId, designationId } }, { paranoid: false }),
+    UD.findOne({ where: { userId, designationId }, paranoid: false }),
 };
 
 function loadExisting(Model, values) {

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -555,6 +555,19 @@ export async function medicationSetLoader(item, { models, pushError }) {
     .map((id) => id.trim())
     .filter(Boolean);
 
+  const duplicateIds = medicationTemplateIds.filter(
+    (templateId, index) => medicationTemplateIds.indexOf(templateId) !== index
+  );
+  
+  if (duplicateIds.length > 0) {
+    const uniqueDuplicates = [...new Set(duplicateIds)];
+    pushError(
+      `Duplicate medication template IDs found in medication set "${id}": ${uniqueDuplicates.join(', ')}.`
+    );
+
+    return rows;
+  }
+
   let existingTemplateIds = [];
   if (medicationTemplateIds.length > 0) {
     const existingTemplates = await models.ReferenceData.findAll({

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -19,7 +19,7 @@ function stripNotes(fields) {
   return values;
 }
 
-export const loaderFactory = (model) => (fields) => [{ model, values: stripNotes(fields) }];
+export const loaderFactory = model => fields => [{ model, values: stripNotes(fields) }];
 
 export function referenceDataLoaderFactory(type) {
   return ({ id, code, name, visibilityStatus }) => [
@@ -44,8 +44,8 @@ export function patientFieldDefinitionLoader(values) {
         ...stripNotes(values),
         options: (values.options || '')
           .split(',')
-          .map((v) => v.trim())
-          .filter((v) => v !== ''),
+          .map(v => v.trim())
+          .filter(v => v !== ''),
       },
     },
   ];
@@ -93,7 +93,7 @@ export function administeredVaccineLoader(item) {
 
         date,
         reason,
-        consent: ['true', 'yes', 't', 'y'].some((v) => v === consent?.toLowerCase()),
+        consent: ['true', 'yes', 't', 'y'].some(v => v === consent?.toLowerCase()),
         ...data,
 
         // relationships
@@ -153,7 +153,7 @@ export async function patientDataLoader(item, { models, foreignKeySchemata }) {
     // Foreign keys will not appear as they are under rawAttributes (i.e: village -> villageId)
     if (
       predefinedPatientFields.includes(definitionId) ||
-      foreignKeySchemata.Patient.find((schema) => schema.field === definitionId) ||
+      foreignKeySchemata.Patient.find(schema => schema.field === definitionId) ||
       !value
     )
       continue;
@@ -271,8 +271,8 @@ export function labTestPanelLoader(item) {
 
   (testTypesInPanel || '')
     .split(',')
-    .map((t) => t.trim())
-    .forEach((testType) => {
+    .map(t => t.trim())
+    .forEach(testType => {
       rows.push({
         model: 'LabTestPanelLabTestTypes',
         values: {
@@ -290,13 +290,13 @@ export const taskSetLoader = async (item, { models, pushError }) => {
   const { id: taskSetId, tasks: taskIdsString } = item;
   const taskIds = taskIdsString
     .split(',')
-    .map((taskId) => taskId.trim())
+    .map(taskId => taskId.trim())
     .filter(Boolean);
 
   const existingTaskIds = await models.ReferenceData.findAll({
     where: { id: { [Op.in]: taskIds } },
-  }).then((tasks) => tasks.map(({ id }) => id));
-  const nonExistentTaskIds = taskIds.filter((taskId) => !existingTaskIds.includes(taskId));
+  }).then(tasks => tasks.map(({ id }) => id));
+  const nonExistentTaskIds = taskIds.filter(taskId => !existingTaskIds.includes(taskId));
   if (nonExistentTaskIds.length > 0) {
     pushError(`Tasks ${nonExistentTaskIds.join(', ')} not found`);
   }
@@ -313,7 +313,7 @@ export const taskSetLoader = async (item, { models, pushError }) => {
   });
 
   // Upsert tasks that are in task set
-  const rows = existingTaskIds.map((taskId) => ({
+  const rows = existingTaskIds.map(taskId => ({
     model: 'ReferenceDataRelation',
     values: {
       referenceDataId: taskId,
@@ -330,7 +330,7 @@ export async function userLoader(item, { models, pushError }) {
   const rows = [];
 
   const allowedFacilityIds = allowedFacilities
-    ? allowedFacilities.split(',').map((t) => t.trim())
+    ? allowedFacilities.split(',').map(t => t.trim())
     : [];
 
   rows.push({
@@ -348,10 +348,10 @@ export async function userLoader(item, { models, pushError }) {
 
   if (existingUser) {
     const idsToBeDeleted = existingUser.facilities
-      .map((f) => f.id)
-      .filter((id) => !allowedFacilityIds.includes(id));
+      .map(f => f.id)
+      .filter(id => !allowedFacilityIds.includes(id));
 
-    idsToBeDeleted.forEach((facilityId) => {
+    idsToBeDeleted.forEach(facilityId => {
       rows.push({
         model: 'UserFacility',
         values: {
@@ -364,7 +364,7 @@ export async function userLoader(item, { models, pushError }) {
     });
   }
 
-  allowedFacilityIds.forEach((facilityId) => {
+  allowedFacilityIds.forEach(facilityId => {
     rows.push({
       model: 'UserFacility',
       values: {
@@ -377,7 +377,7 @@ export async function userLoader(item, { models, pushError }) {
 
   const designationIds = (designations || '')
     .split(',')
-    .map((d) => d.trim())
+    .map(d => d.trim())
     .filter(Boolean);
 
   if (id) {
@@ -435,7 +435,7 @@ export async function taskTemplateLoader(item, { models, pushError }) {
 
   const designationIds = (assignedTo || '')
     .split(',')
-    .map((d) => d.trim())
+    .map(d => d.trim())
     .filter(Boolean);
 
   await models.TaskTemplateDesignation.destroy({
@@ -443,7 +443,7 @@ export async function taskTemplateLoader(item, { models, pushError }) {
   });
 
   const existingDesignationIds = await models.ReferenceData.findByIds(designationIds).then(
-    (designations) => designations.map((d) => d.id),
+    designations => designations.map(d => d.id),
   );
   for (const designationId of designationIds) {
     if (!existingDesignationIds.includes(designationId)) {
@@ -552,20 +552,18 @@ export async function medicationSetLoader(item, { models, pushError }) {
 
   const medicationTemplateIds = (medicationTemplateIdsString || '')
     .split(',')
-    .map((id) => id.trim())
+    .map(id => id.trim())
     .filter(Boolean);
 
   const duplicateIds = medicationTemplateIds.filter(
-    (templateId, index) => medicationTemplateIds.indexOf(templateId) !== index
+    (templateId, index) => medicationTemplateIds.indexOf(templateId) !== index,
   );
-  
+
   if (duplicateIds.length > 0) {
     const uniqueDuplicates = [...new Set(duplicateIds)];
     pushError(
-      `Duplicate medication template IDs found in medication set "${id}": ${uniqueDuplicates.join(', ')}.`
+      `Duplicate medication template IDs found in medication set "${id}": ${uniqueDuplicates.join(', ')}.`,
     );
-
-    return rows;
   }
 
   let existingTemplateIds = [];
@@ -579,7 +577,7 @@ export async function medicationSetLoader(item, { models, pushError }) {
     existingTemplateIds = existingTemplates.map(({ id }) => id);
 
     const nonExistentTemplateIds = medicationTemplateIds.filter(
-      (id) => !existingTemplateIds.includes(id),
+      id => !existingTemplateIds.includes(id),
     );
     if (nonExistentTemplateIds.length > 0) {
       pushError(


### PR DESCRIPTION
### Changes

- Handle null duration when exporting medication templates
- Fix issue when re-adding deleted medication templates to a set
- Add validation to prevent duplicate medication templates in a set

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
