### PR TITLE
tweak(settings): default audit.changes.enabled to true

### DIFF
--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -68,7 +68,7 @@ export const globalSettings = {
             enabled: {
               description: 'Enable audit changes',
               type: yup.boolean(),
-              defaultValue: false,
+              defaultValue: true,
             },
           },
         },


### PR DESCRIPTION
### Changes

[Documenting](https://beyondessential.slack.com/archives/GE9NHB95F/p1761610250693059) that the reason this was off was:

> The original idea was that we'd do the backfill and then turn it on, but I think a few steps down the track we went with "enable it and then do the backfill later".


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
