### PR TITLE
fix(invoicing): SAV-1017: Automatic invoices on triages

### DIFF
--- a/packages/constants/src/invoices.ts
+++ b/packages/constants/src/invoices.ts
@@ -1,3 +1,4 @@
+import { ENCOUNTER_TYPES } from './encounters';
 import { IMAGING_AREA_TYPES } from './imaging';
 import { REFERENCE_TYPES } from './importable';
 
@@ -94,3 +95,8 @@ export const INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES = {
   MANUAL_ENTRY: 'manual-entry',
   HIDDEN: 'hidden',
 };
+
+export const AUTOMATIC_INVOICE_CREATION_EXCLUDED_ENCOUNTER_TYPES = [
+  ENCOUNTER_TYPES.SURVEY_RESPONSE,
+  ENCOUNTER_TYPES.VACCINATION,
+];

--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -5,6 +5,7 @@ import {
   INVOICE_STATUSES,
   SYNC_DIRECTIONS,
   SYSTEM_USER_UUID,
+  ENCOUNTER_TYPES,
 } from '@tamanu/constants';
 import { Model } from '../Model';
 import { buildEncounterLinkedSyncFilter } from '../../sync/buildEncounterLinkedSyncFilter';
@@ -16,6 +17,8 @@ import type { ImagingRequest } from 'models/ImagingRequest';
 import type { LabTestPanelRequest } from 'models/LabTestPanelRequest';
 import type { LabTest } from 'models/LabTest';
 import type { ImagingRequestArea } from 'models/ImagingRequestArea';
+import type { ReadSettings } from '@tamanu/settings';
+import { generateInvoiceDisplayId } from '@tamanu/utils/generateInvoiceDisplayId';
 
 type InvoiceItemSourceRecord =
   | Procedure
@@ -210,6 +213,27 @@ export class Invoice extends Model {
         sourceRecordType: removedItemSource.getModelName(),
         sourceRecordId: removedItemSource.id,
       },
+    });
+  }
+
+  static async automaticallyCreateForEncounter(
+    encounterId: string,
+    encounterType: string,
+    date: string,
+    settings: ReadSettings,
+  ) {
+    const isInvoicingEnabled = await settings.get('features.enableInvoicing');
+    const excludedEncounterTypes = [ENCOUNTER_TYPES.SURVEY_RESPONSE, ENCOUNTER_TYPES.VACCINATION];
+    const shouldCreateInvoice = !excludedEncounterTypes.includes(encounterType);
+    if (!isInvoicingEnabled || !shouldCreateInvoice) {
+      return null;
+    }
+
+    return await this.create({
+      displayId: generateInvoiceDisplayId(),
+      status: INVOICE_STATUSES.IN_PROGRESS,
+      date,
+      encounterId,
     });
   }
 }

--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -5,7 +5,7 @@ import {
   INVOICE_STATUSES,
   SYNC_DIRECTIONS,
   SYSTEM_USER_UUID,
-  ENCOUNTER_TYPES,
+  AUTOMATIC_INVOICE_CREATION_EXCLUDED_ENCOUNTER_TYPES,
 } from '@tamanu/constants';
 import { Model } from '../Model';
 import { buildEncounterLinkedSyncFilter } from '../../sync/buildEncounterLinkedSyncFilter';
@@ -223,8 +223,7 @@ export class Invoice extends Model {
     settings: ReadSettings,
   ) {
     const isInvoicingEnabled = await settings?.get('features.enableInvoicing');
-    const excludedEncounterTypes = [ENCOUNTER_TYPES.SURVEY_RESPONSE, ENCOUNTER_TYPES.VACCINATION];
-    const isValidEncounterType = !excludedEncounterTypes.includes(encounterType);
+    const isValidEncounterType = !AUTOMATIC_INVOICE_CREATION_EXCLUDED_ENCOUNTER_TYPES.includes(encounterType);
     if (!isInvoicingEnabled || !isValidEncounterType) {
       return null;
     }

--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -222,7 +222,7 @@ export class Invoice extends Model {
     date: string,
     settings: ReadSettings,
   ) {
-    const isInvoicingEnabled = await settings.get('features.enableInvoicing');
+    const isInvoicingEnabled = await settings?.get('features.enableInvoicing');
     const excludedEncounterTypes = [ENCOUNTER_TYPES.SURVEY_RESPONSE, ENCOUNTER_TYPES.VACCINATION];
     const isValidEncounterType = !excludedEncounterTypes.includes(encounterType);
     if (!isInvoicingEnabled || !isValidEncounterType) {

--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -224,8 +224,8 @@ export class Invoice extends Model {
   ) {
     const isInvoicingEnabled = await settings.get('features.enableInvoicing');
     const excludedEncounterTypes = [ENCOUNTER_TYPES.SURVEY_RESPONSE, ENCOUNTER_TYPES.VACCINATION];
-    const shouldCreateInvoice = !excludedEncounterTypes.includes(encounterType);
-    if (!isInvoicingEnabled || !shouldCreateInvoice) {
+    const isValidEncounterType = !excludedEncounterTypes.includes(encounterType);
+    if (!isInvoicingEnabled || !isValidEncounterType) {
       return null;
     }
 

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -16,8 +16,6 @@ import {
   TASK_STATUSES,
   SURVEY_TYPES,
   DASHBOARD_ONLY_TASK_TYPES,
-  INVOICE_STATUSES,
-  ENCOUNTER_TYPES,
 } from '@tamanu/constants';
 import {
   simpleGet,

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -80,6 +80,13 @@ triage.post(
     });
     await encounter.addTriageScoreNote(triageRecord, user);
 
+    await models.Invoice.automaticallyCreateForEncounter(
+      encounter.id,
+      encounter.encounterType,
+      encounter.startDate,
+      settings[facilityId],
+    );
+
     res.send(triageRecord);
   }),
 );


### PR DESCRIPTION
### Changes

Automatic invoice creation for encounters include triages, this was missed because they are created in a different endpoint.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes automatic invoice creation in the `Invoice` model and triggers it on encounter and triage creation, excluding specific encounter types.
> 
> - **Backend**
>   - **Model (`Invoice`)**:
>     - Add `automaticallyCreateForEncounter(encounterId, encounterType, date, settings)` to create `IN_PROGRESS` invoices when invoicing is enabled and encounter type isn’t excluded; uses `generateInvoiceDisplayId`.
>   - **Constants**:
>     - Add `AUTOMATIC_INVOICE_CREATION_EXCLUDED_ENCOUNTER_TYPES` with `ENCOUNTER_TYPES.SURVEY_RESPONSE` and `ENCOUNTER_TYPES.VACCINATION`.
>   - **Routes**:
>     - `routes/apiv1/encounter.js` (`POST /encounters`): replace inline invoice creation with `Invoice.automaticallyCreateForEncounter`.
>     - `routes/apiv1/triage.js` (`POST /triage`): call `Invoice.automaticallyCreateForEncounter` to create invoices for triage-linked encounters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6217a23a5b406570ac367cc412c01f497bc4cafe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->