### PR TITLE
fix(logs): Hotfix 2.32: Non logged tables

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,7 @@ ehr = "ehr"
 mch = "mch"
 nam = "nam" # VDS
 nce = "nce"
+brin = "brin" # Type of database index
 
 # Common default facility names
 ba = "ba"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamanu",
-  "version": "2.32.0",
+  "version": "2.32.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamanu",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-and-later AND BUSL-1.1",
       "dependencies": {
         "@rnx-kit/metro-resolver-symlinks": "^0.1.36",
@@ -73027,7 +73027,7 @@
     },
     "packages/api-client": {
       "name": "@tamanu/api-client",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73041,7 +73041,7 @@
     },
     "packages/build-tooling": {
       "name": "@tamanu/build-tooling",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@swc/cli": "^0.1.63",
@@ -73081,7 +73081,7 @@
     },
     "packages/central-server": {
       "name": "@tamanu/central-server",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
@@ -73414,7 +73414,7 @@
     },
     "packages/constants": {
       "name": "@tamanu/constants",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "^18.14.6",
@@ -73466,7 +73466,7 @@
     },
     "packages/database": {
       "name": "@tamanu/database",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73701,7 +73701,7 @@
     },
     "packages/e2e-tests": {
       "name": "@tamanu/e2e-tests",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "devDependencies": {
         "@playwright/test": "^1.42.1",
         "@types/node": "^20.9.0",
@@ -73727,7 +73727,7 @@
     },
     "packages/facility-server": {
       "name": "@tamanu/facility-server",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^7.22.4",
@@ -74264,7 +74264,7 @@
     },
     "packages/fake-data": {
       "name": "@tamanu/fake-data",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -74311,7 +74311,7 @@
     },
     "packages/mobile": {
       "name": "@tamanu/mobile",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "hasInstallScript": true,
       "dependencies": {
         "@casl/ability": "^4.1.0",
@@ -76165,7 +76165,7 @@
       }
     },
     "packages/scripts": {
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -76203,7 +76203,7 @@
     },
     "packages/settings": {
       "name": "@tamanu/settings",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -76472,7 +76472,7 @@
     },
     "packages/shared": {
       "name": "@tamanu/shared",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@casl/ability": "^6.7.1",
@@ -78521,7 +78521,7 @@
     },
     "packages/utils": {
       "name": "@tamanu/utils",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "date-fns": "^4.1.0",
@@ -78743,7 +78743,7 @@
     },
     "packages/web": {
       "name": "@tamanu/web-frontend",
-      "version": "2.32.0",
+      "version": "2.32.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",

--- a/packages/database/src/demoData/diagnoses.js
+++ b/packages/database/src/demoData/diagnoses.js
@@ -5485,7 +5485,7 @@ export const DIAGNOSES = splitIds(`
   Urethrolithiasis	N21.1
   Uricemia	E79.0
   Urinary incontinence	R32
-  Urinary retension	R33
+  Urinary retention	R33
   Urinary tract infection	N39.0
   Urinary tract infection, site not specified	N39.0
   Urinary tract infection, unspecified	N39.0

--- a/packages/database/src/services/migrations/constants.ts
+++ b/packages/database/src/services/migrations/constants.ts
@@ -17,6 +17,9 @@ export const NON_SYNCING_TABLES = [
 ];
 
 export const NON_LOGGED_TABLES = [
+  // logs
+  'logs.*',
+
   // internal authentication tables
   'one_time_logins',
   'refresh_tokens',

--- a/packages/database/src/services/migrations/migrationHooks.ts
+++ b/packages/database/src/services/migrations/migrationHooks.ts
@@ -52,7 +52,7 @@ export const tablesWithoutColumn = (
           schema: (row as any).schema as string,
           table: (row as any).table as string,
         }))
-        .filter(({ schema, table }) => !NON_SYNCING_TABLES.includes(`${schema}.${table}`)),
+        .filter(({ schema, table }) => !tableNameMatch(schema, table, excludes)),
     );
 };
 

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -61,7 +61,7 @@ surveyResponse.post(
       settings,
     } = req;
     // Responses for the vitals survey will check against 'Vitals' create permissions
-    // All others witll check against 'SurveyResponse' create permissions
+    // All others will check against 'SurveyResponse' create permissions
     const noun = await models.Survey.getResponsePermissionCheck(body.surveyId);
     req.checkPermission('create', noun);
 

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -28,7 +28,7 @@ import { DefaultIconButton } from '../Button';
 // has some unusual input handling (switching focus between day/month/year etc) that
 // a value change will interfere with.
 
-// Here I have made a data URL for the new calendar icon. The existing calander icon was a pseudo element
+// Here I have made a data URL for the new calendar icon. The existing calendar icon was a pseudo element
 // in the user agent shadow DOM. In order to add a new icon I had to make the pseudo element invisible
 // a new icon I had to make the pseudo element invisible and render a replacement on top using svg data url.
 const CustomIconTextInput = styled(TextInput)`

--- a/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
+++ b/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
@@ -421,7 +421,7 @@ const encounter = {
         id: 'drug-aciclovir345',
         code: 'aciclovir345',
         type: 'drug',
-        name: 'Aciclovir 3%w/w Eye Oint 4.5g',
+        name: 'Aciclovir 3%w/w Eye Ointment 4.5g',
         visibilityStatus: 'current',
         updatedAtSyncTick: '-999',
         createdAt: '2023-11-07T02:15:34.721Z',


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates migration hooks to correctly detect/create triggers and excludes `logs.*` tables from changelog logging; includes minor data/text fixes.
> 
> - **Database Migrations**:
>   - Add `logs.*` to `NON_LOGGED_TABLES` in `packages/database/src/services/migrations/constants.ts`.
>   - Refactor `migrationHooks.ts`:
>     - Introduce `tableNameMatch` and export `tablesWithoutColumn`/`tablesWithoutTrigger` with flexible excludes.
>     - Replace trigger detection using `information_schema.triggers`; filter via helper instead of static list.
>     - Apply `NON_LOGGED_TABLES` when creating changelog triggers.
> - **Data/Content Fixes**:
>   - Correct diagnosis entry typo: `Urinary retention` in `packages/database/src/demoData/diagnoses.js`.
>   - Update mock medication name to `Aciclovir 3%w/w Eye Ointment 4.5g` in `packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx`.
>   - Minor comment/typo fixes (e.g., calendar icon comment, survey response comment); add `brin` to `.typos.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eba8954516669c3a30f0deb6bce04c95371c1ef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->