### PR TITLE
fix(mobile): Properly show lockout warning message

### DIFF
--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -46,6 +46,7 @@ const diagnoseProblem = (err: AxiosError, isLogin: boolean): Error => {
     return new AuthenticationError(invalidDeviceMessage);
   }
 
+  // Auth login errors are handled down the line as we need to access data from the problem object
   if (problem.type.startsWith(ERROR_TYPE.AUTH) && !isLogin) {
     return new AuthenticationError(invalidTokenMessage);
   }

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -47,7 +47,7 @@ const diagnoseProblem = (err: AxiosError, isLogin: boolean): Error => {
   }
 
   if (problem.type.startsWith(ERROR_TYPE.AUTH) && !isLogin) {
-    throw new AuthenticationError(invalidTokenMessage);
+    return new AuthenticationError(invalidTokenMessage);
   }
 
   if (problem.type === ERROR_TYPE.CLIENT_INCOMPATIBLE) {

--- a/packages/mobile/App/services/sync/CentralServerConnection.ts
+++ b/packages/mobile/App/services/sync/CentralServerConnection.ts
@@ -11,7 +11,6 @@ import {
   generalErrorMessage,
   invalidTokenMessage,
   invalidDeviceMessage,
-  invalidUserCredentialsMessage,
   OutdatedVersionError,
 } from '../error';
 import { version } from '/root/package.json';
@@ -47,8 +46,8 @@ const diagnoseProblem = (err: AxiosError, isLogin: boolean): Error => {
     return new AuthenticationError(invalidDeviceMessage);
   }
 
-  if (problem.type.startsWith(ERROR_TYPE.AUTH)) {
-    return new AuthenticationError(isLogin ? invalidUserCredentialsMessage : invalidTokenMessage);
+  if (problem.type.startsWith(ERROR_TYPE.AUTH) && !isLogin) {
+    throw new AuthenticationError(invalidTokenMessage);
   }
 
   if (problem.type === ERROR_TYPE.CLIENT_INCOMPATIBLE) {


### PR DESCRIPTION
### Changes

I'm guessing this was a merge conflict issue that got lost. However there was something funky going on with how the axios promise was working and it wasn't as obvious this was the issue.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->
