### PR TITLE
feat(sync): TAMOC-371: Mark sync session as errored if error occurs on the facility-server

### DIFF
--- a/packages/central-server/app/sync/buildSyncRoutes.js
+++ b/packages/central-server/app/sync/buildSyncRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import * as z from 'zod';
 
 import { Op } from 'sequelize';
 import { log } from '@tamanu/shared/services/logging';
@@ -339,13 +340,17 @@ export const buildSyncRoutes = ctx => {
     }),
   );
 
+  const postErrorBodySchema = z.object({
+    error: z.string(),
+  });
   // mark session as errored, so server will record the error and cancel the sync
   syncRoutes.post(
     '/:sessionId/error',
     asyncHandler(async (req, res) => {
-      const { params, body } = req;
+      const { params } = req;
       const { sessionId } = params;
-      const { error } = body;
+      const { error } = await postErrorBodySchema.parseAsync(req.body);
+
       await syncManager.endSession(sessionId, error);
       res.json({});
     }),

--- a/packages/central-server/app/sync/buildSyncRoutes.js
+++ b/packages/central-server/app/sync/buildSyncRoutes.js
@@ -339,6 +339,18 @@ export const buildSyncRoutes = ctx => {
     }),
   );
 
+  // mark session as errored, so server will record the error and cancel the sync
+  syncRoutes.post(
+    '/:sessionId/error',
+    asyncHandler(async (req, res) => {
+      const { params, body } = req;
+      const { sessionId } = params;
+      const { error } = body;
+      await syncManager.endSession(sessionId, error);
+      res.json({});
+    }),
+  );
+
   // end session
   syncRoutes.delete(
     '/:sessionId',

--- a/packages/facility-server/__tests__/sync/FacilitySyncManager-edgecases.test.js
+++ b/packages/facility-server/__tests__/sync/FacilitySyncManager-edgecases.test.js
@@ -113,8 +113,8 @@ describe('FacilitySyncManager edge cases', () => {
     // argument to pushOutgoingChanges, which we spy on)
     expect(
       syncManager.__testOnlyPushChangesSpy[0].outgoingChanges
-        .filter((c) => c.recordType === 'patients')
-        .map((c) => c.recordId)
+        .filter(c => c.recordType === 'patients')
+        .map(c => c.recordId)
         .sort(),
     ).toStrictEqual([safePatientId, riskyPatientId].sort());
   });
@@ -177,6 +177,7 @@ describe('FacilitySyncManager edge cases', () => {
               },
             },
           ]),
+          markSessionErrored: jest.fn(),
           completePush: jest.fn(),
           endSyncSession: jest.fn(),
           initiatePull: jest.fn().mockImplementation(async () => ({
@@ -200,7 +201,7 @@ describe('FacilitySyncManager edge cases', () => {
 
     it('does not throw an error if pulled records was not updated between push and pull', async () => {
       let resolvePushOutgoingChangesPromise;
-      const pushOutgoingChangesPromise = new Promise((resolve) => {
+      const pushOutgoingChangesPromise = new Promise(resolve => {
         resolvePushOutgoingChangesPromise = async () => resolve(true);
       });
       jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({
@@ -229,7 +230,7 @@ describe('FacilitySyncManager edge cases', () => {
 
     it('throws an error if a pulled record was updated between push and pull', async () => {
       let resolvePushOutgoingChangesPromise;
-      const pushOutgoingChangesPromise = new Promise((resolve) => {
+      const pushOutgoingChangesPromise = new Promise(resolve => {
         resolvePushOutgoingChangesPromise = async () => resolve(true);
       });
       jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({
@@ -264,7 +265,7 @@ describe('FacilitySyncManager edge cases', () => {
 
     it('does not throw an error if a pulled record was updated between push and pull, but the config was disabled', async () => {
       let resolvePushOutgoingChangesPromise;
-      const pushOutgoingChangesPromise = new Promise((resolve) => {
+      const pushOutgoingChangesPromise = new Promise(resolve => {
         resolvePushOutgoingChangesPromise = async () => resolve(true);
       });
       jest.doMock('../../dist/sync/pushOutgoingChanges', () => ({

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -152,6 +152,10 @@ export class CentralServerConnection extends TamanuApi {
     return { sessionId, startedAtTick };
   }
 
+  async markSessionErrored(sessionId, error) {
+    return this.fetch(`sync/${sessionId}/error`, { method: 'POST', body: { error } });
+  }
+
   async endSyncSession(sessionId) {
     return this.fetch(`sync/${sessionId}`, { method: 'DELETE' });
   }

--- a/packages/facility-server/app/sync/FacilitySyncManager.js
+++ b/packages/facility-server/app/sync/FacilitySyncManager.js
@@ -163,8 +163,8 @@ export class FacilitySyncManager {
       await this.pullChanges(sessionId);
       await this.centralServer.endSyncSession(sessionId);
     } catch (error) {
-      if (!(error instanceof Problem)) {
-        // if the error is not a Problem, it occurred locally on the facility-server and we should notify the central server
+      if (!(error instanceof Problem && error.response)) {
+        // if the error is not a Problem or doesn't have a response, it occurred locally on the facility-server and we should notify the central server
         await this.centralServer.markSessionErrored(sessionId, error.message);
       }
       throw error;


### PR DESCRIPTION
### Changes

Currently we never see the actual error from the facility-server in the sync_session, and we just rely on the session being marked as overriden.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
