### PR TITLE
repo: Add new sync codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 #
-# Edwin and Chris currently own sync, because it's complicated and fragile
+# Edwin, Chris, Rohan, Daniel and Félix currently own sync, because it's complicated and fragile
 # functionality that's core to the app, and sync bugs have scary potential for
 # data loss.
 #
@@ -9,11 +9,11 @@
 # See Slack discussion:
 # https://beyondessential.slack.com/archives/GE9NHB95F/p1649711118757929
 #
-/packages/shared/src/sync/                              @edmofro @chris-bes
-/packages/facility-server/app/sync/                     @edmofro @chris-bes
-/packages/central-server/app/sync/                      @edmofro @chris-bes
-/packages/mobile/App/services/sync/                     @edmofro @chris-bes
-/packages/database/src/sync/                            @edmofro @chris-bes
+/packages/shared/src/sync/                              @edmofro @chris-bes @rohan-b @danielnash100 @passcod
+/packages/facility-server/app/sync/                     @edmofro @chris-bes @rohan-b @danielnash100 @passcod  
+/packages/central-server/app/sync/                      @edmofro @chris-bes @rohan-b @danielnash100 @passcod
+/packages/mobile/App/services/sync/                     @edmofro @chris-bes @rohan-b @danielnash100 @passcod
+/packages/database/src/sync/                            @edmofro @chris-bes @rohan-b @danielnash100 @passcod    
 
 #
 # The deployment team are code owner of the default config files to make sure

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,11 +9,11 @@
 # See Slack discussion:
 # https://beyondessential.slack.com/archives/GE9NHB95F/p1649711118757929
 #
-/packages/shared/src/sync/                              @edmofro @chris-bes @rohan-b @danielnash100 @passcod
-/packages/facility-server/app/sync/                     @edmofro @chris-bes @rohan-b @danielnash100 @passcod  
-/packages/central-server/app/sync/                      @edmofro @chris-bes @rohan-b @danielnash100 @passcod
-/packages/mobile/App/services/sync/                     @edmofro @chris-bes @rohan-b @danielnash100 @passcod
-/packages/database/src/sync/                            @edmofro @chris-bes @rohan-b @danielnash100 @passcod    
+/packages/shared/src/sync/                              @edmofro @chris-bes @rohan-bes @dannash100 @passcod
+/packages/facility-server/app/sync/                     @edmofro @chris-bes @rohan-bes @dannash100 @passcod
+/packages/central-server/app/sync/                      @edmofro @chris-bes @rohan-bes @dannash100 @passcod
+/packages/mobile/App/services/sync/                     @edmofro @chris-bes @rohan-bes @dannash100 @passcod
+/packages/database/src/sync/                            @edmofro @chris-bes @rohan-bes @dannash100 @passcod
 
 #
 # The deployment team are code owner of the default config files to make sure


### PR DESCRIPTION
### Changes
Adding 3 new sync code owners as requested
- Félix, Daniel, Rohan

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
