### PR TITLE
Convert rem units to px

### DIFF
--- a/packages/patient-portal/src/routes/PublicRoute.tsx
+++ b/packages/patient-portal/src/routes/PublicRoute.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { styled } from '@mui/material/styles';
+import { Navigate, Outlet } from 'react-router';
+import { CircularProgress, Paper, Box } from '@mui/material';
+import { useCurrentUserQuery } from '@api/queries/useCurrentUserQuery';
+import tamanuLogoBlue from '../assets/images/tamanu_logo_blue.svg';
+import { TAMANU_COLORS } from '@tamanu/ui-components';
+
+const PageContainer = styled(Box)`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+  justify-content: center;
+  background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.5) 0%,
+      rgba(255, 255, 255, 0.485) 8.1%,
+      rgba(253, 253, 255, 0.46) 15.5%,
+      rgba(248, 248, 255, 0.425) 22.5%,
+      rgba(240, 243, 255, 0.385) 29%,
+      rgba(229, 237, 255, 0.345) 35.3%,
+      rgba(215, 230, 255, 0.31) 41.2%,
+      rgba(198, 222, 255, 0.28) 47.1%,
+      rgba(178, 213, 255, 0.26) 52.9%,
+      rgba(156, 203, 255, 0.25) 58.8%,
+      rgba(132, 192, 255, 0.255) 64.7%,
+      rgba(106, 180, 255, 0.27) 71%,
+      rgba(79, 167, 252, 0.285) 77.5%,
+      rgba(52, 153, 245, 0.305) 84.5%,
+      rgba(26, 138, 235, 0.32) 91.9%,
+      rgba(17, 114, 209, 0.3) 100%
+    ),
+    ${TAMANU_COLORS.white};
+`;
+
+const Card = styled(Paper)`
+  margin: 100px auto;
+  display: block;
+  padding: 22px;
+  min-width: 300px;
+  width: 520px;
+  max-width: 100%;
+  text-align: center;
+  border-radius: 10px;
+  box-shadow: none;
+  border: none;
+`;
+
+const TamanuLogo = styled('img')`
+  width: 160px;
+  position: absolute;
+  top: 64px;
+`;
+
+const PublicPageLayout = ({ children }: { children: React.ReactNode }) => (
+  <PageContainer>
+    <TamanuLogo src={tamanuLogoBlue} alt="Tamanu Logo" />
+    <Card>{children}</Card>
+  </PageContainer>
+);
+
+export const PublicRoute = () => {
+  const { data: user, isPending } = useCurrentUserQuery();
+
+  if (isPending) {
+    return <CircularProgress />;
+  }
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <PublicPageLayout>
+      <Outlet />
+    </PublicPageLayout>
+  );
+};


### PR DESCRIPTION
### Changes

Converted `rem` units to `px` units in `packages/patient-portal/src/routes/PublicRoute.tsx` using a standard 1rem = 16px conversion.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
<a href="https://cursor.com/background-agent?bcId=bc-9a7ab54a-29de-4e4f-a876-270f92c976e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a7ab54a-29de-4e4f-a876-270f92c976e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

