### PR TITLE
fix: procedure created without encounterId

### DIFF
--- a/packages/facility-server/app/routes/apiv1/procedure.js
+++ b/packages/facility-server/app/routes/apiv1/procedure.js
@@ -35,7 +35,7 @@ procedure.post(
   asyncHandler(async (req, res) => {
     const {
       models,
-      body: { procedureId },
+      body: { procedureId, procedureTypeId },
     } = req;
     req.checkPermission('create', 'Procedure');
 
@@ -53,6 +53,8 @@ procedure.post(
         procedure = await models.Procedure.create({
           completed: false,
           date: getCurrentDateTimeString(),
+          encounterId: newSurveyResponse.encounterId,
+          procedureTypeId,
         });
       }
 

--- a/packages/web/app/forms/ProcedureForm/ProcedureAdditionalData.jsx
+++ b/packages/web/app/forms/ProcedureForm/ProcedureAdditionalData.jsx
@@ -85,6 +85,7 @@ export const ProcedureAdditionalData = ({
         endTime: getCurrentDateTimeString(),
         answers: await getAnswersFromData(body, survey),
         procedureId,
+        procedureTypeId,
       });
     },
     {


### PR DESCRIPTION
### Changes

Procedure wasn't being created with an encounter id which was causing downstream sync issues.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure procedures created from survey responses include encounterId and procedureTypeId, with the frontend sending procedureTypeId to the API.
> 
> - **Backend**:
>   - `POST /procedure/surveyResponse`: Accepts `procedureTypeId`; when creating a new `Procedure` (no `procedureId`), sets `encounterId` from `newSurveyResponse.encounterId` and persists `procedureTypeId`.
> - **Frontend**:
>   - `ProcedureAdditionalData.jsx`: Sends `procedureTypeId` in `procedure/surveyResponse` request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 965043b19f8be8773e6d15ec184454e8cf6f4f17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->