### PR TITLE
fix(encounters): no-issue: Unified patient move fixes

### DIFF
--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -243,6 +243,8 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
       .array()
       .of(yup.string())
       .nullable();
+
+    initialValues.startTime = getCurrentDateTimeString();
   }
 
   return { initialValues, validationSchema: yup.object().shape(validationObject) };

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -11,6 +11,7 @@ import {
   Form,
   FormGrid,
   TAMANU_COLORS,
+  useTranslation,
 } from '@tamanu/ui-components';
 import {
   BodyText,
@@ -194,23 +195,24 @@ const PlannedMoveFields = () => {
 };
 
 const EncounterChangeText = ({ newEncounterType }) => {
+  const { getEnumTranslation } = useTranslation();
   if (newEncounterType === ENCOUNTER_TYPES.ADMISSION) {
     return (
       <TranslatedText stringId="encounter.action.admitToHospital" fallback="Admit to hospital" />
     );
   }
+
   return (
     <TranslatedText
       stringId="patient.encounter.modal.movePatient.action.transferToNewEncounterType"
       fallback="Transfer to :newEncounterType"
       replacements={{
-        newEncounterType: (
-          <TranslatedEnum enumValues={ENCOUNTER_TYPE_LABELS} value={newEncounterType} />
-        ),
+        newEncounterType: getEnumTranslation(ENCOUNTER_TYPE_LABELS, newEncounterType),
       }}
     />
   );
 };
+
 const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospital }) => {
   const validationObject = {
     examinerId: yup.string().required(),
@@ -231,8 +233,6 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
 
     initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
-  } else {
-    validationObject.locationId = yup.string().nullable();
   }
 
   if (isAdmittingToHospital) {

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -229,15 +229,6 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
   const validationObject = {
     examinerId: yup.string().required(),
     departmentId: yup.string().required(),
-    locationGroupId: yup.string().nullable(),
-    locationId: yup
-      .string()
-      .nullable()
-      .when('locationGroupId', {
-        is: value => !!value,
-        then: schema => schema.required('Location is required when area is selected'),
-        otherwise: schema => schema.nullable(),
-      }),
   };
 
   const initialValues = {
@@ -254,6 +245,15 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
 
     initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
+  } else {
+    validationObject.locationId = yup
+      .string()
+      .nullable()
+      .when('locationGroupId', {
+        is: value => !!value,
+        then: schema => schema.required('Location is required when area is selected'),
+        otherwise: schema => schema.nullable(),
+      });
   }
 
   if (isAdmittingToHospital) {

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -81,6 +81,12 @@ const EncounterTypeLabel = styled.b`
 `;
 
 const BasicMoveFields = () => {
+  const { setFieldValue, values } = useFormikContext();
+
+  const handleGroupChange = groupValue => {
+    setFieldValue('locationGroupId', groupValue);
+  };
+
   return (
     <>
       <SectionDescription>
@@ -90,7 +96,13 @@ const BasicMoveFields = () => {
         />
       </SectionDescription>
       <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
-        <Field name="locationId" component={LocalisedLocationField} data-testid="field-tykg" />
+        <Field
+          name="locationId"
+          component={LocalisedLocationField}
+          groupValue={values.locationGroupId}
+          onGroupChange={handleGroupChange}
+          data-testid="field-tykg"
+        />
       </StyledFormGrid>
     </>
   );
@@ -217,6 +229,15 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
   const validationObject = {
     examinerId: yup.string().required(),
     departmentId: yup.string().required(),
+    locationGroupId: yup.string().nullable(),
+    locationId: yup
+      .string()
+      .nullable()
+      .when('locationGroupId', {
+        is: value => !!value,
+        then: schema => schema.required('Location is required when area is selected'),
+        otherwise: schema => schema.nullable(),
+      }),
   };
 
   const initialValues = {
@@ -354,6 +375,7 @@ export const MoveModal = React.memo(({ open, onClose, encounter, newEncounterTyp
   const isAdmittingToHospital = newEncounterType === ENCOUNTER_TYPES.ADMISSION;
   const onSubmit = async values => {
     const { locationId, plannedLocationId, action, ...rest } = values;
+    delete rest.locationGroupId;
 
     const locationData = {};
     if (action === PATIENT_MOVE_ACTIONS.PLAN) {


### PR DESCRIPTION
### Changes

3 tweaks from testing:

- Require location when area is filled
- Prefill admission date
- Correct label translation

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces location selection when an area is chosen, prefills admission date/time, and fixes encounter type transfer label translation in the Move modal.
> 
> - **Move modal (`packages/web/app/views/patients/components/MoveModal.jsx`)**
>   - **Validation**: Require `locationId` when `locationGroupId` (area) is selected.
>   - **Location field wiring**: Pass `groupValue`/`onGroupChange` to `LocalisedLocationField` and store `locationGroupId`; exclude it from submission payload.
>   - **Admission defaults**: Prefill `startTime` with `getCurrentDateTimeString()` for hospital admissions.
>   - **Translations**: Use `useTranslation().getEnumTranslation` for `:newEncounterType` label in transfer text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8caad9a75673f518d6572ae6430c261b49655287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->