### PR TITLE
fix(unifiedMove): no-issue: Triage change bug

### DIFF
--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -489,7 +489,7 @@ export class Encounter extends Model {
     await triage.update({ closedTime: endDate });
   }
 
-  async update(data: any, user: any): Promise<any> {
+  async update(data: any, user?: any): Promise<any> {
     const { Department, Location, EncounterHistory, ReferenceData, User } = this.sequelize.models;
     // Track change types for encounter history snapshot
     const changeTypes: string[] = [];

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -130,7 +130,7 @@ export class Triage extends Model {
   }
 
   async update(data: any, user: any): Promise<any> {
-    const { Encounter, ReferenceData, User } = this.sequelize.models;
+    const { Encounter, ReferenceData } = this.sequelize.models;
     // To collect system note messages describing all changes in this triage update
     const systemNoteRows: string[] = [];
 
@@ -141,12 +141,6 @@ export class Triage extends Model {
     );
 
     const updateTriage = async () => {
-      await onChangeForeignKey({
-        columnName: 'practitionerId',
-        fieldLabel: 'practitioner',
-        model: User,
-        accessor: (record: any) => record?.displayName ?? '-',
-      });
       await onChangeForeignKey({
         columnName: 'chiefComplaintId',
         fieldLabel: 'chief complaint',
@@ -170,11 +164,6 @@ export class Triage extends Model {
       await onChangeTextColumn({
         columnName: 'triageTime',
         fieldLabel: 'triage time',
-        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
-      });
-      await onChangeTextColumn({
-        columnName: 'closedTime',
-        fieldLabel: 'closed time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await onChangeTextColumn({

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -129,7 +129,7 @@ export class Triage extends Model {
     });
   }
 
-  async update(data: any, user: any): Promise<any> {
+  async update(data: any, user?: any): Promise<any> {
     const { Encounter, ReferenceData } = this.sequelize.models;
     // To collect system note messages describing all changes in this triage update
     const systemNoteRows: string[] = [];


### PR DESCRIPTION
### Changes

This was a bit of a weird one. I was getting really confusing behaviour whenever running `Encounter.closeTriage()`. Basically forms that triggered this were not working on the first submission. This happened on the discharge and move form.

After some investigation I discovered that all the weird behaviour went away after no longer supplying user to the `Triage.update` inside closeTriage. While I am not completely sure how this was related, I didn't actually need to supply the user here as we don't record system notes for this action so I have removed it. I also updated the `Triage` and `Encounter` model args to properly reflect the optional nature of the user arg.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors triage closing to not require a user, inlines triage lookup, makes update user param optional, and removes practitioner/closed-time change tracking in triage updates.
> 
> - **Encounter model (`packages/database/src/models/Encounter.ts`)**:
>   - Refactor `closeTriage` to inline triage lookup and remove `user` dependency; update triage via `triage.update({ closedTime })`.
>   - Update `onDischarge` and encounter type change handler to call `closeTriage(endDate)` (no user).
>   - Make `update(data, user)` accept an optional `user`.
> - **Triage model (`packages/database/src/models/Triage.ts`)**:
>   - Make `update(data, user)` accept an optional `user`.
>   - Remove change tracking for `practitionerId` and `closedTime`.
>   - Continue change tracking for complaints, arrival time/triage time, score; add arrival mode tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5182fb30f4da48b8f1f83808dc876382d2cb03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->