### PR TITLE
tweak(patientPortal): NASS-1767: Deceased patient handling in patient portal auth

### DIFF
--- a/packages/central-server/__tests__/patientPortal/patientPortalAuth.test.js
+++ b/packages/central-server/__tests__/patientPortal/patientPortalAuth.test.js
@@ -220,17 +220,7 @@ describe('Patient Portal Auth', () => {
       expect(response).toHaveRequestError();
     });
 
-    it('Should reject request for deceased patient with a valid token', async () => {
-      const token = await getPatientAuthToken(baseApp, store.models, TEST_PATIENT_EMAIL);
-      // mark patient as deceased
-      await testPatient.update({ dateOfDeath: new Date().toISOString() });
 
-      const response = await baseApp
-        .get('/api/portal/me')
-        .set('Authorization', `Bearer ${token}`);
-      expect(response).toHaveRequestError();
-
-    });
   });
 
   describe('Patient Portal Route Protection', () => {

--- a/packages/central-server/__tests__/patientPortal/patientPortalAuth.test.js
+++ b/packages/central-server/__tests__/patientPortal/patientPortalAuth.test.js
@@ -230,8 +230,6 @@ describe('Patient Portal Auth', () => {
         .set('Authorization', `Bearer ${token}`);
       expect(response).toHaveRequestError();
 
-      // cleanup to avoid affecting other tests
-      await testPatient.update({ dateOfDeath: null });
     });
   });
 

--- a/packages/central-server/app/patientPortal/auth/patientPortalLogin.js
+++ b/packages/central-server/app/patientPortal/auth/patientPortalLogin.js
@@ -54,10 +54,10 @@ export const requestLoginToken = asyncHandler(async (req, res) => {
     });
   }
 
-  // Do not issue login tokens for deceased patients (avoid enumeration: respond with success)
+  // Do not issue login tokens for deceased patients
   const patient = await portalUser.getPatient();
   if (patient?.dateOfDeath) {
-    log.debug('Patient portal login: Deceased patient - suppressing token issuance', {
+    log.debug('Patient portal login: Deceased patient - suppressing issuing token', {
       email,
       patientId: patient.id,
     });

--- a/packages/central-server/app/patientPortal/auth/patientPortalLogin.js
+++ b/packages/central-server/app/patientPortal/auth/patientPortalLogin.js
@@ -97,14 +97,19 @@ export const patientPortalLogin = ({ secret }) =>
     const patient = await portalUser?.getPatient();
     
     let portalUserIdParam = portalUser?.id;
-    if (patient?.dateOfDeath || !portalUser) {
-      log.debug('Patient portal login: suppressing issuing token', {
+    if (!portalUser) {
+      log.debug('Patient portal login: suppressing issuing token for unknown user', {
         email,
-        patientId: patient?.id,
-        portalUserId: portalUser?.id,
-        isDeceased: patient?.dateOfDeath,
       });
-      // If the email is unknown, or the patient is deceased, pass undefined so the service throws a generic auth error.
+      // If the email is unknown, pass undefined so the service throws a generic auth error.
+      portalUserIdParam = undefined;
+    } else if (patient?.dateOfDeath) {
+      log.debug('Patient portal login: suppressing issuing token for deceased patient', {
+        email,
+        patientId: patient.id,
+        portalUserId: portalUser.id,
+      });
+      // If the patient is deceased, pass undefined so the service throws a generic auth error.
       portalUserIdParam = undefined;
     }
 

--- a/packages/central-server/app/patientPortal/auth/patientPortalMiddleware.js
+++ b/packages/central-server/app/patientPortal/auth/patientPortalMiddleware.js
@@ -62,18 +62,6 @@ export const patientPortalMiddleware = ({ secret }) =>
       );
     }
 
-    // Reject access if the patient is deceased
-    if (patient.dateOfDeath) {
-      log.debug('Patient portal auth error: Deceased patient token use', {
-        portalUserId,
-        patientId: patient.id,
-      });
-      res.status(401).send({
-        error: { message: 'Invalid token' },
-      });
-      return;
-    }
-
     /* eslint-disable require-atomic-updates */
     req.portalUser = portalUser;
     req.patient = patient;

--- a/packages/central-server/app/patientPortal/auth/patientPortalMiddleware.js
+++ b/packages/central-server/app/patientPortal/auth/patientPortalMiddleware.js
@@ -62,6 +62,18 @@ export const patientPortalMiddleware = ({ secret }) =>
       );
     }
 
+    // Reject access if the patient is deceased
+    if (patient.dateOfDeath) {
+      log.debug('Patient portal auth error: Deceased patient token use', {
+        portalUserId,
+        patientId: patient.id,
+      });
+      res.status(401).send({
+        error: { message: 'Invalid token' },
+      });
+      return;
+    }
+
     /* eslint-disable require-atomic-updates */
     req.portalUser = portalUser;
     req.patient = patient;


### PR DESCRIPTION
### Changes

- Basically revoke access if deceased

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
