### PR TITLE
feat: EPI-1310: Be able to set the order of lab tests within a panel.

### DIFF
--- a/packages/central-server/app/admin/exporter/modelExporters/LabTestPanelExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/LabTestPanelExporter.js
@@ -8,7 +8,18 @@ export class LabTestPanelExporter extends DefaultDataExporter {
           model: this.models.LabTestType,
           as: 'labTestTypes',
           attributes: ['id'],
+          through: {
+            attributes: ['order'],
+          },
         },
+      ],
+      order: [
+        [
+          { model: this.models.LabTestType, as: 'labTestTypes' },
+          this.models.LabTestPanelLabTestTypes,
+          'order',
+          'ASC',
+        ],
       ],
     });
 

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -313,13 +313,14 @@ export function labTestPanelLoader(item) {
   (testTypesInPanel || '')
     .split(',')
     .map(t => t.trim())
-    .forEach(testType => {
+    .forEach((testType, index) => {
       rows.push({
         model: 'LabTestPanelLabTestTypes',
         values: {
           id: `${id};${testType}`,
           labTestPanelId: id,
           labTestTypeId: testType,
+          order: index,
         },
       });
     });

--- a/packages/database/src/migrations/1764233018112-addOrderColumnToLabTestPanelLabTestTypes.ts
+++ b/packages/database/src/migrations/1764233018112-addOrderColumnToLabTestPanelLabTestTypes.ts
@@ -1,0 +1,13 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('lab_test_panel_lab_test_types', 'order', {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn('lab_test_panel_lab_test_types', 'order');
+}

--- a/packages/database/src/models/LabTestPanelLabTestTypes.ts
+++ b/packages/database/src/models/LabTestPanelLabTestTypes.ts
@@ -1,3 +1,4 @@
+import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
 import type { InitOptions, Models } from '../types/model';
@@ -6,11 +7,17 @@ export class LabTestPanelLabTestTypes extends Model {
   declare id: string;
   declare labTestPanelId?: string;
   declare labTestTypeId?: string;
+  declare order: number;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
       {
         id: primaryKey,
+        order: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 0,
+        },
       },
       {
         ...options,

--- a/packages/facility-server/app/routes/apiv1/patient/patientRelations.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientRelations.js
@@ -381,6 +381,17 @@ patientRelations.get(
         'id', lab_tests.id
       )
     ) AS results
+    ${
+      panelId
+        ? `, (
+        SELECT "order"
+        FROM lab_test_panel_lab_test_types
+        WHERE lab_test_panel_id = :panelId
+        AND lab_test_type_id = lab_test_types.id
+        LIMIT 1
+      ) AS panel_order`
+        : ''
+    }
   FROM
     lab_tests
   INNER JOIN
@@ -423,9 +434,9 @@ patientRelations.get(
       : ''
   }
   GROUP BY
-    test_category, test_type, test_options, test_type_id
+    test_category, test_type, test_options, test_type_id ${panelId ? ', panel_order' : ''}
   ORDER BY
-    test_category`,
+    ${panelId ? 'panel_order ASC,' : ''} test_category`,
       {
         replacements: { patientId: params.id, status, categoryId, panelId, canListSensitive },
         model: LabTest,

--- a/packages/web/app/views/patients/EncounterLabRequestsTable.jsx
+++ b/packages/web/app/views/patients/EncounterLabRequestsTable.jsx
@@ -37,6 +37,7 @@ const columns = [
       />
     ),
     accessor: getRequestType,
+    sortable: false,
   },
   {
     key: 'requestedDate',
@@ -48,6 +49,7 @@ const columns = [
       />
     ),
     accessor: getDateWithTimeTooltip,
+    sortable: false,
   },
   {
     key: 'displayName',
@@ -71,6 +73,7 @@ const columns = [
       />
     ),
     accessor: getPriority,
+    sortable: false,
   },
   {
     key: 'status',
@@ -83,6 +86,7 @@ const columns = [
     ),
     accessor: getStatus,
     maxWidth: 200,
+    sortable: false,
   },
 ];
 

--- a/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
+++ b/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
@@ -49,6 +49,7 @@ const columns = (sex) => [
         data-testid="translatedreferencedata-kplb"
       />
     ),
+    sortable: false,
   },
   {
     title: (
@@ -70,6 +71,7 @@ const columns = (sex) => [
       }
       return result ?? '';
     },
+    sortable: false,
   },
   {
     title: (
@@ -81,6 +83,7 @@ const columns = (sex) => [
     ),
     key: 'labTestType.unit',
     accessor: ({ labTestType }) => labTestType?.unit || 'N/A',
+    sortable: false,
   },
   {
     title: (
@@ -115,6 +118,7 @@ const columns = (sex) => [
       />
     ),
     key: 'laboratoryOfficer',
+    sortable: false,
   },
   {
     title: (
@@ -125,6 +129,7 @@ const columns = (sex) => [
       />
     ),
     key: 'verification',
+    sortable: false,
   },
   {
     title: (


### PR DESCRIPTION

### Changes

- Introduced an 'order' column in the LabTestPanelLabTestTypes model to manage the order of lab test types within panels.
- Updated the LabTestPanelExporter to include ordering by the new 'order' attribute.
- Modified lab test panel loading logic to assign order based on index.
- Adjusted queries in various routes to utilize the new ordering feature for lab test panels.
- Ensured compatibility with existing functionality while enhancing the ordering capabilities for lab tests.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
