### PR TITLE
feat(invoicing): SAV-1023: Price list rules update

### DIFF
--- a/packages/database/src/models/Invoice/InvoicePriceList.ts
+++ b/packages/database/src/models/Invoice/InvoicePriceList.ts
@@ -2,7 +2,11 @@ import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from '@tamanu/constants';
 import { Model } from '../Model';
 import type { InitOptions, Models } from '../../types/model';
-import { matchesAgeIfPresent, equalsIfPresent } from './invoicePriceListMatching';
+import {
+  matchesAgeIfPresent,
+  equalsIfPresent,
+  matchesFacilityWithExclusionaryLogic,
+} from './invoicePriceListMatching';
 
 export class InvoicePriceList extends Model {
   declare id: string;
@@ -88,13 +92,16 @@ export class InvoicePriceList extends Model {
       ],
     });
 
+    // Collect all rules for exclusionary logic
+    const allRules = priceLists.map(pl => pl.rules ?? {});
+
     const matches: Array<{ id: string; name: string }> = [];
 
     for (const priceList of priceLists) {
       const rules = priceList.rules ?? {};
 
       const match =
-        equalsIfPresent(rules.facilityId, facilityId) &&
+        matchesFacilityWithExclusionaryLogic(rules.facilityId, facilityId, allRules) &&
         equalsIfPresent(rules.patientType, patientType) &&
         matchesAgeIfPresent(rules.patientAge, patientDOB);
 

--- a/packages/database/src/models/Invoice/invoicePriceListMatching.ts
+++ b/packages/database/src/models/Invoice/invoicePriceListMatching.ts
@@ -46,3 +46,37 @@ export const matchesAgeIfPresent = (
   const meetsMax = max === undefined || ageYears <= max;
   return meetsMin && meetsMax;
 };
+
+/**
+ * Matches facility with exclusionary logic:
+ * - If any price list specifies a facilityId, then price lists without a facilityId
+ *   match all facilities EXCEPT those explicitly specified by other price lists
+ * - If no price lists specify a facilityId, then all price lists match any facility
+ */
+export const matchesFacilityWithExclusionaryLogic = (
+  ruleFacilityId: string | undefined,
+  inputFacilityId: string | undefined,
+  allRules: Array<Record<string, any>>,
+): boolean => {
+  // If input facility not provided, match anything
+  if (!inputFacilityId) {
+    return true;
+  }
+
+  // If this rule specifies a facility, do direct comparison
+  if (ruleFacilityId) {
+    return ruleFacilityId === inputFacilityId;
+  }
+
+  // Rule has no facilityId - apply exclusionary logic
+  const specifiedFacilityIds = new Set(
+    allRules.map(rule => rule?.facilityId).filter((id): id is string => id != null),
+  );
+
+  // If no rules specify facilityId, match anything
+  if (specifiedFacilityIds.size === 0) {
+    return true;
+  }
+  // Otherwise, match all facilities EXCEPT those explicitly specified
+  return !specifiedFacilityIds.has(inputFacilityId);
+};


### PR DESCRIPTION
### Changes

Update price list rules logic to have exclusionary logic so that there isn't overlapping matches. If a price list has a rule that includes a facilityId and another price list has a rule without facilityId specified then the second list will match all facilities excluding the facilityId from the first list.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce exclusionary `facilityId` matching in price list selection and add comprehensive tests.
> 
> - **Invoice price list matching**:
>   - Add `matchesFacilityWithExclusionaryLogic` in `packages/database/src/models/Invoice/invoicePriceListMatching.ts` to implement exclusionary facility matching across all rules.
>   - Update `InvoicePriceList.getIdForPatientEncounter` to use the new matcher and aggregate `allRules` for evaluation.
> - **Tests**:
>   - Expand `packages/database/__tests__/models/invoicePriceListMatching.test.ts` with extensive cases for facility exclusion logic, age matching, and overall price list selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ba7e15d4a2e024f2fc99d8361c601595619d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->