### PR TITLE
fix(audit): TAMOC-352: Prevent audit logs being logged against the wrong user when queries are run within a transaction

### DIFF
--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -137,6 +137,14 @@ async function connectToDatabase(dbOptions) {
         } catch (error) {
           log.error(error);
           throw error;
+        } finally {
+          // Clear audit userid so that system user changes aren't unintentionally recorded against it
+          if (userid) {
+            await super.run('SELECT public.set_session_config($1, $2)', [
+              AUDIT_USERID_KEY,
+              SYSTEM_USER_UUID,
+            ]);
+          }
         }
       }
     }

--- a/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
+++ b/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
@@ -1,14 +1,15 @@
 import type { ExpressRequest } from 'types/express';
 import type { NextFunction } from 'express';
+import { AsyncLocalStorage } from 'async_hooks';
 
-import { setSessionConfigInNamespace } from '../../services/database';
+const auditUserIdAsyncLocalStorage = new AsyncLocalStorage();
 
-import { AUDIT_USERID_KEY } from '@tamanu/constants/database';
+export const getAuditUserId = () => auditUserIdAsyncLocalStorage.getStore();
 
 export const attachAuditUserToDbSession = async (
   req: ExpressRequest,
   _res: Response,
   next: NextFunction,
 ) => {
-  setSessionConfigInNamespace(AUDIT_USERID_KEY, req.user?.id, next);
+  auditUserIdAsyncLocalStorage.run(req.user?.id, next);
 };

--- a/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
+++ b/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
@@ -7,11 +7,17 @@ import { agent as _agent } from 'supertest';
 import { attachAuditUserToDbSession } from '@tamanu/database';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { fakeUser } from '@tamanu/fake-data/fake';
-import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { authMiddleware, buildToken } from '../../app/middleware/auth';
 import { createTestContext } from '../utilities';
 import bodyParser from 'body-parser';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+
+const runInAFewRandomMs = async callback => {
+  await sleepAsync(Math.floor(Math.random() * 100));
+  return await callback();
+};
 
 describe('Attach audit user to DB session', () => {
   let ctx;
@@ -38,7 +44,7 @@ describe('Attach audit user to DB session', () => {
     });
     models = ctx.models;
 
-    await models.Setting.set('audit.changes.enabled', true)
+    await models.Setting.set('audit.changes.enabled', true);
 
     // Setup a mock express app with a route that updates a user
     // and includes the attachAuditUserToDbSession middleware
@@ -55,16 +61,38 @@ describe('Attach audit user to DB session', () => {
       authMiddleware,
       attachAuditUserToDbSession,
       asyncHandler(async (req, res) => {
-        const { sleep } = req.query;
-        await sleepAsync(parseInt(sleep, 10));
+        const userUpdated = await req.models.User.update(
+          { displayName: `changed-by-${req.user.id}` },
+          { where: { id: req.user.id } },
+        );
 
-        // Update the authenticated user to have a different display name
-        const userUpdated = await req.models.User.update(req.body, { where: { id: req.user.id } });
+        res.json(userUpdated);
+      }),
+    );
+    mockApp.post(
+      '/updateAuthenticatedUserInTransaction',
+      (req, _res, next) => {
+        req.models = models;
+        req.db = ctx.sequelize;
+        next();
+      },
+      authMiddleware,
+      attachAuditUserToDbSession,
+      asyncHandler(async (req, res) => {
+        let userUpdated;
+        await req.db.transaction(async () => {
+          // Update the authenticated user to have a different display name
+          userUpdated = await req.models.User.update(
+            { displayName: `changed-by-${req.user.id}` },
+            { where: { id: req.user.id } },
+          );
+        });
+
         res.json(userUpdated);
       }),
     );
 
-    const asUser = async (user) => {
+    const asUser = async user => {
       const agent = _agent(mockApp);
       const token = await buildToken(user, facilityIds[0], '1d');
       agent.set('authorization', `Bearer ${token}`);
@@ -88,34 +116,56 @@ describe('Attach audit user to DB session', () => {
   afterAll(() => ctx.close());
 
   it('audit log updated_by_user_id should match authenticated user with multiple simultaneous requests', async () => {
-    // Stagger the response times of the 4 requests to ensure they are processed in parallel
-    await Promise.all([
-      userApp1.post('/updateAuthenticatedUser?sleep=4000').send({
-        displayName: 'changed',
-      }),
-      userApp2.post('/updateAuthenticatedUser?sleep=3000').send({
-        displayName: 'changed',
-      }),
-      userApp3.post('/updateAuthenticatedUser?sleep=2000').send({
-        displayName: 'changed',
-      }),
-      userApp4.post('/updateAuthenticatedUser?sleep=1000').send({
-        displayName: 'changed',
-      }),
+    // Randomising the order of execution makes this test a little intermittent but tests are broader range of cases so worth it imo
+    const changeRequests = await Promise.all([
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user1.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user2.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user3.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user4.id } },
+        ),
+      ),
     ]);
 
-    // Get the created audit entries for the 4 users that updated their own records
+    // Get the created audit entries
     const changes = await ctx.sequelize.query(
-      `SELECT * FROM logs.changes WHERE record_id IN (:userIds) AND record_data->>'display_name' = 'changed'`,
+      `SELECT * FROM logs.changes WHERE record_id IN (:userIds) AND record_data->>'display_name' like 'changed-by-%'`,
       {
         type: QueryTypes.SELECT,
         replacements: {
-          userIds: [user1, user2, user3, user4].map((user) => user.id),
+          userIds: [user1, user2, user3, user4].map(user => user.id),
         },
       },
     );
-    expect(changes).toHaveLength(4);
-    // Each user should be shown to have updated their own record in the audit log
-    expect(changes.every((change) => change.updated_by_user_id === change.record_id)).toBeTruthy();
+    expect(changes).toHaveLength(changeRequests.length);
+
+    changes.forEach(change => {
+      expect(`changed-by-${change.updated_by_user_id}`).toEqual(change.record_data.display_name);
+    });
   });
 });


### PR DESCRIPTION
### Changes

This one was a bit of a deep dive and tbh there's still something that doesn't fully make sense to me.

Previously we were sharing the same `AsyncLocalStorage` instance for the `SequelizeCLS` behaviour and for storing the `auditUserId`. The problem with this is that sequelize will create a new `run` of that `asyncLocalStorage` instance if we start a new transaction, effectively clearing out the initial `auditUserId`. This explains why we saw this issue when changing MedicationAdministrationRecords as there's changes made within transactions there.

There's no reason for us to use the same instance for both, so the main fix here is to create a separate `asyncLocalStorage` instance for the `auditUserId`.

The other fix was to set the `auditUserId` to `SYSTEM_USER_UUID` in the database once the query has finished running, otherwise that `id` would be used for any changes that didn't come in via a request endpoint (ie. system user changes).

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separate CLS contexts and set/clear audit user per query with transaction-aware logic; add helpers and expand tests for concurrent and transactional scenarios.
> 
> - **Database**:
>   - Replace shared CLS with dedicated `AsyncLocalStorage` for Sequelize transactions and separate store for audit user (`getAuditUserId`).
>   - Wrap query execution to set `public.set_session_config(AUDIT_USERID_KEY, userId, inTransaction)` only when transaction context is ready; reset to `SYSTEM_USER_UUID` after non-transaction queries.
>   - Add helpers: `sequelize.isInsideTransaction` and `sequelize.isTransactionReady`.
>   - Remove `SESSION_CONFIG_PREFIX`-based session config usage.
> - **Middleware**:
>   - New `auditUserIdAsyncLocalStorage` and `attachAuditUserToDbSession` uses `run(req.user?.id, next)`; export `getAuditUserId`.
> - **Tests**:
>   - Enhance concurrency and transaction coverage: add routes for updates in/without transactions and with custom isolation; verify `updated_by_user_id` matches changes across multiple simultaneous requests, including system-initiated updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79c5c60dfe99a98f4d84e80a02152e0b0929bc48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->