### PR TITLE
fix(sync): TAMOC-331: Fixup lookup table state for prescriptions and encounter_prescriptions (hotfix 2.34)

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -122,6 +122,8 @@ describe('Sync Lookup data', () => {
       EncounterPrescription,
       PatientOngoingPrescription,
       Prescription,
+      MedicationAdministrationRecord,
+      MedicationAdministrationRecordDose,
       ImagingRequest,
       ImagingRequestArea,
       ImagingResult,
@@ -305,6 +307,22 @@ describe('Sync Lookup data', () => {
         prescriptionId: prescription.id,
       }),
     );
+
+    const mar = await MedicationAdministrationRecord.create(
+      fake(MedicationAdministrationRecord, {
+        prescriptionId: prescription.id,
+        recordedByUserId: examiner.id,
+      }),
+    );
+
+    await MedicationAdministrationRecordDose.create(
+      fake(MedicationAdministrationRecordDose, {
+        marId: mar.id,
+        givenByUserId: examiner.id,
+        recordedByUserId: examiner.id,
+      }),
+    );
+
     const imagingRequest = await ImagingRequest.create(
       fake(ImagingRequest, {
         encounterId: encounter1.id,

--- a/packages/central-server/__tests__/tasks/MedicationDiscontinuer.test.js
+++ b/packages/central-server/__tests__/tasks/MedicationDiscontinuer.test.js
@@ -1,0 +1,54 @@
+import { fake, fakeUser } from '@tamanu/fake-data/fake';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+import { sub } from 'date-fns';
+
+import { MedicationDiscontinuer } from '../../dist/tasks/MedicationDiscontinuer';
+import { createTestContext } from '../utilities';
+
+describe('Medication Discontinuer', () => {
+  let ctx;
+  let models;
+  let examiner;
+
+  const runDiscontinuer = async () => {
+    const discontinuer = new MedicationDiscontinuer(ctx, {
+      schedule: '',
+    });
+    return await discontinuer.run();
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+    examiner = await models.User.create(fakeUser());
+  });
+
+  afterAll(() => ctx.close());
+
+  it('Should discontinue a medication that has reached its end date', async () => {
+    const startDate = toDateTimeString(new Date());
+    const endDate = toDateTimeString(sub(new Date(), { days: 1 }));
+    const medication = await models.Prescription.create(
+      fake(models.Prescription, {
+        presciberId: examiner.id,
+        discontinued: false,
+        discontinuedDate: null,
+        discontinuingClinicianId: null,
+        discontinuingReason: null,
+        durationValue: null,
+        durationUnit: null,
+        startDate,
+        endDate,
+      }),
+    );
+
+    await runDiscontinuer();
+    await medication.reload();
+
+    expect(medication.discontinued).toBe(true);
+    expect(medication.discontinuingClinicianId).toEqual(SYSTEM_USER_UUID);
+    expect(medication.discontinuedDate).toEqual(endDate);
+    expect(medication.discontinuingReason).toEqual('Prescription end date and time reached');
+  });
+});

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -305,6 +305,7 @@ export class CentralSyncManager {
           : SYNC_TICK_FLAGS.LOOKUP_PENDING_UPDATE;
 
         await updateLookupTable(
+          this.store.models,
           getModelsForPull(this.store.models),
           previouslyUpToTick,
           this.constructor.config,

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -140,7 +140,7 @@ export const updateLookupTable = withConfig(
         const modelChangesCount = await updateLookupTableForModel(
           model,
           config,
-          shouldFullyRebuild ? 0 : since,
+          shouldFullyRebuild ? -1 : since,
           sessionConfig,
           syncLookupTick,
         );

--- a/packages/central-server/app/sync/updateLookupTable.js
+++ b/packages/central-server/app/sync/updateLookupTable.js
@@ -19,7 +19,7 @@ const updateLookupTableForModel = async (
   let fromId = '';
   let totalCount = 0;
   const attributes = model.getAttributes();
-  const { select, joins, where } = model.buildSyncLookupQueryDetails(sessionConfig) || {};
+  const { select, joins, where } = (await model.buildSyncLookupQueryDetails(sessionConfig)) || {};
   const useUpdatedAtByFieldSum = !!attributes.updatedAtByField;
 
   while (fromId != null) {

--- a/packages/constants/src/facts.ts
+++ b/packages/constants/src/facts.ts
@@ -13,6 +13,7 @@ export const FACT_LAST_SUCCESSFUL_SYNC_PULL = 'lastSuccessfulSyncPull';
 export const FACT_LAST_SUCCESSFUL_SYNC_PUSH = 'lastSuccessfulSyncPush';
 export const FACT_LOOKUP_UP_TO_TICK = 'lastSuccessfulLookupTableUpdate';
 export const FACT_SYNC_TRIGGER_CONTROL = 'syncTrigger';
+export const FACT_LOOKUP_MODELS_TO_REBUILD = 'lookupModelsToRebuild';
 
 // Device identity facts
 export const FACT_CENTRAL_HOST = 'syncHost';

--- a/packages/database/src/migrations/1755227673457-AddLookupModelsToRebuildFact.ts
+++ b/packages/database/src/migrations/1755227673457-AddLookupModelsToRebuildFact.ts
@@ -1,0 +1,31 @@
+import { FACT_LOOKUP_MODELS_TO_REBUILD } from '@tamanu/constants';
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION flag_lookup_model_to_rebuild(model_name text) RETURNS void AS $$
+    BEGIN
+      INSERT INTO local_system_facts (key, value)
+      VALUES ('${FACT_LOOKUP_MODELS_TO_REBUILD}', model_name)
+      ON CONFLICT (key) DO UPDATE SET value = 
+        CASE 
+        WHEN local_system_facts.value IS NULL THEN
+          -- If the value is null, set it to the model name
+          model_name
+        WHEN model_name = ANY(string_to_array(local_system_facts.value, ',')) THEN
+          -- If the model name is already in the array, do nothing
+          local_system_facts.value
+        ELSE
+          -- If the model name is not in the array, add it
+          local_system_facts.value || ',' || model_name
+        END;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    DROP FUNCTION flag_lookup_model_to_rebuild(text);
+  `);
+}

--- a/packages/database/src/migrations/1755227673457-AddLookupModelsToRebuildFact.ts
+++ b/packages/database/src/migrations/1755227673457-AddLookupModelsToRebuildFact.ts
@@ -9,8 +9,8 @@ export async function up(query: QueryInterface): Promise<void> {
       VALUES ('${FACT_LOOKUP_MODELS_TO_REBUILD}', model_name)
       ON CONFLICT (key) DO UPDATE SET value = 
         CASE 
-        WHEN local_system_facts.value IS NULL THEN
-          -- If the value is null, set it to the model name
+        WHEN local_system_facts.value IS NULL OR local_system_facts.value = '' THEN
+	          -- If the value is null or empty, set it to the model name
           model_name
         WHEN model_name = ANY(string_to_array(local_system_facts.value, ',')) THEN
           -- If the model name is already in the array, do nothing

--- a/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
+++ b/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
@@ -9,11 +9,12 @@ export async function up(query: QueryInterface): Promise<void> {
   // Set the updated_at_sync_tick to the greatest of the encounter, encounter_prescription, and prescription updated_at_sync_tick
   // They had been initially set to 0, so just ensuring that they don't get missed
   await query.sequelize.query(`
-    UPDATE encounter_prescriptions ep
+    UPDATE encounter_prescriptions
     SET updated_at_sync_tick = GREATEST(ep.updated_at_sync_tick, e.updated_at_sync_tick, p.updated_at_sync_tick)
-    FROM encounters e 
-    JOIN prescriptions p on p.id = ep.prescription_id
-    WHERE e.id = ep.encounter_id;
+    FROM encounter_prescriptions ep 
+    JOIN prescriptions p ON p.id = ep.prescription_id
+    JOIN encounters e ON e.id = ep.encounter_id
+    WHERE encounter_prescriptions.id = ep.id
   `);
 
   await query.sequelize.query(`

--- a/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
+++ b/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
@@ -22,6 +22,6 @@ export async function up(query: QueryInterface): Promise<void> {
   `);
 }
 
-export async function down(query: QueryInterface): Promise<void> {
-  // write your down migration here
+export async function down(): Promise<void> {
+  // No reverse migration
 }

--- a/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
+++ b/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
@@ -1,0 +1,27 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    DELETE FROM sync_lookup
+    WHERE record_type = 'encounter_medications';
+  `);
+
+  // Set the updated_at_sync_tick to the greatest of the encounter, encounter_prescription, and prescription updated_at_sync_tick
+  // They had been initially set to 0, so just ensuring that they don't get missed
+  await query.sequelize.query(`
+    UPDATE encounter_prescriptions ep
+    SET updated_at_sync_tick = GREATEST(ep.updated_at_sync_tick, e.updated_at_sync_tick, p.updated_at_sync_tick)
+    FROM encounters e 
+    JOIN prescriptions p on p.id = ep.prescription_id
+    WHERE e.id = ep.encounter_id;
+  `);
+
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('prescriptions');
+    SELECT flag_lookup_model_to_rebuild('encounter_prescriptions');
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // write your down migration here
+}

--- a/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
+++ b/packages/database/src/migrations/1755237235317-RebuildLookupTableForPrescriptionsChanges.ts
@@ -6,17 +6,6 @@ export async function up(query: QueryInterface): Promise<void> {
     WHERE record_type = 'encounter_medications';
   `);
 
-  // Set the updated_at_sync_tick to the greatest of the encounter, encounter_prescription, and prescription updated_at_sync_tick
-  // They had been initially set to 0, so just ensuring that they don't get missed
-  await query.sequelize.query(`
-    UPDATE encounter_prescriptions
-    SET updated_at_sync_tick = GREATEST(ep.updated_at_sync_tick, e.updated_at_sync_tick, p.updated_at_sync_tick)
-    FROM encounter_prescriptions ep 
-    JOIN prescriptions p ON p.id = ep.prescription_id
-    JOIN encounters e ON e.id = ep.encounter_id
-    WHERE encounter_prescriptions.id = ep.id
-  `);
-
   await query.sequelize.query(`
     SELECT flag_lookup_model_to_rebuild('prescriptions');
     SELECT flag_lookup_model_to_rebuild('encounter_prescriptions');

--- a/packages/database/src/migrations/1756948183158-CorrectDiscontinuedDateForHistoricallyDiscontinuedPrescriptions.ts
+++ b/packages/database/src/migrations/1756948183158-CorrectDiscontinuedDateForHistoricallyDiscontinuedPrescriptions.ts
@@ -1,0 +1,20 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Prescriptions that had been discontinued automatically by the MedicationDiscontinuer
+  // prior to 2.34 had no discontinued date.
+  await query.sequelize.query(`
+    UPDATE prescriptions
+    SET discontinued_date = end_date
+    WHERE discontinued = true AND discontinued_date IS NULL
+  `);
+
+  // Rebuild lookup table so that the correct discontinued date is present
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('prescriptions');
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No reverse behaviour here
+}

--- a/packages/database/src/models/AdministeredVaccine.ts
+++ b/packages/database/src/models/AdministeredVaccine.ts
@@ -140,9 +140,9 @@ export class AdministeredVaccine extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         encounterId: 'encounters.id',
       }),

--- a/packages/database/src/models/Appointment.ts
+++ b/packages/database/src/models/Appointment.ts
@@ -135,9 +135,9 @@ export class Appointment extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: `${this.tableName}.patient_id`,
         facilityId: 'COALESCE(location_groups.facility_id, locations.facility_id)',
       }),

--- a/packages/database/src/models/AppointmentSchedule.ts
+++ b/packages/database/src/models/AppointmentSchedule.ts
@@ -153,9 +153,9 @@ export class AppointmentSchedule extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'appointments.patient_id',
         facilityId: 'COALESCE(location_groups.facility_id, locations.facility_id)',
       }),

--- a/packages/database/src/models/Asset.ts
+++ b/packages/database/src/models/Asset.ts
@@ -57,7 +57,7 @@ export class Asset extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/CertifiableVaccine.ts
+++ b/packages/database/src/models/CertifiableVaccine.ts
@@ -98,7 +98,7 @@ export class CertifiableVaccine extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ContributingDeathCause.ts
+++ b/packages/database/src/models/ContributingDeathCause.ts
@@ -71,9 +71,9 @@ export class ContributingDeathCause extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'patient_death_data.patient_id',
       }),
       joins: `

--- a/packages/database/src/models/DeathRevertLog.ts
+++ b/packages/database/src/models/DeathRevertLog.ts
@@ -62,7 +62,7 @@ export class DeathRevertLog extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Department.ts
+++ b/packages/database/src/models/Department.ts
@@ -58,7 +58,7 @@ export class Department extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Discharge.ts
+++ b/packages/database/src/models/Discharge.ts
@@ -80,7 +80,7 @@ export class Discharge extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/DocumentMetadata.ts
+++ b/packages/database/src/models/DocumentMetadata.ts
@@ -96,9 +96,9 @@ export class DocumentMetadata extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'COALESCE(document_metadata.patient_id, encounters.patient_id)',
       }),
       joins: `

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -381,9 +381,9 @@ export class Encounter extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         encounterId: 'encounters.id',
         isLabRequestValue: 'new_labs.encounter_id IS NOT NULL',

--- a/packages/database/src/models/EncounterDiagnosis.ts
+++ b/packages/database/src/models/EncounterDiagnosis.ts
@@ -85,7 +85,7 @@ export class EncounterDiagnosis extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/EncounterDiet.ts
+++ b/packages/database/src/models/EncounterDiet.ts
@@ -42,7 +42,7 @@ export class EncounterDiet extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/EncounterHistory.ts
+++ b/packages/database/src/models/EncounterHistory.ts
@@ -104,7 +104,7 @@ export class EncounterHistory extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/EncounterPausePrescription.ts
+++ b/packages/database/src/models/EncounterPausePrescription.ts
@@ -133,9 +133,9 @@ export class EncounterPausePrescription extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([
         this.tableName,
         'encounter_prescriptions',

--- a/packages/database/src/models/EncounterPausePrescriptionHistory.ts
+++ b/packages/database/src/models/EncounterPausePrescriptionHistory.ts
@@ -71,9 +71,9 @@ export class EncounterPausePrescriptionHistory extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([
         this.tableName,
         'encounter_prescriptions',

--- a/packages/database/src/models/EncounterPrescription.ts
+++ b/packages/database/src/models/EncounterPrescription.ts
@@ -21,8 +21,8 @@ export class EncounterPrescription extends Model {
         isSelectedForDischarge: {
           type: DataTypes.BOOLEAN,
           allowNull: false,
-          defaultValue: false
-        }
+          defaultValue: false,
+        },
       },
       {
         ...options,
@@ -42,7 +42,7 @@ export class EncounterPrescription extends Model {
     });
     this.hasMany(models.EncounterPausePrescription, {
       foreignKey: 'encounterPrescriptionId',
-      as: 'pausePrescriptions'
+      as: 'pausePrescriptions',
     });
   }
 
@@ -56,7 +56,7 @@ export class EncounterPrescription extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/Facility.ts
+++ b/packages/database/src/models/Facility.ts
@@ -89,7 +89,7 @@ export class Facility extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ImagingAreaExternalCode.ts
+++ b/packages/database/src/models/ImagingAreaExternalCode.ts
@@ -57,7 +57,7 @@ export class ImagingAreaExternalCode extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ImagingRequest.ts
+++ b/packages/database/src/models/ImagingRequest.ts
@@ -226,7 +226,7 @@ export class ImagingRequest extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/ImagingRequestArea.ts
+++ b/packages/database/src/models/ImagingRequestArea.ts
@@ -45,9 +45,9 @@ export class ImagingRequestArea extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([
         this.tableName,
         'imaging_requests',

--- a/packages/database/src/models/ImagingResult.ts
+++ b/packages/database/src/models/ImagingResult.ts
@@ -91,9 +91,9 @@ export class ImagingResult extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([
         this.tableName,
         'imaging_requests',

--- a/packages/database/src/models/Invoice.ts
+++ b/packages/database/src/models/Invoice.ts
@@ -85,7 +85,7 @@ export class Invoice extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/InvoiceDiscount.ts
+++ b/packages/database/src/models/InvoiceDiscount.ts
@@ -60,9 +60,9 @@ export class InvoiceDiscount extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'invoices', 'encounters']),

--- a/packages/database/src/models/InvoiceInsurer.ts
+++ b/packages/database/src/models/InvoiceInsurer.ts
@@ -49,9 +49,9 @@ export class InvoiceInsurer extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'invoices', 'encounters']),

--- a/packages/database/src/models/InvoiceInsurerPayment.ts
+++ b/packages/database/src/models/InvoiceInsurerPayment.ts
@@ -59,9 +59,9 @@ export class InvoiceInsurerPayment extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([

--- a/packages/database/src/models/InvoiceItem.ts
+++ b/packages/database/src/models/InvoiceItem.ts
@@ -98,9 +98,9 @@ export class InvoiceItem extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'invoices', 'encounters']),

--- a/packages/database/src/models/InvoiceItemDiscount.ts
+++ b/packages/database/src/models/InvoiceItemDiscount.ts
@@ -53,9 +53,9 @@ export class InvoiceItemDiscount extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([

--- a/packages/database/src/models/InvoicePatientPayment.ts
+++ b/packages/database/src/models/InvoicePatientPayment.ts
@@ -53,9 +53,9 @@ export class InvoicePatientPayment extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([

--- a/packages/database/src/models/InvoicePayment.ts
+++ b/packages/database/src/models/InvoicePayment.ts
@@ -65,9 +65,9 @@ export class InvoicePayment extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'invoices', 'encounters']),

--- a/packages/database/src/models/InvoiceProduct.ts
+++ b/packages/database/src/models/InvoiceProduct.ts
@@ -63,7 +63,7 @@ export class InvoiceProduct extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 

--- a/packages/database/src/models/LabRequest.ts
+++ b/packages/database/src/models/LabRequest.ts
@@ -290,9 +290,9 @@ export class LabRequest extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         encounterId: `${this.tableName}.encounter_id`,
         isLabRequestValue: 'TRUE',

--- a/packages/database/src/models/LabRequestAttachment.ts
+++ b/packages/database/src/models/LabRequestAttachment.ts
@@ -66,9 +66,9 @@ export class LabRequestAttachment extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         isLabRequestValue: 'TRUE',
       }),

--- a/packages/database/src/models/LabRequestLog.ts
+++ b/packages/database/src/models/LabRequestLog.ts
@@ -55,9 +55,9 @@ export class LabRequestLog extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         isLabRequestValue: 'TRUE',
       }),

--- a/packages/database/src/models/LabTest.ts
+++ b/packages/database/src/models/LabTest.ts
@@ -89,9 +89,9 @@ export class LabTest extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         isLabRequestValue: 'TRUE',
       }),

--- a/packages/database/src/models/LabTestPanel.ts
+++ b/packages/database/src/models/LabTestPanel.ts
@@ -57,7 +57,7 @@ export class LabTestPanel extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/LabTestPanelLabTestTypes.ts
+++ b/packages/database/src/models/LabTestPanelLabTestTypes.ts
@@ -35,7 +35,7 @@ export class LabTestPanelLabTestTypes extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/LabTestPanelRequest.ts
+++ b/packages/database/src/models/LabTestPanelRequest.ts
@@ -55,9 +55,9 @@ export class LabTestPanelRequest extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
         isLabRequestValue: 'TRUE',
       }),

--- a/packages/database/src/models/LabTestType.ts
+++ b/packages/database/src/models/LabTestType.ts
@@ -123,7 +123,7 @@ export class LabTestType extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/LocalSystemFact.ts
+++ b/packages/database/src/models/LocalSystemFact.ts
@@ -1,7 +1,7 @@
 import { DataTypes } from 'sequelize';
 import { EndpointKey } from 'mushi';
 
-import { SYNC_DIRECTIONS, FACT_DEVICE_KEY } from '@tamanu/constants';
+import { SYNC_DIRECTIONS, FACT_DEVICE_KEY, FACT_LOOKUP_MODELS_TO_REBUILD } from '@tamanu/constants';
 import { Model } from './Model';
 import type { InitOptions } from '../types/model';
 import { randomUUID } from 'node:crypto';
@@ -87,5 +87,33 @@ export class LocalSystemFact extends Model {
     const newDeviceKey = EndpointKey.generateFor('ecdsa256');
     await this.set(FACT_DEVICE_KEY, newDeviceKey.privateKeyPem());
     return newDeviceKey;
+  }
+
+  static async getLookupModelsToRebuild() {
+    const value = await this.get(FACT_LOOKUP_MODELS_TO_REBUILD);
+    if (!value) {
+      return [];
+    }
+    return value.split(',').map((model) => model.trim());
+  }
+
+  static async markLookupModelRebuilt(modelName: string) {
+    await this.sequelize.query(
+      `
+      UPDATE local_system_facts
+      SET value =
+      CASE
+        WHEN value IS NULL THEN NULL
+      ELSE array_to_string(array_remove(string_to_array(value, ','), :modelName), ',')
+      END
+      WHERE key = :key
+    `,
+      {
+        replacements: {
+          modelName,
+          key: FACT_LOOKUP_MODELS_TO_REBUILD,
+        },
+      },
+    );
   }
 }

--- a/packages/database/src/models/LocalSystemFact.ts
+++ b/packages/database/src/models/LocalSystemFact.ts
@@ -97,6 +97,11 @@ export class LocalSystemFact extends Model {
     return value.split(',').map((model) => model.trim());
   }
 
+  static async isLookupRebuildingModel(modelName: string) {
+    const modelsToRebuild = await this.getLookupModelsToRebuild();
+    return modelsToRebuild.includes(modelName);
+  }
+
   static async markLookupModelRebuilt(modelName: string) {
     await this.sequelize.query(
       `

--- a/packages/database/src/models/LocalSystemFact.ts
+++ b/packages/database/src/models/LocalSystemFact.ts
@@ -100,13 +100,9 @@ export class LocalSystemFact extends Model {
   static async markLookupModelRebuilt(modelName: string) {
     await this.sequelize.query(
       `
-      UPDATE local_system_facts
-      SET value =
-      CASE
-        WHEN value IS NULL THEN NULL
-      ELSE array_to_string(array_remove(string_to_array(value, ','), :modelName), ',')
-      END
-      WHERE key = :key
+        UPDATE local_system_facts
+	      SET value = array_to_string(array_remove(string_to_array(value, ','), :modelName), ',')
+	      WHERE key = :key
     `,
       {
         replacements: {

--- a/packages/database/src/models/Location.ts
+++ b/packages/database/src/models/Location.ts
@@ -140,7 +140,7 @@ export class Location extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/LocationGroup.ts
+++ b/packages/database/src/models/LocationGroup.ts
@@ -70,7 +70,7 @@ export class LocationGroup extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -16,6 +16,7 @@ import { Model } from './Model';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
 import type { Prescription } from './Prescription';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { buildSyncLookupSelect } from '../sync/buildSyncLookupSelect';
 
 export class MedicationAdministrationRecord extends Model {
   declare id: string;
@@ -329,11 +330,33 @@ export class MedicationAdministrationRecord extends Model {
     });
   }
 
-  static buildSyncFilter() {
-    return null; // syncs everywhere
+  static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return `
+      LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+      LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+      LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+      WHERE (
+        (encounters.patient_id IS NOT NULL AND encounters.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+        OR 
+        (patient_ongoing_prescriptions.patient_id IS NOT NULL AND patient_ongoing_prescriptions.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+      )
+      AND medication_administration_records.updated_at_sync_tick > :since
+    `;
   }
 
   static async buildSyncLookupQueryDetails() {
-    return null; // syncs everywhere
+    return {
+      select: await buildSyncLookupSelect(this, {
+        patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
+      }),
+      joins: `
+        LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+        LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+        LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+      `,
+    };
   }
 }

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -333,7 +333,7 @@ export class MedicationAdministrationRecord extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/MedicationAdministrationRecordDose.ts
+++ b/packages/database/src/models/MedicationAdministrationRecordDose.ts
@@ -2,6 +2,7 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
+import { buildSyncLookupSelect } from '../sync/buildSyncLookupSelect';
 
 export class MedicationAdministrationRecordDose extends Model {
   declare id: string;
@@ -77,11 +78,35 @@ export class MedicationAdministrationRecordDose extends Model {
     });
   }
 
-  static buildSyncFilter() {
-    return null; // syncs everywhere
+  static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return `
+      LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
+      LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+      LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+      LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+      WHERE (
+        (encounters.patient_id IS NOT NULL AND encounters.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+        OR 
+        (patient_ongoing_prescriptions.patient_id IS NOT NULL AND patient_ongoing_prescriptions.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+      )
+      AND medication_administration_record_doses.updated_at_sync_tick > :since
+    `;
   }
 
   static async buildSyncLookupQueryDetails() {
-    return null; // syncs everywhere
+    return {
+      select: await buildSyncLookupSelect(this, {
+        patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
+      }),
+      joins: `
+        LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
+        LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+        LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+        LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+      `,
+    };
   }
 }

--- a/packages/database/src/models/MedicationAdministrationRecordDose.ts
+++ b/packages/database/src/models/MedicationAdministrationRecordDose.ts
@@ -81,7 +81,7 @@ export class MedicationAdministrationRecordDose extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Note.ts
+++ b/packages/database/src/models/Note.ts
@@ -126,9 +126,9 @@ export class Note extends Model {
     return (this as any)[parentGetter](options);
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: getPatientIdColumnOfNotes(),
       }),
       joins: buildNoteLinkedJoins().join('\n'),

--- a/packages/database/src/models/Notification.ts
+++ b/packages/database/src/models/Notification.ts
@@ -60,7 +60,7 @@ export class Notification extends Model {
 
   static buildPatientSyncFilter = buildPatientSyncFilterViaPatientId;
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/Patient.ts
+++ b/packages/database/src/models/Patient.ts
@@ -342,7 +342,7 @@ export class Patient extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 

--- a/packages/database/src/models/PatientAdditionalData.ts
+++ b/packages/database/src/models/PatientAdditionalData.ts
@@ -150,7 +150,7 @@ export class PatientAdditionalData extends Model {
     return ['countryOfBirth', 'country', 'nationality', 'ethnicity', 'insurer'];
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
   static buildPatientSyncFilter = buildPatientSyncFilterViaPatientId;

--- a/packages/database/src/models/PatientAllergy.ts
+++ b/packages/database/src/models/PatientAllergy.ts
@@ -43,7 +43,7 @@ export class PatientAllergy extends Model {
     return ['allergy', 'reaction'];
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientBirthData.ts
+++ b/packages/database/src/models/PatientBirthData.ts
@@ -103,7 +103,7 @@ export class PatientBirthData extends Model {
     'registeredBirthPlace',
   ];
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientCarePlan.ts
+++ b/packages/database/src/models/PatientCarePlan.ts
@@ -47,7 +47,7 @@ export class PatientCarePlan extends Model {
     return ['carePlan', 'examiner'];
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientCondition.ts
+++ b/packages/database/src/models/PatientCondition.ts
@@ -52,7 +52,7 @@ export class PatientCondition extends Model {
     return ['condition'];
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientContact.ts
+++ b/packages/database/src/models/PatientContact.ts
@@ -43,7 +43,7 @@ export class PatientContact extends Model {
     });
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientDeathData.ts
+++ b/packages/database/src/models/PatientDeathData.ts
@@ -152,7 +152,7 @@ export class PatientDeathData extends Model {
     });
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientFacility.ts
+++ b/packages/database/src/models/PatientFacility.ts
@@ -59,9 +59,9 @@ export class PatientFacility extends Model {
     return `WHERE facility_id in (:facilityIds) AND ${this.tableName}.updated_at_sync_tick > :since`;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         facilityId: `${this.tableName}.facility_id`,
       }),
     };

--- a/packages/database/src/models/PatientFamilyHistory.ts
+++ b/packages/database/src/models/PatientFamilyHistory.ts
@@ -43,7 +43,7 @@ export class PatientFamilyHistory extends Model {
     return ['diagnosis'];
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientFieldDefinition.ts
+++ b/packages/database/src/models/PatientFieldDefinition.ts
@@ -76,7 +76,7 @@ export class PatientFieldDefinition extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/PatientFieldDefinitionCategory.ts
+++ b/packages/database/src/models/PatientFieldDefinitionCategory.ts
@@ -35,7 +35,7 @@ export class PatientFieldDefinitionCategory extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/PatientFieldValue.ts
+++ b/packages/database/src/models/PatientFieldValue.ts
@@ -78,7 +78,7 @@ export class PatientFieldValue extends Model {
     });
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientIssue.ts
+++ b/packages/database/src/models/PatientIssue.ts
@@ -39,7 +39,7 @@ export class PatientIssue extends Model {
     this.belongsTo(models.Patient, { foreignKey: 'patientId' });
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientOngoingPrescription.ts
+++ b/packages/database/src/models/PatientOngoingPrescription.ts
@@ -32,7 +32,7 @@ export class PatientOngoingPrescription extends Model {
     });
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/PatientProgramRegistration.ts
+++ b/packages/database/src/models/PatientProgramRegistration.ts
@@ -126,7 +126,7 @@ export class PatientProgramRegistration extends Model {
     return null;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/PatientProgramRegistrationCondition.ts
+++ b/packages/database/src/models/PatientProgramRegistrationCondition.ts
@@ -84,9 +84,9 @@ export class PatientProgramRegistrationCondition extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'patient_program_registrations.patient_id',
       }),
       joins: [

--- a/packages/database/src/models/PatientSecondaryId.ts
+++ b/packages/database/src/models/PatientSecondaryId.ts
@@ -43,7 +43,7 @@ export class PatientSecondaryId extends Model {
     });
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildPatientLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/Permission.ts
+++ b/packages/database/src/models/Permission.ts
@@ -74,7 +74,7 @@ export class Permission extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -177,14 +177,11 @@ export class Prescription extends Model {
     return {
       select: await buildSyncLookupSelect(this, {
         patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
-        facilityId: `CASE WHEN ${this.tableName}.is_ongoing THEN NULL ELSE locations.facility_id END`, // Sync ongoing prescriptions to all facilities
       }),
       joins: `
         LEFT JOIN encounter_prescriptions ON prescriptions.id = encounter_prescriptions.prescription_id
         LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
         LEFT JOIN patient_ongoing_prescriptions ON prescriptions.id = patient_ongoing_prescriptions.prescription_id
-        LEFT JOIN locations ON encounters.location_id = locations.id
-        LEFT JOIN facilities ON locations.facility_id = facilities.id
       `,
     };
   }

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -177,7 +177,7 @@ export class Prescription extends Model {
     return {
       select: await buildSyncLookupSelect(this, {
         patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
-        facilityId: `CASE WHEN ${this.tableName}.is_ongoing THEN NULL ELSE COALESCE(location_groups.facility_id, locations.facility_id) END`, // Sync ongoing prescriptions to all facilities
+        facilityId: `CASE WHEN ${this.tableName}.is_ongoing THEN NULL ELSE locations.facility_id END`, // Sync ongoing prescriptions to all facilities
       }),
       joins: `
         LEFT JOIN encounter_prescriptions ON prescriptions.id = encounter_prescriptions.prescription_id

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -157,7 +157,7 @@ export class Prescription extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -134,6 +134,7 @@ export class Prescription extends Model {
       foreignKey: 'prescriptionId',
       as: 'patientOngoingPrescription',
     });
+
     this.belongsToMany(models.Patient, {
       through: models.PatientOngoingPrescription,
       foreignKey: 'prescriptionId',

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -145,6 +145,7 @@ export class Prescription extends Model {
       foreignKey: 'medicationId',
       as: 'medication',
     });
+
     this.hasMany(models.MedicationAdministrationRecord, {
       foreignKey: 'prescriptionId',
       as: 'medicationAdministrationRecords',

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -3,7 +3,7 @@ import { NOTIFICATION_TYPES, SYNC_DIRECTIONS } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { Model } from './Model';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
-import { buildSyncLookupSelect } from 'sync';
+import { buildSyncLookupSelect } from '../sync/buildSyncLookupSelect';
 
 export class Prescription extends Model {
   declare id: string;

--- a/packages/database/src/models/Procedure.ts
+++ b/packages/database/src/models/Procedure.ts
@@ -84,7 +84,7 @@ export class Procedure extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 }

--- a/packages/database/src/models/Program.ts
+++ b/packages/database/src/models/Program.ts
@@ -43,7 +43,7 @@ export class Program extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ProgramDataElement.ts
+++ b/packages/database/src/models/ProgramDataElement.ts
@@ -56,7 +56,7 @@ export class ProgramDataElement extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ProgramRegistry.ts
+++ b/packages/database/src/models/ProgramRegistry.ts
@@ -72,7 +72,7 @@ export class ProgramRegistry extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ProgramRegistryClinicalStatus.ts
+++ b/packages/database/src/models/ProgramRegistryClinicalStatus.ts
@@ -53,7 +53,7 @@ export class ProgramRegistryClinicalStatus extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ProgramRegistryCondition.ts
+++ b/packages/database/src/models/ProgramRegistryCondition.ts
@@ -51,7 +51,7 @@ export class ProgramRegistryCondition extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ReferenceData.ts
+++ b/packages/database/src/models/ReferenceData.ts
@@ -197,7 +197,7 @@ export class ReferenceData extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ReferenceDataRelation.ts
+++ b/packages/database/src/models/ReferenceDataRelation.ts
@@ -50,7 +50,7 @@ export class ReferenceDataRelation extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ReferenceDrug.ts
+++ b/packages/database/src/models/ReferenceDrug.ts
@@ -51,7 +51,7 @@ export class ReferenceDrug extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 

--- a/packages/database/src/models/ReferenceMedicationTemplate.ts
+++ b/packages/database/src/models/ReferenceMedicationTemplate.ts
@@ -71,7 +71,7 @@ export class ReferenceMedicationTemplate extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Referral.ts
+++ b/packages/database/src/models/Referral.ts
@@ -57,9 +57,9 @@ export class Referral extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: 'JOIN encounters ON referrals.initiating_encounter_id = encounters.id',
     };
   }

--- a/packages/database/src/models/ReportDefinition.ts
+++ b/packages/database/src/models/ReportDefinition.ts
@@ -42,7 +42,7 @@ export class ReportDefinition extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ReportDefinitionVersion.ts
+++ b/packages/database/src/models/ReportDefinitionVersion.ts
@@ -177,7 +177,7 @@ export class ReportDefinitionVersion extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Role.ts
+++ b/packages/database/src/models/Role.ts
@@ -34,7 +34,7 @@ export class Role extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/ScheduledVaccine.ts
+++ b/packages/database/src/models/ScheduledVaccine.ts
@@ -69,7 +69,7 @@ export class ScheduledVaccine extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Setting.ts
+++ b/packages/database/src/models/Setting.ts
@@ -240,9 +240,9 @@ export class Setting extends Model {
     return `WHERE (facility_id in (:facilityIds) OR scope = '${SETTINGS_SCOPES.GLOBAL}') AND ${this.tableName}.updated_at_sync_tick > :since`;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         facilityId: 'settings.facility_id',
       }),
     };

--- a/packages/database/src/models/Survey.ts
+++ b/packages/database/src/models/Survey.ts
@@ -104,7 +104,7 @@ export class Survey extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/SurveyResponse.ts
+++ b/packages/database/src/models/SurveyResponse.ts
@@ -235,9 +235,9 @@ export class SurveyResponse extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'encounters']),
     };
   }

--- a/packages/database/src/models/SurveyResponseAnswer.ts
+++ b/packages/database/src/models/SurveyResponseAnswer.ts
@@ -84,9 +84,9 @@ export class SurveyResponseAnswer extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: `
         JOIN survey_responses ON survey_response_answers.response_id = survey_responses.id
         JOIN encounters ON survey_responses.encounter_id = encounters.id

--- a/packages/database/src/models/SurveyScreenComponent.ts
+++ b/packages/database/src/models/SurveyScreenComponent.ts
@@ -116,7 +116,7 @@ export class SurveyScreenComponent extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Task.ts
+++ b/packages/database/src/models/Task.ts
@@ -203,7 +203,7 @@ export class Task extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return buildEncounterLinkedLookupFilter(this);
   }
 

--- a/packages/database/src/models/TaskDesignation.ts
+++ b/packages/database/src/models/TaskDesignation.ts
@@ -43,9 +43,9 @@ export class TaskDesignation extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildSyncLookupSelect(this, {
+      select: await buildSyncLookupSelect(this, {
         patientId: 'encounters.patient_id',
       }),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'tasks', 'encounters']),

--- a/packages/database/src/models/TaskTemplate.ts
+++ b/packages/database/src/models/TaskTemplate.ts
@@ -55,7 +55,7 @@ export class TaskTemplate extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 

--- a/packages/database/src/models/TaskTemplateDesignation.ts
+++ b/packages/database/src/models/TaskTemplateDesignation.ts
@@ -32,7 +32,7 @@ export class TaskTemplateDesignation extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/Template.ts
+++ b/packages/database/src/models/Template.ts
@@ -64,7 +64,7 @@ export class Template extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/TranslatedString.ts
+++ b/packages/database/src/models/TranslatedString.ts
@@ -85,7 +85,7 @@ export class TranslatedString extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -80,9 +80,9 @@ export class Triage extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'encounters']),
     };
   }

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -218,7 +218,7 @@ export class User extends Model {
     ];
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 

--- a/packages/database/src/models/UserDesignation.ts
+++ b/packages/database/src/models/UserDesignation.ts
@@ -32,7 +32,7 @@ export class UserDesignation extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/UserFacility.ts
+++ b/packages/database/src/models/UserFacility.ts
@@ -51,7 +51,7 @@ export class UserFacility extends Model {
     return null; // syncs everywhere
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/UserPreference.ts
+++ b/packages/database/src/models/UserPreference.ts
@@ -82,7 +82,7 @@ export class UserPreference extends Model {
     return null;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return null; // syncs everywhere
   }
 }

--- a/packages/database/src/models/VitalLog.ts
+++ b/packages/database/src/models/VitalLog.ts
@@ -101,9 +101,9 @@ export class VitalLog extends Model {
     `;
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: `
         INNER JOIN survey_response_answers ON vital_logs.answer_id = survey_response_answers.id
         INNER JOIN survey_responses ON survey_response_answers.response_id = survey_responses.id

--- a/packages/database/src/models/Vitals.ts
+++ b/packages/database/src/models/Vitals.ts
@@ -101,9 +101,9 @@ export class Vitals extends Model {
     );
   }
 
-  static buildSyncLookupQueryDetails() {
+  static async buildSyncLookupQueryDetails() {
     return {
-      select: buildEncounterPatientIdSelect(this),
+      select: await buildEncounterPatientIdSelect(this),
       joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'encounters']),
     };
   }

--- a/packages/database/src/sync/buildEncounterLinkedLookupFilter.ts
+++ b/packages/database/src/sync/buildEncounterLinkedLookupFilter.ts
@@ -2,9 +2,9 @@ import { buildEncounterLinkedSyncFilterJoins } from './buildEncounterLinkedSyncF
 import { buildSyncLookupSelect } from './buildSyncLookupSelect';
 import type { Model } from '../models/Model';
 
-export function buildEncounterLinkedLookupFilter(model: typeof Model) {
+export async function buildEncounterLinkedLookupFilter(model: typeof Model) {
   return {
-    select: buildSyncLookupSelect(model, {
+    select: await buildSyncLookupSelect(model, {
       patientId: 'encounters.patient_id',
     }),
     joins: buildEncounterLinkedSyncFilterJoins([model.tableName, 'encounters']),

--- a/packages/database/src/sync/buildPatientLinkedLookupFilter.ts
+++ b/packages/database/src/sync/buildPatientLinkedLookupFilter.ts
@@ -1,15 +1,15 @@
 import type { Model } from '../models/Model';
 import { buildSyncLookupSelect } from './buildSyncLookupSelect';
 
-export function buildPatientLinkedLookupFilter(model: typeof Model) {
+export async function buildPatientLinkedLookupFilter(model: typeof Model) {
   return {
-    select: buildSyncLookupSelect(model, {
+    select: await buildSyncLookupSelect(model, {
       patientId: `${model.tableName}.patient_id`,
     }),
   };
 }
 
-export function buildEncounterPatientIdSelect(model: typeof Model) {
+export async function buildEncounterPatientIdSelect(model: typeof Model) {
   return buildSyncLookupSelect(model, {
     patientId: 'encounters.patient_id',
   });

--- a/packages/database/src/sync/buildSyncLookupSelect.ts
+++ b/packages/database/src/sync/buildSyncLookupSelect.ts
@@ -10,7 +10,11 @@ interface Columns {
 }
 
 /**
- * When fully rebuilding we want to use the underlying
+ * When fully rebuilding we want to use base table's updated_at_sync_tick so that clients don't
+ * resync records they already have. Calling this the 'historicalRecordSyncTick'
+ *
+ * During regular sync lookup building, we either want to use the passed in `updatedAtSyncTick` variable (which is usually the SYNC_LOOKUP_PENDING_UPDATE_FLAG)
+ * or if that value is null (typically for an initial build) we use th base table's updated at sync tick again.
  */
 const updatedAtSyncTickClause = (table: string, isFullyRebuilding: boolean) => {
   const historicRecordSyncTick = `${table}.updated_at_sync_tick`;

--- a/packages/database/src/sync/buildSyncLookupSelect.ts
+++ b/packages/database/src/sync/buildSyncLookupSelect.ts
@@ -9,18 +9,32 @@ interface Columns {
   isLabRequestValue?: string;
 }
 
-export function buildSyncLookupSelect(model: typeof Model, columns: Columns = {}) {
+/**
+ * When fully rebuilding we want to use the underlying
+ */
+const updatedAtSyncTickClause = (table: string, isFullyRebuilding: boolean) => {
+  const historicRecordSyncTick = `${table}.updated_at_sync_tick`;
+  const newRecordSyncTick = `COALESCE(:updatedAtSyncTick, ${table}.updated_at_sync_tick)`;
+
+  return isFullyRebuilding
+    ? `CASE WHEN ${table}.updated_at_sync_tick <= :since THEN ${historicRecordSyncTick} ELSE ${newRecordSyncTick} END`
+    : newRecordSyncTick;
+};
+
+export async function buildSyncLookupSelect(model: typeof Model, columns: Columns = {}) {
   const attributes = model.getAttributes();
+  const table = model.tableName;
+  const isFullyRebuilding =
+    await model.sequelize.models.LocalSystemFact.isLookupRebuildingModel(table);
   const useUpdatedAtByFieldSum = !!attributes.updatedAtByField;
   const { patientId, facilityId, encounterId, isLabRequestValue } = columns;
-  const table = model.tableName;
 
   return `
     SELECT
       ${table}.id,
       '${table}',
       ${table}.deleted_at IS NOT NULL,
-      COALESCE(:updatedAtSyncTick, ${table}.updated_at_sync_tick),
+      ${updatedAtSyncTickClause(table, isFullyRebuilding)},
       sync_device_ticks.device_id,
       json_build_object(
         ${Object.keys(attributes)

--- a/packages/web/app/components/Medication/MedicationDetails.jsx
+++ b/packages/web/app/components/Medication/MedicationDetails.jsx
@@ -277,8 +277,8 @@ export const MedicationDetails = ({
                         />
                       </MidText>
                       <DarkestText mt={0.5}>{`${formatShortest(
-                        new Date(medication.discontinuedDate),
-                      )} ${formatTimeSlot(new Date(medication.discontinuedDate))}`}</DarkestText>
+                        medication.discontinuedDate,
+                      )} ${formatTimeSlot(medication.discontinuedDate)}`}</DarkestText>
                     </Box>
                   </DetailsContainer>
                   <Box my={2.5} height={'1px'} bgcolor={Colors.outline} />


### PR DESCRIPTION
### Changes

Introduced a new local_system_fact called `lookupModelsToRebuild` as well as a utility function to add table names to it. That way in migrations that modify a table schema we can just add this function call at the end and let the lookup table rebuild the records.

Does handle the issue of removing deleted/renamed tables tho, so that still needs to be done manually.

Also added a migration that calls this function on `prescriptions` and `encounter_prescriptions` as they currently aren't populating in the lookup table by default.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
