### PR TITLE
feat(invoicing): SAV-1063: Set default current date on ad hoc invoice items

### DIFF
--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -20,7 +20,7 @@ import { useUpdateInvoice } from '../../../api/mutations/useInvoiceMutation';
 import { InvoiceRecordModal } from '../../../components/PatientPrinting/modals/InvoiceRecordModal';
 import { useAuth } from '../../../contexts/Auth';
 import { invoiceFormSchema } from './invoiceFormSchema';
-import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { getCurrentDateString } from '@tamanu/utils/dateTime';
 
 const AddButton = styled(MuiButton)`
   font-size: 14px;
@@ -58,7 +58,7 @@ const PrintButton = styled(Button)`
   right: 70px;
 `;
 
-const getDefaultRow = () => ({ id: uuidv4(), quantity: 1, orderDate: getCurrentDateTimeString() });
+const getDefaultRow = () => ({ id: uuidv4(), quantity: 1, orderDate: getCurrentDateString() });
 
 export const InvoiceForm = ({ invoice, isPatientView }) => {
   const { ability } = useAuth();

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -20,6 +20,7 @@ import { useUpdateInvoice } from '../../../api/mutations/useInvoiceMutation';
 import { InvoiceRecordModal } from '../../../components/PatientPrinting/modals/InvoiceRecordModal';
 import { useAuth } from '../../../contexts/Auth';
 import { invoiceFormSchema } from './invoiceFormSchema';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 const AddButton = styled(MuiButton)`
   font-size: 14px;
@@ -57,7 +58,7 @@ const PrintButton = styled(Button)`
   right: 70px;
 `;
 
-const getDefaultRow = () => ({ id: uuidv4(), quantity: 1 });
+const getDefaultRow = () => ({ id: uuidv4(), quantity: 1, orderDate: getCurrentDateTimeString() });
 
 export const InvoiceForm = ({ invoice, isPatientView }) => {
   const { ability } = useAuth();


### PR DESCRIPTION
### Changes

Small change on title

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default `orderDate` is set to the current date for newly added invoice items.
> 
> - **Frontend**:
>   - **Invoice form** (`packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx`):
>     - New invoice item default now includes `orderDate` set via `getCurrentDateString()`.
>     - Adds import for `getCurrentDateString` from `@tamanu/utils/dateTime`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcc104241d55fa0503c049147945b9cd3ba75464. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->