### PR TITLE
fix(labs): 2.46 fix: Restore sorting on encounter lab request table

### DIFF
--- a/packages/web/app/views/patients/EncounterLabRequestsTable.jsx
+++ b/packages/web/app/views/patients/EncounterLabRequestsTable.jsx
@@ -37,7 +37,6 @@ const columns = [
       />
     ),
     accessor: getRequestType,
-    sortable: false,
   },
   {
     key: 'requestedDate',
@@ -49,7 +48,6 @@ const columns = [
       />
     ),
     accessor: getDateWithTimeTooltip,
-    sortable: false,
   },
   {
     key: 'displayName',
@@ -73,7 +71,6 @@ const columns = [
       />
     ),
     accessor: getPriority,
-    sortable: false,
   },
   {
     key: 'status',
@@ -86,7 +83,6 @@ const columns = [
     ),
     accessor: getStatus,
     maxWidth: 200,
-    sortable: false,
   },
 ];
 


### PR DESCRIPTION
### Changes
- Wrong table had its ability to sort removed

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
