### PR TITLE
Update medication route label

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
@@ -444,7 +444,7 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                 <Field
                   component={Dropdown}
                   name="route"
-                  label={<TranslatedText stringId="medication.route.label" fallback="Route" />}
+                  label={<TranslatedText stringId="medication.route.label" fallback="Route of administration" />}
                   selectPlaceholderText={getTranslation('general.placeholder.select', 'Select')}
                   options={routeOptions}
                   required

--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -532,7 +532,7 @@ const EncounterRecordPrintoutComponent = ({
       },
       {
         key: 'route',
-        title: getTranslation('medication.route.label', 'Route'),
+        title: getTranslation('medication.route.label', 'Route of administration'),
         accessor: ({ route }) => (route ? getEnumTranslation(DRUG_ROUTE_LABELS, route) : ''),
         style: { width: '10%' },
       },

--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -181,7 +181,7 @@ const MEDICATION_COLUMNS = (getTranslation, getEnumTranslation, disableTooltip) 
   },
   {
     key: 'route',
-    title: <TranslatedText stringId="medication.route.label" fallback="Route" />,
+    title: <TranslatedText stringId="medication.route.label" fallback="Route of administration" />,
     accessor: ({ route, encounterPrescription, discontinued }) => {
       const pauseData = encounterPrescription?.pausePrescriptions?.[0];
       const isPausing = !!pauseData && !discontinued;

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -806,7 +806,7 @@ export const MedicationForm = ({
             />
             <Field
               name="route"
-              label={<TranslatedText stringId="medication.route.label" fallback="Route" />}
+              label={<TranslatedText stringId="medication.route.label" fallback="Route of administration" />}
               component={TranslatedSelectField}
               enumValues={DRUG_ROUTE_LABELS}
               required


### PR DESCRIPTION
### Changes

Updates the label for medication 'Route' fields to 'Route of administration' in the 'New prescription' and 'Add ongoing medication' forms, the encounter level medications table, and related components. This addresses EPI-1258.

Note: The label 'Route of admission' was not found in the codebase. This change updates the existing fallback text for the `medication.route.label` string ID from 'Route' to 'Route of administration'.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- [ ] ...write or update tests
- [ ] ...add UI screenshots and **testing notes** to the Linear issue
- [ ] ...add any **manual upgrade steps** to the Linear issue
- [ ] ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- [ ] ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
<a href="https://cursor.com/background-agent?bcId=bc-2f02e428-2e95-4959-9ab3-acb0761edf95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f02e428-2e95-4959-9ab3-acb0761edf95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

