### PR TITLE
fix(desktop): SAV-1010: Download data button fix

### DIFF
--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -10,6 +10,7 @@ import { saveFile } from '../../utils/fileSystemAccess';
 import { TranslationContext, useTranslation } from '../../contexts/Translation';
 import { GreyOutlinedButton } from '../Button';
 import { isTranslatedText, TranslatedText } from '../Translation';
+import { ViewPhotoLink } from '../ViewPhotoLink';
 
 /**
  * Recursive mapper for transforming leaf nodes in a DOM tree. Used here to explicitly wrap
@@ -31,6 +32,12 @@ const normalizeRecursively = (element, normalizeFn) => {
       : normalizeRecursively(children, normalizeFn),
   });
 };
+
+// Some elements should be ignored when exporting data because they are not
+// text-based, too complex or otherwise not suitable for export.
+function shouldIgnoreElement(element) {
+  return [ViewPhotoLink].includes(element.type);
+}
 
 export function DownloadDataButton({ exportName, columns, data, ExportButton }) {
   const queryClient = useQueryClient();
@@ -61,6 +68,8 @@ export function DownloadDataButton({ exportName, columns, data, ExportButton }) 
         </QueryClientProvider>
       );
     };
+
+    if (shouldIgnoreElement(element)) return '';
 
     const normalizedElement = normalizeRecursively(element, contextualizeIfIsTranslatedText);
     return renderToText(normalizedElement);

--- a/packages/web/app/components/VitalsTable.jsx
+++ b/packages/web/app/components/VitalsTable.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { SETTING_KEYS, PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
-import { getReferenceDataOptionStringId } from '@tamanu/shared/utils/translation';
+import { getReferenceDataOptionStringId, getReferenceDataStringId } from '@tamanu/shared/utils/translation';
 
 import { DynamicColumnTable } from './Table';
 import { useEncounter } from '../contexts/Encounter';
@@ -11,7 +11,6 @@ import { useVitalsQuery } from '../api/queries/useVitalsQuery';
 import { EditVitalCellModal } from './EditVitalCellModal';
 import { getVitalsTableColumns } from './VitalsAndChartsTableColumns';
 import { useSettings } from '../contexts/Settings';
-import { TranslatedReferenceData } from './Translation';
 import { useTranslation } from '../contexts/Translation';
 
 const StyledDynamicColumnTable = styled(DynamicColumnTable)`
@@ -43,12 +42,9 @@ export const VitalsTable = React.memo(() => {
     // First translate the element heading
     const processedRecord = {
       ...record,
-      value: (
-        <TranslatedReferenceData
-          category="programDataElement"
-          value={record.dataElementId}
-          fallback={record.value}
-        />
+      value: getTranslation(
+        getReferenceDataStringId(record.dataElementId, 'programDataElement'),
+        record.value,
       ),
     };
 


### PR DESCRIPTION
### Changes

So the issue happens because the table `data` had translation components and they don't work with how we download stuff. This happens in vitals/charts because the data object in those tables is different so this shouldn't be a problem elsewhere.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->
