### PR TITLE
feat(meta): KAM-429: Use random jitter to report to meta server

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -288,6 +288,7 @@
       "enabled": true,
       // every minute
       "schedule": "* * * * *",
+      jitterTime: "30s",
     },
     "medicationDiscontinuer": {
       // every hour

--- a/packages/facility-server/config/default.json5
+++ b/packages/facility-server/config/default.json5
@@ -113,6 +113,7 @@
       "enabled": true,
       // every minute
       "schedule": "* * * * *",
+      jitterTime: "30s",
     },
     "timeSync": {
       "enabled": false,

--- a/packages/shared/src/tasks/SendStatusToMetaServer.js
+++ b/packages/shared/src/tasks/SendStatusToMetaServer.js
@@ -16,10 +16,8 @@ export class SendStatusToMetaServer extends ScheduledTask {
   }
   constructor(context, overrideConfig = null) {
     const { 'service.type': serverType, 'service.version': version } = serviceContext();
-    const randomJitterMs = Math.random() * 5000; // 0-5000ms
-    const { schedule, jitterTime = randomJitterMs, enabled } =
+    const { schedule, jitterTime, enabled } =
       overrideConfig || config.schedules.sendStatusToMetaServer;
-
     super(schedule, log, jitterTime, enabled);
     this.context = context;
     this.models = context.models || context.store.models;

--- a/packages/shared/src/tasks/SendStatusToMetaServer.js
+++ b/packages/shared/src/tasks/SendStatusToMetaServer.js
@@ -16,8 +16,10 @@ export class SendStatusToMetaServer extends ScheduledTask {
   }
   constructor(context, overrideConfig = null) {
     const { 'service.type': serverType, 'service.version': version } = serviceContext();
-    const { schedule, jitterTime, enabled } =
+    const randomJitterMs = Math.random() * 5000; // 0-5000ms
+    const { schedule, jitterTime = randomJitterMs, enabled } =
       overrideConfig || config.schedules.sendStatusToMetaServer;
+
     super(schedule, log, jitterTime, enabled);
     this.context = context;
     this.models = context.models || context.store.models;


### PR DESCRIPTION
### Changes

We already had a way to specify through config, though that's manual. So I decided to make it a default value instead that gets set on initialization, I think the 0-5s range should be enough.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
