### PR TITLE
fix(invoicing): SAV-1031: Filter invoice products properly

### DIFF
--- a/database/model/public/invoice_price_list_items.md
+++ b/database/model/public/invoice_price_list_items.md
@@ -13,3 +13,7 @@ Foreign key reference to the invoice products/services that can be priced. Ident
 {% docs invoice_price_list_items__price %}
 The price amount for this product in the context of this price list. Stored as a numeric value representing the cost in the system's base currency.
 {% enddocs %}
+
+{% docs invoice_price_list_items__is_hidden %}
+Determines whether the related invoice product should be hidden from searches on the frontend and also whether it should be automatically added to the invoice.
+{% enddocs %}

--- a/database/model/public/invoice_price_list_items.yml
+++ b/database/model/public/invoice_price_list_items.yml
@@ -61,11 +61,8 @@ sources:
           - name: price
             data_type: numeric
             description: "{{ doc('invoice_price_list_items__price') }}"
-          - name: visibility_status
-            data_type: text
-            description: "{{ doc('generic__visibility_status') }} in invoice_price_list_items."
+          - name: is_hidden
+            data_type: boolean
+            description: "{{ doc('invoice_price_list_items__is_hidden') }}"
             data_tests:
               - not_null
-            config:
-              meta:
-                masking: text

--- a/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
+++ b/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
@@ -746,7 +746,7 @@ describe('Reference data exporter', () => {
         {
           data: [
             ['invoiceProductId', 'A', 'B'],
-            ['prod-a', '100', 'manual-entry'],
+            ['prod-a', '100', null],
             ['prod-b', 'hidden', '50'],
           ],
           name: 'Invoice Price List Items',

--- a/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
+++ b/packages/central-server/__tests__/exporters/referenceDataExporter.test.js
@@ -28,7 +28,6 @@ import {
   INVOICE_ITEMS_CATEGORIES_MODELS,
   REFERENCE_DATA_TRANSLATION_PREFIX,
   REFERENCE_TYPES,
-  VISIBILITY_STATUSES,
 } from '@tamanu/constants';
 import { createTestContext } from '../utilities';
 import { exporter } from '../../dist/admin/exporter';
@@ -728,7 +727,7 @@ describe('Reference data exporter', () => {
       invoiceProductId: p2.id,
       invoicePriceListId: pl2.id, // code 'A'
       price: null,
-      visibilityStatus: VISIBILITY_STATUSES.HISTORICAL,
+      isHidden: true,
     });
 
     await exporter(store, { 1: 'invoicePriceList', 2: 'invoicePriceListItem' });

--- a/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
+++ b/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
@@ -122,7 +122,7 @@ describe('Invoice price list item import', () => {
     const headers = ['invoiceProductId', 'PL_A', 'PL_B'];
     const rows = [
       { invoiceProductId: 'prod-1', PL_A: 'hidden', PL_B: '' }, // hidden should be set to historical
-      { invoiceProductId: 'prod-2', PL_A: '', PL_B: 'manual-entry' }, // manual-entry should be set to null
+      { invoiceProductId: 'prod-2', PL_A: '', PL_B: null },
     ];
     const buffer = buildWorkbookBuffer(headers, rows);
 

--- a/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
+++ b/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
@@ -80,16 +80,16 @@ describe('Invoice price list item import', () => {
     const headers = ['invoiceProductId', 'PL_A', 'PL_B'];
     const rows = [
       { invoiceProductId: 'prod-1', PL_A: 100, PL_B: 200 },
-      { invoiceProductId: 'prod-2', PL_A: '', PL_B: 300 }, // blank should be ignored
+      { invoiceProductId: 'prod-2', PL_A: 300, PL_B: 400 },
     ];
     const buffer = buildWorkbookBuffer(headers, rows);
 
     const { errors, stats } = await doImport(ctx, { buffer });
     expect(errors).toBeEmpty();
 
-    // Expect 3 items created
+    // Expect 4 items created
     expect(stats).toMatchObject({
-      InvoicePriceListItem: { created: 3, updated: 0, errored: 0 },
+      InvoicePriceListItem: { created: 4, updated: 0, errored: 0 },
     });
 
     // Verify DB state
@@ -104,8 +104,9 @@ describe('Invoice price list item import', () => {
     const pricesProd1 = itemsProd1.map(i => i.price).sort((a, b) => a - b);
     expect(pricesProd1).toEqual(['100', '200']);
 
-    expect(itemsProd2).toHaveLength(1);
-    expect(itemsProd2[0].price).toEqual('300');
+    expect(itemsProd2).toHaveLength(2);
+    const pricesProd2 = itemsProd2.map(i => i.price).sort((a, b) => a - b);
+    expect(pricesProd2).toEqual(['300', '400']);
   });
 
   it('should create price list items from sheet headers and rows with special values', async () => {
@@ -121,8 +122,7 @@ describe('Invoice price list item import', () => {
 
     const headers = ['invoiceProductId', 'PL_A', 'PL_B'];
     const rows = [
-      { invoiceProductId: 'prod-1', PL_A: 'hidden', PL_B: '' }, // hidden should be set to historical
-      { invoiceProductId: 'prod-2', PL_A: '', PL_B: null },
+      { invoiceProductId: 'prod-1', PL_A: 'hidden', PL_B: '' },
     ];
     const buffer = buildWorkbookBuffer(headers, rows);
 
@@ -138,17 +138,14 @@ describe('Invoice price list item import', () => {
     const itemsProd1 = await InvoicePriceListItem.findAll({
       where: { invoiceProductId: 'prod-1' },
     });
-    const itemsProd2 = await InvoicePriceListItem.findAll({
-      where: { invoiceProductId: 'prod-2' },
-    });
 
-    expect(itemsProd1).toHaveLength(1);
-    expect(itemsProd1[0].price).toBeNull();
-    expect(itemsProd1[0].isHidden).toEqual(true);
-
-    expect(itemsProd2).toHaveLength(1);
-    expect(itemsProd2[0].price).toBeNull();
-    expect(itemsProd2[0].isHidden).toEqual(false);
+    expect(itemsProd1).toHaveLength(2);
+    const hiddenItem = itemsProd1.find(i => i.isHidden);
+    expect(hiddenItem).toBeDefined();
+    expect(hiddenItem.price).toBeNull();
+    const visibleItem = itemsProd1.find(i => !i.isHidden);
+    expect(visibleItem).toBeDefined();
+    expect(visibleItem.price).toBeNull();
   });
 
   it('should validate non-numeric price values', async () => {

--- a/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
+++ b/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
@@ -144,11 +144,11 @@ describe('Invoice price list item import', () => {
 
     expect(itemsProd1).toHaveLength(1);
     expect(itemsProd1[0].price).toBeNull();
-    expect(itemsProd1[0].visibilityStatus).toEqual('historical');
+    expect(itemsProd1[0].isHidden).toEqual(true);
 
     expect(itemsProd2).toHaveLength(1);
     expect(itemsProd2[0].price).toBeNull();
-    expect(itemsProd2[0].visibilityStatus).toEqual('current');
+    expect(itemsProd2[0].isHidden).toEqual(false);
   });
 
   it('should validate non-numeric price values', async () => {

--- a/packages/central-server/app/admin/exporter/modelExporters/InvoicePriceListItemExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/InvoicePriceListItemExporter.js
@@ -1,7 +1,7 @@
 import { INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { ProductMatrixByCodeExporter } from './ProductMatrixByCodeExporter';
 
-const { MANUAL_ENTRY, HIDDEN } = INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES;
+const { HIDDEN } = INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES;
 
 export class InvoicePriceListItemExporter extends ProductMatrixByCodeExporter {
   constructor(context, dataType) {
@@ -13,7 +13,6 @@ export class InvoicePriceListItemExporter extends ProductMatrixByCodeExporter {
       valueExtractor: item => {
         const { price, visibilityStatus } = item;
         if (visibilityStatus === VISIBILITY_STATUSES.HISTORICAL) return HIDDEN;
-        if (price === null) return MANUAL_ENTRY;
         return price;
       },
       itemModelAttributes: ['visibilityStatus'],

--- a/packages/central-server/app/admin/exporter/modelExporters/InvoicePriceListItemExporter.js
+++ b/packages/central-server/app/admin/exporter/modelExporters/InvoicePriceListItemExporter.js
@@ -1,4 +1,4 @@
-import { INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES, VISIBILITY_STATUSES } from '@tamanu/constants';
+import { INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES } from '@tamanu/constants';
 import { ProductMatrixByCodeExporter } from './ProductMatrixByCodeExporter';
 
 const { HIDDEN } = INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES;
@@ -11,11 +11,11 @@ export class InvoicePriceListItemExporter extends ProductMatrixByCodeExporter {
       parentIdField: 'invoicePriceListId',
       valueField: 'price',
       valueExtractor: item => {
-        const { price, visibilityStatus } = item;
-        if (visibilityStatus === VISIBILITY_STATUSES.HISTORICAL) return HIDDEN;
+        const { price, isHidden } = item;
+        if (isHidden) return HIDDEN;
         return price;
       },
-      itemModelAttributes: ['visibilityStatus'],
+      itemModelAttributes: ['isHidden'],
       tabName: 'Invoice Price List Items',
     });
   }

--- a/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
+++ b/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
@@ -22,6 +22,7 @@ export function productMatrixByCodeLoaderFactory(config) {
     parentIdField,
     valueField,
     valueExtractor = defaultValueExtractor,
+    allowEmptyValues = false,
     messages,
   } = config;
 
@@ -95,9 +96,10 @@ export function productMatrixByCodeLoaderFactory(config) {
     for (const code of state.codes) {
       const rawValue = item[code];
       // Skip empties
-      if (rawValue === undefined || rawValue === null || `${rawValue}`.trim() === '') continue;
+      const isEmpty = rawValue === undefined || rawValue === null || `${rawValue}`.trim() === '';
+      if (!allowEmptyValues && isEmpty) continue;
 
-      const { parsedValue, isValidValue, visibilityStatus } = valueExtractor(rawValue);
+      const { parsedValue, isValidValue, visibilityStatus } = valueExtractor(rawValue, isEmpty);
       if (!isValidValue) {
         pushError(messages.invalidValue(rawValue, code, invoiceProductId), itemModel);
         return [];

--- a/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
+++ b/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
@@ -95,11 +95,11 @@ export function productMatrixByCodeLoaderFactory(config) {
     const rows = [];
     for (const code of state.codes) {
       const rawValue = item[code];
-      // Skip empties
+
       const isEmpty = rawValue === undefined || rawValue === null || `${rawValue}`.trim() === '';
       if (!allowEmptyValues && isEmpty) continue;
 
-      const { parsedValue, isValidValue, visibilityStatus } = valueExtractor(rawValue, isEmpty);
+      const { parsedValue, isValidValue, ...otherColumns } = valueExtractor(rawValue, isEmpty);
       if (!isValidValue) {
         pushError(messages.invalidValue(rawValue, code, invoiceProductId), itemModel);
         return [];
@@ -121,7 +121,7 @@ export function productMatrixByCodeLoaderFactory(config) {
           [parentIdField]: parentId,
           invoiceProductId,
           [valueField]: parsedValue,
-          ...(visibilityStatus ? { visibilityStatus } : {}),
+          ...otherColumns,
         },
       });
     }

--- a/packages/central-server/app/admin/referenceDataImporter/invoicePriceListItemLoaderFactory.js
+++ b/packages/central-server/app/admin/referenceDataImporter/invoicePriceListItemLoaderFactory.js
@@ -1,4 +1,4 @@
-import { INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES, VISIBILITY_STATUSES } from '@tamanu/constants';
+import { INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES } from '@tamanu/constants';
 import { productMatrixByCodeLoaderFactory } from './ProductMatrixByCodeLoaderFactory';
 
 const { HIDDEN } = INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES;
@@ -13,8 +13,8 @@ export function invoicePriceListItemLoaderFactory() {
       const isSpecialValue = isEmpty || value === HIDDEN;
       const parsedValue = isSpecialValue ? null : Number(value);
       const isValidValue = isSpecialValue ? true : !Number.isNaN(parsedValue);
-      const visibilityStatus = value === HIDDEN ? VISIBILITY_STATUSES.HISTORICAL : VISIBILITY_STATUSES.CURRENT;
-      return { parsedValue, isValidValue, visibilityStatus };
+      const isHidden = value === HIDDEN;
+      return { parsedValue, isValidValue, isHidden };
     },
     allowEmptyValues: true,
     messages: {

--- a/packages/central-server/app/admin/referenceDataImporter/invoicePriceListItemLoaderFactory.js
+++ b/packages/central-server/app/admin/referenceDataImporter/invoicePriceListItemLoaderFactory.js
@@ -1,7 +1,7 @@
 import { INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { productMatrixByCodeLoaderFactory } from './ProductMatrixByCodeLoaderFactory';
 
-const { MANUAL_ENTRY, HIDDEN } = INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES;
+const { HIDDEN } = INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES;
 
 export function invoicePriceListItemLoaderFactory() {
   return productMatrixByCodeLoaderFactory({
@@ -9,13 +9,14 @@ export function invoicePriceListItemLoaderFactory() {
     itemModel: 'InvoicePriceListItem',
     parentIdField: 'invoicePriceListId',
     valueField: 'price',
-    valueExtractor: value => {
-      const isSpecialValue = value === MANUAL_ENTRY || value === HIDDEN;
+    valueExtractor: (value, isEmpty) => {
+      const isSpecialValue = isEmpty || value === HIDDEN;
       const parsedValue = isSpecialValue ? null : Number(value);
       const isValidValue = isSpecialValue ? true : !Number.isNaN(parsedValue);
       const visibilityStatus = value === HIDDEN ? VISIBILITY_STATUSES.HISTORICAL : VISIBILITY_STATUSES.CURRENT;
       return { parsedValue, isValidValue, visibilityStatus };
     },
+    allowEmptyValues: true,
     messages: {
       duplicateCode: code => `duplicate price list code: ${code}`,
       missingParentByCode: code => `InvoicePriceList with code '${code}' does not exist`,

--- a/packages/constants/src/invoices.ts
+++ b/packages/constants/src/invoices.ts
@@ -91,6 +91,5 @@ export const INVOICE_INSURER_PAYMENT_STATUS_LABELS = {
 };
 
 export const INVOICE_PRICE_LIST_ITEM_IMPORT_VALUES = {
-  MANUAL_ENTRY: 'manual-entry',
   HIDDEN: 'hidden',
 };

--- a/packages/database/src/migrations/1765142814817-updateInvoicePriceListItemColumns.ts
+++ b/packages/database/src/migrations/1765142814817-updateInvoicePriceListItemColumns.ts
@@ -1,0 +1,19 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.removeColumn('invoice_price_list_items', 'visibility_status');
+  await query.addColumn('invoice_price_list_items', 'is_hidden', {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.addColumn('invoice_price_list_items', 'visibility_status', {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: 'current',
+  });
+  await query.removeColumn('invoice_price_list_items', 'is_hidden');
+}

--- a/packages/database/src/models/Invoice/Invoice.ts
+++ b/packages/database/src/models/Invoice/Invoice.ts
@@ -176,6 +176,24 @@ export class Invoice extends Model {
       return;
     }
 
+    // Confirm price list exists
+    const invoicePriceListId = await this.sequelize.models.InvoicePriceList.getIdForPatientEncounter(encounterId);
+    if (!invoicePriceListId) {
+      return;
+    }
+
+    // Confirm invoice product is not configured to be hidden for this price list
+    const invoicePriceListItem = await this.sequelize.models.InvoicePriceListItem.findOne({
+      where: {
+        invoicePriceListId,
+        invoiceProductId: invoiceProduct.id,
+        isHidden: false,
+      },
+    });
+    if (!invoicePriceListItem) {
+      return;
+    }
+
     await this.sequelize.models.InvoiceItem.upsert(
       {
         invoiceId: invoice.id,

--- a/packages/database/src/models/Invoice/InvoiceItem.ts
+++ b/packages/database/src/models/Invoice/InvoiceItem.ts
@@ -1,5 +1,5 @@
 import { DataTypes, literal, Op } from 'sequelize';
-import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from '@tamanu/constants';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from '../Model';
 import { buildEncounterLinkedSyncFilter } from '../../sync/buildEncounterLinkedSyncFilter';
 import { dateType, type InitOptions, type Models } from '../../types/model';
@@ -164,7 +164,7 @@ export class InvoiceItem extends Model {
     if (invoicePriceListId) {
       productInclude.push({
         model: models.InvoicePriceListItem,
-        where: { invoicePriceListId, visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+        where: { invoicePriceListId },
         as: 'invoicePriceListItem',
         attributes: ['price', 'invoicePriceListId'],
         required: false,

--- a/packages/database/src/models/Invoice/InvoicePriceListItem.ts
+++ b/packages/database/src/models/Invoice/InvoicePriceListItem.ts
@@ -1,5 +1,5 @@
 import { DataTypes } from 'sequelize';
-import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from '@tamanu/constants';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from '../Model';
 import type { InitOptions, Models } from '../../types/model';
 
@@ -8,7 +8,7 @@ export class InvoicePriceListItem extends Model {
   declare invoicePriceListId: string;
   declare invoiceProductId: string;
   declare price: number | null;
-  declare visibilityStatus: string;
+  declare isHidden: boolean;
 
   static initModel({ primaryKey, ...options }: InitOptions) {
     super.init(
@@ -26,9 +26,9 @@ export class InvoicePriceListItem extends Model {
           type: DataTypes.DECIMAL,
           allowNull: true,
         },
-        visibilityStatus: {
-          type: DataTypes.TEXT,
-          defaultValue: VISIBILITY_STATUSES.CURRENT,
+        isHidden: {
+          type: DataTypes.BOOLEAN,
+          defaultValue: false,
           allowNull: false,
         },
       },

--- a/packages/facility-server/__tests__/apiv1/EncounterInvoice.test.js
+++ b/packages/facility-server/__tests__/apiv1/EncounterInvoice.test.js
@@ -12,12 +12,29 @@ import {
 } from '@tamanu/constants';
 import { describe } from 'node:test';
 
+async function createPriceListItemForProduct(
+  models,
+  invoiceProductId,
+  invoicePriceListId,
+  price = 100,
+) {
+  return await models.InvoicePriceListItem.create(fake(models.InvoicePriceListItem, {
+    invoiceProductId,
+    invoicePriceListId,
+    price,
+    isHidden: false,
+  }));
+}
+
 describe('Encounter invoice', () => {
   let patient = null;
   let user = null;
   let app = null;
   let baseApp = null;
   let models = null;
+  let facility = null;
+  let location = null;
+  let priceList = null;
   let ctx;
 
   beforeAll(async () => {
@@ -27,6 +44,26 @@ describe('Encounter invoice', () => {
     patient = await models.Patient.create(await createDummyPatient(models));
     user = await models.User.create({ ...fakeUser(), role: 'practitioner' });
     app = await baseApp.asUser(user);
+
+    facility = await models.Facility.findOne({
+      order: [['createdAt', 'ASC']],
+    });
+    location = await models.Location.create(
+      fake(models.Location, {
+        facilityId: facility.id,
+        name: 'Location Invoice Test',
+        code: 'LOCATION-INVOICE-TEST',
+      }),
+    );
+    priceList = await models.InvoicePriceList.create(
+      fake(models.InvoicePriceList, {
+        name: 'Facility Price List',
+        code: 'FACILITY',
+        rules: {
+          facilityId: facility.id,
+        },
+      }),
+    );
   });
 
   beforeEach(async () => {
@@ -66,6 +103,7 @@ describe('Encounter invoice', () => {
     it('should automatically add/remove items to the invoice when a procedure is created/deleted', async () => {
       const encounter = await models.Encounter.create({
         ...(await createDummyEncounter(models)),
+        locationId: location.id,
         patientId: patient.id,
       });
       await models.Invoice.create({
@@ -89,6 +127,7 @@ describe('Encounter invoice', () => {
           sourceRecordId: procedureType.id,
         }),
       );
+      await createPriceListItemForProduct(models, invoiceProduct.id, priceList.id);
       const procedure = await models.Procedure.create(
         fake(models.Procedure, {
           encounterId: encounter.id,
@@ -168,6 +207,7 @@ describe('Encounter invoice', () => {
             sourceRecordId: labTestBloodsType.id,
           }),
         );
+        await createPriceListItemForProduct(models, labTestBloodsProduct.id, priceList.id);
         labTestFluType = await models.LabTestType.create(
           fake(models.LabTestType, {
             name: 'Flu',
@@ -183,6 +223,7 @@ describe('Encounter invoice', () => {
             sourceRecordId: labTestFluType.id,
           }),
         );
+        await createPriceListItemForProduct(models, labTestFluProduct.id, priceList.id);
         labTestHeartType = await models.LabTestType.create(
           fake(models.LabTestType, {
             name: 'Heart',
@@ -198,6 +239,7 @@ describe('Encounter invoice', () => {
             sourceRecordId: labTestPanelGeneral.id,
           }),
         );
+        await createPriceListItemForProduct(models, labTestPanelGeneralProduct.id, priceList.id);
         labTestPanelAll = await models.LabTestPanel.create(
           fake(models.LabTestPanel, {
             name: 'All',
@@ -233,6 +275,7 @@ describe('Encounter invoice', () => {
       it('should automatically add/remove the panel product to the invoice when a lab request is created/deleted', async () => {
         const encounter = await models.Encounter.create({
           ...(await createDummyEncounter(models)),
+          locationId: location.id,
           patientId: patient.id,
         });
         await models.Invoice.create({
@@ -296,6 +339,7 @@ describe('Encounter invoice', () => {
       it('should automatically add/remove the test products to the invoice when a lab request is created/deleted', async () => {
         const encounter = await models.Encounter.create({
           ...(await createDummyEncounter(models)),
+          locationId: location.id,
           patientId: patient.id,
         });
         await models.Invoice.create({
@@ -380,6 +424,7 @@ describe('Encounter invoice', () => {
       it('should automatically add/remove the test products to the invoice when a product is not configured for the panel', async () => {
         const encounter = await models.Encounter.create({
           ...(await createDummyEncounter(models)),
+          locationId: location.id,
           patientId: patient.id,
         });
         await models.Invoice.create({
@@ -499,6 +544,7 @@ describe('Encounter invoice', () => {
             sourceRecordId: imagingType.id,
           }),
         );
+        await createPriceListItemForProduct(models, imagingRequestProduct.id, priceList.id);
         imagingAreaHeadProduct = await models.InvoiceProduct.create(
           fake(models.InvoiceProduct, {
             category: INVOICE_ITEMS_CATEGORIES.IMAGING_AREA,
@@ -507,11 +553,13 @@ describe('Encounter invoice', () => {
             sourceRecordId: imagingAreaHead.id,
           }),
         );
+        await createPriceListItemForProduct(models, imagingAreaHeadProduct.id, priceList.id);
       });
 
       it('should automatically add/remove items to the invoice when an imaging request is created/deleted', async () => {
         const encounter = await models.Encounter.create({
           ...(await createDummyEncounter(models)),
+          locationId: location.id,
           patientId: patient.id,
         });
         await models.Invoice.create({
@@ -590,6 +638,7 @@ describe('Encounter invoice', () => {
       it('should not automatically add/remove items to the invoice when the transaction is rolled back', async () => {
         const encounter = await models.Encounter.create({
           ...(await createDummyEncounter(models)),
+          locationId: location.id,
           patientId: patient.id,
         });
         await models.Invoice.create({
@@ -741,6 +790,7 @@ describe('Encounter invoice', () => {
     it('should include insurance plan items with default coverage for invoice items', async () => {
       const encounter = await models.Encounter.create({
         ...(await createDummyEncounter(models)),
+        locationId: location.id,
         patientId: patient.id,
       });
 
@@ -781,6 +831,7 @@ describe('Encounter invoice', () => {
           sourceRecordId: procedureType.id,
         }),
       );
+      await createPriceListItemForProduct(models, invoiceProduct.id, priceList.id);
 
       const procedure = await models.Procedure.create(
         fake(models.Procedure, {
@@ -812,6 +863,7 @@ describe('Encounter invoice', () => {
     it('should include insurance plan items with custom coverage values', async () => {
       const encounter = await models.Encounter.create({
         ...(await createDummyEncounter(models)),
+        locationId: location.id,
         patientId: patient.id,
       });
 
@@ -852,6 +904,7 @@ describe('Encounter invoice', () => {
           sourceRecordId: procedureType.id,
         }),
       );
+      await createPriceListItemForProduct(models, invoiceProduct.id, priceList.id);
 
       // Create custom coverage for this specific product
       await models.InvoiceInsurancePlanItem.create({
@@ -890,6 +943,7 @@ describe('Encounter invoice', () => {
     it('should include multiple insurance plans for a single invoice', async () => {
       const encounter = await models.Encounter.create({
         ...(await createDummyEncounter(models)),
+        locationId: location.id,
         patientId: patient.id,
       });
 
@@ -941,6 +995,7 @@ describe('Encounter invoice', () => {
           sourceRecordId: procedureType.id,
         }),
       );
+      await createPriceListItemForProduct(models, invoiceProduct.id, priceList.id);
 
       // Create custom coverage for second plan only
       await models.InvoiceInsurancePlanItem.create({

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -43,7 +43,7 @@ invoiceRoute.get(
       where: {
         invoicePriceListId,
         invoiceProductId: productId,
-        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        isHidden: false,
       },
       attributes: ['price'],
     });

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -1,11 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { ValidationError, NotFoundError, InvalidOperationError } from '@tamanu/errors';
-import {
-  INVOICE_ITEMS_DISCOUNT_TYPES,
-  INVOICE_STATUSES,
-  VISIBILITY_STATUSES,
-} from '@tamanu/constants';
+import { INVOICE_ITEMS_DISCOUNT_TYPES, INVOICE_STATUSES } from '@tamanu/constants';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { Op } from 'sequelize';

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -600,8 +600,30 @@ createSuggester(
   },
 );
 
-createSuggester('invoiceProduct', 'InvoiceProduct', ({ endpoint, modelName }) =>
-  DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
+createSuggester(
+  'invoiceProduct',
+  'InvoiceProduct',
+  ({ endpoint, modelName }) => DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
+  {
+    includeBuilder: req => {
+      const { priceListId } = req.query;
+
+      if (!priceListId) return [];
+
+      return [
+        {
+          model: req.models.InvoicePriceListItem,
+          as: 'invoicePriceListItems',
+          required: true,
+          where: {
+            invoicePriceListId: priceListId,
+            isHidden: false,
+          },
+        },
+      ];
+    },
+    queryOptions: { subQuery: false },
+  },
 );
 
 createSuggester('invoiceInsurancePlan', 'InvoiceInsurancePlan', ({ endpoint, modelName }) =>

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -101,6 +101,7 @@ export const InvoiceForm = ({ invoice }) => {
                           index={index}
                           item={item}
                           encounterId={invoice.encounterId}
+                          priceListId={invoice.priceList?.id}
                           isDeleteDisabled={values.invoiceItems?.length === 1}
                           showActionMenu={item.productId || values.invoiceItems.length > 1}
                           formArrayMethods={formArrayMethods}

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -118,6 +118,7 @@ export const InvoiceItemRow = ({
   formArrayMethods,
   invoiceIsEditable,
   encounterId,
+  priceListId,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const isItemEditable = !item.product?.id && invoiceIsEditable;
@@ -127,6 +128,7 @@ export const InvoiceItemRow = ({
       label: name,
       value: id,
     }),
+    baseQueryParameters: { priceListId },
   });
   const practitionerSuggester = useSuggester('practitioner');
 


### PR DESCRIPTION
### Changes

So there was a bit of confusion with the first iteration of this. Here we change the import/export rules to treat empty cells as manual price entries and keep the "hidden" text to hide the invoice product when it's being looked up for a specific price list.

Also included is to prevent automatically adding items that are also configured as hidden.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `visibilityStatus` with boolean `isHidden` for invoice price list items, adjust import/export semantics (empty = manual price, `hidden` = isHidden), and filter hidden products from auto-adds, API, suggesters, and UI.
> 
> - **Database/Models**
>   - Replace `invoice_price_list_items.visibility_status` with boolean `is_hidden`; add migration and update model/DBT docs (`invoice_price_list_items.md/.yml`).
> - **Import/Export**
>   - Import: treat empty cells as manual (null price) and `hidden` as `{ isHidden: true }`; allow empty values; remove `manual-entry` constant.
>   - Export: output `hidden` when `isHidden` else price; include `isHidden` attribute.
> - **Server/API Logic**
>   - Prevent auto-adding invoice items when corresponding `InvoicePriceListItem.isHidden` is true.
>   - Price lookup and includes now filter by `isHidden: false`.
>   - Remove `visibilityStatus` checks from invoice item associations.
> - **Suggestions/UI**
>   - `invoiceProduct` suggester accepts `priceListId` and only returns products with `isHidden: false` for that list.
>   - Invoice form passes `priceListId` to suggester; fetch price list item price accordingly.
> - **Tests**
>   - Update/import/export tests to new semantics; add tests for hidden items not auto-adding and suggester filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acfc61befdab91c79b46376f2fd4fa58243c6aef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->