### PR TITLE
feat: EPI-1287: Vaccine injection site not syncing from mobile to web

### DIFF
--- a/packages/mobile/App/types/IAdministeredVaccine.ts
+++ b/packages/mobile/App/types/IAdministeredVaccine.ts
@@ -5,6 +5,7 @@ import { IUser } from './IUser';
 import { ILocation } from './ILocation';
 import { IDepartment } from './IDepartment';
 import { VaccineStatus } from '~/ui/helpers/patient';
+import { INJECTION_SITE_VALUES, INJECTION_SITE_LABELS } from '@tamanu/constants';
 
 export interface IAdministeredVaccine {
   id: ID;
@@ -26,17 +27,8 @@ export interface IAdministeredVaccine {
   notGivenReasonId?: string;
 }
 
-export const InjectionSiteType = {
-  LeftArm: 'Left arm',
-  RightArm: 'Right arm',
-  LeftThigh: 'Left thigh',
-  RightThigh: 'Right thigh',
-  Oral: 'Oral',
-  Other: 'Other',
-} as const;
+export type InjectionSiteType = (typeof INJECTION_SITE_VALUES)[keyof typeof INJECTION_SITE_VALUES];
 
-export type InjectionSiteType = (typeof InjectionSiteType)[keyof typeof InjectionSiteType];
-
-export const INJECTION_SITE_OPTIONS = Object.keys(InjectionSiteType).map(
-  k => InjectionSiteType[k as keyof typeof InjectionSiteType],
+export const INJECTION_SITE_OPTIONS = Object.entries(INJECTION_SITE_LABELS).map(
+  ([value, label]) => ({ value, label }),
 );

--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from '~/ui/contexts/TranslationContext';
 const InjectionSiteDropdown = ({ value, label, onChange, selectPlaceholderText }): JSX.Element => (
   <Dropdown
     value={value}
-    options={INJECTION_SITE_OPTIONS.map((o) => ({ label: o, value: o }))}
+    options={INJECTION_SITE_OPTIONS}
     onChange={onChange}
     label={label}
     selectPlaceholderText={selectPlaceholderText}

--- a/packages/mobile/App/ui/components/VaccineCard/GivenOnTimeFields.tsx
+++ b/packages/mobile/App/ui/components/VaccineCard/GivenOnTimeFields.tsx
@@ -10,6 +10,8 @@ import { formatStringDate } from '../../helpers/date';
 import { DateFormats } from '../../helpers/constants';
 import { TranslatedText } from '../Translations/TranslatedText';
 import { TranslatedReferenceData } from '../Translations/TranslatedReferenceData';
+import { TranslatedEnum } from '../Translations/TranslatedEnum';
+import { INJECTION_SITE_LABELS } from '@tamanu/constants';
 
 const GivenOnTimeFields: FC<VaccineDataProps> = ({ administeredVaccine }) => (
   <StyledView
@@ -40,7 +42,7 @@ const GivenOnTimeFields: FC<VaccineDataProps> = ({ administeredVaccine }) => (
       label={
         <TranslatedText stringId="vaccine.form.injectionSite.label" fallback="Injection site" />
       }
-      value={administeredVaccine.injectionSite}
+      value={<TranslatedEnum value={administeredVaccine.injectionSite} enumValues={INJECTION_SITE_LABELS} />}
     />
     {!administeredVaccine.givenElsewhere ? (
       <View>


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches mobile vaccine injection site types/options to shared constants and updates the dropdown to use `{ value, label }` options.
> 
> - **Mobile types (`packages/mobile/App/types/IAdministeredVaccine.ts`)**:
>   - Replace local `InjectionSiteType` constant with shared `@tamanu/constants` (`INJECTION_SITE_VALUES`, `INJECTION_SITE_LABELS`).
>   - Derive `InjectionSiteType` from `INJECTION_SITE_VALUES` and expose `INJECTION_SITE_OPTIONS` as `{ value, label }` pairs from `INJECTION_SITE_LABELS`.
> - **UI (`VaccineCommonFields.tsx`)**:
>   - Use `INJECTION_SITE_OPTIONS` directly in `InjectionSiteDropdown` (expects `{ value, label }`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1ae54b62be0c91a42be04e795f1bf675d277d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->