### PR TITLE
Investigate ips button visibility

### DIFF
--- a/docs/patient-resources-ips-button.md
+++ b/docs/patient-resources-ips-button.md
@@ -1,0 +1,7 @@
+# Patient resources IPS button
+
+## Can I hide the International Patient Summary button?
+
+- There is no toggle in the Tamanu settings or facility configuration to hide the International Patient Summary option inside **Patient resources**.
+- The button only appears for accounts that have the International Patient Summary permission; if your administrator removes that permission from your role, the button disappears automatically.
+- If you need it hidden, ask an administrator to remove the permission for your account or role. There is no way to turn it off yourself from the patient view.


### PR DESCRIPTION
### Changes

Adds `docs/patient-resources-ips-button.md` to document how the International Patient Summary (IPS) button in Patient Resources is controlled. This clarifies that the button's visibility is tied to user permissions (specifically, the ability to 'create IPSRequest') rather than a configurable setting.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
<a href="https://cursor.com/background-agent?bcId=bc-5c4e05b1-f282-43ac-9d44-270b526db3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c4e05b1-f282-43ac-9d44-270b526db3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

