### PR TITLE
fix(pdf): 2.46 fix: lab results printout translations

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/LabResultsPrintoutModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/LabResultsPrintoutModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { Modal, TranslatedText } from '@tamanu/ui-components';
+import { Modal, TranslatedText, useTranslation } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 import { useApi } from '../../../api';
 import {
@@ -16,6 +16,7 @@ import { useSettings } from '../../../contexts/Settings';
 import { LabResultsPrintout } from '@tamanu/shared/utils/patientCertificates';
 
 export const LabResultsPrintoutModal = React.memo(({ labRequest, patient, open, onClose }) => {
+  const { translations } = useTranslation();
   const { getLocalisation } = useLocalisation();
   const { getSetting } = useSettings();
   const api = useApi();
@@ -92,6 +93,7 @@ export const LabResultsPrintoutModal = React.memo(({ labRequest, patient, open, 
           labRequest={labRequestWithDetails}
           getLocalisation={getLocalisation}
           getSetting={getSetting}
+          translations={translations}
           data-testid="labresultsprintout-component"
         />
       </PDFLoader>


### PR DESCRIPTION
### Changes

just missed the prop!

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Injects `translations` from `useTranslation` into `LabResultsPrintout` to enable localized lab results printouts.
> 
> - **Patient Printing**
>   - `LabResultsPrintoutModal.jsx`: Import `useTranslation`, obtain `translations`, and pass it to `LabResultsPrintout` via new `translations` prop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87efcd387db636d919f38edd68e720f7e753ad84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->