### PR TITLE
feat(meta): KAM-437: Support URL fallbacks for meta server

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -43,11 +43,13 @@
     // and the errors will get stack traces.
     apiErrorsToken: false,
   },
-  "metaServer": {
-    "host": "https://meta.tamanu.app",
-    "serverId": null,
-    "timeoutMs": 20000
-  },
+  "metaServer": [
+      {
+      "host": "https://meta.tamanu.app",
+      "serverId": null,
+      "timeoutMs": 20000
+    },
+  ],
   "updateUrls": {
     "mobile": "https://meta.tamanu.app/versions/~{minVersion}/mobile",
   },

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -43,13 +43,13 @@
     // and the errors will get stack traces.
     apiErrorsToken: false,
   },
-  "metaServer": [
-      {
-      "host": "https://meta.tamanu.app",
-      "serverId": null,
-      "timeoutMs": 20000
-    },
-  ],
+  "metaServer": {
+    "hosts": [
+      "https://meta.tamanu.app",
+    ],
+    "serverId": null,
+    "timeoutMs": 20000,
+  },
   "updateUrls": {
     "mobile": "https://meta.tamanu.app/versions/~{minVersion}/mobile",
   },

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -74,13 +74,13 @@
       }
     }
   },
-  "metaServer": [
-    {
-      "host": "https://meta.tamanu.app",
-      "serverId": null,
-      "timeoutMs": 20000
-    },
-  ],
+  "metaServer": {
+    "hosts": [
+      "https://meta.tamanu.app",
+    ],
+    "serverId": null,
+    "timeoutMs": 20000,
+  },
   "senaite": {
     "enabled": false,
     "server": "https://192.168.33.100",

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -74,11 +74,13 @@
       }
     }
   },
-  "metaServer": {
-    "host": "https://meta.tamanu.app",
-    "serverId": null,
-    "timeoutMs": 20000
-  },
+  "metaServer": [
+    {
+      "host": "https://meta.tamanu.app",
+      "serverId": null,
+      "timeoutMs": 20000
+    },
+  ],
   "senaite": {
     "enabled": false,
     "server": "https://192.168.33.100",

--- a/packages/shared/src/tasks/SendStatusToMetaServer.js
+++ b/packages/shared/src/tasks/SendStatusToMetaServer.js
@@ -58,7 +58,7 @@ export class SendStatusToMetaServer extends ScheduledTask {
   async getMetaServerId() {
     this.metaServerId = await this.models.LocalSystemFact.get(FACT_META_SERVER_ID);
     if (this.metaServerId) return this.metaServerId;
-    console.log( path.join('http://', os.hostname()))
+    console.log(path.join('http://', os.hostname()));
     this.metaServerId =
       config.metaServer.serverId ||
       (

--- a/packages/shared/src/tasks/SendStatusToMetaServer.js
+++ b/packages/shared/src/tasks/SendStatusToMetaServer.js
@@ -73,7 +73,6 @@ export class SendStatusToMetaServer extends ScheduledTask {
   async getMetaServerId() {
     this.metaServerId = await this.models.LocalSystemFact.get(FACT_META_SERVER_ID);
     if (this.metaServerId) return this.metaServerId;
-    console.log(path.join('http://', os.hostname()));
     this.metaServerId =
       config.metaServer.serverId ||
       (

--- a/packages/shared/src/tasks/SendStatusToMetaServer.js
+++ b/packages/shared/src/tasks/SendStatusToMetaServer.js
@@ -9,6 +9,7 @@ import { FACT_CURRENT_SYNC_TICK, FACT_META_SERVER_ID } from '@tamanu/constants';
 
 import { ScheduledTask } from './ScheduledTask';
 import { serviceContext } from '../services/logging/context';
+import { getMetaServerHosts } from '../utils';
 
 export class SendStatusToMetaServer extends ScheduledTask {
   getName() {
@@ -55,13 +56,7 @@ export class SendStatusToMetaServer extends ScheduledTask {
   }
 
   async fetchFromHosts(path, options) {
-    const metaServerHosts = config?.metaServer?.hosts;
-    if (!Array.isArray(metaServerHosts)) {
-      throw new Error('metaServer.hosts is not an array');
-    }
-    if (metaServerHosts.length === 0) {
-      throw new Error('No meta server hosts configured');
-    }
+    const metaServerHosts = getMetaServerHosts();
 
     const deviceKey = await this.models.LocalSystemFact.getDeviceKey();
     for (const metaServerHost of metaServerHosts) {

--- a/packages/shared/src/utils/getMetaServerHosts.js
+++ b/packages/shared/src/utils/getMetaServerHosts.js
@@ -1,7 +1,7 @@
 import config from 'config';
 
 export const getMetaServerHosts = () => {
-  const metaServerHosts = config?.metaServer?.hosts;
+  const metaServerHosts = config?.metaServer?.hosts ?? [config?.metaServer?.host];
   if (!Array.isArray(metaServerHosts)) {
     throw new Error('metaServer.hosts is not an array');
   }

--- a/packages/shared/src/utils/getMetaServerHosts.js
+++ b/packages/shared/src/utils/getMetaServerHosts.js
@@ -1,0 +1,12 @@
+import config from 'config';
+
+export const getMetaServerHosts = () => {
+  const metaServerHosts = config?.metaServer?.hosts;
+  if (!Array.isArray(metaServerHosts)) {
+    throw new Error('metaServer.hosts is not an array');
+  }
+  if (metaServerHosts.length === 0) {
+    throw new Error('No meta server hosts configured');
+  }
+  return metaServerHosts;
+};

--- a/packages/shared/src/utils/index.js
+++ b/packages/shared/src/utils/index.js
@@ -1,4 +1,5 @@
 export * from './buildVersionCompatibilityCheck';
+export * from './getMetaServerHosts';
 export * from './getPatientAdditionalData';
 export * from './getPatientSurveyResponseAnswer';
 export * from './getResponseJsonSafely';

--- a/packages/upgrade/__tests__/steps/1752105049000-importDefaultTranslations.test.ts
+++ b/packages/upgrade/__tests__/steps/1752105049000-importDefaultTranslations.test.ts
@@ -13,11 +13,11 @@ import {
 // Mock dependencies
 vi.mock('config', () => ({
   default: {
-    metaServer: [
-      {
-        host: 'https://meta.example.com',
-      },
-    ],
+    metaServer: {
+      hosts: [
+        'https://meta.example.com',
+      ],
+    },
   },
 }));
 

--- a/packages/upgrade/__tests__/steps/1752105049000-importDefaultTranslations.test.ts
+++ b/packages/upgrade/__tests__/steps/1752105049000-importDefaultTranslations.test.ts
@@ -433,7 +433,7 @@ describe('1752105049000-importDefaultTranslations', () => {
         'Failed to import default report translations, you will need to manually import them',
         expect.objectContaining({
           error: expect.objectContaining({
-            message: expect.stringContaining('No report-translations artifact found'),
+            message: expect.stringContaining('No meta server succeeded downloading the artifacts'),
           }),
         }),
       );

--- a/packages/upgrade/__tests__/steps/1752105049000-importDefaultTranslations.test.ts
+++ b/packages/upgrade/__tests__/steps/1752105049000-importDefaultTranslations.test.ts
@@ -13,9 +13,11 @@ import {
 // Mock dependencies
 vi.mock('config', () => ({
   default: {
-    metaServer: {
-      host: 'https://meta.example.com',
-    },
+    metaServer: [
+      {
+        host: 'https://meta.example.com',
+      },
+    ],
   },
 }));
 

--- a/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
+++ b/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
@@ -1,4 +1,3 @@
-import config from 'config';
 import { QueryTypes } from 'sequelize';
 import { uniqBy } from 'lodash';
 import * as xlsx from 'xlsx';
@@ -13,6 +12,7 @@ import {
   ENGLISH_COUNTRY_CODE,
   ENGLISH_LANGUAGE_NAME,
 } from '@tamanu/constants';
+import { getMetaServerHosts } from '@tamanu/shared/utils';
 
 interface Artifact {
   artifact_type: string;
@@ -72,13 +72,7 @@ async function downloadFromMetaServerHosts(
   extractor: (resp: Response) => Promise<Translation[]>,
   stepArgs: StepArgs,
 ): Promise<Translation[]> {
-  const metaServerHosts = (config as any)?.metaServer?.hosts;
-  if (!Array.isArray(metaServerHosts)) {
-    throw new Error('metaServer.hosts is not an array');
-  }
-  if (metaServerHosts.length === 0) {
-    throw new Error('No meta server hosts configured');
-  }
+  const metaServerHosts = getMetaServerHosts();
 
   const { log } = stepArgs;
   for (const metaServerHost of metaServerHosts) {

--- a/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
+++ b/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
@@ -74,10 +74,10 @@ async function downloadFromMetaServerHosts(
 ): Promise<Translation[]> {
   const metaServerHosts = (config as any)?.metaServer?.hosts;
   if (!Array.isArray(metaServerHosts)) {
-    throw new Error('metaServer is not an array');
+    throw new Error('metaServer.hosts is not an array');
   }
   if (metaServerHosts.length === 0) {
-    throw new Error('No meta servers configured');
+    throw new Error('No meta server hosts configured');
   }
 
   const { log } = stepArgs;

--- a/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
+++ b/packages/upgrade/src/steps/1752105049000-importDefaultTranslations.ts
@@ -67,26 +67,26 @@ async function download(
 
 // Tries each meta server in the array until one succeeds
 // Returns the translations or throws an error if all fail
-async function downloadFromMetaServerArray(
+async function downloadFromMetaServerHosts(
   artifactType: string,
   extractor: (resp: Response) => Promise<Translation[]>,
   stepArgs: StepArgs,
 ): Promise<Translation[]> {
-  const metaServerConfig = (config as any).metaServer;
-  if (!Array.isArray(metaServerConfig)) {
+  const metaServerHosts = (config as any)?.metaServer?.hosts;
+  if (!Array.isArray(metaServerHosts)) {
     throw new Error('metaServer is not an array');
   }
-  if (metaServerConfig.length === 0) {
+  if (metaServerHosts.length === 0) {
     throw new Error('No meta servers configured');
   }
 
   const { log } = stepArgs;
-  for (const metaServer of metaServerConfig) {
+  for (const metaServerHost of metaServerHosts) {
     try {
-      const rows = await download(metaServer.host, artifactType, extractor, stepArgs);
+      const rows = await download(metaServerHost, artifactType, extractor, stepArgs);
       return rows;
     } catch (error) {
-      log.error(`Failed to download from meta server host: ${metaServer.host}`, { error });
+      log.error(`Failed to download from meta server host: ${metaServerHost}`, { error });
     }
   }
   throw new Error('No meta server succeeded downloading the artifacts');
@@ -202,7 +202,7 @@ export const STEPS: Steps = [
       }
 
       try {
-        const rows = await downloadFromMetaServerArray('report-translations', xlsxExtractor, {
+        const rows = await downloadFromMetaServerHosts('report-translations', xlsxExtractor, {
           ...args,
           toVersion: zeroPatch,
         });


### PR DESCRIPTION
### Changes

We now have a `hosts` array instead of just one value, this will allow us to try different fallbacks in order until one is successful or all fail.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->