### PR TITLE
fix(auditing): 2.32 Hotfix: Prevent audit logs being logged against the wrong user when queries are run within a transaction

### DIFF
--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -3,7 +3,7 @@ import { Sequelize } from 'sequelize';
 import pg from 'pg';
 import util from 'util';
 
-import { SYNC_DIRECTIONS, AUDIT_USERID_KEY, SESSION_CONFIG_PREFIX } from '@tamanu/constants';
+import { SYNC_DIRECTIONS, AUDIT_USERID_KEY, SYSTEM_USER_UUID } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 import { serviceContext, serviceName } from '@tamanu/shared/services/logging/context';
 
@@ -11,31 +11,30 @@ import { assertUpToDate, migrate, NON_SYNCING_TABLES } from './migrations';
 import * as models from '../models';
 import { createDateTypes } from './createDateTypes';
 import { setupQuote } from '../utils/pgComposite';
+import { getAuditUserId } from '../utils';
 
 createDateTypes();
 
-export const asyncLocalStorage = new AsyncLocalStorage();
-// this allows us to use transaction callbacks without manually managing a transaction handle
+// This allows us to use transaction callbacks without manually managing a transaction handle
 // https://sequelize.org/master/manual/transactions.html#automatically-pass-transactions-to-all-queries
 // done once for all sequelize objects. Instead of cls-hooked we use the built-in AsyncLocalStorage.
-export const namespace = {
-  bind: () => {}, // compatibility with cls-hooked, not used by sequelize
-  get: (id) => asyncLocalStorage.getStore()?.get(id),
-  set: (id, value) => asyncLocalStorage.getStore()?.set(id, value),
-  run: (callback) => asyncLocalStorage.run(new Map(), callback),
-};
-
-export const setSessionConfigInNamespace = (key, value, callback) => {
-  namespace.run(() => {
-    namespace.set(`${SESSION_CONFIG_PREFIX}${key}`, value);
-    callback()
-  });
-};
-
-export const getSessionConfigInNamespace = (key) => namespace.get(`${SESSION_CONFIG_PREFIX}${key}`);
-
+// NOTE: Do not use this storage for anything, sequelize manages it and may clear it unexpectedly
+const sequelizeTransactionAsyncLocalStorage = new AsyncLocalStorage();
 // eslint-disable-next-line react-hooks/rules-of-hooks
-Sequelize.useCLS(namespace);
+Sequelize.useCLS({
+  bind: () => {}, // compatibility with cls-hooked, not used by sequelize
+  get: (id) => sequelizeTransactionAsyncLocalStorage.getStore()?.get(id),
+  set: (id, value) => sequelizeTransactionAsyncLocalStorage.getStore()?.set(id, value),
+  run: (callback) => sequelizeTransactionAsyncLocalStorage.run(new Map(), callback),
+});
+
+// When a transaction is started, Sequelize wraps all calls in a `run()` call on the clsAsyncLocalStorage,
+// so we know we're in a transaction if the value is not empty
+const isInsideTransaction = () => Boolean(sequelizeTransactionAsyncLocalStorage.getStore());
+
+// Once Sequelize has set up the transaction (ie. calling 'START TRANSACTION' and 'SET ISOLATION LEVEL ...') it will add a 'transaction' object to the store
+const isTransactionReady = () =>
+  Boolean(sequelizeTransactionAsyncLocalStorage.getStore()?.get('transaction'));
 
 // this is dangerous and should only be used in test mode
 const unsafeRecreatePgDb = async ({ name, username, password, host, port }) => {
@@ -134,13 +133,37 @@ async function connectToDatabase(dbOptions) {
   if (!disableChangesAudit) {
     class QueryWithAuditConfig extends sequelize.dialect.Query {
       async run(sql, options) {
-        const userid = getSessionConfigInNamespace(AUDIT_USERID_KEY);
-        if (userid)
-          await super.run(
-            'SELECT public.set_session_config($1, $2)',
-            [AUDIT_USERID_KEY, userid],
-          );
-        return super.run(sql, options);
+        const userid = getAuditUserId();
+        const isInsideATransaction = isInsideTransaction();
+        const isThisTransactionReady = isTransactionReady();
+        // Set audit userid so that any changes in this query are recorded against it
+        // If in a transaction, just use a transaction scoped variable to avoid needing to clear it
+        if (userid) {
+          if (isInsideATransaction && !isThisTransactionReady) {
+            // This may be the 'START TRANSACTION' or 'SET ISOLATION LEVEL ...' queries being run by sequelize.
+            // We don't want to run any queries until the transaction has been set up. So do nothing.
+          } else {
+            await super.run('SELECT public.set_session_config($1, $2, $3)', [
+              AUDIT_USERID_KEY,
+              userid,
+              isInsideATransaction,
+            ]);
+          }
+        }
+        try {
+          return await super.run(sql, options);
+        } catch (error) {
+          log.error(error);
+          throw error;
+        } finally {
+          // Clear audit userid so that system user changes aren't unintentionally recorded against it
+          if (userid && !isInsideATransaction) {
+            await super.run('SELECT public.set_session_config($1, $2)', [
+              AUDIT_USERID_KEY,
+              SYSTEM_USER_UUID,
+            ]);
+          }
+        }
       }
     }
     sequelize.dialect.Query = QueryWithAuditConfig;
@@ -235,8 +258,9 @@ export async function initDatabase(dbOptions) {
     }
   });
 
-  // add isInsideTransaction helper to avoid exposing the asynclocalstorage
-  sequelize.isInsideTransaction = () => !!asyncLocalStorage.getStore();
+  // add isInsideTransaction and isTransactionReady helpers to avoid exposing the asynclocalstorage
+  sequelize.isInsideTransaction = isInsideTransaction;
+  sequelize.isTransactionReady = isTransactionReady;
 
   return { sequelize, models };
 }

--- a/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
+++ b/packages/database/src/utils/audit/attachAuditUserToDbSession.ts
@@ -1,14 +1,15 @@
 import type { ExpressRequest } from 'types/express';
 import type { NextFunction } from 'express';
+import { AsyncLocalStorage } from 'async_hooks';
 
-import { setSessionConfigInNamespace } from '../../services/database';
+const auditUserIdAsyncLocalStorage = new AsyncLocalStorage();
 
-import { AUDIT_USERID_KEY } from '@tamanu/constants/database';
+export const getAuditUserId = () => auditUserIdAsyncLocalStorage.getStore();
 
 export const attachAuditUserToDbSession = async (
   req: ExpressRequest,
   _res: Response,
   next: NextFunction,
 ) => {
-  setSessionConfigInNamespace(AUDIT_USERID_KEY, req.user?.id, next);
+  auditUserIdAsyncLocalStorage.run(req.user?.id, next);
 };

--- a/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
+++ b/packages/facility-server/__tests__/audit/attachAuditUserToDbSession.test.js
@@ -1,17 +1,23 @@
 import config from 'config';
 import defineExpress from 'express';
-import { QueryTypes } from 'sequelize';
+import { QueryTypes, Sequelize } from 'sequelize';
 import asyncHandler from 'express-async-handler';
 import { agent as _agent } from 'supertest';
 
 import { attachAuditUserToDbSession } from '@tamanu/database';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
 import { fakeUser } from '@tamanu/fake-data/fake';
-import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { authMiddleware, buildToken } from '../../app/middleware/auth';
 import { createTestContext } from '../utilities';
 import bodyParser from 'body-parser';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+
+const runInAFewRandomMs = async (callback) => {
+  await sleepAsync(Math.floor(Math.random() * 100));
+  return await callback();
+};
 
 describe('Attach audit user to DB session', () => {
   let ctx;
@@ -38,7 +44,7 @@ describe('Attach audit user to DB session', () => {
     });
     models = ctx.models;
 
-    await models.Setting.set('audit.changes.enabled', true)
+    await models.Setting.set('audit.changes.enabled', true);
 
     // Setup a mock express app with a route that updates a user
     // and includes the attachAuditUserToDbSession middleware
@@ -55,17 +61,64 @@ describe('Attach audit user to DB session', () => {
       authMiddleware,
       attachAuditUserToDbSession,
       asyncHandler(async (req, res) => {
-        const { sleep } = req.query;
-        await sleepAsync(parseInt(sleep, 10));
+        const userUpdated = await req.models.User.update(
+          { displayName: `changed-by-${req.user.id}` },
+          { where: { id: req.user.id } },
+        );
 
-        // Update the authenticated user to have a different display name
-        const userUpdated = await req.models.User.update(req.body, { where: { id: req.user.id } });
+        res.json(userUpdated);
+      }),
+    );
+    mockApp.post(
+      '/updateAuthenticatedUserInTransaction',
+      (req, _res, next) => {
+        req.models = models;
+        req.db = ctx.sequelize;
+        next();
+      },
+      authMiddleware,
+      attachAuditUserToDbSession,
+      asyncHandler(async (req, res) => {
+        let userUpdated;
+        await req.db.transaction(async () => {
+          // Update the authenticated user to have a different display name
+          userUpdated = await req.models.User.update(
+            { displayName: `changed-by-${req.user.id}` },
+            { where: { id: req.user.id } },
+          );
+        });
+
+        res.json(userUpdated);
+      }),
+    );
+    mockApp.post(
+      '/updateAuthenticatedUserInIsolatedTransaction',
+      (req, _res, next) => {
+        req.models = models;
+        req.db = ctx.sequelize;
+        next();
+      },
+      authMiddleware,
+      attachAuditUserToDbSession,
+      asyncHandler(async (req, res) => {
+        let userUpdated;
+        await req.db.transaction(
+          { isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED },
+          async () => {
+            // Update the authenticated user to have a different display name
+            userUpdated = await req.models.User.update(
+              { displayName: `changed-by-${req.user.id}` },
+              { where: { id: req.user.id } },
+            );
+          },
+        );
+
         res.json(userUpdated);
       }),
     );
 
     const asUser = async (user) => {
-      const agent = _agent(mockApp, { http2: true });
+      const agent = _agent(mockApp);
       const token = await buildToken(user, facilityIds[0], '1d');
       agent.set('authorization', `Bearer ${token}`);
       agent.user = user;
@@ -88,25 +141,49 @@ describe('Attach audit user to DB session', () => {
   afterAll(() => ctx.close());
 
   it('audit log updated_by_user_id should match authenticated user with multiple simultaneous requests', async () => {
-    // Stagger the response times of the 4 requests to ensure they are processed in parallel
-    await Promise.all([
-      userApp1.post('/updateAuthenticatedUser?sleep=4000').send({
-        displayName: 'changed',
-      }),
-      userApp2.post('/updateAuthenticatedUser?sleep=3000').send({
-        displayName: 'changed',
-      }),
-      userApp3.post('/updateAuthenticatedUser?sleep=2000').send({
-        displayName: 'changed',
-      }),
-      userApp4.post('/updateAuthenticatedUser?sleep=1000').send({
-        displayName: 'changed',
-      }),
+    // Randomising the order of execution makes this test a little intermittent but tests are broader range of cases so worth it imo
+    const changeRequests = await Promise.all([
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp1.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user1.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp2.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user2.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp3.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user3.id } },
+        ),
+      ),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUser')),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInTransaction')),
+      runInAFewRandomMs(() => userApp4.post('/updateAuthenticatedUserInIsolatedTransaction')),
+      runInAFewRandomMs(() =>
+        models.User.update(
+          { displayName: `changed-by-${SYSTEM_USER_UUID}` },
+          { where: { id: user4.id } },
+        ),
+      ),
     ]);
 
-    // Get the created audit entries for the 4 users that updated their own records
+    // Get the created audit entries
     const changes = await ctx.sequelize.query(
-      `SELECT * FROM logs.changes WHERE record_id IN (:userIds) AND record_data->>'display_name' = 'changed'`,
+      `SELECT * FROM logs.changes WHERE record_id IN (:userIds) AND record_data->>'display_name' like 'changed-by-%'`,
       {
         type: QueryTypes.SELECT,
         replacements: {
@@ -114,8 +191,10 @@ describe('Attach audit user to DB session', () => {
         },
       },
     );
-    expect(changes).toHaveLength(4);
-    // Each user should be shown to have updated their own record in the audit log
-    expect(changes.every((change) => change.updated_by_user_id === change.record_id)).toBeTruthy();
+    expect(changes).toHaveLength(changeRequests.length);
+
+    changes.forEach((change) => {
+      expect(`changed-by-${change.updated_by_user_id}`).toEqual(change.record_data.display_name);
+    });
   });
 });


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes audit user with AsyncLocalStorage and updates Sequelize query handling to set/clear AUDIT_USERID per-request/transaction, with comprehensive concurrency/transaction tests.
> 
> - **Database**:
>   - Replace custom CLS namespace with dedicated `AsyncLocalStorage` for Sequelize transactions; add helpers `sequelize.isInsideTransaction` and `sequelize.isTransactionReady`.
>   - Introduce `getAuditUserId` and use it in a custom query wrapper to set `AUDIT_USERID_KEY` before queries, respecting transaction setup and clearing to `SYSTEM_USER_UUID` after non-transactional queries; add error logging.
> - **Middleware**:
>   - Rewrite `attachAuditUserToDbSession` to store the authenticated user id in `AsyncLocalStorage` (removing `setSessionConfigInNamespace`).
> - **Tests**:
>   - Expand test suite to cover concurrent requests and updates inside transactions with different isolation levels; add `runWithDelay` helper and assertions tying `updated_by_user_id` to `record_data.display_name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9b2e8b5223af440e3d49ef45c74aba89586c58e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->