### PR TITLE
fix(survey): EPI-1288: Update select referral list to be listed in alphabetical order

### DIFF
--- a/packages/facility-server/app/routes/apiv1/survey.js
+++ b/packages/facility-server/app/routes/apiv1/survey.js
@@ -142,7 +142,7 @@ survey.get(
         surveyType: req.query.type,
         visibilityStatus: { [Op.ne]: VISIBILITY_STATUSES.HISTORICAL },
       },
-      order: [['name', 'ASC']],
+      order: [literal('LOWER(name) ASC')],
     });
     const filteredSurveys = getFilteredListByPermission(ability, surveys, 'submit');
 

--- a/packages/mobile/App/ui/navigation/screens/referrals/ReferralFormListScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/referrals/ReferralFormListScreen.tsx
@@ -28,7 +28,9 @@ export const ReferralFormListScreen = (): ReactElement => {
     }),
   );
 
-  const filteredSurveys = surveys?.filter(survey => survey.shouldShowInList(ability));
+  const filteredSurveys = surveys
+    ?.filter(survey => survey.shouldShowInList(ability))
+    .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }));
 
   const onNavigateToSurvey = (survey): any => {
     navigation.navigate(Routes.HomeStack.ReferralStack.ReferralList.AddReferralDetails, {


### PR DESCRIPTION

### Changes

Update survey ordering to be case-insensitive by using LOWER function

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Order surveys by case-insensitive name using SQL LOWER(name) in the list endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1e12471c479c8dc327daa216ef7542ed6b4bd21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->