### PR TITLE
feat(invoicing): SAV-018: Allow finalising with active encounter

### DIFF
--- a/database/model/public/invoice_item_finalised_insurances.md
+++ b/database/model/public/invoice_item_finalised_insurances.md
@@ -1,7 +1,7 @@
 {% docs table__invoice_item_finalised_insurances %}
 Finalised insurance coverage values for invoice items.
 
-This table stores the insurance coverage amounts that were locked in when an invoice item is finalized, 
+This table stores the insurance coverage amounts that were locked in when an invoice item is finalised, 
 preserving the coverage percentage at that point in time even if the insurance plan's coverage changes later.
 {% enddocs %}
 
@@ -12,7 +12,7 @@ The [invoice item](#!/source/source.tamanu.tamanu.invoice_items) this insurance 
 {% docs invoice_item_finalised_insurances__coverage_value_final %}
 The finalised coverage percentage for this invoice item.
 
-This value is copied from the insurance plan's coverage at the time the invoice item is finalized,
+This value is copied from the insurance plan's coverage at the time the invoice item is finalised,
 preserving it for the record even if the insurance plan's coverage percentage changes later.
 {% enddocs %}
 

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -248,7 +248,6 @@ invoiceRoute.put(
 
 /**
  * Finalize invoice
- * - An invoice cannot be finalised until the Encounter has been closed
  * - Only in progress invoices can be finalised
  * - Invoice items data will be frozen
  */
@@ -265,18 +264,6 @@ invoiceRoute.put(
     //only in progress invoices can be finalised
     if (invoice.status !== INVOICE_STATUSES.IN_PROGRESS) {
       throw new InvalidOperationError('Only in progress invoices can be finalised');
-    }
-
-    //An invoice cannot be finalised until the Encounter has been closed
-    //an encounter is considered closed if it has an end date
-    const encounterClosed = await req.models.Encounter.findByPk(invoice.encounterId, {
-      attributes: ['endDate'],
-    }).then(encounter => !!encounter?.endDate);
-
-    if (encounterClosed) {
-      throw new InvalidOperationError(
-        'Ivnvoice cannot be finalised until the Encounter has been closed',
-      );
     }
 
     invoice.status = INVOICE_STATUSES.FINALISED;

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -55,6 +55,14 @@ invoiceRoute.post(
     });
     if (!encounter) throw new ValidationError(`encounter ${data.encounterId} not found`);
 
+    // Ensure no other invoice exists for the same encounter
+    const existingInvoice = await req.models.Invoice.findOne({
+      where: {
+        encounterId: data.encounterId,
+      },
+    });
+    if (existingInvoice) throw new InvalidOperationError('An invoice already exists for this encounter');
+
     // Handles invoice creation with default insurer and discount
     const invoice = await req.models.Invoice.initializeInvoice(
       req.user.id,

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -247,12 +247,12 @@ invoiceRoute.put(
 );
 
 /**
- * Finalize invoice
+ * Finalise invoice
  * - Only in progress invoices can be finalised
  * - Invoice items data will be frozen
  */
 invoiceRoute.put(
-  '/:id/finalize',
+  '/:id/finalise',
   asyncHandler(async (req, res) => {
     req.checkPermission('write', 'Invoice');
     const invoiceId = req.params.id;
@@ -272,7 +272,7 @@ invoiceRoute.put(
   }),
 );
 /**
- * Finalize invoice
+ * Finalise invoice
  * You cannot delete a Finalised invoice
  * You can delete a cancelled or in progress invoice
  */

--- a/packages/web/app/api/mutations/useInvoiceMutation.js
+++ b/packages/web/app/api/mutations/useInvoiceMutation.js
@@ -48,7 +48,7 @@ export const useFinaliseInvoice = invoice => {
 
   return useMutation({
     mutationFn: async () => {
-      await api.put(`invoices/${invoice?.id}/finalize`);
+      await api.put(`invoices/${invoice?.id}/finalise`);
       await queryClient.invalidateQueries([`encounter/${invoice?.encounterId}/invoice`]);
       await queryClient.invalidateQueries({
         queryKey: [`patient/${invoice.encounter?.patientId}/invoices/totalOutstandingBalance`],

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -182,6 +182,7 @@ export const EncounterInvoicingPane = ({ encounter }) => {
                   <NoteModalActionBlocker>
                     <OutlinedButton
                       onClick={() => handleOpenInvoiceModal(INVOICE_MODAL_TYPES.FINALISE_INVOICE)}
+                      style={{ marginRight: 10 }}
                       data-testid="button-yicz"
                     >
                       <TranslatedText stringId="invoice.action.finalise" fallback="Finalise" />

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -139,7 +139,7 @@ export const EncounterInvoicingPane = ({ encounter }) => {
               </Box>
               <InvoiceStatus status={invoice.status} data-testid="invoicestatus-qb63" />
             </InvoiceHeading>
-            {(cancelable || deletable) && (
+            {(cancelable || deletable || finalisable) && (
               <ActionsPane data-testid="actionspane-l9ey">
                 <NoteModalActionBlocker>
                   <ThreeDotMenu

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -90,7 +90,7 @@ export const EncounterInvoicingPane = ({ encounter }) => {
   const cancelable = invoice && isInvoiceEditable(invoice) && canWriteInvoice;
   const editable = invoice && isInvoiceEditable(invoice) && canWriteInvoice;
   const deletable = invoice && invoice.status !== INVOICE_STATUSES.FINALISED && canDeleteInvoice;
-  const finalisable = invoice.status === INVOICE_STATUSES.IN_PROGRESS && canCreateInvoice;
+  const finalisable = invoice && isInvoiceEditable(invoice) && canCreateInvoice;
   const insurancePlans = invoice?.insurancePlans.map(plan => plan.name).join(', ');
 
   if (isLoading) {

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -84,11 +84,13 @@ export const EncounterInvoicingPane = ({ encounter }) => {
 
   const handleOpenInvoiceModal = type => setOpenInvoiceModal(type);
 
+  const canCreateInvoice = ability.can('create', 'Invoice');
   const canWriteInvoice = ability.can('write', 'Invoice');
   const canDeleteInvoice = ability.can('delete', 'Invoice');
   const cancelable = invoice && isInvoiceEditable(invoice) && canWriteInvoice;
   const editable = invoice && isInvoiceEditable(invoice) && canWriteInvoice;
   const deletable = invoice && invoice.status !== INVOICE_STATUSES.FINALISED && canDeleteInvoice;
+  const finalisable = invoice.status === INVOICE_STATUSES.IN_PROGRESS && canCreateInvoice;
   const insurancePlans = invoice?.insurancePlans.map(plan => plan.name).join(', ');
 
   if (isLoading) {
@@ -176,6 +178,16 @@ export const EncounterInvoicingPane = ({ encounter }) => {
                     <TranslatedText stringId="invoice.action.insurance" fallback="Insurance plan" />
                   </Button>
                 </NoteModalActionBlocker>
+                {finalisable && (
+                  <NoteModalActionBlocker>
+                    <OutlinedButton
+                      onClick={() => handleOpenInvoiceModal(INVOICE_MODAL_TYPES.FINALISE_INVOICE)}
+                      data-testid="button-yicz"
+                    >
+                      <TranslatedText stringId="invoice.action.finalise" fallback="Finalise" />
+                    </OutlinedButton>
+                  </NoteModalActionBlocker>
+                )}
               </ActionsPane>
             )}
             {!editable && (


### PR DESCRIPTION
### Changes

I also updated a small naming issue and restricted one invoice per encounter as we do not need to support more than one at the moment - I encountered that having more than one makes things pretty clumsy so this is trying to avoid that situation

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->
