### PR TITLE
feat(invoicing): SAV-1051: Encounter invoice UI fixes

### DIFF
--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import { keyBy, round } from 'lodash';
 import { ValidationError, NotFoundError, InvalidOperationError } from '@tamanu/errors';
 import {
   INVOICE_ITEMS_DISCOUNT_TYPES,
@@ -15,7 +16,6 @@ import { invoiceItemsRoute } from './invoiceItems';
 import { getCurrentCountryTimeZoneDateTimeString } from '@tamanu/shared/utils/countryDateTime';
 import { patientPaymentRoute } from './patientPayment';
 import { insurancePlansRoute } from './insurancePlans';
-import { round } from 'lodash';
 
 const invoiceRoute = express.Router();
 export { invoiceRoute as invoices };
@@ -70,6 +70,14 @@ invoiceRoute.get(
     const invoice = await Invoice.findOne({
       where: { encounterId },
       attributes: ['id'],
+      include: [
+        {
+          model: InvoiceInsurancePlan,
+          as: 'insurancePlans',
+          attributes: ['name', 'id', 'defaultCoverage'],
+          where: { visibilityStatus: VISIBILITY_STATUSES.CURRENT },
+        },
+      ],
     });
 
     if (!invoice) {
@@ -89,26 +97,22 @@ invoiceRoute.get(
           as: 'invoiceInsurancePlan',
           required: true,
           attributes: ['name', 'id'],
-          include: [
-            {
-              model: Invoice,
-              as: 'relatedInvoices',
-              required: true,
-              where: { encounterId },
-              attributes: [],
-              through: { attributes: [] },
-            },
-          ],
         },
       ],
     });
 
+    const itemsById = keyBy(items, 'invoiceInsurancePlanId');
+
     // Normalise to the shape expected by the client UI
-    const response = items.map(item => ({
-      id: item.invoiceInsurancePlanId,
-      label: item.invoiceInsurancePlan?.name,
-      coverageValue: item.coverageValue,
-    }));
+    const response = invoice.insurancePlans.map(insurancePlan => {
+      const planItem = itemsById[insurancePlan.id];
+      const coverageValue = planItem?.coverageValue ?? insurancePlan.defaultCoverage;
+      return {
+        id: insurancePlan.id,
+        label: insurancePlan.name,
+        coverageValue,
+      };
+    });
 
     res.json(response);
   }),

--- a/packages/web/app/components/Icons/ArrowRight.jsx
+++ b/packages/web/app/components/Icons/ArrowRight.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export const ArrowRight = ({ htmlColor = 'currentcolor', width = 24, height = 24, ...props }) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M15.5669 12.0131C15.811 12.2571 15.811 12.6529 15.5669 12.8969L9.31694 19.1469C9.07286 19.391 8.67714 19.391 8.43306 19.1469C8.18898 18.9029 8.18898 18.5071 8.43306 18.2631L14.2411 12.455L8.43306 6.64694C8.18898 6.40286 8.18898 6.00714 8.43306 5.76306C8.67714 5.51898 9.07286 5.51898 9.31694 5.76306L15.5669 12.0131Z"
+        stroke={htmlColor}
+        fill={htmlColor}
+        strokeWidth="0.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/packages/web/app/components/Icons/index.js
+++ b/packages/web/app/components/Icons/index.js
@@ -9,3 +9,4 @@ export { ChevronIcon } from './ChevronIcon';
 export { ClearIcon } from './ClearIcon';
 export { RefreshIcon } from './RefreshIcon';
 export { VitalVectorIcon } from './VitalVectorIcon';
+export { ArrowRight } from './ArrowRight';

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -13,7 +13,6 @@ import { useUpdateInvoice } from '../../../api/mutations/useInvoiceMutation';
 import { useAuth } from '../../../contexts/Auth';
 import { invoiceFormSchema } from './invoiceFormSchema';
 import { InvoiceSummaryPanel } from '../InvoiceSummaryPanel';
-import { INVOICE_STATUSES } from '@tamanu/constants';
 import { getCurrentDateString } from '@tamanu/utils/dateTime';
 
 const AddButton = styled(MuiButton)`
@@ -39,11 +38,9 @@ const SubmitButton = styled(FormSubmitButton)`
   }
 `;
 
-const ButtonRow = styled.div`
+const FormFooter = styled.div`
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 10px;
   margin: 10px 0;
 `;
 
@@ -111,38 +108,43 @@ export const InvoiceForm = ({ invoice }) => {
                     })}
                   </Box>
                   {editable && canWriteInvoice && (
-                    <ButtonRow>
-                      <AddButton
-                        variant="text"
-                        onClick={() => formArrayMethods.push(getDefaultRow())}
-                        startIcon={<Plus />}
-                      >
-                        <TranslatedText
-                          stringId="invoice.form.action.addItem"
-                          fallback="Add item"
-                          data-testid="translatedtext-9vs0"
-                        />
-                      </AddButton>
-                      <FormCancelButton
-                        style={{ marginLeft: 'auto' }}
-                        disabled={!dirty}
-                        onClick={() => {
-                          resetForm();
-                        }}
-                      >
-                        Cancel
-                      </FormCancelButton>
-                      <SubmitButton onSubmit={submitForm} disabled={isUpdatingInvoice}>
-                        <TranslatedText
-                          stringId="invoice.form.action.save"
-                          fallback="Save item/s"
-                          data-testid="translatedtext-26ji"
-                        />
-                      </SubmitButton>
-                    </ButtonRow>
-                  )}
-                  {invoice?.status === INVOICE_STATUSES.IN_PROGRESS && (
-                    <InvoiceSummaryPanel invoiceItems={values.invoiceItems} />
+                    <FormFooter>
+                      <Box>
+                        <AddButton
+                          variant="text"
+                          onClick={() => formArrayMethods.push(getDefaultRow())}
+                          startIcon={<Plus />}
+                        >
+                          <TranslatedText
+                            stringId="invoice.form.action.addItem"
+                            fallback="Add item"
+                            data-testid="translatedtext-9vs0"
+                          />
+                        </AddButton>
+                      </Box>
+                      <Box>
+                        {dirty && (
+                          <Box textAlign="right" mb={1}>
+                            <FormCancelButton
+                              style={{ marginRight: 8 }}
+                              onClick={() => {
+                                resetForm();
+                              }}
+                            >
+                              Cancel
+                            </FormCancelButton>
+                            <SubmitButton onSubmit={submitForm} disabled={isUpdatingInvoice}>
+                              <TranslatedText
+                                stringId="invoice.form.action.save"
+                                fallback="Save item/s"
+                                data-testid="translatedtext-26ji"
+                              />
+                            </SubmitButton>
+                          </Box>
+                        )}
+                        <InvoiceSummaryPanel invoiceItems={values.invoiceItems} />
+                      </Box>
+                    </FormFooter>
                   )}
                 </>
               );

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -28,6 +28,10 @@ const StyledItemRow = styled.div`
   flex-wrap: nowrap;
   align-items: flex-start;
 
+  .MuiInputBase-input {
+    font-size: 14px;
+  }
+
   &:last-child {
     border-bottom: 1px solid ${Colors.outline};
   }

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -4,7 +4,7 @@ import { useFormikContext } from 'formik';
 import { useSuggester } from '../../../api';
 import { Colors } from '../../../constants';
 import { IconButton } from '@material-ui/core';
-import { ChevronRight } from '@material-ui/icons';
+import { ArrowRight } from '../../../components/Icons';
 import { useInvoicePriceListItemPriceQuery } from '../../../api/queries/useInvoicePriceListItemPriceQuery';
 import { useInvoiceInsurancePlanItemsQuery } from '../../../api/queries/useInvoiceInsurancePlanItemsQuery';
 import {
@@ -36,15 +36,10 @@ const StyledItemRow = styled.div`
 const Button = styled(IconButton)`
   position: absolute;
   padding: 6px;
-  top: 0;
-  left: -15px;
+  top: 3px;
+  left: -12px;
   transform: rotate(${props => (props.$isExpanded ? '90deg' : '0')});
   transition: transform 0.2s ease-in-out;
-
-  .MuiSvgIcon-root {
-    font-size: 32px;
-    color: #b8b8b8;
-  }
 `;
 
 const useInvoiceItemPrice = ({
@@ -182,7 +177,7 @@ export const InvoiceItemRow = ({
     <StyledItemRow>
       {!isItemEditable && item.insurancePlanItems?.length > 0 && (
         <Button onClick={onClick} $isExpanded={isExpanded}>
-          <ChevronRight />
+          <ArrowRight htmlColor={Colors.softText} />
         </Button>
       )}
       <DateCell index={index} item={item} isItemEditable={isItemEditable} />

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -162,7 +162,7 @@ export const InvoiceItemRow = ({
   useInvoiceItemInsurance({
     encounterId,
     productId,
-    existingPrice: priceListPrice,
+    existingPrice: priceListPrice || item.manualEntryPrice,
     index,
     formArrayMethods,
   });

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionModal.jsx
@@ -327,6 +327,20 @@ export const InvoiceItemActionModal = ({ open, onClose, onAction, item, action }
       form: <MarkupForm data-testid="markupform-ia46" />,
       schema: markupValidationSchema,
     },
+    [INVOICE_ITEM_ACTION_MODAL_TYPES.DELETE]: {
+      description: (
+        <TranslatedText
+          stringId="invoice.modal.deleteInvoice.description"
+          fallback="Are you sure you would like to delete the below item from the patient invoice?"
+        />
+      ),
+      confirmText: (
+        <TranslatedText
+          stringId="invoice.modal.deleteInvoice.action.delete"
+          fallback="Delete item"
+        />
+      ),
+    },
     [INVOICE_ITEM_ACTION_MODAL_TYPES.ADD_NOTE]: {
       form: <AddNoteForm data-testid="addnoteform-ilq2" />,
       initialValues: { note: item.note },
@@ -340,6 +354,15 @@ export const InvoiceItemActionModal = ({ open, onClose, onAction, item, action }
 
   const handleSubmit = async submitData => {
     onAction(submitData);
+  };
+
+  const renderDescription = () => {
+    const description = formData[action]?.description;
+    return description ? (
+      <Box mb={3} mt={3} pr={3}>
+        {description}
+      </Box>
+    ) : null;
   };
 
   const renderForm = ({ submitForm }) => (
@@ -362,6 +385,7 @@ export const InvoiceItemActionModal = ({ open, onClose, onAction, item, action }
       onClose={onClose}
       data-testid="modal-bs2m"
     >
+      {renderDescription()}
       <InvoiceItemCard item={item} data-testid="invoiceitemcard-74ar" />
       <Form
         validationSchema={formData[action]?.schema}

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionModal.jsx
@@ -7,7 +7,6 @@ import { InvoiceItemCard } from './InvoiceItemCard';
 import { INVOICE_ITEM_ACTION_MODAL_TYPES, Colors } from '../../../constants';
 import { Field, NumberField } from '../../../components/Field';
 import { useTranslation } from '../../../contexts/Translation';
-import { ConfirmCancelRowField } from '../../../components/VaccineCommonFields';
 import {
   TextField,
   SelectField,
@@ -15,6 +14,7 @@ import {
   FormGrid,
   Modal,
   TranslatedText,
+  FormSubmitCancelRow,
 } from '@tamanu/ui-components';
 import { INVOICE_ITEMS_DISCOUNT_TYPES } from '@tamanu/constants';
 import { getInvoiceItemPriceDisplay } from '@tamanu/shared/utils/invoice';
@@ -330,6 +330,11 @@ export const InvoiceItemActionModal = ({ open, onClose, onAction, item, action }
     [INVOICE_ITEM_ACTION_MODAL_TYPES.ADD_NOTE]: {
       form: <AddNoteForm data-testid="addnoteform-ilq2" />,
       initialValues: { note: item.note },
+      confirmText: item.note ? (
+        <TranslatedText stringId="general.action.confirm" fallback="Confirm" />
+      ) : (
+        <TranslatedText stringId="invoice.modal.editInvoice.addNote" fallback="Add note" />
+      ),
     },
   };
 
@@ -340,11 +345,11 @@ export const InvoiceItemActionModal = ({ open, onClose, onAction, item, action }
   const renderForm = ({ submitForm }) => (
     <>
       {formData[action]?.form}
-      <StyledDivider data-testid="styleddivider-g7cs" />
-      <ConfirmCancelRowField
+      <StyledDivider />
+      <FormSubmitCancelRow
         onConfirm={submitForm}
         onCancel={onClose}
-        data-testid="confirmcancelrowfield-nhgq"
+        confirmText={formData[action]?.confirmText}
       />
     </>
   );

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCard.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCard.jsx
@@ -110,7 +110,7 @@ export const InvoiceItemCard = ({ item }) => {
               data-testid="translatedtext-qh0h"
             />
           }
-          value={item.productNameFinal ?? item.product.name}
+          value={item.productNameFinal ?? item.product?.name}
           data-testid="carditem-pohl"
         />
         <CardItem

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCard.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCard.jsx
@@ -110,7 +110,7 @@ export const InvoiceItemCard = ({ item }) => {
               data-testid="translatedtext-qh0h"
             />
           }
-          value={item.productNameFinal ?? item.productName}
+          value={item.productNameFinal ?? item.product.name}
           data-testid="carditem-pohl"
         />
         <CardItem

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/OrderedByCell.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/OrderedByCell.jsx
@@ -18,7 +18,6 @@ export const OrderedByCell = ({
           required
           component={AutocompleteField}
           suggester={practitionerSuggester}
-          size="small"
           onChange={handleChangeOrderedBy}
           data-testid="field-xin4"
         />

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/QuantityCell.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/QuantityCell.jsx
@@ -17,7 +17,6 @@ export const QuantityCell = ({ index, item, isItemEditable }) => (
               event.target.value = '';
             }
           }}
-          size="small"
           required
           data-testid="field-6aku"
         />

--- a/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
@@ -8,6 +8,13 @@ import { ModalActionRow } from '../../components/ModalActionRow';
 import { useInvoiceInsurancePlansMutation } from '../../api/mutations/useInvoiceMutation';
 import { MultiAutocompleteInput } from '../../components/Field';
 
+const StyledModal = styled(Modal)`
+  .MuiPaper-root,
+  .MuiPaper-root > div {
+    overflow: visible;
+  }
+`;
+
 const ModalBody = styled.div`
   margin: 20px 0 50px;
 
@@ -34,7 +41,7 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
   };
 
   return (
-    <Modal
+    <StyledModal
       width="sm"
       title={
         <TranslatedText stringId="invoice.modal.insurancePlans.title" fallback="Insurance plans" />
@@ -63,6 +70,6 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
         />
       </ModalBody>
       <ModalActionRow onConfirm={onConfirm} onCancel={onClose} />
-    </Modal>
+    </StyledModal>
   );
 };

--- a/packages/web/app/features/Invoice/InvoicesTable.jsx
+++ b/packages/web/app/features/Invoice/InvoicesTable.jsx
@@ -130,10 +130,13 @@ const getEncounterType = row => {
 
   return (
     <ThemedTooltip title={label} data-testid="themedtooltip-zxwp">
-      <TranslatedEnum
-        enumValues={ENCOUNTER_TYPE_ABBREVIATION_LABELS}
-        value={encounter.encounterType}
-      />
+      {/* span needed for the tooltip to work */}
+      <span>
+        <TranslatedEnum
+          enumValues={ENCOUNTER_TYPE_ABBREVIATION_LABELS}
+          value={encounter.encounterType}
+        />
+      </span>
     </ThemedTooltip>
   );
 };


### PR DESCRIPTION
### Changes

Fixes

* When a user has saved the items, the 'Cancel' and 'Save items' button should disappear. Currently it's always visible
* Update dropdown arrow style to match figma (they're too thick)
* Delete modal. Copy above details missing (refer to figma). Update CTA button to match figma. 'Details' data is missing (also occuring on other modals).
* Add note modal. Update CTA to read 'Add note' when adding a note (currently it says 'Confirm'. Leave CTA as confirm for when editing a note.


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines invoice UI: conditionally shows action buttons, introduces a thinner ArrowRight icon, updates modal copy/CTAs, fixes product details display, and improves tooltip/overflow behavior.
> 
> - **Invoice Form**
>   - Show Cancel/Save only when form is dirty; reorganized footer layout with always-visible summary panel.
> - **Invoice Item & Icons**
>   - Added `components/Icons/ArrowRight` and replaced chevron usage; adjusted toggle button positioning/rotation.
> - **Item Action Modal**
>   - Switched to `FormSubmitCancelRow`; added delete description and custom confirm text; conditional confirm text for Add note; renders description block.
> - **Invoice Item Card**
>   - Fix details to read from `item.product.name` (fallback remains).
> - **Insurance Modal**
>   - Styled modal to allow visible overflow.
> - **Invoices Table**
>   - Wrapped encounter type content to ensure tooltip renders correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54fda4061ad485693372c7825fad4fa0f07f9b9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->