### PR TITLE
feat(web): SAV-1008: new login errors (with lockout support)

### DIFF
--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -92,9 +92,6 @@ const StyledCheckboxField = styled(Field)`
   }
 `;
 
-const INCORRECT_CREDENTIALS_ERROR_MESSAGE =
-  'Server error response: Incorrect username or password, please try again';
-
 const LoginFormComponent = ({
   errorMessage,
   onNavToResetPassword,
@@ -102,20 +99,6 @@ const LoginFormComponent = ({
   rememberEmail,
 }) => {
   const { getTranslation } = useTranslation();
-
-  const [genericMessage, setGenericMessage] = useState(null);
-
-  useEffect(() => {
-    if (errorMessage === INCORRECT_CREDENTIALS_ERROR_MESSAGE) {
-      setFieldError('email', 'Incorrect credentials');
-      setFieldError('password', 'Incorrect credentials');
-    } else {
-      setGenericMessage(errorMessage);
-    }
-
-    // only run this logic when error message is updated
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errorMessage]);
 
   const removeValidation = () => {
     setFieldError('email', '');
@@ -147,7 +130,7 @@ const LoginFormComponent = ({
             data-testid="translatedtext-hwc1"
           />
         </LoginSubtext>
-        {!!genericMessage && <LoginAlert>{genericMessage}</LoginAlert>}
+        {!!errorMessage && <LoginAlert>{errorMessage}</LoginAlert>}
       </div>
       <StyledField
         name="email"

--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -3,6 +3,7 @@ import * as yup from 'yup';
 import styled from 'styled-components';
 
 import { Typography } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
 import { FormGrid } from '../components/FormGrid';
 import {
   BodyText,
@@ -18,9 +19,14 @@ import { LanguageSelector } from '../components/LanguageSelector';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 import { useTranslation } from '../contexts/Translation';
 
-const FormSubtext = styled(BodyText)`
-  color: ${Colors.midText};
-  padding: 10px 0;
+const LoginAlert = styled(({ children, ...props }) => (
+  <Alert severity="error" icon={false} data-testid="loginerror-ppw6" {...props}>
+    {children}
+  </Alert>
+))`
+  border: oklch(from currentColor calc(l * 1.9) calc(c * 2) h) solid 1px;
+  border-radius: 0.5em;
+  margin-top: 1em;
 `;
 
 const LoginHeading = styled(Typography)`
@@ -141,9 +147,7 @@ const LoginFormComponent = ({
             data-testid="translatedtext-hwc1"
           />
         </LoginSubtext>
-        {!!genericMessage && (
-          <FormSubtext data-testid="formsubtext-ppw6">{genericMessage}</FormSubtext>
-        )}
+        {!!genericMessage && <LoginAlert>{genericMessage}</LoginAlert>}
       </div>
       <StyledField
         name="email"

--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -43,9 +43,10 @@ const LoginButton = styled(FormSubmitButton)`
 `;
 
 const ForgotPasswordButton = styled(TextButton)`
-  font-size: 11px;
   color: black;
+  font-size: 11px;
   font-weight: 400;
+  text-transform: none;
 
   :hover {
     color: ${Colors.primary};
@@ -214,7 +215,7 @@ const LoginFormComponent = ({
       >
         <TranslatedText
           stringId="login.forgotPassword.label"
-          fallback="Forgot your password?"
+          fallback="Forgot password?"
           data-testid="translatedtext-427q"
         />
       </ForgotPasswordButton>

--- a/packages/web/app/forms/LoginForm.jsx
+++ b/packages/web/app/forms/LoginForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import * as yup from 'yup';
 import styled from 'styled-components';
 

--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -45,7 +45,7 @@ export const login =
         )} minutes.`;
       } else if (error.type === ERROR_TYPE.AUTH_CREDENTIAL_INVALID && error.extra.has('lockout-attempts')) {
         const attemptsLeft = error.extra.get('lockout-attempts');
-        const lockoutDuration = Math.ceil(error.extra.get('lockout-duration') ?? 0 / 60);
+        const lockoutDuration = Math.ceil((error.extra.get('lockout-duration') ?? 0) / 60);
         const lockoutWarning = lockoutDuration > 0 ? ` before you are locked out for ${lockoutDuration} minutes` : '';
         message = `${error.title}, please try again.\n\nYou have ${attemptsLeft} more log in attempts${lockoutWarning}.`;
       }

--- a/packages/web/app/store/auth.js
+++ b/packages/web/app/store/auth.js
@@ -1,3 +1,4 @@
+import { ERROR_TYPE } from '@tamanu/errors';
 import { createStatePreservingReducer } from '../utils/createStatePreservingReducer';
 
 // actions
@@ -37,7 +38,18 @@ export const login =
       const loginInfo = await api.login(email, password);
       await handleLoginSuccess(dispatch, loginInfo);
     } catch (error) {
-      dispatch({ type: LOGIN_FAILURE, error: error.message });
+      let message = error.message;
+      if (error.type === ERROR_TYPE.RATE_LIMITED) {
+        message = `You have been locked out due to too many log in attempts. Please try again in ${Math.ceil(
+          error.extra.get('retry-after') / 60,
+        )} minutes.`;
+      } else if (error.type === ERROR_TYPE.AUTH_CREDENTIAL_INVALID && error.extra.has('lockout-attempts')) {
+        const attemptsLeft = error.extra.get('lockout-attempts');
+        const lockoutDuration = Math.ceil(error.extra.get('lockout-duration') ?? 0 / 60);
+        const lockoutWarning = lockoutDuration > 0 ? ` before you are locked out for ${lockoutDuration} minutes` : '';
+        message = `${error.title}, please try again.\n\nYou have ${attemptsLeft} more log in attempts${lockoutWarning}.`;
+      }
+      dispatch({ type: LOGIN_FAILURE, error: message });
     }
   };
 
@@ -116,7 +128,13 @@ export const requestPasswordReset =
       await api.requestPasswordReset(email);
       dispatch({ type: REQUEST_PASSWORD_RESET_SUCCESS, email });
     } catch (error) {
-      dispatch({ type: REQUEST_PASSWORD_RESET_FAILURE, error: error.message });
+      let message = error.message;
+      if (error.type === ERROR_TYPE.RATE_LIMITED) {
+        message = `User locked out. ${Math.ceil(
+          error.extra.get('retry-after') / 60,
+        )} minutes remaining.`;
+      }
+      dispatch({ type: REQUEST_PASSWORD_RESET_FAILURE, error: message });
     }
   };
 


### PR DESCRIPTION
### Changes

Builds on top of #8416 which adds a way to carry arbitrary context with errors in a structured way, and unifies API errors across server and client.

Includes design changes to match new views from figma.

This sketches out a scheme where:

- if a user is fully locked out, the endpoint should return a `RateLimitedError`, with the normal `retry-after` extra data (in seconds)
- if a user has entered wrong credentials, the endpoint should return `InvalidCredentialError` (as currently) and additionally include two new extra data fields:
  - `lockout-attempts`, an integer number of remaining login attempts
  - `lockout-duration`, the number of seconds that a lockout lasts for

When those errors / extra data fields are received by the frontend, it renders the errors as per figma, and otherwise falls back to the normal error messages.

The cool thing about this approach is we totally can translate those errors; the PR doesn't do that _yet_ just to avoid churn if we change things around a bit.

### Testing notes

For this PR in isolation: login on both central and facility, ensure that works, then logout, then:
- fail to fill in either or both of the email/password, and check the fields go red with "Required" labels
- fill both fields but with an invalid email address e.g. `invalid`, and check the email field goes red with an appropriate label
- fill both fields but with a wrong password, and verify the style of the alert match the figma designs

The lockout functionality is _not_ implemented in this PR, so there's no need to test for those scenarios yet.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
