### PR TITLE
tweak(patientPortal): NASS-1767: Make default register expiry 1 month

### DIFF
--- a/packages/central-server/__tests__/patientPortal/portalOneTimeTokenService.test.js
+++ b/packages/central-server/__tests__/patientPortal/portalOneTimeTokenService.test.js
@@ -142,7 +142,7 @@ describe('PortalOneTimeTokenService', () => {
       const result = await customService.createRegisterToken(testPortalUser.id);
 
       // Verify expiry time is correct (to closest minute to avoid false negatives)
-      const defaultExpiryMinutes = 1440;
+      const defaultExpiryMinutes = 43800;
       const expectedExpiry = addMinutes(now, defaultExpiryMinutes);
 
       const expiry = parseISO(result.expiresAt);

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -527,6 +527,6 @@
     "portalUrl": "http://localhost:5175",
     "tokenDuration": "24h",
     "loginTokenDurationMinutes": 20,
-    "registerTokenDurationMinutes": 1440
+    "registerTokenDurationMinutes": 43800 // 1 month
   }
 }


### PR DESCRIPTION
### Changes

Discussed that this is appropriate given portal users cannot re-issue a link without contacting clinicians

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
