### PR TITLE
fix(integrations): no-issue: Switch to using a Basic auth header in the MerlinProvider (hotfix 2.38)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamanu",
-  "version": "2.38.8",
+  "version": "2.38.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamanu",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-and-later AND BUSL-1.1",
       "dependencies": {
         "@rnx-kit/metro-resolver-symlinks": "^0.1.36",
@@ -73468,7 +73468,7 @@
     },
     "packages/api-client": {
       "name": "@tamanu/api-client",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73482,7 +73482,7 @@
     },
     "packages/build-tooling": {
       "name": "@tamanu/build-tooling",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@swc/cli": "^0.1.63",
@@ -73508,7 +73508,7 @@
     },
     "packages/central-server": {
       "name": "@tamanu/central-server",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
@@ -73842,7 +73842,7 @@
     },
     "packages/constants": {
       "name": "@tamanu/constants",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/date-fns": "^2.6.3",
@@ -73895,7 +73895,7 @@
     },
     "packages/database": {
       "name": "@tamanu/database",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -73984,7 +73984,7 @@
     },
     "packages/e2e-tests": {
       "name": "@tamanu/e2e-tests",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "dependencies": {
         "date-fns": "^4.1.0"
       },
@@ -74023,7 +74023,7 @@
     },
     "packages/facility-server": {
       "name": "@tamanu/facility-server",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^7.22.4",
@@ -74562,7 +74562,7 @@
     },
     "packages/fake-data": {
       "name": "@tamanu/fake-data",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -74609,7 +74609,7 @@
     },
     "packages/mobile": {
       "name": "@tamanu/mobile",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "hasInstallScript": true,
       "dependencies": {
         "@casl/ability": "^4.1.0",
@@ -75628,7 +75628,7 @@
       }
     },
     "packages/scripts": {
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/database": "*",
@@ -75666,7 +75666,7 @@
     },
     "packages/settings": {
       "name": "@tamanu/settings",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -75935,7 +75935,7 @@
     },
     "packages/shared": {
       "name": "@tamanu/shared",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later AND BUSL-1.1",
       "dependencies": {
         "@casl/ability": "^6.7.1",
@@ -77984,7 +77984,7 @@
     },
     "packages/upgrade": {
       "name": "@tamanu/upgrade",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tamanu/constants": "*",
@@ -78036,7 +78036,7 @@
     },
     "packages/utils": {
       "name": "@tamanu/utils",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "date-fns": "^4.1.0",
@@ -78111,7 +78111,7 @@
     },
     "packages/web": {
       "name": "@tamanu/web-frontend",
-      "version": "2.38.8",
+      "version": "2.38.9",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",

--- a/packages/facility-server/__tests__/integrations/imaging/MerlinProvider.test.js
+++ b/packages/facility-server/__tests__/integrations/imaging/MerlinProvider.test.js
@@ -1,0 +1,97 @@
+import { fake } from '@tamanu/fake-data/fake';
+import { MerlinProvider } from '../../../dist/integrations/imaging/MerlinProvider';
+import { createTestContext } from '../../utilities';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+
+global.fetch = jest.fn();
+
+const EXTERNAL_CODE = 'EXT123';
+const PATIENT_ID_TYPE = 'AUID';
+const URLGEN = 'https://rispacs.aspen-dev.fj/WebData/UrlGen/Encode';
+
+describe('MerlinProvider', () => {
+  let models;
+  let ctx;
+  let provider;
+  let patient;
+  let encounter;
+  let request;
+  let result;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+
+    patient = await models.Patient.create(fake(models.Patient));
+    const facility = await models.Facility.create(fake(models.Facility));
+    const department = await models.Department.create(
+      fake(models.Department, { facilityId: facility.id }),
+    );
+    const location = await models.Location.create(
+      fake(models.Location, { departmentId: department.id, facilityId: facility.id }),
+    );
+    encounter = await models.Encounter.create(
+      fake(models.Encounter, {
+        patientId: patient.id,
+        locationId: location.id,
+        departmentId: department.id,
+        examinerId: SYSTEM_USER_UUID,
+      }),
+    );
+    request = await models.ImagingRequest.create(
+      fake(models.ImagingRequest, { encounterId: encounter.id, requestedById: SYSTEM_USER_UUID }),
+    );
+    result = await models.ImagingResult.create({
+      imagingRequestId: request.id,
+      description: 'external result description',
+      externalCode: EXTERNAL_CODE,
+    });
+
+    await models.Setting.set('integrations.imaging', {
+      enabled: true,
+      provider: 'merlin',
+      urlgen: URLGEN,
+      auth: {
+        username: 'test',
+        password: 'test',
+      },
+      patientId: {
+        type: PATIENT_ID_TYPE,
+        field: 'displayId',
+      },
+    });
+
+    provider = new MerlinProvider(models, await models.Setting.get('integrations.imaging'));
+  });
+
+  beforeEach(() => {
+    global.fetch.mockClear();
+  });
+
+  afterAll(() => {
+    ctx.close();
+  });
+
+  describe('getUrlForResult', () => {
+    it('should request from the configured MerlinVue server for the imaging results url', async () => {
+      const returnedUrl = `https://rispacs.aspen-dev.fj/MerlinVue/#!/urlgen/${EXTERNAL_CODE}`;
+      global.fetch.mockResolvedValue({
+        text: jest.fn().mockResolvedValue(returnedUrl),
+      });
+
+      const url = await provider.getUrlForResult(result);
+
+      expect(url).toEqual(returnedUrl);
+
+      const expectedFetchUrl = new URL(URLGEN);
+      expectedFetchUrl.searchParams.set('accession', EXTERNAL_CODE);
+      expectedFetchUrl.searchParams.set('patIdType', PATIENT_ID_TYPE);
+      expectedFetchUrl.searchParams.set('patId', patient.displayId);
+      expect(global.fetch).toHaveBeenCalledWith(expectedFetchUrl, {
+        headers: {
+          Authorization: `Basic ${Buffer.from('test:test').toString('base64')}`,
+        },
+      });
+    });
+  });
+});

--- a/packages/facility-server/app/integrations/imaging/MerlinProvider.js
+++ b/packages/facility-server/app/integrations/imaging/MerlinProvider.js
@@ -25,14 +25,16 @@ export class MerlinProvider extends Provider {
     } = this.config;
 
     const url = new URL(urlgen);
-    url.username = username;
-    url.password = password;
     url.searchParams.set('accession', externalCode);
 
     url.searchParams.set('patIdType', type);
     url.searchParams.set('patId', patient[field]);
 
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+      },
+    });
     return res.text();
   }
 }


### PR DESCRIPTION
### Changes

Backporting this hotfix to get the Aspen UAT to fetch from the RISPACS UAT server succesfully.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
