### PR TITLE
tweak(dev): no-issue: Add "tamanu" to the spellcheck dictionary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.language": "en-GB",
-  "cSpell.words": ["clearable", "Formik", "ilike", "singularize", "upsert", "upserted", "tamanu"],
+  "cSpell.words": ["clearable", "Formik", "ilike", "singularize", "tamanu", "upsert", "upserted"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.experimental.useFlatConfig": true,
   "eslint.lintTask.enable": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.language": "en-GB",
-  "cSpell.words": ["clearable", "Formik", "ilike", "singularize", "upsert", "upserted"],
+  "cSpell.words": ["clearable", "Formik", "ilike", "singularize", "upsert", "upserted", "tamanu"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.experimental.useFlatConfig": true,
   "eslint.lintTask.enable": true,


### PR DESCRIPTION
### Changes

Stop the cSpell error for mentions of `Tamanu`

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
