### PR TITLE
fix(logs): Hotfix 2.40: Non logged tables

### DIFF
--- a/database/model/logs/fhir_writes.yml
+++ b/database/model/logs/fhir_writes.yml
@@ -9,8 +9,7 @@ sources:
         config:
           tags: []
           meta:
-            triggers:
-              - record_fhir_writes_changelog
+            triggers: []
         columns:
           - name: id
             data_type: uuid

--- a/database/model/logs/migrations.yml
+++ b/database/model/logs/migrations.yml
@@ -11,7 +11,6 @@ sources:
           meta:
             triggers:
               - notify_migrations_changed
-              - record_migrations_changelog
               - set_migrations_updated_at
               - set_migrations_updated_at_sync_tick
         columns:

--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -23,9 +23,7 @@ export const NON_SYNCING_TABLES = [
 
 export const NON_LOGGED_TABLES = [
   // logs
-  'logs.changes',
-  'logs.accesses',
-  'logs.debug_logs',
+  'logs.*',
 
   // internal authentication tables
   'public.one_time_logins',

--- a/packages/database/src/services/migrations/migrationHooks.ts
+++ b/packages/database/src/services/migrations/migrationHooks.ts
@@ -123,7 +123,7 @@ export const tablesWithTrigger = (
           schema: (row as any).schema as string,
           table: (row as any).table as string,
         }))
-        .filter(({ schema, table }) => !allExcludes.includes(`${schema}.${table}`)),
+        .filter(({ schema, table }) => !tableNameMatch(schema, table, allExcludes)),
     );
 };
 

--- a/packages/database/src/services/migrations/migrationHooks.ts
+++ b/packages/database/src/services/migrations/migrationHooks.ts
@@ -7,6 +7,22 @@ import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { GLOBAL_EXCLUDE_TABLES, NON_LOGGED_TABLES, NON_SYNCING_TABLES } from './constants';
 import { SYNC_TICK_FLAGS } from '../../sync/constants';
 
+const tableNameMatch = (schema: string, table: string, matches: string[]) => {
+  const matchTableSchemas = matches
+    .map(match => match.split('.'))
+    .map(([excludeSchema, excludeTable]) => ({ schema: excludeSchema, table: excludeTable }));
+  const wholeSchemaMatches = matchTableSchemas
+    .filter(({ table: matchTable }) => matchTable === '*')
+    .map(({ schema: matchSchema }) => matchSchema);
+  if (wholeSchemaMatches.includes(schema)) {
+    return true;
+  }
+
+  return matchTableSchemas.some(
+    ({ schema: matchSchema, table: matchTable }) => schema === matchSchema && table === matchTable,
+  );
+};
+
 export const tablesWithoutColumn = (
   sequelize: Sequelize,
   column: string,
@@ -37,7 +53,7 @@ export const tablesWithoutColumn = (
           schema: (row as any).schema as string,
           table: (row as any).table as string,
         }))
-        .filter(({ schema, table }) => !allExcludes.includes(`${schema}.${table}`)),
+        .filter(({ schema, table }) => !tableNameMatch(schema, table, allExcludes)),
     );
 };
 export const tablesWithoutTrigger = (
@@ -72,7 +88,7 @@ export const tablesWithoutTrigger = (
           schema: (row as any).schema as string,
           table: (row as any).table as string,
         }))
-        .filter(({ schema, table }) => !allExcludes.includes(`${schema}.${table}`)),
+        .filter(({ schema, table }) => !tableNameMatch(schema, table, allExcludes)),
     );
 };
 


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude the entire `logs` schema from changelog triggers via `logs.*`, add wildcard matching for excluded tables in migration hooks, and remove specific changelog triggers from `logs.fhir_writes` and `logs.migrations` models.
> 
> - **Migrations/Logging**:
>   - Expand `NON_LOGGED_TABLES` to `logs.*` (exclude all `logs` tables from changelog triggers).
>   - Add wildcard-aware table exclusion (`schema.*`) in migration helpers and use it when filtering tables for columns/triggers.
> - **DBT Models (`logs` schema)**:
>   - `logs.fhir_writes`: clear `meta.triggers` (remove `record_fhir_writes_changelog`).
>   - `logs.migrations`: remove `record_migrations_changelog` from `meta.triggers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 013f3df95d785f129977986c2f8e616465108fae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->