### PR TITLE
test(e2e): Update locators that causing 2.46 e2e tests fail

### DIFF
--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
@@ -78,7 +78,7 @@ export class LabRequestModalBase {
       description: 'styledbodytext-8egc',
       requestingClinicianInput: 'field-z6gb-input',
       requestDateTimeInput: 'field-y6ku-input',
-      departmentInput: 'field-wobc-input', 
+      departmentInput: 'field-wobc-input',
       panelRadioButton: 'radio-il3t-panel',
       individualRadioButton: 'radio-il3t-individual',
       backButton: 'styledbackbutton-016f',

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
@@ -78,8 +78,7 @@ export class LabRequestModalBase {
       description: 'styledbodytext-8egc',
       requestingClinicianInput: 'field-z6gb-input',
       requestDateTimeInput: 'field-y6ku-input',
-      departmentInput: 'field-wobc-input',
-      prioritySelect: 'selectinput-phtg-select',
+      departmentInput: 'field-wobc-input', 
       panelRadioButton: 'radio-il3t-panel',
       individualRadioButton: 'radio-il3t-individual',
       backButton: 'styledbackbutton-016f',
@@ -128,6 +127,7 @@ export class LabRequestModalBase {
     this.requestingClinicianInput = page.getByTestId('field-z6gb-input').locator('input');
     this.requestDateTimeInput = page.getByTestId('field-y6ku-input').locator('input');
     this.departmentInput = page.getByTestId('field-wobc-input').locator('input');
+    this.prioritySelect = page.getByTestId('formgrid-wses').getByTestId('selectinput-phtg-select');
     this.selectedPriority = this.prioritySelect.locator('div').locator('div').first();
     this.cancelButton = page.getByTestId('formgrid-wses').getByTestId('outlinedbutton-8rnr');
     this.selectedItemsList = page.getByTestId('testitemwrapper-o7ha').getByTestId('labeltext-6stl');

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
@@ -44,6 +44,7 @@ export class RecordSampleModal {
     this.dateTimeCollectedInput = page.getByTestId('styledfield-dmjl-input').locator('input');
     this.collectedByInput = page.getByTestId('styledfield-v88m-input').locator('input');
     this.specimenTypeInput = page.getByTestId('styledfield-0950-input').locator('input');
+    this.siteInputDropdownIcon = page.getByRole('dialog').getByTestId('selectinput-phtg-expandmoreicon-h115');
   }
 
   async waitForModalToLoad() {

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
@@ -29,7 +29,6 @@ export class RecordSampleModal {
       collectedByDropdown: 'styledfield-v88m-input-expandmoreicon',
       specimenTypeInput: 'styledfield-0950-input',
       specimenTypeDropdown: 'styledfield-0950-input-expandmoreicon',
-      siteInputDropdownIcon: 'selectinput-phtg-expandmoreicon-h115',
       recordSampleConfirmButton: 'row-vpng-confirmButton',
       closeButton: 'close-button',
       cancelButton: 'cancel-button',


### PR DESCRIPTION
### Changes

Update locators that causing 2.46 e2e tests fail.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
