### PR TITLE
feat: EPI-1295: UI improvements for floating encounter notes

### DIFF
--- a/packages/web/app/components/Field/SelectField.jsx
+++ b/packages/web/app/components/Field/SelectField.jsx
@@ -105,6 +105,7 @@ export const SelectInput = ({
   isClearable = true,
   clearValue = undefined,
   customStyleObject,
+  $fontSize,
   ['data-testid']: dataTestId,
   ...props
 }) => {
@@ -129,7 +130,7 @@ export const SelectInput = ({
     control: (provided, state) => {
       const mainBorderColor = state.isFocused ? Colors.primary : Colors.outline;
       const borderColor = props.error ? Colors.alert : mainBorderColor;
-      const fontSize = props.size === 'small' ? '11px' : '15px';
+      const fontSize = $fontSize || (props.size === 'small' ? '11px' : '15px');
       return {
         ...provided,
         borderColor,

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -209,7 +209,7 @@ export const NoteContentField = ({
   isEditMode = false,
   isTreatmentPlanNote = false,
 }) => {
-  const minHeight = isEditMode && isTreatmentPlanNote ? 308 : 390;
+  const minHeight = isEditMode && isTreatmentPlanNote ? 378 : 460;
 
   return (
     <NoteContentBox>
@@ -287,7 +287,7 @@ export const NoteInfoSection = ({
   </StyledInfoCard>
 );
 
-export const NoteTypeField = ({ required, noteTypeCountByType, onChange, size, disabled }) => (
+export const NoteTypeField = ({ required, noteTypeCountByType, onChange, size, disabled, customStyleObject }) => (
   <Field
     name="noteType"
     label={
@@ -300,6 +300,7 @@ export const NoteTypeField = ({ required, noteTypeCountByType, onChange, size, d
     required={required}
     component={TranslatedSelectField}
     enumValues={NOTE_TYPE_LABELS}
+    customStyleObject={customStyleObject}
     transformOptions={types =>
       types
         .filter(option => !option.hideFromDropdown)

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -162,14 +162,22 @@ const NoteContentBox = styled(Box)`
   flex-direction: column;
   min-height: 0;
   margin-top: 1.2rem;
-  margin-bottom: 30px;
+`;
+
+const StyledField = styled(Field)`
+  .MuiOutlinedInput-notchedOutline {
+    min-height: ${props => `${props.$minHeight - 12}px`};
+  }
+  &.MuiTextField-root {
+    min-height: ${props => `${props.$minHeight}px`};
+    padding-bottom: 12px;
+  }
 `;
 
 const fieldWrapperSx = {
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
-  minHeight: 0,
 };
 
 const inputContainerSx = {
@@ -198,27 +206,34 @@ export const NoteContentField = ({
   ),
   onChange,
   size,
-}) => (
-  <NoteContentBox>
-    <Field
-      name="content"
-      label={label}
-      required
-      component={TextField}
-      multiline
-      onChange={onChange}
-      style={fieldWrapperSx}
-      InputProps={{
-        style: inputContainerSx,
-      }}
-      inputProps={{
-        style: textareaSx,
-      }}
-      data-testid="field-wxzr"
-      size={size}
-    />
-  </NoteContentBox>
-);
+  isEditMode = false,
+  isTreatmentPlanNote = false,
+}) => {
+  const minHeight = isEditMode && isTreatmentPlanNote ? 308 : 390;
+
+  return (
+    <NoteContentBox>
+      <StyledField
+        $minHeight={minHeight}
+        name="content"
+        label={label}
+        required
+        component={TextField}
+        multiline
+        onChange={onChange}
+        style={fieldWrapperSx}
+        InputProps={{
+          style: inputContainerSx,
+        }}
+        inputProps={{
+          style: textareaSx,
+        }}
+        data-testid="field-wxzr"
+        size={size}
+      />
+    </NoteContentBox>
+  );
+};
 
 export const NoteInfoSection = ({
   noteType,

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -165,9 +165,6 @@ const NoteContentBox = styled(Box)`
 `;
 
 const StyledField = styled(Field)`
-  .MuiOutlinedInput-notchedOutline {
-    min-height: ${props => `${props.$minHeight - 12}px`};
-  }
   &.MuiTextField-root {
     min-height: ${props => `${props.$minHeight}px`};
     padding-bottom: 12px;
@@ -193,7 +190,7 @@ const textareaSx = {
   minHeight: 0,
   overflow: 'auto',
   width: '100%',
-  boxSizing: 'border-box',  
+  boxSizing: 'border-box',
 };
 
 export const NoteContentField = ({
@@ -287,7 +284,14 @@ export const NoteInfoSection = ({
   </StyledInfoCard>
 );
 
-export const NoteTypeField = ({ required, noteTypeCountByType, onChange, size, disabled, customStyleObject }) => (
+export const NoteTypeField = ({
+  required,
+  noteTypeCountByType,
+  onChange,
+  size,
+  disabled,
+  $fontSize,
+}) => (
   <Field
     name="noteType"
     label={
@@ -300,7 +304,7 @@ export const NoteTypeField = ({ required, noteTypeCountByType, onChange, size, d
     required={required}
     component={TranslatedSelectField}
     enumValues={NOTE_TYPE_LABELS}
-    customStyleObject={customStyleObject}
+    $fontSize={$fontSize}
     transformOptions={types =>
       types
         .filter(option => !option.hideFromDropdown)

--- a/packages/web/app/components/NoteModal/NoteModal.jsx
+++ b/packages/web/app/components/NoteModal/NoteModal.jsx
@@ -20,12 +20,12 @@ const NOTE_MODAL_DIMENSIONS = {
   WIDTH: {
     MIN: 480,
     BASE_RATIO: 0.37,
-    MAX_RATIO: 0.95,
+    MAX_RATIO: 1,
   },
   HEIGHT: {
     MIN_DEFAULT: 415,
     BASE_RATIO: 0.9,
-    MAX_RATIO: 0.9,
+    MAX_RATIO: 1,
   },
 };
 

--- a/packages/web/app/components/NoteModal/NoteModal.jsx
+++ b/packages/web/app/components/NoteModal/NoteModal.jsx
@@ -81,7 +81,22 @@ const MemoizedNoteModalContents = React.memo(
   }) => {
     const { WIDTH, HEIGHT } = NOTE_MODAL_DIMENSIONS;
 
-    const viewport = useMemo(() => ({ vw: window.innerWidth, vh: window.innerHeight }), []);
+    const [viewport, setViewport] = useState({
+      vw: window.innerWidth,
+      vh: window.innerHeight,
+    });
+
+    useEffect(() => {
+      const handleResize = () => {
+        setViewport({ vw: window.innerWidth, vh: window.innerHeight });
+      };
+
+      window.addEventListener('resize', handleResize);
+
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }, []);
 
     const minConstraints = [WIDTH.MIN, HEIGHT.MIN_DEFAULT];
 

--- a/packages/web/app/components/NoteModal/NoteModal.jsx
+++ b/packages/web/app/components/NoteModal/NoteModal.jsx
@@ -20,12 +20,12 @@ const NOTE_MODAL_DIMENSIONS = {
   WIDTH: {
     MIN: 480,
     BASE_RATIO: 0.37,
-    MAX_RATIO: 1,
+    MAX_RATIO: 0.9,
   },
   HEIGHT: {
     MIN_DEFAULT: 415,
     BASE_RATIO: 0.9,
-    MAX_RATIO: 1,
+    MAX_RATIO: 0.9,
   },
 };
 

--- a/packages/web/app/components/NoteModal/NoteModal.jsx
+++ b/packages/web/app/components/NoteModal/NoteModal.jsx
@@ -15,23 +15,17 @@ import { TranslatedText } from '../Translation/TranslatedText';
 import { withModalFloating } from '../withModalFloating';
 import { useNoteModal } from '../../contexts/NoteModal';
 import { NoteModalDialogTitle } from './NoteModalCommonComponents';
-import { useMediaQuery } from '@material-ui/core';
 
 const NOTE_MODAL_DIMENSIONS = {
-  BREAKPOINTS: {
-    HEIGHT: 850, // px
-  },
   WIDTH: {
-    BASE: 500,
-    MIN: 400,
-    MAX: 500,
+    MIN: 480,
+    BASE_RATIO: 0.37,
+    MAX_RATIO: 0.95,
   },
   HEIGHT: {
-    BASE: 500,
-    MIN_DEFAULT: 450,
-    MIN_TREATMENT_PLAN: 500,
-    MAX_DEFAULT: 500,
-    MAX_TALL: 775,
+    MIN_DEFAULT: 415,
+    BASE_RATIO: 0.9,
+    MAX_RATIO: 0.9,
   },
 };
 
@@ -85,30 +79,33 @@ const MemoizedNoteModalContents = React.memo(
     cancelText,
     handleCreateOrEditNewNote,
   }) => {
-    const { BREAKPOINTS, WIDTH, HEIGHT } = NOTE_MODAL_DIMENSIONS;
+    const { WIDTH, HEIGHT } = NOTE_MODAL_DIMENSIONS;
 
-    const isHeightBreakpoint = useMediaQuery(`(min-height: ${BREAKPOINTS.HEIGHT}px)`);
-    const isTreatmentPlanEdit =
-      noteFormMode === NOTE_FORM_MODES.EDIT_NOTE && note.noteType === NOTE_TYPES.TREATMENT_PLAN;
+    const viewport = useMemo(() => ({ vw: window.innerWidth, vh: window.innerHeight }), []);
 
-    const minConstraints = useMemo(() => {
-      if (isTreatmentPlanEdit) {
-        return [WIDTH.MIN, HEIGHT.MIN_TREATMENT_PLAN];
-      }
-      return [WIDTH.MIN, HEIGHT.MIN_DEFAULT];
-    }, [isTreatmentPlanEdit, WIDTH, HEIGHT]);
+    const minConstraints = [WIDTH.MIN, HEIGHT.MIN_DEFAULT];
 
     const maxConstraints = useMemo(() => {
-      const height = isHeightBreakpoint ? HEIGHT.MAX_TALL : HEIGHT.MAX_DEFAULT;
-      return [WIDTH.MAX, height];
-    }, [isHeightBreakpoint, WIDTH, HEIGHT]);
+      const maxW = Math.max(WIDTH.MIN, Math.round(viewport.vw * WIDTH.MAX_RATIO));
+      const maxH = Math.max(HEIGHT.MIN_DEFAULT, Math.round(viewport.vh * HEIGHT.MAX_RATIO));
+      return [maxW, maxH];
+    }, [viewport, WIDTH, HEIGHT]);
+
+    const baseWidth = useMemo(
+      () => Math.max(WIDTH.MIN, Math.round(viewport.vw * WIDTH.BASE_RATIO)),
+      [viewport, WIDTH.MIN, WIDTH.BASE_RATIO],
+    );
+    const baseHeight = useMemo(
+      () => Math.max(HEIGHT.MIN_DEFAULT, Math.round(viewport.vh * HEIGHT.BASE_RATIO)),
+      [viewport, HEIGHT.MIN_DEFAULT, HEIGHT.BASE_RATIO],
+    );
 
     return (
       <FloatingMuiDialog
         open={open}
         onClose={onClose}
-        baseWidth={WIDTH.BASE}
-        baseHeight={isHeightBreakpoint ? HEIGHT.MAX_TALL : HEIGHT.BASE}
+        baseWidth={baseWidth}
+        baseHeight={baseHeight}
         minConstraints={minConstraints}
         maxConstraints={maxConstraints}
       >
@@ -262,7 +259,7 @@ export const NoteModal = React.memo(() => {
         unblockRef.current();
       }
     };
-  }, [isNoteModalOpen, history, closeNoteModal]);
+  }, [isNoteModalOpen, history, closeNoteModal, getTranslation]);
 
   return (
     <>

--- a/packages/web/app/components/NoteModal/NoteModalCommonComponents.jsx
+++ b/packages/web/app/components/NoteModal/NoteModalCommonComponents.jsx
@@ -11,7 +11,8 @@ const StyledTitleContents = styled(Box)`
   align-items: center;
   width: 100%;
   justify-content: space-between;
-  padding: 10px 19px;
+  padding: 4px 19px;
+  font-size: 14px;
 `;
 
 export const NoteModalDialogTitle = ({ title, onClose }) => {

--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import { Resizable } from 're-resizable';
@@ -17,8 +17,14 @@ export const withModalFloating = ModalComponent => {
       pointer-events: none;
     }
 
+    & .MuiDialog-container {
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
+
     & .MuiDialog-paper {
       pointer-events: auto;
+      margin: 0;
     }
 
     & ${props => props.draggableHandle} {
@@ -46,6 +52,14 @@ export const withModalFloating = ModalComponent => {
     ...modalProps
   }) => {
     const positionRef = useRef({ x: 0, y: 0 });
+    const defaultPosition = useMemo(() => {
+      if (typeof window !== 'undefined') {
+        const x = Math.max(0, Math.round(window.innerWidth / 2 - Number(baseWidth) / 2));
+        const y = Math.max(0, Math.round(window.innerHeight / 2 - Number(baseHeight) / 2));
+        return { x, y };
+      }
+      return { x: 0, y: 0 };
+    }, [baseWidth, baseHeight]);
 
     const PaperComponent = useCallback(
       paperProps => {
@@ -54,7 +68,7 @@ export const withModalFloating = ModalComponent => {
           <Draggable
             handle={draggableHandle}
             bounds={draggableBounds}
-            defaultPosition={positionRef.current}
+            defaultPosition={defaultPosition}
             cancel=".MuiDialogTitle-root button, .MuiDialogActions-root button"
             onStop={(e, data) => {
               positionRef.current = { x: data.x, y: data.y };
@@ -156,7 +170,7 @@ export const withModalFloating = ModalComponent => {
     draggableBounds: 'body',
     hideBackdrop: true,
     BackdropProps: { invisible: true, style: { pointerEvents: 'none' } },
-    resizeRatio: 2,
+    resizeRatio: 1,
   };
 
   return FloatingModal;

--- a/packages/web/app/forms/CreateEditNoteForm.jsx
+++ b/packages/web/app/forms/CreateEditNoteForm.jsx
@@ -68,10 +68,7 @@ export const CreateEditNoteForm = ({
               noteTypeCountByType={noteTypeCountByType}
               onChange={onChangeNoteType}
               disabled={disableFields}
-              customStyleObject={{
-                control: provided => ({ ...provided, fontSize: '14px' }),
-                option: provided => ({ ...provided, fontSize: '14px' }),
-              }}
+              $fontSize="14px"
             />
             <NoteTemplateField
               noteType={values.noteType}

--- a/packages/web/app/forms/CreateEditNoteForm.jsx
+++ b/packages/web/app/forms/CreateEditNoteForm.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import styled from 'styled-components';
 
 import { FormSubmitCancelRow } from '../components/ButtonRow';
 import {
@@ -17,6 +18,12 @@ import {
   NoteModalDialogActions,
   DisabledWrapper,
 } from '../components/NoteModal/NoteModalCommonComponents';
+
+const StyledNoteModalDialogContent = styled(NoteModalDialogContent)`
+  .MuiInputBase-input {
+    font-size: 14px;
+  }
+`;
 
 export const CreateEditNoteForm = ({
   onSubmit,
@@ -53,31 +60,32 @@ export const CreateEditNoteForm = ({
 
   return (
     <>
-      <NoteModalDialogContent>
+      <StyledNoteModalDialogContent>
         <DisabledWrapper color={Colors.background}>
           <FormGrid columns={2} style={{ marginTop: 0 }}>
             <NoteTypeField
               required
               noteTypeCountByType={noteTypeCountByType}
               onChange={onChangeNoteType}
-              size="small"
               disabled={disableFields}
+              customStyleObject={{
+                control: provided => ({ ...provided, fontSize: '14px' }),
+                option: provided => ({ ...provided, fontSize: '14px' }),
+              }}
             />
             <NoteTemplateField
               noteType={values.noteType}
               onChangeTemplate={onChangeTemplate}
-              size="small"
               disabled={disableFields}
             />
-            <WrittenByField required size="small" disabled={disableFields} />
-            <NoteDateTimeField required size="small" disabled={disableFields} />
+            <WrittenByField required disabled={disableFields} />
+            <NoteDateTimeField required disabled={disableFields} />
           </FormGrid>
         </DisabledWrapper>
         <NoteContentField
           label={<TranslatedText stringId="note.modal.addNote.label" fallback="Add note" />}
-          size="small"
         />
-      </NoteModalDialogContent>
+      </StyledNoteModalDialogContent>
       <NoteModalDialogActions>
         <FormSubmitCancelRow
           style={{ marginTop: '0' }}

--- a/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
+++ b/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { FormSubmitCancelRow } from '../components/ButtonRow';
 import {
   NoteContentField,
@@ -11,12 +12,18 @@ import {
 } from '../components/NoteCommonFields';
 import {
   DisabledWrapper,
-  NoteModalDialogContent,
   NoteModalDialogActions,
   NoteModalFormGrid,
+  NoteModalDialogContent,
 } from '../components/NoteModal/NoteModalCommonComponents';
 import { TranslatedText } from '../components';
 import { Colors } from '../constants';
+
+const StyledNoteModalDialogContent = styled(NoteModalDialogContent)`
+  .MuiInputBase-input {
+    font-size: 14px;
+  }
+`;
 
 export const EditTreatmentPlanNoteForm = ({
   note,
@@ -29,28 +36,25 @@ export const EditTreatmentPlanNoteForm = ({
 
   return (
     <>
-      <NoteModalDialogContent>
+      <StyledNoteModalDialogContent>
         <DisabledWrapper color={Colors.background}>
           <NoteModalFormGrid columns={2}>
             <NoteTypeField
               noteTypeCountByType={noteTypeCountByType}
               size="small"
-              fontSize="12px"
+              customStyleObject={{
+                control: provided => ({ ...provided, fontSize: '14px' }),
+                option: provided => ({ ...provided, fontSize: '14px' }),
+              }}
               disabled
             />
             <NoteTemplateField
               noteType={note.noteType}
               onChangeTemplate={onChangeTemplate}
               size="small"
-              fontSize="12px"
               disabled
             />
-            <PreviouslyWrittenByField
-              value={noteOnBehalfOfName}
-              size="small"
-              fontSize="12px"
-              disabled
-            />
+            <PreviouslyWrittenByField value={noteOnBehalfOfName} size="small" disabled />
             <PreviousDateTimeField value={note.createdAt} size="small" />
             <WrittenByField
               label={
@@ -62,7 +66,7 @@ export const EditTreatmentPlanNoteForm = ({
               required
               size="small"
             />
-            <NoteDateTimeField required size="small" fontSize="12px" />
+            <NoteDateTimeField required size="small" />
           </NoteModalFormGrid>
         </DisabledWrapper>
         <NoteContentField
@@ -71,7 +75,7 @@ export const EditTreatmentPlanNoteForm = ({
           isEditMode
           isTreatmentPlanNote
         />
-      </NoteModalDialogContent>
+      </StyledNoteModalDialogContent>
       <NoteModalDialogActions>
         <FormSubmitCancelRow
           style={{ marginTop: '0' }}

--- a/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
+++ b/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
@@ -68,6 +68,8 @@ export const EditTreatmentPlanNoteForm = ({
         <NoteContentField
           label={<TranslatedText stringId="note.modal.addNote.label" fallback="Add note" />}
           size="small"
+          isEditMode
+          isTreatmentPlanNote
         />
       </NoteModalDialogContent>
       <NoteModalDialogActions>

--- a/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
+++ b/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
@@ -41,10 +41,7 @@ export const EditTreatmentPlanNoteForm = ({
           <NoteModalFormGrid columns={2}>
             <NoteTypeField
               noteTypeCountByType={noteTypeCountByType}
-              customStyleObject={{
-                control: provided => ({ ...provided, fontSize: '14px' }),
-                option: provided => ({ ...provided, fontSize: '14px' }),
-              }}
+              $fontSize="14px"
               disabled
             />
             <NoteTemplateField

--- a/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
+++ b/packages/web/app/forms/EditTreatmentPlanNoteForm.jsx
@@ -41,7 +41,6 @@ export const EditTreatmentPlanNoteForm = ({
           <NoteModalFormGrid columns={2}>
             <NoteTypeField
               noteTypeCountByType={noteTypeCountByType}
-              size="small"
               customStyleObject={{
                 control: provided => ({ ...provided, fontSize: '14px' }),
                 option: provided => ({ ...provided, fontSize: '14px' }),
@@ -51,11 +50,10 @@ export const EditTreatmentPlanNoteForm = ({
             <NoteTemplateField
               noteType={note.noteType}
               onChangeTemplate={onChangeTemplate}
-              size="small"
               disabled
             />
-            <PreviouslyWrittenByField value={noteOnBehalfOfName} size="small" disabled />
-            <PreviousDateTimeField value={note.createdAt} size="small" />
+            <PreviouslyWrittenByField value={noteOnBehalfOfName} disabled />
+            <PreviousDateTimeField value={note.createdAt} />
             <WrittenByField
               label={
                 <TranslatedText
@@ -64,14 +62,12 @@ export const EditTreatmentPlanNoteForm = ({
                 />
               }
               required
-              size="small"
             />
-            <NoteDateTimeField required size="small" />
+            <NoteDateTimeField required />
           </NoteModalFormGrid>
         </DisabledWrapper>
         <NoteContentField
           label={<TranslatedText stringId="note.modal.addNote.label" fallback="Add note" />}
-          size="small"
           isEditMode
           isTreatmentPlanNote
         />


### PR DESCRIPTION
### Changes

- Introduced StyledField to manage input height based on edit mode and note type.
- Updated NoteModal to calculate modal dimensions dynamically based on viewport size.
- Adjusted CreateEditNoteForm and EditTreatmentPlanNoteForm to pass new props for edit mode and treatment plan status.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
