### PR TITLE
fix(translations): No-issue: Use async handler for language options endpoint

### DIFF
--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -78,12 +78,15 @@ apiv1.get(
   }),
 );
 
-apiv1.get('/public/translation/languageOptions', async (req, res) => {
-  req.flagPermissionChecked();
-  const { TranslatedString } = req.models;
-  const response = await TranslatedString.getPossibleLanguages();
-  res.send(response);
-});
+apiv1.get(
+  '/public/translation/languageOptions',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const { TranslatedString } = req.models;
+    const response = await TranslatedString.getPossibleLanguages();
+    res.send(response);
+  }),
+);
 
 apiv1.get(
   '/public/translation/:language',


### PR DESCRIPTION
### Changes

Almost certain this is the cause of an issue on support. It seems that we can crash the whole server if this endpoint returns an error. This is because old Thomas didn't use async handler 🤦 

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps `GET /public/translation/languageOptions` with `asyncHandler` for consistent async error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49b4471c1afc3ab4fdf5d14e82919143fce2fd59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->