### PR TITLE
fix(patientMerge): TAMOC-370: Fix merging patients when the keep patient has a deleted patient program registration

### DIFF
--- a/packages/central-server/app/admin/patientMerge/mergePatient.js
+++ b/packages/central-server/app/admin/patientMerge/mergePatient.js
@@ -238,6 +238,7 @@ export async function mergePatientProgramRegistrations(models, keepPatientId, un
 
   const existingKeepRegistrations = await models.PatientProgramRegistration.findAll({
     where: { patientId: keepPatientId },
+    paranoid: false, // Include soft deleted registrations, as we don't want to create new registrations if they've already been deleted on the keep
   });
   const keepRegistrationMap = new Map(existingKeepRegistrations.map(r => [r.programRegistryId, r]));
 


### PR DESCRIPTION
### Changes

Previously we didn't check for soft-deleted PPRs of the keep patient. This meant that when we created new ones from the merge patient, we could have a duplicate id clash as the PPR ids are formatted `patientId-programRegistryId`

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
