### PR TITLE
tweak(encounters): NASS-1854: Front end permission checks

### DIFF
--- a/packages/web/app/components/PatientHistory.jsx
+++ b/packages/web/app/components/PatientHistory.jsx
@@ -351,9 +351,12 @@ export const PatientHistory = ({ patient, onItemClick }) => {
     });
   }
 
+  const canReadEncounter = ability.can('read', 'Encounter');
+
   if (!patient.markedForSync) {
     return <MarkPatientForSync patient={patient} data-testid="markpatientforsync-t5tf" />;
   }
+
   return (
     <>
       <SyncWarningBanner
@@ -363,7 +366,11 @@ export const PatientHistory = ({ patient, onItemClick }) => {
       />
       <StyledTable
         columns={columns}
-        onRowClick={row => onItemClick(row.id)}
+        onRowClick={row => {
+          if (canReadEncounter) {
+            onItemClick(row.id);
+          }
+        }}
         noDataMessage={
           <Box mx="auto" p="40px" data-testid="box-t8fy">
             <TranslatedText

--- a/packages/web/app/components/PatientHistory.jsx
+++ b/packages/web/app/components/PatientHistory.jsx
@@ -366,11 +366,7 @@ export const PatientHistory = ({ patient, onItemClick }) => {
       />
       <StyledTable
         columns={columns}
-        onRowClick={row => {
-          if (canReadEncounter) {
-            onItemClick(row.id);
-          }
-        }}
+        onRowClick={canReadEncounter ? row => onItemClick(row.id) : null}
         noDataMessage={
           <Box mx="auto" p="40px" data-testid="box-t8fy">
             <TranslatedText

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -180,24 +180,24 @@ export const EncounterActions = React.memo(({ encounter }) => {
               size="small"
               variant="outlined"
               onClick={() => setOpenModal(ENCOUNTER_MODALS.DISCHARGE)}
+              disabled={canWriteEncounter}
             >
               <TranslatedText
                 stringId="encounter.action.prepareDischarge"
                 fallback="Prepare discharge"
               />
             </StyledButton>
-            {canWrite && (
-              <MoveButton
-                size="small"
-                color="primary"
-                onClick={() => {
-                  setNewEncounterType(null);
-                  setOpenModal(ENCOUNTER_MODALS.MOVE);
-                }}
-              >
-                <TranslatedText stringId="encounter.action.movePatient" fallback="Move patient" />
-              </MoveButton>
-            )}
+            <MoveButton
+              size="small"
+              color="primary"
+              disabled={!canWriteEncounter}
+              onClick={() => {
+                setNewEncounterType(null);
+                setOpenModal(ENCOUNTER_MODALS.MOVE);
+              }}
+            >
+              <TranslatedText stringId="encounter.action.movePatient" fallback="Move patient" />
+            </MoveButton>
           </>
         )}
         <ThreeDotMenu items={actions} data-testid="threedotmenu-5t9u" />

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -180,7 +180,7 @@ export const EncounterActions = React.memo(({ encounter }) => {
               size="small"
               variant="outlined"
               onClick={() => setOpenModal(ENCOUNTER_MODALS.DISCHARGE)}
-              disabled={canWriteEncounter}
+              disabled={!canWriteEncounter}
             >
               <TranslatedText
                 stringId="encounter.action.prepareDischarge"

--- a/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
+++ b/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
@@ -20,6 +20,7 @@ import {
 import { ENCOUNTER_TYPE_LABELS } from '@tamanu/constants';
 import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 import { getEncounterStartDateLabel } from '../../../utils/getEncounterStartDateLabel';
+import { useAuth } from '../../../contexts/Auth';
 
 const Border = css`
   border: 1px solid ${Colors.outline};
@@ -208,6 +209,7 @@ const PatientDeathSummary = React.memo(({ patient }) => {
 
 export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckin }) => {
   const { getLocalisation } = useLocalisation();
+  const { ability } = useAuth();
   const { data: encounter, error, isLoading } = usePatientCurrentEncounterQuery(patient.id);
 
   if (patient.dateOfDeath) {
@@ -275,6 +277,7 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckin })
   } = encounter;
 
   const patientStatus = getPatientStatus(encounterType);
+  const canReadEncounter = ability.can('read', 'Encounter');
 
   return (
     <Container patientStatus={patientStatus} data-testid="container-2i3h">
@@ -304,13 +307,15 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckin })
           )}
         </Title>
         <div style={{ flexGrow: 1 }} />
-        <Button onClick={() => viewEncounter(id)} size="small" data-testid="button-t8zb">
-          <TranslatedText
-            stringId="patient.encounterSummary.viewEncounter"
-            fallback="View encounter"
-            data-testid="translatedtext-nqf5"
-          />
-        </Button>
+        {canReadEncounter && (
+          <Button onClick={() => viewEncounter(id)} size="small" data-testid="button-t8zb">
+            <TranslatedText
+              stringId="patient.encounterSummary.viewEncounter"
+              fallback="View encounter"
+              data-testid="translatedtext-nqf5"
+            />
+          </Button>
+        )}
       </Header>
       <Content data-testid="content-j9id">
         <ContentItem data-testid="contentitem-hcvt">

--- a/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
+++ b/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
@@ -307,15 +307,18 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckin })
           )}
         </Title>
         <div style={{ flexGrow: 1 }} />
-        {canReadEncounter && (
-          <Button onClick={() => viewEncounter(id)} size="small" data-testid="button-t8zb">
-            <TranslatedText
-              stringId="patient.encounterSummary.viewEncounter"
-              fallback="View encounter"
-              data-testid="translatedtext-nqf5"
-            />
-          </Button>
-        )}
+        <Button
+          onClick={() => viewEncounter(id)}
+          size="small"
+          data-testid="button-t8zb"
+          disabled={!canReadEncounter}
+        >
+          <TranslatedText
+            stringId="patient.encounterSummary.viewEncounter"
+            fallback="View encounter"
+            data-testid="translatedtext-nqf5"
+          />
+        </Button>
       </Header>
       <Content data-testid="content-j9id">
         <ContentItem data-testid="contentitem-hcvt">

--- a/packages/web/app/views/patients/components/PlannedMoveActions.jsx
+++ b/packages/web/app/views/patients/components/PlannedMoveActions.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { TAMANU_COLORS, TextButton } from '@tamanu/ui-components';
 import { FinalisePatientMoveModal } from './FinalisePatientMoveModal';
 import { CancelPatientMoveModal } from './CancelPatientMoveModal';
+import { useAuth } from '../../../contexts/Auth';
 
 import { BedIcon } from '../../../assets/icons/BedIcon';
 
@@ -33,8 +34,14 @@ const CancelButton = styled(TextButton)`
 `;
 
 export const PlannedMoveActions = ({ encounter }) => {
+  const { ability } = useAuth();
   const [cancelModalOpen, setCancelModalOpen] = useState(false);
   const [finaliseModalOpen, setFinaliseModalOpen] = useState(false);
+
+  const canWriteEncounter = ability.can('write', 'Encounter');
+  if (!canWriteEncounter) {
+    return null;
+  }
 
   return (
     <>

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -37,6 +37,7 @@ import { DateField, Field, Form, TAMANU_COLORS } from '@tamanu/ui-components';
 import { useEncounter } from '../../../contexts/Encounter.jsx';
 import { getEncounterStartDateLabel } from '../../../utils/getEncounterStartDateLabel.jsx';
 import { PlusIcon } from '../../../assets/icons/PlusIcon';
+import { useAuth } from '../../../contexts/Auth';
 
 const InfoCardFirstColumn = styled.div`
   display: flex;
@@ -201,7 +202,9 @@ const LengthOfStayDisplay = ({ startDate, endDate }) => {
 };
 
 export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBillingType }) => {
+  const { ability } = useAuth();
   const [isEstimatedDischargeModalOpen, setIsEstimatedDischargeModalOpen] = useState(false);
+  const canWriteEncounter = ability.can('write', 'Encounter');
 
   return (
     <InfoCard inlineValues contentPadding={25} paddingTop={0} data-testid="infocard-o4i8">
@@ -314,22 +317,24 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               encounter.estimatedEndDate ? (
                 <DateDisplay date={encounter.estimatedEndDate} data-testid="datedisplay-fa08" />
               ) : (
-                <>
-                  <AddButton onClick={() => setIsEstimatedDischargeModalOpen(true)}>
-                    <PlusIcon fill={TAMANU_COLORS.darkestText} />
-                    <AddButtonText>
-                      <TranslatedText
-                        stringId="encounter.summary.addEstimatedDischargeDate"
-                        fallback="Add"
-                      />
-                    </AddButtonText>
-                  </AddButton>
-                  <SetDischargeDateModal
-                    open={isEstimatedDischargeModalOpen}
-                    onClose={() => setIsEstimatedDischargeModalOpen(false)}
-                    encounter={encounter}
-                  />
-                </>
+                canWriteEncounter && (
+                  <>
+                    <AddButton onClick={() => setIsEstimatedDischargeModalOpen(true)}>
+                      <PlusIcon fill={TAMANU_COLORS.darkestText} />
+                      <AddButtonText>
+                        <TranslatedText
+                          stringId="encounter.summary.addEstimatedDischargeDate"
+                          fallback="Add"
+                        />
+                      </AddButtonText>
+                    </AddButton>
+                    <SetDischargeDateModal
+                      open={isEstimatedDischargeModalOpen}
+                      onClose={() => setIsEstimatedDischargeModalOpen(false)}
+                      encounter={encounter}
+                    />
+                  </>
+                )
               )
             }
             icon={dischargeDateIcon}


### PR DESCRIPTION
### Changes

This card was to check that all permissions are applied correctly. Endpoints look good but there are a couple of buttons we can disable and actions we can hide 🙏 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces front-end Encounter permissions, gating view/edit actions, buttons, and UI affordances based on read/write ability.
> 
> - **Permissions (Encounter)**
>   - **Read**: Gate `onRowClick` in `components/PatientHistory.jsx`; disable "View encounter" button in `views/patients/components/PatientEncounterSummary.jsx` when lacking `read`.
>   - **Write**: Apply `ability.can('write','Encounter')` to action availability in `views/patients/components/EncounterActions.jsx` (menu items and Discharge/Move buttons disabled when unauthorized).
>     - Hide `views/patients/components/PlannedMoveActions.jsx` entirely without `write`.
>     - Show "Add estimated discharge date" UI in `views/patients/panes/EncounterInfoPane.jsx` only with `write`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0652bfb6883ea2f403dff4dbcb3f8ced06e23170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->