### PR TITLE
fix(desktop): COOL-31: Prevent changing values when scrolling on focused number inputs

### DIFF
--- a/packages/ui-components/src/components/Field/NumberField.jsx
+++ b/packages/ui-components/src/components/Field/NumberField.jsx
@@ -13,7 +13,7 @@ export const NumberInput = ({ min, max, step, inputProps = {}, ...props }) => (
     type="number"
     onWheel={(event) => {
       // Prevents increasing/decreasing the value. It needs to be blurred because
-      // it's not possible to prevent the event from bubbling up to the parent element.
+      // it's not possible to prevent the event default behavior.
       // This makes the element no longer focused and so the value is not changed.
       event.target.blur();
     }}

--- a/packages/ui-components/src/components/Field/NumberField.jsx
+++ b/packages/ui-components/src/components/Field/NumberField.jsx
@@ -11,6 +11,12 @@ export const NumberInput = ({ min, max, step, inputProps = {}, ...props }) => (
       ...inputProps,
     }}
     type="number"
+    onWheel={(event) => {
+      // Prevents increasing/decreasing the value. It needs to be blurred because
+      // it's not possible to prevent the event from bubbling up to the parent element.
+      // This makes the element no longer focused and so the value is not changed.
+      event.target.blur();
+    }}
   />
 );
 


### PR DESCRIPTION
### Changes

Pretty much the title. This is the most straightforward way to fix it and retain the step buttons on the input plus the supported charset.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an onWheel handler to `NumberInput` that blurs the field to stop scroll from changing its value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1643eaf63549d53e51b5a7e1a94020a63410081. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->