### PR TITLE
fix(upgrade): TAMOC-328: Fix upgrade steps being run every time HOTFIX (2.36)

### DIFF
--- a/packages/upgrade/src/index.ts
+++ b/packages/upgrade/src/index.ts
@@ -107,7 +107,9 @@ export async function upgrade({
     const beforeMigrations = onlyMigrations(step.before);
     if (
       beforeMigrations.length > 0 &&
-      beforeMigrations.every((need) => doneMigrations.some((mig) => mig.testFileName(need)))
+      beforeMigrations.every(need =>
+        doneMigrations.some(mig => mig.testFileName(migrationFile(need))),
+      )
     ) {
       logger.debug('Step has no before:Migration that has not already run, skipping');
       continue;
@@ -118,7 +120,9 @@ export async function upgrade({
     const afterMigrations = onlyMigrations(step.after);
     if (
       afterMigrations.length > 0 &&
-      afterMigrations.every((need) => doneMigrations.some((mig) => mig.testFileName(need)))
+      afterMigrations.every(need =>
+        doneMigrations.some(mig => mig.testFileName(migrationFile(need))),
+      )
     ) {
       logger.debug('Step has no after:Migration that had not already run, skipping');
       continue;


### PR DESCRIPTION
### Changes
- TAMOC-328: Fix upgrade steps being run every time HOTFIX (2.36)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
