### PR TITLE
fix: EPI-1248: Add graph data and enhance charting in program registry dashboard view

### DIFF
--- a/packages/facility-server/app/routes/apiv1/programRegistry.js
+++ b/packages/facility-server/app/routes/apiv1/programRegistry.js
@@ -85,10 +85,10 @@ programRegistry.get(
       offset: page && rowsPerPage ? page * rowsPerPage : undefined,
     });
 
-    const filteredObjects = objects.filter((programRegistry) =>
+    const filteredObjects = objects.filter(programRegistry =>
       req.ability.can('list', programRegistry),
     );
-    const filteredData = filteredObjects.map((x) => x.forResponse());
+    const filteredData = filteredObjects.map(x => x.forResponse());
     const filteredCount =
       objects.length !== filteredObjects.length ? filteredObjects.length : count;
 
@@ -182,12 +182,12 @@ programRegistry.get(
           active_status: REGISTRATION_STATUSES.ACTIVE,
         }),
       ),
-    ].filter((f) => f);
+    ].filter(f => f);
 
-    const whereClauses = filters.map((f) => f.sql).join(' AND ');
+    const whereClauses = filters.map(f => f.sql).join(' AND ');
 
     const filterReplacements = filters
-      .filter((f) => f.transform)
+      .filter(f => f.transform)
       .reduce(
         (current, { transform }) => ({
           ...current,
@@ -378,7 +378,11 @@ programRegistry.get(
       where: {
         programId: registry.programId,
         surveyType: {
-          [Op.in]: [SURVEY_TYPES.SIMPLE_CHART, SURVEY_TYPES.COMPLEX_CHART, SURVEY_TYPES.COMPLEX_CHART_CORE],
+          [Op.in]: [
+            SURVEY_TYPES.SIMPLE_CHART,
+            SURVEY_TYPES.COMPLEX_CHART,
+            SURVEY_TYPES.COMPLEX_CHART_CORE,
+          ],
         },
         visibilityStatus: VISIBILITY_STATUSES.CURRENT,
       },
@@ -398,6 +402,68 @@ programRegistry.get(
 );
 
 programRegistry.get(
+  '/patient/:patientId/initialChart',
+  asyncHandler(async (req, res) => {
+    const { models, params, query } = req;
+    const { patientId } = params;
+    const { programRegistryId } = query;
+
+    req.checkPermission('read', 'Patient');
+
+    let surveyWhereClause = {
+      surveyType: [SURVEY_TYPES.SIMPLE_CHART, SURVEY_TYPES.COMPLEX_CHART],
+    };
+
+    if (programRegistryId) {
+      const registry = await models.ProgramRegistry.findByPk(programRegistryId);
+      if (!registry) {
+        throw new NotFoundError('Program registry not found');
+      }
+
+      surveyWhereClause = {
+        ...surveyWhereClause,
+        programId: registry.programId,
+      };
+    }
+
+    // Get all chart surveys that have responses for this patient
+    // SurveyResponses are linked to encounters, which are linked to patients
+    const chartSurvey = await models.SurveyResponse.findAll({
+      attributes: [],
+      include: [
+        {
+          attributes: [],
+          required: true,
+          model: models.Encounter,
+          as: 'encounter',
+          where: { patientId },
+        },
+        {
+          attributes: ['id', 'name'],
+          required: true,
+          model: models.Survey,
+          as: 'survey',
+          where: surveyWhereClause,
+        },
+      ],
+      order: [['survey', 'name', 'ASC']],
+      group: ['survey.id', 'survey.name'],
+      raw: true,
+    });
+    req.flagPermissionChecked();
+    const allowedSurvey = chartSurvey.find(response =>
+      req.ability.can('list', subject('Charting', { id: response['survey.id'] })),
+    );
+
+    res.send({
+      data: allowedSurvey
+        ? { survey: { id: allowedSurvey['survey.id'], name: allowedSurvey['survey.name'] } }
+        : undefined,
+    });
+  }),
+);
+
+programRegistry.get(
   '/patient/:patientId/charts/:surveyId',
   fetchAnswersWithHistory({
     permissionAction: 'read',
@@ -410,13 +476,13 @@ programRegistry.get(
   fetchGraphData({
     permissionAction: 'read',
     permissionNoun: 'Charting',
-    dateDataElementId: CHARTING_DATA_ELEMENT_IDS.dateRecorded
+    dateDataElementId: CHARTING_DATA_ELEMENT_IDS.dateRecorded,
   }),
 );
 
 programRegistry.get(
   '/patient/:patientId/charts/:chartSurveyId/chartInstances',
-  fetchChartInstances(), 
+  fetchChartInstances(),
 );
 
 programRegistry.delete(

--- a/packages/facility-server/app/routes/apiv1/programRegistry.js
+++ b/packages/facility-server/app/routes/apiv1/programRegistry.js
@@ -385,9 +385,14 @@ programRegistry.get(
       order: [['name', 'ASC']],
     });
 
+    // check permissions for each chart
+    const permittedCharts = charts.filter(chart =>
+      req.ability.can('list', subject('Charting', { id: chart.id })),
+    );
+
     res.send({
-      data: charts.map(c => c.forResponse()),
-      count: charts.length,
+      data: permittedCharts.map(c => c.forResponse()),
+      count: permittedCharts.length,
     });
   }),
 );

--- a/packages/ui-components/src/utils/survey.jsx
+++ b/packages/ui-components/src/utils/survey.jsx
@@ -302,7 +302,15 @@ export const getValidationSchema = (surveyData, getTranslation, valuesToCheckMan
         case PROGRAM_DATA_ELEMENT_TYPES.DATE:
         case PROGRAM_DATA_ELEMENT_TYPES.DATE_TIME:
         case PROGRAM_DATA_ELEMENT_TYPES.SUBMISSION_DATE:
-          valueSchema = yup.date();
+          valueSchema = yup
+            .date()
+            .transform((value, originalValue) => {
+              // Convert empty strings to null/undefined to prevent validation errors
+              if (typeof originalValue === 'string' && originalValue.trim() === '') {
+                return null;
+              }
+              return value;
+            });
           break;
         default:
           valueSchema = yup.mixed();

--- a/packages/utils/src/dateTime.ts
+++ b/packages/utils/src/dateTime.ts
@@ -44,6 +44,9 @@ export const isISOString = (dateString: string) =>
 export const parseDate = (date: string | Date | null | undefined) => {
   if (date == null) return null;
 
+  // Handle empty strings
+  if (typeof date === 'string' && date.trim() === '') return null;
+
   const dateObj =
     typeof date === 'string'
       ? isISOString(date)

--- a/packages/web/app/api/queries/index.js
+++ b/packages/web/app/api/queries/index.js
@@ -26,6 +26,7 @@ export {
 export { useProgramRegistryQuery, useListOfProgramRegistryQuery } from './useProgramRegistryQuery';
 export { useProgramRegistryLinkedChartsQuery } from './useProgramRegistryLinkedChartsQuery';
 export { useProgramRegistryPatientChartsQuery } from './useProgramRegistryPatientChartsQuery';
+export { useProgramRegistryPatientInitialChartQuery } from './useProgramRegistryPatientInitialChartQuery';
 export { useProgramRegistryPatientComplexChartInstancesQuery } from './useProgramRegistryPatientComplexChartInstancesQuery';
 export { useLocationAssignmentsQuery } from './useLocationAssignmentsQuery';
 export { useFacilityLocationAssignmentsQuery } from './useFacilityLocationAssignmentsQuery';

--- a/packages/web/app/api/queries/useGraphDataQuery.js
+++ b/packages/web/app/api/queries/useGraphDataQuery.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { isErrorUnknownAllow404s, useApi } from '../index';
 
-const transformVitalDataToChartData = (vitalQuery) => {
+const transformVitalDataToChartData = vitalQuery => {
   const { data: vitalDataAndCount = {} } = vitalQuery;
   const { data: vitalData = [] } = vitalDataAndCount;
 
@@ -19,12 +19,14 @@ export const useGraphDataQuery = (encounterId, vitalDataElementId, dateRange, is
   const directory = isVital ? 'vitals' : 'charts';
   const query = useQuery(
     ['encounter', encounterId, 'graphData', directory, vitalDataElementId, startDate, endDate, isVital],
-    () => {
-      return api.get(
+    () =>
+      api.get(
         `encounter/${encounterId}/graphData/${directory}/${vitalDataElementId}`,
         { startDate, endDate },
         { isErrorUnknown: isErrorUnknownAllow404s },
-      );
+      ),
+    {
+      enabled: Boolean(encounterId),
     },
   );
 
@@ -35,3 +37,5 @@ export const useGraphDataQuery = (encounterId, vitalDataElementId, dateRange, is
     data: graphData,
   };
 };
+
+export { transformVitalDataToChartData };

--- a/packages/web/app/api/queries/useProgramRegistryChartsVisualisationConfigsQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryChartsVisualisationConfigsQuery.js
@@ -1,0 +1,16 @@
+import { combineQueries } from '../combineQueries';
+import { usePatientDataQuery } from './usePatientDataQuery';
+import { useSurveyQuery } from './useSurveyQuery';
+import { getVisualisationConfig } from '../../utils/getVisualisationConfig';
+
+export const useProgramRegistryChartsVisualisationConfigsQuery = (patientId, chartSurveyId) => {
+  const patientQuery = usePatientDataQuery(patientId);
+  const chartSurveyQuery = useSurveyQuery(chartSurveyId);
+
+  const {
+    data: [patientData, surveyData],
+    ...restOfQuery
+  } = combineQueries([patientQuery, chartSurveyQuery]);
+
+  return getVisualisationConfig(patientData, surveyData, restOfQuery);
+};

--- a/packages/web/app/api/queries/useProgramRegistryGraphDataQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryGraphDataQuery.js
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { isErrorUnknownAllow404s, useApi } from '../index';
+import { transformVitalDataToChartData } from './useGraphDataQuery';
+
+export const useProgramRegistryGraphDataQuery = (patientId, dataElementId, dateRange) => {
+  const api = useApi();
+  const [startDate, endDate] = dateRange;
+  const directory = 'charts';
+
+  const query = useQuery(
+    [
+      'programRegistry',
+      'patient',
+      patientId,
+      'graphData',
+      directory,
+      dataElementId,
+      startDate,
+      endDate,
+    ],
+    () =>
+      api.get(
+        `programRegistry/patient/${patientId}/graphData/${directory}/${dataElementId}`,
+        { startDate, endDate },
+        { isErrorUnknown: isErrorUnknownAllow404s },
+      ),
+    {
+      enabled: Boolean(patientId),
+    },
+  );
+
+  const graphData = transformVitalDataToChartData(query);
+
+  return {
+    ...query,
+    data: graphData,
+  };
+};

--- a/packages/web/app/api/queries/useProgramRegistryPatientInitialChartQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryPatientInitialChartQuery.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { isErrorUnknownAllow404s, useApi } from '../index';
+
+// Gets the first alphabetically ordered chart survey (for a specific program registry)
+// that has any answer for this patient
+export const useProgramRegistryPatientInitialChartQuery = (patientId, programRegistryId) => {
+  const api = useApi();
+
+  return useQuery(
+    ['programRegistryPatientInitialChart', patientId, programRegistryId],
+    () =>
+      api.get(
+        `programRegistry/patient/${patientId}/initialChart`,
+        { programRegistryId },
+        { isErrorUnknown: isErrorUnknownAllow404s },
+      ),
+    { enabled: Boolean(patientId) && Boolean(programRegistryId) },
+  );
+};

--- a/packages/web/app/components/Charting/ChartDropdown.jsx
+++ b/packages/web/app/components/Charting/ChartDropdown.jsx
@@ -9,15 +9,20 @@ const StyledTranslatedSelectField = styled(SelectField)`
   z-index: 3;
 `;
 
-export const ChartDropdown = ({ selectedChartTypeId, setSelectedChartTypeId, chartTypes }) => {
+export const ChartDropdown = ({
+  selectedChartTypeId,
+  setSelectedChartTypeId,
+  chartTypes,
+  preferenceKey = 'selectedChartTypeId',
+}) => {
   const userPreferencesMutation = useUserPreferencesMutation();
 
-  const handleChange = (newValues) => {
+  const handleChange = newValues => {
     const newSelectedChartType = newValues.target.value;
 
     setSelectedChartTypeId(newSelectedChartType);
     userPreferencesMutation.mutate({
-      key: 'selectedChartTypeId',
+      key: preferenceKey,
       value: newSelectedChartType,
     });
   };

--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -50,7 +50,7 @@ export const CoreComplexChartData = ({
   const { ability } = useAuth();
   const [open, setModalOpen] = useState(false);
   const { encounter } = useEncounter();
-  const { data } = useEncounterChartsQuery(encounter.id, selectedSurveyId, currentInstanceId);
+  const { data } = useEncounterChartsQuery(encounter?.id, selectedSurveyId, currentInstanceId);
   const actions = [
     {
       label: (

--- a/packages/web/app/components/EditVitalCellModal.jsx
+++ b/packages/web/app/components/EditVitalCellModal.jsx
@@ -4,7 +4,16 @@ import { formatShortest, formatTime } from '@tamanu/utils/dateTime';
 import { EditVitalCellForm } from '../forms/EditVitalCellForm';
 import { TranslatedReferenceData } from './Translation';
 
-export const EditVitalCellModal = ({ open, dataPoint, onClose, isVital = false }) => {
+export const EditVitalCellModal = ({ 
+  open, 
+  dataPoint, 
+  onClose, 
+  isVital = false,
+  // Program registry context props (optional)
+  programRegistryPatientId,
+  programRegistrySurveyId,
+  programRegistryInstanceId,
+}) => {
   const vitalLabel = (
     <TranslatedReferenceData
       category="programDataElement"
@@ -37,6 +46,9 @@ export const EditVitalCellModal = ({ open, dataPoint, onClose, isVital = false }
         vitalLabel={vitalLabel}
         dataPoint={dataPoint}
         handleClose={handleClose}
+        programRegistryPatientId={programRegistryPatientId}
+        programRegistrySurveyId={programRegistrySurveyId}
+        programRegistryInstanceId={programRegistryInstanceId}
         data-testid="editvitalcellform-h4wy"
       />
     </FormModal>

--- a/packages/web/app/components/ProgramRegistryChartsTable.jsx
+++ b/packages/web/app/components/ProgramRegistryChartsTable.jsx
@@ -95,6 +95,9 @@ export const ProgramRegistryChartsTable = React.memo(({
         onClose={() => {
           setOpenEditModal(false);
         }}
+        programRegistryPatientId={patientId}
+        programRegistrySurveyId={selectedSurveyId}
+        programRegistryInstanceId={currentInstanceId}
         data-testid="editvitalcellmodal-2jqx"
       />
       <StyledDynamicColumnTable

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -4,6 +4,7 @@ import { DATE_TIME_FORMAT } from '../components/Charts/components/DateTimeSelect
 
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,
+  visualisationConfigQueryArgs = [],
   Context,
   isVital = false,
   children,
@@ -16,7 +17,7 @@ export const GraphDataProviderFactory = ({
     format(new Date(), DATE_TIME_FORMAT),
   ]);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
-  const { data } = visualisationConfigQueryFn();
+  const { data } = visualisationConfigQueryFn(...visualisationConfigQueryArgs);
   const { visualisationConfigs, allGraphedChartKeys } = data;
 
   const contextValue = useMemo(() => ({

--- a/packages/web/app/contexts/VitalChartData.jsx
+++ b/packages/web/app/contexts/VitalChartData.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { useVitalsVisualisationConfigsQuery } from '../api/queries/useVitalsVisualisationConfigsQuery';
 import { GraphDataProviderFactory } from './GraphData';
 import { useChartsVisualisationConfigsQuery } from '../api/queries/useChartsVisualisationConfigsQuery';
+import { useProgramRegistryChartsVisualisationConfigsQuery } from '../api/queries/useProgramRegistryChartsVisualisationConfigsQuery';
 
 export const VitalChartDataContext = React.createContext({
   isVital: false,
@@ -37,6 +38,18 @@ export const ChartGraphDataProvider = ({ children }) => {
   return (
     <GraphDataProviderFactory
       visualisationConfigQueryFn={useChartsVisualisationConfigsQuery}
+      Context={VitalChartDataContext}
+    >
+      {children}
+    </GraphDataProviderFactory>
+  );
+};
+
+export const ProgramRegistryChartGraphDataProvider = ({ patientId, selectedChartTypeId, children }) => {
+  return (
+    <GraphDataProviderFactory
+      visualisationConfigQueryFn={useProgramRegistryChartsVisualisationConfigsQuery}
+      visualisationConfigQueryArgs={[patientId, selectedChartTypeId]}
       Context={VitalChartDataContext}
     >
       {children}

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -147,7 +147,7 @@ export const EditVitalCellForm = ({
   const valueName = dataPoint.component.dataElement.id;
   const editVitalData = getEditVitalData(dataPoint.component, isReasonMandatory);
   const validationSchema = getValidationSchema(editVitalData, getTranslation, {
-    encounterType: encounter.encounterType,
+    encounterType: encounter?.encounterType,
   });
   const handleDeleteEntry = useCallback(
     setFieldValue => {
@@ -177,13 +177,13 @@ export const EditVitalCellForm = ({
       const newVitalData = {
         ...newShapeData,
         dataElementId: valueName,
-        encounterId: encounter.id,
+        encounterId: encounter?.id,
         recordedDate: dataPoint.recordedDate,
       };
       await api.post(`surveyResponseAnswer/${directory}`, { facilityId, ...newVitalData });
     }
     const primaryQueryKey = isVital ? 'encounterVitals' : 'encounterCharts';
-    queryClient.invalidateQueries([primaryQueryKey, encounter.id]);
+    queryClient.invalidateQueries([primaryQueryKey, encounter?.id]);
     
     // Also invalidate program registry queries if in program registry context
     if (!isVital && programRegistryPatientId && programRegistrySurveyId) {

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -114,7 +114,16 @@ const HistoryLog = ({ logData, vitalLabel, vitalEditReasons }) => {
   );
 };
 
-export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose, isVital }) => {
+export const EditVitalCellForm = ({ 
+  vitalLabel, 
+  dataPoint, 
+  handleClose, 
+  isVital,
+  // Program registry context props (optional)
+  programRegistryPatientId,
+  programRegistrySurveyId,
+  programRegistryInstanceId,
+}) => {
   const { getTranslation } = useTranslation();
   const [isDeleted, setIsDeleted] = useState(false);
   const api = useApi();
@@ -175,6 +184,17 @@ export const EditVitalCellForm = ({ vitalLabel, dataPoint, handleClose, isVital 
     }
     const primaryQueryKey = isVital ? 'encounterVitals' : 'encounterCharts';
     queryClient.invalidateQueries([primaryQueryKey, encounter.id]);
+    
+    // Also invalidate program registry queries if in program registry context
+    if (!isVital && programRegistryPatientId && programRegistrySurveyId) {
+      queryClient.invalidateQueries([
+        'programRegistryPatientCharts',
+        programRegistryPatientId,
+        programRegistrySurveyId,
+        programRegistryInstanceId,
+      ]);
+    }
+    
     handleClose();
   };
   const validateFn = values => {

--- a/packages/web/app/views/charts/VitalChartLineChart.jsx
+++ b/packages/web/app/views/charts/VitalChartLineChart.jsx
@@ -1,15 +1,31 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { useRouteMatch } from 'react-router-dom';
 import { LineChart } from '../../components/Charts/LineChart';
 import { getVitalChartProps } from '../../components/Charts/helpers/getVitalChartProps';
 import { useEncounter } from '../../contexts/Encounter';
 import { useGraphDataQuery } from '../../api/queries/useGraphDataQuery';
+import { useProgramRegistryGraphDataQuery } from '../../api/queries/useProgramRegistryGraphDataQuery';
 import { useVitalChartData } from '../../contexts/VitalChartData';
 
 export const VitalChartLineChart = props => {
   const { chartKey, visualisationConfig, dateRange, isInMultiChartsView } = props;
   const { encounter } = useEncounter();
   const { isVital } = useVitalChartData();
-  const { data: chartData, isLoading } = useGraphDataQuery(encounter.id, chartKey, dateRange, isVital);
+  const patient = useSelector(state => state.patient);
+  const isProgramRegistryRoute = !!useRouteMatch(
+    '/patients/:category/:patientId/program-registry/:programRegistryId',
+  );
+
+  const encounterGraphQuery = useGraphDataQuery(encounter?.id, chartKey, dateRange, isVital);
+  const programRegistryGraphQuery = useProgramRegistryGraphDataQuery(
+    patient?.id,
+    chartKey,
+    dateRange,
+  );
+
+  const { data: chartData, isLoading } =
+    !isVital && isProgramRegistryRoute ? programRegistryGraphQuery : encounterGraphQuery;
   const chartProps = getVitalChartProps({
     visualisationConfig,
     dateRange,

--- a/packages/web/app/views/programRegistry/PatientProgramRegistryView.jsx
+++ b/packages/web/app/views/programRegistry/PatientProgramRegistryView.jsx
@@ -17,7 +17,6 @@ import { RegistrationStatusIndicator } from './RegistrationStatusIndicator';
 import { PatientNavigation } from '../../components/PatientNavigation';
 import { usePatientRoutes } from '../../routes/PatientRoutes';
 import { ProgramRegistryChartsView } from './ProgramRegistryChartsView';
-import { useProgramRegistryLinkedChartsQuery } from '../../api/queries/useProgramRegistryLinkedChartsQuery';
 
 const ViewHeader = styled.div`
   background-color: ${Colors.white};
@@ -75,12 +74,6 @@ export const PatientProgramRegistryView = () => {
     programRegistryId,
   );
 
-  // Check if there are linked charts for this program registry
-  const { data: { chartSurveys = [] } = {} } = useProgramRegistryLinkedChartsQuery(
-    programRegistryId,
-  );
-  const hasLinkedCharts = chartSurveys.length > 0;
-
   const patientRoutes = usePatientRoutes();
 
   if (isLoading || isFetching) {
@@ -131,8 +124,7 @@ export const PatientProgramRegistryView = () => {
         <Row>
           <PatientProgramRegistryFormHistory patientProgramRegistration={data} />
         </Row>
-        {/* Charts section - only show if there are linked charts */}
-        {hasLinkedCharts && patient && (
+        {patient && (
           <Row>
             <ProgramRegistryChartsView programRegistryId={programRegistryId} patient={patient} />
           </Row>

--- a/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
@@ -251,7 +251,17 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
     }
 
     await api.post('surveyResponse', responseData);
-    queryClient.invalidateQueries(['programRegistryPatientCharts', patient.id, survey.id]);
+    
+    // Invalidate queries for the currently displayed chart to refresh the table
+    if (selectedChartTypeId) {
+      queryClient.invalidateQueries([
+        'programRegistryPatientCharts',
+        patient.id,
+        selectedChartTypeId,
+        currentComplexChartInstance?.chartInstanceId,
+      ]);
+    }
+    
     if (chartSurveyToSubmit.surveyType === SURVEY_TYPES.COMPLEX_CHART_CORE) {
       reloadChartInstances();
     }
@@ -264,6 +274,16 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
         `programRegistry/patient/${patient.id}/chartInstances/${currentComplexChartInstance?.chartInstanceId}`,
       );
 
+      // Invalidate queries for the currently displayed chart to refresh the table
+      if (selectedChartTypeId) {
+        queryClient.invalidateQueries([
+          'programRegistryPatientCharts',
+          patient.id,
+          selectedChartTypeId,
+          currentComplexChartInstance?.chartInstanceId,
+        ]);
+      }
+
       handleCloseModal();
       setCurrentComplexChartTab(null);
 
@@ -274,8 +294,10 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
   }, [
     api,
     patient.id,
+    selectedChartTypeId,
     currentComplexChartInstance?.chartInstanceId,
     reloadChartInstances,
+    queryClient,
   ]);
 
   const isComplexChart = selectedChartSurvey?.surveyType === SURVEY_TYPES.COMPLEX_CHART;

--- a/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
@@ -13,12 +13,15 @@ import { getAnswersFromData } from '@tamanu/ui-components';
 
 import { TableButtonRow, ButtonWithPermissionCheck } from '../../components';
 import { useProgramRegistryLinkedChartsQuery } from '../../api/queries/useProgramRegistryLinkedChartsQuery';
-import { ProgramRegistryChartsTable, EmptyProgramRegistryChartsTable } from '../../components/ProgramRegistryChartsTable';
+import {
+  ProgramRegistryChartsTable,
+  EmptyProgramRegistryChartsTable,
+} from '../../components/ProgramRegistryChartsTable';
 import { TranslatedText } from '../../components/Translation/TranslatedText';
 
 import { useAuth } from '../../contexts/Auth';
 import { useApi } from '../../api';
-import { ChartGraphDataProvider } from '../../contexts/VitalChartData';
+import { ProgramRegistryChartGraphDataProvider } from '../../contexts/VitalChartData';
 import { VitalChartsModal } from '../../components/VitalChartsModal';
 import { useProgramRegistryPatientComplexChartInstancesQuery } from '../../api/queries/useProgramRegistryPatientComplexChartInstancesQuery';
 import { useProgramRegistryPatientChartsQuery } from '../../api/queries/useProgramRegistryPatientChartsQuery';
@@ -206,12 +209,14 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
   );
 
   // Determine if the current complex chart instance can be deleted (no answers across encounters)
-  const { data: prChartRecords = [], isLoading: isPrChartLoading } =
-    useProgramRegistryPatientChartsQuery(
-      patient?.id,
-      selectedChartTypeId,
-      currentComplexChartInstance?.chartInstanceId,
-    );
+  const {
+    data: prChartRecords = [],
+    isLoading: isPrChartLoading,
+  } = useProgramRegistryPatientChartsQuery(
+    patient?.id,
+    selectedChartTypeId,
+    currentComplexChartInstance?.chartInstanceId,
+  );
   const canDeleteInstance = !isPrChartLoading && prChartRecords.length === 0;
 
   // Sets initial instance tab when selecting a complex chart
@@ -251,7 +256,7 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
     }
 
     await api.post('surveyResponse', responseData);
-    
+
     // Invalidate queries for the currently displayed chart to refresh the table
     if (selectedChartTypeId) {
       queryClient.invalidateQueries([
@@ -261,7 +266,7 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
         currentComplexChartInstance?.chartInstanceId,
       ]);
     }
-    
+
     if (chartSurveyToSubmit.surveyType === SURVEY_TYPES.COMPLEX_CHART_CORE) {
       reloadChartInstances();
     }
@@ -346,7 +351,11 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
   return (
     <ChartsContainer data-testid="charts-container">
       <ChartsPanel>
-        <ChartGraphDataProvider data-testid="chartgraphdataprovider-hz37">
+        <ProgramRegistryChartGraphDataProvider
+          patientId={patient?.id}
+          selectedChartTypeId={selectedChartTypeId}
+          data-testid="chartgraphdataprovider-hz37"
+        >
           {isComplexChart ? (
             <ComplexChartModal
               {...baseChartModalProps}
@@ -454,7 +463,7 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
             )}
             data-testid="chartstable-vxv2"
           />
-        </ChartGraphDataProvider>
+        </ProgramRegistryChartGraphDataProvider>
       </ChartsPanel>
     </ChartsContainer>
   );

--- a/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
@@ -93,9 +93,7 @@ const ComplexChartInstancesTab = styled(TabDisplay)`
 `;
 
 const ChartsContainer = styled.div`
-  margin-top: 30px;
-  border-top: 2px solid ${Colors.outline};
-  padding-top: 20px;
+  margin-top: 20px;
 `;
 
 const ChartsPanel = styled.div`


### PR DESCRIPTION
### Changes

- Program registry chart data: Added dedicated graph data queries and integrated them with existing chart data contexts.
- Chart permissions: Implemented permission checks for program registry charts in the API and UI.
- Charts UI & preferences: Improved ChartDropdown and ProgramRegistryChartsView to better handle chart selection and user preferences.
- Vitals editing integration: Updated vital editing modals/forms to accept program registry context and avoid null-reference errors.
- Date & survey handling: Refined date utilities and survey components to improve chart-related query invalidation.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds program registry chart graphing (API + hooks), filters charts by permissions, persists per-registry chart selection, and updates editing/validation and data utils.
> 
> - **Backend (programRegistry API)**
>   - Filter linked charts by permissions in `GET /:id/linkedCharts`, returning only permitted `Survey`s.
>   - Expose program registry chart graph data via `GET /patient/:patientId/graphData/charts/:dataElementId`.
> - **Frontend – Charting for Program Registry**
>   - New hooks: `useProgramRegistryGraphDataQuery` and `useProgramRegistryChartsVisualisationConfigsQuery` for graph data and visualisation configs.
>   - Add `ProgramRegistryChartGraphDataProvider` and pass args via `GraphDataProviderFactory`.
>   - `VitalChartLineChart` selects graph source (encounter vs program registry) based on route.
>   - `ProgramRegistryChartsView`:
>     - Initialize selected chart from user prefs (`USER_PREFERENCES_KEYS`); invalidate precise queries after record/delete.
>     - Wrap with `ProgramRegistryChartGraphDataProvider`; minor UI tidy.
>   - `ChartDropdown` accepts `preferenceKey` to persist per-registry selection.
> - **Editing & Tables**
>   - `EditVitalCellModal`/`EditVitalCellForm`: accept program registry context IDs, use optional chaining for encounter, and invalidate program registry queries on save.
>   - `ProgramRegistryChartsTable`: passes program registry context to modal.
>   - `CoreComplexChartData`: guard encounter ID usage.
> - **Validation/Utils**
>   - Treat empty date strings as null in `ui-components/src/utils/survey.jsx` and `utils/src/dateTime.ts::parseDate`.
>   - `useGraphDataQuery`: enable flag for encounter ID and export `transformVitalDataToChartData`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f3b274037880c97233ccac2a6796ea03a4cad6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->