### PR TITLE
tweak(labs): NASS-1848: Default date times in 2 lab forms

### DIFF
--- a/packages/web/app/views/patients/components/LabRequestRecordSampleModal.jsx
+++ b/packages/web/app/views/patients/components/LabRequestRecordSampleModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as yup from 'yup';
 import { LAB_REQUEST_STATUSES, SETTING_KEYS, FORM_TYPES } from '@tamanu/constants';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import styled from 'styled-components';
 import { Form, FormGrid, TranslatedText } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
@@ -14,7 +15,6 @@ import {
 import { useSuggester } from '../../../api';
 import { ModalFormActionRow } from '../../../components/ModalActionRow';
 import { useSettings } from '../../../contexts/Settings';
-import { getCurrentDateString } from '@tamanu/utils/dateTime';
 
 const validationSchema = yup.object().shape({
   sampleTime: yup
@@ -205,7 +205,7 @@ export const LabRequestRecordSampleModal = React.memo(
           showInlineErrorsOnly
           formType={FORM_TYPES.EDIT_FORM}
           initialValues={{
-            sampleTime: labRequest.sampleTime || getCurrentDateString(),
+            sampleTime: labRequest.sampleTime || getCurrentDateTimeString(),
             labSampleSiteId: labRequest.labSampleSiteId,
             specimenTypeId: labRequest.specimenTypeId,
             collectedById: labRequest.collectedById,

--- a/packages/web/app/views/patients/components/LabRequestRecordSampleModal.jsx
+++ b/packages/web/app/views/patients/components/LabRequestRecordSampleModal.jsx
@@ -14,6 +14,7 @@ import {
 import { useSuggester } from '../../../api';
 import { ModalFormActionRow } from '../../../components/ModalActionRow';
 import { useSettings } from '../../../contexts/Settings';
+import { getCurrentDateString } from '@tamanu/utils/dateTime';
 
 const validationSchema = yup.object().shape({
   sampleTime: yup
@@ -204,7 +205,7 @@ export const LabRequestRecordSampleModal = React.memo(
           showInlineErrorsOnly
           formType={FORM_TYPES.EDIT_FORM}
           initialValues={{
-            sampleTime: labRequest.sampleTime,
+            sampleTime: labRequest.sampleTime || getCurrentDateString(),
             labSampleSiteId: labRequest.labSampleSiteId,
             specimenTypeId: labRequest.specimenTypeId,
             collectedById: labRequest.collectedById,

--- a/packages/web/app/views/patients/components/LabTestResultsModal.jsx
+++ b/packages/web/app/views/patients/components/LabTestResultsModal.jsx
@@ -231,6 +231,13 @@ const ResultsFormError = ({ error }) => (
   </Box>
 );
 
+const getPrefilledValue = (uniqueValues, name) => {
+  if (uniqueValues.length === 1) return uniqueValues[0];
+  if (uniqueValues.length === 0 && name === LAB_TEST_PROPERTIES.COMPLETED_DATE)
+    return getCurrentDateTimeString();
+  return null;
+};
+
 const ResultsForm = ({
   labTestResults,
   isLoading,
@@ -260,18 +267,10 @@ const ResultsForm = ({
           .map(([, row]) => row[name]);
 
         const uniqueValues = [...new Set(otherRowsValues)];
+        const valueToSet = getPrefilledValue(uniqueValues, name);
 
-        let valueToSet = null;
-
-        if (uniqueValues.length === 1) {
-          valueToSet = uniqueValues[0];
-        } else if (uniqueValues.length === 0 && name === LAB_TEST_PROPERTIES.COMPLETED_DATE) {
-          valueToSet = getCurrentDateTimeString();
-        }
-
-        if (valueToSet) {
-          setFieldValue(`${labTestId}.${name}`, valueToSet);
-        }
+        if (!valueToSet) return;
+        setFieldValue(`${labTestId}.${name}`, valueToSet);
       });
     },
     [values, setFieldValue],

--- a/packages/web/app/views/patients/components/LabTestResultsModal.jsx
+++ b/packages/web/app/views/patients/components/LabTestResultsModal.jsx
@@ -231,13 +231,6 @@ const ResultsFormError = ({ error }) => (
   </Box>
 );
 
-const getPrefilledValue = (uniqueValues, name) => {
-  if (uniqueValues.length === 1) return uniqueValues[0];
-  if (uniqueValues.length === 0 && name === LAB_TEST_PROPERTIES.COMPLETED_DATE)
-    return getCurrentDateTimeString();
-  return null;
-};
-
 const ResultsForm = ({
   labTestResults,
   isLoading,
@@ -267,10 +260,12 @@ const ResultsForm = ({
           .map(([, row]) => row[name]);
 
         const uniqueValues = [...new Set(otherRowsValues)];
-        const valueToSet = getPrefilledValue(uniqueValues, name);
-
-        if (!valueToSet) return;
-        setFieldValue(`${labTestId}.${name}`, valueToSet);
+        const fieldName = `${labTestId}.${name}`;
+        if (name === LAB_TEST_PROPERTIES.COMPLETED_DATE) {
+          setFieldValue(fieldName, getCurrentDateTimeString());
+        } else if (uniqueValues.length > 0) {
+          setFieldValue(fieldName, uniqueValues[0]);
+        }
       });
     },
     [values, setFieldValue],

--- a/packages/web/app/views/patients/components/LabTestResultsModal.jsx
+++ b/packages/web/app/views/patients/components/LabTestResultsModal.jsx
@@ -243,7 +243,7 @@ const ResultsForm = ({
   const { count, data } = labTestResults;
   /**
    * On entering lab result field for a test some other fields are auto-filled optimistically
-   * This occurs in the case that:
+   * In the case of labTestMethod this occurs in the case that:
    * 1. The user has only entered a single unique value for this field across other rows
    * 2. The user has not already entered a value for this field in the current row
    */
@@ -263,7 +263,7 @@ const ResultsForm = ({
         const fieldName = `${labTestId}.${name}`;
         if (name === LAB_TEST_PROPERTIES.COMPLETED_DATE) {
           setFieldValue(fieldName, getCurrentDateTimeString());
-        } else if (uniqueValues.length > 0) {
+        } else if (uniqueValues.length === 1) {
           setFieldValue(fieldName, uniqueValues[0]);
         }
       });


### PR DESCRIPTION
### Changes

- There was already some autofilling logic on the results form but it wasn't working as documented so fixed that

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefills current date-time in sample and results forms and updates results autofill to use unique values (defaulting completed date to now).
> 
> - **Labs UI**:
>   - **Record Sample Modal (`LabRequestRecordSampleModal.jsx`)**: Prefills `sampleTime` with `getCurrentDateTimeString()` when missing.
>   - **Results Modal (`LabTestResultsModal.jsx`)**:
>     - Refactors autofill on result entry to prefill `completedDate` and `labTestMethodId` only when the current row field is empty and other rows share a single unique value.
>     - If no unique values exist for `completedDate`, defaults it to `getCurrentDateTimeString()`.
>     - Skips autofill when the entered result is empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 728ab488ed91709628d458e1a86b2be750886ddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->