### PR TITLE
fix(medication): EPI-1265: Release 2.38: "Patient weight if printing (kg)" is not displaying for all patients under 16

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
@@ -178,7 +178,7 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
   });
 
   const patient = useSelector(state => state.patient);
-  const age = getAgeDurationFromDate(patient.dateOfBirth).years;
+  const age = getAgeDurationFromDate(patient.dateOfBirth)?.years ?? 0;
   const showPatientWeight = age < MAX_AGE_TO_RECORD_WEIGHT;
 
   useEffect(() => {

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -533,7 +533,7 @@ export const MedicationForm = ({
   const weightUnit = getTranslation('general.localisedField.weightUnit.label', 'kg');
 
   const patient = useSelector(state => state.patient);
-  const age = getAgeDurationFromDate(patient.dateOfBirth).years;
+  const age = getAgeDurationFromDate(patient.dateOfBirth)?.years ?? 0;
   const showPatientWeight = age < MAX_AGE_TO_RECORD_WEIGHT && !isOngoingPrescription;
   const canPrintPrescription = ability.can('read', 'Medication');
 


### PR DESCRIPTION

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
