### PR TITLE
fix(translations): TAMOC-354: Fix translations on Select fields

### DIFF
--- a/packages/web/app/components/Translation/getTranslatedOptions.jsx
+++ b/packages/web/app/components/Translation/getTranslatedOptions.jsx
@@ -6,17 +6,18 @@ export const getTranslatedOptions = (options, prefix, TranslatedTextProps = {}) 
   if (!options) return [];
 
   return options.map((option, index) => {
-    const { label, ...rest } = option;
+    const { value, label, ...rest } = option;
     return typeof label === 'string'
       ? {
           label: (
             <TranslatedText
-              stringId={`${prefix}.${toCamelCase(label)}`}
+              stringId={`${prefix}.${toCamelCase(value)}`}
               fallback={label}
               {...TranslatedTextProps}
               data-testid={`translatedtext-x1yr-${index}`}
             />
           ),
+          value,
           ...rest,
         }
       : option;


### PR DESCRIPTION
### Changes

We were using the `label` for the translation stringId for enum translations in select fields, but we should have been using the enum `value`.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build `TranslatedText` stringId from option `value` (not `label`) in `getTranslatedOptions`, and propagate `value` in returned options.
> 
> - **Translations**:
>   - Update `packages/web/app/components/Translation/getTranslatedOptions.jsx`:
>     - Use `value` (via `toCamelCase(value)`) to construct `TranslatedText` `stringId` instead of `label`.
>     - Include `value` in the returned option object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8ce6b71c5bc7fe91533689c9c44a5033a07995b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->