### PR TITLE
release-fix: broken mobile survey answers

### DIFF
--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseDetailsScreen/index.tsx
@@ -79,6 +79,7 @@ function getAnswerText(type, answer): string | number {
     case FieldTypes.RADIO:
     case FieldTypes.CONDITION:
     case FieldTypes.USER_DATA:
+      return answer || 'N/A';
     case FieldTypes.BINARY:
     case FieldTypes.CHECKBOX:
       return answer.toLowerCase() === 'yes' ? 'Yes' : 'No';


### PR DESCRIPTION
### Changes

Fix mobile survey answers

Return clause in switch statement was accidentally removed [[here]](https://github.com/beyondessential/tamanu/commit/62b095615205a2b69724164d8c0ba63b0ae42a9a#diff-d83bee5fa0406be1e3694ce9195ec9ad53a35288fbbf5e0a2cc5eb854bb9925c) and so the answers were getting interpreted as binary answers 


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
