### PR TITLE
feat: EPI-1299: Mobile: Multiselect not working on form

### DIFF
--- a/packages/mobile/App/ui/components/Dropdown/index.tsx
+++ b/packages/mobile/App/ui/components/Dropdown/index.tsx
@@ -11,7 +11,6 @@ import { useBackend } from '~/ui/hooks';
 import { TranslatedTextElement } from '../Translations/TranslatedText';
 import { useTranslation } from '~/ui/contexts/TranslationContext';
 import { getReferenceDataStringId } from '../Translations/TranslatedReferenceData';
-import { isEqual } from 'lodash';
 
 const MIN_COUNT_FILTERABLE_BY_DEFAULT = 8;
 
@@ -39,6 +38,7 @@ export interface DropdownProps extends BaseInputProps {
   clearable?: boolean;
   required?: boolean;
   error?: any;
+  allowResetSingleValue?: boolean;
 }
 
 const baseStyleDropdownMenuSubsection = {
@@ -99,6 +99,7 @@ export const Dropdown = React.memo(
     disabled,
     required = false,
     clearable = true,
+    allowResetSingleValue,
   }: DropdownProps) => {
     const [selectedItems, setSelectedItems] = useState(() => {
       if (!value) {
@@ -108,17 +109,12 @@ export const Dropdown = React.memo(
       return Array.isArray(value) ? value : [value];
     });
 
-      useEffect(() => {
-        if (Array.isArray(value)) {
-          if (!isEqual(value, selectedItems)) {
-            setSelectedItems(value);
-          }
-        } else {
-          if (value !== selectedItems[0]) {
-            setSelectedItems([value]);
-          }
-        }
-      }, [value]);
+    useEffect(() => {
+      if (!allowResetSingleValue || Array.isArray(value)) return;
+      if (value !== selectedItems[0]) {
+        setSelectedItems([value]);
+      }
+    }, [value, allowResetSingleValue]);
 
     const componentRef = useRef(null);
     const { getTranslation } = useTranslation();

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
@@ -426,6 +426,7 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                   labelFontSize={14}
                   fieldFontSize={14}
                   value={values.units}
+                  allowResetSingleValue
                 />
 
                 <Field
@@ -458,6 +459,7 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
                   labelColor={theme.colors.TEXT_DARK}
                   labelFontSize={14}
                   fieldFontSize={14}
+                  allowResetSingleValue
                 />
 
                 <Field


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `allowResetSingleValue` prop to `Dropdown` to control single-value syncing and enables it for `units` and `route` in the prescribe medication screen.
> 
> - **UI Components**:
>   - **`packages/mobile/App/ui/components/Dropdown/index.tsx`**:
>     - Add `allowResetSingleValue` prop to `DropdownProps` and component.
>     - Change value sync: for single-select, reset `selectedItems` from `value` only when `allowResetSingleValue` is true; no changes for arrays.
>     - Remove lodash `isEqual`-based sync logic.
> - **Screens**:
>   - **`packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx`**:
>     - Pass `allowResetSingleValue` to `Dropdown` fields for `units` and `route`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82bd9e6c0bfc9d2e3b4d3f2c445b5dc47aa0a660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->