### PR TITLE
fix(websockets): no-issue: Add missing path to facility websocketClientService

### DIFF
--- a/packages/facility-server/app/services/websocketClientService.js
+++ b/packages/facility-server/app/services/websocketClientService.js
@@ -1,5 +1,5 @@
 import { io } from 'socket.io-client';
-import { WS_EVENTS } from '@tamanu/constants';
+import { WS_EVENTS, WS_PATH } from '@tamanu/constants';
 
 /**
  *
@@ -7,8 +7,7 @@ import { WS_EVENTS } from '@tamanu/constants';
  */
 export const defineWebsocketClientService = injector => {
   const url = new URL(injector.config.sync.host);
-  url.pathname = '/api';
-  const client = io(url.toString(), { transports: ['websocket', 'webtransport'] });
+  const client = io(url.toString(), { path: WS_PATH, transports: ['websocket', 'webtransport'] });
   const getClient = () => client;
 
   //forward event to facility client


### PR DESCRIPTION
### Changes

Missed this one when fixing the other usages of socket.io.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
