### PR TITLE
fix(audit): TAMOC-325: Improve performance of syncing audit logs

### DIFF
--- a/packages/utils/src/runFunctionInBatches.ts
+++ b/packages/utils/src/runFunctionInBatches.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_BATCH_SIZE = 10000;
+
+export async function runFunctionInBatches<T, R>(
+  arrayToBeBatched: T[],
+  functionToRun: (batch: T[]) => Promise<R[]>,
+  batchSize = DEFAULT_BATCH_SIZE,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < arrayToBeBatched.length; i += batchSize) {
+    const batch = arrayToBeBatched.slice(i, i + batchSize);
+    const chunkedResult = await functionToRun(batch);
+    results.push(...chunkedResult);
+  }
+  return results;
+}


### PR DESCRIPTION
### Changes
- TAMOC-325: Improve performance of syncing audit logs

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
