### PR TITLE
tweak(labs): 2.46 fix: lower case n/a on lab result table

### DIFF
--- a/packages/e2e-tests/tests/patients/labRequest.spec.ts
+++ b/packages/e2e-tests/tests/patients/labRequest.spec.ts
@@ -548,9 +548,9 @@ test.describe('Lab Request Tests', () => {
       const tableResultItems = await getTableItems(page, 1, 'result')
       await expect(tableResultItems[0]).toBe(result);  
       const tableUnitItems = await getTableItems(page, 1, 'labTestType.unit')
-      await expect(tableUnitItems[0]).toBe('N/A');  
+      await expect(tableUnitItems[0]).toBe('n/a');  
       const tableReferenceItems = await getTableItems(page, 1, 'reference')
-      await expect(tableReferenceItems[0]).toBe('N/A');  
+      await expect(tableReferenceItems[0]).toBe('n/a');  
       const tableLabTestMethodItems = await getTableItems(page, 1, 'labTestMethod')
       await expect(tableLabTestMethodItems[0]).toBe(labTestMethod); 
       const tableLaboratoryOfficerItems = await getTableItems(page, 1, 'laboratoryOfficer')

--- a/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
+++ b/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
@@ -76,7 +76,7 @@ export const LabRequestResultsTable = React.memo(({ labRequest, patient, refresh
       ),
       key: 'labTestType.unit',
       accessor: ({ labTestType }) =>
-        labTestType?.unit || getTranslation('general.fallback.notApplicable', 'N/A'),
+        labTestType?.unit || getTranslation('general.fallback.notApplicable', 'N/A', { casing: 'lower' }),
       sortable: false,
     },
     {

--- a/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
+++ b/packages/web/app/views/patients/components/LabRequestResultsTable.jsx
@@ -76,7 +76,8 @@ export const LabRequestResultsTable = React.memo(({ labRequest, patient, refresh
       ),
       key: 'labTestType.unit',
       accessor: ({ labTestType }) =>
-        labTestType?.unit || getTranslation('general.fallback.notApplicable', 'N/A', { casing: 'lower' }),
+        labTestType?.unit ||
+        getTranslation('general.fallback.notApplicable', 'N/A', { casing: 'lower' }),
       sortable: false,
     },
     {


### PR DESCRIPTION
### Changes

Want it lower case

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowercases the "N/A" fallback to "n/a" for the Units column in `LabRequestResultsTable` via `getTranslation` casing option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39fecdd525fb472848b0734f93eb7837b72779df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->