### PR TITLE
fix: EPI-1244: Prevent edit chart responses when the patient has been removed from the program registry

### DIFF
--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -46,6 +46,7 @@ export const CoreComplexChartData = ({
   fieldVisibility,
   coreComplexDataElements,
   canDeleteInstance,
+  isPatientRemoved = false,
 }) => {
   const { ability } = useAuth();
   const [open, setModalOpen] = useState(false);
@@ -62,7 +63,7 @@ export const CoreComplexChartData = ({
       ),
       action: () => setModalOpen(true),
       permissionCheck: () => {
-        return ability?.can('delete', subject('Charting', { id: coreComplexChartSurveyId }));
+        return !isPatientRemoved && ability?.can('delete', subject('Charting', { id: coreComplexChartSurveyId }));
       },
     },
   ].filter(({ permissionCheck }) => {

--- a/packages/web/app/components/EditVitalCellModal.jsx
+++ b/packages/web/app/components/EditVitalCellModal.jsx
@@ -13,6 +13,7 @@ export const EditVitalCellModal = ({
   programRegistryPatientId,
   programRegistrySurveyId,
   programRegistryInstanceId,
+  isPatientRemoved = false,
 }) => {
   const vitalLabel = (
     <TranslatedReferenceData
@@ -49,6 +50,7 @@ export const EditVitalCellModal = ({
         programRegistryPatientId={programRegistryPatientId}
         programRegistrySurveyId={programRegistrySurveyId}
         programRegistryInstanceId={programRegistryInstanceId}
+        isPatientRemoved={isPatientRemoved}
         data-testid="editvitalcellform-h4wy"
       />
     </FormModal>

--- a/packages/web/app/components/ProgramRegistryChartsTable.jsx
+++ b/packages/web/app/components/ProgramRegistryChartsTable.jsx
@@ -42,6 +42,7 @@ export const ProgramRegistryChartsTable = React.memo(({
   selectedChartSurveyName,
   noDataMessage,
   currentInstanceId,
+  isPatientRemoved = false,
 }) => {
   const { ability } = useAuth();
   const patient = useSelector((state) => state.patient);
@@ -70,7 +71,7 @@ export const ProgramRegistryChartsTable = React.memo(({
     patient,
     recordedDates,
     onCellClick,
-    isChartingEditEnabled && hasReadPermission,
+    isChartingEditEnabled && hasReadPermission && !isPatientRemoved,
   );
 
   // There is a bug in react-query that even if the query is not enabled, it will still return isLoading = true
@@ -98,6 +99,7 @@ export const ProgramRegistryChartsTable = React.memo(({
         programRegistryPatientId={patientId}
         programRegistrySurveyId={selectedSurveyId}
         programRegistryInstanceId={currentInstanceId}
+        isPatientRemoved={isPatientRemoved}
         data-testid="editvitalcellmodal-2jqx"
       />
       <StyledDynamicColumnTable
@@ -121,4 +123,5 @@ ProgramRegistryChartsTable.propTypes = {
   selectedChartSurveyName: PropTypes.string,
   noDataMessage: PropTypes.node,
   currentInstanceId: PropTypes.string,
+  isPatientRemoved: PropTypes.bool,
 };

--- a/packages/web/app/forms/EditVitalCellForm.jsx
+++ b/packages/web/app/forms/EditVitalCellForm.jsx
@@ -123,6 +123,7 @@ export const EditVitalCellForm = ({
   programRegistryPatientId,
   programRegistrySurveyId,
   programRegistryInstanceId,
+  isPatientRemoved = false,
 }) => {
   const { getTranslation } = useTranslation();
   const [isDeleted, setIsDeleted] = useState(false);
@@ -140,7 +141,7 @@ export const EditVitalCellForm = ({
   const permissionSubject = isVital
     ? 'Vitals'
     : subject('Charting', { id: dataPoint.component.surveyId });
-  const hasPermission = ability.can(permissionVerb, permissionSubject);
+  const hasPermission = ability.can(permissionVerb, permissionSubject) && !isPatientRemoved;
 
   const initialValue = dataPoint.value;
   const showDeleteEntryButton = !['', undefined].includes(initialValue);

--- a/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
+++ b/packages/web/app/views/programRegistry/ProgramRegistryChartsView.jsx
@@ -547,6 +547,7 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
               coreComplexDataElements={coreComplexDataElements}
               fieldVisibility={fieldVisibility}
               canDeleteInstance={canDeleteInstance}
+              isPatientRemoved={isPatientRemoved}
               data-testid="corecomplexchartdata-tepa"
             />
           ) : null}
@@ -556,6 +557,7 @@ export const ProgramRegistryChartsView = React.memo(({ programRegistryId, patien
             selectedSurveyId={selectedChartTypeId}
             selectedChartSurveyName={selectedChartSurveyName}
             currentInstanceId={currentComplexChartInstance?.chartInstanceId}
+            isPatientRemoved={isPatientRemoved}
             noDataMessage={getNoDataMessage(
               isComplexChart,
               complexChartInstances,


### PR DESCRIPTION
### Changes

Prevent edit chart responses when the patient has been removed from the program registry

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
