### PR TITLE
fix(encounters): NASS-1814: Small tweaks 

### DIFF
--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -66,13 +66,6 @@ const BasicMoveFields = () => {
         <Field
           name="locationId"
           component={LocalisedLocationField}
-          label={
-            <TranslatedText
-              stringId="patient.encounter.movePatient.location.label"
-              fallback="New location"
-              data-testid="translatedtext-35a6"
-            />
-          }
           required
           data-testid="field-tykg"
         />
@@ -209,17 +202,21 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
         initialValues={{
           examinerId: encounter.examinerId,
           departmentId: encounter.departmentId,
-          ...(enablePatientMoveActions && {
-            plannedLocationId: encounter.plannedLocationId,
-            action: PATIENT_MOVE_ACTIONS.PLAN,
-          }),
+          ...(enablePatientMoveActions
+            ? {
+                plannedLocationId: encounter.plannedLocationId,
+                action: PATIENT_MOVE_ACTIONS.PLAN,
+              }
+            : {
+                locationId: encounter.locationId,
+              }),
         }}
         formType={FORM_TYPES.EDIT_FORM}
         onSubmit={async ({ departmentId, examinerId, locationId, plannedLocationId, action }) => {
           const locationData =
             action === PATIENT_MOVE_ACTIONS.PLAN
               ? { plannedLocationId: plannedLocationId || null }
-              : { locationId: plannedLocationId || locationId || null };
+              : { locationId: plannedLocationId || locationId };
           await writeAndViewEncounter(encounter.id, {
             submittedTime: getCurrentDateTimeString(),
             departmentId,


### PR DESCRIPTION
### Changes

A couple small fixes from dev testing. Main change is location is autofilled and also cant be cleared

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the explicit label from the patient move location field in `MoveModal`.
> 
> - **UI**
>   - In `packages/web/app/views/patients/components/MoveModal.jsx`:
>     - `BasicMoveFields`: Removes `label` prop (previously a `TranslatedText` "New location") from the `Field` using `LocalisedLocationField` for `locationId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43f0630896f09b694fb0fd99ecdad31b8d5e2f35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->