### PR TITLE
fix(patientPortal): NASS-1776: patient portal models patient merge & lookup

### DIFF
--- a/packages/central-server/__tests__/admin/patientMerge/patientMerge.test.js
+++ b/packages/central-server/__tests__/admin/patientMerge/patientMerge.test.js
@@ -922,7 +922,6 @@ describe('Patient merge', () => {
       const [keep, merge] = await makeTwoPatients(models);
       await mergePatient(models, keep.id, merge.id);
 
-      // Create PatientUser records after the merge to simulate records that need remerging
       const keepPatientUser = await PatientUser.create({
         email: 'keep@test.com',
         patientId: keep.id,

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncLookup.test.js
@@ -106,6 +106,7 @@ describe('Sync Lookup data', () => {
       PatientProgramRegistration,
       PatientProgramRegistrationCondition,
       PatientSecondaryId,
+      PatientSurveyAssignment,
       Permission,
       ReportDefinitionVersion,
       Setting,
@@ -366,6 +367,13 @@ describe('Sync Lookup data', () => {
         surveyId: survey.id,
         option: '{"foo":"bar"}',
         config: '{"source": "ReferenceData", "where": {"type": "facility"}}',
+      }),
+    );
+    await PatientSurveyAssignment.create(
+      fake(PatientSurveyAssignment, {
+        patientId: patient.id,
+        surveyId: survey.id,
+        assignedById: examiner.id,
       }),
     );
     const surveyResponse = await SurveyResponse.create(

--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -35,6 +35,8 @@ export const simpleUpdateModels = [
   'PatientContact',
   'IPSRequest',
   'Notification',
+  'PatientUser',
+  'PatientSurveyAssignment',
 ];
 
 // These ones need a little more attention.

--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -337,14 +337,12 @@ export async function mergePatientUser(models, keepPatientId, unwantedPatientId)
     });
   }
 
-  // If both patients have portal accounts, we need to decide which one to keep
-  // Priority logic:
-  // 1. Keep the account with the most recent activity (if status indicates activity)
-  // 2. Keep the account that's currently active/enabled
+  // If both patients have portal accounts
+  // 1. Keep the account with the most recent activity
+  // 2. Keep the account that's currently registered
   // 3. Keep the account from the keep patient as fallback
-
   const shouldKeepUnwantedAccount =
-    // If keep account is inactive but unwanted account is active
+    // If keep account is inactive but unwanted account is registered
     (existingKeepPatientUser.status !== PATIENT_USER_STATUSES.REGISTERED &&
       existingUnwantedPatientUser.status === PATIENT_USER_STATUSES.REGISTERED) ||
     // If both have same status, prefer the one with more recent updates

--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -336,11 +336,7 @@ export async function mergePatientUser(models, keepPatientId, unwantedPatientId)
       patientId: keepPatientId,
     });
   }
-
-  // If both patients have portal accounts
-  // 1. Keep the account with the most recent activity
-  // 2. Keep the account that's currently registered
-  // 3. Keep the account from the keep patient as fallback
+  
   const shouldKeepUnwantedAccount =
     // If keep account is inactive but unwanted account is registered
     (existingKeepPatientUser.status !== PATIENT_USER_STATUSES.REGISTERED &&

--- a/packages/central-server/app/tasks/PatientMergeMaintainer.js
+++ b/packages/central-server/app/tasks/PatientMergeMaintainer.js
@@ -266,7 +266,6 @@ export class PatientMergeMaintainer extends ScheduledTask {
   }
 
   async specificUpdate_PatientUser() {
-    // PatientUser records need to be reconciled to ensure only one portal account per patient
     const { PatientUser } = this.models;
     const patientUserMerges = await this.findPendingMergePatients(PatientUser);
 

--- a/packages/database/src/models/PatientSurveyAssignment.ts
+++ b/packages/database/src/models/PatientSurveyAssignment.ts
@@ -3,6 +3,8 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS, PATIENT_SURVEY_ASSIGNMENTS_STATUSES } from '@tamanu/constants';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
 import { Model } from './Model';
+import { buildPatientSyncFilterViaPatientId } from '../sync/buildPatientSyncFilterViaPatientId';
+import { buildPatientLinkedLookupFilter } from '../sync/buildPatientLinkedLookupFilter';
 
 export class PatientSurveyAssignment extends Model {
   declare id: string;
@@ -92,11 +94,9 @@ export class PatientSurveyAssignment extends Model {
     });
   }
 
-  static buildPatientSyncFilter() {
-    return null;
+  static buildSyncLookupQueryDetails() {
+    return buildPatientLinkedLookupFilter(this);
   }
 
-  static buildSyncLookupQueryDetails() {
-    return null;
-  }
+  static buildPatientSyncFilter = buildPatientSyncFilterViaPatientId;
 }


### PR DESCRIPTION
### Changes

Question: Should PatientSurveyAssignment be push only? its currently bidirectional but not sure thats what we want 🤔.

Two broken tests on epic

- Add merge handling for new models (mabye we can go back over this logic) but tried to do a sensible job of conflict resolution for PatientUser
- Make `buildSyncLookupQueryDetails` & `buildPatientSyncFilter` be attached to patient and only synced if marked for sync 🤔 That makes sense to me rather than sync everywhere unnecisarily

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
