### PR TITLE
fix(sensitiveFacilities): Release fix 2.38: Fix medication administration record sync

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -162,6 +162,8 @@ describe('Sync Lookup data', () => {
       Notification,
       EncounterPausePrescription,
       EncounterPausePrescriptionHistory,
+      MedicationAdministrationRecord,
+      MedicationAdministrationRecordDose,
     } = models;
 
     await Asset.create(fake(Asset), {
@@ -308,6 +310,21 @@ describe('Sync Lookup data', () => {
       fake(PatientOngoingPrescription, {
         patientId: patient.id,
         prescriptionId: prescription.id,
+      }),
+    );
+
+    const mar = await MedicationAdministrationRecord.create(
+      fake(models.MedicationAdministrationRecord, {
+        prescriptionId: prescription.id,
+        recordedByUserId: examiner.id,
+      }),
+    );
+
+    await MedicationAdministrationRecordDose.create(
+      fake(models.MedicationAdministrationRecordDose, {
+        marId: mar.id,
+        givenByUserId: examiner.id,
+        recordedByUserId: examiner.id,
       }),
     );
 

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -3477,12 +3477,16 @@ describe('CentralSyncManager', () => {
             await models.MedicationAdministrationRecordDose.create(
               fake(models.MedicationAdministrationRecordDose, {
                 marId: sensitiveMedicationAdministrationRecord.id,
+                recordedByUserId: practitioner.id,
+                givenByUserId: practitioner.id,
               }),
             );
           const nonSensitiveMedicationAdministrationRecordDose =
             await models.MedicationAdministrationRecordDose.create(
               fake(models.MedicationAdministrationRecordDose, {
                 marId: nonSensitiveMedicationAdministrationRecord.id,
+                recordedByUserId: practitioner.id,
+                givenByUserId: practitioner.id,
               }),
             );
 

--- a/packages/central-server/__tests__/sync/CentralSyncManager.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.test.js
@@ -3374,6 +3374,8 @@ describe('CentralSyncManager', () => {
         let nonSensitivePrescription;
         let sensitiveEncounterPrescription;
         let nonSensitiveEncounterPrescription;
+        let sensitiveMedicationAdministrationRecord;
+        let nonSensitiveMedicationAdministrationRecord;
 
         beforeEach(async () => {
           sensitivePrescription = await models.Prescription.create(fake(models.Prescription));
@@ -3390,6 +3392,20 @@ describe('CentralSyncManager', () => {
               prescriptionId: nonSensitivePrescription.id,
             }),
           );
+
+          sensitiveMedicationAdministrationRecord =
+            await models.MedicationAdministrationRecord.create(
+              fake(models.MedicationAdministrationRecord, {
+                prescriptionId: sensitivePrescription.id,
+              }),
+            );
+
+          nonSensitiveMedicationAdministrationRecord =
+            await models.MedicationAdministrationRecord.create(
+              fake(models.MedicationAdministrationRecord, {
+                prescriptionId: nonSensitivePrescription.id,
+              }),
+            );
         });
 
         it("won't sync sensitive prescriptions", async () => {
@@ -3445,6 +3461,35 @@ describe('CentralSyncManager', () => {
             model: models.EncounterPausePrescriptionHistory,
             sensitiveId: sensitiveEncounterPausePrescriptionHistory.id,
             nonSensitiveId: nonSensitiveEncounterPausePrescriptionHistory.id,
+          });
+        });
+
+        it("won't sync sensitive medication administration records", async () => {
+          await checkSensitiveRecordFiltering({
+            model: models.MedicationAdministrationRecord,
+            sensitiveId: sensitiveMedicationAdministrationRecord.id,
+            nonSensitiveId: nonSensitiveMedicationAdministrationRecord.id,
+          });
+        });
+
+        it("won't sync sensitive medication administration record doses", async () => {
+          const sensitiveMedicationAdministrationRecordDose =
+            await models.MedicationAdministrationRecordDose.create(
+              fake(models.MedicationAdministrationRecordDose, {
+                marId: sensitiveMedicationAdministrationRecord.id,
+              }),
+            );
+          const nonSensitiveMedicationAdministrationRecordDose =
+            await models.MedicationAdministrationRecordDose.create(
+              fake(models.MedicationAdministrationRecordDose, {
+                marId: nonSensitiveMedicationAdministrationRecord.id,
+              }),
+            );
+
+          await checkSensitiveRecordFiltering({
+            model: models.MedicationAdministrationRecordDose,
+            sensitiveId: sensitiveMedicationAdministrationRecordDose.id,
+            nonSensitiveId: nonSensitiveMedicationAdministrationRecordDose.id,
           });
         });
       });

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -544,7 +544,6 @@ export class MedicationAdministrationRecord extends Model {
       return null;
     }
     return `
-      LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
       LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
       LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
       LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
@@ -553,7 +552,7 @@ export class MedicationAdministrationRecord extends Model {
         OR 
         (patient_ongoing_prescriptions.patient_id IS NOT NULL AND patient_ongoing_prescriptions.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
       )
-      AND medication_administration_record_doses.updated_at_sync_tick > :since
+      AND medication_administration_records.updated_at_sync_tick > :since
     `;
   }
 
@@ -563,7 +562,6 @@ export class MedicationAdministrationRecord extends Model {
         patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
       }),
       joins: `
-        LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
         LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
         LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
         LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id

--- a/packages/database/src/models/MedicationAdministrationRecord.ts
+++ b/packages/database/src/models/MedicationAdministrationRecord.ts
@@ -27,6 +27,7 @@ import { dateTimeType, type InitOptions, type Models } from '../types/model';
 import type { Prescription } from './Prescription';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { Task } from './Task';
+import { buildEncounterLinkedLookupSelect } from '../sync/buildEncounterLinkedLookupFilter';
 
 export class MedicationAdministrationRecord extends Model {
   declare id: string;
@@ -538,11 +539,37 @@ export class MedicationAdministrationRecord extends Model {
     });
   }
 
-  static buildSyncFilter() {
-    return null; // syncs everywhere
+  static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return `
+      LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
+      LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+      LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+      LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+      WHERE (
+        (encounters.patient_id IS NOT NULL AND encounters.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+        OR 
+        (patient_ongoing_prescriptions.patient_id IS NOT NULL AND patient_ongoing_prescriptions.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+      )
+      AND medication_administration_record_doses.updated_at_sync_tick > :since
+    `;
   }
 
   static buildSyncLookupQueryDetails() {
-    return null; // syncs everywhere
+    return {
+      select: buildEncounterLinkedLookupSelect(this, {
+        patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
+      }),
+      joins: `
+        LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
+        LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+        LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+        LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+        LEFT JOIN locations ON encounters.location_id = locations.id
+        LEFT JOIN facilities ON locations.facility_id = facilities.id
+      `,
+    };
   }
 }

--- a/packages/database/src/models/MedicationAdministrationRecordDose.ts
+++ b/packages/database/src/models/MedicationAdministrationRecordDose.ts
@@ -2,6 +2,7 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
+import { buildEncounterLinkedLookupSelect } from '../sync/buildEncounterLinkedLookupFilter';
 
 export class MedicationAdministrationRecordDose extends Model {
   declare id: string;
@@ -77,11 +78,37 @@ export class MedicationAdministrationRecordDose extends Model {
     });
   }
 
-  static buildSyncFilter() {
-    return null; // syncs everywhere
+  static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return `
+      LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
+      LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+      LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+      LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+      WHERE (
+        (encounters.patient_id IS NOT NULL AND encounters.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+        OR 
+        (patient_ongoing_prescriptions.patient_id IS NOT NULL AND patient_ongoing_prescriptions.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+      )
+      AND medication_administration_record_doses.updated_at_sync_tick > :since
+    `;
   }
 
   static buildSyncLookupQueryDetails() {
-    return null; // syncs everywhere
+    return {
+      select: buildEncounterLinkedLookupSelect(this, {
+        patientId: 'COALESCE(encounters.patient_id, patient_ongoing_prescriptions.patient_id)',
+      }),
+      joins: `
+        LEFT JOIN medication_administration_records ON medication_administration_record_doses.mar_id = medication_administration_records.id
+        LEFT JOIN encounter_prescriptions ON medication_administration_records.prescription_id = encounter_prescriptions.prescription_id
+        LEFT JOIN encounters ON encounter_prescriptions.encounter_id = encounters.id
+        LEFT JOIN patient_ongoing_prescriptions ON medication_administration_records.prescription_id = patient_ongoing_prescriptions.prescription_id
+        LEFT JOIN locations ON encounters.location_id = locations.id
+        LEFT JOIN facilities ON locations.facility_id = facilities.id
+      `,
+    };
   }
 }


### PR DESCRIPTION
### Changes

We discovered some issues in testing with a new case related to models linked thourgh `prescription`. We have an issue where `presciption` can be linked to a facility thorough 2 possible join tables. To get around this we have to extend the fix done to the `prescription` model to these models that link through `prescription`. Now that there are 3 cases like this its possible we should make some kind of cleaner util to dry up the code but feels out of scope for a last min release fix.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
