### PR TITLE
fix(auditing): 2.42 Hotfix: Prevent audit logs being logged against the wrong user when queries are run within a transaction

### DIFF
--- a/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
+++ b/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
@@ -1,14 +1,15 @@
 import type { ExpressRequest } from 'types/express';
 import type { NextFunction } from 'express';
+import { AsyncLocalStorage } from 'async_hooks';
 
-import { setSessionConfigInNamespace } from '../../services/database';
+const auditUserIdAsyncLocalStorage = new AsyncLocalStorage();
 
-import { AUDIT_USERID_KEY } from '@tamanu/constants/database';
+export const getAuditUserId = () => auditUserIdAsyncLocalStorage.getStore();
 
 export const attachAuditUserToDbSession = async (
   req: ExpressRequest,
   _res: Response,
   next: NextFunction,
 ) => {
-  setSessionConfigInNamespace(AUDIT_USERID_KEY, req.user?.id, next);
+  auditUserIdAsyncLocalStorage.run(req.user?.id, next);
 };

--- a/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
+++ b/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
@@ -1,17 +1,23 @@
 import config from 'config';
 import defineExpress from 'express';
-import { QueryTypes } from 'sequelize';
+import { QueryTypes, Sequelize } from 'sequelize';
 import asyncHandler from 'express-async-handler';
 import { agent as _agent } from 'supertest';
 
 import { attachAuditUserToDbSession } from '@tamanu/database';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { fakeUser } from '@tamanu/fake-data/fake';
-import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { authMiddleware, buildToken } from '../../app/middleware/auth';
 import { createTestContext } from '../utilities';
 import bodyParser from 'body-parser';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+
+const runInAFewRandomMs = async callback => {
+  await sleepAsync(Math.floor(Math.random() * 100));
+  return await callback();
+};
 
 describe('Attach audit user to DB session', () => {
   let ctx;
@@ -38,7 +44,7 @@ describe('Attach audit user to DB session', () => {
     });
     models = ctx.models;
 
-    await models.Setting.set('audit.changes.enabled', true)
+    await models.Setting.set('audit.changes.enabled', true);
 
     // Setup a mock express app with a route that updates a user
     // and includes the attachAuditUserToDbSession middleware
@@ -55,16 +61,63 @@ describe('Attach audit user to DB session', () => {
       authMiddleware,
       attachAuditUserToDbSession,
       asyncHandler(async (req, res) => {
-        const { sleep } = req.query;
-        await sleepAsync(parseInt(sleep, 10));
+        const userUpdated = await req.models.User.update(
+          { displayName: `changed-by-${req.user.id}` },
+          { where: { id: req.user.id } },
+        );
 
-        // Update the authenticated user to have a different display name
-        const userUpdated = await req.models.User.update(req.body, { where: { id: req.user.id } });
+        res.json(userUpdated);
+      }),
+    );
+    mockApp.post(
+      '/updateAuthenticatedUserInTransaction',
+      (req, _res, next) => {
+        req.models = models;
+        req.db = ctx.sequelize;
+        next();
+      },
+      authMiddleware,
+      attachAuditUserToDbSession,
+      asyncHandler(async (req, res) => {
+        let userUpdated;
+        await req.db.transaction(async () => {
+          // Update the authenticated user to have a different display name
+          userUpdated = await req.models.User.update(
+            { displayName: `changed-by-${req.user.id}` },
+            { where: { id: req.user.id } },
+          );
+        });
+
+        res.json(userUpdated);
+      }),
+    );
+    mockApp.post(
+      '/updateAuthenticatedUserInIsolatedTransaction',
+      (req, _res, next) => {
+        req.models = models;
+        req.db = ctx.sequelize;
+        next();
+      },
+      authMiddleware,
+      attachAuditUserToDbSession,
+      asyncHandler(async (req, res) => {
+        let userUpdated;
+        await req.db.transaction(
+          { isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED },
+          async () => {
+            // Update the authenticated user to have a different display name
+            userUpdated = await req.models.User.update(
+              { displayName: `changed-by-${req.user.id}` },
+              { where: { id: req.user.id } },
+            );
+          },
+        );
+
         res.json(userUpdated);
       }),
     );
 
-    const asUser = async (user) => {
+    const asUser = async user => {
       const agent = _agent(mockApp);
       const token = await buildToken(user, facilityIds[0], '1d');
       agent.set('authorization', `Bearer ${token}`);
@@ -88,34 +141,60 @@ describe('Attach audit user to DB session', () => {
   afterAll(() => ctx.close());
 
   it('audit log updated_by_user_id should match authenticated user with multiple simultaneous requests', async () => {
-    // Stagger the response times of the 4 requests to ensure they are processed in parallel
-    await Promise.all([
-      userApp1.post('/updateAuthenticatedUser?sleep=4000').send({
-        displayName: 'changed',
-      }),
-      userApp2.post('/updateAuthenticatedUser?sleep=3000').send({
-        displayName: 'changed',
-      }),
-      userApp3.post('/updateAuthenticatedUser?sleep=2000').send({
-        displayName: 'changed',
-      }),
-      userApp4.post('/updateAuthenticatedUser?sleep=1000').send({
-        displayName: 'changed',
-      }),
+    // Randomising the order of execution makes this test a little intermittent but tests are broader range of cases so worth it imo
+    const changeRequests = await Promise.all([
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user1.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user2.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user3.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user4.id } },
+        ),
+      ),
     ]);
 
-    // Get the created audit entries for the 4 users that updated their own records
+    // Get the created audit entries
     const changes = await ctx.sequelize.query(
-      `SELECT * FROM logs.changes WHERE record_id IN (:userIds) AND record_data->>'display_name' = 'changed'`,
+      `SELECT * FROM logs.changes WHERE record_id IN (:userIds) AND record_data->>'display_name' like 'changed-by-%'`,
       {
         type: QueryTypes.SELECT,
         replacements: {
-          userIds: [user1, user2, user3, user4].map((user) => user.id),
+          userIds: [user1, user2, user3, user4].map(user => user.id),
         },
       },
     );
-    expect(changes).toHaveLength(4);
-    // Each user should be shown to have updated their own record in the audit log
-    expect(changes.every((change) => change.updated_by_user_id === change.record_id)).toBeTruthy();
+    expect(changes).toHaveLength(changeRequests.length);
+
+    changes.forEach(change => {
+      expect(`changed-by-${change.updated_by_user_id}`).toEqual(change.record_data.display_name);
+    });
   });
 });

--- a/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
+++ b/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
@@ -14,9 +14,13 @@ import bodyParser from 'body-parser';
 import { SYSTEM_USER_UUID } from '@tamanu/constants';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
-const runInAFewRandomMs = async callback => {
-  await sleepAsync(Math.floor(Math.random() * 100));
-  return await callback();
+const runWithDelay = async (callbacks, delay = 50) => {
+  return Promise.all(
+    callbacks.map(async (callback, index) => {
+      await sleepAsync(delay * index);
+      return await callback();
+    }),
+  );
 };
 
 describe('Attach audit user to DB session', () => {
@@ -141,44 +145,42 @@ describe('Attach audit user to DB session', () => {
   afterAll(() => ctx.close());
 
   it('audit log updated_by_user_id should match authenticated user with multiple simultaneous requests', async () => {
-    // Randomising the order of execution makes this test a little intermittent but tests are broader range of cases so worth it imo
-    const changeRequests = await Promise.all([
-      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
-        models.User.update(
-          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
-          { where: { id: user1.id } },
-        ),
-      ),
-      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
-        models.User.update(
-          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
-          { where: { id: user2.id } },
-        ),
-      ),
-      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
-        models.User.update(
-          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
-          { where: { id: user3.id } },
-        ),
-      ),
-      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUser')),
-      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInTransaction')),
-      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInIsolatedTransaction')),
-      runInAFewRandomMs(() =>
+    const changeRequests = await runWithDelay([
+      () => userApp1.post('/updateAuthenticatedUser'),
+      () => userApp2.post('/updateAuthenticatedUserInTransaction'),
+      () => userApp3.post('/updateAuthenticatedUserInIsolatedTransaction'),
+      () =>
         models.User.update(
           { displayName: `changed-by-${SYSTEM_USER_UUID}` },
           { where: { id: user4.id } },
         ),
-      ),
+
+      () => userApp4.post('/updateAuthenticatedUserInIsolatedTransaction'),
+      () => userApp2.post('/updateAuthenticatedUser'),
+      () =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user3.id } },
+        ),
+      () => userApp1.post('/updateAuthenticatedUserInTransaction'),
+
+      () => userApp4.post('/updateAuthenticatedUserInTransaction'),
+      () =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user2.id } },
+        ),
+      () => userApp3.post('/updateAuthenticatedUser'),
+      () => userApp1.post('/updateAuthenticatedUserInIsolatedTransaction'),
+
+      () =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user1.id } },
+        ),
+      () => userApp2.post('/updateAuthenticatedUserInIsolatedTransaction'),
+      () => userApp3.post('/updateAuthenticatedUserInTransaction'),
+      () => userApp4.post('/updateAuthenticatedUser'),
     ]);
 
     // Get the created audit entries


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make audit user scoping transaction-aware using AsyncLocalStorage/CLS, safely setting/clearing session vars to avoid logging changes against the wrong user, with expanded tests.
> 
> - **Database/Audit**:
>   - Replace custom CLS namespace with dedicated `AsyncLocalStorage` for Sequelize transactions; add `sequelize.isInsideTransaction` and `sequelize.isTransactionReady` helpers.
>   - Set audit user via request-scoped `getAuditUserId()` and call `public.set_session_config` with transaction awareness; defer until transaction is ready and scope within transactions.
>   - Clear audit user to `SYSTEM_USER_UUID` after non-transaction queries to prevent leakage.
>   - Remove `setSessionConfigInNamespace`/`getSessionConfigInNamespace`; stop using `SESSION_CONFIG_PREFIX`.
> - **Middleware**:
>   - `attachAuditUserToDbSession`: store authenticated user id in `AsyncLocalStorage`; export `getAuditUserId`.
> - **Tests**:
>   - Add routes and tests for updates inside/outside transactions and different isolation levels; verify `updated_by_user_id` matches the user who made the change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20223280ffddf1aac49591cbaff9a9041f2b1d34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->