### PR TITLE
fix(ci): no-issue: Update the package-lock.json after we bump the version on a release branch

### DIFF
--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -50,7 +50,9 @@ jobs:
         git push --follow-tags
 
     - name: Bump version on branch
-      run: node scripts/version.mjs '${{ inputs.version }}'
+      run: |
+        node scripts/version.mjs '${{ inputs.version }}'
+        npm install
 
     - name: Commit and push
       id: nextv


### PR DESCRIPTION
### Changes

When we publish a new version of a release, we bump the version number of all the tamanu packages, but we don't update the package-lock.json file, so it's out of date.

Recently ran into this issue when cascading up a hotfix commit: https://github.com/beyondessential/tamanu/actions/runs/17310347494/job/49143140710?pr=8340

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
