### PR TITLE
chore(e2e): no-issue: Use new default-provisioning for e2e tests

### DIFF
--- a/.github/scripts/e2e-test-setup.sh
+++ b/.github/scripts/e2e-test-setup.sh
@@ -63,7 +63,7 @@ EOF
 
         referenceData: [
             {
-                 defaultSpreadsheet: true,
+                defaultSpreadsheet: true,
             },
         ],
     }

--- a/.github/scripts/e2e-test-setup.sh
+++ b/.github/scripts/e2e-test-setup.sh
@@ -63,7 +63,7 @@ EOF
 
         referenceData: [
             {
-                url: 'https://bes-tamanu-dev-referencedata.s3.ap-southeast-2.amazonaws.com/referencedata/default.xlsx',
+                 defaultSpreadsheet: true,
             },
         ],
     }


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches e2e central provisioning to use the default reference data spreadsheet instead of a hard-coded S3 URL.
> 
> - **E2E Setup** (`.github/scripts/e2e-test-setup.sh`):
>   - Update `packages/central-server/provisioning.json5` `referenceData` to use `defaultSpreadsheet: true` instead of an explicit `url`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9707d1888e690d07dbbb0d17446ef81ef6f72814. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->