### PR TITLE
fix: EPI-1184: Handle scheduling conflicts in User Leave Section

### DIFF
--- a/packages/central-server/app/admin/locationAssignments.js
+++ b/packages/central-server/app/admin/locationAssignments.js
@@ -34,6 +34,7 @@ const customAssignmentValidation = (data, ctx) => {
 const getLocationAssignmentsSchema = z.object({
   after: dateCustomValidation.optional(),
   before: dateCustomValidation.optional(),
+  userId: z.string().optional(),
   locationId: z.string().optional(),
   facilityId: z.string().optional(),
   page: z.coerce.number().int().min(0).optional().default(0),
@@ -54,7 +55,7 @@ locationAssignmentsRouter.get(
 
     const query = await getLocationAssignmentsSchema.parseAsync(req.query);
 
-    const { after, before, locationId, facilityId, page, rowsPerPage, all } = query;
+    const { after, before, locationId, facilityId, userId, page, rowsPerPage, all } = query;
 
     const includeOptions = [
       {
@@ -95,6 +96,7 @@ locationAssignmentsRouter.get(
         ...(before && { [Op.lte]: before }),
       },
       ...(locationId && { locationId }),
+      ...(userId && { userId }),
       ...(facilityId && {
         [Op.or]: [
           { '$location.facility_id$': facilityId },

--- a/packages/web/app/components/LocationAssignmentConflictModal.jsx
+++ b/packages/web/app/components/LocationAssignmentConflictModal.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import styled from 'styled-components';
+import { formatShort } from '@tamanu/utils/dateTime';
+import { Box } from '@mui/material';
+
+import { ConfirmModal } from './ConfirmModal';
+import { TranslatedText } from './Translation';
+import { Colors } from '../constants';
+import { BodyText } from './Typography';
+
+
+const StyledConfirmModal = styled(ConfirmModal)`
+  & .MuiPaper-root {
+    max-width: 575px;
+  }
+`;
+
+const Container = styled.div`
+  width: 100%;
+  padding-top: 16px;
+  padding-bottom: 4px;
+`;
+
+const ScheduledLeaveWrapper = styled.div`
+  padding: 12px 20px;
+  border: 1px solid ${Colors.outline};
+  border-radius: 3px;
+  background-color: ${Colors.white};
+  margin-top: 20px;
+`;
+
+const ScheduledLeaveTitle = styled(BodyText)`
+  color: ${Colors.midText};
+  margin-bottom: 8px;
+`;
+
+const ScheduledLeaveDates = styled(BodyText)`
+  color: ${Colors.darkestText};
+  font-weight: 500;
+`;
+
+export const LocationAssignmentConflictModal = ({ 
+  open, 
+  onClose, 
+  onConfirm, 
+  startDate, 
+  endDate 
+}) => {
+  return (
+    <StyledConfirmModal
+      open={open}
+      onCancel={onClose}
+      onConfirm={onConfirm}
+      title={
+        <TranslatedText
+          stringId="admin.users.leave.locationConflict.title"
+          fallback="Location assigned during scheduled leave"
+        />
+      }
+      cancelButtonText={
+        <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
+      }
+      confirmButtonText={
+        <TranslatedText stringId="general.action.confirm" fallback="Confirm" />
+      }
+      customContent={
+        <Container>
+          <BodyText color={Colors.darkestText}>
+            <TranslatedText
+              stringId="admin.users.leave.locationConflict.description"
+              fallback="The user has one or more locations assigned during the leave dates selected."
+            />{' '}
+            <Box fontWeight={500}>
+            <TranslatedText
+              stringId="admin.users.leave.locationConflict.warning"
+              fallback="The user will be automatically removed from any assigned locations during the scheduled leave dates."
+            />
+            </Box>
+          </BodyText>
+          <ScheduledLeaveWrapper>
+            <ScheduledLeaveTitle>
+              <TranslatedText
+                stringId="admin.users.leave.locationConflict.scheduledLeave"
+                fallback="User scheduled leave"
+              />
+            </ScheduledLeaveTitle>
+            <ScheduledLeaveDates>
+              {formatShort(startDate)} - {formatShort(endDate)}
+            </ScheduledLeaveDates>
+          </ScheduledLeaveWrapper>
+        </Container>
+      }
+    />
+  );
+};


### PR DESCRIPTION
### Changes

- Introduced a new modal component for displaying location assignment conflicts during user leave scheduling.
- Updated UserLeaveSection to check for existing location assignments before creating a leave, triggering the conflict modal if necessary.
- Enhanced location assignment query to include userId for conflict detection.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
