### PR TITLE
fix: 2.37 hotfix: Duplicate PPR record fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamanu",
-  "version": "2.37.3",
+  "version": "2.37.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamanu",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-and-later AND BUSL-1.1",
       "dependencies": {
         "@rnx-kit/metro-resolver-symlinks": "^0.1.36",
@@ -73253,7 +73253,7 @@
     },
     "packages/api-client": {
       "name": "@tamanu/api-client",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73267,7 +73267,7 @@
     },
     "packages/build-tooling": {
       "name": "@tamanu/build-tooling",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@swc/cli": "^0.1.63",
@@ -73307,7 +73307,7 @@
     },
     "packages/central-server": {
       "name": "@tamanu/central-server",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
@@ -73641,7 +73641,7 @@
     },
     "packages/constants": {
       "name": "@tamanu/constants",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/date-fns": "^2.6.3",
@@ -73694,7 +73694,7 @@
     },
     "packages/database": {
       "name": "@tamanu/database",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73783,7 +73783,7 @@
     },
     "packages/e2e-tests": {
       "name": "@tamanu/e2e-tests",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "dependencies": {
         "date-fns": "^4.1.0"
       },
@@ -73823,7 +73823,7 @@
     },
     "packages/facility-server": {
       "name": "@tamanu/facility-server",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^7.22.4",
@@ -74362,7 +74362,7 @@
     },
     "packages/fake-data": {
       "name": "@tamanu/fake-data",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -74409,7 +74409,7 @@
     },
     "packages/mobile": {
       "name": "@tamanu/mobile",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "hasInstallScript": true,
       "dependencies": {
         "@casl/ability": "^4.1.0",
@@ -76260,7 +76260,7 @@
       }
     },
     "packages/scripts": {
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -76298,7 +76298,7 @@
     },
     "packages/settings": {
       "name": "@tamanu/settings",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -76567,7 +76567,7 @@
     },
     "packages/shared": {
       "name": "@tamanu/shared",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@casl/ability": "^6.7.1",
@@ -78616,7 +78616,7 @@
     },
     "packages/upgrade": {
       "name": "@tamanu/upgrade",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -78668,7 +78668,7 @@
     },
     "packages/utils": {
       "name": "@tamanu/utils",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "date-fns": "^4.1.0",
@@ -78743,7 +78743,7 @@
     },
     "packages/web": {
       "name": "@tamanu/web-frontend",
-      "version": "2.37.3",
+      "version": "2.37.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",

--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -23,7 +23,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
   const userCount = await store.models.User.count({
     where: {
       id: { [Op.ne]: SYSTEM_USER_UUID },
-    }
+    },
   });
 
   if (userCount > 0) {
@@ -129,7 +129,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
   const combineSettings = async (settingData, scope, facilityId) => {
     const existing = await store.models.Setting.get('', facilityId, scope);
     const combined = defaultsDeep(settingData, existing);
-    return store.models.Settings.set('', combined, scope, facilityId);
+    return store.models.Setting.set('', combined, scope, facilityId);
   };
 
   if (settings.global) {

--- a/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientProgramRegistration.test.js
@@ -56,7 +56,7 @@ describe('PatientProgramRegistration', () => {
     const unknownConditionCategory = await models.ProgramRegistryConditionCategory.create(
       fake(models.ProgramRegistryConditionCategory, {
         programRegistryId,
-        code: categoryCode ||PROGRAM_REGISTRY_CONDITION_CATEGORIES.UNKNOWN,
+        code: categoryCode || PROGRAM_REGISTRY_CONDITION_CATEGORIES.UNKNOWN,
       }),
     );
     return models.PatientProgramRegistrationCondition.create(
@@ -187,10 +187,11 @@ describe('PatientProgramRegistration', () => {
         date: '2023-09-02 08:00:00',
       });
 
-      const createdRegistrationCondition =
-        await models.PatientProgramRegistrationCondition.findOne({
+      const createdRegistrationCondition = await models.PatientProgramRegistrationCondition.findOne(
+        {
           where: { id: result.body.conditions[0].id },
-        });
+        },
+      );
 
       expect(createdRegistrationCondition).toMatchObject({
         clinicianId: clinician.id,
@@ -603,7 +604,7 @@ describe('PatientProgramRegistration', () => {
     });
 
     describe('DELETE /programRegistration/:id', () => {
-      it('should mark patient program registration as deleted and update status to recordedInError', async () => {
+      it('should update patient program registration status to recordedInError', async () => {
         // Create test data
         const patient = await models.Patient.create(fake(models.Patient));
         const programRegistry = await createProgramRegistry();
@@ -646,7 +647,6 @@ describe('PatientProgramRegistration', () => {
         expect(updatedRegistration.registrationStatus).toBe(
           REGISTRATION_STATUSES.RECORDED_IN_ERROR,
         );
-        expect(updatedRegistration.deletedAt).toBeTruthy();
 
         // Verify related conditions are also soft deleted
         const updatedCondition1 = await models.PatientProgramRegistrationCondition.findByPk(
@@ -740,7 +740,7 @@ describe('PatientProgramRegistration', () => {
         expect(conditions[1].id).toBe(condition1.id);
 
         // Verify each condition has the expected properties
-        conditions.forEach((condition) => {
+        conditions.forEach(condition => {
           expect(condition).toHaveProperty('id');
           expect(condition).toHaveProperty('patientProgramRegistrationId', registration.id);
           expect(condition).toHaveProperty('programRegistryConditionId');
@@ -773,7 +773,7 @@ describe('PatientProgramRegistration', () => {
         expect(result).toHaveSucceeded();
 
         const conditions = result.body.data;
-        const conditionWithHistory = conditions.find((c) => c.id === condition1.id);
+        const conditionWithHistory = conditions.find(c => c.id === condition1.id);
 
         // Verify history data
         expect(conditionWithHistory.history.length).toBe(2);

--- a/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientProgramRegistration/patientProgramRegistration.js
@@ -22,7 +22,7 @@ patientProgramRegistration.get(
       params.patientId,
     );
 
-    const filteredData = registrationData.filter((x) => req.ability.can('read', x.programRegistry));
+    const filteredData = registrationData.filter(x => req.ability.can('read', x.programRegistry));
     res.send({ data: filteredData });
   }),
 );
@@ -36,18 +36,7 @@ patientProgramRegistration.post(
 
     await validatePatientProgramRegistrationRequest(req, patientId, programRegistryId);
 
-    const existingRegistration = await models.PatientProgramRegistration.findOne({
-      where: {
-        programRegistryId,
-        patientId,
-      },
-    });
-
-    if (existingRegistration) {
-      req.checkPermission('write', 'PatientProgramRegistration');
-    } else {
-      req.checkPermission('create', 'PatientProgramRegistration');
-    }
+    req.checkPermission('create', 'PatientProgramRegistration');
 
     const { conditions = [], ...registrationData } = body;
 
@@ -56,21 +45,48 @@ patientProgramRegistration.post(
     }
 
     // Run in a transaction so it either fails or succeeds together
-    const [registration, conditionsRecords] = await db.transaction(async (transaction) => {
-      const newRegistration = await models.PatientProgramRegistration.create(
-        {
-          patientId,
+    const [registration, conditionsRecords] = await db.transaction(async transaction => {
+      let registrationRecord;
+
+      // Check if this PPR has been previously deleted
+      const existingRecordedInErrorRegistration = await models.PatientProgramRegistration.findOne({
+        where: {
           programRegistryId,
-          ...registrationData,
+          patientId,
+          registrationStatus: REGISTRATION_STATUSES.RECORDED_IN_ERROR,
         },
-        { transaction },
-      );
+        transaction,
+      });
+
+      // If the registration was previously recorded in error, update that record to preserve the unique id. Otherwise, create a new one.
+      if (existingRecordedInErrorRegistration) {
+        registrationRecord = await existingRecordedInErrorRegistration.update(
+          {
+            clinicalStatusId: null,
+            deactivatedDate: null,
+            deactivatedClinicianId: null,
+            ...registrationData,
+          },
+          {
+            transaction,
+          },
+        );
+      } else {
+        registrationRecord = await models.PatientProgramRegistration.create(
+          {
+            patientId,
+            programRegistryId,
+            ...registrationData,
+          },
+          { transaction },
+        );
+      }
 
       const newConditions = await models.PatientProgramRegistrationCondition.bulkCreate(
         conditions
-          .filter((condition) => condition.conditionId)
-          .map((condition) => ({
-            patientProgramRegistrationId: newRegistration.id,
+          .filter(condition => condition.conditionId)
+          .map(condition => ({
+            patientProgramRegistrationId: registrationRecord.id,
             clinicianId: registrationData.clinicianId,
             date: registrationData.date,
             programRegistryConditionId: condition.conditionId,
@@ -87,7 +103,7 @@ patientProgramRegistration.post(
         { transaction },
       );
 
-      return [newRegistration, newConditions];
+      return [registrationRecord, newConditions];
     });
 
     // Convert Sequelize model to use a custom object as response
@@ -121,7 +137,7 @@ patientProgramRegistration.put(
       throw new NotFoundError('PatientProgramRegistration not found');
     }
 
-    const conditionsData = conditions.map((condition) => ({
+    const conditionsData = conditions.map(condition => ({
       id: condition.id,
       patientProgramRegistrationId: existingRegistration.id,
       clinicianId: registrationData.clinicianId,
@@ -178,13 +194,12 @@ patientProgramRegistration.delete(
       throw new NotFoundError('PatientProgramRegistration not found');
     }
 
-    await db.transaction(async (transaction) => {
-      // Update the status to recordedInError and soft delete the registration
+    await db.transaction(async transaction => {
+      // Update the status to recordedInError
       await existingRegistration.update(
         { registrationStatus: REGISTRATION_STATUSES.RECORDED_IN_ERROR },
         { transaction },
       );
-      await existingRegistration.destroy({ transaction });
 
       // Soft delete all related conditions
       await PatientProgramRegistrationCondition.destroy({
@@ -283,7 +298,7 @@ patientProgramRegistration.get(
 
     // Get all unique clinical status IDs from the changes
     const clinicalStatusIds = [
-      ...new Set(changes.map((change) => change.recordData.clinical_status_id).filter(Boolean)),
+      ...new Set(changes.map(change => change.recordData.clinical_status_id).filter(Boolean)),
     ];
 
     // Fetch all clinical statuses in one query
@@ -303,7 +318,7 @@ patientProgramRegistration.get(
     }, {});
 
     const history = changes
-      .map((change) => {
+      .map(change => {
         const data = change.recordData;
         return {
           id: change.id,
@@ -317,7 +332,7 @@ patientProgramRegistration.get(
           registrationDate: data.date,
         };
       })
-      .filter((change) => change.registrationStatus !== REGISTRATION_STATUSES.INACTIVE)
+      .filter(change => change.registrationStatus !== REGISTRATION_STATUSES.INACTIVE)
       // Add this filter to remove entries with unchanged clinical status
       .filter((change, index, array) => {
         if (index === array.length - 1) return true; // Always keep the original record


### PR DESCRIPTION
* lint

* remove soft delete and only update status

* it works

* Update patientProgramRegistration.js

* Update 1749080866176-changePatientProgramRegistrationIdColumn.ts

* Update patientProgramRegistration.js

* Update 1749080866176-changePatientProgramRegistrationIdColumn.ts

* Update patientProgramRegistration.js

* registration record variable

* Update package-lock.json

* Revert "Update 1749080866176-changePatientProgramRegistrationIdColumn.ts"

This reverts commit eb5f12bd9f09395f642fc0aaa74f59756633c446.

* Revert "Update 1749080866176-changePatientProgramRegistrationIdColumn.ts"

This reverts commit 78f6f1f8603febf76d4d6c2d6bcca030f958dfcd.

* Update PatientProgramRegistration.test.js

* Update patientProgramRegistration.js

* Update patientProgramRegistration.js

* this somehow?

* Update patientProgramRegistration.js

* Update patientProgramRegistration.js

* Update patientProgramRegistration.js

* Update patientProgramRegistration.js

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate PatientProgramRegistration by updating previously recordedInError records on create and marks deletions as recordedInError without soft-deleting; also fixes a typo in central provisioning settings setter and updates tests.
> 
> - **Backend**
>   - **Patient Program Registration (facility-server)**:
>     - On create, reuse existing `RECORDED_IN_ERROR` `PatientProgramRegistration` by updating it instead of creating a new record (avoids duplicate IDs).
>     - On delete, only set `registrationStatus` to `RECORDED_IN_ERROR` (no soft delete of the registration); related conditions are still soft-deleted.
>     - Permissions: always require `create` for creating registrations; minor arrow/lint cleanups.
>   - **Provisioning (central-server)**:
>     - Fix settings setter: `Setting.set` (was `Settings.set`).
> - **Tests**
>   - Update deletion test to expect status change without `deletedAt`; minor formatting/lint adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32fbabc5a5ede4afcfd43b86a070c35ab7a41c2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->