### PR TITLE
feat: allow debugging of errors in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29070,6 +29070,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/get-uri": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
@@ -42505,6 +42518,16 @@
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "license": "MIT"
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -46045,6 +46068,536 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -52281,6 +52834,7 @@
         "@types/node": "^20.9.0",
         "@types/toposort": "^2.0.7",
         "rimraf": "^6.0.1",
+        "tsx": "^4.20.6",
         "type-fest": "^4.31.0",
         "vitest": "^2.1.9"
       }

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -1,3 +1,4 @@
+import { convertDatabaseError } from '@tamanu/database';
 import { errorHandlerProblem } from '@tamanu/shared/utils';
 
 // eslint-disable-next-line no-unused-vars
@@ -8,7 +9,7 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
     return;
   }
 
-  const { problem, json } = errorHandlerProblem(error, req);
+  const { problem, json } = errorHandlerProblem(error, req, { convertDatabaseError });
 
   res.set(problem.headers);
   res.status(problem.status).send(getResponse(error, json));

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -20,7 +20,7 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
     error instanceof Problem ? error : Problem.fromError(error)
   ).excludeSensitiveFields(
     process.env.NODE_ENV === 'production' &&
-      req.get('tamanu-debug') === config.debugging.apiErrorsToken,
+      req.get('tamanu-debug') !== config.debugging.apiErrorsToken,
   );
 
   if (problem.status >= 500) {

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { BaseError as SequelizeError } from 'sequelize';
 import { convertDatabaseError } from '@tamanu/database';
 import { Problem } from '@tamanu/errors';
@@ -17,7 +18,10 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
 
   const problem = (
     error instanceof Problem ? error : Problem.fromError(error)
-  ).excludeSensitiveFields(process.env.NODE_ENV === 'production');
+  ).excludeSensitiveFields(
+    process.env.NODE_ENV === 'production' &&
+      req.get('tamanu-debug') === config.debugging.apiErrorsToken,
+  );
 
   if (problem.status >= 500) {
     log.error(`Error ${problem.status} (${problem.type}): `, error);

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -19,7 +19,8 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
 
   const exposeSensitive =
     process.env.NODE_ENV !== 'production' ||
-    (config.debugging.apiErrorsToken &&
+    (typeof config.debugging.apiErrorsToken === 'string' &&
+      config.debugging.apiErrorsToken.length > 0 &&
       timingSafeEqual(
         Buffer.from(req.get('tamanu-debug') ?? ''),
         Buffer.from(config.debugging.apiErrorsToken ?? ''),

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -20,6 +20,7 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
     error instanceof Problem ? error : Problem.fromError(error)
   ).excludeSensitiveFields(
     process.env.NODE_ENV === 'production' &&
+      config.debugging.apiErrorsToken &&
       req.get('tamanu-debug') !== config.debugging.apiErrorsToken,
   );
 

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -16,13 +16,13 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
     error = convertDatabaseError(error);
   }
 
+  const exposeSensitive =
+    process.env.NODE_ENV !== 'production' ||
+    (config.debugging.apiErrorsToken &&
+      req.get('tamanu-debug') === config.debugging.apiErrorsToken);
   const problem = (
     error instanceof Problem ? error : Problem.fromError(error)
-  ).excludeSensitiveFields(
-    process.env.NODE_ENV === 'production' &&
-      config.debugging.apiErrorsToken &&
-      req.get('tamanu-debug') !== config.debugging.apiErrorsToken,
-  );
+  ).excludeSensitiveFields(!exposeSensitive);
 
   if (problem.status >= 500) {
     log.error(`Error ${problem.status} (${problem.type}): `, error);

--- a/packages/central-server/app/middleware/errorHandler.js
+++ b/packages/central-server/app/middleware/errorHandler.js
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import config from 'config';
 import { BaseError as SequelizeError } from 'sequelize';
 import { convertDatabaseError } from '@tamanu/database';
@@ -19,7 +20,10 @@ export const buildErrorHandler = getResponse => (error, req, res, next) => {
   const exposeSensitive =
     process.env.NODE_ENV !== 'production' ||
     (config.debugging.apiErrorsToken &&
-      req.get('tamanu-debug') === config.debugging.apiErrorsToken);
+      timingSafeEqual(
+        Buffer.from(req.get('tamanu-debug') ?? ''),
+        Buffer.from(config.debugging.apiErrorsToken ?? ''),
+      ));
   const problem = (
     error instanceof Problem ? error : Problem.fromError(error)
   ).excludeSensitiveFields(!exposeSensitive);

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -38,6 +38,11 @@
       }
     }
   },
+  debugging: {
+    // set a `tamanu-debug` header on a request with the value of this key
+    // and the errors will get stack traces.
+    apiErrorsToken: false,
+  },
   "metaServer": {
     "host": "https://meta.tamanu.app",
     "serverId": null,

--- a/packages/errors/src/Problem.ts
+++ b/packages/errors/src/Problem.ts
@@ -124,11 +124,9 @@ export class Problem extends Error {
 
     const problem = new Problem(type, json.title, json.status, json.detail);
 
-    if (json.extra) {
-      for (const [key, value] of Object.entries(json.extra)) {
-        if (WELL_KNOWN_PROBLEM_KEYS.includes(key)) continue;
-        problem.extra.set(kebabCase(key), value);
-      }
+    for (const [key, value] of Object.entries(json)) {
+      if (WELL_KNOWN_PROBLEM_KEYS.includes(key)) continue;
+      problem.extra.set(kebabCase(key), value);
     }
 
     return problem;

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -1,3 +1,4 @@
+import { convertDatabaseError } from '@tamanu/database';
 import { errorHandlerProblem } from '@tamanu/shared/utils';
 
 export default function errorHandler(error, req, res, next) {
@@ -7,7 +8,7 @@ export default function errorHandler(error, req, res, next) {
     return;
   }
 
-  const { problem, json } = errorHandlerProblem(error, req);
+  const { problem, json } = errorHandlerProblem(error, req, { convertDatabaseError });
 
   // we're past the point of permission checking; this just
   // makes sure the error send doesn't get intercepted by the

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -13,7 +13,8 @@ export default function errorHandler(error, req, res, _) {
 
   const exposeSensitive =
     process.env.NODE_ENV !== 'production' ||
-    (config.debugging.apiErrorsToken &&
+    (typeof config.debugging.apiErrorsToken === 'string' &&
+      config.debugging.apiErrorsToken.length > 0 &&
       timingSafeEqual(
         Buffer.from(req.get('tamanu-debug') ?? ''),
         Buffer.from(config.debugging.apiErrorsToken ?? ''),

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -10,13 +10,13 @@ export default function errorHandler(error, req, res, _) {
     error = convertDatabaseError(error);
   }
 
+  const exposeSensitive =
+    process.env.NODE_ENV !== 'production' ||
+    (config.debugging.apiErrorsToken &&
+      req.get('tamanu-debug') === config.debugging.apiErrorsToken);
   const problem = (
     error instanceof Problem ? error : Problem.fromError(error)
-  ).excludeSensitiveFields(
-    process.env.NODE_ENV === 'production' &&
-      config.debugging.apiErrorsToken &&
-      req.get('tamanu-debug') !== config.debugging.apiErrorsToken,
-  );
+  ).excludeSensitiveFields(!exposeSensitive);
 
   if (problem.type.includes('auth')) {
     log.warn(`Error ${problem.status} (${problem.type}): ${error.message}`);

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { BaseError as SequelizeError } from 'sequelize';
 import { convertDatabaseError } from '@tamanu/database';
 import { Problem } from '@tamanu/errors';
@@ -11,7 +12,10 @@ export default function errorHandler(error, req, res, _) {
 
   const problem = (
     error instanceof Problem ? error : Problem.fromError(error)
-  ).excludeSensitiveFields(process.env.NODE_ENV === 'production');
+  ).excludeSensitiveFields(
+    process.env.NODE_ENV === 'production' &&
+      req.get('tamanu-debug') === config.debugging.apiErrorsToken,
+  );
 
   if (problem.type.includes('auth')) {
     log.warn(`Error ${problem.status} (${problem.type}): ${error.message}`);

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -14,6 +14,7 @@ export default function errorHandler(error, req, res, _) {
     error instanceof Problem ? error : Problem.fromError(error)
   ).excludeSensitiveFields(
     process.env.NODE_ENV === 'production' &&
+      config.debugging.apiErrorsToken &&
       req.get('tamanu-debug') !== config.debugging.apiErrorsToken,
   );
 

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -14,7 +14,7 @@ export default function errorHandler(error, req, res, _) {
     error instanceof Problem ? error : Problem.fromError(error)
   ).excludeSensitiveFields(
     process.env.NODE_ENV === 'production' &&
-      req.get('tamanu-debug') === config.debugging.apiErrorsToken,
+      req.get('tamanu-debug') !== config.debugging.apiErrorsToken,
   );
 
   if (problem.type.includes('auth')) {

--- a/packages/facility-server/app/middleware/errorHandler.js
+++ b/packages/facility-server/app/middleware/errorHandler.js
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import config from 'config';
 import { BaseError as SequelizeError } from 'sequelize';
 import { convertDatabaseError } from '@tamanu/database';
@@ -13,7 +14,10 @@ export default function errorHandler(error, req, res, _) {
   const exposeSensitive =
     process.env.NODE_ENV !== 'production' ||
     (config.debugging.apiErrorsToken &&
-      req.get('tamanu-debug') === config.debugging.apiErrorsToken);
+      timingSafeEqual(
+        Buffer.from(req.get('tamanu-debug') ?? ''),
+        Buffer.from(config.debugging.apiErrorsToken ?? ''),
+      ));
   const problem = (
     error instanceof Problem ? error : Problem.fromError(error)
   ).excludeSensitiveFields(!exposeSensitive);

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -97,6 +97,9 @@
   "serverFacilityId": null,
   "serverFacilityIds": null,
   "debugging": {
+    // set a `tamanu-debug` header on a request with the value of this key
+    // and the errors will get stack traces.
+    apiErrorsToken: false,
     "requestFailureRate": 0
   },
   "schedules": {

--- a/packages/shared/src/utils/errorHandlerProblem.js
+++ b/packages/shared/src/utils/errorHandlerProblem.js
@@ -1,11 +1,10 @@
 import { timingSafeEqual } from 'node:crypto';
 import config from 'config';
 import { BaseError as SequelizeError } from 'sequelize';
-import { convertDatabaseError } from '@tamanu/database';
 import { ERROR_TYPE, Problem } from '@tamanu/errors';
 import { log } from '../services/logging';
 
-export function errorHandlerProblem(error, req) {
+export function errorHandlerProblem(error, req, { convertDatabaseError }) {
   if (error instanceof SequelizeError) {
     error = convertDatabaseError(error);
   }

--- a/packages/shared/src/utils/errorHandlerProblem.js
+++ b/packages/shared/src/utils/errorHandlerProblem.js
@@ -1,0 +1,47 @@
+import { timingSafeEqual } from 'node:crypto';
+import config from 'config';
+import { BaseError as SequelizeError } from 'sequelize';
+import { convertDatabaseError } from '@tamanu/database';
+import { ERROR_TYPE, Problem } from '@tamanu/errors';
+import { log } from '../services/logging';
+
+export function errorHandlerProblem(req, error) {
+  if (error instanceof SequelizeError) {
+    error = convertDatabaseError(error);
+  }
+
+  const exposeSensitive =
+    process.env.NODE_ENV !== 'production' ||
+    (typeof config.debugging.apiErrorsToken === 'string' &&
+      config.debugging.apiErrorsToken.length > 0 &&
+      timingSafeEqual(
+        Buffer.from(req.get('tamanu-debug') ?? ''),
+        Buffer.from(config.debugging.apiErrorsToken ?? ''),
+      ));
+  const problem = (
+    error instanceof Problem ? error : Problem.fromError(error)
+  ).excludeSensitiveFields(!exposeSensitive);
+
+  if (problem.type.includes(ERROR_TYPE.AUTH)) {
+    log.warn(`Error ${problem.status} (${problem.type}): ${error.message}`);
+  } else if (problem.status >= 500) {
+    log.error(`Error ${problem.status} (${problem.type}): `, error);
+  } else {
+    log.info(`Error ${problem.status} (${problem.type}): `, error);
+  }
+
+  return {
+    problem,
+    json: {
+      // RFC 7807 Problem Details for HTTP APIs
+      ...problem.toJSON(),
+
+      // legacy error format
+      error: {
+        message: error.message,
+        name: error.name,
+        status: problem.status,
+      },
+    },
+  };
+}

--- a/packages/shared/src/utils/errorHandlerProblem.js
+++ b/packages/shared/src/utils/errorHandlerProblem.js
@@ -5,7 +5,7 @@ import { convertDatabaseError } from '@tamanu/database';
 import { ERROR_TYPE, Problem } from '@tamanu/errors';
 import { log } from '../services/logging';
 
-export function errorHandlerProblem(req, error) {
+export function errorHandlerProblem(error, req) {
   if (error instanceof SequelizeError) {
     error = convertDatabaseError(error);
   }

--- a/packages/shared/src/utils/index.js
+++ b/packages/shared/src/utils/index.js
@@ -19,3 +19,4 @@ export * from './enumRegistry';
 export * from './invoice';
 export * from './medication';
 export * from './initDeviceId';
+export * from './errorHandlerProblem';

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -28,13 +28,14 @@
     "clean": "rimraf dist *.tsbuildInfo",
     "clean:deps": "rimraf node_modules",
     "test": "vitest run --no-file-parallelism",
-    "package-default-translations": "npx tsx scripts/scrapeTranslations.ts > dist/default-translations.json",
+    "package-default-translations": "tsx scripts/scrapeTranslations.ts > dist/default-translations.json",
     "test:watch": "vitest watch"
   },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "@types/toposort": "^2.0.7",
     "rimraf": "^6.0.1",
+    "tsx": "^4.20.6",
     "type-fest": "^4.31.0",
     "vitest": "^2.1.9"
   },


### PR DESCRIPTION
### Changes

- In staging (like in auto-deploys), we get stack traces in the API errors
- In production, if it's enabled in config, _and_ we add a special header to the request with the right secret value, then we can also get stack traces in the API errors

That could really help us in a couple situations and is basically free (also lbh the security value of hiding the stack trace in an open source app is dubious).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
