### PR TITLE
tweak(dbt): no-issue: Use fresh database for dbt generateModels script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "central-migrate": "npm run build-shared && npm run --workspace @tamanu/central-server start-watch upgrade",
     "central-migrate-down": "npm run build-shared && npm run --workspace @tamanu/central-server start-watch just-migrate down",
     "build-report": "npm run build-shared && npm run --workspace @tamanu/central-server build && npm run --workspace @tamanu/central-server start report",
-    "dbt-generate-model": "node packages/scripts/src/dbt/generateModel.js",
-    "dbt-generate-docs": "node packages/scripts/src/dbt/generateDocs.js",
-    "dbt-check-todos": "node packages/scripts/src/dbt/checkTodos.js",
+    "dbt-generate-model": "npm run --workspace scripts build && NODE_CONFIG_DIR=packages/central-server/config node packages/scripts/dist/dbt/generateModel.js",
+    "dbt-generate-docs": "npm run --workspace scripts build && NODE_CONFIG_DIR=packages/central-server/config node packages/scripts/dist/dbt/generateDocs.js",
+    "dbt-check-todos": "npm run --workspace scripts build && NODE_CONFIG_DIR=packages/central-server/config node packages/scripts/dist/dbt/checkTodos.js",
     "e2e-test": "npm run --workspace @tamanu/e2e-tests test",
     "e2e-show-report": "npm run --workspace @tamanu/e2e-tests show-report",
     "synthetic-test": "npm run build-shared && npm run --workspace @tamanu/synthetic-tests test"

--- a/packages/database/src/services/database.js
+++ b/packages/database/src/services/database.js
@@ -75,13 +75,16 @@ async function connectToDatabase(dbOptions) {
     alwaysCreateConnection = true,
     loggingOverride = null, // used in tests for migration determinism
     disableChangesAudit = false,
+    recreateDatabase = false,
   } = dbOptions;
   let { name } = dbOptions;
 
   // configure one test db per jest worker
   const workerId = process.env.JEST_WORKER_ID;
-  if (testMode && workerId) {
-    name = `${name}-${workerId}`;
+  if (testMode && (workerId || recreateDatabase)) {
+    if (workerId) {
+      name = `${name}-${workerId}`;
+    }
     if (alwaysCreateConnection) {
       await unsafeRecreatePgDb({ ...dbOptions, name });
     }

--- a/packages/scripts/src/dbt/generateModel.js
+++ b/packages/scripts/src/dbt/generateModel.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-import { runCommand } from '../runCommand';
-
 const fs = require('node:fs/promises');
 const path = require('node:path');
 const YAML = require('yaml');
@@ -654,16 +652,10 @@ async function run(opts) {
   try {
     console.log(' | connecting to database');
     console.log('Create new database', dbName);
-    const env = {
-      ...process.env,
-      PGUSER: dbConfig.username,
-      PGPASSWORD: dbConfig.password,
-    };
-    await runCommand('dropdb', ['--if-exists', dbName], env);
-    await runCommand('createdb', ['-O', dbConfig.username, dbName], env);
     const db = await initDatabase({
       ...dbConfig,
       testMode: true,
+      recreateDatabase: true,
       name: dbName,
     });
     await db.sequelize.drop({ cascade: true });

--- a/packages/scripts/src/runCommand.ts
+++ b/packages/scripts/src/runCommand.ts
@@ -1,0 +1,56 @@
+import { execFile, ExecFileOptions, spawn } from 'child_process';
+
+async function runCommandImpl(
+  prog: string,
+  args: string[],
+  opts: ExecFileOptions,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    console.log('$', prog, ...args);
+    execFile(prog, args, { encoding: 'utf-8', ...opts }, (error, stdout, stderr) => {
+      if (error) {
+        console.log(stdout);
+        console.error(stderr);
+        reject(error);
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+  });
+}
+
+let repoRoot: string;
+async function findRepoRoot(): Promise<string> {
+  if (!repoRoot) {
+    const root = await runCommandImpl('npm', ['root'], {});
+    if (!repoRoot) {
+      repoRoot = root;
+    }
+  }
+
+  return repoRoot;
+}
+
+export async function runCommand(
+  prog: string,
+  args: string[],
+  env?: Record<string, string>,
+): Promise<string> {
+  return runCommandImpl(prog, args, { cwd: await findRepoRoot(), env });
+}
+
+export async function spawnCommand(prog: string, args: string[]): Promise<void> {
+  const repoRoot = await findRepoRoot();
+  return new Promise((resolve, reject) => {
+    console.log('$', prog, ...args);
+    const child = spawn(prog, args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+    child.on('error', err => reject(err));
+    child.on('exit', code => {
+      if (code !== 0) reject(new Error(`exited with code ${code}`));
+      else resolve();
+    });
+  });
+}


### PR DESCRIPTION
### Changes

This means that we can run this without needing to clean up our local database state.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generate dbt models against a freshly created migrated database; add shared command runner and refactor scripts to use it.
> 
> - **Scripts**
>   - **DBT generation**: `packages/scripts/src/dbt/generateModel.js` now creates a fresh temp DB (`dropdb/createdb`), runs migrations, and connects via Sequelize before generating models; loads config from `packages/central-server/config`.
>   - **Shared command runner**: Add `packages/scripts/src/runCommand.ts` with `runCommand`/`spawnCommand` and switch consumers to it.
>   - **Determinism test**: Refactor `packages/scripts/src/testDeterminism.ts` to use the shared runner and minor cleanups.
>   - **NPM scripts**: Update `dbt-*` commands in `package.json` to build the `scripts` workspace first and set `NODE_CONFIG_DIR`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07af8ab5640dd01654adb6f58cae690173878ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->