### PR TITLE
fix(sensitiveFacilities): NASS-1751: Keep historical sensitive data unsynced

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.sensitiveFacilities.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.sensitiveFacilities.test.js
@@ -1018,7 +1018,7 @@ describe('CentralSyncManager Sensitive Facilities', () => {
       expect(encounterIds).not.toContain(sensitiveEncounterB.id);
     });
 
-    it('will keep historical sensitive data unsynced to other facilities when a facility changes from sensitive to non-sensitive, until the data is edited', async () => {
+    it('will keep historical sensitive data unsynced to other facilities when a facility changes from sensitive to non-sensitive, even after the data is edited', async () => {
       // Create a facility that starts as sensitive
       const facility = await models.Facility.create(fake(models.Facility, { isSensitive: true }));
       const department = await models.Department.create(
@@ -1058,7 +1058,7 @@ describe('CentralSyncManager Sensitive Facilities', () => {
       await encounter.update({ reasonForEncounter: 'Updated reason for encounter' });
       await centralSyncManager.updateLookupTable();
 
-      // Check that the new encounter changes are synced to the non-sensitive facility
+      // Check that the new encounter changes are still not synced to the non-sensitive facility
       const updatedEncounterIds = await getOutgoingIdsForRecordType(
         centralSyncManager,
         nonSensitiveFacility.id,

--- a/packages/central-server/__tests__/sync/CentralSyncManager.sensitiveFacilities.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.sensitiveFacilities.test.js
@@ -1064,7 +1064,7 @@ describe('CentralSyncManager Sensitive Facilities', () => {
         nonSensitiveFacility.id,
         'encounters',
       );
-      expect(updatedEncounterIds).toContain(encounter.id);
+      expect(updatedEncounterIds).not.toContain(encounter.id);
     });
 
     it('will keep historical non-sensitive data synced to other facilities when a facility changes to sensitive, but stop syncing new changes', async () => {

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -72,16 +72,19 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
           ORDER BY ${table}.id
           LIMIT :limit
           ON CONFLICT (record_id, record_type)
-          DO UPDATE SET
-            data = EXCLUDED.data,
-            updated_at_sync_tick = EXCLUDED.updated_at_sync_tick,
-            is_lab_request = EXCLUDED.is_lab_request,
-            patient_id = EXCLUDED.patient_id,
-            encounter_id = EXCLUDED.encounter_id,
-            facility_id = EXCLUDED.facility_id,
-            updated_at_by_field_sum = EXCLUDED.updated_at_by_field_sum,
-            is_deleted = EXCLUDED.is_deleted,
-            pushed_by_device_id = EXCLUDED.pushed_by_device_id
+            DO UPDATE SET
+              data = EXCLUDED.data,
+              updated_at_sync_tick = EXCLUDED.updated_at_sync_tick,
+              is_lab_request = EXCLUDED.is_lab_request,
+              patient_id = EXCLUDED.patient_id,
+              encounter_id = EXCLUDED.encounter_id,
+              facility_id = CASE 
+                WHEN EXCLUDED.facility_id IS NOT NULL THEN EXCLUDED.facility_id
+                ELSE sync_lookup.facility_id
+              END,
+              updated_at_by_field_sum = EXCLUDED.updated_at_by_field_sum,
+              is_deleted = EXCLUDED.is_deleted,
+              pushed_by_device_id = EXCLUDED.pushed_by_device_id
           RETURNING record_id
         )
         SELECT MAX(record_id) as "maxId",
@@ -116,12 +119,12 @@ export const updateLookupTable = withConfig(
   async (outgoingModels, since, config, syncLookupTick, debugObject) => {
     const invalidModelNames = Object.values(outgoingModels)
       .filter(
-        (m) =>
+        m =>
           ![SYNC_DIRECTIONS.BIDIRECTIONAL, SYNC_DIRECTIONS.PULL_FROM_CENTRAL].includes(
             m.syncDirection,
           ),
       )
-      .map((m) => m.tableName);
+      .map(m => m.tableName);
 
     if (invalidModelNames.length) {
       throw new Error(

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -72,19 +72,19 @@ const updateLookupTableForModel = async (model, config, since, sessionConfig, sy
           ORDER BY ${table}.id
           LIMIT :limit
           ON CONFLICT (record_id, record_type)
-            DO UPDATE SET
-              data = EXCLUDED.data,
-              updated_at_sync_tick = EXCLUDED.updated_at_sync_tick,
-              is_lab_request = EXCLUDED.is_lab_request,
-              patient_id = EXCLUDED.patient_id,
-              encounter_id = EXCLUDED.encounter_id,
-              facility_id = CASE 
-                WHEN EXCLUDED.facility_id IS NOT NULL THEN EXCLUDED.facility_id
-                ELSE sync_lookup.facility_id
-              END,
-              updated_at_by_field_sum = EXCLUDED.updated_at_by_field_sum,
-              is_deleted = EXCLUDED.is_deleted,
-              pushed_by_device_id = EXCLUDED.pushed_by_device_id
+          DO UPDATE SET
+            data = EXCLUDED.data,
+            updated_at_sync_tick = EXCLUDED.updated_at_sync_tick,
+            is_lab_request = EXCLUDED.is_lab_request,
+            patient_id = EXCLUDED.patient_id,
+            encounter_id = EXCLUDED.encounter_id,
+            facility_id = CASE 
+              WHEN EXCLUDED.facility_id IS NOT NULL THEN EXCLUDED.facility_id
+              ELSE sync_lookup.facility_id
+            END,
+            updated_at_by_field_sum = EXCLUDED.updated_at_by_field_sum,
+            is_deleted = EXCLUDED.is_deleted,
+            pushed_by_device_id = EXCLUDED.pushed_by_device_id
           RETURNING record_id
         )
         SELECT MAX(record_id) as "maxId",


### PR DESCRIPTION
### Changes

We need to handle this edge case a bit differently for sensitive facilities

If an encounter was created when a facility is **sensitive**, that encounter and its related data should never sync down to other facilities even if the parent facility is changed to **non-sensitive**. Currently an edit to any data will trigger that record to sync down which both creates foreign key issues and also exposes sensitive data.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
