### PR TITLE
List tamanu v2.44 configurations and settings

### DIFF
--- a/docs/releases/tamanu-v2-44-settings.json
+++ b/docs/releases/tamanu-v2-44-settings.json
@@ -1,0 +1,8468 @@
+[
+  {
+    "scope": "global",
+    "path": "audit.accesses.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Audit accesses",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "audit",
+      "accesses"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "audit.changes.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Audit changes",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "audit",
+      "changes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "auth.restrictUsersToFacilities",
+    "key": "restrictUsersToFacilities",
+    "name": "restrictUsersToFacilities",
+    "description": "Authentication options",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "auth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "auth.restrictUsersToSync",
+    "key": "restrictUsersToSync",
+    "name": "restrictUsersToSync",
+    "description": "Authentication options",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "auth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "ageDisplayFormat",
+    "key": "ageDisplayFormat",
+    "name": "ageDisplayFormat",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      {
+        "as": "days",
+        "range": {
+          "min": {
+            "duration": {
+              "days": 0
+            },
+            "exclusive": false
+          },
+          "max": {
+            "duration": {
+              "days": 8
+            },
+            "exclusive": true
+          }
+        }
+      },
+      {
+        "as": "weeks",
+        "range": {
+          "min": {
+            "duration": {
+              "days": 8
+            }
+          },
+          "max": {
+            "duration": {
+              "months": 1
+            },
+            "exclusive": true
+          }
+        }
+      },
+      {
+        "as": "months",
+        "range": {
+          "min": {
+            "duration": {
+              "months": 1
+            }
+          },
+          "max": {
+            "duration": {
+              "years": 2
+            },
+            "exclusive": true
+          }
+        }
+      },
+      {
+        "as": "years",
+        "range": {
+          "min": {
+            "duration": {
+              "years": 2
+            }
+          }
+        }
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "appointments.maxRepeatingAppointmentsPerGeneration",
+    "key": "maxRepeatingAppointmentsPerGeneration",
+    "name": "maxRepeatingAppointmentsPerGeneration",
+    "description": "Appointment settings",
+    "defaultValue": 50,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "appointments"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "locationAssignments.assignmentMaxFutureMonths",
+    "key": "assignmentMaxFutureMonths",
+    "name": "assignmentMaxFutureMonths",
+    "description": "Location assignment settings",
+    "defaultValue": 24,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "locationAssignments"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "features.mandateSpecimenType",
+    "key": "mandateSpecimenType",
+    "name": "mandateSpecimenType",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableAppointmentsExtentions",
+    "key": "enableAppointmentsExtentions",
+    "name": "enableAppointmentsExtentions",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableVaccineConsent",
+    "key": "enableVaccineConsent",
+    "name": "enableVaccineConsent",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.filterDischargeDispositions",
+    "key": "filterDischargeDispositions",
+    "name": "filterDischargeDispositions",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.editPatientDetailsOnMobile",
+    "key": "editPatientDetailsOnMobile",
+    "name": "editPatientDetailsOnMobile",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.quickPatientGenerator",
+    "key": "quickPatientGenerator",
+    "name": "quickPatientGenerator",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableInvoicing",
+    "key": "enableInvoicing",
+    "name": "enableInvoicing",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableTasking",
+    "key": "enableTasking",
+    "name": "enableTasking",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.registerNewPatient",
+    "key": "registerNewPatient",
+    "name": "registerNewPatient",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.hideOtherSex",
+    "key": "hideOtherSex",
+    "name": "hideOtherSex",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.hideUpcomingVaccines",
+    "key": "hideUpcomingVaccines",
+    "name": "hideUpcomingVaccines",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enablePatientDeaths",
+    "key": "enablePatientDeaths",
+    "name": "enablePatientDeaths",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableNoteBackdating",
+    "key": "enableNoteBackdating",
+    "name": "enableNoteBackdating",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableCovidClearanceCertificate",
+    "key": "enableCovidClearanceCertificate",
+    "name": "enableCovidClearanceCertificate",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.editPatientDisplayId",
+    "key": "editPatientDisplayId",
+    "name": "editPatientDisplayId",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enablePatientInsurer",
+    "key": "enablePatientInsurer",
+    "name": "enablePatientInsurer",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.patientPlannedMove",
+    "key": "patientPlannedMove",
+    "name": "patientPlannedMove",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.patientPortal",
+    "key": "patientPortal",
+    "name": "patientPortal",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.onlyAllowLabPanels",
+    "key": "onlyAllowLabPanels",
+    "name": "onlyAllowLabPanels",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.displayProcedureCodesInDischargeSummary",
+    "key": "displayProcedureCodesInDischargeSummary",
+    "name": "displayProcedureCodesInDischargeSummary",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.displayIcd10CodesInDischargeSummary",
+    "key": "displayIcd10CodesInDischargeSummary",
+    "name": "displayIcd10CodesInDischargeSummary",
+    "description": "Toggle features on/off",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.mandatoryVitalEditReason",
+    "key": "mandatoryVitalEditReason",
+    "name": "mandatoryVitalEditReason",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableVitalEdit",
+    "key": "enableVitalEdit",
+    "name": "enableVitalEdit",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.reminderContactModule.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "reminderContactModule"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.mandatoryChartingEditReason",
+    "key": "mandatoryChartingEditReason",
+    "name": "mandatoryChartingEditReason",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.enableChartingEdit",
+    "key": "enableChartingEdit",
+    "name": "enableChartingEdit",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.desktopCharting.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Enable desktop charting module",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "desktopCharting"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.idleTimeout.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Automatically logout idle users / inactive sessions after a certain time",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "idleTimeout"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.idleTimeout.timeoutDuration",
+    "key": "timeoutDuration",
+    "name": "timeoutDuration",
+    "description": "Automatically logout idle users / inactive sessions after a certain time",
+    "defaultValue": 600,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "idleTimeout"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "features.idleTimeout.warningPromptDuration",
+    "key": "warningPromptDuration",
+    "name": "warningPromptDuration",
+    "description": "Automatically logout idle users / inactive sessions after a certain time",
+    "defaultValue": 30,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "idleTimeout"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "features.idleTimeout.refreshInterval",
+    "key": "refreshInterval",
+    "name": "refreshInterval",
+    "description": "Automatically logout idle users / inactive sessions after a certain time",
+    "defaultValue": 150,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "idleTimeout"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "features.tableAutoRefresh.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Enable the auto refresh feature on tables where it is implemented: Currently supports imaging and lab listing views",
+    "defaultValue": true,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "tableAutoRefresh"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.tableAutoRefresh.interval",
+    "key": "interval",
+    "name": "interval",
+    "description": "Enable the auto refresh feature on tables where it is implemented: Currently supports imaging and lab listing views",
+    "defaultValue": 300,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "tableAutoRefresh"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "features.disableInputPasting",
+    "key": "disableInputPasting",
+    "name": "disableInputPasting",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.discharge.dischargeNoteMandatory",
+    "key": "dischargeNoteMandatory",
+    "name": "dischargeNoteMandatory",
+    "description": "Encounter discharge configuration",
+    "defaultValue": false,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "discharge"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.discharge.dischargeDiagnosisMandatory",
+    "key": "dischargeDiagnosisMandatory",
+    "name": "dischargeDiagnosisMandatory",
+    "description": "Encounter discharge configuration",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "discharge"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.patientDetailsLocationHierarchy",
+    "key": "patientDetailsLocationHierarchy",
+    "name": "patientDetailsLocationHierarchy",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.pharmacyOrder.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Pharmacy order settings",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "pharmacyOrder"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.pharmacyOrder.medicationAlreadyOrderedConfirmationTimeout",
+    "key": "medicationAlreadyOrderedConfirmationTimeout",
+    "name": "medicationAlreadyOrderedConfirmationTimeout",
+    "description": "Pharmacy order settings",
+    "defaultValue": 24,
+    "unit": "hours",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "pharmacyOrder"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "features.useGlobalPdfFont",
+    "key": "useGlobalPdfFont",
+    "name": "useGlobalPdfFont",
+    "description": "Toggle features on/off",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "features.deviceRegistrationQuota.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Device registration quota settings",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "features",
+      "deviceRegistrationQuota"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "customisations.componentVersions",
+    "key": "componentVersions",
+    "name": "componentVersions",
+    "description": "Customisation of the application",
+    "defaultValue": {},
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Customisations"
+    ],
+    "type": "object"
+  },
+  {
+    "scope": "global",
+    "path": "fhir.worker.heartbeat",
+    "key": "heartbeat",
+    "name": "Heartbeat interval",
+    "description": "FHIR worker settings",
+    "defaultValue": "1 minute",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "FHIR",
+      "FHIR worker"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fhir.worker.assumeDroppedAfter",
+    "key": "assumeDroppedAfter",
+    "name": "assumeDroppedAfter",
+    "description": "FHIR worker settings",
+    "defaultValue": "10 minutes",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "FHIR",
+      "FHIR worker"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.emergencyContactName.required",
+    "key": "required",
+    "name": "required",
+    "description": "Patients emergency contact name",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Emergency contact name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.emergencyContactName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "Patients emergency contact name",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Emergency contact name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.emergencyContactName.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "Patients emergency contact name",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Emergency contact name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.emergencyContactNumber.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Emergency contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.emergencyContactNumber.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Emergency contact number"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.emergencyContactNumber.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Emergency contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.displayId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Display ID"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.displayId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Display ID"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.displayId.pattern",
+    "key": "pattern",
+    "name": "pattern",
+    "description": "_",
+    "defaultValue": "[\\s\\S]*",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Display ID"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.firstName.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "First name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.firstName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "First name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.firstName.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "First name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.middleName.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Middle name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.middleName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Middle name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.middleName.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Middle name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.middleName.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Middle name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.lastName.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Last name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.lastName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Last name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.lastName.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Last name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.culturalName.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Cultural name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.culturalName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Cultural name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.culturalName.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Cultural name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.culturalName.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Cultural name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.sex.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Sex"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.sex.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Sex"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.sex.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Sex"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.sex.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Sex"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.email.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Email"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.email.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Email"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.email.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Email"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.email.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Email"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirth.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirth.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirth.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.bloodType.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Blood type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.bloodType.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Blood type"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.bloodType.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Blood type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.bloodType.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Blood type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.title.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Title"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.title.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Title"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.title.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Title"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.title.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Title"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.placeOfBirth.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Place of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.placeOfBirth.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Place of birth"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.placeOfBirth.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Place of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.placeOfBirth.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Place of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryOfBirthId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryOfBirthId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country of birth"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryOfBirthId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryOfBirthId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.maritalStatus.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Marital status"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.maritalStatus.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Marital status"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.maritalStatus.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Marital status"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.maritalStatus.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Marital status"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.primaryContactNumber.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Primary contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.primaryContactNumber.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Primary contact number"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.primaryContactNumber.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Primary contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.primaryContactNumber.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Primary contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.secondaryContactNumber.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Secondary contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.secondaryContactNumber.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Secondary contact number"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.secondaryContactNumber.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Secondary contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.secondaryContactNumber.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Secondary contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.socialMedia.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Social media"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.socialMedia.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Social media"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.socialMedia.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Social media"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.socialMedia.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Social media"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.settlementId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Settlement"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.settlementId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Settlement"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.settlementId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Settlement"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.settlementId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Settlement"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.streetVillage.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Street village"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.streetVillage.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Street village"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.streetVillage.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Street village"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.streetVillage.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Street village"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.cityTown.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "City town"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.cityTown.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "City town"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.cityTown.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "City town"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.cityTown.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "City town"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.subdivisionId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Subdivision"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.subdivisionId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Subdivision"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.subdivisionId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Subdivision"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.subdivisionId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Subdivision"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.divisionId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Division"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.divisionId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Division"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.divisionId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Division"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.divisionId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Division"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.countryId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Country"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.medicalAreaId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Medical area"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.medicalAreaId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Medical area"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.medicalAreaId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Medical area"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.medicalAreaId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Medical area"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nursingZoneId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nursing zone"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nursingZoneId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nursing zone"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nursingZoneId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nursing zone"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nursingZoneId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nursing zone"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nationalityId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nationality"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nationalityId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nationality"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nationalityId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nationality"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nationalityId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Nationality"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.ethnicityId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Ethnicity"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.ethnicityId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Ethnicity"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.ethnicityId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Ethnicity"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.ethnicityId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Ethnicity"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.occupationId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Occupation"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.occupationId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Occupation"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.occupationId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Occupation"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.occupationId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Occupation"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.educationalLevel.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Educational level"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.educationalLevel.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Educational level"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.educationalLevel.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Educational level"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.educationalLevel.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Educational level"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageName.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageName.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.villageId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Village"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthCertificate.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth certificate"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthCertificate.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth certificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthCertificate.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth certificate"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthCertificate.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth certificate"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerPolicyNumber.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer policy number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerPolicyNumber.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer policy number"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerPolicyNumber.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer policy number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.insurerPolicyNumber.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Insurer policy number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.drivingLicense.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Driving license"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.drivingLicense.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Driving license"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.drivingLicense.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Driving license"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.drivingLicense.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Driving license"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.passport.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Passport"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.passport.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Passport"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.passport.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Passport"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.passport.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Passport"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.religionId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Religion"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.religionId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Religion"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.religionId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Religion"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.religionId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Religion"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.patientBillingTypeId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Patient billing type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.patientBillingTypeId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Patient billing type"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.patientBillingTypeId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Patient billing type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.patientBillingTypeId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Patient billing type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.motherId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Mother"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.motherId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Mother"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.motherId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Mother"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.motherId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Mother"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.fatherId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Father"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.fatherId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Father"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.fatherId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Father"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.fatherId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Father"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthWeight.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth weight"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthWeight.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth weight"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthWeight.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth weight"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthWeight.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth weight"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthLength.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth length"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthLength.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth length"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthLength.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth length"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthLength.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth length"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthDeliveryType.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth delivery type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthDeliveryType.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth delivery type"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthDeliveryType.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth delivery type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthDeliveryType.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth delivery type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.gestationalAgeEstimate.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Gestational age estimate"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.gestationalAgeEstimate.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Gestational age estimate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.gestationalAgeEstimate.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Gestational age estimate"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.gestationalAgeEstimate.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Gestational age estimate"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreOneMinute.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after one minute"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreOneMinute.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after one minute"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreOneMinute.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after one minute"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreOneMinute.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after one minute"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreFiveMinutes.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after five minutes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreFiveMinutes.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after five minutes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreFiveMinutes.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after five minutes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreFiveMinutes.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after five minutes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreTenMinutes.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after ten minutes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreTenMinutes.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after ten minutes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreTenMinutes.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after ten minutes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.apgarScoreTenMinutes.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Apgar score after ten minutes"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.timeOfBirth.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Time of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.timeOfBirth.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Time of birth"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.timeOfBirth.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Time of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.timeOfBirth.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Time of birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.attendantAtBirth.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Attendant at birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.attendantAtBirth.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Attendant at birth"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.attendantAtBirth.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Attendant at birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.attendantAtBirth.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Attendant at birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nameOfAttendantAtBirth.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Name of attendant at birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nameOfAttendantAtBirth.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Name of attendant at birth"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nameOfAttendantAtBirth.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Name of attendant at birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.nameOfAttendantAtBirth.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Name of attendant at birth"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthType.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthType.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth type"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthType.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthType.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth type"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthFacilityId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth facility"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthFacilityId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth facility"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthFacilityId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth facility"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.birthFacilityId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Birth facility"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.healthCenterId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Health center"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.healthCenterId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Health center"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.healthCenterId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Health center"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.healthCenterId.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Health center"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBirthPlace.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered birth place"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBirthPlace.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered birth place"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBirthPlace.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered birth place"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBirthPlace.requiredPatientData",
+    "key": "requiredPatientData",
+    "name": "requiredPatientData",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered birth place"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.referralSourceId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Referral source"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.referralSourceId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Referral source"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.referralSourceId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Referral source"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.arrivalModeId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Arrival mode"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.arrivalModeId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Arrival mode"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.arrivalModeId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Arrival mode"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.prescriber.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Prescriber"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.prescriber.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Prescriber"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.prescriber.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Prescriber"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.prescriberId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Prescriber"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.prescriberId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Prescriber"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.prescriberId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Prescriber"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.facility.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Facility"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.facility.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Facility"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.facility.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Facility"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dischargeDisposition.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Discharge disposition"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dischargeDisposition.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Discharge disposition"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dischargeDisposition.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Discharge disposition"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.notGivenReasonId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Not given reason"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.notGivenReasonId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Not given reason"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.notGivenReasonId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Not given reason"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.markedForSync.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Marked for sync"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.markedForSync.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Marked for sync"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirthFrom.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth from"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirthFrom.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth from"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirthTo.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth to"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirthTo.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth to"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirthExact.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth exact"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfBirthExact.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of birth exact"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfDeath.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of death"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.dateOfDeath.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date of death"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.age.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Age"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.age.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Age"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.clinician.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Clinician"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.clinician.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Clinician"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.clinician.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Clinician"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.diagnosis.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Diagnosis"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.diagnosis.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Diagnosis"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.diagnosis.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Diagnosis"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.locationId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Location"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.locationId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Location"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.locationId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Location"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.locationGroupId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Location group (Area)"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.locationGroupId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Location group (Area)"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.locationGroupId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Location group (Area)"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.circumstanceId.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Circumstance"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.circumstanceId.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Circumstance"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.circumstanceId.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Circumstance"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.date.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.date.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Date"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBy.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered by"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBy.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered by"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.registeredBy.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Registered by"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.status.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Status"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.status.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Status"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.status.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Status"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.conditions.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Conditions"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.conditions.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Conditions"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.conditions.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Conditions"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.programRegistry.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Program registry"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.programRegistry.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Program registry"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.programRegistry.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Program registry"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.reminderContactName.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Reminder contact name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.reminderContactName.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Reminder contact name"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.reminderContactName.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Reminder contact name"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.reminderContactNumber.required",
+    "key": "required",
+    "name": "required",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Reminder contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fields.reminderContactNumber.defaultValue",
+    "key": "defaultValue",
+    "name": "defaultValue",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Reminder contact number"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "fields.reminderContactNumber.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Fields (Previously localised fields)",
+      "Reminder contact number"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "fileChooserMbSizeLimit",
+    "key": "fileChooserMbSizeLimit",
+    "name": "fileChooserMbSizeLimit",
+    "description": "Settings that apply to all servers",
+    "defaultValue": 10,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "integrations.imaging.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Imaging integration settings",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Integrations",
+      "imaging"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "integrations.imaging.provider",
+    "key": "provider",
+    "name": "Imaging provider",
+    "description": "Imaging integration settings",
+    "defaultValue": "test",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Integrations",
+      "imaging"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "invoice.slidingFeeScale",
+    "key": "slidingFeeScale",
+    "name": "Sliding fee scale",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      [
+        0,
+        5700,
+        10050,
+        12600,
+        14100,
+        17500
+      ],
+      [
+        0,
+        6600,
+        13500,
+        16300,
+        19000,
+        21800
+      ],
+      [
+        0,
+        7400,
+        17000,
+        20500,
+        23900,
+        27500
+      ],
+      [
+        0,
+        8500,
+        20600,
+        24800,
+        28900,
+        32500
+      ],
+      [
+        0,
+        9700,
+        24200,
+        29000,
+        33800,
+        38700
+      ],
+      [
+        0,
+        10700,
+        27700,
+        33200,
+        37500,
+        43000
+      ],
+      [
+        0,
+        11500,
+        31200,
+        37400,
+        43700,
+        46000
+      ],
+      [
+        0,
+        12600,
+        34700,
+        41600,
+        48600,
+        55600
+      ],
+      [
+        0,
+        14800,
+        38300,
+        45900,
+        53600,
+        65000
+      ],
+      [
+        0,
+        16600,
+        41800,
+        50200,
+        58500,
+        70000
+      ],
+      [
+        0,
+        18900,
+        45300,
+        54400,
+        63400,
+        75000
+      ],
+      [
+        0,
+        23500,
+        48800,
+        58600,
+        68400,
+        85000
+      ]
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "invoice"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "imagingCancellationReasons",
+    "key": "imagingCancellationReasons",
+    "name": "imagingCancellationReasons",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      {
+        "value": "clinical",
+        "label": "Clinical reason",
+        "hidden": false
+      },
+      {
+        "value": "duplicate",
+        "label": "Duplicate",
+        "hidden": false
+      },
+      {
+        "value": "entered-in-error",
+        "label": "Entered in error",
+        "hidden": false
+      },
+      {
+        "value": "patient-discharged",
+        "label": "Patient discharged",
+        "hidden": false
+      },
+      {
+        "value": "patient-refused",
+        "label": "Patient refused",
+        "hidden": false
+      },
+      {
+        "value": "cancelled-externally",
+        "label": "Cancelled externally via API",
+        "hidden": true
+      },
+      {
+        "value": "other",
+        "label": "Other",
+        "hidden": false
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "imagingPriorities",
+    "key": "imagingPriorities",
+    "name": "Imaging priorities",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      {
+        "value": "routine",
+        "label": "Routine"
+      },
+      {
+        "value": "urgent",
+        "label": "Urgent"
+      },
+      {
+        "value": "asap",
+        "label": "ASAP"
+      },
+      {
+        "value": "stat",
+        "label": "STAT"
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "labsCancellationReasons",
+    "key": "labsCancellationReasons",
+    "name": "labsCancellationReasons",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      {
+        "value": "clinical",
+        "label": "Clinical reason"
+      },
+      {
+        "value": "duplicate",
+        "label": "Duplicate"
+      },
+      {
+        "value": "entered-in-error",
+        "label": "Entered in error"
+      },
+      {
+        "value": "patient-discharged",
+        "label": "Patient discharged"
+      },
+      {
+        "value": "patient-refused",
+        "label": "Patient refused"
+      },
+      {
+        "value": "other",
+        "label": "Other"
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.labRequestPrintLabel.width",
+    "key": "width",
+    "name": "width",
+    "description": "Lab request label with basic info + barcode",
+    "defaultValue": 50.8,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "labRequestPrintLabel"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.pageWidth",
+    "key": "pageWidth",
+    "name": "pageWidth",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 210,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.pageHeight",
+    "key": "pageHeight",
+    "name": "pageHeight",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 297,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.pageMarginTop",
+    "key": "pageMarginTop",
+    "name": "pageMarginTop",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 15.09,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.pageMarginLeft",
+    "key": "pageMarginLeft",
+    "name": "pageMarginLeft",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 6.4,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.columnWidth",
+    "key": "columnWidth",
+    "name": "columnWidth",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 64,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.columnGap",
+    "key": "columnGap",
+    "name": "columnGap",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 3.01,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.rowHeight",
+    "key": "rowHeight",
+    "name": "rowHeight",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 26.7,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.stickerLabelPage.rowGap",
+    "key": "rowGap",
+    "name": "rowGap",
+    "description": "The multiple ID labels printout on the patient view",
+    "defaultValue": 0,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "stickerLabelPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.idCardPage.cardMarginTop",
+    "key": "cardMarginTop",
+    "name": "cardMarginTop",
+    "description": "The ID card found on the patient view",
+    "defaultValue": 1,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "idCardPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "printMeasures.idCardPage.cardMarginLeft",
+    "key": "cardMarginLeft",
+    "name": "cardMarginLeft",
+    "description": "The ID card found on the patient view",
+    "defaultValue": 5,
+    "unit": "mm",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "printMeasures",
+      "idCardPage"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.programRegistries.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "programRegistries"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.diagnosisAndTreatment.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "diagnosisAndTreatment"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.diagnosisAndTreatment.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "diagnosisAndTreatment"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.vitals.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "vitals"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.vitals.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "vitals"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.programs.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "programs"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.programs.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "programs"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.referral.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "referral"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.referral.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "referral"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.vaccine.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "vaccine"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.vaccine.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "vaccine"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.tests.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "tests"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.mobilePatientModules.tests.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "mobilePatientModules",
+      "tests"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.summary.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": -100,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "summary"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.details.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": -100,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "details"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.results.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "results"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.results.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "results"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.referrals.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "referrals"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.referrals.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "referrals"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.programs.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "programs"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.programs.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "programs"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.documents.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "documents"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.documents.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "documents"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.vaccines.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "vaccines"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.vaccines.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "vaccines"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.medication.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "medication"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.medication.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "medication"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.invoices.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "invoices"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientTabs.invoices.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientTabs",
+      "invoices"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.dashboard.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "dashboard"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.dashboard.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "dashboard"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.patients.patientsInpatients.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "patients",
+      "patientsInpatients"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.patients.patientsInpatients.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "patients",
+      "patientsInpatients"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.patients.patientsEmergency.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "patients",
+      "patientsEmergency"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.patients.patientsEmergency.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "patients",
+      "patientsEmergency"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.patients.patientsOutpatients.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "patients",
+      "patientsOutpatients"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.patients.patientsOutpatients.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "patients",
+      "patientsOutpatients"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.scheduling.schedulingOutpatients.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "scheduling",
+      "schedulingOutpatients"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.scheduling.schedulingOutpatients.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "scheduling",
+      "schedulingOutpatients"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.scheduling.schedulingLocations.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "scheduling",
+      "schedulingLocations"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.scheduling.schedulingLocations.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "scheduling",
+      "schedulingLocations"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.imaging.imagingActive.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "imaging",
+      "imagingActive"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.imaging.imagingActive.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "imaging",
+      "imagingActive"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.imaging.imagingCompleted.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "imaging",
+      "imagingCompleted"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.imaging.imagingCompleted.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "imaging",
+      "imagingCompleted"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.labs.labsAll.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "labs",
+      "labsAll"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.labs.labsAll.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "labs",
+      "labsAll"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.labs.labsPublished.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "labs",
+      "labsPublished"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.labs.labsPublished.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "labs",
+      "labsPublished"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.immunisations.immunisationsAll.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "immunisations",
+      "immunisationsAll"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.immunisations.immunisationsAll.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "immunisations",
+      "immunisationsAll"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.facilityAdmin.reports.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "facilityAdmin",
+      "reports"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.facilityAdmin.reports.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "facilityAdmin",
+      "reports"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.facilityAdmin.bedManagement.sortPriority",
+    "key": "sortPriority",
+    "name": "sortPriority",
+    "description": "_",
+    "defaultValue": 0,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "facilityAdmin",
+      "bedManagement"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.sidebar.facilityAdmin.bedManagement.hidden",
+    "key": "hidden",
+    "name": "hidden",
+    "description": "_",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "sidebar",
+      "facilityAdmin",
+      "bedManagement"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientView.showLocationBookings",
+    "key": "showLocationBookings",
+    "name": "showLocationBookings",
+    "description": "The patient view in the facility",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientView"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "layouts.patientView.showOutpatientAppointments",
+    "key": "showOutpatientAppointments",
+    "name": "showOutpatientAppointments",
+    "description": "The patient view in the facility",
+    "defaultValue": false,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "layouts",
+      "patientView"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "security.reportNoUserError",
+    "key": "reportNoUserError",
+    "name": "reportNoUserError",
+    "description": "Security settings",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "security"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "security.loginAttempts.lockoutThreshold",
+    "key": "lockoutThreshold",
+    "name": "lockoutThreshold",
+    "description": "Login attempts settings",
+    "defaultValue": 10,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "security",
+      "loginAttempts"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "security.loginAttempts.observationWindow",
+    "key": "observationWindow",
+    "name": "observationWindow",
+    "description": "Login attempts settings",
+    "defaultValue": 10,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "security",
+      "loginAttempts"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "security.loginAttempts.lockoutDuration",
+    "key": "lockoutDuration",
+    "name": "lockoutDuration",
+    "description": "Login attempts settings",
+    "defaultValue": 10,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "security",
+      "loginAttempts"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "security.mobile.allowUnencryptedStorage",
+    "key": "allowUnencryptedStorage",
+    "name": "allowUnencryptedStorage",
+    "description": "Mobile security settings",
+    "defaultValue": true,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "security",
+      "mobile"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "security.mobile.allowUnprotected",
+    "key": "allowUnprotected",
+    "name": "allowUnprotected",
+    "description": "Mobile security settings",
+    "defaultValue": true,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "security",
+      "mobile"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalLoginEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email sent to the patient with their login code",
+    "defaultValue": "Your Tamanu Patient Portal Login Code",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalLoginEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalLoginEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email sent to the patient with their login code",
+    "defaultValue": "Your 6-digit login code for Tamanu Patient Portal is: $token$\n\nDo not respond to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalLoginEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalRegistrationEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email sent to the patient to register for the patient portal",
+    "defaultValue": "Tamanu Patient Portal Registration",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalRegistrationEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalRegistrationEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email sent to the patient to register for the patient portal",
+    "defaultValue": "Please follow the link below to complete Tamanu Patient Portal registration for $firstName$ $lastName$.\n\n$registrationLink$\n\nDo not respond to this email",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalRegistrationEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalRegisteredFormEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email sent to a registered patient to complete a form",
+    "defaultValue": "New Patient Form Request from $facilityName$",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalRegisteredFormEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalRegisteredFormEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email sent to a registered patient to complete a form",
+    "defaultValue": "A new patient form request has been sent from $facilityName$ for $firstName$ $lastName$. Please follow the below link to log in to your Tamanu Patient Portal to access and complete this form.\n\n$loginLink$\n\nDo not respond to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalRegisteredFormEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalUnregisteredFormEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email sent to an unregistered patient to complete a form",
+    "defaultValue": "New Patient Form Request from $facilityName$",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalUnregisteredFormEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.patientPortalUnregisteredFormEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email sent to an unregistered patient to complete a form",
+    "defaultValue": "A new patient form request has been sent from $facilityName$ for $firstName$ $lastName$. Before you can access this form, you must register for a Tamanu Patient Portal account.\n\nPlease follow the link below to complete Tamanu Patient Portal registration for $firstName$ $lastName$. Once you have set up your patient portal account, you will be able to log in and access the requested form.\n\n$registrationLink$\n\nDo not respond to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "patientPortalUnregisteredFormEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.appointmentConfirmation.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email sent to confirm an appointment",
+    "defaultValue": "Appointment confirmation",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "appointmentConfirmation"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.appointmentConfirmation.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email sent to confirm an appointment",
+    "defaultValue": "Hi $firstName$ $lastName$,\n\n This is a confirmation that your appointment has been scheduled at $facilityName$.\nDate: $startDate$\nTime: $startTime$\nLocation: $locationName$, $facilityName$$clinicianName$\n\nDo not respond to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "appointmentConfirmation"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.letterhead.title",
+    "key": "title",
+    "name": "title",
+    "description": "The text at the top of most patient PDFs",
+    "defaultValue": "TAMANU MINISTRY OF HEALTH & MEDICAL SERVICES",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "letterhead"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.letterhead.subTitle",
+    "key": "subTitle",
+    "name": "subTitle",
+    "description": "The text at the top of most patient PDFs",
+    "defaultValue": "PO Box 12345, Melbourne, Australia",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "letterhead"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.signerRenewalEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email sent when the signer runs out",
+    "defaultValue": "Tamanu ICAO Certificate Signing Request",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "signerRenewalEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.signerRenewalEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email sent when the signer runs out",
+    "defaultValue": "Please sign the following certificate signing request (CSR) with the Country Signing Certificate Authority (CSCA), and return it to the Tamanu team or Tamanu deployment administration team.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "signerRenewalEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.vaccineCertificateEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email containing patient vaccine certificate",
+    "defaultValue": "Medical Certificate now available",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "vaccineCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.vaccineCertificateEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email containing patient vaccine certificate",
+    "defaultValue": "A medical certificate has been generated for you.\nYour certificate is available attached to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "vaccineCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidVaccineCertificateEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "The email containing COVID patient vaccine certificate",
+    "defaultValue": "Medical Certificate now available",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidVaccineCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidVaccineCertificateEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "The email containing COVID patient vaccine certificate",
+    "defaultValue": "A medical certificate has been generated for you.\nYour certificate is available attached to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidVaccineCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidTestCertificateEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "Email with certificate containing the list of COVID tests for this patient",
+    "defaultValue": "Medical Certificate now available",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidTestCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidTestCertificateEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "Email with certificate containing the list of COVID tests for this patient",
+    "defaultValue": "A medical certificate has been generated for you.\nYour certificate is attached to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidTestCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidClearanceCertificateEmail.subject",
+    "key": "subject",
+    "name": "subject",
+    "description": "Certificate containing the list of COVID tests for this patient used for proof of over 13 days since infection",
+    "defaultValue": "COVID-19 Clearance Certificate now available",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidClearanceCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidClearanceCertificateEmail.body",
+    "key": "body",
+    "name": "body",
+    "description": "Certificate containing the list of COVID tests for this patient used for proof of over 13 days since infection",
+    "defaultValue": "A COVID-19 clearance certificate has been generated for you.\nYour certificate is attached to this email.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidClearanceCertificateEmail"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.vaccineCertificate.emailAddress",
+    "key": "emailAddress",
+    "name": "emailAddress",
+    "description": "Certificate containing the list of vaccines for this patient",
+    "defaultValue": "tamanu@health.gov",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "vaccineCertificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.vaccineCertificate.contactNumber",
+    "key": "contactNumber",
+    "name": "contactNumber",
+    "description": "Certificate containing the list of vaccines for this patient",
+    "defaultValue": "12345",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "vaccineCertificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.vaccineCertificate.healthFacility",
+    "key": "healthFacility",
+    "name": "healthFacility",
+    "description": "Certificate containing the list of vaccines for this patient",
+    "defaultValue": "State level",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "vaccineCertificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidTestCertificate.laboratoryName",
+    "key": "laboratoryName",
+    "name": "laboratoryName",
+    "description": "Certificate containing the list of COVID vaccines for this patient",
+    "defaultValue": "Approved test provider",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidTestCertificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.covidTestCertificate.clearanceCertRemark",
+    "key": "clearanceCertRemark",
+    "name": "clearanceCertRemark",
+    "description": "Certificate containing the list of COVID vaccines for this patient",
+    "defaultValue": "This notice certifies that $firstName$ $lastName$ is no longer considered infectious following 13 days of self-isolation from the date of their first positive SARS-CoV-2 test and are medically cleared from COVID-19. This certificate is valid for 3 months from the date of issue.",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates",
+      "covidTestCertificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "global",
+    "path": "templates.plannedMoveTimeoutHours",
+    "key": "plannedMoveTimeoutHours",
+    "name": "plannedMoveTimeoutHours",
+    "description": "Strings to be inserted into emails/PDFs",
+    "defaultValue": 24,
+    "unit": "hours",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "templates"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "triageCategories",
+    "key": "triageCategories",
+    "name": "Triage categories",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      {
+        "level": 1,
+        "label": "Emergency",
+        "color": "#F76853"
+      },
+      {
+        "level": 2,
+        "label": "Very Urgent",
+        "color": "#F17F16"
+      },
+      {
+        "level": 3,
+        "label": "Urgent",
+        "color": "#FFCC24"
+      },
+      {
+        "level": 4,
+        "label": "Non-urgent",
+        "color": "#47CA80"
+      },
+      {
+        "level": 5,
+        "label": "Deceased",
+        "color": "#67A6E3"
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "upcomingVaccinations.ageLimit",
+    "key": "ageLimit",
+    "name": "ageLimit",
+    "description": "Settings related to upcoming vaccinations",
+    "defaultValue": 15,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Upcoming vaccinations"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "upcomingVaccinations.thresholds",
+    "key": "thresholds",
+    "name": "thresholds",
+    "description": "Settings related to upcoming vaccinations",
+    "defaultValue": [
+      {
+        "threshold": 28,
+        "status": "SCHEDULED"
+      },
+      {
+        "threshold": 7,
+        "status": "UPCOMING"
+      },
+      {
+        "threshold": -7,
+        "status": "DUE"
+      },
+      {
+        "threshold": -55,
+        "status": "OVERDUE"
+      },
+      {
+        "threshold": "-Infinity",
+        "status": "MISSED"
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Upcoming vaccinations"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "vitalEditReasons",
+    "key": "vitalEditReasons",
+    "name": "vitalEditReasons",
+    "description": "Settings that apply to all servers",
+    "defaultValue": [
+      {
+        "value": "incorrect-patient",
+        "label": "Incorrect patient"
+      },
+      {
+        "value": "incorrect-value",
+        "label": "Incorrect value recorded"
+      },
+      {
+        "value": "recorded-in-error",
+        "label": "Recorded in error"
+      },
+      {
+        "value": "other",
+        "label": "Other"
+      }
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "notifications.recentNotificationsTimeFrame",
+    "key": "recentNotificationsTimeFrame",
+    "name": "recentNotificationsTimeFrame",
+    "description": "Notification settings",
+    "defaultValue": 48,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "notifications"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Daily in the morning",
+    "key": "Daily in the morning",
+    "name": "Daily in the morning",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Daily at midday",
+    "key": "Daily at midday",
+    "name": "Daily at midday",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Daily at night",
+    "key": "Daily at night",
+    "name": "Daily at night",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Daily",
+    "key": "Daily",
+    "name": "Daily",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Two times daily",
+    "key": "Two times daily",
+    "name": "Two times daily",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Three times daily",
+    "key": "Three times daily",
+    "name": "Three times daily",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Four times daily",
+    "key": "Four times daily",
+    "name": "Four times daily",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Every 4 hours",
+    "key": "Every 4 hours",
+    "name": "Every 4 hours",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Every 6 hours",
+    "key": "Every 6 hours",
+    "name": "Every 6 hours",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Every 8 hours",
+    "key": "Every 8 hours",
+    "name": "Every 8 hours",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Every second day",
+    "key": "Every second day",
+    "name": "Every second day",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Once a week",
+    "key": "Once a week",
+    "name": "Once a week",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Once a month",
+    "key": "Once a month",
+    "name": "Once a month",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Immediately",
+    "key": "Immediately",
+    "name": "Immediately",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.As directed",
+    "key": "As directed",
+    "name": "As directed",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.frequenciesEnabled.Twice daily - AM and midday",
+    "key": "Twice daily - AM and midday",
+    "name": "Twice daily - AM and midday",
+    "description": "Enable medication frequencies",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "frequenciesEnabled"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Daily in the morning",
+    "key": "Daily in the morning",
+    "name": "Daily in the morning",
+    "description": "-",
+    "defaultValue": [
+      "06:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Daily at midday",
+    "key": "Daily at midday",
+    "name": "Daily at midday",
+    "description": "-",
+    "defaultValue": [
+      "12:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Daily at night",
+    "key": "Daily at night",
+    "name": "Daily at night",
+    "description": "-",
+    "defaultValue": [
+      "18:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Daily",
+    "key": "Daily",
+    "name": "Daily",
+    "description": "-",
+    "defaultValue": [
+      "06:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Two times daily",
+    "key": "Two times daily",
+    "name": "Two times daily",
+    "description": "-",
+    "defaultValue": [
+      "06:00",
+      "18:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Three times daily",
+    "key": "Three times daily",
+    "name": "Three times daily",
+    "description": "-",
+    "defaultValue": [
+      "06:00",
+      "12:00",
+      "18:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Four times daily",
+    "key": "Four times daily",
+    "name": "Four times daily",
+    "description": "-",
+    "defaultValue": [
+      "06:00",
+      "12:00",
+      "18:00",
+      "22:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Every 4 hours",
+    "key": "Every 4 hours",
+    "name": "Every 4 hours",
+    "description": "-",
+    "defaultValue": [
+      "02:00",
+      "06:00",
+      "10:00",
+      "14:00",
+      "18:00",
+      "22:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Every 6 hours",
+    "key": "Every 6 hours",
+    "name": "Every 6 hours",
+    "description": "-",
+    "defaultValue": [
+      "00:00",
+      "06:00",
+      "12:00",
+      "18:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Every 8 hours",
+    "key": "Every 8 hours",
+    "name": "Every 8 hours",
+    "description": "-",
+    "defaultValue": [
+      "06:00",
+      "14:00",
+      "22:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Every second day",
+    "key": "Every second day",
+    "name": "Every second day",
+    "description": "-",
+    "defaultValue": [
+      "06:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Once a week",
+    "key": "Once a week",
+    "name": "Once a week",
+    "description": "-",
+    "defaultValue": [
+      "06:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Once a month",
+    "key": "Once a month",
+    "name": "Once a month",
+    "description": "-",
+    "defaultValue": [
+      "06:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "global",
+    "path": "medications.defaultAdministrationTimes.Twice daily - AM and midday",
+    "key": "Twice daily - AM and midday",
+    "name": "Twice daily - AM and midday",
+    "description": "-",
+    "defaultValue": [
+      "06:00",
+      "12:00"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "medications",
+      "defaultAdministrationTimes"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "central",
+    "path": "disk.freeSpaceRequired.gigabytesForUploadingDocuments",
+    "key": "gigabytesForUploadingDocuments",
+    "name": "Gigabytes for uploading documents",
+    "description": "Settings related to free disk space required during uploads",
+    "defaultValue": 16,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "Disk",
+      "Free space required"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "sync.streaming.enabled",
+    "key": "enabled",
+    "name": "enabled",
+    "description": "Settings related to sync",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "sync",
+      "streaming"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "central",
+    "path": "sync.streaming.databasePollBatchSize",
+    "key": "databasePollBatchSize",
+    "name": "databasePollBatchSize",
+    "description": "Settings related to sync",
+    "defaultValue": 100,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "sync",
+      "streaming"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "sync.streaming.databasePollInterval",
+    "key": "databasePollInterval",
+    "name": "databasePollInterval",
+    "description": "Settings related to sync",
+    "defaultValue": 1000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "sync",
+      "streaming"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.useUnsafeSchemaForInitialSync",
+    "key": "useUnsafeSchemaForInitialSync",
+    "name": "useUnsafeSchemaForInitialSync",
+    "description": "Settings related to mobile sync",
+    "defaultValue": true,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.maxBatchesToKeepInMemory",
+    "key": "maxBatchesToKeepInMemory",
+    "name": "maxBatchesToKeepInMemory",
+    "description": "Settings related to mobile sync",
+    "defaultValue": 5,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.maxRecordsPerInsertBatch",
+    "key": "maxRecordsPerInsertBatch",
+    "name": "maxRecordsPerInsertBatch",
+    "description": "Settings related to mobile sync",
+    "defaultValue": 2000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.maxRecordsPerUpdateBatch",
+    "key": "maxRecordsPerUpdateBatch",
+    "name": "maxRecordsPerUpdateBatch",
+    "description": "Settings related to mobile sync",
+    "defaultValue": 2000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.maxRecordsPerSnapshotBatch",
+    "key": "maxRecordsPerSnapshotBatch",
+    "name": "maxRecordsPerSnapshotBatch",
+    "description": "Settings related to mobile sync",
+    "defaultValue": 1000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.dynamicLimiter.initialLimit",
+    "key": "initialLimit",
+    "name": "initialLimit",
+    "description": "Settings for the sync page size dynamic limiter",
+    "defaultValue": 10000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync",
+      "dynamicLimiter"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.dynamicLimiter.minLimit",
+    "key": "minLimit",
+    "name": "minLimit",
+    "description": "Settings for the sync page size dynamic limiter",
+    "defaultValue": 1000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync",
+      "dynamicLimiter"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.dynamicLimiter.maxLimit",
+    "key": "maxLimit",
+    "name": "maxLimit",
+    "description": "Settings for the sync page size dynamic limiter",
+    "defaultValue": 40000,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync",
+      "dynamicLimiter"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.dynamicLimiter.maxLimitChangePerPage",
+    "key": "maxLimitChangePerPage",
+    "name": "maxLimitChangePerPage",
+    "description": "Settings for the sync page size dynamic limiter",
+    "defaultValue": 0.3,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync",
+      "dynamicLimiter"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "mobileSync.dynamicLimiter.optimalTimePerPage",
+    "key": "optimalTimePerPage",
+    "name": "optimalTimePerPage",
+    "description": "Settings for the sync page size dynamic limiter",
+    "defaultValue": 10000,
+    "unit": "ms",
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "mobileSync",
+      "dynamicLimiter"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "questionCodeIds.passport",
+    "key": "passport",
+    "name": "passport",
+    "description": "Avoid using questionCodeIds. The PatientData question type has made this setting redundant.",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": true,
+    "sections": [
+      "Central server settings",
+      "questionCodeIds"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "questionCodeIds.nationalityId",
+    "key": "nationalityId",
+    "name": "nationalityId",
+    "description": "Avoid using questionCodeIds. The PatientData question type has made this setting redundant.",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": true,
+    "sections": [
+      "Central server settings",
+      "questionCodeIds"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "questionCodeIds.email",
+    "key": "email",
+    "name": "email",
+    "description": "Avoid using questionCodeIds. The PatientData question type has made this setting redundant.",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": true,
+    "sections": [
+      "Central server settings",
+      "questionCodeIds"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "reportProcess.timeOutDurationSeconds",
+    "key": "timeOutDurationSeconds",
+    "name": "timeOutDurationSeconds",
+    "description": "Settings that apply only to a central server",
+    "defaultValue": 7200,
+    "unit": "seconds",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "reportProcess"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "reportProcess.runInChildProcess",
+    "key": "runInChildProcess",
+    "name": "runInChildProcess",
+    "description": "Settings that apply only to a central server",
+    "defaultValue": true,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "reportProcess"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "central",
+    "path": "reportProcess.processOptions",
+    "key": "processOptions",
+    "name": "processOptions",
+    "description": "Settings that apply only to a central server",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "reportProcess"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "central",
+    "path": "reportProcess.childProcessEnv",
+    "key": "childProcessEnv",
+    "name": "childProcessEnv",
+    "description": "Settings that apply only to a central server",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "reportProcess"
+    ],
+    "type": "object"
+  },
+  {
+    "scope": "central",
+    "path": "reportProcess.sleepAfterReport.duration",
+    "key": "duration",
+    "name": "duration",
+    "description": "To mitigate resource-hungry reports affecting operational use of Tamanu, if a report takes too long, then report generation can be suspended for a some time",
+    "defaultValue": "5m",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "reportProcess",
+      "sleepAfterReport"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "reportProcess.sleepAfterReport.ifRunAtLeast",
+    "key": "ifRunAtLeast",
+    "name": "ifRunAtLeast",
+    "description": "To mitigate resource-hungry reports affecting operational use of Tamanu, if a report takes too long, then report generation can be suspended for a some time",
+    "defaultValue": "5m",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "reportProcess",
+      "sleepAfterReport"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "locationAssignments.assignmentSlots.startTime",
+    "key": "startTime",
+    "name": "startTime",
+    "description": "Configure the available time slots for assigning locations to users",
+    "defaultValue": "09:00",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "locationAssignments",
+      "assignmentSlots"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "locationAssignments.assignmentSlots.endTime",
+    "key": "endTime",
+    "name": "endTime",
+    "description": "Configure the available time slots for assigning locations to users",
+    "defaultValue": "17:00",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "locationAssignments",
+      "assignmentSlots"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "locationAssignments.assignmentSlots.slotDuration",
+    "key": "slotDuration",
+    "name": "slotDuration",
+    "description": "Configure the available time slots for assigning locations to users",
+    "defaultValue": "30min",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "locationAssignments",
+      "assignmentSlots"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.host",
+    "key": "host",
+    "name": "host",
+    "description": "DHIS2 settings",
+    "defaultValue": "",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.reportIds",
+    "key": "reportIds",
+    "name": "Reports",
+    "description": "DHIS2 settings",
+    "defaultValue": [],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.idSchemes.dataElementIdScheme",
+    "key": "dataElementIdScheme",
+    "name": "Data element ID scheme",
+    "description": "The ID schemes to use for the reports",
+    "defaultValue": "uid",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "idSchemes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.idSchemes.orgUnitIdScheme",
+    "key": "orgUnitIdScheme",
+    "name": "Organisation unit ID scheme",
+    "description": "The ID schemes to use for the reports",
+    "defaultValue": "uid",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "idSchemes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.idSchemes.categoryOptionComboIdScheme",
+    "key": "categoryOptionComboIdScheme",
+    "name": "Category option combo ID scheme",
+    "description": "The ID schemes to use for the reports",
+    "defaultValue": "uid",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "idSchemes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.idSchemes.dataSetIdScheme",
+    "key": "dataSetIdScheme",
+    "name": "Data set ID scheme",
+    "description": "The ID schemes to use for the reports",
+    "defaultValue": "uid",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "idSchemes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.idSchemes.idScheme",
+    "key": "idScheme",
+    "name": "ID scheme",
+    "description": "The ID schemes to use for the reports",
+    "defaultValue": "uid",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "idSchemes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.backoff.maxAttempts",
+    "key": "maxAttempts",
+    "name": "Max attempts",
+    "description": "Backoff settings",
+    "defaultValue": 15,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "Backoff"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.backoff.multiplierMs",
+    "key": "multiplierMs",
+    "name": "Multiplier",
+    "description": "Backoff settings",
+    "defaultValue": 300,
+    "unit": "ms",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "Backoff"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "central",
+    "path": "integrations.dhis2.backoff.maxWaitMs",
+    "key": "maxWaitMs",
+    "name": "Max wait",
+    "description": "Backoff settings",
+    "defaultValue": 10000,
+    "unit": "ms",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Central server settings",
+      "integrations",
+      "dhis2",
+      "Backoff"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "facility",
+    "path": "appointments.bookingSlots.startTime",
+    "key": "startTime",
+    "name": "startTime",
+    "description": "Configure the available booking slots for appointments",
+    "defaultValue": "09:00",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "appointments",
+      "bookingSlots"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "appointments.bookingSlots.endTime",
+    "key": "endTime",
+    "name": "endTime",
+    "description": "Configure the available booking slots for appointments",
+    "defaultValue": "17:00",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "appointments",
+      "bookingSlots"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "appointments.bookingSlots.slotDuration",
+    "key": "slotDuration",
+    "name": "slotDuration",
+    "description": "Configure the available booking slots for appointments",
+    "defaultValue": "30min",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "appointments",
+      "bookingSlots"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "certifications.covidClearanceCertificate.after",
+    "key": "after",
+    "name": "After date",
+    "description": "Settings that apply only to a facility server",
+    "defaultValue": "2022-09-01",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "certifications",
+      "covidClearanceCertificate"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "certifications.covidClearanceCertificate.daysSinceSampleTime",
+    "key": "daysSinceSampleTime",
+    "name": "daysSinceSampleTime",
+    "description": "Settings that apply only to a facility server",
+    "defaultValue": 13,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "certifications",
+      "covidClearanceCertificate"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "facility",
+    "path": "certifications.covidClearanceCertificate.labTestCategories",
+    "key": "labTestCategories",
+    "name": "labTestCategories",
+    "description": "Settings that apply only to a facility server",
+    "defaultValue": [],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "certifications",
+      "covidClearanceCertificate"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "facility",
+    "path": "certifications.covidClearanceCertificate.labTestTypes",
+    "key": "labTestTypes",
+    "name": "labTestTypes",
+    "description": "Settings that apply only to a facility server",
+    "defaultValue": [],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "certifications",
+      "covidClearanceCertificate"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "facility",
+    "path": "certifications.covidClearanceCertificate.labTestResults",
+    "key": "labTestResults",
+    "name": "labTestResults",
+    "description": "Settings that apply only to a facility server",
+    "defaultValue": [
+      "Positive"
+    ],
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "certifications",
+      "covidClearanceCertificate"
+    ],
+    "type": "array"
+  },
+  {
+    "scope": "facility",
+    "path": "questionCodeIds.passport",
+    "key": "passport",
+    "name": "passport",
+    "description": "Avoid using questionCodeIds. The PatientData question type has made this setting redundant.",
+    "defaultValue": "pde-FijCOVRDT005",
+    "highRisk": false,
+    "deprecated": true,
+    "sections": [
+      "Facility server settings",
+      "questionCodeIds"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "questionCodeIds.nationalityId",
+    "key": "nationalityId",
+    "name": "nationalityId",
+    "description": "Avoid using questionCodeIds. The PatientData question type has made this setting redundant.",
+    "defaultValue": "pde-PalauCOVSamp7",
+    "highRisk": false,
+    "deprecated": true,
+    "sections": [
+      "Facility server settings",
+      "questionCodeIds"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "questionCodeIds.email",
+    "key": "email",
+    "name": "email",
+    "description": "Avoid using questionCodeIds. The PatientData question type has made this setting redundant.",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": true,
+    "sections": [
+      "Facility server settings",
+      "questionCodeIds"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "sync.syncAllLabRequests",
+    "key": "syncAllLabRequests",
+    "name": "syncAllLabRequests",
+    "description": "Facility sync settings",
+    "defaultValue": false,
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "sync"
+    ],
+    "type": "boolean"
+  },
+  {
+    "scope": "facility",
+    "path": "sync.urgentIntervalInSeconds",
+    "key": "urgentIntervalInSeconds",
+    "name": "Sync urgent interval",
+    "description": "Facility sync settings",
+    "defaultValue": 10,
+    "unit": "seconds",
+    "highRisk": true,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "sync"
+    ],
+    "type": "number"
+  },
+  {
+    "scope": "facility",
+    "path": "vaccinations.defaults.locationGroupId",
+    "key": "locationGroupId",
+    "name": "Location group",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Vaccinations",
+      "defaults"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "vaccinations.defaults.locationId",
+    "key": "locationId",
+    "name": "Location",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Vaccinations",
+      "defaults"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "vaccinations.defaults.departmentId",
+    "key": "departmentId",
+    "name": "Department",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Vaccinations",
+      "defaults"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "vaccinations.givenElsewhere.defaults.locationGroupId",
+    "key": "locationGroupId",
+    "name": "Location group",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Vaccinations",
+      "givenElsewhere",
+      "defaults"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "vaccinations.givenElsewhere.defaults.locationId",
+    "key": "locationId",
+    "name": "Location",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Vaccinations",
+      "givenElsewhere",
+      "defaults"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "vaccinations.givenElsewhere.defaults.departmentId",
+    "key": "departmentId",
+    "name": "Department",
+    "description": "_",
+    "defaultValue": null,
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Vaccinations",
+      "givenElsewhere",
+      "defaults"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "survey.defaultCodes.department",
+    "key": "department",
+    "name": "department",
+    "description": "Default reference data codes to use when creating a survey encounter (includes vitals) when none are explicitly specified",
+    "defaultValue": "GeneralClinic",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Survey settings",
+      "defaultCodes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "survey.defaultCodes.location",
+    "key": "location",
+    "name": "location",
+    "description": "Default reference data codes to use when creating a survey encounter (includes vitals) when none are explicitly specified",
+    "defaultValue": "GeneralClinic",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "Survey settings",
+      "defaultCodes"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "templates.letterhead.title",
+    "key": "title",
+    "name": "title",
+    "description": "The text at the top of most patient PDFs",
+    "defaultValue": "TAMANU MINISTRY OF HEALTH & MEDICAL SERVICES",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "templates",
+      "letterhead"
+    ],
+    "type": "string"
+  },
+  {
+    "scope": "facility",
+    "path": "templates.letterhead.subTitle",
+    "key": "subTitle",
+    "name": "subTitle",
+    "description": "The text at the top of most patient PDFs",
+    "defaultValue": "PO Box 12345, Melbourne, Australia",
+    "highRisk": false,
+    "deprecated": false,
+    "sections": [
+      "Facility server settings",
+      "templates",
+      "letterhead"
+    ],
+    "type": "string"
+  }
+]

--- a/docs/releases/tamanu-v2-44-settings.md
+++ b/docs/releases/tamanu-v2-44-settings.md
@@ -1,0 +1,620 @@
+## Global Settings
+
+### ageDisplayFormat
+- `ageDisplayFormat` — default [{"as":"days","range":{"min":{"duration":{"days":0},"excl… — Settings that apply to all servers
+
+### appointments
+- `appointments.maxRepeatingAppointmentsPerGeneration` — default 50 — Appointment settings
+
+### audit
+- `audit.accesses.enabled` — default false (high-risk) — Audit accesses
+- `audit.changes.enabled` — default false (high-risk) — Audit changes
+
+### auth
+- `auth.restrictUsersToFacilities` — default false (high-risk) — Authentication options
+- `auth.restrictUsersToSync` — default false (high-risk) — Authentication options
+
+### customisations
+- `customisations.componentVersions` — default {} — Customisation of the application
+
+### features
+- `features.desktopCharting.enabled` — default false — Enable desktop charting module
+- `features.deviceRegistrationQuota.enabled` — default true — Device registration quota settings
+- `features.disableInputPasting` — default false — Toggle features on/off
+- `features.discharge.dischargeDiagnosisMandatory` — default false — Encounter discharge configuration
+- `features.discharge.dischargeNoteMandatory` — default false — Encounter discharge configuration
+- `features.displayIcd10CodesInDischargeSummary` — default true — Toggle features on/off
+- `features.displayProcedureCodesInDischargeSummary` — default true — Toggle features on/off
+- `features.editPatientDetailsOnMobile` — default true — Toggle features on/off
+- `features.editPatientDisplayId` — default true — Toggle features on/off
+- `features.enableAppointmentsExtentions` — default false — Toggle features on/off
+- `features.enableChartingEdit` — default false — Toggle features on/off
+- `features.enableCovidClearanceCertificate` — default false — Toggle features on/off
+- `features.enableInvoicing` — default false — Toggle features on/off
+- `features.enableNoteBackdating` — default true — Toggle features on/off
+- `features.enablePatientDeaths` — default false — Toggle features on/off
+- `features.enablePatientInsurer` — default false — Toggle features on/off
+- `features.enableTasking` — default false — Toggle features on/off
+- `features.enableVaccineConsent` — default true — Toggle features on/off
+- `features.enableVitalEdit` — default false — Toggle features on/off
+- `features.filterDischargeDispositions` — default false — Toggle features on/off
+- `features.hideOtherSex` — default true — Toggle features on/off
+- `features.hideUpcomingVaccines` — default false — Toggle features on/off
+- `features.idleTimeout.enabled` — default true — Automatically logout idle users / inactive sessions after a certain time
+- `features.idleTimeout.refreshInterval` — default 150 — Automatically logout idle users / inactive sessions after a certain time
+- `features.idleTimeout.timeoutDuration` — default 600 — Automatically logout idle users / inactive sessions after a certain time
+- `features.idleTimeout.warningPromptDuration` — default 30 — Automatically logout idle users / inactive sessions after a certain time
+- `features.mandateSpecimenType` — default false — Toggle features on/off
+- `features.mandatoryChartingEditReason` — default false — Toggle features on/off
+- `features.mandatoryVitalEditReason` — default false — Toggle features on/off
+- `features.onlyAllowLabPanels` — default false — Toggle features on/off
+- `features.patientDetailsLocationHierarchy` — default false — Toggle features on/off
+- `features.patientPlannedMove` — default false — Toggle features on/off
+- `features.patientPortal` — default false (high-risk) — Toggle features on/off
+- `features.pharmacyOrder.enabled` — default false — Pharmacy order settings
+- `features.pharmacyOrder.medicationAlreadyOrderedConfirmationTimeout` — default 24 — Pharmacy order settings
+- `features.quickPatientGenerator` — default false — Toggle features on/off
+- `features.registerNewPatient` — default true — Toggle features on/off
+- `features.reminderContactModule.enabled` — default false — Toggle features on/off
+- `features.tableAutoRefresh.enabled` — default true — Enable the auto refresh feature on tables where it is implemented: Currently supports imaging and lab listing views
+- `features.tableAutoRefresh.interval` — default 300 — Enable the auto refresh feature on tables where it is implemented: Currently supports imaging and lab listing views
+- `features.useGlobalPdfFont` — default false — Toggle features on/off
+
+### fhir
+- `fhir.worker.assumeDroppedAfter` — default "10 minutes" — FHIR worker settings
+- `fhir.worker.heartbeat` — default "1 minute" — FHIR worker settings
+
+### fields
+- `fields.age.defaultValue` — default null — _
+- `fields.age.required` — default false — _
+- `fields.apgarScoreFiveMinutes.defaultValue` — default null — _
+- `fields.apgarScoreFiveMinutes.hidden` — default false — _
+- `fields.apgarScoreFiveMinutes.required` — default false — _
+- `fields.apgarScoreFiveMinutes.requiredPatientData` — default false — _
+- `fields.apgarScoreOneMinute.defaultValue` — default null — _
+- `fields.apgarScoreOneMinute.hidden` — default false — _
+- `fields.apgarScoreOneMinute.required` — default false — _
+- `fields.apgarScoreOneMinute.requiredPatientData` — default false — _
+- `fields.apgarScoreTenMinutes.defaultValue` — default null — _
+- `fields.apgarScoreTenMinutes.hidden` — default false — _
+- `fields.apgarScoreTenMinutes.required` — default false — _
+- `fields.apgarScoreTenMinutes.requiredPatientData` — default false — _
+- `fields.arrivalModeId.defaultValue` — default null — _
+- `fields.arrivalModeId.hidden` — default false — _
+- `fields.arrivalModeId.required` — default false — _
+- `fields.attendantAtBirth.defaultValue` — default null — _
+- `fields.attendantAtBirth.hidden` — default false — _
+- `fields.attendantAtBirth.required` — default false — _
+- `fields.attendantAtBirth.requiredPatientData` — default false — _
+- `fields.birthCertificate.defaultValue` — default null — _
+- `fields.birthCertificate.hidden` — default false — _
+- `fields.birthCertificate.required` — default false — _
+- `fields.birthCertificate.requiredPatientData` — default false — _
+- `fields.birthDeliveryType.defaultValue` — default null — _
+- `fields.birthDeliveryType.hidden` — default false — _
+- `fields.birthDeliveryType.required` — default false — _
+- `fields.birthDeliveryType.requiredPatientData` — default false — _
+- `fields.birthFacilityId.defaultValue` — default null — _
+- `fields.birthFacilityId.hidden` — default false — _
+- `fields.birthFacilityId.required` — default false — _
+- `fields.birthFacilityId.requiredPatientData` — default false — _
+- `fields.birthLength.defaultValue` — default null — _
+- `fields.birthLength.hidden` — default false — _
+- `fields.birthLength.required` — default false — _
+- `fields.birthLength.requiredPatientData` — default false — _
+- `fields.birthType.defaultValue` — default null — _
+- `fields.birthType.hidden` — default false — _
+- `fields.birthType.required` — default false — _
+- `fields.birthType.requiredPatientData` — default false — _
+- `fields.birthWeight.defaultValue` — default null — _
+- `fields.birthWeight.hidden` — default false — _
+- `fields.birthWeight.required` — default false — _
+- `fields.birthWeight.requiredPatientData` — default false — _
+- `fields.bloodType.defaultValue` — default null — _
+- `fields.bloodType.hidden` — default false — _
+- `fields.bloodType.required` — default false — _
+- `fields.bloodType.requiredPatientData` — default false — _
+- `fields.circumstanceId.defaultValue` — default null — _
+- `fields.circumstanceId.hidden` — default false — _
+- `fields.circumstanceId.required` — default false — _
+- `fields.cityTown.defaultValue` — default null — _
+- `fields.cityTown.hidden` — default false — _
+- `fields.cityTown.required` — default false — _
+- `fields.cityTown.requiredPatientData` — default false — _
+- `fields.clinician.defaultValue` — default null — _
+- `fields.clinician.hidden` — default false — _
+- `fields.clinician.required` — default false — _
+- `fields.conditions.defaultValue` — default null — _
+- `fields.conditions.hidden` — default false — _
+- `fields.conditions.required` — default false — _
+- `fields.countryId.defaultValue` — default null — _
+- `fields.countryId.hidden` — default false — _
+- `fields.countryId.required` — default false — _
+- `fields.countryId.requiredPatientData` — default false — _
+- `fields.countryOfBirthId.defaultValue` — default null — _
+- `fields.countryOfBirthId.hidden` — default false — _
+- `fields.countryOfBirthId.required` — default false — _
+- `fields.countryOfBirthId.requiredPatientData` — default false — _
+- `fields.culturalName.defaultValue` — default null — _
+- `fields.culturalName.hidden` — default false — _
+- `fields.culturalName.required` — default false — _
+- `fields.culturalName.requiredPatientData` — default false — _
+- `fields.date.defaultValue` — default null — _
+- `fields.date.required` — default false — _
+- `fields.dateOfBirth.defaultValue` — default null — _
+- `fields.dateOfBirth.required` — default false — _
+- `fields.dateOfBirth.requiredPatientData` — default false — _
+- `fields.dateOfBirthExact.defaultValue` — default null — _
+- `fields.dateOfBirthExact.required` — default false — _
+- `fields.dateOfBirthFrom.defaultValue` — default null — _
+- `fields.dateOfBirthFrom.required` — default false — _
+- `fields.dateOfBirthTo.defaultValue` — default null — _
+- `fields.dateOfBirthTo.required` — default false — _
+- `fields.dateOfDeath.defaultValue` — default null — _
+- `fields.dateOfDeath.required` — default false — _
+- `fields.diagnosis.defaultValue` — default null — _
+- `fields.diagnosis.hidden` — default false — _
+- `fields.diagnosis.required` — default false — _
+- `fields.dischargeDisposition.defaultValue` — default null — _
+- `fields.dischargeDisposition.hidden` — default false — _
+- `fields.dischargeDisposition.required` — default false — _
+- `fields.displayId.defaultValue` — default null — _
+- `fields.displayId.pattern` — default "[\s\S]*" — _
+- `fields.displayId.required` — default false — _
+- `fields.divisionId.defaultValue` — default null — _
+- `fields.divisionId.hidden` — default false — _
+- `fields.divisionId.required` — default false — _
+- `fields.divisionId.requiredPatientData` — default false — _
+- `fields.drivingLicense.defaultValue` — default null — _
+- `fields.drivingLicense.hidden` — default false — _
+- `fields.drivingLicense.required` — default false — _
+- `fields.drivingLicense.requiredPatientData` — default false — _
+- `fields.educationalLevel.defaultValue` — default null — _
+- `fields.educationalLevel.hidden` — default false — _
+- `fields.educationalLevel.required` — default false — _
+- `fields.educationalLevel.requiredPatientData` — default false — _
+- `fields.email.defaultValue` — default null — _
+- `fields.email.hidden` — default false — _
+- `fields.email.required` — default false — _
+- `fields.email.requiredPatientData` — default false — _
+- `fields.emergencyContactName.defaultValue` — default null — Patients emergency contact name
+- `fields.emergencyContactName.required` — default false — Patients emergency contact name
+- `fields.emergencyContactName.requiredPatientData` — default false — Patients emergency contact name
+- `fields.emergencyContactNumber.defaultValue` — default null — _
+- `fields.emergencyContactNumber.required` — default false — _
+- `fields.emergencyContactNumber.requiredPatientData` — default false — _
+- `fields.ethnicityId.defaultValue` — default null — _
+- `fields.ethnicityId.hidden` — default false — _
+- `fields.ethnicityId.required` — default false — _
+- `fields.ethnicityId.requiredPatientData` — default false — _
+- `fields.facility.defaultValue` — default null — _
+- `fields.facility.hidden` — default false — _
+- `fields.facility.required` — default false — _
+- `fields.fatherId.defaultValue` — default null — _
+- `fields.fatherId.hidden` — default false — _
+- `fields.fatherId.required` — default false — _
+- `fields.fatherId.requiredPatientData` — default false — _
+- `fields.firstName.defaultValue` — default null — _
+- `fields.firstName.required` — default false — _
+- `fields.firstName.requiredPatientData` — default false — _
+- `fields.gestationalAgeEstimate.defaultValue` — default null — _
+- `fields.gestationalAgeEstimate.hidden` — default false — _
+- `fields.gestationalAgeEstimate.required` — default false — _
+- `fields.gestationalAgeEstimate.requiredPatientData` — default false — _
+- `fields.healthCenterId.defaultValue` — default null — _
+- `fields.healthCenterId.hidden` — default false — _
+- `fields.healthCenterId.required` — default false — _
+- `fields.healthCenterId.requiredPatientData` — default false — _
+- `fields.insurerId.defaultValue` — default null — _
+- `fields.insurerId.hidden` — default false — _
+- `fields.insurerId.required` — default false — _
+- `fields.insurerId.requiredPatientData` — default false — _
+- `fields.insurerPolicyNumber.defaultValue` — default null — _
+- `fields.insurerPolicyNumber.hidden` — default false — _
+- `fields.insurerPolicyNumber.required` — default false — _
+- `fields.insurerPolicyNumber.requiredPatientData` — default false — _
+- `fields.lastName.defaultValue` — default null — _
+- `fields.lastName.required` — default false — _
+- `fields.lastName.requiredPatientData` — default false — _
+- `fields.locationGroupId.defaultValue` — default null — _
+- `fields.locationGroupId.hidden` — default false — _
+- `fields.locationGroupId.required` — default false — _
+- `fields.locationId.defaultValue` — default null — _
+- `fields.locationId.hidden` — default false — _
+- `fields.locationId.required` — default false — _
+- `fields.maritalStatus.defaultValue` — default null — _
+- `fields.maritalStatus.hidden` — default false — _
+- `fields.maritalStatus.required` — default false — _
+- `fields.maritalStatus.requiredPatientData` — default false — _
+- `fields.markedForSync.defaultValue` — default null — _
+- `fields.markedForSync.required` — default false — _
+- `fields.medicalAreaId.defaultValue` — default null — _
+- `fields.medicalAreaId.hidden` — default false — _
+- `fields.medicalAreaId.required` — default false — _
+- `fields.medicalAreaId.requiredPatientData` — default false — _
+- `fields.middleName.defaultValue` — default null — _
+- `fields.middleName.hidden` — default false — _
+- `fields.middleName.required` — default false — _
+- `fields.middleName.requiredPatientData` — default false — _
+- `fields.motherId.defaultValue` — default null — _
+- `fields.motherId.hidden` — default false — _
+- `fields.motherId.required` — default false — _
+- `fields.motherId.requiredPatientData` — default false — _
+- `fields.nameOfAttendantAtBirth.defaultValue` — default null — _
+- `fields.nameOfAttendantAtBirth.hidden` — default false — _
+- `fields.nameOfAttendantAtBirth.required` — default false — _
+- `fields.nameOfAttendantAtBirth.requiredPatientData` — default false — _
+- `fields.nationalityId.defaultValue` — default null — _
+- `fields.nationalityId.hidden` — default false — _
+- `fields.nationalityId.required` — default false — _
+- `fields.nationalityId.requiredPatientData` — default false — _
+- `fields.notGivenReasonId.defaultValue` — default null — _
+- `fields.notGivenReasonId.hidden` — default false — _
+- `fields.notGivenReasonId.required` — default false — _
+- `fields.nursingZoneId.defaultValue` — default null — _
+- `fields.nursingZoneId.hidden` — default false — _
+- `fields.nursingZoneId.required` — default false — _
+- `fields.nursingZoneId.requiredPatientData` — default false — _
+- `fields.occupationId.defaultValue` — default null — _
+- `fields.occupationId.hidden` — default false — _
+- `fields.occupationId.required` — default false — _
+- `fields.occupationId.requiredPatientData` — default false — _
+- `fields.passport.defaultValue` — default null — _
+- `fields.passport.hidden` — default false — _
+- `fields.passport.required` — default false — _
+- `fields.passport.requiredPatientData` — default false — _
+- `fields.patientBillingTypeId.defaultValue` — default null — _
+- `fields.patientBillingTypeId.hidden` — default false — _
+- `fields.patientBillingTypeId.required` — default false — _
+- `fields.patientBillingTypeId.requiredPatientData` — default false — _
+- `fields.placeOfBirth.defaultValue` — default null — _
+- `fields.placeOfBirth.hidden` — default false — _
+- `fields.placeOfBirth.required` — default false — _
+- `fields.placeOfBirth.requiredPatientData` — default false — _
+- `fields.prescriber.defaultValue` — default null — _
+- `fields.prescriber.hidden` — default false — _
+- `fields.prescriber.required` — default false — _
+- `fields.prescriberId.defaultValue` — default null — _
+- `fields.prescriberId.hidden` — default false — _
+- `fields.prescriberId.required` — default false — _
+- `fields.primaryContactNumber.defaultValue` — default null — _
+- `fields.primaryContactNumber.hidden` — default false — _
+- `fields.primaryContactNumber.required` — default false — _
+- `fields.primaryContactNumber.requiredPatientData` — default false — _
+- `fields.programRegistry.defaultValue` — default null — _
+- `fields.programRegistry.hidden` — default false — _
+- `fields.programRegistry.required` — default false — _
+- `fields.referralSourceId.defaultValue` — default null — _
+- `fields.referralSourceId.hidden` — default false — _
+- `fields.referralSourceId.required` — default false — _
+- `fields.registeredBirthPlace.defaultValue` — default null — _
+- `fields.registeredBirthPlace.hidden` — default false — _
+- `fields.registeredBirthPlace.required` — default false — _
+- `fields.registeredBirthPlace.requiredPatientData` — default false — _
+- `fields.registeredBy.defaultValue` — default null — _
+- `fields.registeredBy.hidden` — default false — _
+- `fields.registeredBy.required` — default false — _
+- `fields.religionId.defaultValue` — default null — _
+- `fields.religionId.hidden` — default false — _
+- `fields.religionId.required` — default false — _
+- `fields.religionId.requiredPatientData` — default false — _
+- `fields.reminderContactName.defaultValue` — default null — _
+- `fields.reminderContactName.hidden` — default false — _
+- `fields.reminderContactName.required` — default false — _
+- `fields.reminderContactNumber.defaultValue` — default null — _
+- `fields.reminderContactNumber.hidden` — default false — _
+- `fields.reminderContactNumber.required` — default false — _
+- `fields.secondaryContactNumber.defaultValue` — default null — _
+- `fields.secondaryContactNumber.hidden` — default false — _
+- `fields.secondaryContactNumber.required` — default false — _
+- `fields.secondaryContactNumber.requiredPatientData` — default false — _
+- `fields.settlementId.defaultValue` — default null — _
+- `fields.settlementId.hidden` — default false — _
+- `fields.settlementId.required` — default false — _
+- `fields.settlementId.requiredPatientData` — default false — _
+- `fields.sex.defaultValue` — default null — _
+- `fields.sex.hidden` — default false — _
+- `fields.sex.required` — default false — _
+- `fields.sex.requiredPatientData` — default false — _
+- `fields.socialMedia.defaultValue` — default null — _
+- `fields.socialMedia.hidden` — default false — _
+- `fields.socialMedia.required` — default false — _
+- `fields.socialMedia.requiredPatientData` — default false — _
+- `fields.status.defaultValue` — default null — _
+- `fields.status.hidden` — default false — _
+- `fields.status.required` — default false — _
+- `fields.streetVillage.defaultValue` — default null — _
+- `fields.streetVillage.hidden` — default false — _
+- `fields.streetVillage.required` — default false — _
+- `fields.streetVillage.requiredPatientData` — default false — _
+- `fields.subdivisionId.defaultValue` — default null — _
+- `fields.subdivisionId.hidden` — default false — _
+- `fields.subdivisionId.required` — default false — _
+- `fields.subdivisionId.requiredPatientData` — default false — _
+- `fields.timeOfBirth.defaultValue` — default null — _
+- `fields.timeOfBirth.hidden` — default false — _
+- `fields.timeOfBirth.required` — default false — _
+- `fields.timeOfBirth.requiredPatientData` — default false — _
+- `fields.title.defaultValue` — default null — _
+- `fields.title.hidden` — default false — _
+- `fields.title.required` — default false — _
+- `fields.title.requiredPatientData` — default false — _
+- `fields.villageId.defaultValue` — default null — _
+- `fields.villageId.hidden` — default false — _
+- `fields.villageId.required` — default false — _
+- `fields.villageId.requiredPatientData` — default false — _
+- `fields.villageName.defaultValue` — default null — _
+- `fields.villageName.hidden` — default false — _
+- `fields.villageName.required` — default false — _
+
+### fileChooserMbSizeLimit
+- `fileChooserMbSizeLimit` — default 10 — Settings that apply to all servers
+
+### imagingCancellationReasons
+- `imagingCancellationReasons` — default [{"value":"clinical","label":"Clinical reason","hidden":f… — Settings that apply to all servers
+
+### imagingPriorities
+- `imagingPriorities` — default [{"value":"routine","label":"Routine"},{"value":"urgent",… — Settings that apply to all servers
+
+### integrations
+- `integrations.imaging.enabled` — default false — Imaging integration settings
+- `integrations.imaging.provider` — default "test" — Imaging integration settings
+
+### invoice
+- `invoice.slidingFeeScale` — default [[0,5700,10050,12600,14100,17500],[0,6600,13500,16300,190… — Settings that apply to all servers
+
+### labsCancellationReasons
+- `labsCancellationReasons` — default [{"value":"clinical","label":"Clinical reason"},{"value":… — Settings that apply to all servers
+
+### layouts
+- `layouts.mobilePatientModules.diagnosisAndTreatment.hidden` — default false — _
+- `layouts.mobilePatientModules.diagnosisAndTreatment.sortPriority` — default 0 — _
+- `layouts.mobilePatientModules.programRegistries.hidden` — default false — _
+- `layouts.mobilePatientModules.programs.hidden` — default false — _
+- `layouts.mobilePatientModules.programs.sortPriority` — default 0 — _
+- `layouts.mobilePatientModules.referral.hidden` — default false — _
+- `layouts.mobilePatientModules.referral.sortPriority` — default 0 — _
+- `layouts.mobilePatientModules.tests.hidden` — default false — _
+- `layouts.mobilePatientModules.tests.sortPriority` — default 0 — _
+- `layouts.mobilePatientModules.vaccine.hidden` — default false — _
+- `layouts.mobilePatientModules.vaccine.sortPriority` — default 0 — _
+- `layouts.mobilePatientModules.vitals.hidden` — default false — _
+- `layouts.mobilePatientModules.vitals.sortPriority` — default 0 — _
+- `layouts.patientTabs.details.sortPriority` — default -100 — _
+- `layouts.patientTabs.documents.hidden` — default false — _
+- `layouts.patientTabs.documents.sortPriority` — default 0 — _
+- `layouts.patientTabs.invoices.hidden` — default false — _
+- `layouts.patientTabs.invoices.sortPriority` — default 0 — _
+- `layouts.patientTabs.medication.hidden` — default false — _
+- `layouts.patientTabs.medication.sortPriority` — default 0 — _
+- `layouts.patientTabs.programs.hidden` — default false — _
+- `layouts.patientTabs.programs.sortPriority` — default 0 — _
+- `layouts.patientTabs.referrals.hidden` — default false — _
+- `layouts.patientTabs.referrals.sortPriority` — default 0 — _
+- `layouts.patientTabs.results.hidden` — default false — _
+- `layouts.patientTabs.results.sortPriority` — default 0 — _
+- `layouts.patientTabs.summary.sortPriority` — default -100 — _
+- `layouts.patientTabs.vaccines.hidden` — default false — _
+- `layouts.patientTabs.vaccines.sortPriority` — default 0 — _
+- `layouts.patientView.showLocationBookings` — default false — The patient view in the facility
+- `layouts.patientView.showOutpatientAppointments` — default false — The patient view in the facility
+- `layouts.sidebar.dashboard.hidden` — default false — _
+- `layouts.sidebar.dashboard.sortPriority` — default 0 — _
+- `layouts.sidebar.facilityAdmin.bedManagement.hidden` — default false — _
+- `layouts.sidebar.facilityAdmin.bedManagement.sortPriority` — default 0 — _
+- `layouts.sidebar.facilityAdmin.reports.hidden` — default false — _
+- `layouts.sidebar.facilityAdmin.reports.sortPriority` — default 0 — _
+- `layouts.sidebar.imaging.imagingActive.hidden` — default false — _
+- `layouts.sidebar.imaging.imagingActive.sortPriority` — default 0 — _
+- `layouts.sidebar.imaging.imagingCompleted.hidden` — default false — _
+- `layouts.sidebar.imaging.imagingCompleted.sortPriority` — default 0 — _
+- `layouts.sidebar.immunisations.immunisationsAll.hidden` — default false — _
+- `layouts.sidebar.immunisations.immunisationsAll.sortPriority` — default 0 — _
+- `layouts.sidebar.labs.labsAll.hidden` — default false — _
+- `layouts.sidebar.labs.labsAll.sortPriority` — default 0 — _
+- `layouts.sidebar.labs.labsPublished.hidden` — default false — _
+- `layouts.sidebar.labs.labsPublished.sortPriority` — default 0 — _
+- `layouts.sidebar.patients.patientsEmergency.hidden` — default false — _
+- `layouts.sidebar.patients.patientsEmergency.sortPriority` — default 0 — _
+- `layouts.sidebar.patients.patientsInpatients.hidden` — default false — _
+- `layouts.sidebar.patients.patientsInpatients.sortPriority` — default 0 — _
+- `layouts.sidebar.patients.patientsOutpatients.hidden` — default false — _
+- `layouts.sidebar.patients.patientsOutpatients.sortPriority` — default 0 — _
+- `layouts.sidebar.scheduling.schedulingLocations.hidden` — default false — _
+- `layouts.sidebar.scheduling.schedulingLocations.sortPriority` — default 0 — _
+- `layouts.sidebar.scheduling.schedulingOutpatients.hidden` — default false — _
+- `layouts.sidebar.scheduling.schedulingOutpatients.sortPriority` — default 0 — _
+
+### locationAssignments
+- `locationAssignments.assignmentMaxFutureMonths` — default 24 — Location assignment settings
+
+### medications
+- `medications.defaultAdministrationTimes.Daily` — default ["06:00"] — -
+- `medications.defaultAdministrationTimes.Daily at midday` — default ["12:00"] — -
+- `medications.defaultAdministrationTimes.Daily at night` — default ["18:00"] — -
+- `medications.defaultAdministrationTimes.Daily in the morning` — default ["06:00"] — -
+- `medications.defaultAdministrationTimes.Every 4 hours` — default ["02:00","06:00","10:00","14:00","18:00","22:00"] — -
+- `medications.defaultAdministrationTimes.Every 6 hours` — default ["00:00","06:00","12:00","18:00"] — -
+- `medications.defaultAdministrationTimes.Every 8 hours` — default ["06:00","14:00","22:00"] — -
+- `medications.defaultAdministrationTimes.Every second day` — default ["06:00"] — -
+- `medications.defaultAdministrationTimes.Four times daily` — default ["06:00","12:00","18:00","22:00"] — -
+- `medications.defaultAdministrationTimes.Once a month` — default ["06:00"] — -
+- `medications.defaultAdministrationTimes.Once a week` — default ["06:00"] — -
+- `medications.defaultAdministrationTimes.Three times daily` — default ["06:00","12:00","18:00"] — -
+- `medications.defaultAdministrationTimes.Twice daily - AM and midday` — default ["06:00","12:00"] — -
+- `medications.defaultAdministrationTimes.Two times daily` — default ["06:00","18:00"] — -
+- `medications.frequenciesEnabled.As directed` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Daily` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Daily at midday` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Daily at night` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Daily in the morning` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Every 4 hours` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Every 6 hours` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Every 8 hours` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Every second day` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Four times daily` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Immediately` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Once a month` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Once a week` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Three times daily` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Twice daily - AM and midday` — default true — Enable medication frequencies
+- `medications.frequenciesEnabled.Two times daily` — default true — Enable medication frequencies
+
+### notifications
+- `notifications.recentNotificationsTimeFrame` — default 48 — Notification settings
+
+### printMeasures
+- `printMeasures.idCardPage.cardMarginLeft` — default 5 — The ID card found on the patient view
+- `printMeasures.idCardPage.cardMarginTop` — default 1 — The ID card found on the patient view
+- `printMeasures.labRequestPrintLabel.width` — default 50.8 — Lab request label with basic info + barcode
+- `printMeasures.stickerLabelPage.columnGap` — default 3.01 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.columnWidth` — default 64 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.pageHeight` — default 297 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.pageMarginLeft` — default 6.4 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.pageMarginTop` — default 15.09 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.pageWidth` — default 210 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.rowGap` — default 0 — The multiple ID labels printout on the patient view
+- `printMeasures.stickerLabelPage.rowHeight` — default 26.7 — The multiple ID labels printout on the patient view
+
+### security
+- `security.loginAttempts.lockoutDuration` — default 10 (high-risk) — Login attempts settings
+- `security.loginAttempts.lockoutThreshold` — default 10 (high-risk) — Login attempts settings
+- `security.loginAttempts.observationWindow` — default 10 (high-risk) — Login attempts settings
+- `security.mobile.allowUnencryptedStorage` — default true (high-risk) — Mobile security settings
+- `security.mobile.allowUnprotected` — default true (high-risk) — Mobile security settings
+- `security.reportNoUserError` — default false (high-risk) — Security settings
+
+### templates
+- `templates.appointmentConfirmation.body` — default "Hi $firstName$ $lastName$,
+
+ This is a confirma…" — The email sent to confirm an appointment
+- `templates.appointmentConfirmation.subject` — default "Appointment confirmation" — The email sent to confirm an appointment
+- `templates.covidClearanceCertificateEmail.body` — default "A COVID-19 clearance certificate has been gener…" — Certificate containing the list of COVID tests for this patient used for proof of over 13 days since infection
+- `templates.covidClearanceCertificateEmail.subject` — default "COVID-19 Clearance Certificate now available" — Certificate containing the list of COVID tests for this patient used for proof of over 13 days since infection
+- `templates.covidTestCertificate.clearanceCertRemark` — default "This notice certifies that $firstName$ $lastNam…" — Certificate containing the list of COVID vaccines for this patient
+- `templates.covidTestCertificate.laboratoryName` — default "Approved test provider" — Certificate containing the list of COVID vaccines for this patient
+- `templates.covidTestCertificateEmail.body` — default "A medical certificate has been generated for yo…" — Email with certificate containing the list of COVID tests for this patient
+- `templates.covidTestCertificateEmail.subject` — default "Medical Certificate now available" — Email with certificate containing the list of COVID tests for this patient
+- `templates.covidVaccineCertificateEmail.body` — default "A medical certificate has been generated for yo…" — The email containing COVID patient vaccine certificate
+- `templates.covidVaccineCertificateEmail.subject` — default "Medical Certificate now available" — The email containing COVID patient vaccine certificate
+- `templates.letterhead.subTitle` — default "PO Box 12345, Melbourne, Australia" — The text at the top of most patient PDFs
+- `templates.letterhead.title` — default "TAMANU MINISTRY OF HEALTH & MEDICAL SERVICES" — The text at the top of most patient PDFs
+- `templates.patientPortalLoginEmail.body` — default "Your 6-digit login code for Tamanu Patient Port…" — The email sent to the patient with their login code
+- `templates.patientPortalLoginEmail.subject` — default "Your Tamanu Patient Portal Login Code" — The email sent to the patient with their login code
+- `templates.patientPortalRegisteredFormEmail.body` — default "A new patient form request has been sent from $…" — The email sent to a registered patient to complete a form
+- `templates.patientPortalRegisteredFormEmail.subject` — default "New Patient Form Request from $facilityName$" — The email sent to a registered patient to complete a form
+- `templates.patientPortalRegistrationEmail.body` — default "Please follow the link below to complete Tamanu…" — The email sent to the patient to register for the patient portal
+- `templates.patientPortalRegistrationEmail.subject` — default "Tamanu Patient Portal Registration" — The email sent to the patient to register for the patient portal
+- `templates.patientPortalUnregisteredFormEmail.body` — default "A new patient form request has been sent from $…" — The email sent to an unregistered patient to complete a form
+- `templates.patientPortalUnregisteredFormEmail.subject` — default "New Patient Form Request from $facilityName$" — The email sent to an unregistered patient to complete a form
+- `templates.plannedMoveTimeoutHours` — default 24 — Strings to be inserted into emails/PDFs
+- `templates.signerRenewalEmail.body` — default "Please sign the following certificate signing r…" — The email sent when the signer runs out
+- `templates.signerRenewalEmail.subject` — default "Tamanu ICAO Certificate Signing Request" — The email sent when the signer runs out
+- `templates.vaccineCertificate.contactNumber` — default "12345" — Certificate containing the list of vaccines for this patient
+- `templates.vaccineCertificate.emailAddress` — default "tamanu@health.gov" — Certificate containing the list of vaccines for this patient
+- `templates.vaccineCertificate.healthFacility` — default "State level" — Certificate containing the list of vaccines for this patient
+- `templates.vaccineCertificateEmail.body` — default "A medical certificate has been generated for yo…" — The email containing patient vaccine certificate
+- `templates.vaccineCertificateEmail.subject` — default "Medical Certificate now available" — The email containing patient vaccine certificate
+
+### triageCategories
+- `triageCategories` — default [{"level":1,"label":"Emergency","color":"#F76853"},{"leve… — Settings that apply to all servers
+
+### upcomingVaccinations
+- `upcomingVaccinations.ageLimit` — default 15 — Settings related to upcoming vaccinations
+- `upcomingVaccinations.thresholds` — default [{"threshold":28,"status":"SCHEDULED"},{"threshold":7,"st… — Settings related to upcoming vaccinations
+
+### vitalEditReasons
+- `vitalEditReasons` — default [{"value":"incorrect-patient","label":"Incorrect patient"… — Settings that apply to all servers
+
+
+## Central Settings
+
+### disk
+- `disk.freeSpaceRequired.gigabytesForUploadingDocuments` — default 16 — Settings related to free disk space required during uploads
+
+### integrations
+- `integrations.dhis2.backoff.maxAttempts` — default 15 — Backoff settings
+- `integrations.dhis2.backoff.maxWaitMs` — default 10000 — Backoff settings
+- `integrations.dhis2.backoff.multiplierMs` — default 300 — Backoff settings
+- `integrations.dhis2.host` — default "" — DHIS2 settings
+- `integrations.dhis2.idSchemes.categoryOptionComboIdScheme` — default "uid" — The ID schemes to use for the reports
+- `integrations.dhis2.idSchemes.dataElementIdScheme` — default "uid" — The ID schemes to use for the reports
+- `integrations.dhis2.idSchemes.dataSetIdScheme` — default "uid" — The ID schemes to use for the reports
+- `integrations.dhis2.idSchemes.idScheme` — default "uid" — The ID schemes to use for the reports
+- `integrations.dhis2.idSchemes.orgUnitIdScheme` — default "uid" — The ID schemes to use for the reports
+- `integrations.dhis2.reportIds` — default [] — DHIS2 settings
+
+### locationAssignments
+- `locationAssignments.assignmentSlots.endTime` — default "17:00" — Configure the available time slots for assigning locations to users
+- `locationAssignments.assignmentSlots.slotDuration` — default "30min" — Configure the available time slots for assigning locations to users
+- `locationAssignments.assignmentSlots.startTime` — default "09:00" — Configure the available time slots for assigning locations to users
+
+### mobileSync
+- `mobileSync.dynamicLimiter.initialLimit` — default 10000 (high-risk) — Settings for the sync page size dynamic limiter
+- `mobileSync.dynamicLimiter.maxLimit` — default 40000 (high-risk) — Settings for the sync page size dynamic limiter
+- `mobileSync.dynamicLimiter.maxLimitChangePerPage` — default 0.3 (high-risk) — Settings for the sync page size dynamic limiter
+- `mobileSync.dynamicLimiter.minLimit` — default 1000 (high-risk) — Settings for the sync page size dynamic limiter
+- `mobileSync.dynamicLimiter.optimalTimePerPage` — default 10000 (high-risk) — Settings for the sync page size dynamic limiter
+- `mobileSync.maxBatchesToKeepInMemory` — default 5 (high-risk) — Settings related to mobile sync
+- `mobileSync.maxRecordsPerInsertBatch` — default 2000 (high-risk) — Settings related to mobile sync
+- `mobileSync.maxRecordsPerSnapshotBatch` — default 1000 (high-risk) — Settings related to mobile sync
+- `mobileSync.maxRecordsPerUpdateBatch` — default 2000 (high-risk) — Settings related to mobile sync
+- `mobileSync.useUnsafeSchemaForInitialSync` — default true (high-risk) — Settings related to mobile sync
+
+### questionCodeIds
+- `questionCodeIds.email` — default null (deprecated) — Avoid using questionCodeIds. The PatientData question type has made this setting redundant.
+- `questionCodeIds.nationalityId` — default null (deprecated) — Avoid using questionCodeIds. The PatientData question type has made this setting redundant.
+- `questionCodeIds.passport` — default null (deprecated) — Avoid using questionCodeIds. The PatientData question type has made this setting redundant.
+
+### reportProcess
+- `reportProcess.childProcessEnv` — default null — Settings that apply only to a central server
+- `reportProcess.processOptions` — default null — Settings that apply only to a central server
+- `reportProcess.runInChildProcess` — default true — Settings that apply only to a central server
+- `reportProcess.sleepAfterReport.duration` — default "5m" — To mitigate resource-hungry reports affecting operational use of Tamanu, if a report takes too long, then report generation can be suspended for a some time
+- `reportProcess.sleepAfterReport.ifRunAtLeast` — default "5m" — To mitigate resource-hungry reports affecting operational use of Tamanu, if a report takes too long, then report generation can be suspended for a some time
+- `reportProcess.timeOutDurationSeconds` — default 7200 — Settings that apply only to a central server
+
+### sync
+- `sync.streaming.databasePollBatchSize` — default 100 (high-risk) — Settings related to sync
+- `sync.streaming.databasePollInterval` — default 1000 (high-risk) — Settings related to sync
+- `sync.streaming.enabled` — default false (high-risk) — Settings related to sync
+
+
+## Facility Settings
+
+### appointments
+- `appointments.bookingSlots.endTime` — default "17:00" — Configure the available booking slots for appointments
+- `appointments.bookingSlots.slotDuration` — default "30min" — Configure the available booking slots for appointments
+- `appointments.bookingSlots.startTime` — default "09:00" — Configure the available booking slots for appointments
+
+### certifications
+- `certifications.covidClearanceCertificate.after` — default "2022-09-01" — Settings that apply only to a facility server
+- `certifications.covidClearanceCertificate.daysSinceSampleTime` — default 13 — Settings that apply only to a facility server
+- `certifications.covidClearanceCertificate.labTestCategories` — default [] — Settings that apply only to a facility server
+- `certifications.covidClearanceCertificate.labTestResults` — default ["Positive"] — Settings that apply only to a facility server
+- `certifications.covidClearanceCertificate.labTestTypes` — default [] — Settings that apply only to a facility server
+
+### questionCodeIds
+- `questionCodeIds.email` — default null (deprecated) — Avoid using questionCodeIds. The PatientData question type has made this setting redundant.
+- `questionCodeIds.nationalityId` — default "pde-PalauCOVSamp7" (deprecated) — Avoid using questionCodeIds. The PatientData question type has made this setting redundant.
+- `questionCodeIds.passport` — default "pde-FijCOVRDT005" (deprecated) — Avoid using questionCodeIds. The PatientData question type has made this setting redundant.
+
+### survey
+- `survey.defaultCodes.department` — default "GeneralClinic" — Default reference data codes to use when creating a survey encounter (includes vitals) when none are explicitly specified
+- `survey.defaultCodes.location` — default "GeneralClinic" — Default reference data codes to use when creating a survey encounter (includes vitals) when none are explicitly specified
+
+### sync
+- `sync.syncAllLabRequests` — default false (high-risk) — Facility sync settings
+- `sync.urgentIntervalInSeconds` — default 10 (high-risk) — Facility sync settings
+
+### templates
+- `templates.letterhead.subTitle` — default "PO Box 12345, Melbourne, Australia" — The text at the top of most patient PDFs
+- `templates.letterhead.title` — default "TAMANU MINISTRY OF HEALTH & MEDICAL SERVICES" — The text at the top of most patient PDFs
+
+### vaccinations
+- `vaccinations.defaults.departmentId` — default null — _
+- `vaccinations.defaults.locationGroupId` — default null — _
+- `vaccinations.defaults.locationId` — default null — _
+- `vaccinations.givenElsewhere.defaults.departmentId` — default null — _
+- `vaccinations.givenElsewhere.defaults.locationGroupId` — default null — _
+- `vaccinations.givenElsewhere.defaults.locationId` — default null — _


### PR DESCRIPTION
### Changes

Adds a machine-readable JSON file (`docs/releases/tamanu-v2-44-settings.json`) containing a comprehensive inventory of all global, central, and facility configurations and settings for Tamanu v2.44, including their defaults, descriptions, and high-risk/deprecated flags. This enables programmatic access to the settings for review and automation.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
<a href="https://cursor.com/background-agent?bcId=bc-3019fdca-3ebd-4fc6-a9a2-f567a513a35d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3019fdca-3ebd-4fc6-a9a2-f567a513a35d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

