### PR TITLE
fix(desktopCharting): SAV-691: One last permission change

### DIFF
--- a/packages/web/app/components/ChartsTable.jsx
+++ b/packages/web/app/components/ChartsTable.jsx
@@ -54,7 +54,7 @@ export const ChartsTable = React.memo(({
   const [selectedCell, setSelectedCell] = useState(null);
   const { getSetting } = useSettings();
   const isChartingEditEnabled = getSetting(SETTING_KEYS.FEATURES_ENABLE_CHARTING_EDIT);
-  const hasWritePermission = ability.can('write', subject('Charting', { id: selectedSurveyId }));
+  const hasReadPermission = ability.can('read', subject('Charting', { id: selectedSurveyId }));
   const showFooterLegend = data.some((entry) =>
     recordedDates.some((date) => entry[date].historyLogs.length > 1),
   );
@@ -70,7 +70,7 @@ export const ChartsTable = React.memo(({
     patient,
     recordedDates,
     onCellClick,
-    isChartingEditEnabled && hasWritePermission,
+    isChartingEditEnabled && hasReadPermission,
   );
 
   // There is a bug in react-query that even if the query is not enabled, it will still return isLoading = true

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -129,9 +129,10 @@ export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose, isVital 
     : getSetting(SETTING_KEYS.FEATURES_MANDATORY_CHARTING_EDIT_REASON);
   const vitalEditReasons = getSetting(SETTING_KEYS.VITAL_EDIT_REASONS);
   const permissionVerb = dataPoint.answerId ? 'write' : 'create';
-  const hasPermission = isVital
-    ? ability.can(permissionVerb, 'Vitals')
-    : ability.can(permissionVerb, subject('Charting', { id: dataPoint.component.surveyId }));
+  const permissionSubject = isVital
+    ? 'Vitals'
+    : subject('Charting', { id: dataPoint.component.surveyId });
+  const hasPermission = ability.can(permissionVerb, permissionSubject);
 
   const initialValue = dataPoint.value;
   const showDeleteEntryButton = !['', undefined].includes(initialValue);


### PR DESCRIPTION
### Changes

Given that the edit log is within the edit modal, the decision is that you should be able to read to click on it. I just disabled everything else to make it clear about what can/can't be done (though we also have server checks so not really an issue).