### PR TITLE
fix(encounters): No-issue: Encounter enchancements dev tweaks

### DIFF
--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -620,7 +620,7 @@ export class Encounter extends Model {
       });
 
       let startDateLabel = 'Date';
-      switch (this.encounterType) {
+      switch (data.encounterType ?? this.encounterType) {
         case ENCOUNTER_TYPES.ADMISSION:
           startDateLabel = 'Admission date';
           break;

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -671,7 +671,11 @@ export class Encounter extends Model {
       if (this.encounterType === ENCOUNTER_TYPES.ADMISSION) {
         startDateLabel = 'Admission date';
       }
-      if (this.encounterType === ENCOUNTER_TYPES.TRIAGE) {
+      if (
+        [ENCOUNTER_TYPES.TRIAGE, ENCOUNTER_TYPES.OBSERVATION, ENCOUNTER_TYPES.EMERGENCY].includes(
+          this.encounterType as string,
+        )
+      ) {
         startDateLabel = 'Triage date';
       }
 

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -667,9 +667,17 @@ export class Encounter extends Model {
         changeType: EncounterChangeType.Examiner,
       });
 
+      let startDateLabel = 'Date';
+      if (this.encounterType === ENCOUNTER_TYPES.ADMISSION) {
+        startDateLabel = 'Admission date';
+      }
+      if (this.encounterType === ENCOUNTER_TYPES.TRIAGE) {
+        startDateLabel = 'Triage date';
+      }
+
       await recordTextColumnChange({
         columnName: 'startDate',
-        fieldLabel: this.encounterType === ENCOUNTER_TYPES.ADMISSION ? 'Admission date' : 'Date',
+        fieldLabel: startDateLabel,
         formatText: formatShort,
       });
       await recordTextColumnChange({

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -507,7 +507,7 @@ export class Encounter extends Model {
     // To collect system note messages describing all changes in this encounter update
     const systemNoteRows: string[] = [];
 
-    const { recordForeignKeyChange, recordTextColumnChange } = createChangeRecorders(
+    const { onChangeForeignKey, onChangeTextColumn } = createChangeRecorders(
       this,
       data,
       systemNoteRows,
@@ -581,7 +581,7 @@ export class Encounter extends Model {
         );
       }
 
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'locationId',
         fieldLabel: 'location',
         model: Location,
@@ -596,7 +596,7 @@ export class Encounter extends Model {
           additionalChanges.plannedLocationStartTime = null;
         },
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'encounterType',
         fieldLabel: 'encounter type',
         formatText: capitalize,
@@ -605,13 +605,13 @@ export class Encounter extends Model {
           await this.closeTriage(data.submittedTime, user);
         },
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'departmentId',
         fieldLabel: 'department',
         model: Department,
         changeType: EncounterChangeType.Department,
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'examinerId',
         fieldLabel: 'supervising clinician',
         model: User,
@@ -631,27 +631,27 @@ export class Encounter extends Model {
           break;
       }
 
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'startDate',
         fieldLabel: startDateLabel,
         formatText: formatShort,
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'estimatedEndDate',
         fieldLabel: 'estimated discharge date',
         formatText: formatShort,
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'patientBillingTypeId',
         fieldLabel: 'patient type',
         model: ReferenceData,
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'referralSourceId',
         fieldLabel: 'referral source',
         model: ReferenceData,
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'reasonForEncounter',
         fieldLabel: 'reason for encounter',
       });

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -634,12 +634,12 @@ export class Encounter extends Model {
       await onChangeTextColumn({
         columnName: 'startDate',
         fieldLabel: startDateLabel,
-        formatText: formatShort,
+        formatText: date => (date ? formatShort(date) : '-'),
       });
       await onChangeTextColumn({
         columnName: 'estimatedEndDate',
         fieldLabel: 'estimated discharge date',
-        formatText: formatShort,
+        formatText: date => (date ? formatShort(date) : '-'),
       });
       await onChangeForeignKey({
         columnName: 'patientBillingTypeId',

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -499,8 +499,7 @@ export class Encounter extends Model {
     );
   }
 
-  async update(...args: any): Promise<any> {
-    const [data, user] = args;
+  async update(data: any, user: any): Promise<any> {
     const { Department, Location, EncounterHistory, ReferenceData, User } = this.sequelize.models;
     // Track change types for encounter history snapshot
     const changeTypes: string[] = [];

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -483,17 +483,20 @@ export class Encounter extends Model {
     });
 
     await this.addSystemNote(systemNote || 'Discharged patient.', submittedTime, user);
-    await this.closeTriage(endDate);
+    await this.closeTriage(endDate, user);
   }
 
-  async closeTriage(endDate: string) {
+  async closeTriage(endDate: string, user: ModelProperties<User>) {
     const triage = await this.getLinkedTriage();
     if (!triage) return;
     if (triage.closedTime) return; // already closed
 
-    await triage.update({
-      closedTime: endDate,
-    });
+    await triage.update(
+      {
+        closedTime: endDate,
+      },
+      user,
+    );
   }
 
   async update(...args: any): Promise<any> {
@@ -599,7 +602,7 @@ export class Encounter extends Model {
         formatText: capitalize,
         changeType: EncounterChangeType.EncounterType,
         onChange: async () => {
-          await this.closeTriage(data.submittedTime);
+          await this.closeTriage(data.submittedTime, user);
         },
       });
       await recordForeignKeyChange({

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -3,6 +3,7 @@ import { capitalize, isEqual } from 'lodash';
 
 import {
   ENCOUNTER_TYPE_VALUES,
+  ENCOUNTER_TYPES,
   EncounterChangeType,
   NOTE_TYPES,
   SYNC_DIRECTIONS,
@@ -665,9 +666,10 @@ export class Encounter extends Model {
         accessor: (record: any) => record?.displayName ?? '-',
         changeType: EncounterChangeType.Examiner,
       });
+
       await recordTextColumnChange({
         columnName: 'startDate',
-        fieldLabel: 'start date',
+        fieldLabel: this.encounterType === ENCOUNTER_TYPES.ADMISSION ? 'Admission date' : 'Date',
         formatText: formatShort,
       });
       await recordTextColumnChange({

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -176,7 +176,7 @@ export class Triage extends Model {
       await recordTextColumnChange({
         columnName: 'closedTime',
         fieldLabel: 'closed time',
-        formatText: formatShort,
+        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await recordTextColumnChange({
         columnName: 'score',

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -129,8 +129,7 @@ export class Triage extends Model {
     });
   }
 
-  async update(...args: any): Promise<any> {
-    const [data, user] = args;
+  async update(data: any, user: any): Promise<any> {
     const { Encounter, ReferenceData, User } = this.sequelize.models;
     // To collect system note messages describing all changes in this triage update
     const systemNoteRows: string[] = [];

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -135,50 +135,50 @@ export class Triage extends Model {
     // To collect system note messages describing all changes in this triage update
     const systemNoteRows: string[] = [];
 
-    const { recordForeignKeyChange, recordTextColumnChange } = createChangeRecorders(
+    const { onChangeForeignKey, onChangeTextColumn } = createChangeRecorders(
       this,
       data,
       systemNoteRows,
     );
 
     const updateTriage = async () => {
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'practitionerId',
         fieldLabel: 'practitioner',
         model: User,
         accessor: (record: any) => record?.displayName ?? '-',
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'chiefComplaintId',
         fieldLabel: 'chief complaint',
         model: ReferenceData,
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'secondaryComplaintId',
         fieldLabel: 'secondary complaint',
         model: ReferenceData,
       });
-      await recordForeignKeyChange({
+      await onChangeForeignKey({
         columnName: 'arrivalModeId',
         fieldLabel: 'arrival mode',
         model: ReferenceData,
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'arrivalTime',
         fieldLabel: 'arrival time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'triageTime',
         fieldLabel: 'triage time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'closedTime',
         fieldLabel: 'closed time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
-      await recordTextColumnChange({
+      await onChangeTextColumn({
         columnName: 'score',
         fieldLabel: 'triage score',
       });

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -2,6 +2,7 @@ import { Op, DataTypes } from 'sequelize';
 
 import { ENCOUNTER_TYPES, SYNC_DIRECTIONS } from '@tamanu/constants';
 import { InvalidOperationError } from '@tamanu/errors';
+import { formatShort, getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 import { Model } from './Model';
 import { buildEncounterLinkedSyncFilter } from '../sync/buildEncounterLinkedSyncFilter';
@@ -127,4 +128,131 @@ export class Triage extends Model {
     });
   }
 
+  async update(...args: any): Promise<any> {
+    const [data, user] = args;
+    const { Encounter, ReferenceData, User } = this.sequelize.models;
+    // To collect system note messages describing all changes in this triage update
+    const systemNoteRows: string[] = [];
+
+    // Records changes to foreign key columns (e.g., practitionerId, chiefComplaintId)
+    // Fetches the related records to get human-readable names for the system note
+    const recordForeignKeyChange = async ({
+      columnName,
+      fieldLabel,
+      model,
+      sequelizeOptions = {},
+      accessor = (record: typeof Model) => record?.name ?? '-',
+      onChange,
+    }: {
+      columnName: keyof Triage;
+      fieldLabel: string;
+      model: typeof Model;
+      sequelizeOptions?: any;
+      accessor?: (record: any) => string;
+      onChange?: () => Promise<void>;
+    }) => {
+      const isChanged = columnName in data && data[columnName] !== this[columnName];
+      if (!isChanged) return;
+
+      const oldRecord = await model.findByPk(this[columnName], sequelizeOptions);
+      const newRecord = await model.findByPk(data[columnName], sequelizeOptions);
+
+      systemNoteRows.push(
+        `Changed ${fieldLabel} from '${accessor(oldRecord)}' to '${accessor(newRecord)}'`,
+      );
+      await onChange?.();
+    };
+
+    // Records changes to text/string columns (e.g., score)
+    // Uses the raw values directly since there's no related record to fetch
+    const recordTextColumnChange = async ({
+      columnName,
+      fieldLabel,
+      formatText = (value: string) => value ?? '-',
+      onChange,
+    }: {
+      columnName: keyof Triage;
+      fieldLabel: string;
+      formatText?: (value: string) => string;
+      onChange?: () => Promise<void>;
+    }) => {
+      const isChanged = columnName in data && data[columnName] !== this[columnName];
+      if (!isChanged) return;
+
+      const oldValue = formatText(this[columnName]);
+      const newValue = formatText(data[columnName]);
+      systemNoteRows.push(`Changed ${fieldLabel} from '${oldValue}' to '${newValue}'`);
+      await onChange?.();
+    };
+
+    const updateTriage = async () => {
+      await recordForeignKeyChange({
+        columnName: 'practitionerId',
+        fieldLabel: 'practitioner',
+        model: User,
+        accessor: (record: any) => record?.displayName ?? '-',
+      });
+      await recordForeignKeyChange({
+        columnName: 'chiefComplaintId',
+        fieldLabel: 'chief complaint',
+        model: ReferenceData,
+      });
+      await recordForeignKeyChange({
+        columnName: 'secondaryComplaintId',
+        fieldLabel: 'secondary complaint',
+        model: ReferenceData,
+      });
+      await recordForeignKeyChange({
+        columnName: 'arrivalModeId',
+        fieldLabel: 'arrival mode',
+        model: ReferenceData,
+      });
+      await recordTextColumnChange({
+        columnName: 'arrivalTime',
+        fieldLabel: 'arrival time',
+        formatText: formatShort,
+      });
+      await recordTextColumnChange({
+        columnName: 'triageTime',
+        fieldLabel: 'triage time',
+        formatText: formatShort,
+      });
+      await recordTextColumnChange({
+        columnName: 'closedTime',
+        fieldLabel: 'closed time',
+        formatText: formatShort,
+      });
+      await recordTextColumnChange({
+        columnName: 'score',
+        fieldLabel: 'score',
+      });
+
+      const { submittedTime, ...triageData } = data;
+      const updatedTriage = await super.update(triageData, user);
+
+      if (systemNoteRows.length > 0) {
+        const encounter = await Encounter.findByPk(this.encounterId);
+        if (encounter) {
+          const formattedSystemNote = systemNoteRows.map(row => `• ${row}`).join('\n');
+          await encounter.addSystemNote(
+            formattedSystemNote,
+            submittedTime || getCurrentDateTimeString(),
+            user,
+          );
+        }
+      }
+
+      return updatedTriage;
+    };
+
+    if (this.sequelize.isInsideTransaction()) {
+      return updateTriage();
+    }
+
+    // If the update is not already in a transaction, wrap it in one
+    // Having nested transactions can cause bugs in postgres so only conditionally wrap
+    return this.sequelize.transaction(async () => {
+      return await updateTriage();
+    });
+  }
 }

--- a/packages/database/src/utils/index.ts
+++ b/packages/database/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './beforeDestroyHooks';
 export * from './getDependentAssociations';
 export * from './onCreateEncounterMarkPatientForSync';
+export * from './recordModelChanges';
 export * from './sortInDependencyOrder';
 export * from './fhir';
 export * from './audit';

--- a/packages/database/src/utils/recordModelChanges.ts
+++ b/packages/database/src/utils/recordModelChanges.ts
@@ -7,7 +7,7 @@ import { Model } from '../models/Model';
  * @param modelInstance - The model instance being updated (this)
  * @param updateData - The data object containing the new values
  * @param systemNoteRows - Array to collect system note messages
- * @param changeTypes - Optional array to collect change types for history tracking
+ * @param changeTypes - Optional array to collect change types for history tracking (soon to be deprecated)
  * @returns Object containing recordForeignKeyChange and recordTextColumnChange functions
  */
 export function createChangeRecorders<T extends Model>(

--- a/packages/database/src/utils/recordModelChanges.ts
+++ b/packages/database/src/utils/recordModelChanges.ts
@@ -1,0 +1,92 @@
+import { Model } from '../models/Model';
+
+/**
+ * Creates helper functions for recording model changes in update methods.
+ * These functions track changes to model fields and generate system note messages.
+ *
+ * @param modelInstance - The model instance being updated (this)
+ * @param updateData - The data object containing the new values
+ * @param systemNoteRows - Array to collect system note messages
+ * @param changeTypes - Optional array to collect change types for history tracking
+ * @returns Object containing recordForeignKeyChange and recordTextColumnChange functions
+ */
+export function createChangeRecorders<T extends Model>(
+  modelInstance: T,
+  updateData: Partial<T>,
+  systemNoteRows: string[],
+  changeTypes?: string[],
+) {
+  /**
+   * Records changes to foreign key columns (e.g., locationId, departmentId)
+   * Fetches the related records to get human-readable names for the system note
+   */
+  const recordForeignKeyChange = async ({
+    columnName,
+    fieldLabel,
+    model,
+    sequelizeOptions = {},
+    accessor = (record: typeof Model) => record?.name ?? '-',
+    changeType,
+    onChange,
+  }: {
+    columnName: keyof T;
+    fieldLabel: string;
+    model: typeof Model;
+    sequelizeOptions?: any;
+    accessor?: (record: any) => string;
+    changeType?: string;
+    onChange?: () => Promise<void>;
+  }) => {
+    const isChanged =
+      columnName in updateData && updateData[columnName] !== modelInstance[columnName];
+    if (!isChanged) return;
+
+    if (changeType && changeTypes) {
+      changeTypes.push(changeType);
+    }
+
+    const oldRecord = await model.findByPk(modelInstance[columnName] as any, sequelizeOptions);
+    const newRecord = await model.findByPk(updateData[columnName] as any, sequelizeOptions);
+
+    systemNoteRows.push(
+      `Changed ${fieldLabel} from '${accessor(oldRecord)}' to '${accessor(newRecord)}'`,
+    );
+    await onChange?.();
+  };
+
+  /**
+   * Records changes to text/string columns (e.g., encounterType, reasonForEncounter)
+   * Uses the raw values directly since there's no related record to fetch
+   */
+  const recordTextColumnChange = async ({
+    columnName,
+    fieldLabel,
+    formatText = (value: any) => value ?? '-',
+    changeType,
+    onChange,
+  }: {
+    columnName: keyof T;
+    fieldLabel: string;
+    formatText?: (value: any) => string;
+    changeType?: string;
+    onChange?: () => Promise<void>;
+  }) => {
+    const isChanged =
+      columnName in updateData && updateData[columnName] !== modelInstance[columnName];
+    if (!isChanged) return;
+
+    if (changeType && changeTypes) {
+      changeTypes.push(changeType);
+    }
+
+    const oldValue = formatText(modelInstance[columnName]);
+    const newValue = formatText(updateData[columnName]);
+    systemNoteRows.push(`Changed ${fieldLabel} from '${oldValue}' to '${newValue}'`);
+    await onChange?.();
+  };
+
+  return {
+    recordForeignKeyChange,
+    recordTextColumnChange,
+  };
+}

--- a/packages/database/src/utils/recordModelChanges.ts
+++ b/packages/database/src/utils/recordModelChanges.ts
@@ -1,13 +1,5 @@
 import { Model } from '../models/Model';
 
-const detectColumnChange = (
-  modelInstance: Model,
-  updateData: Partial<Model>,
-  columnName: keyof Model,
-) => {
-  return columnName in updateData && updateData[columnName] !== modelInstance[columnName];
-};
-
 /**
  * Creates helper functions for recording model changes in update methods.
  * These functions track changes to model fields and generate system note messages.

--- a/packages/database/src/utils/recordModelChanges.ts
+++ b/packages/database/src/utils/recordModelChanges.ts
@@ -49,7 +49,7 @@ export function createChangeRecorders<T extends Model>(
     const newRecord = await model.findByPk(updateData[columnName] as any, sequelizeOptions);
 
     systemNoteRows.push(
-      `Changed ${fieldLabel} from '${accessor(oldRecord)}' to '${accessor(newRecord)}'`,
+      `Changed ${fieldLabel} from ‘${accessor(oldRecord)}’ to ‘${accessor(newRecord)}’`,
     );
     await onChange?.();
   };
@@ -81,7 +81,7 @@ export function createChangeRecorders<T extends Model>(
 
     const oldValue = formatText(modelInstance[columnName]);
     const newValue = formatText(updateData[columnName]);
-    systemNoteRows.push(`Changed ${fieldLabel} from '${oldValue}' to '${newValue}'`);
+    systemNoteRows.push(`Changed ${fieldLabel} from ‘${oldValue}’ to ‘${newValue}’`);
     await onChange?.();
   };
 

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -459,7 +459,7 @@ describe('Encounter', () => {
         expect(notes).toHaveLength(1);
         console.log(notes);
         expect(
-          notes[0].content.includes('triage') && notes[0].content.includes('admission'),
+          notes[0].content.includes('Triage') && notes[0].content.includes('Admission'),
         ).toEqual(true);
         expect(notes[0].authorId).toEqual(app.user.id);
       });

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -457,7 +457,6 @@ describe('Encounter', () => {
 
         const notes = await v.getNotes();
         expect(notes).toHaveLength(1);
-        console.log(notes);
         expect(
           notes[0].content.includes('Triage') && notes[0].content.includes('Admission'),
         ).toEqual(true);

--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -457,6 +457,7 @@ describe('Encounter', () => {
 
         const notes = await v.getNotes();
         expect(notes).toHaveLength(1);
+        console.log(notes);
         expect(
           notes[0].content.includes('triage') && notes[0].content.includes('admission'),
         ).toEqual(true);

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -19,7 +19,7 @@ triage.put(
     req.checkPermission('read', 'Triage');
     const triageObject = await models.Triage.findByPk(params.id);
     if (!triageObject) throw new NotFoundError();
-    req.checkPermission('write', 'Triage');
+    req.checkPermission('write', triageObject);
     await triageObject.update(req.body, user);
     res.send(triageObject);
   }),

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -19,7 +19,7 @@ triage.put(
     req.checkPermission('read', 'Triage');
     const triageObject = await models.Triage.findByPk(params.id);
     if (!triageObject) throw new NotFoundError();
-    req.checkPermission('write', triageObject);
+    req.checkPermission('write', 'Triage');
     await triageObject.update(req.body, user);
     res.send(triageObject);
   }),

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -24,6 +24,7 @@ import {
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
 import { useEncounter } from '../../../contexts/Encounter';
 import { ENCOUNTER_TYPES } from '@tamanu/constants';
+import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 const StyledFormGrid = styled(FormGrid)`
   margin-bottom: 20px;
@@ -335,6 +336,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
 
     if (triage) {
       await api.put(`triage/${triage.id}`, {
+        submittedTime: getCurrentDateTimeString(),
         encounterId: encounter.id,
         arrivalTime,
         triageTime: startDate,

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -82,7 +82,6 @@ const EncounterTypeLabel = styled.b`
 
 const BasicMoveFields = () => {
   const { setFieldValue, values } = useFormikContext();
-
   const handleGroupChange = groupValue => {
     setFieldValue('locationGroupId', groupValue);
   };

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -159,7 +159,7 @@ const PlannedMoveFields = () => {
             label={
               <TranslatedText
                 stringId="encounter.modal.patientMove.action.label"
-                fallback="Would you like to finalise the patient location move now or plan change?"
+                fallback="Would you like to finalise the patient location move now or plan the move?"
                 data-testid="translatedtext-l7v1"
               />
             }
@@ -179,7 +179,7 @@ const PlannedMoveFields = () => {
                 label: (
                   <TranslatedText
                     stringId="encounter.modal.patientMove.action.plan"
-                    fallback="Plan change"
+                    fallback="Plan move"
                     data-testid="translatedtext-patient-move-action-plan"
                   />
                 ),

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -311,9 +311,10 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               ) : (
                 <>
                   <AddButton onClick={() => setIsEstimatedDischargeModalOpen(true)}>
+                    +{' '}
                     <TranslatedText
                       stringId="encounter.summary.addEstimatedDischargeDate"
-                      fallback="+ Add"
+                      fallback="Add"
                     />
                   </AddButton>
                   <SetDischargeDateModal

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -149,7 +149,7 @@ const SetDischargeDateModal = ({ encounter, open, onClose }) => {
                 saveDateAsString
               />
             </DischargeDateFieldContainer>
-            <StyledModalFormActionRow onConfirm={submitForm} />
+            <StyledModalFormActionRow onCancel={onClose} onConfirm={submitForm} />
           </>
         )}
       />

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -36,6 +36,7 @@ import { ENCOUNTER_TYPE_LABELS, FORM_TYPES } from '@tamanu/constants';
 import { DateField, Field, Form, TAMANU_COLORS } from '@tamanu/ui-components';
 import { useEncounter } from '../../../contexts/Encounter.jsx';
 import { getEncounterStartDateLabel } from '../../../utils/getEncounterStartDateLabel.jsx';
+import { PlusIcon } from '../../../assets/icons/PlusIcon';
 
 const InfoCardFirstColumn = styled.div`
   display: flex;
@@ -315,7 +316,7 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               ) : (
                 <>
                   <AddButton onClick={() => setIsEstimatedDischargeModalOpen(true)}>
-                    +
+                    <PlusIcon fill={TAMANU_COLORS.darkestText} />
                     <AddButtonText>
                       <TranslatedText
                         stringId="encounter.summary.addEstimatedDischargeDate"

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -56,9 +56,13 @@ const DietCardValue = styled.div`
 
 const AddButton = styled(TextButton)`
   color: ${TAMANU_COLORS.darkestText};
-  text-decoration: underline;
   font-size: 14px;
   line-height: 18px;
+`;
+
+const AddButtonText = styled.span`
+  text-decoration: underline;
+  margin-left: 4px;
 `;
 
 const StyledModalFormActionRow = styled(ModalFormActionRow)`
@@ -311,11 +315,13 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               ) : (
                 <>
                   <AddButton onClick={() => setIsEstimatedDischargeModalOpen(true)}>
-                    +{' '}
-                    <TranslatedText
-                      stringId="encounter.summary.addEstimatedDischargeDate"
-                      fallback="Add"
-                    />
+                    +
+                    <AddButtonText>
+                      <TranslatedText
+                        stringId="encounter.summary.addEstimatedDischargeDate"
+                        fallback="Add"
+                      />
+                    </AddButtonText>
                   </AddButton>
                   <SetDischargeDateModal
                     open={isEstimatedDischargeModalOpen}


### PR DESCRIPTION
### Changes

Few fixes from dev testing:
1 major change
- Added note taking funcitonality to triage column updates using the same logic as encounter

2 Minor changes;
- Missed cancel button
- Add button styling

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds change-note recording for triage updates and refactors encounter updates to a shared change-recording utility, with minor API and UI tweaks.
> 
> - **Database/Models**:
>   - **Shared change recorder**: Introduces `utils/recordModelChanges.ts` with `createChangeRecorders` for FK/text change logging; exported via `utils/index.ts`.
>   - **Encounter**: Refactors `update` to use change recorders; formats dates via `formatShort`; capitalizes `encounterType` in notes; dynamic label for `startDate`; passes `user` to `closeTriage`; `closeTriage(endDate, user)` updates linked triage; minor discharge/triage integration.
>   - **Triage**: Adds `update(data, user)` using change recorders to log changes (practitioner, complaints, arrival mode, times, score) as system notes on the linked encounter; formats date/time; wraps in transaction.
> - **API**:
>   - `PUT /api/triage/:id`: Replaces `simplePut` with explicit handler enforcing read/write checks, loads triage, calls `triage.update(req.body, user)`.
> - **Web UI**:
>   - Edit Encounter modal: Sends `submittedTime` when updating `triage` before encounter update.
>   - Move modal: Copy tweaks in radio labels.
>   - Encounter info pane: Adds cancel handler to estimated discharge modal and changes "Add" control to icon+text styling.
> - **Tests**:
>   - Updates expectation for encounter-type note capitalization in `Encounter.test.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 248dbc353ac1b50ebc4c7b7ec6ba22de40cb6ea9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->