### PR TITLE
deps: COOL-28: Fix simple recent dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50115,7 +50115,7 @@
         "styled-components": "^5.1.0",
         "styled-system": "^5.1.2",
         "typeorm": "^0.3.27",
-        "validator": "^13.15.22",
+        "validator": "^13.15.23",
         "yup": "^0.28.5"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50042,7 +50042,7 @@
         "styled-components": "^5.1.0",
         "styled-system": "^5.1.2",
         "typeorm": "^0.3.27",
-        "validator": "^13.15.0",
+        "validator": "^13.15.22",
         "yup": "^0.28.5"
       },
       "devDependencies": {
@@ -50954,10 +50954,9 @@
       }
     },
     "packages/mobile/node_modules/validator": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
-      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
-      "license": "MIT",
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7859,6 +7859,25 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -28854,6 +28873,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -48782,7 +48802,7 @@
         "@swc/cli": "^0.1.63",
         "@swc/core": "^1.3.100",
         "concurrently": "^8.2.1",
-        "glob": "^10.4.1",
+        "glob": "^13.0.0",
         "nodemon": "^2.0.19",
         "swc-loader": "^0.2.3"
       },
@@ -48796,6 +48816,59 @@
       },
       "devDependencies": {
         "rimraf": "^6.0.1"
+      }
+    },
+    "packages/build-tooling/node_modules/glob": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "dependencies": {
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/build-tooling/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/build-tooling/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/build-tooling/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/central-server": {

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -19,7 +19,7 @@
     "@swc/cli": "^0.1.63",
     "@swc/core": "^1.3.100",
     "concurrently": "^8.2.1",
-    "glob": "^10.4.1",
+    "glob": "^13.0.0",
     "nodemon": "^2.0.19",
     "swc-loader": "^0.2.3"
   },

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -104,7 +104,7 @@
     "styled-components": "^5.1.0",
     "styled-system": "^5.1.2",
     "typeorm": "^0.3.27",
-    "validator": "^13.15.0",
+    "validator": "^13.15.22",
     "yup": "^0.28.5"
   },
   "devDependencies": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -104,7 +104,7 @@
     "styled-components": "^5.1.0",
     "styled-system": "^5.1.2",
     "typeorm": "^0.3.27",
-    "validator": "^13.15.22",
+    "validator": "^13.15.23",
     "yup": "^0.28.5"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes

Low risk updates to 2 packages
- glob
- validator

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `glob` to `^13.0.0` in `packages/build-tooling` and `validator` to `^13.15.23` in `packages/mobile`, updating lockfile and transitive deps accordingly.
> 
> - **Dependencies**:
>   - `packages/build-tooling`:
>     - Update `glob` from `^10.4.1` to `^13.0.0`.
>     - Lockfile adds `minimatch@^10`, `path-scurry@^2`, `lru-cache@^11`, and related `@isaacs/*` packages with newer Node engine requirements.
>   - `packages/mobile`:
>     - Update `validator` from `^13.15.0` to `^13.15.23`.
>     - Lockfile refreshed for the new `validator` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eff1da8783e3b1241316f0557e14db04a49c6acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->