### PR TITLE
fix(integrations): no-issue: Switch to using a Basic auth header in the MerlinProvider

### DIFF
--- a/packages/facility-server/__tests__/integrations/imaging/MerlinProvider.test.js
+++ b/packages/facility-server/__tests__/integrations/imaging/MerlinProvider.test.js
@@ -1,0 +1,97 @@
+import { fake } from '@tamanu/fake-data/fake';
+import { MerlinProvider } from '../../../dist/integrations/imaging/MerlinProvider';
+import { createTestContext } from '../../utilities';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+
+global.fetch = jest.fn();
+
+const EXTERNAL_CODE = 'EXT123';
+const PATIENT_ID_TYPE = 'AUID';
+const URLGEN = 'https://rispacs.aspen-dev.fj/WebData/UrlGen/Encode';
+
+describe('MerlinProvider', () => {
+  let models;
+  let ctx;
+  let provider;
+  let patient;
+  let encounter;
+  let request;
+  let result;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+
+    patient = await models.Patient.create(fake(models.Patient));
+    const facility = await models.Facility.create(fake(models.Facility));
+    const department = await models.Department.create(
+      fake(models.Department, { facilityId: facility.id }),
+    );
+    const location = await models.Location.create(
+      fake(models.Location, { departmentId: department.id, facilityId: facility.id }),
+    );
+    encounter = await models.Encounter.create(
+      fake(models.Encounter, {
+        patientId: patient.id,
+        locationId: location.id,
+        departmentId: department.id,
+        examinerId: SYSTEM_USER_UUID,
+      }),
+    );
+    request = await models.ImagingRequest.create(
+      fake(models.ImagingRequest, { encounterId: encounter.id, requestedById: SYSTEM_USER_UUID }),
+    );
+    result = await models.ImagingResult.create({
+      imagingRequestId: request.id,
+      description: 'external result description',
+      externalCode: EXTERNAL_CODE,
+    });
+
+    await models.Setting.set('integrations.imaging', {
+      enabled: true,
+      provider: 'merlin',
+      urlgen: URLGEN,
+      auth: {
+        username: 'test',
+        password: 'test',
+      },
+      patientId: {
+        type: PATIENT_ID_TYPE,
+        field: 'displayId',
+      },
+    });
+
+    provider = new MerlinProvider(models, await models.Setting.get('integrations.imaging'));
+  });
+
+  beforeEach(() => {
+    global.fetch.mockClear();
+  });
+
+  afterAll(() => {
+    ctx.close();
+  });
+
+  describe('getUrlForResult', () => {
+    it('should request from the configured MerlinVue server for the imaging results url', async () => {
+      const returnedUrl = `https://rispacs.aspen-dev.fj/MerlinVue/#!/urlgen/${EXTERNAL_CODE}`;
+      global.fetch.mockResolvedValue({
+        text: jest.fn().mockResolvedValue(returnedUrl),
+      });
+
+      const url = await provider.getUrlForResult(result);
+
+      expect(url).toEqual(returnedUrl);
+
+      const expectedFetchUrl = new URL(URLGEN);
+      expectedFetchUrl.searchParams.set('accession', EXTERNAL_CODE);
+      expectedFetchUrl.searchParams.set('patIdType', PATIENT_ID_TYPE);
+      expectedFetchUrl.searchParams.set('patId', patient.displayId);
+      expect(global.fetch).toHaveBeenCalledWith(expectedFetchUrl, {
+        headers: {
+          Authorization: `Basic ${Buffer.from('test:test').toString('base64')}`,
+        },
+      });
+    });
+  });
+});

--- a/packages/facility-server/app/integrations/imaging/MerlinProvider.js
+++ b/packages/facility-server/app/integrations/imaging/MerlinProvider.js
@@ -25,16 +25,16 @@ export class MerlinProvider extends Provider {
     } = this.config;
 
     const url = new URL(urlgen);
-    url.headers.set(
-      'Authorization',
-      `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
-    );
     url.searchParams.set('accession', externalCode);
 
     url.searchParams.set('patIdType', type);
     url.searchParams.set('patId', patient[field]);
 
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+      },
+    });
     return res.text();
   }
 }

--- a/packages/facility-server/app/integrations/imaging/MerlinProvider.js
+++ b/packages/facility-server/app/integrations/imaging/MerlinProvider.js
@@ -25,8 +25,10 @@ export class MerlinProvider extends Provider {
     } = this.config;
 
     const url = new URL(urlgen);
-    url.username = username;
-    url.password = password;
+    url.headers.set(
+      'Authorization',
+      `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+    );
     url.searchParams.set('accession', externalCode);
 
     url.searchParams.set('patIdType', type);


### PR DESCRIPTION
### Changes

Node fetch no longer supports `https://<user>:<password>@<host>/endpoint` url formatting anymore. User and Password must be passed in via an Authorization header.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches MerlinProvider to send Basic auth via Authorization header when fetching imaging result URLs and adds integration tests.
> 
> - **Integrations/Imaging**:
>   - **MerlinProvider**: Replace embedding credentials in `URL` with `Authorization: Basic ...` header for `fetch(urlgen)`; keep `accession`, `patIdType`, and `patId` query params.
> - **Tests**:
>   - Add integration test for `MerlinProvider.getUrlForResult` asserting Basic auth header usage and returned URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f207ce2fed91cd9da6bd9e2202f023e151da8c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->