### PR TITLE
fix(logs): Hotfix 2.35: Non logged tables

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,7 @@ ehr = "ehr"
 mch = "mch"
 nam = "nam" # VDS
 nce = "nce"
+brin = "brin" # Type of database index
 
 # Common default facility names
 ba = "ba"

--- a/database/model/logs/fhir_writes.yml
+++ b/database/model/logs/fhir_writes.yml
@@ -5,7 +5,7 @@ sources:
     description: "{{ doc('logs__generic__schema') }}"
     tables:
       - name: fhir_writes
-        description: '{{ doc("logs__table__fhir_writes") }}'
+        description: '{{ doc("logs__table__fhir_åwrites") }}'
         tags: []
         columns:
           - name: id

--- a/database/model/logs/fhir_writes.yml
+++ b/database/model/logs/fhir_writes.yml
@@ -5,7 +5,7 @@ sources:
     description: "{{ doc('logs__generic__schema') }}"
     tables:
       - name: fhir_writes
-        description: '{{ doc("logs__table__fhir_åwrites") }}'
+        description: '{{ doc("logs__table__fhir_writes") }}'
         tags: []
         columns:
           - name: id

--- a/packages/database/src/demoData/diagnoses.js
+++ b/packages/database/src/demoData/diagnoses.js
@@ -5485,7 +5485,7 @@ export const DIAGNOSES = splitIds(`
   Urethrolithiasis	N21.1
   Uricemia	E79.0
   Urinary incontinence	R32
-  Urinary retension	R33
+  Urinary retention	R33
   Urinary tract infection	N39.0
   Urinary tract infection, site not specified	N39.0
   Urinary tract infection, unspecified	N39.0

--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -19,10 +19,8 @@ export const NON_SYNCING_TABLES = [
 
 export const NON_LOGGED_TABLES = [
   // logs
-  'logs.changes',
-  'logs.accesses',
-  'logs.debug_logs',
-  
+  'logs.*',
+
   // internal authentication tables
   'public.one_time_logins',
   'public.refresh_tokens',

--- a/packages/database/src/services/migrations/migrationHooks.ts
+++ b/packages/database/src/services/migrations/migrationHooks.ts
@@ -55,6 +55,7 @@ export const tablesWithoutColumn = (
         }))
         .filter(({ schema, table }) => !tableNameMatch(schema, table, excludes)),
     );
+};
 
 const tablesWithoutTrigger = (
   sequelize: Sequelize,

--- a/packages/database/src/services/migrations/migrationHooks.ts
+++ b/packages/database/src/services/migrations/migrationHooks.ts
@@ -7,8 +7,28 @@ import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { NON_LOGGED_TABLES, NON_SYNCING_TABLES } from './constants';
 import { SYNC_TICK_FLAGS } from '../../sync/constants';
 
-const tablesWithoutColumn = (sequelize: Sequelize, column: string) =>
-  sequelize
+const tableNameMatch = (schema: string, table: string, matches: string[]) => {
+  const matchTableSchemas = matches
+    .map(match => match.split('.'))
+    .map(([excludeSchema, excludeTable]) => ({ schema: excludeSchema, table: excludeTable }));
+  const wholeSchemaMatches = matchTableSchemas
+    .filter(({ table: matchTable }) => matchTable === '*')
+    .map(({ schema: matchSchema }) => matchSchema);
+  if (wholeSchemaMatches.includes(schema)) {
+    return true;
+  }
+
+  return matchTableSchemas.some(
+    ({ schema: matchSchema, table: matchTable }) => schema === matchSchema && table === matchTable,
+  );
+};
+
+export const tablesWithoutColumn = (
+  sequelize: Sequelize,
+  column: string,
+  excludes: string[] = NON_SYNCING_TABLES,
+) => {
+  return sequelize
     .query(
       `
     SELECT
@@ -33,7 +53,7 @@ const tablesWithoutColumn = (sequelize: Sequelize, column: string) =>
           schema: (row as any).schema as string,
           table: (row as any).table as string,
         }))
-        .filter(({ schema, table }) => !NON_SYNCING_TABLES.includes(`${schema}.${table}`)),
+        .filter(({ schema, table }) => !tableNameMatch(schema, table, excludes)),
     );
 
 const tablesWithoutTrigger = (
@@ -67,7 +87,7 @@ const tablesWithoutTrigger = (
           schema: (row as any).schema as string,
           table: (row as any).table as string,
         }))
-        .filter(({ schema, table }) => !excludes.includes(`${schema}.${table}`)),
+        .filter(({ schema, table }) => !tableNameMatch(schema, table, excludes)),
     );
 
 const tablesWithTrigger = (

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -61,7 +61,7 @@ surveyResponse.post(
       settings,
     } = req;
     // Responses for the vitals survey will check against 'Vitals' create permissions
-    // All others witll check against 'SurveyResponse' create permissions
+    // All others will check against 'SurveyResponse' create permissions
     const noun = await models.Survey.getResponsePermissionCheck(body.surveyId);
     req.checkPermission('create', noun);
 

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -28,7 +28,7 @@ import { DefaultIconButton } from '../Button';
 // has some unusual input handling (switching focus between day/month/year etc) that
 // a value change will interfere with.
 
-// Here I have made a data URL for the new calendar icon. The existing calander icon was a pseudo element
+// Here I have made a data URL for the new calendar icon. The existing calendar icon was a pseudo element
 // in the user agent shadow DOM. In order to add a new icon I had to make the pseudo element invisible
 // a new icon I had to make the pseudo element invisible and render a replacement on top using svg data url.
 const CustomIconTextInput = styled(TextInput)`

--- a/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
+++ b/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
@@ -418,7 +418,7 @@ const encounter = {
         id: 'drug-aciclovir345',
         code: 'aciclovir345',
         type: 'drug',
-        name: 'Aciclovir 3%w/w Eye Oint 4.5g',
+        name: 'Aciclovir 3%w/w Eye Ointment 4.5g',
         visibilityStatus: 'current',
         updatedAtSyncTick: '-999',
         createdAt: '2023-11-07T02:15:34.721Z',


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add wildcard-aware exclude matching in migration hooks and generalize non-logged logs tables; plus minor typo and demo data corrections.
> 
> - **Database Migrations**:
>   - Add wildcard matching via `tableNameMatch` and use it in `tablesWithoutColumn`, `tablesWithoutTrigger`, and `tablesWithTrigger` in `packages/database/src/services/migrations/migrationHooks.ts`.
>   - Export `tablesWithoutColumn` and allow `excludes` param; adjust filters to use wildcard matching.
>   - Simplify `NON_LOGGED_TABLES` in `packages/database/src/services/migrations/constants.ts` by replacing individual entries with `logs.*`.
> - **Data/Content Fixes**:
>   - Correct diagnosis text `Urinary retention` in `packages/database/src/demoData/diagnoses.js`.
>   - Update demo medication name to "Eye Ointment" in `packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx`.
> - **Misc**:
>   - Add `brin` to `.typos.toml` allowlist; fix minor comment typos in `surveyResponse.js` and `DateField.jsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4c2937db578208ac0a5f92cfc9ca9797d3e6bda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->