### PR TITLE
test(e2e): Add test IDs to vaccine tests

### DIFF
--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
@@ -153,7 +153,8 @@ export class ViewVaccineModal extends BasePatientModal {
   }
 
   async assertGivenElsewhereVaccineModalFields(vaccine: Partial<Vaccine>) {
-    const { vaccineName, givenElsewhereReason, givenElsewhereCountry, dateGiven, category } = vaccine;
+    const { vaccineName, givenElsewhereReason, givenElsewhereCountry, dateGiven, category } =
+      vaccine;
 
     if (!vaccineName || !givenElsewhereReason || !givenElsewhereCountry) {
       throw new Error('Missing required given elsewhere fields');

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
@@ -153,7 +153,7 @@ export class ViewVaccineModal extends BasePatientModal {
   }
 
   async assertGivenElsewhereVaccineModalFields(vaccine: Partial<Vaccine>) {
-    const { vaccineName, givenElsewhereReason, givenElsewhereCountry, dateGiven } = vaccine;
+    const { vaccineName, givenElsewhereReason, givenElsewhereCountry, dateGiven, category } = vaccine;
 
     if (!vaccineName || !givenElsewhereReason || !givenElsewhereCountry) {
       throw new Error('Missing required given elsewhere fields');
@@ -168,8 +168,12 @@ export class ViewVaccineModal extends BasePatientModal {
     await expect(this.givenElsewhereReason).toContainText(givenElsewhereReason);
     await expect(this.givenElsewhereCountry).toContainText(givenElsewhereCountry);
     await expect(this.status).toContainText('Given elsewhere');
-    await expect(this.givenVaccineName).toContainText(vaccineName);
     await expect(this.givenElsewhereFacility).toContainText('facility-1');
     await expect(this.recordedBy).toContainText('Initial Admin');
+    if (category === 'Other') {
+      await expect(this.vaccineNameOther).toContainText(vaccineName);
+    } else {
+      await expect(this.givenVaccineName).toContainText(vaccineName);
+    }
   }
 }

--- a/packages/e2e-tests/tests/patients/vaccine/scheduledVaccine.spec.ts
+++ b/packages/e2e-tests/tests/patients/vaccine/scheduledVaccine.spec.ts
@@ -10,7 +10,7 @@ import { scrollTableToElement } from '@utils/tableHelper';
 import { subYears, subWeeks } from 'date-fns';
 
 test.describe('Scheduled vaccines', () => {
-  test('Vaccines scheduled at birth display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1045]Vaccines scheduled at birth display', async ({ page, api, patientDetailsPage }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const birthDueDate = await expectedDueDateWeek(currentDate, 1);
     const status = 'Due';
@@ -37,7 +37,7 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('Vaccines scheduled weeks from birth display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1046]Vaccines scheduled weeks from birth display', async ({ page, api, patientDetailsPage }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const status = 'Scheduled';
 
@@ -80,7 +80,7 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('Vaccines scheduled months from birth display', async ({
+  test('[AT-1047]Vaccines scheduled months from birth display', async ({
     page,
     api,
     patientDetailsPage,
@@ -120,7 +120,7 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('Vaccines scheduled years from birth display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1048]Vaccines scheduled years from birth display', async ({ page, api, patientDetailsPage }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const birthDateTenYearsAgo = subYears(currentDate, 10);
     const vaccine = 'Td Booster';
@@ -146,7 +146,7 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('Vaccines scheduled weeks from last vaccination display', async ({
+  test('[AT-1049]Vaccines scheduled weeks from last vaccination display', async ({
     page,
     api,
     patientDetailsPage,
@@ -181,7 +181,7 @@ test.describe('Scheduled vaccines', () => {
   });
 
   //Note that the "missed" status is not displayed in this table as per comments on NASS-1113
-  test('Different scheduled statuses display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1050]Different scheduled statuses display', async ({ page, api, patientDetailsPage }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const birthDateThreeWeeksAgo = subWeeks(currentDate, 3);
 
@@ -257,6 +257,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'BCG',
       schedule: 'Birth',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 1),
+      testId: '[AT-1051]'
     },
     {
       status: 'Scheduled',
@@ -264,6 +265,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'PCV13',
       schedule: '6 weeks',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 6),
+      testId: '[AT-1052]'
     },
     {
       status: 'Overdue',
@@ -271,6 +273,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'BCG',
       schedule: 'Birth',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 1),
+      testId: '[AT-1053]'
     },
     {
       status: 'Upcoming',
@@ -278,6 +281,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'PCV13',
       schedule: '6 weeks',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 6),
+      testId: '[AT-1054]'
     },
   ];
 
@@ -287,8 +291,9 @@ test.describe('Scheduled vaccines', () => {
     vaccine,
     schedule,
     getDueDate,
+    testId,
   } of recordScheduledVaccineTestCases) {
-    test(`Record vaccine with ${status.toLowerCase()} status from scheduled vaccines table`, async ({
+    test(`${testId}Record vaccine with ${status.toLowerCase()} status from scheduled vaccines table`, async ({
       page,
       api,
       patientDetailsPage,
@@ -310,7 +315,7 @@ test.describe('Scheduled vaccines', () => {
     });
   }
 
-  test('Vaccine remains scheduled if "not given" is selected when recording', async ({
+  test('[AT-1055]Vaccine remains scheduled if "not given" is selected when recording', async ({
     page,
     api,
     patientDetailsPage,
@@ -342,7 +347,7 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('Record 2nd dose of vaccine scheduled weeks from last vaccination', async ({
+  test('[AT-1056]Record 2nd dose of vaccine scheduled weeks from last vaccination', async ({
     page,
     api,
     patientDetailsPage,

--- a/packages/e2e-tests/tests/patients/vaccine/scheduledVaccine.spec.ts
+++ b/packages/e2e-tests/tests/patients/vaccine/scheduledVaccine.spec.ts
@@ -10,7 +10,11 @@ import { scrollTableToElement } from '@utils/tableHelper';
 import { subYears, subWeeks } from 'date-fns';
 
 test.describe('Scheduled vaccines', () => {
-  test('[AT-1045]Vaccines scheduled at birth display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1045]Vaccines scheduled at birth display', async ({
+    page,
+    api,
+    patientDetailsPage,
+  }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const birthDueDate = await expectedDueDateWeek(currentDate, 1);
     const status = 'Due';
@@ -37,7 +41,11 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('[AT-1046]Vaccines scheduled weeks from birth display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1046]Vaccines scheduled weeks from birth display', async ({
+    page,
+    api,
+    patientDetailsPage,
+  }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const status = 'Scheduled';
 
@@ -120,7 +128,11 @@ test.describe('Scheduled vaccines', () => {
     );
   });
 
-  test('[AT-1048]Vaccines scheduled years from birth display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1048]Vaccines scheduled years from birth display', async ({
+    page,
+    api,
+    patientDetailsPage,
+  }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const birthDateTenYearsAgo = subYears(currentDate, 10);
     const vaccine = 'Td Booster';
@@ -181,7 +193,11 @@ test.describe('Scheduled vaccines', () => {
   });
 
   //Note that the "missed" status is not displayed in this table as per comments on NASS-1113
-  test('[AT-1050]Different scheduled statuses display', async ({ page, api, patientDetailsPage }) => {
+  test('[AT-1050]Different scheduled statuses display', async ({
+    page,
+    api,
+    patientDetailsPage,
+  }) => {
     const currentDate = new Date(patientDetailsPage.getCurrentBrowserDateISOFormat());
     const birthDateThreeWeeksAgo = subWeeks(currentDate, 3);
 
@@ -257,7 +273,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'BCG',
       schedule: 'Birth',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 1),
-      testId: '[AT-1051]'
+      testId: '[AT-1051]',
     },
     {
       status: 'Scheduled',
@@ -265,7 +281,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'PCV13',
       schedule: '6 weeks',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 6),
-      testId: '[AT-1052]'
+      testId: '[AT-1052]',
     },
     {
       status: 'Overdue',
@@ -273,7 +289,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'BCG',
       schedule: 'Birth',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 1),
-      testId: '[AT-1053]'
+      testId: '[AT-1053]',
     },
     {
       status: 'Upcoming',
@@ -281,7 +297,7 @@ test.describe('Scheduled vaccines', () => {
       vaccine: 'PCV13',
       schedule: '6 weeks',
       getDueDate: async (birthDate: Date) => expectedDueDateWeek(birthDate, 6),
-      testId: '[AT-1054]'
+      testId: '[AT-1054]',
     },
   ];
 

--- a/packages/e2e-tests/tests/patients/vaccine/vaccine.spec.ts
+++ b/packages/e2e-tests/tests/patients/vaccine/vaccine.spec.ts
@@ -5,6 +5,7 @@ import {
   triggerDateError,
   editVaccine,
   assertEditedVaccine,
+  testGivenElsewhereForCategory,
 } from '@utils/vaccineTestHelpers';
 
 test.describe('Vaccines', () => {
@@ -13,23 +14,23 @@ test.describe('Vaccines', () => {
     await patientDetailsPage.navigateToVaccineTab();
   });
 
-  test('Add a routine vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1001]Add a routine vaccine', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine');
   });
 
-  test('Add a catchup vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1002]Add a catchup vaccine', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Catchup');
   });
 
-  test('Add a campaign vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1003]Add a campaign vaccine', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Campaign');
   });
 
-  test('Add an other vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0434][AT-1004]Add an other vaccine', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Other');
   });
 
-  test('Add multiple vaccines of different types', async ({ patientDetailsPage }) => {
+  test('[T-0432][T-0434][AT-1005]Add multiple vaccines of different types', async ({ patientDetailsPage }) => {
     test.setTimeout(45000);
 
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, { specificVaccine: 'MMR' });
@@ -44,23 +45,23 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add a routine vaccine (not given)', async ({ patientDetailsPage }) => {
+  test('[T-0438][AT-1011]Add a routine vaccine (not given)', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Routine', 0);
   });
 
-  test('Add a catchup vaccine (not given)', async ({ patientDetailsPage }) => {
+  test('[T-0438][AT-1012]Add a catchup vaccine (not given)', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Catchup', 0);
   });
 
-  test('Add a campaign vaccine (not given)', async ({ patientDetailsPage }) => {
+  test('[T-0438][AT-1013]Add a campaign vaccine (not given)', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Campaign', 0);
   });
 
-  test('Add an other vaccine (not given)', async ({ patientDetailsPage }) => {
+  test('[T-0440][AT-1014]Add an other vaccine (not given)', async ({ patientDetailsPage }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Other', 0);
   });
 
-  test('Add multiple vaccines with different given statuses', async ({ patientDetailsPage }) => {
+  test('[T-0432][T-0438][T-0440][AT-1027]Add multiple vaccines with different given statuses', async ({ patientDetailsPage }) => {
     test.setTimeout(45000);
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, { specificVaccine: 'IPV' });
     await addVaccineAndAssert(patientDetailsPage, false, 'Catchup', 1, { specificVaccine: 'HPV' });
@@ -72,7 +73,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add vaccine and view vaccine record with just required fields filled', async ({
+  test('[T-0432][AT-1028]Add vaccine and view vaccine record with just required fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, {
@@ -82,7 +83,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Select not given, add vaccine and view vaccine record with just required fields filled', async ({
+  test('[T-0438][AT-1029]Select not given, add vaccine and view vaccine record with just required fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Routine', 0, {
@@ -92,7 +93,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add other vaccine and view vaccine record with just required fields filled', async ({
+  test('[T-0434][AT-1030]Add other vaccine and view vaccine record with just required fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Other', 1, {
@@ -102,7 +103,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Select not given, add other vaccine and view vaccine record with just required fields filled', async ({
+  test('[T-0440][AT-1031]Select not given, add other vaccine and view vaccine record with just required fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Other', 0, {
@@ -112,7 +113,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add vaccine and view vaccine record with optional fields filled', async ({
+  test('[T-0432][AT-1032]Add vaccine and view vaccine record with optional fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, {
@@ -122,7 +123,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add other vaccine and view vaccine record with optional fields filled', async ({
+  test('[T-0434][AT-1033]Add other vaccine and view vaccine record with optional fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Other', 1, {
@@ -132,7 +133,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Select not given, add other vaccine and view vaccine record with optional fields filled', async ({
+  test('[T-0440][AT-1034]Select not given, add other vaccine and view vaccine record with optional fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Other', 0, {
@@ -142,7 +143,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Select not given, add vaccine and view vaccine record with optional fields filled', async ({
+  test('[T-0438][AT-1035]Select not given, add vaccine and view vaccine record with optional fields filled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Routine', 0, {
@@ -152,7 +153,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add multiple different vaccines and view each of their vaccine records', async ({
+  test('[T-0432][T-0434][AT-1036]Add multiple different vaccines and view each of their vaccine records', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Other', 1, {
@@ -174,7 +175,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add multiple doses of the same vaccine and confirm the first dose is disabled', async ({
+  test('[T-0432][AT-1037]Add multiple doses of the same vaccine and confirm the first dose is disabled', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, {
@@ -190,7 +191,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('When a vaccine has all doses administered remove it from dropdown', async ({
+  test('[T-0432][AT-1038]When a vaccine has all doses administered remove it from dropdown', async ({
     patientDetailsPage,
   }) => {
     const category = 'Routine';
@@ -214,7 +215,7 @@ test.describe('Vaccines', () => {
     await recordVaccineModal.assertVaccineNotSelectable(vaccineName, category);
   });
 
-  test('Select not given when giving the second scheduled dose of a vaccine', async ({
+  test('[T-0438][AT-1039]Select not given when giving the second scheduled dose of a vaccine', async ({
     patientDetailsPage,
   }) => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, {
@@ -230,7 +231,7 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('Add vaccine and confirm default date is today', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1040]Add vaccine and confirm default date is today', async ({ patientDetailsPage }) => {
     const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
 
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1);
@@ -240,7 +241,7 @@ test.describe('Vaccines', () => {
     );
   });
 
-  test('Add vaccine with custom date given', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1041]Add vaccine with custom date given', async ({ patientDetailsPage }) => {
     //Date is one year ago - a patient is always 18+ years old so this avoids any validation errors
     const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
     const dateGiven = offsetYear(currentBrowserDate, 'decrease', 1);
@@ -255,7 +256,7 @@ test.describe('Vaccines', () => {
     );
   });
 
-  test('Date given cannot be before patient date of birth', async ({
+  test('[T-0432][AT-1042]Date given cannot be before patient date of birth', async ({
     patientDetailsPage,
     newPatient,
   }) => {
@@ -266,7 +267,7 @@ test.describe('Vaccines', () => {
     await triggerDateError(patientDetailsPage, dateBeforePatientDob, expectedErrorMessage);
   });
 
-  test('Date given cannot be in the future', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1043]Date given cannot be in the future', async ({ patientDetailsPage }) => {
     const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
     const futureDateGiven = offsetYear(currentBrowserDate, 'increase', 1);
     const expectedErrorMessage = 'Date cannot be in the future';
@@ -275,7 +276,7 @@ test.describe('Vaccines', () => {
     await triggerDateError(patientDetailsPage, futureDateGiven, expectedErrorMessage);
   });
 
-  test('Mandatory fields must be filled', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1044]Mandatory fields must be filled', async ({ patientDetailsPage }) => {
     const expectedAreaAndLocationError =
       'locationId must be a `string` type, but the final value was: `null`';
     const expectedDepartmentError =
@@ -316,7 +317,7 @@ test.describe('Vaccines', () => {
     ).toContainText(genericExpectedError);
   });
 
-  test('Edit a vaccine and edit all fields', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1015]Edit a vaccine and edit all fields', async ({ patientDetailsPage }) => {
     const given = true;
     const category = 'Routine';
     const fillOptionalFields = true;
@@ -344,7 +345,7 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, editedVaccine);
   });
 
-  test('Edit a vaccine and fill fields that were originally skipped', async ({
+  test('[T-0441][AT-1016]Edit a vaccine and fill fields that were originally skipped', async ({
     patientDetailsPage,
   }) => {
     const vaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1);
@@ -368,7 +369,7 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, editedVaccine);
   });
 
-  test('Edit unique fields for other vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1017]Edit unique fields for other vaccine', async ({ patientDetailsPage }) => {
     const vaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Other', 1, {
       specificVaccine: 'Test Vaccine',
       fillOptionalFields: true,
@@ -391,7 +392,7 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, editedVaccine);
   });
 
-  test('Edit unique fields for not given vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1018]Edit unique fields for not given vaccine', async ({ patientDetailsPage }) => {
     const vaccine = await addVaccineAndAssert(patientDetailsPage, false, 'Routine', 0, {
       specificVaccine: 'Hep B',
       fillOptionalFields: true,
@@ -417,7 +418,7 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, editedVaccine);
   });
 
-  test('Edit one vaccine when multiple are present', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1019]Edit one vaccine when multiple are present', async ({ patientDetailsPage }) => {
     const firstVaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Catchup', 1);
 
     const secondVaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Campaign', 2);
@@ -439,7 +440,7 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, secondVaccine);
   });
 
-  test('Validation works when editing a vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1020]Validation works when editing a vaccine', async ({ patientDetailsPage }) => {
     const vaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1);
 
     if (!vaccine) {
@@ -457,7 +458,7 @@ test.describe('Vaccines', () => {
     await patientDetailsPage.patientVaccinePane?.editVaccineModal?.assertRequiredFieldErrors();
   });
 
-  test('Delete a vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0443][AT-1021]Delete a vaccine', async ({ patientDetailsPage }) => {
     const vaccineToDelete = await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1);
     const vaccineToKeep = await addVaccineAndAssert(patientDetailsPage, true, 'Campaign', 2);
     const vaccineCountAfterDeletion = 1;
@@ -479,7 +480,7 @@ test.describe('Vaccines', () => {
     );
   });
 
-  test('Vaccine does not appear in dropdown if all doses have been given (vaccine with 1 dose)', async ({
+  test('[T-0445][AT-1022]Vaccine does not appear in dropdown if all doses have been given (vaccine with 1 dose)', async ({
     patientDetailsPage,
   }) => {
     const category = 'Routine';
@@ -501,7 +502,7 @@ test.describe('Vaccines', () => {
     );
   });
 
-  test('Vaccine does not appear in dropdown if all doses have been given (vaccine with multiple doses)', async ({
+  test('[T-0445][AT-1023]Vaccine does not appear in dropdown if all doses have been given (vaccine with multiple doses)', async ({
     patientDetailsPage,
   }) => {
     const category = 'Routine';
@@ -531,7 +532,7 @@ test.describe('Vaccines', () => {
     );
   });
 
-  test('Not given vaccines should be hidden if there is a corresponding given vaccine (desktop only)', async ({
+  test('[T-0447][AT-1024]Not given vaccines should be hidden if there is a corresponding given vaccine (desktop only)', async ({
     patientDetailsPage,
   }) => {
     const uniqueVaccineName = 'Hep B';
@@ -576,7 +577,7 @@ test.describe('Vaccines', () => {
     );
   });
 
-  test('Recorded vaccines table can be sorted by clicking column headers', async ({
+  test('[T-0448][AT-1025]Recorded vaccines table can be sorted by clicking column headers', async ({
     patientDetailsPage,
   }) => {
     const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
@@ -619,7 +620,7 @@ test.describe('Vaccines', () => {
     await patientDetailsPage.patientVaccinePane?.assertVaccineOrder(vaccines, 'date', 'asc');
   });
 
-  test('Location is prefilled for patients with active encounter', async ({
+  test('[T-0449][AT-1026]Location is prefilled for patients with active encounter', async ({
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {
@@ -662,23 +663,35 @@ test.describe('Vaccines', () => {
     await patientDetailsPage.patientVaccinePane?.viewVaccineRecordAndAssert(vaccine);
   });
 
-  test('Record given elsewhere for patient with active encounter', async ({
+  test('[T-0435][AT-1006]Record given elsewhere for Routine vaccine', async ({
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {
-    const givenElsewhereReason = 'Given overseas';
-    const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
-    await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
-    await patientDetailsPage.navigateToVaccineTab();
-
-    await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, {
-      vaccineGivenElsewhere: givenElsewhereReason,
-      specificDate: currentBrowserDate,
-      viewVaccineRecord: true,
-    });
+    await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Routine');
   });
 
-  test('Date field can be empty when vaccine is given elsewhere', async ({
+  test('[T-0435][AT-1007]Record given elsewhere for Catchup vaccine', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
+    await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Catchup');
+  });
+
+  test('[T-0435][AT-1008]Record given elsewhere for Campaign vaccine', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
+    await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Campaign');
+  });
+
+  test('[T-0437][AT-1009]Record given elsewhere for Other vaccine', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
+   await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Other');
+  });
+
+  test('[T-0435][AT-1010]Date field can be empty when vaccine is given elsewhere', async ({
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {

--- a/packages/e2e-tests/tests/patients/vaccine/vaccine.spec.ts
+++ b/packages/e2e-tests/tests/patients/vaccine/vaccine.spec.ts
@@ -30,7 +30,9 @@ test.describe('Vaccines', () => {
     await addVaccineAndAssert(patientDetailsPage, true, 'Other');
   });
 
-  test('[T-0432][T-0434][AT-1005]Add multiple vaccines of different types', async ({ patientDetailsPage }) => {
+  test('[T-0432][T-0434][AT-1005]Add multiple vaccines of different types', async ({
+    patientDetailsPage,
+  }) => {
     test.setTimeout(45000);
 
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, { specificVaccine: 'MMR' });
@@ -61,7 +63,9 @@ test.describe('Vaccines', () => {
     await addVaccineAndAssert(patientDetailsPage, false, 'Other', 0);
   });
 
-  test('[T-0432][T-0438][T-0440][AT-1027]Add multiple vaccines with different given statuses', async ({ patientDetailsPage }) => {
+  test('[T-0432][T-0438][T-0440][AT-1027]Add multiple vaccines with different given statuses', async ({
+    patientDetailsPage,
+  }) => {
     test.setTimeout(45000);
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1, { specificVaccine: 'IPV' });
     await addVaccineAndAssert(patientDetailsPage, false, 'Catchup', 1, { specificVaccine: 'HPV' });
@@ -231,7 +235,9 @@ test.describe('Vaccines', () => {
     });
   });
 
-  test('[T-0432][AT-1040]Add vaccine and confirm default date is today', async ({ patientDetailsPage }) => {
+  test('[T-0432][AT-1040]Add vaccine and confirm default date is today', async ({
+    patientDetailsPage,
+  }) => {
     const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
 
     await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1);
@@ -392,7 +398,9 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, editedVaccine);
   });
 
-  test('[T-0441][AT-1018]Edit unique fields for not given vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1018]Edit unique fields for not given vaccine', async ({
+    patientDetailsPage,
+  }) => {
     const vaccine = await addVaccineAndAssert(patientDetailsPage, false, 'Routine', 0, {
       specificVaccine: 'Hep B',
       fillOptionalFields: true,
@@ -418,7 +426,9 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, editedVaccine);
   });
 
-  test('[T-0441][AT-1019]Edit one vaccine when multiple are present', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1019]Edit one vaccine when multiple are present', async ({
+    patientDetailsPage,
+  }) => {
     const firstVaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Catchup', 1);
 
     const secondVaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Campaign', 2);
@@ -440,7 +450,9 @@ test.describe('Vaccines', () => {
     await assertEditedVaccine(patientDetailsPage, secondVaccine);
   });
 
-  test('[T-0441][AT-1020]Validation works when editing a vaccine', async ({ patientDetailsPage }) => {
+  test('[T-0441][AT-1020]Validation works when editing a vaccine', async ({
+    patientDetailsPage,
+  }) => {
     const vaccine = await addVaccineAndAssert(patientDetailsPage, true, 'Routine', 1);
 
     if (!vaccine) {
@@ -667,28 +679,44 @@ test.describe('Vaccines', () => {
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {
-    await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Routine');
+    await testGivenElsewhereForCategory(
+      patientDetailsPage,
+      newPatientWithHospitalAdmission,
+      'Routine',
+    );
   });
 
   test('[T-0435][AT-1007]Record given elsewhere for Catchup vaccine', async ({
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {
-    await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Catchup');
+    await testGivenElsewhereForCategory(
+      patientDetailsPage,
+      newPatientWithHospitalAdmission,
+      'Catchup',
+    );
   });
 
   test('[T-0435][AT-1008]Record given elsewhere for Campaign vaccine', async ({
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {
-    await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Campaign');
+    await testGivenElsewhereForCategory(
+      patientDetailsPage,
+      newPatientWithHospitalAdmission,
+      'Campaign',
+    );
   });
 
   test('[T-0437][AT-1009]Record given elsewhere for Other vaccine', async ({
     newPatientWithHospitalAdmission,
     patientDetailsPage,
   }) => {
-   await testGivenElsewhereForCategory(patientDetailsPage, newPatientWithHospitalAdmission, 'Other');
+    await testGivenElsewhereForCategory(
+      patientDetailsPage,
+      newPatientWithHospitalAdmission,
+      'Other',
+    );
   });
 
   test('[T-0435][AT-1010]Date field can be empty when vaccine is given elsewhere', async ({

--- a/packages/e2e-tests/utils/vaccineTestHelpers.ts
+++ b/packages/e2e-tests/utils/vaccineTestHelpers.ts
@@ -1,4 +1,5 @@
 import { PatientDetailsPage } from '@pages/patients/PatientDetailsPage';
+import { createPatient } from '../utils/apiHelpers';
 import { expect } from '@playwright/test';
 import { Vaccine } from 'types/vaccine/Vaccine';
 import { addWeeks, startOfWeek, format } from 'date-fns';
@@ -282,7 +283,7 @@ export async function expectedDueDateWeek(date: Date, weeksToAdd: number) {
  */
 export async function testGivenElsewhereForCategory(
   patientDetailsPage: PatientDetailsPage,
-  newPatientWithHospitalAdmission: any,
+  newPatientWithHospitalAdmission: Awaited<ReturnType<typeof createPatient>>,
   category: 'Routine' | 'Catchup' | 'Campaign' | 'Other',
 ) {
   const givenElsewhereReason = 'Given overseas';

--- a/packages/e2e-tests/utils/vaccineTestHelpers.ts
+++ b/packages/e2e-tests/utils/vaccineTestHelpers.ts
@@ -273,3 +273,26 @@ export async function expectedDueDateWeek(date: Date, weeksToAdd: number) {
 
   return formattedUtcWeekStart;
 }
+
+/**
+ * Tests given elsewhere functionality across vaccine categories
+ * @param patientDetailsPage - The patient details page
+ * @param newPatientWithHospitalAdmission - The new patient with hospital admission
+ * @param category - The category of the vaccine
+ */
+  export async function testGivenElsewhereForCategory(
+    patientDetailsPage: PatientDetailsPage,
+    newPatientWithHospitalAdmission: any,
+    category: 'Routine' | 'Catchup' | 'Campaign' | 'Other'
+  ) {
+    const givenElsewhereReason = 'Given overseas';
+    const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
+    await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
+    await patientDetailsPage.navigateToVaccineTab();
+
+    await addVaccineAndAssert(patientDetailsPage, true, category, 1, {
+      vaccineGivenElsewhere: givenElsewhereReason,
+      specificDate: currentBrowserDate,
+      viewVaccineRecord: true,
+    });
+  }

--- a/packages/e2e-tests/utils/vaccineTestHelpers.ts
+++ b/packages/e2e-tests/utils/vaccineTestHelpers.ts
@@ -280,19 +280,19 @@ export async function expectedDueDateWeek(date: Date, weeksToAdd: number) {
  * @param newPatientWithHospitalAdmission - The new patient with hospital admission
  * @param category - The category of the vaccine
  */
-  export async function testGivenElsewhereForCategory(
-    patientDetailsPage: PatientDetailsPage,
-    newPatientWithHospitalAdmission: any,
-    category: 'Routine' | 'Catchup' | 'Campaign' | 'Other'
-  ) {
-    const givenElsewhereReason = 'Given overseas';
-    const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
-    await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
-    await patientDetailsPage.navigateToVaccineTab();
+export async function testGivenElsewhereForCategory(
+  patientDetailsPage: PatientDetailsPage,
+  newPatientWithHospitalAdmission: any,
+  category: 'Routine' | 'Catchup' | 'Campaign' | 'Other',
+) {
+  const givenElsewhereReason = 'Given overseas';
+  const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
+  await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
+  await patientDetailsPage.navigateToVaccineTab();
 
-    await addVaccineAndAssert(patientDetailsPage, true, category, 1, {
-      vaccineGivenElsewhere: givenElsewhereReason,
-      specificDate: currentBrowserDate,
-      viewVaccineRecord: true,
-    });
-  }
+  await addVaccineAndAssert(patientDetailsPage, true, category, 1, {
+    vaccineGivenElsewhere: givenElsewhereReason,
+    specificDate: currentBrowserDate,
+    viewVaccineRecord: true,
+  });
+}


### PR DESCRIPTION
### Changes

- This basically just prefixes the vaccine tests with unique test IDs based on the format that @sepidehdehghani992 introduced in[ this PR](https://github.com/beyondessential/tamanu/pull/8565)
- This PR also splits the test "Record given elsewhere for patient with active encounter" into four separate tests: one for each category of vaccine
   - Any code changes not related to adding a test ID will be because of this change

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
