### PR TITLE
refactor(encounters): no-issue: Reorganise unified patient move form arguments

### DIFF
--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -225,6 +225,10 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
 
     initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
+  } else {
+    validationObject.locationId = yup.string().nullable();
+
+    initialValues.locationId = encounter.locationId;
   }
 
   return (

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -180,6 +180,35 @@ const PlannedMoveFields = () => {
   );
 };
 
+const getFormProps = ({ encounter, enablePatientMoveActions }) => {
+  const validationObject = {
+    examinerId: yup.string().required(),
+    departmentId: yup.string().required(),
+  };
+
+  const initialValues = {
+    examinerId: encounter.examinerId,
+    departmentId: encounter.departmentId,
+  };
+
+  if (enablePatientMoveActions) {
+    validationObject.plannedLocationId = yup.string().nullable();
+    validationObject.action = yup
+      .string()
+      .oneOf([PATIENT_MOVE_ACTIONS.PLAN, PATIENT_MOVE_ACTIONS.FINALISE])
+      .nullable();
+
+    initialValues.plannedLocationId = encounter.plannedLocationId;
+    initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
+  } else {
+    validationObject.locationId = yup.string().nullable();
+
+    initialValues.locationId = encounter.locationId;
+  }
+
+  return { initialValues, validationSchema: yup.object().shape(validationObject) };
+};
+
 export const MoveModal = React.memo(({ open, onClose, encounter }) => {
   const { getSetting } = useSettings();
   const enablePatientMoveActions = getSetting('features.patientPlannedMove');
@@ -206,30 +235,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
     });
   };
 
-  const validationObject = {
-    examinerId: yup.string().required(),
-    departmentId: yup.string().required(),
-  };
-
-  const initialValues = {
-    examinerId: encounter.examinerId,
-    departmentId: encounter.departmentId,
-  };
-
-  if (enablePatientMoveActions) {
-    validationObject.plannedLocationId = yup.string().nullable();
-    validationObject.action = yup
-      .string()
-      .oneOf([PATIENT_MOVE_ACTIONS.PLAN, PATIENT_MOVE_ACTIONS.FINALISE])
-      .nullable();
-
-    initialValues.plannedLocationId = encounter.plannedLocationId;
-    initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
-  } else {
-    validationObject.locationId = yup.string().nullable();
-
-    initialValues.locationId = encounter.locationId;
-  }
+  const { initialValues, validationSchema } = getFormProps({ encounter, enablePatientMoveActions });
 
   return (
     <FormModal
@@ -249,7 +255,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
         initialValues={initialValues}
         formType={FORM_TYPES.EDIT_FORM}
         onSubmit={onSubmit}
-        validationSchema={yup.object().shape(validationObject)}
+        validationSchema={validationSchema}
         render={({ submitForm }) => (
           <>
             <SectionHeading>

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -182,7 +182,7 @@ const PlannedMoveFields = () => {
 
 export const MoveModal = React.memo(({ open, onClose, encounter }) => {
   const { getSetting } = useSettings();
-  const enablePlannedPatientMove = getSetting('features.patientPlannedMove');
+  const enablePatientMoveActions = getSetting('features.patientPlannedMove');
 
   const { writeAndViewEncounter } = useEncounter();
 
@@ -195,7 +195,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
     const { locationId, plannedLocationId, action, ...rest } = values;
 
     const locationData =
-      enablePlannedPatientMove && action === PATIENT_MOVE_ACTIONS.PLAN
+      enablePatientMoveActions && action === PATIENT_MOVE_ACTIONS.PLAN
         ? { plannedLocationId: plannedLocationId || null } // Null clears the planned move
         : { locationId: plannedLocationId || locationId };
 
@@ -216,7 +216,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
     departmentId: encounter.departmentId,
   };
 
-  if (enablePlannedPatientMove) {
+  if (enablePatientMoveActions) {
     validationObject.plannedLocationId = yup.string().nullable();
     validationObject.action = yup
       .string()
@@ -295,7 +295,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
                 fallback="Move location"
               />
             </SectionHeading>
-            {enablePlannedPatientMove ? <PlannedMoveFields /> : <BasicMoveFields />}
+            {enablePatientMoveActions ? <PlannedMoveFields /> : <BasicMoveFields />}
             <ModalFormActionRow
               onConfirm={submitForm}
               onCancel={onClose}


### PR DESCRIPTION
### Changes

Extracted this cleanup from another pr to simplify things for reviews

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts form initialization/validation and submit logic in `MoveModal` into helper functions and updates the form to use them.
> 
> - **MoveModal (`packages/web/app/views/patients/components/MoveModal.jsx`)**:
>   - Introduces `getFormProps` to generate `initialValues` and `validationSchema` conditionally for planned vs basic moves.
>   - Extracts submit logic into `onSubmit`, setting `submittedTime` and applying `locationId` or `plannedLocationId` based on `action`.
>   - Updates `<Form>` to consume extracted `initialValues`, `validationSchema`, and `onSubmit` instead of inline definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85c154ca55077c53d487f6fc6cc6e629fe4695af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->