### PR TITLE
fix(permissions): TAMOC-324: Fix importing Medication permissions HOTFIX 2.34

### DIFF
--- a/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
+++ b/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
@@ -1,0 +1,22 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(
+    `
+      UPDATE permissions
+      SET id = REPLACE(id, 'encountermedication', 'medication')
+      WHERE id LIKE '%encountermedication%';
+    `,
+  );
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(
+    `
+      UPDATE permissions
+      SET id = REPLACE(id, 'medication', 'encountermedication')
+      WHERE id LIKE '%medication%' 
+        AND id NOT LIKE '%encountermedication%';
+    `,
+  );
+}

--- a/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
+++ b/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
@@ -11,7 +11,7 @@ export async function up(query: QueryInterface): Promise<void> {
   );
 }
 
-export async function down(query: QueryInterface): Promise<void> {
+export async function down(): Promise<void> {
   // It's not possible to reverse the migration to its original state,
   //
   // An edge case:

--- a/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
+++ b/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
@@ -5,7 +5,8 @@ export async function up(query: QueryInterface): Promise<void> {
     `
       UPDATE permissions
       SET id = REPLACE(id, 'encountermedication', 'medication')
-      WHERE id LIKE '%encountermedication%';
+      WHERE id LIKE '%encountermedication%'
+      AND noun = 'Medication';
     `,
   );
 }
@@ -16,7 +17,8 @@ export async function down(query: QueryInterface): Promise<void> {
       UPDATE permissions
       SET id = REPLACE(id, 'medication', 'encountermedication')
       WHERE id LIKE '%medication%' 
-        AND id NOT LIKE '%encountermedication%';
+        AND id NOT LIKE '%encountermedication%'
+        AND noun = 'Medication';
     `,
   );
 }

--- a/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
+++ b/packages/database/src/migrations/1754523298680-updateMedicationPermissionIds.ts
@@ -12,13 +12,19 @@ export async function up(query: QueryInterface): Promise<void> {
 }
 
 export async function down(query: QueryInterface): Promise<void> {
-  await query.sequelize.query(
-    `
-      UPDATE permissions
-      SET id = REPLACE(id, 'medication', 'encountermedication')
-      WHERE id LIKE '%medication%' 
-        AND id NOT LIKE '%encountermedication%'
-        AND noun = 'Medication';
-    `,
-  );
+  // It's not possible to reverse the migration to its original state,
+  //
+  // An edge case:
+  // practitioner.medication.read.any (noun = 'Medication')
+  // admin.encountermedication.write.any (noun = 'Medication')
+  //
+  // After up:
+  // practitioner.medication.read.any (unchanged - doesn't contain 'encountermedication')
+  // admin.medication.write.any (changed from 'encountermedication' -> 'medication')
+  //
+  // After down:
+  // practitioner.encountermedication.read.any (WRONG! This was never 'encountermedication')
+  // admin.encountermedication.write.any (correct reversal)
+  //
+  // This is an edge case that we can't reverse. So leaving down migration empty.
 }


### PR DESCRIPTION
### Changes
- Fix importing Medication permissions

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
