### PR TITLE
fix(ci): SAV-1015: Fix typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,7 @@ ehr = "ehr"
 mch = "mch"
 nam = "nam" # VDS
 nce = "nce"
+brin = "brin" # Type of database index
 
 # Common default facility names
 ba = "ba"

--- a/packages/database/src/demoData/diagnoses.js
+++ b/packages/database/src/demoData/diagnoses.js
@@ -5485,7 +5485,7 @@ export const DIAGNOSES = splitIds(`
   Urethrolithiasis	N21.1
   Uricemia	E79.0
   Urinary incontinence	R32
-  Urinary retension	R33
+  Urinary retention	R33
   Urinary tract infection	N39.0
   Urinary tract infection, site not specified	N39.0
   Urinary tract infection, unspecified	N39.0

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -28,7 +28,7 @@ import { DefaultIconButton } from '../Button';
 // has some unusual input handling (switching focus between day/month/year etc) that
 // a value change will interfere with.
 
-// Here I have made a data URL for the new calendar icon. The existing calander icon was a pseudo element
+// Here I have made a data URL for the new calendar icon. The existing calendar icon was a pseudo element
 // in the user agent shadow DOM. In order to add a new icon I had to make the pseudo element invisible
 // a new icon I had to make the pseudo element invisible and render a replacement on top using svg data url.
 const CustomIconTextInput = styled(TextInput)`

--- a/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
+++ b/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
@@ -418,7 +418,7 @@ const encounter = {
         id: 'drug-aciclovir345',
         code: 'aciclovir345',
         type: 'drug',
-        name: 'Aciclovir 3%w/w Eye Oint 4.5g',
+        name: 'Aciclovir 3%w/w Eye Ointment 4.5g',
         visibilityStatus: 'current',
         updatedAtSyncTick: '-999',
         createdAt: '2023-11-07T02:15:34.721Z',


### PR DESCRIPTION
### Changes

Somehow were missed. Notice the empty commit to be able to trigger the spellcheck with the same thing we had on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `brin` to typos dictionary and fix spelling in diagnoses data, a DateField comment, and a PDF story medication name.
> 
> - **Spellcheck Config**:
>   - Add `brin` to `[default.extend-words]` in `.typos.toml`.
> - **Database Demo Data**:
>   - Correct `Urinary retension` to `Urinary retention` in `packages/database/src/demoData/diagnoses.js`.
> - **Web**:
>   - Fix comment typo (`calander` → `calendar`) in `components/Field/DateField.jsx`.
>   - Update medication name (`Aciclovir 3%w/w Eye Oint 4.5g` → `... Eye Ointment 4.5g`) in `stories/pdfs/DischargeSummaryPrintout.stories.jsx`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1a3fe6db67d866ab0410eee022a9aa76a6c7e96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->