### PR TITLE
test(e2e): Fixing the test failure on lab request test (small)

### DIFF
--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts
@@ -16,6 +16,10 @@ export class EnterResultsModal {
   readonly verificationFirstRow!: Locator;
   readonly completedDateFirstRow!: Locator;
   readonly labTestTypeTitle!: Locator;
+  
+  // Dropdown option locators
+  readonly resultOptions!: Locator;
+  readonly labTestMethodOptions!: Locator;
  
 
   constructor(page: Page) {
@@ -43,6 +47,10 @@ export class EnterResultsModal {
     this.labTestMethodFirstRowIcon = this.page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-labTestMethodId`).getByTestId('selectinput-phtg-expandmoreicon-h115');
     this.verificationFirstRow = page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-verification`).locator('input');
     this.completedDateFirstRow = page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-completedDate`).locator('input');
+    
+    // Dropdown option locators
+    this.resultOptions = page.getByTestId('styledfield-h653-option');
+    this.labTestMethodOptions = page.getByTestId('selectinput-phtg-option');
   }
 
   async waitForModalToLoad() {
@@ -53,6 +61,16 @@ export class EnterResultsModal {
   async waitForModalToClose() {
     await this.form.waitFor({ state: 'detached' });
     await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+  }
+
+  async selectResult(result: string) {
+    await this.resultsFirstRowIcon.click();
+    await this.resultOptions.getByText(result).click();
+  }
+
+  async selectLabTestMethod(method: string) {
+    await this.labTestMethodFirstRowIcon.click();
+    await this.labTestMethodOptions.getByText(method).click();
   }
 
 }

--- a/packages/e2e-tests/tests/patients/labRequest.spec.ts
+++ b/packages/e2e-tests/tests/patients/labRequest.spec.ts
@@ -566,12 +566,10 @@ test.describe('Lab Request Tests', () => {
       const labRequestDetailsPage = new LabRequestDetailsPage(page);
       await labRequestDetailsPage.enterResultsButton.click();
       await labRequestDetailsPage.enterResultsModal.waitForModalToLoad();
-      await labRequestDetailsPage.enterResultsModal.resultsFirstRowIcon.click();
       const result = 'Positive';
-      await page.getByTestId('styledfield-h653-option').getByText(result).click();
-      await labRequestDetailsPage.enterResultsModal.labTestMethodFirstRowIcon.click();
+      await labRequestDetailsPage.enterResultsModal.selectResult(result);
       const labTestMethod = 'GeneXpert';
-      await page.getByTestId('selectinput-phtg-option').getByText(labTestMethod).click();
+      await labRequestDetailsPage.enterResultsModal.selectLabTestMethod(labTestMethod);
       const verification = 'test';
       await labRequestDetailsPage.enterResultsModal.verificationFirstRow.fill(verification);
       const currentDateTime = new Date().toISOString().slice(0, 16);

--- a/packages/e2e-tests/tests/patients/labRequest.spec.ts
+++ b/packages/e2e-tests/tests/patients/labRequest.spec.ts
@@ -567,11 +567,11 @@ test.describe('Lab Request Tests', () => {
       await labRequestDetailsPage.enterResultsButton.click();
       await labRequestDetailsPage.enterResultsModal.waitForModalToLoad();
       await labRequestDetailsPage.enterResultsModal.resultsFirstRowIcon.click();
-      await page.getByTestId('styledfield-h653-option').getByText('Positive').click();
-      const result = await labRequestDetailsPage.enterResultsModal.resultsFirstRow.textContent();
+      const result = 'Positive';
+      await page.getByTestId('styledfield-h653-option').getByText(result).click();
       await labRequestDetailsPage.enterResultsModal.labTestMethodFirstRowIcon.click();
-      await page.getByTestId('selectinput-phtg-option').getByText('GeneXpert').click();
-      const labTestMethod = await labRequestDetailsPage.enterResultsModal.labTestMethodFirstRow.textContent();
+      const labTestMethod = 'GeneXpert';
+      await page.getByTestId('selectinput-phtg-option').getByText(labTestMethod).click();
       const verification = 'test';
       await labRequestDetailsPage.enterResultsModal.verificationFirstRow.fill(verification);
       const currentDateTime = new Date().toISOString().slice(0, 16);
@@ -586,7 +586,7 @@ test.describe('Lab Request Tests', () => {
       const tableReferenceItems = await getTableItems(page, 1, 'reference')
       await expect(tableReferenceItems[0]).toBe('N/A');  
       const tableLabTestMethodItems = await getTableItems(page, 1, 'labTestMethod')
-      await expect(tableLabTestMethodItems[0]).toBe(labTestMethod);  
+      await expect(tableLabTestMethodItems[0]).toBe(labTestMethod); 
       const tableLaboratoryOfficerItems = await getTableItems(page, 1, 'laboratoryOfficer')
       const currentUser = await labRequestModal.getCurrentUser();
       await expect(tableLaboratoryOfficerItems[0]).toBe(currentUser.displayName); 


### PR DESCRIPTION
### Changes

Fixing the test failure on lab requests e2e test

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dropdown option locators and helper methods to `EnterResultsModal` and updates the lab results test to use them.
> 
> - **E2E Page Object (`packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts`)**:
>   - Add dropdown option locators: `resultOptions`, `labTestMethodOptions`.
>   - Add helper methods: `selectResult(result)`, `selectLabTestMethod(method)`.
> - **Test (`packages/e2e-tests/tests/patients/labRequest.spec.ts`)**:
>   - Refactor results entry test to use `selectResult` and `selectLabTestMethod` instead of inline dropdown interactions; keep table validations unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b59281437d0e3781b0b72ef630b211599b0c091d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->