### PR TITLE
feat(cd): Automate reporting config in k8s

### DIFF
--- a/packages/shared/docker/postgres/init.sh
+++ b/packages/shared/docker/postgres/init.sh
@@ -6,8 +6,8 @@ psql -v ON_ERROR_STOP=1 <<-EOF
     CREATE DATABASE "tamanu-facility" WITH OWNER "tamanu-facility";
     CREATE ROLE "tamanu-central" WITH LOGIN ENCRYPTED PASSWORD 'tamanu-central';
     CREATE DATABASE "tamanu-central" WITH OWNER "tamanu-central";
-    CREATE ROLE tamanu_reporting_user WITH LOGIN PASSWORD 'test';
-    CREATE ROLE tamanu_raw_user WITH LOGIN PASSWORD 'test';
+    CREATE ROLE "tamanu_reporting_user" WITH LOGIN PASSWORD 'test';
+    CREATE ROLE "tamanu_raw_user" WITH LOGIN PASSWORD 'test';
     \c app
     CREATE SCHEMA IF NOT EXISTS reporting;
     ALTER ROLE "tamanu_reporting_user" SET search_path TO reporting;

--- a/packages/shared/docker/postgres/init.sh
+++ b/packages/shared/docker/postgres/init.sh
@@ -6,4 +6,13 @@ psql -v ON_ERROR_STOP=1 <<-EOF
     CREATE DATABASE "tamanu-facility" WITH OWNER "tamanu-facility";
     CREATE ROLE "tamanu-central" WITH LOGIN ENCRYPTED PASSWORD 'tamanu-central';
     CREATE DATABASE "tamanu-central" WITH OWNER "tamanu-central";
+    CREATE ROLE tamanu_reporting_user WITH LOGIN PASSWORD 'test';
+    CREATE ROLE tamanu_raw_user WITH LOGIN PASSWORD 'test';
+    \c app
+    CREATE SCHEMA IF NOT EXISTS reporting;
+    ALTER ROLE "tamanu_reporting_user" SET search_path TO reporting;
+    GRANT USAGE ON SCHEMA reporting TO "tamanu_reporting_user";
+    GRANT USAGE ON SCHEMA public TO "tamanu_raw_user";
+    GRANT SELECT ON ALL TABLES IN SCHEMA reporting TO "tamanu_reporting_user";
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO "tamanu_raw_user";
 EOF


### PR DESCRIPTION
### Changes

Alright, this will be mostly experimental. I've already changed the default deployment configs to have the username and the password. Now with the rest of the queries.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->
