### PR TITLE
fix(translations): Hotfix 2.30: Async languageOptions handler

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,7 @@ ehr = "ehr"
 mch = "mch"
 nam = "nam" # VDS
 nce = "nce"
+brin = "brin" # Type of database index
 
 # Common default facility names
 ba = "ba"

--- a/packages/database/src/demoData/diagnoses.js
+++ b/packages/database/src/demoData/diagnoses.js
@@ -5485,7 +5485,7 @@ export const DIAGNOSES = splitIds(`
   Urethrolithiasis	N21.1
   Uricemia	E79.0
   Urinary incontinence	R32
-  Urinary retension	R33
+  Urinary retention	R33
   Urinary tract infection	N39.0
   Urinary tract infection, site not specified	N39.0
   Urinary tract infection, unspecified	N39.0

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -77,12 +77,15 @@ apiv1.get(
   }),
 );
 
-apiv1.get('/public/translation/languageOptions', async (req, res) => {
-  req.flagPermissionChecked();
-  const { TranslatedString } = req.models;
-  const response = await TranslatedString.getPossibleLanguages();
-  res.send(response);
-});
+apiv1.get(
+  '/public/translation/languageOptions',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const { TranslatedString } = req.models;
+    const response = await TranslatedString.getPossibleLanguages();
+    res.send(response);
+  }),
+);
 
 apiv1.get(
   '/public/translation/:language',

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -31,8 +31,8 @@ surveyResponse.get(
     res.send({
       ...surveyResponseRecord.forResponse(),
       components,
-      answers: answers.map(answer => {
-        const transformedAnswer = transformedAnswers.find(a => a.id === answer.id);
+      answers: answers.map((answer) => {
+        const transformedAnswer = transformedAnswers.find((a) => a.id === answer.id);
         return {
           ...answer.dataValues,
           originalBody: answer.body,
@@ -54,11 +54,11 @@ surveyResponse.post(
       settings,
     } = req;
     // Responses for the vitals survey will check against 'Vitals' create permissions
-    // All others witll check against 'SurveyResponse' create permissions
+    // All others will check against 'SurveyResponse' create permissions
     const noun = await models.Survey.getResponsePermissionCheck(body.surveyId);
     req.checkPermission('create', noun);
 
-    const getDefaultId = async type =>
+    const getDefaultId = async (type) =>
       models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
     const updatedBody = {
       locationId: body.locationId || (await getDefaultId('location')),

--- a/packages/web/app/components/Field/DateField.jsx
+++ b/packages/web/app/components/Field/DateField.jsx
@@ -28,7 +28,7 @@ import { DefaultIconButton } from '../Button';
 // has some unusual input handling (switching focus between day/month/year etc) that
 // a value change will interfere with.
 
-// Here I have made a data URL for the new calendar icon. The existing calander icon was a pseudo element
+// Here I have made a data URL for the new calendar icon. The existing calendar icon was a pseudo element
 // in the user agent shadow DOM. In order to add a new icon I had to make the pseudo element invisible
 // a new icon I had to make the pseudo element invisible and render a replacement on top using svg data url.
 const CustomIconTextInput = styled(TextInput)`

--- a/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
+++ b/packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx
@@ -421,7 +421,7 @@ const encounter = {
         id: 'drug-aciclovir345',
         code: 'aciclovir345',
         type: 'drug',
-        name: 'Aciclovir 3%w/w Eye Oint 4.5g',
+        name: 'Aciclovir 3%w/w Eye Ointment 4.5g',
         visibilityStatus: 'current',
         updatedAtSyncTick: '-999',
         createdAt: '2023-11-07T02:15:34.721Z',


### PR DESCRIPTION
…ndpoint (#8644)

Update index.js

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps `/public/translation/languageOptions` in `asyncHandler` and fixes minor typos across data, comments, and stories (plus typos dictionary update).
> 
> - **Backend (API v1)**:
>   - Wrap `/public/translation/languageOptions` handler in `asyncHandler` in `packages/facility-server/app/routes/apiv1/index.js`.
> - **Data and UI content**:
>   - Fix diagnosis label typo: `Urinary retension` → `Urinary retention` in `packages/database/src/demoData/diagnoses.js`.
>   - Update story medication name: `Eye Oint` → `Eye Ointment` in `packages/web/stories/pdfs/DischargeSummaryPrintout.stories.jsx`.
> - **Misc**:
>   - Minor comment/arrow-style cleanups in `surveyResponse.js` and `DateField.jsx`.
>   - Add `brin` to allowed words in `.typos.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8603539f3208e57729383325ac8a510c2c564bf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->