### PR TITLE
feat: EPI-1297: Remove options config for PatientData survey questions with Select type

### DIFF
--- a/packages/database/src/models/SurveyScreenComponent.ts
+++ b/packages/database/src/models/SurveyScreenComponent.ts
@@ -90,20 +90,6 @@ export class SurveyScreenComponent extends Model {
     return this.getComponentsForSurveys([surveyId], options);
   }
 
-  getOptions() {
-    try {
-      const optionString = this.options || this.dataElement?.defaultOptions || '';
-      if (!optionString) {
-        return [];
-      }
-      const optionArray = JSON.parse(optionString);
-      return Object.entries(optionArray).map(([label, value]) => ({ label, value }));
-    } catch (e) {
-      log.error(e);
-      return [];
-    }
-  }
-
   forResponse() {
     const { options, ...values } = this.dataValues;
     return {

--- a/packages/database/src/models/SurveyScreenComponent.ts
+++ b/packages/database/src/models/SurveyScreenComponent.ts
@@ -1,7 +1,6 @@
 import { Op, DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { safeJsonParse } from '@tamanu/utils/safeJsonParse';
-import { log } from '@tamanu/shared/services/logging';
 import { Model } from './Model';
 import type { InitOptions, Models } from '../types/model';
 import type { ProgramDataElement } from './ProgramDataElement';

--- a/packages/mobile/App/models/SurveyScreenComponent.ts
+++ b/packages/mobile/App/models/SurveyScreenComponent.ts
@@ -55,20 +55,6 @@ export class SurveyScreenComponent extends BaseModel implements ISurveyScreenCom
   @RelationId(({ dataElement }) => dataElement)
   dataElementId: string;
 
-  getOptions(): any {
-    try {
-      const optionString = this.options || this.dataElement.defaultOptions || '';
-      if (!optionString) {
-        return [];
-      }
-      const optionArray = JSON.parse(optionString);
-      return Object.entries(optionArray).map(([label, value]) => ({ label, value }));
-    } catch (e) {
-      console.error(e);
-      return [];
-    }
-  }
-
   getConfigObject(): any {
     if (!this.config) return {};
 

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -112,7 +112,7 @@ export const SurveyQuestion = ({
         value,
       };
     });
-  }, [getTranslation, dataElement.id, options, dataElement.type, getEnumTranslation, component]);
+  }, [getTranslation, dataElement.id, options, dataElement.type, getEnumTranslation, component.config]);
 
   if (!fieldInput) return null;
   const isMultiline = dataElement.type === FieldTypes.MULTILINE;

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { StyledText, StyledView } from '/styled/common';
 import { IPatient, ISurveyScreenComponent, SurveyScreenConfig } from '~/types';
 import { Field } from '../FormField';
@@ -6,6 +6,9 @@ import { FieldTypes } from '~/ui/helpers/fields';
 import { FieldByType } from '~/ui/helpers/fieldComponents';
 import { useBackendEffect } from '~/ui/hooks';
 import { PatientDataDisplayField } from '../../PatientDataDisplayField/PatientDataDisplayField';
+import { useTranslation } from '~/ui/contexts/TranslationContext';
+import { PATIENT_DATA_FIELD_LOCATIONS } from '@tamanu/constants';
+import { getReferenceDataOptionStringId } from '../../Translations/TranslatedReferenceData';
 
 interface SurveyQuestionProps {
   component: ISurveyScreenComponent;
@@ -56,6 +59,17 @@ const useGetConfig = component => {
   return configObject;
 };
 
+// Keep in sync with web/app/utils/survey.jsx
+function mapOptionsToValues(options) {
+  if (!options) return null;
+  if (typeof options === 'object') {
+    // sometimes this is a map of value => value
+    return Object.values(options).map(x => ({ label: x, value: x }));
+  }
+  if (!Array.isArray(options)) return null;
+  return options.map(x => ({ label: x, value: x }));
+}
+
 export const SurveyQuestion = ({
   component,
   patient,
@@ -63,9 +77,37 @@ export const SurveyQuestion = ({
   zIndex,
   setDisableSubmit,
 }: SurveyQuestionProps): ReactElement => {
+  const { getTranslation, getEnumTranslation } = useTranslation();
   const config = useGetConfig(component);
   const { dataElement } = component;
   const fieldInput: any = getField(dataElement.type, config);
+
+  const options = mapOptionsToValues(component.options || component.dataElement.defaultOptions);
+  const translatedOptions = useMemo(() => {
+    // if the question is a patient data question with a select field type,
+    // we need to get the options from the patient data field locations, so the users don't need to translate the options twice
+    // If the options aren't available, we'll use the options from the componentOptions
+    if (dataElement.type === FieldTypes.PATIENT_DATA) {
+      const config = component.getConfigObject();
+      const { writeToPatient, column } = config;
+      if (writeToPatient.fieldType === FieldTypes.SELECT) {
+        const [, , options] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
+        if (options) {
+          return Object.keys(options).map(value => ({
+            label: getEnumTranslation(options, value),
+            value,
+          }));
+        }
+      }
+    }
+    return options?.map(({ value }) => {
+      const stringId = getReferenceDataOptionStringId(dataElement.id, 'programDataElement', value);
+      return {
+        label: getTranslation(stringId, value),
+        value,
+      };
+    });
+  }, [getTranslation, dataElement.id, options, dataElement.type, getEnumTranslation, component]);
 
   if (!fieldInput) return null;
   const isMultiline = dataElement.type === FieldTypes.MULTILINE;
@@ -82,7 +124,7 @@ export const SurveyQuestion = ({
         component={fieldInput}
         name={dataElement.code}
         defaultText={dataElement.defaultText}
-        options={component.getOptions && component.getOptions()}
+        options={translatedOptions || []}
         multiline={isMultiline}
         patient={patient}
         config={config}

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -95,7 +95,7 @@ export const SurveyQuestion = ({
     if (dataElement.type === FieldTypes.PATIENT_DATA) {
       const config = component.getConfigObject();
       const { writeToPatient, column } = config;
-      if (writeToPatient.fieldType === FieldTypes.SELECT) {
+      if (writeToPatient?.fieldType === FieldTypes.SELECT) {
         const [, , constantOptions] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
         if (constantOptions) {
           return Object.keys(constantOptions).map(value => ({

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -7,8 +7,9 @@ import { FieldByType } from '~/ui/helpers/fieldComponents';
 import { useBackendEffect } from '~/ui/hooks';
 import { PatientDataDisplayField } from '../../PatientDataDisplayField/PatientDataDisplayField';
 import { useTranslation } from '~/ui/contexts/TranslationContext';
-import { PATIENT_DATA_FIELD_LOCATIONS } from '@tamanu/constants';
+import { PATIENT_DATA_FIELD_LOCATIONS, SEX_VALUES } from '@tamanu/constants';
 import { getReferenceDataOptionStringId } from '../../Translations/TranslatedReferenceData';
+import { useSettings } from '~/ui/contexts/SettingsContext';
 
 interface SurveyQuestionProps {
   component: ISurveyScreenComponent;
@@ -82,6 +83,7 @@ export const SurveyQuestion = ({
   zIndex,
   setDisableSubmit,
 }: SurveyQuestionProps): ReactElement => {
+  const { getSetting } = useSettings();
   const { getTranslation, getEnumTranslation } = useTranslation();
   const config = useGetConfig(component);
   const { dataElement } = component;
@@ -98,10 +100,16 @@ export const SurveyQuestion = ({
       if (writeToPatient?.fieldType === FieldTypes.SELECT) {
         const [, , constantOptions] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
         if (constantOptions) {
-          return Object.keys(constantOptions).map(value => ({
+          const result = Object.keys(constantOptions).map(value => ({
             label: getEnumTranslation(constantOptions, value),
             value,
           }));
+
+          if (column === 'sex' && getSetting('features.hideOtherSex')) {
+            return result.filter(option => option.value !== SEX_VALUES.OTHER);
+          }
+
+          return result;
         }
       }
     }

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -60,14 +60,19 @@ const useGetConfig = component => {
 };
 
 // Keep in sync with web/app/utils/survey.jsx
-function mapOptionsToValues(options) {
-  if (!options) return null;
-  if (typeof options === 'object') {
-    // sometimes this is a map of value => value
-    return Object.values(options).map(x => ({ label: x, value: x }));
+function mapOptionsToValues(optionsString: string) {
+  if (!optionsString) return null;
+  try {
+    const options = JSON.parse(optionsString);
+    if (typeof options === 'object') {
+      // sometimes this is a map of value => value
+      return Object.values(options).map(x => ({ label: x, value: x }));
+    }
+    if (!Array.isArray(options)) return null;
+    return options.map(x => ({ label: x, value: x }));
+  } catch (e) {
+    return null;
   }
-  if (!Array.isArray(options)) return null;
-  return options.map(x => ({ label: x, value: x }));
 }
 
 export const SurveyQuestion = ({
@@ -91,10 +96,10 @@ export const SurveyQuestion = ({
       const config = component.getConfigObject();
       const { writeToPatient, column } = config;
       if (writeToPatient.fieldType === FieldTypes.SELECT) {
-        const [, , options] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
-        if (options) {
-          return Object.keys(options).map(value => ({
-            label: getEnumTranslation(options, value),
+        const [, , constantOptions] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
+        if (constantOptions) {
+          return Object.keys(constantOptions).map(value => ({
+            label: getEnumTranslation(constantOptions, value),
             value,
           }));
         }

--- a/packages/mobile/App/ui/components/Translations/TranslatedReferenceData.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedReferenceData.tsx
@@ -1,6 +1,24 @@
 import React from 'react';
 import { TranslatedText } from './TranslatedText';
 
+/**
+ * Replace any spaces and dots with underscores (dots are the delimiter in translation ids)
+ *
+ * @example "hello world" → "hello_world"
+ * @example "test.value" → "test_value"
+ * @example "hello.world test" → "hello_world_test"
+ */
+const formatOptionForStringId = (str: string) => `${str}`.replace(/[\s.]/g, '_');
+
+/**
+ * Returns the stringId for a reference data option.
+ * @example getReferenceDataOptionStringId('question1', 'surveyScreenComponent', 'undecided') -> "refData.surveyScreenComponent.detail.question1.option.undecided"
+ */
+export const getReferenceDataOptionStringId = (value: string, category: string, option: string) => {
+  const baseStringId = `${getReferenceDataStringId(value, category)}.option`;
+  return `${baseStringId}.${formatOptionForStringId(option)}`;
+};
+
 export const getReferenceDataStringId = (value: string, category: string) => {
   return `refData.${category}.${value}`;
 };

--- a/packages/web/app/components/Surveys/SurveyQuestion.jsx
+++ b/packages/web/app/components/Surveys/SurveyQuestion.jsx
@@ -4,6 +4,7 @@ import {
   CHARTING_DATA_ELEMENT_IDS,
   PATIENT_DATA_FIELD_LOCATIONS,
   PROGRAM_DATA_ELEMENT_TYPES,
+  SEX_VALUES,
 } from '@tamanu/constants';
 import { getReferenceDataOptionStringId } from '@tamanu/shared/utils/translation';
 import {
@@ -19,6 +20,7 @@ import { Box, Typography } from '@material-ui/core';
 import { Colors } from '../../constants';
 import { TranslatedReferenceData, TranslatedText } from '../Translation';
 import { useTranslation } from '../../contexts/Translation';
+import { useSettings } from '../../contexts/Settings';
 
 const Text = styled.div`
   margin-bottom: 10px;
@@ -94,6 +96,7 @@ const getCustomComponentForQuestion = (component, required, FieldComponent) => {
 };
 
 export const SurveyQuestion = ({ component, patient, inputRef, disabled, encounterType }) => {
+  const { getSetting } = useSettings();
   const { encounter } = useEncounter();
   const { getTranslation, getEnumTranslation } = useTranslation();
 
@@ -136,10 +139,17 @@ export const SurveyQuestion = ({ component, patient, inputRef, disabled, encount
         if (writeToPatient?.fieldType === PROGRAM_DATA_ELEMENT_TYPES.SELECT) {
           const [, , options] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
           if (options) {
-            return Object.keys(options).map(value => ({
+            const result = Object.keys(options).map(value => ({
               label: getEnumTranslation(options, value),
               value,
             }));
+
+            // if the question is a sex question and the other sex is hidden, we need to filter out the other option
+            if (column === 'sex' && getSetting('features.hideOtherSex')) {
+              return result.filter(option => option.value !== SEX_VALUES.OTHER);
+            }
+
+            return result;
           }
         }
       } catch (e) {

--- a/packages/web/app/components/Surveys/SurveyQuestion.jsx
+++ b/packages/web/app/components/Surveys/SurveyQuestion.jsx
@@ -133,7 +133,7 @@ export const SurveyQuestion = ({ component, patient, inputRef, disabled, encount
       try {
         const config = JSON.parse(componentConfig);
         const { writeToPatient, column } = config;
-        if (writeToPatient.fieldType === PROGRAM_DATA_ELEMENT_TYPES.SELECT) {
+        if (writeToPatient?.fieldType === PROGRAM_DATA_ELEMENT_TYPES.SELECT) {
           const [, , options] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
           if (options) {
             return Object.keys(options).map(value => ({

--- a/packages/web/app/components/Surveys/SurveyQuestion.jsx
+++ b/packages/web/app/components/Surveys/SurveyQuestion.jsx
@@ -1,6 +1,10 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { CHARTING_DATA_ELEMENT_IDS, PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
+import {
+  CHARTING_DATA_ELEMENT_IDS,
+  PATIENT_DATA_FIELD_LOCATIONS,
+  PROGRAM_DATA_ELEMENT_TYPES,
+} from '@tamanu/constants';
 import { getReferenceDataOptionStringId } from '@tamanu/shared/utils/translation';
 import {
   checkMandatory,
@@ -15,7 +19,6 @@ import { Box, Typography } from '@material-ui/core';
 import { Colors } from '../../constants';
 import { TranslatedReferenceData, TranslatedText } from '../Translation';
 import { useTranslation } from '../../contexts/Translation';
-
 
 const Text = styled.div`
   margin-bottom: 10px;
@@ -80,8 +83,10 @@ const getCustomComponentForQuestion = (component, required, FieldComponent) => {
     );
   }
 
-  if (component.dataElement.id === CHARTING_DATA_ELEMENT_IDS.dateRecorded
-    || component.dataElement.type === PROGRAM_DATA_ELEMENT_TYPES.PHOTO) {
+  if (
+    component.dataElement.id === CHARTING_DATA_ELEMENT_IDS.dateRecorded ||
+    component.dataElement.type === PROGRAM_DATA_ELEMENT_TYPES.PHOTO
+  ) {
     return <FullWidthCol data-testid="fullwidthcol-6f9p">{FieldComponent}</FullWidthCol>;
   }
 
@@ -90,7 +95,7 @@ const getCustomComponentForQuestion = (component, required, FieldComponent) => {
 
 export const SurveyQuestion = ({ component, patient, inputRef, disabled, encounterType }) => {
   const { encounter } = useEncounter();
-  const { getTranslation } = useTranslation();
+  const { getTranslation, getEnumTranslation } = useTranslation();
 
   const {
     id: componentId,
@@ -120,17 +125,35 @@ export const SurveyQuestion = ({ component, patient, inputRef, disabled, encount
     />
   );
   const options = mapOptionsToValues(componentOptions || defaultOptions);
-  const translatedOptions = useMemo(
-    () =>
-      options?.map(({ value }) => {
-        const stringId = getReferenceDataOptionStringId(id, 'programDataElement', value);
-        return {
-          label: getTranslation(stringId, value),
-          value,
-        };
-      }),
-    [getTranslation, id, options],
-  );
+  const translatedOptions = useMemo(() => {
+    // if the question is a patient data question with a select field type,
+    // we need to get the options from the patient data field locations, so the users don't need to translate the options twice
+    // If the options aren't available, we'll use the options from the componentOptions
+    if (type === PROGRAM_DATA_ELEMENT_TYPES.PATIENT_DATA) {
+      try {
+        const config = JSON.parse(componentConfig);
+        const { writeToPatient, column } = config;
+        if (writeToPatient.fieldType === PROGRAM_DATA_ELEMENT_TYPES.SELECT) {
+          const [, , options] = PATIENT_DATA_FIELD_LOCATIONS[column] || [];
+          if (options) {
+            return Object.keys(options).map(value => ({
+              label: getEnumTranslation(options, value),
+              value,
+            }));
+          }
+        }
+      } catch (e) {
+        console.error('Error parsing componentConfig', e);
+      }
+    }
+    return options?.map(({ value }) => {
+      const stringId = getReferenceDataOptionStringId(id, 'programDataElement', value);
+      return {
+        label: getTranslation(stringId, value),
+        value,
+      };
+    });
+  }, [getTranslation, id, options, type, componentConfig, getEnumTranslation]);
 
   const configObject = getConfigObject(id, componentConfig);
   const FieldComponent = getComponentForQuestionType(type, configObject);


### PR DESCRIPTION

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes model-level option parsing and implements UI-side option mapping/translation, including using PATIENT_DATA_FIELD_LOCATIONS for PatientData select questions on mobile and web.
> 
> - **Surveys/UI**:
>   - Implement UI-side option mapping/translation for questions on mobile and web.
>   - For PatientData questions with select fields, source options from `PATIENT_DATA_FIELD_LOCATIONS` and translate via enums; otherwise translate using reference-data string IDs.
> - **Mobile**:
>   - Add `mapOptionsToValues` and translated option generation in `ui/components/Forms/SurveyForm/SurveyQuestion.tsx`.
>   - Pass `translatedOptions` to `Field` instead of using model `getOptions`.
>   - Add `getReferenceDataOptionStringId` helper in translations.
> - **Web**:
>   - Update `components/Surveys/SurveyQuestion.jsx` to generate `translatedOptions` with PatientData select handling and enum translations.
> - **Database/Mobile Models**:
>   - Remove `getOptions()` from `SurveyScreenComponent` models; responses now return raw `options` (JSON-parsed in DB `forResponse`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96a57e9f62698c201c8f718e16e19ff34f3150bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->