### PR TITLE
fix(surveys): TAMOC-332: Display correct decimal places for calculated question values when completing a survey

### DIFF
--- a/packages/shared/src/utils/calculations.js
+++ b/packages/shared/src/utils/calculations.js
@@ -1,3 +1,4 @@
+import { isNil } from 'lodash';
 import { all as allMath, create } from 'mathjs';
 
 // set up math context
@@ -56,7 +57,7 @@ export function runCalculations(components, values) {
           calculatedValues[c.dataElement.id] = null;
           continue;
         }
-        
+
         let value = math.evaluate(c.calculation, inputValues);
 
         if (Number.isNaN(value)) {
@@ -76,3 +77,15 @@ export function runCalculations(components, values) {
 
   return calculatedValues;
 }
+
+export const getStringOfCalculatedValue = value => {
+  if (isNil(value)) {
+    return '';
+  }
+
+  if (!(typeof value === 'number')) {
+    throw new Error(`Unexpected calculated value is not a number: ${value}`);
+  }
+
+  return value.toFixed(1);
+};

--- a/packages/shared/src/utils/calculations.js
+++ b/packages/shared/src/utils/calculations.js
@@ -84,7 +84,9 @@ export const getStringOfCalculatedValue = value => {
   }
 
   if (!(typeof value === 'number')) {
-    throw new Error(`Unexpected calculated value is not a number: ${value}`);
+    throw new Error(
+      `The result of a calculation must be a number, but got: ${value} (${typeof value})`,
+    );
   }
 
   return value.toFixed(1);

--- a/packages/shared/src/utils/fields.js
+++ b/packages/shared/src/utils/fields.js
@@ -1,17 +1,17 @@
-import {
-  ACTION_DATA_ELEMENT_TYPES,
-  PROGRAM_DATA_ELEMENT_TYPES,
-} from '@tamanu/constants';
+import { ACTION_DATA_ELEMENT_TYPES, PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 import { log } from '../services/logging';
 import { checkJSONCriteria } from './criteria';
+import { getStringOfCalculatedValue } from './calculations';
 
 export function getStringValue(type, value) {
   if (value === null) {
     return null;
   }
+
   switch (type) {
-    case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED:
-      return value.toFixed(1);
+    case PROGRAM_DATA_ELEMENT_TYPES.CALCULATED: {
+      return getStringOfCalculatedValue(value);
+    }
     default:
       return `${value}`;
   }


### PR DESCRIPTION
### Changes

Switched to using the same logic on the frontend when displaying calculated question values that we use in the backend when saving the value. Useful as it both displays `0` correctly now and also rounds to the correct number of decimal places.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
