### PR TITLE
fix(changelogs): KOR-52: Add deviceId and version to model

### DIFF
--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -1,4 +1,4 @@
-import { DataTypes, Sequelize } from 'sequelize';
+import { DataTypes } from 'sequelize';
 
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 

--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -19,6 +19,7 @@ export class ChangeLog extends Model {
   declare recordDeletedAt: Date | null;
   declare recordData: string;
   declare deviceId: string;
+  declare version: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(

--- a/packages/database/src/models/ChangeLog.ts
+++ b/packages/database/src/models/ChangeLog.ts
@@ -18,6 +18,7 @@ export class ChangeLog extends Model {
   declare recordUpdatedAt: Date;
   declare recordDeletedAt: Date | null;
   declare recordData: string;
+  declare deviceId: string;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -38,7 +39,6 @@ export class ChangeLog extends Model {
         loggedAt: {
           type: DataTypes.DATE,
           allowNull: false,
-          defaultValue: Sequelize.fn('adjusted_timestamp'),
         },
         updatedByUserId: {
           type: DataTypes.TEXT,
@@ -62,6 +62,14 @@ export class ChangeLog extends Model {
         },
         recordData: {
           type: DataTypes.JSONB,
+          allowNull: false,
+        },
+        deviceId: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+        version: {
+          type: DataTypes.TEXT,
           allowNull: false,
         },
       },

--- a/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
+++ b/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
@@ -55,6 +55,8 @@ describe('insertChangelogRecords', () => {
         tableSchema: 'public',
         recordId: '1',
         recordData: { first_name: 'Patient Updated' },
+        deviceId: 'test-device-id',
+        version: '1.0.0',
       },
       {
         // New record
@@ -68,6 +70,8 @@ describe('insertChangelogRecords', () => {
         tableSchema: 'public',
         recordId: '2',
         recordData: { first_name: 'Patient 2' },
+        deviceId: 'test-device-id',
+        version: '1.0.0',
       },
       {
         // New record
@@ -81,6 +85,8 @@ describe('insertChangelogRecords', () => {
         tableSchema: 'public',
         recordId: '3',
         recordData: { encounter_type: ENCOUNTER_TYPES.ADMISSION },
+        deviceId: 'test-device-id',
+        version: '1.0.0',
       },
     ];
 
@@ -95,10 +101,18 @@ describe('insertChangelogRecords', () => {
 
     // Should ignore the change to the existing record as changelog records are immutable
     expect(results[0].recordData).toEqual({ first_name: 'Patient 1' });
-    // Check the inserted records
-    expect(results[1].recordId).toBe('2');
-    expect(results[1].tableName).toBe('patients');
-    expect(results[2].recordId).toBe('3');
-    expect(results[2].tableName).toBe('encounters');
+    // Check the inserted records include device/version metadata
+    expect(results[1]).toMatchObject({
+      recordId: '2',
+      tableName: 'patients',
+      deviceId: 'test-device-id',
+      version: '1.0.0',
+    });
+    expect(results[2]).toMatchObject({
+      recordId: '3',
+      tableName: 'encounters',
+      deviceId: 'test-device-id',
+      version: '1.0.0',
+    });
   });
 });

--- a/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
+++ b/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
@@ -104,21 +104,17 @@ describe('insertChangelogRecords', () => {
     // Should ignore the change to the existing record as changelog records are immutable
     expect(results[0].recordData).toEqual({ first_name: 'Patient 1' });
     // Check the inserted records include device/version metadata
-    expect(results[1]).toMatchObject(
-{
-        recordId: '2',
-        tableName: 'patients',
-        deviceId: 'test-device-id-2',
-        version: '1.0.2',
-},
-    );
-    expect(results[2]).toMatchObject(
-    {
-        recordId: '3',
-        tableName: 'encounters',
-        deviceId: 'test-device-id-3',
-        version: '1.0.3',
-      },
-    );
+    expect(results[1]).toMatchObject({
+      recordId: '2',
+      tableName: 'patients',
+      deviceId: 'test-device-id-2',
+      version: '1.0.2',
+    });
+    expect(results[2]).toMatchObject({
+      recordId: '3',
+      tableName: 'encounters',
+      deviceId: 'test-device-id-3',
+      version: '1.0.3',
+    });
   });
 });

--- a/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
+++ b/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
@@ -40,6 +40,8 @@ describe('insertChangelogRecords', () => {
       updatedByUserId: SYSTEM_USER_UUID,
       recordId: '1',
       recordData: { first_name: 'Patient 1' },
+      deviceId: 'test-device-id',
+      version: '1.0.0',
     });
 
     const changelogRecords = [
@@ -55,8 +57,8 @@ describe('insertChangelogRecords', () => {
         tableSchema: 'public',
         recordId: '1',
         recordData: { first_name: 'Patient Updated' },
-        deviceId: 'test-device-id',
-        version: '1.0.0',
+        deviceId: 'test-device-id-1',
+        version: '1.0.1',
       },
       {
         // New record
@@ -70,8 +72,8 @@ describe('insertChangelogRecords', () => {
         tableSchema: 'public',
         recordId: '2',
         recordData: { first_name: 'Patient 2' },
-        deviceId: 'test-device-id',
-        version: '1.0.0',
+        deviceId: 'test-device-id-2',
+        version: '1.0.2',
       },
       {
         // New record
@@ -85,8 +87,8 @@ describe('insertChangelogRecords', () => {
         tableSchema: 'public',
         recordId: '3',
         recordData: { encounter_type: ENCOUNTER_TYPES.ADMISSION },
-        deviceId: 'test-device-id',
-        version: '1.0.0',
+        deviceId: 'test-device-id-3',
+        version: '1.0.3',
       },
     ];
 
@@ -97,22 +99,27 @@ describe('insertChangelogRecords', () => {
     const results = await models.ChangeLog.findAll({
       order: [['recordId', 'ASC']],
     });
+    console.log(results)
     expect(results).toHaveLength(3); // Should have 3 records (existing + 2 new)
 
     // Should ignore the change to the existing record as changelog records are immutable
     expect(results[0].recordData).toEqual({ first_name: 'Patient 1' });
     // Check the inserted records include device/version metadata
-    expect(results[1]).toMatchObject({
-      recordId: '2',
-      tableName: 'patients',
-      deviceId: 'test-device-id',
-      version: '1.0.0',
-    });
-    expect(results[2]).toMatchObject({
-      recordId: '3',
-      tableName: 'encounters',
-      deviceId: 'test-device-id',
-      version: '1.0.0',
-    });
+    expect(results[1]).toMatchObject(
+      expect.objectContaining({
+        recordId: '2',
+        tableName: 'patients',
+        deviceId: 'test-device-id-2',
+        version: '1.0.2',
+      }),
+    );
+    expect(results[2]).toMatchObject(
+      expect.objectContaining({
+        recordId: '3',
+        tableName: 'encounters',
+        deviceId: 'test-device-id-3',
+        version: '1.0.3',
+      }),
+    );
   });
 });

--- a/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
+++ b/packages/facility-server/__tests__/audit/insertChangelogRecords.test.js
@@ -99,27 +99,26 @@ describe('insertChangelogRecords', () => {
     const results = await models.ChangeLog.findAll({
       order: [['recordId', 'ASC']],
     });
-    console.log(results)
     expect(results).toHaveLength(3); // Should have 3 records (existing + 2 new)
 
     // Should ignore the change to the existing record as changelog records are immutable
     expect(results[0].recordData).toEqual({ first_name: 'Patient 1' });
     // Check the inserted records include device/version metadata
     expect(results[1]).toMatchObject(
-      expect.objectContaining({
+{
         recordId: '2',
         tableName: 'patients',
         deviceId: 'test-device-id-2',
         version: '1.0.2',
-      }),
+},
     );
     expect(results[2]).toMatchObject(
-      expect.objectContaining({
+    {
         recordId: '3',
         tableName: 'encounters',
         deviceId: 'test-device-id-3',
         version: '1.0.3',
-      }),
+      },
     );
   });
 });


### PR DESCRIPTION
### Changes
Note we don't need any defaults on model level as only complete created changelogs are inserted via model as part of sync.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
