### PR TITLE
tweak(labs): NASS-893: Lab results printout permissions

### DIFF
--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -218,9 +218,8 @@ export const LabRequestView = () => {
   const canWriteLabRequest = ability?.can('write', 'LabRequest');
   const canWriteLabRequestStatus = ability?.can('write', 'LabRequestStatus');
   const canWriteLabTest = ability?.can('write', 'LabTest');
-  // const canReadLabTestResult = ability?.can('read', 'LabTestResult');
-  const canReadLabTestResult = false;
-   
+  const canReadLabTestResult = ability?.can('read', 'LabTestResult');
+ 
   const isPublished = labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED;
   const isVerified = labRequest.status === LAB_REQUEST_STATUSES.VERIFIED;
 

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -218,8 +218,9 @@ export const LabRequestView = () => {
   const canWriteLabRequest = ability?.can('write', 'LabRequest');
   const canWriteLabRequestStatus = ability?.can('write', 'LabRequestStatus');
   const canWriteLabTest = ability?.can('write', 'LabTest');
-  const canReadLabTestResult = ability?.can('read', 'LabTestResult');
-
+  // const canReadLabTestResult = ability?.can('read', 'LabTestResult');
+  const canReadLabTestResult = false;
+   
   const isPublished = labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED;
   const isVerified = labRequest.status === LAB_REQUEST_STATUSES.VERIFIED;
 

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -292,22 +292,23 @@ export const LabRequestView = () => {
           isReadOnly={areLabRequestsReadOnly}
           actions={
             <Box display="flex" alignItems="center" data-testid="box-qy3e">
-              {canReadLabTestResult && (isPublished || isVerified) && (
-                <OutlinedButton
-                  disabled={isHidden}
-                  onClick={() => {
-                    handleChangeModalId(MODAL_IDS.RESULTS_PRINT);
-                  }}
-                  data-testid="outlinedbutton-fdjm"
-                >
-                  <TranslatedText
-                    stringId="lab.action.printResults"
-                    fallback="Print results"
-                    data-testid="translatedtext-7zng"
-                  />
-                </OutlinedButton>
-              )}
-              {!(isPublished || isVerified) && (
+              {(isPublished || isVerified) ? (
+                canReadLabTestResult && (
+                  <OutlinedButton
+                    disabled={isHidden}
+                    onClick={() => {
+                      handleChangeModalId(MODAL_IDS.RESULTS_PRINT);
+                    }}
+                    data-testid="outlinedbutton-fdjm"
+                  >
+                    <TranslatedText
+                      stringId="lab.action.printResults"
+                      fallback="Print results"
+                      data-testid="translatedtext-7zng"
+                    />
+                  </OutlinedButton>
+                )
+              ) : (
                 <OutlinedButton
                   disabled={isHidden}
                   onClick={() => {

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -293,7 +293,7 @@ export const LabRequestView = () => {
           isReadOnly={areLabRequestsReadOnly}
           actions={
             <Box display="flex" alignItems="center" data-testid="box-qy3e">
-              {canReadLabTestResult && (isPublished || isVerified) ? (
+              {canReadLabTestResult && (isPublished || isVerified) && (
                 <OutlinedButton
                   disabled={isHidden}
                   onClick={() => {
@@ -307,7 +307,8 @@ export const LabRequestView = () => {
                     data-testid="translatedtext-7zng"
                   />
                 </OutlinedButton>
-              ) : (
+              )}
+              {!(isPublished || isVerified) && (
                 <OutlinedButton
                   disabled={isHidden}
                   onClick={() => {

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -292,36 +292,35 @@ export const LabRequestView = () => {
           isReadOnly={areLabRequestsReadOnly}
           actions={
             <Box display="flex" alignItems="center" data-testid="box-qy3e">
-              {canReadLabTestResult &&
-                (isPublished || isVerified ? (
-                  <OutlinedButton
-                    disabled={isHidden}
-                    onClick={() => {
-                      handleChangeModalId(MODAL_IDS.RESULTS_PRINT);
-                    }}
-                    data-testid="outlinedbutton-fdjm"
-                  >
-                    <TranslatedText
-                      stringId="lab.action.printResults"
-                      fallback="Print results"
-                      data-testid="translatedtext-7zng"
-                    />
-                  </OutlinedButton>
-                ) : (
-                  <OutlinedButton
-                    disabled={isHidden}
-                    onClick={() => {
-                      handleChangeModalId(MODAL_IDS.PRINT);
-                    }}
-                    data-testid="outlinedbutton-fdjm"
-                  >
-                    <TranslatedText
-                      stringId="lab.action.printRequest"
-                      fallback="Print request"
-                      data-testid="translatedtext-7zng"
-                    />
-                  </OutlinedButton>
-                ))}
+              {canReadLabTestResult && (isPublished || isVerified) ? (
+                <OutlinedButton
+                  disabled={isHidden}
+                  onClick={() => {
+                    handleChangeModalId(MODAL_IDS.RESULTS_PRINT);
+                  }}
+                  data-testid="outlinedbutton-fdjm"
+                >
+                  <TranslatedText
+                    stringId="lab.action.printResults"
+                    fallback="Print results"
+                    data-testid="translatedtext-7zng"
+                  />
+                </OutlinedButton>
+              ) : (
+                <OutlinedButton
+                  disabled={isHidden}
+                  onClick={() => {
+                    handleChangeModalId(MODAL_IDS.PRINT);
+                  }}
+                  data-testid="outlinedbutton-fdjm"
+                >
+                  <TranslatedText
+                    stringId="lab.action.printRequest"
+                    fallback="Print request"
+                    data-testid="translatedtext-7zng"
+                  />
+                </OutlinedButton>
+              )}
               <Menu
                 setModal={handleChangeModalId}
                 status={labRequest.status}

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -219,7 +219,7 @@ export const LabRequestView = () => {
   const canWriteLabRequestStatus = ability?.can('write', 'LabRequestStatus');
   const canWriteLabTest = ability?.can('write', 'LabTest');
   const canReadLabTestResult = ability?.can('read', 'LabTestResult');
- 
+
   const isPublished = labRequest.status === LAB_REQUEST_STATUSES.PUBLISHED;
   const isVerified = labRequest.status === LAB_REQUEST_STATUSES.VERIFIED;
 


### PR DESCRIPTION
### Changes
- These changes discussed in depth in ticket
  - No button should not show up if missing permission and published or verified
  - We still want the print request button to show up when no results permission.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
