### PR TITLE
tweak(encounters): no-issue: Encounter edit modal form spacing

### DIFF
--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -125,6 +125,7 @@ const ClinicFields = () => {
         required
         data-testid="field-check-in-time"
       />
+      <div /> {/* Spacer for field position */}
       <LocalisedField
         name="patientBillingTypeId"
         label={

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -108,6 +108,10 @@ const HospitalAdmissionFields = () => {
   );
 };
 
+const PatientTypeField = styled(LocalisedField)`
+  grid-column-start: 1;
+`;
+
 const ClinicFields = () => {
   const referralSourceSuggester = useSuggester('referralSource');
 
@@ -125,8 +129,7 @@ const ClinicFields = () => {
         required
         data-testid="field-check-in-time"
       />
-      <div /> {/* Spacer for field position */}
-      <LocalisedField
+      <PatientTypeField
         name="patientBillingTypeId"
         label={
           <TranslatedText


### PR DESCRIPTION
### Changes



### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a spacer div in the clinic encounter form of EditEncounterModal to fix field alignment/spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f480a2c441869958ec069b67e927eafe3dc8c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->