### PR TITLE
fix: use --legacy-peer-deps to work around npm/deps issues (v2.40)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-packages/mobile
 **/node_modules
 node_modules
 .ssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,15 @@ COPY package.json package-lock.json COPYRIGHT LICENSE-GPL LICENSE-BSL ./
 
 FROM base AS build-base
 RUN apk add --no-cache \
-    --virtual .build-deps \
-    bash \
-    g++ \
-    gcc \
-    git \
-    jq \
-    make \
-    python3
+  --virtual .build-deps \
+  bash \
+  g++ \
+  gcc \
+  git \
+  jq \
+  make \
+  python3
+RUN pip install distutils
 COPY common.* ./
 COPY scripts/ scripts/
 
@@ -104,7 +105,7 @@ RUN apt update && apt install -y --no-install-recommends \
   zstd
 RUN \
   curl -L --proto '=https' --tlsv1.2 -sSf -o step-cli.deb \
-    "https://dl.smallstep.com/cli/docs-cli-install/latest/step-cli_$(dpkg --print-architecture).deb" \
+  "https://dl.smallstep.com/cli/docs-cli-install/latest/step-cli_$(dpkg --print-architecture).deb" \
   && dpkg -i step-cli.deb \
   && rm step-cli.deb
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
   make \
   python3 \
   py3-setuptools
+RUN npm install -g node-gyp
 COPY common.* ./
 COPY scripts/ scripts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
   jq \
   make \
   python3 \
-  py3-distutils-extra
+  py3-setuptools
 COPY common.* ./
 COPY scripts/ scripts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add --no-cache \
   git \
   jq \
   make \
-  python3
-RUN pip install distutils
+  python3 \
+  py3-distutils-extra
 COPY common.* ./
 COPY scripts/ scripts/
 

--- a/scripts/_do-with-all-packages.mjs
+++ b/scripts/_do-with-all-packages.mjs
@@ -65,7 +65,7 @@ export function doWithAllPackages(fn) {
         try {
           pkg = JSON.parse(readFileSync(pkgPath));
         } catch (err) {
-          console.log(`Skipping ${workspace} as we can't read its package.json...`);
+          console.error(`Skipping ${workspace} as we can't read its package.json...`);
           continue;
         }
 

--- a/scripts/_do-with-all-packages.mjs
+++ b/scripts/_do-with-all-packages.mjs
@@ -16,7 +16,7 @@ function extractDependencyTree(workspaceTree, workspaces) {
   Object.entries(workspaceTree.dependencies).forEach(([workspace, info]) => {
     let dependencies = [];
     if (info.dependencies) {
-      dependencies = Object.keys(info.dependencies).filter((dependency) =>
+      dependencies = Object.keys(info.dependencies).filter(dependency =>
         workspaces.has(dependency),
       );
     }
@@ -34,7 +34,9 @@ function extractLocation(resolvedPath) {
 export function doWithAllPackages(fn) {
   const workspaceTree = JSON.parse(
     cleanupLeadingGarbage(
-      execFileSync('npm', ['ls', '--workspaces', '--json'], { encoding: 'utf8' }),
+      execFileSync('npm', ['ls', '--workspaces', '--legacy-peer-deps', '--json'], {
+        encoding: 'utf8',
+      }),
     ),
   );
 
@@ -55,7 +57,7 @@ export function doWithAllPackages(fn) {
       const location = extractLocation(resolved);
       const workspaceDependencies = dependencyTree[workspace];
 
-      if (workspaceDependencies.every((dep) => processed.has(dep))) {
+      if (workspaceDependencies.every(dep => processed.has(dep))) {
         processed.add(workspace);
 
         const pkgPath = `./${location}/package.json`;

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -22,6 +22,7 @@ remove_irrelevant_packages() {
   # remove from npm workspace list all packages that aren't the ones we're building
   cp package.json{,.working}
   scripts/list-packages.mjs -- --no-shared -- --paths \
+    | tee /dev/stderr \
     | jq \
       --arg wanted "$1" \
       '(. - ["packages/\($wanted)"])' \

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -22,11 +22,16 @@ remove_irrelevant_packages() {
   # remove from npm workspace list all packages that aren't the ones we're building
   cp package.json{,.working}
   scripts/list-packages.mjs -- --no-shared -- --paths \
-    | tee /dev/stderr \
+    | tee debug.json \
     | jq \
       --arg wanted "$1" \
       '(. - ["packages/\($wanted)"])' \
-    > /tmp/unwanted.json
+    > /tmp/unwanted.json || true
+    if [[ ! -s /tmp/unwanted.json ]]; then
+      stat debug.json || true
+      cat debug.json || true
+      exit 1
+    fi
 
   # erase from the package.json
   jq \


### PR DESCRIPTION
### Changes

This is actually all because we use unholy hacks to avoid upgrading deps properly to support React 18.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
