### PR TITLE
fix(sync): TAMOC-333: Prevent SequelizeConnectionAcquireTimeoutError when several syncs start at the same time

### DIFF
--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -111,8 +111,11 @@ export class CentralSyncManager {
       // If the session creation fails, we need to release the lock otherwise it will hold up
       // an open connection until the application restarts
       await unmarkSessionAsProcessing();
-      error.message = `Failed to create sync session, server may be overloaded with sync requests: ${error.message}`;
-      throw error;
+      const wrappedError = new Error(
+        `Failed to create sync session, server may be overloaded with sync requests: ${error.message}`,
+      );
+      wrappedError.stack = error.stack; // Preserve the original stack trace
+      throw wrappedError;
     }
 
     // no await as prepare session (especially the tickTockGlobalClock action) might get blocked

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -37,7 +37,7 @@ import { startSnapshotWhenCapacityAvailable } from './startSnapshotWhenCapacityA
 import { createMarkedForSyncPatientsTable } from './createMarkedForSyncPatientsTable';
 import { updateLookupTable, updateSyncLookupPendingRecords } from './updateLookupTable';
 
-const errorMessageFromSession = (session) =>
+const errorMessageFromSession = session =>
   `Sync session '${session.id}' encountered an error: ${session.errors[session.errors.length - 1]}`;
 
 // about variables lapsedSessionSeconds and lapsedSessionCheckFrequencySeconds:
@@ -98,13 +98,22 @@ export class CentralSyncManager {
     const parameters = { deviceId, facilityIds, isMobile };
 
     const unmarkSessionAsProcessing = await this.markSessionAsProcessing(sessionId);
-    const syncSession = await this.store.models.SyncSession.create({
-      id: sessionId,
-      startTime,
-      lastConnectionTime: startTime,
-      debugInfo,
-      parameters,
-    });
+    let syncSession;
+    try {
+      syncSession = await this.store.models.SyncSession.create({
+        id: sessionId,
+        startTime,
+        lastConnectionTime: startTime,
+        debugInfo,
+        parameters,
+      });
+    } catch (error) {
+      // If the session creation fails, we need to release the lock otherwise it will hold up
+      // an open connection until the application restarts
+      await unmarkSessionAsProcessing();
+      error.message = `Failed to create sync session, server may be overloaded with sync requests: ${error.message}`;
+      throw error;
+    }
 
     // no await as prepare session (especially the tickTockGlobalClock action) might get blocked
     // and take a while if the central server is concurrently persisting records from another client.
@@ -272,7 +281,7 @@ export class CentralSyncManager {
 
       const isInitialBuildOfLookupTable = parseInt(previouslyUpToTick, 10) === -1;
 
-      await repeatableReadTransaction(store.sequelize, async (transaction) => {
+      await repeatableReadTransaction(store.sequelize, async transaction => {
         // do not need to update pending records when it is initial build
         // because it uses ticks from the actual tables for updated_at_sync_tick
         if (isInitialBuildOfLookupTable) {
@@ -340,13 +349,13 @@ export class CentralSyncManager {
   async waitForPendingEdits(tick) {
     // get all the ticks (ie: keys of in-flight transaction advisory locks) of previously pending edits
     const pendingSyncTicks = (await getSyncTicksOfPendingEdits(this.store.sequelize)).filter(
-      (t) => t < tick,
+      t => t < tick,
     );
 
     // wait for any in-flight transactions of pending edits
     // that we don't miss any changes that are in progress
     await Promise.all(
-      pendingSyncTicks.map((t) => waitForPendingEditsUsingSyncTick(this.store.sequelize, t)),
+      pendingSyncTicks.map(t => waitForPendingEditsUsingSyncTick(this.store.sequelize, t)),
     );
   }
 
@@ -683,7 +692,7 @@ export class CentralSyncManager {
   async addIncomingChanges(sessionId, changes) {
     const { sequelize } = this.store;
     await this.connectToSession(sessionId);
-    const incomingSnapshotRecords = changes.map((c) => ({
+    const incomingSnapshotRecords = changes.map(c => ({
       ...c,
       direction: SYNC_SESSION_DIRECTION.INCOMING,
       updatedAtByFieldSum: c.data.updatedAtByField

--- a/packages/central-server/config/test.json5
+++ b/packages/central-server/config/test.json5
@@ -2,6 +2,9 @@
 {
   "db": {
     "name": "tamanu-central-test",
+    "pool": {
+      "acquire": 5000,
+    },
     "reportSchemas": {
       "enabled": false,
       "connections": {


### PR DESCRIPTION
### Changes

Pretty chuffed to have got to the bottom of this one :D

If several syncs initiate at the same time, then they all go in and grab their locks, but then there's no connections left to actually create the sessions themselves. If creating the session errors out, we weren't releasing the locks previously, so we'd hold that connection open forever.

Bit by bit the connection pool would grow smaller until a sync session began that grabbed the last open lock, and at that point the server is completely deadlocked.

Fix is to wrap the session creation (any any other DB interactions we might do) in a try/catch so that we definitely unlock the session even if something fails.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
