### PR TITLE
fix(alerts): syntax mistake (jinja vs tera)

### DIFF
--- a/alerts/sync-no-sessions.yml
+++ b/alerts/sync-no-sessions.yml
@@ -31,7 +31,7 @@ send:
 
       **Facilities with no recent successful syncs:**
       {% for row in rows %}
-      - Facility ID: {{ row.facility_id }} - Last successful sync: {% if row.last_successful_sync %}{{ row.last_successful_sync }}{% else %}Unknown{% endif %}
+      - Facility ID: {{ row.facility_id }} - Last successful sync: {{ row.last_successful_sync }}
       {% endfor %}
 
       **Immediate action required:**

--- a/alerts/sync-no-sessions.yml
+++ b/alerts/sync-no-sessions.yml
@@ -31,7 +31,7 @@ send:
 
       **Facilities with no recent successful syncs:**
       {% for row in rows %}
-      - Facility ID: {{ row.facility_id }} - Last successful sync: {{ row.last_successful_sync if row.last_successful_sync else 'Unknown' }}
+      - Facility ID: {{ row.facility_id }} - Last successful sync: {% if row.last_successful_sync %}{{ row.last_successful_sync }}{% else %}Unknown{% endif %}
       {% endfor %}
 
       **Immediate action required:**


### PR DESCRIPTION
### Changes

The alert files are Tera templates, which resembles Jinja2 but isn't quite. This one may have been triggering but would never have sent any emails since the template was broken.
