### PR TITLE
fix: socket.io path is /api/socket.io

### DIFF
--- a/packages/mobile/App/ui/hooks/useSocket.ts
+++ b/packages/mobile/App/ui/hooks/useSocket.ts
@@ -9,10 +9,7 @@ export const useSocket = () => {
   const [connectionUrl, setConnectionUrl] = useState('');
 
   const setupConnectionUrl = async () => {
-    const syncServerLocation = await readConfig('syncServerLocation');
-    const url = new URL(syncServerLocation);
-    url.pathname = '/api';
-    setConnectionUrl(url.toString());
+    setConnectionUrl(await readConfig('syncServerLocation'));
   };
 
   useEffect(() => {

--- a/packages/mobile/App/ui/hooks/useSocket.ts
+++ b/packages/mobile/App/ui/hooks/useSocket.ts
@@ -2,14 +2,9 @@ import io, { Socket } from 'socket.io-client';
 import { useEffect, useState } from 'react';
 import { readConfig } from '~/services/config';
 
-interface Props {
-  uri?: string;
-}
-
 const cachedWebSocketInstances: Record<string, { instance: Socket; count: number }> = {};
 
-export const useSocket = (props: Props = {}) => {
-  const { uri } = props;
+export const useSocket = () => {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [connectionUrl, setConnectionUrl] = useState('');
 
@@ -33,8 +28,9 @@ export const useSocket = (props: Props = {}) => {
 
   const setupConnectionUrl = async () => {
     const syncServerLocation = await readConfig('syncServerLocation');
-    const connectionUrl = uri || syncServerLocation;
-    setConnectionUrl(connectionUrl);
+    const url = new URL(syncServerLocation);
+    url.pathname = '/api';
+    setConnectionUrl(url.toString());
   };
 
   const initSocket = async () => {

--- a/packages/mobile/App/ui/hooks/useSocket.ts
+++ b/packages/mobile/App/ui/hooks/useSocket.ts
@@ -21,7 +21,7 @@ export const useSocket = () => {
     setSocket(
       (cachedSocket = io(connectionUrl, {
         path: '/api/socket.io/',
-        transports: ['webtransport', 'websocket'],
+        transports: ['websocket'],
       })),
     );
     return () => {

--- a/packages/mobile/App/ui/hooks/useSocket.ts
+++ b/packages/mobile/App/ui/hooks/useSocket.ts
@@ -20,7 +20,7 @@ export const useSocket = () => {
     if (!connectionUrl) return;
     setSocket(
       (cachedSocket = io(connectionUrl, {
-        path: '/api',
+        path: '/api/socket.io/',
         transports: ['webtransport', 'websocket'],
       })),
     );

--- a/packages/mobile/App/ui/hooks/useSocket.ts
+++ b/packages/mobile/App/ui/hooks/useSocket.ts
@@ -40,7 +40,7 @@ export const useSocket = () => {
       setSocket(cached.instance);
     }
 
-    const newSocket = io(connectionUrl, { transports: ['websocket'] });
+    const newSocket = io(connectionUrl, { transports: ['webtransport', 'websocket'] });
     cachedWebSocketInstances[connectionUrl] = {
       instance: newSocket,
       count: 1,

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -1,37 +1,16 @@
 import io from 'socket.io-client';
 import { useEffect, useState } from 'react';
 
-const cachedWebSocketInstances = {};
+let cachedSocket;
 
 export const useSocket = () => {
-  const connectionUrl = '/api';
-
-  const initializeSocketInstance = () => {
-    const cached = cachedWebSocketInstances[connectionUrl];
-    if (cached) {
-      cachedWebSocketInstances[connectionUrl].count += 1;
-      return cached.instance;
-    }
-
-    const newSocket = io(connectionUrl, { transports: ['webtransport', 'websocket'] });
-    cachedWebSocketInstances[connectionUrl] = {
-      instance: newSocket,
-      count: 1,
-    };
-    return newSocket;
-  };
-
-  const [socket] = useState(initializeSocketInstance);
+  const [socket] = useState(() => {
+    return (cachedSocket = io('', { path: '/api', transports: ['webtransport', 'websocket'] }));
+  });
 
   useEffect(() => {
     return () => {
-      if (cachedWebSocketInstances[connectionUrl]?.count > 1) {
-        cachedWebSocketInstances[connectionUrl].count -= 1;
-        return;
-      }
-
-      delete cachedWebSocketInstances[connectionUrl];
-      socket?.disconnect();
+      cachedSocket?.disconnect();
     };
   }, []);
 

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -13,7 +13,7 @@ export const useSocket = () => {
       return cached.instance;
     }
 
-    const newSocket = io(connectionUrl, { transports: ['websocket'] });
+    const newSocket = io(connectionUrl, { transports: ['webtransport', 'websocket'] });
     cachedWebSocketInstances[connectionUrl] = {
       instance: newSocket,
       count: 1,

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -7,7 +7,7 @@ export const useSocket = () => {
   const [socket] = useState(() => {
     return (cachedSocket = io('', {
       path: '/api/socket.io/',
-      transports: ['webtransport', 'websocket'],
+      transports: ['websocket'],
     }));
   });
 

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 const cachedWebSocketInstances = {};
 
 export const useSocket = (props = {}) => {
-  const { uri = '' } = props;
+  const { uri = '/api' } = props;
   const connectionUrl = uri;
 
   const initializeSocketInstance = () => {

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -5,7 +5,10 @@ let cachedSocket;
 
 export const useSocket = () => {
   const [socket] = useState(() => {
-    return (cachedSocket = io('', { path: '/api', transports: ['webtransport', 'websocket'] }));
+    return (cachedSocket = io('', {
+      path: '/api/socket.io/',
+      transports: ['webtransport', 'websocket'],
+    }));
   });
 
   useEffect(() => {

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -3,9 +3,8 @@ import { useEffect, useState } from 'react';
 
 const cachedWebSocketInstances = {};
 
-export const useSocket = (props = {}) => {
-  const { uri = '/api' } = props;
-  const connectionUrl = uri;
+export const useSocket = () => {
+  const connectionUrl = '/api';
 
   const initializeSocketInstance = () => {
     const cached = cachedWebSocketInstances[connectionUrl];


### PR DESCRIPTION
### Changes

- I swear I said this a few times but I guess it got forgotten somewhere, anyway, fixed
- The reference-counting logic is unnecessary because _socketio already does this internally_

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
