### PR TITLE
fix(prescription): TAMOC-314: hotfix 2.34: Correct empty string default on prescription startDate

### DIFF
--- a/packages/database/src/migrations/1753393877000-correctPrescriptionStartDates.ts
+++ b/packages/database/src/migrations/1753393877000-correctPrescriptionStartDates.ts
@@ -1,0 +1,23 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Set any incorrectly defaulted empty string start dates to the prescriptions "date" column
+  await query.sequelize.query(`
+    UPDATE prescriptions
+    SET start_date = date
+    WHERE start_date = ''
+  `);
+  // Remove the empty string default value
+  await query.changeColumn('prescriptions', 'start_date', {
+    type: DataTypes.DATETIMESTRING,
+    allowNull: false,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.changeColumn('prescriptions', 'start_date', {
+    type: DataTypes.DATETIMESTRING,
+    allowNull: false,
+    defaultValue: '',
+  });
+}

--- a/packages/mobile/App/migrations/1753393877000-correctPrescriptionStartDates.ts
+++ b/packages/mobile/App/migrations/1753393877000-correctPrescriptionStartDates.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
+
+export class correctPrescriptionStartDates1753393877000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    // Set any incorrectly defaulted empty string start dates to the prescriptions "date" column
+    const prescriptionTable = await getTable(queryRunner, 'prescriptions');
+    await queryRunner.query(`
+      UPDATE prescriptions
+      SET startDate = date
+      WHERE startDate = ''
+    `);
+    // Remove the empty string default value
+    await queryRunner.changeColumn(prescriptionTable, 'startDate', new TableColumn({
+      name: 'startDate',
+      type: 'string',
+      isNullable: false,
+    }));
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const prescriptionTable = await getTable(queryRunner, 'prescriptions');
+    await queryRunner.changeColumn(prescriptionTable, 'startDate', new TableColumn({
+        name: 'startDate',
+        type: 'string',
+        isNullable: false,
+        default: "''",
+      }),
+    );
+  }
+}

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -67,6 +67,7 @@ import { addPatientProgramRegistrationId1743640327000 } from './1743640327000-ad
 import { removeIsMostRecentFromPatientProgramRegistrations1744754327000 } from './1744754327000-removeIsMostRecentFromPatientProgramRegistrations';
 import { addPatientProgramRegistrationInactiveFields1744234389088 } from './1744234389088-addPatientProgramRegistrationInactiveFields';
 import { updateMedicationsDBSchema1750786972719 } from './1750786972719-updateMedicationsDBSchema';
+import { correctPrescriptionStartDates1753393877000 } from './1753393877000-correctPrescriptionStartDates';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -137,4 +138,5 @@ export const migrationList = [
   removeIsMostRecentFromPatientProgramRegistrations1744754327000,
   addPatientProgramRegistrationInactiveFields1744234389088,
   updateMedicationsDBSchema1750786972719,
+  correctPrescriptionStartDates1753393877000,
 ];


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
