### PR TITLE
fix: release-2.36: EPI-1272: Viewing pharmacy note notification causes old medication to reappear after modal confirmation

### DIFF
--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { format } from 'date-fns';
 import { Box } from '@material-ui/core';
 import { DRUG_ROUTE_LABELS, MEDICATION_DURATION_DISPLAY_UNITS_LABELS } from '@tamanu/constants';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { getDose, getTranslatedFrequency } from '@tamanu/shared/utils/medication';
 
 import { DataFetchingTable } from '../Table';
@@ -258,6 +258,7 @@ export const EncounterMedicationTable = ({
   canImportOngoingPrescriptions,
   onImportOngoingPrescriptions,
 }) => {
+  const history = useHistory();
   const location = useLocation();
   const api = useApi();
   const { ability } = useAuth();
@@ -275,6 +276,7 @@ export const EncounterMedicationTable = ({
     const openMedicationId = searchParams.get('openMedicationId');
     if (openMedicationId) {
       handleInitialMedication(openMedicationId);
+      history.replace(location.pathname);
     }
   }, []);
 


### PR DESCRIPTION


### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
