### PR TITLE
tweak(encounterMove): NASS-1814: Location validation tweak

### DIFF
--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -37,6 +37,7 @@ export const LocationInput = React.memo(
     size = 'medium',
     form = {},
     enableLocationStatus = true,
+    hideLocationGroupError = false,
     locationGroupSuggesterType = 'facilityLocationGroup',
     autofill = true,
     isMulti = false,
@@ -147,9 +148,9 @@ export const LocationInput = React.memo(
           disabled={locationGroupSelectIsDisabled || disabled}
           // do not autofill if there is a pre-filled value
           autofill={!value && autofill}
+          error={hideLocationGroupError ? false : error}
+          helperText={error && !hideLocationGroupError ? helperText : undefined}
           size={size}
-          helperText={helperText}
-          error={error}
           data-testid={`${dataTestId}-group`}
         />
         <LocationAutocompleteInput
@@ -179,6 +180,7 @@ LocationInput.propTypes = {
   required: PropTypes.bool,
   disabled: PropTypes.bool,
   error: PropTypes.bool,
+  hideLocationGroupError: PropTypes.bool,
   helperText: PropTypes.string,
   name: PropTypes.string,
   className: PropTypes.string,

--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -149,7 +149,7 @@ export const LocationInput = React.memo(
           // do not autofill if there is a pre-filled value
           autofill={!value && autofill}
           error={hideLocationGroupError ? false : error}
-          helperText={error && !hideLocationGroupError ? helperText : undefined}
+          helperText={hideLocationGroupError ? undefined : helperText}
           size={size}
           data-testid={`${dataTestId}-group`}
         />

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -100,6 +100,7 @@ const BasicMoveFields = () => {
           component={LocalisedLocationField}
           groupValue={values.locationGroupId}
           onGroupChange={handleGroupChange}
+          hideLocationGroupError
           data-testid="field-tykg"
         />
       </StyledFormGrid>
@@ -150,6 +151,7 @@ const PlannedMoveFields = () => {
           component={LocalisedLocationField}
           groupValue={values.locationGroupId}
           onGroupChange={handleGroupChange}
+          hideLocationError
           data-testid="field-n625"
         />
         <LocationAvailabilityWarningMessage

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -243,30 +243,21 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
     departmentId: encounter.departmentId,
   };
 
+  const locationValidationSchema = yup.string().nullable().when('locationGroupId', {
+    is: value => !!value,
+    then: schema => schema.required(),
+    otherwise: schema => schema.nullable(),
+  });
   if (enablePatientMoveActions) {
     validationObject.action = yup
       .string()
       .oneOf([PATIENT_MOVE_ACTIONS.PLAN, PATIENT_MOVE_ACTIONS.FINALISE])
       .nullable();
-    validationObject.plannedLocationId = yup
-      .string()
-      .nullable()
-      .when('locationGroupId', {
-        is: value => !!value,
-        then: schema => schema.required(),
-        otherwise: schema => schema.nullable(),
-      });
+    validationObject.plannedLocationId = locationValidationSchema;
     initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
   } else {
-    validationObject.locationId = yup
-      .string()
-      .nullable()
-      .when('locationGroupId', {
-        is: value => !!value,
-        then: schema => schema.required(),
-        otherwise: schema => schema.nullable(),
-      });
+    validationObject.locationId = locationValidationSchema;
   }
 
   if (isAdmittingToHospital) {

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -80,33 +80,35 @@ const EncounterTypeLabel = styled.b`
   border-bottom: 2px solid ${({ $underlineColor }) => $underlineColor};
 `;
 
-const BasicMoveFields = () => {
-  const { setFieldValue, values } = useFormikContext();
+const PlannedMoveLocationField = ({ name }) => {
+  const { values, setFieldValue } = useFormikContext();
   const handleGroupChange = groupValue => {
     setFieldValue('locationGroupId', groupValue);
   };
-
   return (
-    <>
-      <SectionDescription>
-        <TranslatedText
-          stringId="patient.encounter.movePatient.location.description"
-          fallback="Select new patient location."
-        />
-      </SectionDescription>
-      <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
-        <Field
-          name="locationId"
-          component={LocalisedLocationField}
-          groupValue={values.locationGroupId}
-          onGroupChange={handleGroupChange}
-          hideLocationGroupError
-          data-testid="field-tykg"
-        />
-      </StyledFormGrid>
-    </>
+    <Field
+      name={name}
+      component={LocalisedLocationField}
+      groupValue={values.locationGroupId}
+      onGroupChange={handleGroupChange}
+      hideLocationGroupError
+    />
   );
 };
+
+const BasicMoveFields = () => (
+  <>
+    <SectionDescription>
+      <TranslatedText
+        stringId="patient.encounter.movePatient.location.description"
+        fallback="Select new patient location."
+      />
+    </SectionDescription>
+    <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
+      <PlannedMoveLocationField name="locationId" />
+    </StyledFormGrid>
+  </>
+);
 
 const PATIENT_MOVE_ACTIONS = {
   PLAN: 'plan',
@@ -117,10 +119,6 @@ const PlannedMoveFields = () => {
   const { getSetting } = useSettings();
   const plannedMoveTimeoutHours = getSetting('templates.plannedMoveTimeoutHours');
   const { values, initialValues, setFieldValue } = useFormikContext();
-
-  const handleGroupChange = groupValue => {
-    setFieldValue('locationGroupId', groupValue);
-  };
 
   const isExistingPlannedMove =
     initialValues?.plannedLocationId &&
@@ -146,14 +144,7 @@ const PlannedMoveFields = () => {
     <>
       <SectionDescription>{description}</SectionDescription>
       <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
-        <Field
-          name="plannedLocationId"
-          component={LocalisedLocationField}
-          groupValue={values.locationGroupId}
-          onGroupChange={handleGroupChange}
-          hideLocationGroupError
-          data-testid="field-n625"
-        />
+        <PlannedMoveLocationField name="plannedLocationId" />
         <LocationAvailabilityWarningMessage
           locationId={values.plannedLocationId}
           style={{ gridColumn: '2', fontSize: '12px', marginTop: '-15px' }}

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -243,11 +243,14 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
     departmentId: encounter.departmentId,
   };
 
-  const locationValidationSchema = yup.string().nullable().when('locationGroupId', {
-    is: value => !!value,
-    then: schema => schema.required(),
-    otherwise: schema => schema.nullable(),
-  });
+  const locationValidationSchema = yup
+    .string()
+    .nullable()
+    .when('locationGroupId', {
+      is: value => !!value,
+      then: schema => schema.required(),
+      otherwise: schema => schema.nullable(),
+    });
   if (enablePatientMoveActions) {
     validationObject.action = yup
       .string()

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -117,6 +117,10 @@ const PlannedMoveFields = () => {
   const plannedMoveTimeoutHours = getSetting('templates.plannedMoveTimeoutHours');
   const { values, initialValues, setFieldValue } = useFormikContext();
 
+  const handleGroupChange = groupValue => {
+    setFieldValue('locationGroupId', groupValue);
+  };
+
   const isExistingPlannedMove =
     initialValues?.plannedLocationId &&
     initialValues?.plannedLocationId === values?.plannedLocationId;
@@ -144,6 +148,8 @@ const PlannedMoveFields = () => {
         <Field
           name="plannedLocationId"
           component={LocalisedLocationField}
+          groupValue={values.locationGroupId}
+          onGroupChange={handleGroupChange}
           data-testid="field-n625"
         />
         <LocationAvailabilityWarningMessage
@@ -236,12 +242,18 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
   };
 
   if (enablePatientMoveActions) {
-    validationObject.plannedLocationId = yup.string().nullable();
     validationObject.action = yup
       .string()
       .oneOf([PATIENT_MOVE_ACTIONS.PLAN, PATIENT_MOVE_ACTIONS.FINALISE])
       .nullable();
-
+    validationObject.plannedLocationId = yup
+      .string()
+      .nullable()
+      .when('locationGroupId', {
+        is: value => !!value,
+        then: schema => schema.required(),
+        otherwise: schema => schema.nullable(),
+      });
     initialValues.plannedLocationId = encounter.plannedLocationId;
     initialValues.action = PATIENT_MOVE_ACTIONS.PLAN;
   } else {
@@ -250,7 +262,7 @@ const getFormProps = ({ encounter, enablePatientMoveActions, isAdmittingToHospit
       .nullable()
       .when('locationGroupId', {
         is: value => !!value,
-        then: schema => schema.required('Location is required when area is selected'),
+        then: schema => schema.required(),
         otherwise: schema => schema.nullable(),
       });
   }

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -151,7 +151,7 @@ const PlannedMoveFields = () => {
           component={LocalisedLocationField}
           groupValue={values.locationGroupId}
           onGroupChange={handleGroupChange}
-          hideLocationError
+          hideLocationGroupError
           data-testid="field-n625"
         />
         <LocationAvailabilityWarningMessage

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -37,6 +37,12 @@ import { ENCOUNTER_TYPE_LABELS, ENCOUNTER_TYPES } from '@tamanu/constants';
 import { useFormikContext } from 'formik';
 import { ENCOUNTER_OPTIONS_BY_VALUE } from '../../../constants';
 
+const PATIENT_MOVE_ACTIONS = {
+  PLAN: 'plan',
+  FINALISE: 'finalise',
+};
+
+
 const SectionHeading = styled(Heading3)`
   color: ${TAMANU_COLORS.darkestText};
   margin: 10px 0;
@@ -80,7 +86,7 @@ const EncounterTypeLabel = styled.b`
   border-bottom: 2px solid ${({ $underlineColor }) => $underlineColor};
 `;
 
-const PlannedMoveLocationField = ({ name }) => {
+const MoveLocationField = ({ name }) => {
   const { values, setFieldValue } = useFormikContext();
   const handleGroupChange = groupValue => {
     setFieldValue('locationGroupId', groupValue);
@@ -105,15 +111,10 @@ const BasicMoveFields = () => (
       />
     </SectionDescription>
     <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
-      <PlannedMoveLocationField name="locationId" />
+      <MoveLocationField name="locationId" />
     </StyledFormGrid>
   </>
 );
-
-const PATIENT_MOVE_ACTIONS = {
-  PLAN: 'plan',
-  FINALISE: 'finalise',
-};
 
 const PlannedMoveFields = () => {
   const { getSetting } = useSettings();
@@ -144,7 +145,7 @@ const PlannedMoveFields = () => {
     <>
       <SectionDescription>{description}</SectionDescription>
       <StyledFormGrid columns={2} data-testid="formgrid-wyqp">
-        <PlannedMoveLocationField name="plannedLocationId" />
+        <MoveLocationField name="plannedLocationId" />
         <LocationAvailabilityWarningMessage
           locationId={values.plannedLocationId}
           style={{ gridColumn: '2', fontSize: '12px', marginTop: '-15px' }}

--- a/packages/web/app/views/patients/components/MoveModal.jsx
+++ b/packages/web/app/views/patients/components/MoveModal.jsx
@@ -201,6 +201,7 @@ const PlannedMoveFields = () => {
           <CancelMoveButton
             onClick={() => {
               setFieldValue('plannedLocationId', null);
+              setFieldValue('locationGroupId', null);
             }}
             variant="outlined"
             data-testid="button-cancel-patient-move"


### PR DESCRIPTION
### Changes
- Fix location validation in move modal if `enablePatientMoveActions` is true.
- Hacky way to only show error on location side of area location field. But really don't want to make assumtions with all the usages of this field. I feel regression risk too high for tweak

<img width="815" height="305" alt="Screenshot 2025-12-15 at 2 18 16 PM" src="https://github.com/user-attachments/assets/e70e3944-2aec-4d57-8e1d-f2b3e8a295c3" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Move modal to require location only when an area is selected, sync area selection into form state, and suppress errors on the area selector via a new LocationField prop.
> 
> - **Move modal (`packages/web/app/views/patients/components/MoveModal.jsx`)**
>   - **Validation**: Introduces shared `locationValidationSchema` that requires `plannedLocationId`/`locationId` only when `locationGroupId` is set; applied based on `features.patientPlannedMove`.
>   - **Form wiring**: Passes `groupValue` and `onGroupChange` to `LocalisedLocationField` to keep `locationGroupId` in sync.
>   - **UX**: Uses `hideLocationGroupError` to suppress validation/error display on the area input.
> - **Location field (`packages/web/app/components/Field/LocationField.jsx`)**
>   - Adds `hideLocationGroupError` prop; conditionally disables `error`/`helperText` on the location group `AutocompleteInput`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abfde2e0dd328e2477fc5664eea2a4c70f939077. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->