### PR TITLE
fix(auditing): 2.38 Hotfix: Prevent audit logs being logged against the wrong user when queries are run within a transaction

### DIFF
--- a/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
+++ b/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
@@ -1,14 +1,15 @@
 import type { ExpressRequest } from 'types/express';
 import type { NextFunction } from 'express';
+import { AsyncLocalStorage } from 'async_hooks';
 
-import { setSessionConfigInNamespace } from '../../services/database';
+const auditUserIdAsyncLocalStorage = new AsyncLocalStorage();
 
-import { AUDIT_USERID_KEY } from '@tamanu/constants/database';
+export const getAuditUserId = () => auditUserIdAsyncLocalStorage.getStore();
 
 export const attachAuditUserToDbSession = async (
   req: ExpressRequest,
   _res: Response,
   next: NextFunction,
 ) => {
-  setSessionConfigInNamespace(AUDIT_USERID_KEY, req.user?.id, next);
+  auditUserIdAsyncLocalStorage.run(req.user?.id, next);
 };

--- a/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
+++ b/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
@@ -14,9 +14,13 @@ import bodyParser from 'body-parser';
 import { SYSTEM_USER_UUID } from '@tamanu/constants';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
-const runInAFewRandomMs = async callback => {
-  await sleepAsync(Math.floor(Math.random() * 100));
-  return await callback();
+const runWithDelay = async (callbacks, delay = 50) => {
+  return Promise.all(
+    callbacks.map(async (callback, index) => {
+      await sleepAsync(delay * index);
+      return await callback();
+    }),
+  );
 };
 
 describe('Attach audit user to DB session', () => {
@@ -141,44 +145,42 @@ describe('Attach audit user to DB session', () => {
   afterAll(() => ctx.close());
 
   it('audit log updated_by_user_id should match authenticated user with multiple simultaneous requests', async () => {
-    // Randomising the order of execution makes this test a little intermittent but tests are broader range of cases so worth it imo
-    const changeRequests = await Promise.all([
-      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
-        models.User.update(
-          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
-          { where: { id: user1.id } },
-        ),
-      ),
-      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
-        models.User.update(
-          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
-          { where: { id: user2.id } },
-        ),
-      ),
-      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
-        models.User.update(
-          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
-          { where: { id: user3.id } },
-        ),
-      ),
-      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
+    const changeRequests = await runWithDelay([
+      () => userApp1.post('/updateAuthenticatedUser'),
+      () => userApp2.post('/updateAuthenticatedUserInTransaction'),
+      () => userApp3.post('/updateAuthenticatedUserInIsolatedTransaction'),
+      () =>
         models.User.update(
           { displayName: `changed-by-${SYSTEM_USER_UUID}` },
           { where: { id: user4.id } },
         ),
-      ),
+
+      () => userApp4.post('/updateAuthenticatedUserInIsolatedTransaction'),
+      () => userApp2.post('/updateAuthenticatedUser'),
+      () =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user3.id } },
+        ),
+      () => userApp1.post('/updateAuthenticatedUserInTransaction'),
+
+      () => userApp4.post('/updateAuthenticatedUserInTransaction'),
+      () =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user2.id } },
+        ),
+      () => userApp3.post('/updateAuthenticatedUser'),
+      () => userApp1.post('/updateAuthenticatedUserInIsolatedTransaction'),
+
+      () =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user1.id } },
+        ),
+      () => userApp2.post('/updateAuthenticatedUserInIsolatedTransaction'),
+      () => userApp3.post('/updateAuthenticatedUserInTransaction'),
+      () => userApp4.post('/updateAuthenticatedUser'),
     ]);
 
     // Get the created audit entries


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure audit logs attribute changes to the correct user across concurrent requests and transactions by using AsyncLocalStorage-based per-request user IDs and a transaction-aware Sequelize query wrapper.
> 
> - **Database/Sequelize**
>   - Replace custom CLS namespace with dedicated `AsyncLocalStorage` for Sequelize transactions; add helpers `sequelize.isInsideTransaction` and `sequelize.isTransactionReady`.
>   - Audit hook: set `public.set_session_config` with `AUDIT_USERID_KEY` using `getAuditUserId()`; defer until transaction is ready; scope to transaction when applicable; clear to `SYSTEM_USER_UUID` after non-transaction queries.
>   - Remove `SESSION_CONFIG_PREFIX`, `setSessionConfigInNamespace`, and `getSessionConfigInNamespace` usage.
> - **Middleware/Utils**
>   - Introduce `auditUserIdAsyncLocalStorage` and `getAuditUserId()`; update `attachAuditUserToDbSession` to store `req.user.id` via ALS.
> - **Tests**
>   - Expand tests to simulate concurrent requests and multiple transaction types (including isolated); validate `updated_by_user_id` matches change origin and system updates use `SYSTEM_USER_UUID`-derived display names; add `runWithDelay` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1baad5843e000b247776a30837c8c90293fb5dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->