### PR TITLE
fix(websockets): no-issue: Specify path in server websocketService to match the client path

### DIFF
--- a/packages/central-server/app/services/websocketService.js
+++ b/packages/central-server/app/services/websocketService.js
@@ -9,6 +9,7 @@ import { log } from '@tamanu/shared/services/logging';
  */
 export const defineWebsocketService = async injector => {
   const socketServer = new Server(injector.httpServer, {
+    path: '/api/socket.io/',
     connectionStateRecovery: { skipMiddlewares: true, maxDisconnectionDuration: 120000 },
   });
   const getSocketServer = () => socketServer;

--- a/packages/central-server/app/services/websocketService.js
+++ b/packages/central-server/app/services/websocketService.js
@@ -1,6 +1,7 @@
 import { Server } from 'socket.io';
 import { createAdapter } from '@socket.io/postgres-adapter';
 import { log } from '@tamanu/shared/services/logging';
+import { WS_PATH } from '@tamanu/constants';
 
 /**
  *
@@ -9,7 +10,7 @@ import { log } from '@tamanu/shared/services/logging';
  */
 export const defineWebsocketService = async injector => {
   const socketServer = new Server(injector.httpServer, {
-    path: '/api/socket.io/',
+    path: WS_PATH,
     connectionStateRecovery: { skipMiddlewares: true, maxDisconnectionDuration: 120000 },
   });
   const getSocketServer = () => socketServer;

--- a/packages/constants/src/webSocket.ts
+++ b/packages/constants/src/webSocket.ts
@@ -1,3 +1,5 @@
+export const WS_PATH = '/api/socket.io/';
+
 export const WS_EVENT_NAMESPACES = {
   TELEGRAM: 'telegram',
   PATIENT_CONTACT: 'patient-contact',

--- a/packages/facility-server/app/services/websocketService.js
+++ b/packages/facility-server/app/services/websocketService.js
@@ -1,6 +1,6 @@
 import { Server } from 'socket.io';
 
-import { NOTIFY_CHANNELS, WS_EVENTS } from '@tamanu/constants';
+import { NOTIFY_CHANNELS, WS_EVENTS, WS_PATH } from '@tamanu/constants';
 
 /**
  *
@@ -9,7 +9,7 @@ import { NOTIFY_CHANNELS, WS_EVENTS } from '@tamanu/constants';
  */
 export const defineWebsocketService = injector => {
   const socketServer = new Server(injector.httpServer, {
-    path: '/api/socket.io/',
+    path: WS_PATH,
     connectionStateRecovery: { skipMiddlewares: true, maxDisconnectionDuration: 120000 },
     cors: {
       origin: '*',

--- a/packages/facility-server/app/services/websocketService.js
+++ b/packages/facility-server/app/services/websocketService.js
@@ -7,8 +7,9 @@ import { NOTIFY_CHANNELS, WS_EVENTS } from '@tamanu/constants';
  * @param {{httpServer: import('http').Server, dbNotifier: Awaited<ReturnType<import('./dbNotifier')['defineDbNotifier']>>, models: import('@tamanu/database/models')}} injector
  * @returns
  */
-export const defineWebsocketService = (injector) => {
+export const defineWebsocketService = injector => {
   const socketServer = new Server(injector.httpServer, {
+    path: '/api/socket.io/',
     connectionStateRecovery: { skipMiddlewares: true, maxDisconnectionDuration: 120000 },
     cors: {
       origin: '*',
@@ -20,16 +21,16 @@ export const defineWebsocketService = (injector) => {
 
   const onMaterializedViewRefreshed =
     injector.dbNotifier.listeners[NOTIFY_CHANNELS.MATERIALIZED_VIEW_REFRESHED];
-  onMaterializedViewRefreshed((viewName) =>
+  onMaterializedViewRefreshed(viewName =>
     socketServer.emit(`${WS_EVENTS.DATABASE_MATERIALIZED_VIEW_REFRESHED}:${viewName}`),
   );
 
   const onTableChanged = injector.dbNotifier.listeners[NOTIFY_CHANNELS.TABLE_CHANGED];
-  onTableChanged((payload) => {
+  onTableChanged(payload => {
     socketServer.emit(`${WS_EVENTS.DATABASE_TABLE_CHANGED}:${payload.table}`, payload);
   });
 
-  onTableChanged(async (payload) => {
+  onTableChanged(async payload => {
     if (payload.table === 'tasks') {
       const task = await injector.models.Task.findOne({
         where: { id: payload.newId },
@@ -51,8 +52,8 @@ export const defineWebsocketService = (injector) => {
       });
 
       const userIds = new Set(
-        task?.designations?.flatMap((designation) =>
-          designation.designationUsers.map((user) => user.id),
+        task?.designations?.flatMap(designation =>
+          designation.designationUsers.map(user => user.id),
         ) ?? [],
       );
 

--- a/packages/mobile/App/ui/hooks/useSocket.ts
+++ b/packages/mobile/App/ui/hooks/useSocket.ts
@@ -1,6 +1,7 @@
 import io, { type Socket } from 'socket.io-client';
 import { useEffect, useState } from 'react';
 import { readConfig } from '~/services/config';
+import { WS_PATH } from '@tamanu/constants';
 
 let cachedSocket: undefined | Socket;
 
@@ -20,7 +21,7 @@ export const useSocket = () => {
     if (!connectionUrl) return;
     setSocket(
       (cachedSocket = io(connectionUrl, {
-        path: '/api/socket.io/',
+        path: WS_PATH,
         transports: ['websocket'],
       })),
     );

--- a/packages/web/app/utils/useSocket.js
+++ b/packages/web/app/utils/useSocket.js
@@ -1,12 +1,13 @@
 import io from 'socket.io-client';
 import { useEffect, useState } from 'react';
+import { WS_PATH } from '@tamanu/constants';
 
 let cachedSocket;
 
 export const useSocket = () => {
   const [socket] = useState(() => {
     return (cachedSocket = io('', {
-      path: '/api/socket.io/',
+      path: WS_PATH,
       transports: ['websocket'],
     }));
   });


### PR DESCRIPTION
### Changes

The path in the socket.io `Server` instance [must match the path used by client connecting to it](https://socket.io/docs/v4/server-options/#path). The docs mention that a path rewriting proxy might resolve this, but I think this seems simpler.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
