### PR TITLE
Investigate soft delete timestamp inconsistency

### DIFF
--- a/packages/database/src/migrations/1760500000000-fixSoftDeleteTimestampInAudit.ts
+++ b/packages/database/src/migrations/1760500000000-fixSoftDeleteTimestampInAudit.ts
@@ -1,0 +1,65 @@
+import { QueryInterface } from 'sequelize';
+
+/**
+ * Fix for soft delete timestamp inconsistency between raw tables and logs.changes
+ * 
+ * When records are soft deleted (deleted_at is set), the updated_at in the raw table
+ * is correctly updated by the set_updated_at trigger, but the audit trigger captures
+ * the old value because Sequelize may explicitly set updated_at in the UPDATE query,
+ * preventing the BEFORE trigger from auto-updating it.
+ * 
+ * This fix ensures that whenever deleted_at is being set (soft delete), we always
+ * update updated_at to the current timestamp, regardless of whether it was already
+ * explicitly set in the query.
+ */
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION public.set_updated_at()
+     RETURNS trigger
+     LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+        IF (to_jsonb(NEW) ? 'updated_at') THEN
+            -- Check if this is a soft delete (deleted_at is being set)
+            IF (to_jsonb(NEW) ? 'deleted_at' 
+                AND NEW.deleted_at IS NOT NULL 
+                AND (OLD.deleted_at IS NULL OR OLD.deleted_at IS DISTINCT FROM NEW.deleted_at)) THEN
+                -- Always update updated_at during soft delete
+                NEW.updated_at := current_timestamp;
+            ELSIF (
+                (to_jsonb(NEW) - 'updated_at') IS DISTINCT FROM (to_jsonb(OLD) - 'updated_at')
+                AND
+                (to_jsonb(NEW)->'updated_at') IS NOT DISTINCT FROM (to_jsonb(OLD)->'updated_at')
+            ) THEN
+                -- Normal update: only set updated_at if it wasn't explicitly changed
+                NEW.updated_at := current_timestamp;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END;
+    $function$
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // Revert to the previous version
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION public.set_updated_at()
+     RETURNS trigger
+     LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+        IF (to_jsonb(NEW) ? 'updated_at') THEN
+            IF (
+                (to_jsonb(NEW) - 'updated_at') IS DISTINCT FROM (to_jsonb(OLD) - 'updated_at')
+                AND
+                (to_jsonb(NEW)->'updated_at') IS NOT DISTINCT FROM (to_jsonb(OLD)->'updated_at')
+            ) THEN
+                NEW.updated_at := current_timestamp;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END;
+    $function$
+  `);
+}


### PR DESCRIPTION
### Changes

This PR addresses an inconsistency where `logs.changes` would record an outdated `updated_at` timestamp when a record was soft-deleted.

The `set_updated_at` trigger has been modified to ensure that `updated_at` is always set to `current_timestamp` when `deleted_at` is being applied (i.e., during a soft delete). This guarantees that the audit log (`logs.changes`) accurately reflects the `updated_at` timestamp at the time of the soft deletion, aligning it with the raw table's `updated_at` value.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
[Slack Thread](https://beyondessential.slack.com/archives/GE9NHB95F/p1760300400327189?thread_ts=1760300400.327189&cid=GE9NHB95F)

<a href="https://cursor.com/background-agent?bcId=bc-45e71928-685a-4cbf-ae75-50e7a74976e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45e71928-685a-4cbf-ae75-50e7a74976e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

