### PR TITLE
fix: EPI-1192: Fix Booking Details popout display

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -183,7 +183,7 @@ const LocationBookingDetails = ({
             data-testid="translatedtext-linkedencounter"
           />
         }
-        value={<LinkedEncounter encounter={linkEncounter} />}
+        value={linkEncounter && <LinkedEncounter encounter={linkEncounter} />}
         data-testid="detailsdisplay-linkedencounter"
       />
       {isOvernight && (

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -51,7 +51,6 @@ const ClinicianContainer = styled('div')`
 
 const LinkedEncounter = ({ encounter }) => {
   const { getTranslation, getEnumTranslation, getReferenceDataTranslation } = useTranslation();
-  if (!encounter) return '—';
 
   const encounterPath = generatePath(PATIENT_PATHS.ENCOUNTER, {
     category: PATIENT_CATEGORIES.ALL,

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -51,7 +51,7 @@ const ClinicianContainer = styled('div')`
 
 const LinkedEncounter = ({ encounter }) => {
   const { getTranslation, getEnumTranslation, getReferenceDataTranslation } = useTranslation();
-  if (!encounter) return null;
+  if (!encounter) return '—';
 
   const encounterPath = generatePath(PATIENT_PATHS.ENCOUNTER, {
     category: PATIENT_CATEGORIES.ALL,
@@ -84,6 +84,7 @@ const LinkedEncounter = ({ encounter }) => {
 
 const LocationBookingDetails = ({
   location,
+  locationGroup,
   bookingType,
   isOvernight,
   appointmentProcedureTypes,
@@ -112,12 +113,21 @@ const LocationBookingDetails = ({
             />
           }
           value={
-            <TranslatedReferenceData
-              fallback={location?.name}
-              value={location?.id}
-              category="location"
-              data-testid="translatedreferencedata-505o"
-            />
+            <span>
+              <TranslatedReferenceData
+                fallback={location?.locationGroup?.name || locationGroup?.name}
+                value={location?.locationGroup?.id || locationGroup?.id}
+                category="locationGroup"
+                data-testid="translatedreferencedata-gbn6"
+              />
+              {', '}
+              <TranslatedReferenceData
+                fallback={location?.name}
+                value={location?.id}
+                category="location"
+                data-testid="translatedreferencedata-505o"
+              />
+            </span>
           }
           data-testid="detailsdisplay-zzp3"
         />
@@ -295,28 +305,11 @@ export const AppointmentDetailsDisplay = ({ appointment, isOvernight }) => {
           data-testid="detailsdisplay-additionalclinician"
         />
       </ClinicianContainer>
-      <DetailsDisplay
-        label={
-          <TranslatedText
-            stringId="general.localisedField.locationGroupId.label"
-            fallback="Area"
-            data-testid="translatedtext-f8to"
-          />
-        }
-        value={
-          <TranslatedReferenceData
-            fallback={location?.locationGroup?.name || locationGroup?.name}
-            value={location?.locationGroup?.id || locationGroup?.id}
-            category="locationGroup"
-            data-testid="translatedreferencedata-gbn6"
-          />
-        }
-        data-testid="detailsdisplay-w60y"
-      />
       {/* Location booking specific data */}
       {location && bookingType && (
         <LocationBookingDetails
           location={location}
+          locationGroup={locationGroup}
           bookingType={bookingType}
           isOvernight={isOvernight}
           appointmentProcedureTypes={appointmentProcedureTypes}

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -114,13 +114,17 @@ const LocationBookingDetails = ({
           }
           value={
             <span>
-              <TranslatedReferenceData
-                fallback={location?.locationGroup?.name || locationGroup?.name}
-                value={location?.locationGroup?.id || locationGroup?.id}
-                category="locationGroup"
-                data-testid="translatedreferencedata-gbn6"
-              />
-              {', '}
+              {(location?.locationGroup?.id || locationGroup?.id) && (
+                <>
+                  <TranslatedReferenceData
+                    fallback={location?.locationGroup?.name || locationGroup?.name}
+                    value={location?.locationGroup?.id || locationGroup?.id}
+                    category="locationGroup"
+                    data-testid="translatedreferencedata-gbn6"
+                  />
+                  {', '}
+                </>
+              )}
               <TranslatedReferenceData
                 fallback={location?.name}
                 value={location?.id}

--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsDailyCalendar.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsDailyCalendar.jsx
@@ -626,26 +626,6 @@ export const LocationBookingsDailyCalendar = ({
                           className="appointment-tile"
                           onEdit={() => openBookingForm(appointment)}
                           onCancel={() => openCancelModal(appointment)}
-                          actions={
-                            canCreateAppointment
-                              ? [
-                                  {
-                                    label: (
-                                      <TranslatedText
-                                        stringId="appointments.action.newAppointment"
-                                        fallback="New appointment"
-                                        data-testid={`new-appointment-${locationIndex}-${appointmentIndex}`}
-                                      />
-                                    ),
-                                    action: () =>
-                                      openBookingForm({
-                                        locationId: location.id,
-                                        startDate: selectedDate,
-                                      }),
-                                  },
-                                ]
-                              : []
-                          }
                           testIdPrefix={`${locationIndex}-${appointmentIndex}`}
                         />
                       </AppointmentWrapper>


### PR DESCRIPTION
### Changes

- Changed LinkedEncounter to return '—' when no encounter is present.
- Enhanced LocationBookingDetails to include locationGroup information.
- Removed unused actions from LocationBookingsDailyCalendar for cleaner code.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
