### PR TITLE
fix(mobile): Vitals validation not displayed

### DIFF
--- a/packages/mobile/App/ui/components/Forms/FormField.tsx
+++ b/packages/mobile/App/ui/components/Forms/FormField.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Field as FormikField, useField, useFormikContext } from 'formik';
-import { FORM_STATUSES } from '/helpers/constants';
+import { SUBMIT_ATTEMPTED_STATUS } from '@tamanu/constants/forms';
 import { TranslatedTextElement } from '../Translations/TranslatedText';
 
 export interface FieldProps {
@@ -29,10 +29,10 @@ export const Field = ({
   // Show errors if
   // 1. validateOnChange is false OR
   // 2. if the user has already tried to submit the form (submitCount > 0) OR
-  // 3. if the user has already tried to move to the next page of the form (ie: Survey and status === FORM_STATUSES.SUBMIT_SCREEN_ATTEMPTED)
+  // 3. if the user has already tried to move to the next page of the form (ie: Survey and status === SUBMIT_ATTEMPTED_STATUS)
   // We don't want errors displayed by on change events before user submits.
   const showError =
-    !validateOnChange || status === FORM_STATUSES.SUBMIT_SCREEN_ATTEMPTED || submitCount;
+    !validateOnChange || status === SUBMIT_ATTEMPTED_STATUS || submitCount;
   const error = showError ? meta.error : null;
 
   const combinedOnChange = (newValue: any, selectedItem: any): any => {

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -20,7 +20,7 @@ import { SectionHeader } from '../../SectionHeader';
 import { ErrorBoundary } from '../../ErrorBoundary';
 import { FullView, RowView, StyledText, StyledView } from '../../../styled/common';
 import { theme } from '../../../styled/theme';
-import { SUBMIT_ATTEMPTED_STATUS } from '/helpers/constants';
+import { SUBMIT_ATTEMPTED_STATUS } from '@tamanu/constants/forms';
 import { BackHandler } from 'react-native';
 import { useBackendEffect } from '~/ui/hooks';
 import { LoadingScreen } from '../../LoadingScreen';

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -28,7 +28,7 @@ import { ErrorScreen } from '../../ErrorScreen';
 import { TranslatedText } from '../../Translations/TranslatedText';
 
 interface UseScrollToFirstError {
-  setQuestionPosition: (yPosition: string) => void;
+  setQuestionPosition: (questionCode: string) => (yPosition: string)  => void;
   scrollToQuestion: (scrollViewRef: any, questionCode: string) => void;
 }
 

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -28,7 +28,7 @@ import { ErrorScreen } from '../../ErrorScreen';
 import { TranslatedText } from '../../Translations/TranslatedText';
 
 interface UseScrollToFirstError {
-  setQuestionPosition: (questionCode: string) => (yPosition: string)  => void;
+  setQuestionPosition: (questionCode: string) => (yPosition: number)  => void;
   scrollToQuestion: (scrollViewRef: any, questionCode: string) => void;
 }
 

--- a/packages/mobile/App/ui/helpers/constants.ts
+++ b/packages/mobile/App/ui/helpers/constants.ts
@@ -243,7 +243,3 @@ export const NOTE_TYPES = {
   CLINICAL_MOBILE: 'clinicalMobile',
   HANDOVER: 'handover',
 };
-
-export const FORM_STATUSES = {
-  SUBMIT_SCREEN_ATTEMPTED: 'SUBMIT_SCREEN_ATTEMPTED',
-};


### PR DESCRIPTION
### Changes

A big refactor missed these changes and I also fixed a typescript linting issue that was on one file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches form validation to shared `SUBMIT_ATTEMPTED_STATUS` and refines survey scroll-to-first-error with typed position mapping.
> 
> - **Mobile forms**:
>   - Use `SUBMIT_ATTEMPTED_STATUS` from `@tamanu/constants/forms` in `ui/components/Forms/FormField.tsx` and `ui/components/Forms/SurveyForm/FormFields.tsx` to control error display after submit attempts.
>   - Remove local `FORM_STATUSES` from `ui/helpers/constants.ts`.
> - **Survey form UX**:
>   - Refactor `useScrollToFirstError` to map y-positions by `questionCode` and type positions as `number`; update `setPosition` usage accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcb9d609354e4f569db2963a03a5d3eb65bc343d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->