### PR TITLE
fix(medici): TAN-2536: Fixed timestamps in Medici Reports (hotfix 2.30)

### DIFF
--- a/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
+++ b/packages/central-server/__tests__/integrations/fijiAspenMediciReport/fijiAspenMediciReport.test.js
@@ -489,9 +489,9 @@ describe('fijiAspenMediciReport', () => {
         encounterId,
         patientBillingType: 'Public',
         // Note that seconds is the highest level of precision - so the milliseconds are truncated
-        encounterStartDate: '2022-06-09T00:02:54.000Z',
-        encounterEndDate: '2022-06-12T00:02:54.000Z',
-        dischargeDate: '2022-06-12T00:02:54.000Z',
+        encounterStartDate: '2022-06-09T00:02:54+00:00',
+        encounterEndDate: '2022-06-12T00:02:54+00:00',
+        dischargeDate: '2022-06-12T00:02:54+00:00',
         encounterType: [
           {
             startDate: expect.stringMatching(isoStringRegex),

--- a/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
+++ b/packages/central-server/app/integrations/fijiAspenMediciReport/routes.js
@@ -28,7 +28,7 @@ function formatDate(date) {
 
 const reportQuery = `
 SELECT 
-  last_updated,
+  last_updated::timestamptz at time zone 'UTC' as last_updated,
   patient_id,
   first_name,
   last_name,
@@ -82,7 +82,7 @@ ORDER BY last_updated DESC
 LIMIT $limit OFFSET $offset;
 `;
 
-const parseDateParam = date => {
+const parseDateParam = (date) => {
   const { plain: parsedDate } = parseDateTime(date, { withTz: COUNTRY_TIMEZONE });
   return parsedDate || null;
 };
@@ -145,42 +145,42 @@ routes.get(
       },
     });
 
-    const mapNotes = notes =>
-      notes?.map(note => ({
+    const mapNotes = (notes) =>
+      notes?.map((note) => ({
         ...note,
         noteDate: formatDate(note.noteDate),
       }));
-    const mappedData = data.map(encounterData => {
+    const mappedData = data.map((encounterData) => {
       const encounter = mapKeys(encounterData, (_v, k) => camelCase(k));
       return {
         ...encounter,
         weight: parseFloat(encounter.weight),
-        encounterStartDate: new Date(encounter.encounterStartDate).toISOString(),
-        encounterEndDate: new Date(encounter.encounterEndDate).toISOString(),
-        dischargeDate: new Date(encounter.dischargeDate).toISOString(),
+        encounterStartDate: formatDate(new Date(encounter.encounterStartDate)),
+        encounterEndDate: formatDate(new Date(encounter.encounterEndDate)),
+        dischargeDate: formatDate(new Date(encounter.dischargeDate)),
         sex: upperFirst(encounter.sex),
-        departments: encounter.departments?.map(department => ({
+        departments: encounter.departments?.map((department) => ({
           ...department,
           assignedTime: formatDate(department.assignedTime),
         })),
-        locations: encounter.locations?.map(location => ({
+        locations: encounter.locations?.map((location) => ({
           ...location,
           assignedTime: formatDate(location.assignedTime),
         })),
-        imagingRequests: encounter.imagingRequests?.map(ir => ({
+        imagingRequests: encounter.imagingRequests?.map((ir) => ({
           ...ir,
           notes: mapNotes(ir.notes),
         })),
-        labRequests: encounter.labRequests?.map(lr => ({
+        labRequests: encounter.labRequests?.map((lr) => ({
           ...lr,
           notes: mapNotes(lr.notes),
         })),
-        procedures: encounter.procedures?.map(procedure => ({
+        procedures: encounter.procedures?.map((procedure) => ({
           ...procedure,
           date: formatDate(procedure.date),
         })),
         notes: mapNotes(encounter.notes),
-        encounterType: encounter.encounterType?.map(encounterType => ({
+        encounterType: encounter.encounterType?.map((encounterType) => ({
           ...encounterType,
           startDate: formatDate(encounterType.startDate),
         })),


### PR DESCRIPTION
### Changes

Standardise timestamp format and fix issue where `lastUpdated` showed incorrectly offset by the time difference from UTC

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
