### PR TITLE
fix(charting): TAMOC-358: Fix crash when recording chart entries on a chart with 'rounding' enabled

### DIFF
--- a/packages/web/app/components/FormattedTableCell.jsx
+++ b/packages/web/app/components/FormattedTableCell.jsx
@@ -38,10 +38,12 @@ const HeadCellWrapper = styled.div`
 `;
 
 function round(float, { rounding } = {}) {
-  if (isNaN(float) || !isNumber(rounding)) {
+  const floatNumber = parseFloat(float);
+  if (isNaN(floatNumber) || !isNumber(rounding)) {
     return float;
   }
-  return float.toFixed(rounding);
+
+  return floatNumber.toFixed(rounding);
 }
 
 function getTooltip(float, config = {}, visibilityCriteria = {}) {
@@ -97,11 +99,11 @@ export const DateHeadCell = React.memo(({ value }) => (
 export const DateBodyCell = React.memo(({ value, onClick }) => {
   const CellContainer = onClick ? ClickableCellWrapper : CellWrapper;
   return (
-    <TableTooltip title={DateDisplay.stringFormat(value, formatLong)} data-testid="tabletooltip-3knb">
-      <CellContainer
-        onClick={onClick}
-        data-testid="cellcontainer-slh4"
-      >
+    <TableTooltip
+      title={DateDisplay.stringFormat(value, formatLong)}
+      data-testid="tabletooltip-3knb"
+    >
+      <CellContainer onClick={onClick} data-testid="cellcontainer-slh4">
         <div>{DateDisplay.stringFormat(value, formatShortest)}</div>
         <div>{DateDisplay.stringFormat(value, formatTime)}</div>
       </CellContainer>
@@ -214,7 +216,7 @@ export const RangeValidatedCell = React.memo(
     ...props
   }) => {
     const CellContainer = onClick ? ClickableCellWrapper : CellWrapper;
-    const float = round(parseFloat(value), config);
+    const float = round(value, config);
     const isEditedSuffix = isEdited ? '*' : '';
     const formattedValue = `${formatValue(value, config)}${isEditedSuffix}`;
     const { tooltip, severity } = useMemo(() => getTooltip(float, config, validationCriteria), [


### PR DESCRIPTION
### Changes

Tbf I was a bit surprised that `Number.toFixed()` returns a string, but it does make sense.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
