### PR TITLE
feat: EPI-1313: Add device quota to user profile

### DIFF
--- a/packages/web/app/views/administration/users/AddUserModal.jsx
+++ b/packages/web/app/views/administration/users/AddUserModal.jsx
@@ -6,6 +6,7 @@ import {
   TextField,
   AutocompleteField,
   MultiAutocompleteField,
+  NumberField,
 } from '../../../components/Field';
 import { useSuggester } from '../../../api';
 import { TranslatedText, FormModal, Button, OutlinedButton } from '../../../components';
@@ -138,6 +139,7 @@ export const AddUserModal = ({ open, onClose, handleRefresh }) => {
     phoneNumber: '',
     newPassword: '',
     confirmPassword: '',
+    deviceRegistrationQuota: 0,
   };
 
   return (
@@ -248,6 +250,18 @@ export const AddUserModal = ({ open, onClose, handleRefresh }) => {
                     component={TextField}
                     type="password"
                     required
+                  />
+                  <Field
+                    name="deviceRegistrationQuota"
+                    label={
+                      <TranslatedText
+                        stringId="admin.users.deviceRegistrationQuota.label"
+                        fallback="Device registration quota"
+                      />
+                    }
+                    component={NumberField}
+                    min={0}
+                    style={{ gridColumn: 'span 2' }}
                   />
                   <Field
                     name="allowedFacilityIds"

--- a/packages/web/app/views/administration/users/UserProfileModal.jsx
+++ b/packages/web/app/views/administration/users/UserProfileModal.jsx
@@ -9,6 +9,7 @@ import {
   AutocompleteField,
   MultiAutocompleteField,
   SelectField,
+  NumberField,
 } from '../../../components/Field';
 import { useSuggester } from '../../../api';
 import { TranslatedText, FormModal, Button, OutlinedButton, BodyText } from '../../../components';
@@ -231,7 +232,14 @@ export const UserProfileModal = ({ open, onClose, user, handleRefresh }) => {
       newPassword: '',
       confirmPassword: '',
       allowedFacilityIds: user?.facilities?.map(f => f.id) || [],
+      deviceRegistrationQuota: user?.deviceRegistrationQuota ?? 0,
     };
+  }, [user]);
+
+  const registrationsRemaining = useMemo(() => {
+    const quota = user?.deviceRegistrationQuota ?? 0;
+    const registered = user?.registeredDevicesCount ?? 0;
+    return Math.max(0, quota - registered);
   }, [user]);
 
   return (
@@ -333,6 +341,26 @@ export const UserProfileModal = ({ open, onClose, user, handleRefresh }) => {
                         <TranslatedText stringId="admin.users.phoneNumber.label" fallback="Phone" />
                       }
                       component={TextField}
+                      disabled={!canUpdateUser}
+                    />
+                    <Field
+                      name="deviceRegistrationQuota"
+                      label={
+                        <TranslatedText
+                          stringId="admin.users.deviceRegistrationQuota.label"
+                          fallback="Device registration quota"
+                        />
+                      }
+                      component={NumberField}
+                      min={0}
+                      helperText={
+                        <Box fontWeight={400} fontSize={11}>
+                          <TranslatedText
+                            stringId="admin.users.deviceRegistrationQuota.helperText"
+                            fallback={`${registrationsRemaining} registration${registrationsRemaining !== 1 ? 's' : ''} remaining`}
+                          />
+                        </Box>
+                      }
                       disabled={!canUpdateUser}
                     />
                     <Field


### PR DESCRIPTION
### Changes

- Introduced deviceRegistrationQuota field in user creation and update forms.
- Updated user profile modal to display and manage device registration quota.
- Enhanced user data retrieval to include registered devices count and quota.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
