### PR TITLE
fix(encounters): NASS-1814: Small test fixes

### DIFF
--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -30,9 +30,7 @@ export const LocationInput = React.memo(
     required,
     className,
     value,
-    groupValue,
     onChange,
-    onGroupChange = () => {},
     size = 'medium',
     form = {},
     enableLocationStatus = true,
@@ -47,7 +45,7 @@ export const LocationInput = React.memo(
     const { facilityId: currentFacilityId } = useAuth();
     const facilityId = (facilityIdOverride ?? currentFacilityId) || '';
 
-    const [groupId, setGroupId] = useState(groupValue);
+    const [groupId, setGroupId] = useState('');
     const [locationId, setLocationId] = useState(value);
     const suggester = useSuggester('location', {
       formatter: ({ name, id, locationGroup, availability }) => {
@@ -78,16 +76,9 @@ export const LocationInput = React.memo(
     }, [initialValues, name]);
 
     useEffect(() => {
-      if (value) {
-        setLocationId(value);
-      }
+      setLocationId(value ?? '');
+      if (!value) setGroupId('');
     }, [value]);
-
-    useEffect(() => {
-      if (groupValue) {
-        setGroupId(groupValue);
-      }
-    }, [groupValue]);
 
     // when the location is selected, set the group value automatically if it's not set yet
     useEffect(() => {
@@ -96,29 +87,25 @@ export const LocationInput = React.memo(
       if (isNotSameGroup) {
         // clear the location if the location group is changed
         setLocationId('');
-        onChange({ target: { value: '', name, groupValue: location.locationGroup.id } });
+        onChange({ target: { value: '', name } });
       }
 
       // Initialise the location group state
       // if the form is being opened in edit mode (i.e. there are existing values)
       if (value && !groupId && location?.locationGroup?.id) {
-        onGroupChange(location.locationGroup.id);
         setGroupId(location.locationGroup.id);
       }
-    }, [onChange, value, name, groupId, location?.id, location?.locationGroup, onGroupChange]);
+    }, [onChange, value, name, groupId, location?.id, location?.locationGroup]);
 
     const handleChangeCategory = event => {
       setGroupId(event.target.value);
-      onGroupChange(event.target.value);
-      if (locationId) {
-        setLocationId('');
-        onChange({ target: { value: '', name, groupValue: event.target.value } });
-      }
+      setLocationId('');
+      onChange({ target: { value: '', name } });
     };
 
     const handleChange = async event => {
       setLocationId(event.target.value);
-      onChange({ target: { value: event.target.value, name, groupValue: groupId } });
+      onChange({ target: { value: event.target.value, name } });
     };
 
     // Disable the location and location group fields if:

--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -30,7 +30,9 @@ export const LocationInput = React.memo(
     required,
     className,
     value,
+    groupValue,
     onChange,
+    onGroupChange = () => {},
     size = 'medium',
     form = {},
     enableLocationStatus = true,
@@ -45,7 +47,7 @@ export const LocationInput = React.memo(
     const { facilityId: currentFacilityId } = useAuth();
     const facilityId = (facilityIdOverride ?? currentFacilityId) || '';
 
-    const [groupId, setGroupId] = useState('');
+    const [groupId, setGroupId] = useState(groupValue);
     const [locationId, setLocationId] = useState(value);
     const suggester = useSuggester('location', {
       formatter: ({ name, id, locationGroup, availability }) => {
@@ -76,9 +78,16 @@ export const LocationInput = React.memo(
     }, [initialValues, name]);
 
     useEffect(() => {
-      setLocationId(value ?? '');
-      if (!value) setGroupId('');
+      if (value) {
+        setLocationId(value);
+      }
     }, [value]);
+
+    useEffect(() => {
+      if (groupValue) {
+        setGroupId(groupValue);
+      }
+    }, [groupValue]);
 
     // when the location is selected, set the group value automatically if it's not set yet
     useEffect(() => {
@@ -87,25 +96,29 @@ export const LocationInput = React.memo(
       if (isNotSameGroup) {
         // clear the location if the location group is changed
         setLocationId('');
-        onChange({ target: { value: '', name } });
+        onChange({ target: { value: '', name, groupValue: location.locationGroup.id } });
       }
 
       // Initialise the location group state
       // if the form is being opened in edit mode (i.e. there are existing values)
       if (value && !groupId && location?.locationGroup?.id) {
+        onGroupChange(location.locationGroup.id);
         setGroupId(location.locationGroup.id);
       }
-    }, [onChange, value, name, groupId, location?.id, location?.locationGroup]);
+    }, [onChange, value, name, groupId, location?.id, location?.locationGroup, onGroupChange]);
 
     const handleChangeCategory = event => {
       setGroupId(event.target.value);
-      setLocationId('');
-      onChange({ target: { value: '', name } });
+      onGroupChange(event.target.value);
+      if (locationId) {
+        setLocationId('');
+        onChange({ target: { value: '', name, groupValue: event.target.value } });
+      }
     };
 
     const handleChange = async event => {
       setLocationId(event.target.value);
-      onChange({ target: { value: event.target.value, name } });
+      onChange({ target: { value: event.target.value, name, groupValue: groupId } });
     };
 
     // Disable the location and location group fields if:

--- a/packages/web/app/components/ThreeDotMenu.jsx
+++ b/packages/web/app/components/ThreeDotMenu.jsx
@@ -5,7 +5,6 @@ import { MoreVert } from '@material-ui/icons';
 import { Colors } from '../constants';
 
 const ThreeDotMenuItem = styled(MenuItem)`
-  width: 124px; // Todo: needs to be dynamic
   font-size: 11px;
   line-height: 15px;
   border-radius: 4px;

--- a/packages/web/app/components/ThreeDotMenu.jsx
+++ b/packages/web/app/components/ThreeDotMenu.jsx
@@ -5,7 +5,7 @@ import { MoreVert } from '@material-ui/icons';
 import { Colors } from '../constants';
 
 const ThreeDotMenuItem = styled(MenuItem)`
-  width: 124px;
+  width: 124px; // Todo: needs to be dynamic
   font-size: 11px;
   line-height: 15px;
   border-radius: 4px;

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -189,8 +189,6 @@ const getFormProps = ({ encounter, enablePatientMoveActions }) => {
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
   } else {
     validationObject.locationId = yup.string().nullable();
-
-    // initialValues.locationId = encounter.locationId;
   }
 
   return { initialValues, validationSchema: yup.object().shape(validationObject) };

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -212,8 +212,9 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
     if (action === PATIENT_MOVE_ACTIONS.PLAN) {
       locationData.plannedLocationId = plannedLocationId || null; // null clears the planned move
     } else {
-      if (locationId || plannedLocationId) {
-        locationData.locationId = plannedLocationId || locationId;
+      const finalisedLocation = plannedLocationId || locationId;
+      if (finalisedLocation) {
+        locationData.locationId = finalisedLocation;
       }
     }
 

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -212,7 +212,9 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
     if (action === PATIENT_MOVE_ACTIONS.PLAN) {
       locationData.plannedLocationId = plannedLocationId || null;
     } else {
-      if (locationId) locationData.locationId = locationId;
+      if (locationId || plannedLocationId) {
+        locationData.locationId = plannedLocationId || locationId;
+      }
     }
 
     await writeAndViewEncounter(encounter.id, {

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -210,7 +210,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
 
     const locationData = {};
     if (action === PATIENT_MOVE_ACTIONS.PLAN) {
-      locationData.plannedLocationId = plannedLocationId || null;
+      locationData.plannedLocationId = plannedLocationId || null; // null clears the planned move
     } else {
       if (locationId || plannedLocationId) {
         locationData.locationId = plannedLocationId || locationId;

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -63,12 +63,7 @@ const BasicMoveFields = () => {
         />
       </SectionDescription>
       <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
-        <Field
-          name="locationId"
-          component={LocalisedLocationField}
-          required
-          data-testid="field-tykg"
-        />
+        <Field name="locationId" component={LocalisedLocationField} data-testid="field-tykg" />
       </StyledFormGrid>
     </>
   );
@@ -111,7 +106,6 @@ const PlannedMoveFields = () => {
         <Field
           name="plannedLocationId"
           component={LocalisedLocationField}
-          required
           data-testid="field-n625"
         />
         <LocationAvailabilityWarningMessage
@@ -191,12 +185,12 @@ const getFormProps = ({ encounter, enablePatientMoveActions }) => {
       .oneOf([PATIENT_MOVE_ACTIONS.PLAN, PATIENT_MOVE_ACTIONS.FINALISE])
       .nullable();
 
-    initialValues.plannedLocationId = encounter.plannedLocationId;
+    // initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
   } else {
     validationObject.locationId = yup.string().nullable();
 
-    initialValues.locationId = encounter.locationId;
+    // initialValues.locationId = encounter.locationId;
   }
 
   return { initialValues, validationSchema: yup.object().shape(validationObject) };
@@ -216,10 +210,22 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
   const onSubmit = async values => {
     const { locationId, plannedLocationId, action, ...rest } = values;
 
-    const locationData =
-      enablePatientMoveActions && action === PATIENT_MOVE_ACTIONS.PLAN
-        ? { plannedLocationId: plannedLocationId || null } // Null clears the planned move
-        : { locationId: plannedLocationId || locationId };
+    const locationData = {};
+
+    // const locationData =
+    //   enablePatientMoveActions && action === PATIENT_MOVE_ACTIONS.PLAN
+    //     ? { plannedLocationId: plannedLocationId || null } // Null clears the planned move
+    //     : { locationId: plannedLocationId || locationId };
+
+    if (enablePatientMoveActions) {
+      if (action === PATIENT_MOVE_ACTIONS.PLAN) {
+        locationData.plannedLocationId = plannedLocationId || null;
+      }
+    } else {
+      if (locationId) {
+        locationData.locationId = locationId;
+      }
+    }
 
     await writeAndViewEncounter(encounter.id, {
       submittedTime: getCurrentDateTimeString(),

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -185,7 +185,7 @@ const getFormProps = ({ encounter, enablePatientMoveActions }) => {
       .oneOf([PATIENT_MOVE_ACTIONS.PLAN, PATIENT_MOVE_ACTIONS.FINALISE])
       .nullable();
 
-    // initialValues.plannedLocationId = encounter.plannedLocationId;
+    initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
   } else {
     validationObject.locationId = yup.string().nullable();
@@ -211,20 +211,10 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
     const { locationId, plannedLocationId, action, ...rest } = values;
 
     const locationData = {};
-
-    // const locationData =
-    //   enablePatientMoveActions && action === PATIENT_MOVE_ACTIONS.PLAN
-    //     ? { plannedLocationId: plannedLocationId || null } // Null clears the planned move
-    //     : { locationId: plannedLocationId || locationId };
-
-    if (enablePatientMoveActions) {
-      if (action === PATIENT_MOVE_ACTIONS.PLAN) {
-        locationData.plannedLocationId = plannedLocationId || null;
-      }
+    if (action === PATIENT_MOVE_ACTIONS.PLAN) {
+      locationData.plannedLocationId = plannedLocationId || null;
     } else {
-      if (locationId) {
-        locationData.locationId = locationId;
-      }
+      if (locationId) locationData.locationId = locationId;
     }
 
     await writeAndViewEncounter(encounter.id, {

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -66,13 +66,6 @@ const BasicMoveFields = () => {
         <Field
           name="locationId"
           component={LocalisedLocationField}
-          label={
-            <TranslatedText
-              stringId="patient.encounter.movePatient.location.label"
-              fallback="New location"
-              data-testid="translatedtext-35a6"
-            />
-          }
           required
           data-testid="field-tykg"
         />

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -260,7 +260,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter }) => {
             <SectionDescription>
               <TranslatedText
                 stringId="patient.encounter.modal.movePatient.section.move.description"
-                fallback="Please select the clinician and department for the patient."
+                fallback="Update patient clinician and department details below."
               />
             </SectionDescription>
             <StyledFormGrid columns={2} data-testid="formgrid-wyqp">


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors patient move submission logic, relaxes location field requirements, updates copy, and removes fixed width from three‑dot menu items.
> 
> - **Patient Move Modal (`packages/web/app/views/patients/components/MoveModal.jsx`)**
>   - **Submission logic**: Build `locationData` based on `action`; set `plannedLocationId` when planning, otherwise set `locationId` only if a finalised location exists.
>   - **Form fields**: Remove label/required on `Field name="locationId"`; `plannedLocationId` no longer required; stop initializing `initialValues.locationId`.
>   - **Copy**: Update section description fallback to “Update patient clinician and department details below.”
> - **UI**
>   - **Three-dot menu (`packages/web/app/components/ThreeDotMenu.jsx`)**: Remove fixed width from `ThreeDotMenuItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96baddd5c5b1abd92b75515a254cef6c77017b93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->