### PR TITLE
feat(alerts): TAMOC-372: Stale sync_lookup alert

### DIFF
--- a/alerts/sync-lookup-stale.yml
+++ b/alerts/sync-lookup-stale.yml
@@ -1,0 +1,42 @@
+sql: |
+  SELECT
+    key,
+    value AS last_sync_tick,
+    updated_at::text AS last_updated,
+    (now() - updated_at)::text AS time_since_update
+  FROM local_system_facts
+  WHERE key = 'lastSuccessfulLookupTableUpdate'
+    AND updated_at < now() - interval '1 hour'
+
+send:
+  - target: external
+    id: default
+    subject: '[Tamanu Alert] Sync lookup table has not been updated recently ({{ hostname }})'
+    template: |
+      - Server: {{ hostname }}
+      - Alert: {{ filename }}
+
+      **Report this immediately to support.**
+
+      The sync lookup table has not been updated in the last hour.
+
+      This could indicate:
+      - The sync lookup table update process is not running
+      - The update process is failing silently
+      - The central sync manager is not processing updates
+      - Database connection or transaction issues
+
+      **Details:**
+      {% for row in rows %}
+      - Last sync tick: {{ row.last_sync_tick if row.last_sync_tick else 'Unknown' }}
+      - Last updated: {{ row.last_updated if row.last_updated else 'Unknown' }}
+      - Time since update: {{ row.time_since_update }}
+      {% endfor %}
+
+      **Immediate action required:**
+      1. Check if the central sync manager service is running
+      2. Review system logs for sync lookup table update errors
+      3. Verify database connectivity and transaction logs
+      4. Check if sync sessions are completing successfully
+      5. Review the sync lookup table update process status
+

--- a/alerts/sync-lookup-stale.yml
+++ b/alerts/sync-lookup-stale.yml
@@ -36,7 +36,4 @@ send:
       **Immediate action required:**
       1. Check if the central sync manager service is running
       2. Review system logs for sync lookup table update errors
-      3. Verify database connectivity and transaction logs
-      4. Check if sync sessions are completing successfully
-      5. Review the sync lookup table update process status
-
+      3. Check if sync sessions are completing successfully

--- a/alerts/sync-lookup-stale.yml
+++ b/alerts/sync-lookup-stale.yml
@@ -28,8 +28,8 @@ send:
 
       **Details:**
       {% for row in rows %}
-      - Last sync tick: {{ row.last_sync_tick if row.last_sync_tick else 'Unknown' }}
-      - Last updated: {{ row.last_updated if row.last_updated else 'Unknown' }}
+      - Last sync tick: {{ row.last_sync_tick }}
+      - Last updated: {{ row.last_updated }}
       - Time since update: {{ row.time_since_update }}
       {% endfor %}
 

--- a/alerts/sync-no-sessions.yml
+++ b/alerts/sync-no-sessions.yml
@@ -31,7 +31,7 @@ send:
 
       **Facilities with no recent successful syncs:**
       {% for row in rows %}
-      - Facility ID: {{ row.facility_id }} - Last successful sync: {{ row.last_successful_sync if row.last_successful_sync else 'Unknown' }}
+      - Facility ID: {{ row.facility_id }} - Last successful sync: {{ row.last_successful_sync }}
       {% endfor %}
 
       **Immediate action required:**


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new alert for stale sync lookup table updates and simplifies the facility last-sync display in the no-sessions alert.
> 
> - **Alerts**:
>   - **New**: `alerts/sync-lookup-stale.yml`
>     - SQL checks `local_system_facts` for `lastSuccessfulLookupTableUpdate` older than 1 hour.
>     - Sends external alert with hostname, details (last sync tick/updated/time since), and action steps.
>   - **Update**: `alerts/sync-no-sessions.yml`
>     - Simplifies template output for facility last successful sync by removing the `Unknown` conditional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 793433a55c564d4e2277b9ddc7a4acb1ad7a5621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->