### PR TITLE
fix: release-2.44: EPI-1276: Fix linked encounter not loaded properly from booking view modal

### DIFF
--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -3,6 +3,8 @@ import Overnight from '@mui/icons-material/Brightness2';
 import { styled } from '@mui/material/styles';
 import React from 'react';
 import { Link, generatePath } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 
 import { Colors } from '../../../constants';
 import { PATIENT_PATHS, PATIENT_CATEGORIES } from '../../../constants/patientPaths';
@@ -12,6 +14,8 @@ import { ENCOUNTER_TYPE_LABELS } from '@tamanu/constants';
 import { DetailsDisplay } from './SharedComponents';
 import { LimitedLinesCell } from '../../FormattedTableCell';
 import { useTranslation } from '../../../contexts/Translation';
+import { reloadPatient } from '../../../store';
+import { useEncounter } from '../../../contexts/Encounter';
 
 const AppointmentDetailsContainer = styled('div')`
   border-block: max(0.0625rem, 1px) solid ${Colors.outline};
@@ -51,6 +55,8 @@ const ClinicianContainer = styled('div')`
 
 const LinkedEncounter = ({ encounter }) => {
   const { getTranslation, getEnumTranslation, getReferenceDataTranslation } = useTranslation();
+  const dispatch = useDispatch();
+  const { loadEncounter } = useEncounter();
 
   const encounterPath = generatePath(PATIENT_PATHS.ENCOUNTER, {
     category: PATIENT_CATEGORIES.ALL,
@@ -70,7 +76,14 @@ const LinkedEncounter = ({ encounter }) => {
   })}`;
 
   return (
-    <EncounterLink to={encounterPath}>
+    <EncounterLink
+      onClick={async e => {
+        e.preventDefault();
+        await dispatch(reloadPatient(encounter.patientId));
+        await loadEncounter(encounter.id);
+        dispatch(push(encounterPath));
+      }}
+    >
       <LimitedLinesCell
         value={encounterLabel}
         maxLines={1}

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -75,17 +75,19 @@ const LinkedEncounter = ({ encounter }) => {
     fallback: encounter?.location?.facility.name,
   })}`;
 
+  const handleClick = async (e) => {
+    e.preventDefault();
+    await Promise.all([
+      dispatch(reloadPatient(encounter.patientId)),
+      loadEncounter(encounter.id),
+    ]);
+    dispatch(push(encounterPath));
+  };
+
   return (
     <EncounterLink
       to={encounterPath}
-      onClick={async e => {
-        e.preventDefault();
-        await Promise.all([
-          dispatch(reloadPatient(encounter.patientId)),
-          loadEncounter(encounter.id),
-        ]);
-        dispatch(push(encounterPath));
-      }}
+      onClick={handleClick}
     >
       <LimitedLinesCell
         value={encounterLabel}

--- a/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
+++ b/packages/web/app/components/Appointments/AppointmentDetailPopper/AppointmentDetailsDisplay.jsx
@@ -77,10 +77,13 @@ const LinkedEncounter = ({ encounter }) => {
 
   return (
     <EncounterLink
+      to={encounterPath}
       onClick={async e => {
         e.preventDefault();
-        await dispatch(reloadPatient(encounter.patientId));
-        await loadEncounter(encounter.id);
+        await Promise.all([
+          dispatch(reloadPatient(encounter.patientId)),
+          loadEncounter(encounter.id),
+        ]);
         dispatch(push(encounterPath));
       }}
     >


### PR DESCRIPTION
### Changes

- Added functionality to reload patient data and load encounter details when clicking on an encounter link.
- Integrated Redux for state management and navigation using connected-react-router.
- Improved user experience by ensuring the latest patient and encounter information is displayed.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
