### PR TITLE
fix(web): COOL-29: Note modal behavior

### DIFF
--- a/packages/ui-components/src/components/BaseModal.jsx
+++ b/packages/ui-components/src/components/BaseModal.jsx
@@ -135,6 +135,7 @@ export const BaseModal = memo(
         open={open}
         onClose={onDialogClose}
         transitionDuration={MODAL_TRANSITION_DURATION}
+        disableEnforceFocus
         {...props}
         data-testid="dialog-g9qi"
       >

--- a/packages/ui-components/src/components/Button/ButtonRow.jsx
+++ b/packages/ui-components/src/components/Button/ButtonRow.jsx
@@ -29,9 +29,11 @@ const ConfirmButton = styled(Button)`
   min-width: 90px;
 `;
 
-export const ButtonRow = React.memo(({ children, ...props }) => (
+export const ButtonRow = React.memo(({ children, ButtonWrapper = React.Fragment, ...props }) => (
   <Row items={Children.toArray(children).length || 1} {...props} data-testid="row-atzb">
-    {children}
+    <ButtonWrapper>
+      {children}
+    </ButtonWrapper>
   </Row>
 ));
 

--- a/packages/ui-components/src/components/Button/ButtonRow.jsx
+++ b/packages/ui-components/src/components/Button/ButtonRow.jsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Button, FormCancelButton, FormSubmitButton, OutlinedButton } from './Button';
@@ -30,7 +30,7 @@ const ConfirmButton = styled(Button)`
 `;
 
 export const ButtonRow = React.memo(({ children, ButtonWrapper = React.Fragment, ...props }) => (
-  <Row items={Children.toArray(children).length || 1} {...props} data-testid="row-atzb">
+  <Row {...props} data-testid="row-atzb">
     <ButtonWrapper>
       {children}
     </ButtonWrapper>

--- a/packages/web/app/components/CarePlanNoteDisplay.jsx
+++ b/packages/web/app/components/CarePlanNoteDisplay.jsx
@@ -6,6 +6,7 @@ import { MenuButton } from './MenuButton';
 import { useApi } from '../api';
 import { DateDisplay } from './DateDisplay';
 import { TranslatedText } from './Translation/TranslatedText';
+import { NoteModalActionBlocker } from './NoteModalActionBlocker';
 
 const NoteContainer = styled.div`
   border: 1px solid ${Colors.outline};
@@ -103,6 +104,7 @@ export const CarePlanNoteDisplay = ({ note, isMainCarePlan, onEditClicked, onNot
                 action: () => {
                   onEditClicked();
                 },
+                wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
               },
               ...(isMainCarePlan
                 ? []
@@ -119,6 +121,7 @@ export const CarePlanNoteDisplay = ({ note, isMainCarePlan, onEditClicked, onNot
                         await deleteNote(note.id);
                         onNoteDeleted();
                       },
+                      wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
                     },
                   ]),
             ]}

--- a/packages/web/app/components/CarePlanNoteForm.jsx
+++ b/packages/web/app/components/CarePlanNoteForm.jsx
@@ -14,6 +14,7 @@ import { Colors } from '../constants/styles';
 import { AutocompleteField, DateTimeField, Field } from './Field';
 import { TranslatedText } from './Translation/TranslatedText';
 import { useTranslation } from '../contexts/Translation';
+import { NoteModalActionBlocker } from './NoteModalActionBlocker';
 
 const SubmitError = styled.div`
   color: ${Colors.alert};
@@ -71,43 +72,47 @@ export function CarePlanNoteForm({
       render={() => (
         <>
           <FormGrid columns={2} data-testid="formgrid-fndf">
-            <Field
-              name="onBehalfOfId"
-              label={
-                <TranslatedText
-                  stringId="carePlan.noteOnBehalfOf.label"
-                  fallback="On behalf of"
-                  data-testid="translatedtext-dyao"
-                />
-              }
-              component={AutocompleteField}
-              suggester={practitionerSuggester}
-              data-testid="field-hh8q"
-            />
-            <Field
-              name="date"
-              label={
-                <TranslatedText
-                  stringId="carePlan.noteDateRecorded.label"
-                  fallback="Date Recorded"
-                  data-testid="translatedtext-7ylt"
-                />
-              }
-              component={DateTimeField}
-              saveDateAsString
-              data-testid="field-qouz"
-            />
+            <NoteModalActionBlocker>
+              <Field
+                name="onBehalfOfId"
+                label={
+                  <TranslatedText
+                    stringId="carePlan.noteOnBehalfOf.label"
+                    fallback="On behalf of"
+                    data-testid="translatedtext-dyao"
+                  />
+                }
+                component={AutocompleteField}
+                suggester={practitionerSuggester}
+                data-testid="field-hh8q"
+              />
+              <Field
+                name="date"
+                label={
+                  <TranslatedText
+                    stringId="carePlan.noteDateRecorded.label"
+                    fallback="Date Recorded"
+                    data-testid="translatedtext-7ylt"
+                  />
+                }
+                component={DateTimeField}
+                saveDateAsString
+                data-testid="field-qouz"
+              />
+            </NoteModalActionBlocker>
           </FormGrid>
           <FormGrid columns={1} data-testid="formgrid-fw7y">
-            <Field
-              name="content"
-              placeholder={getTranslation('carePlan.note.placeholder.writeNote', 'Write a note...')}
-              component={TextField}
-              required
-              multiline
-              minRows={4}
-              data-testid="field-e8ln"
-            />
+            <NoteModalActionBlocker>
+              <Field
+                name="content"
+                placeholder={getTranslation('carePlan.note.placeholder.writeNote', 'Write a note...')}
+                component={TextField}
+                required
+                multiline
+                minRows={4}
+                data-testid="field-e8ln"
+              />
+            </NoteModalActionBlocker>
           </FormGrid>
           <SubmitError data-testid="submiterror-89ce">{submitError}</SubmitError>
           <FormSubmitCancelRow
@@ -127,6 +132,7 @@ export function CarePlanNoteForm({
                 />
               )
             }
+            ButtonWrapper={NoteModalActionBlocker}
             data-testid="formsubmitcancelrow-2egx"
           />
         </>

--- a/packages/web/app/components/Charting/CoreComplexChartData.jsx
+++ b/packages/web/app/components/Charting/CoreComplexChartData.jsx
@@ -11,6 +11,7 @@ import { CHARTING_DATA_ELEMENT_IDS, VISIBILITY_STATUSES } from '@tamanu/constant
 import { useEncounter } from '../../contexts/Encounter';
 import { useEncounterChartsQuery } from '../../api/queries';
 import { DateDisplay } from '../DateDisplay';
+import { NoteModalActionBlocker } from '../NoteModalActionBlocker';
 
 const CoreComplexChartDataRow = styled.div`
   margin-bottom: 10px;
@@ -65,6 +66,7 @@ export const CoreComplexChartData = ({
       permissionCheck: () => {
         return !isPatientRemoved && ability?.can('delete', subject('Charting', { id: coreComplexChartSurveyId }));
       },
+      wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
     },
   ].filter(({ permissionCheck }) => {
     return permissionCheck ? permissionCheck() : true;

--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -10,6 +10,7 @@ import { BodyText } from '../Typography';
 import { useAuth } from '../../contexts/Auth';
 import { TranslatedText } from '../Translation/TranslatedText';
 import { MultiAutocompleteInput } from './MultiAutocompleteField';
+import { NoteModalActionBlocker } from '../NoteModalActionBlocker';
 
 const useLocationSuggestion = locationId => {
   const api = useApi();
@@ -42,6 +43,7 @@ export const LocationInput = React.memo(
     showAllLocations = false,
     locationGroupBaseQueryParameters = {},
     facilityId: facilityIdOverride,
+    wrapInNoteModalActionBlocker = false,
   }) => {
     const { facilityId: currentFacilityId } = useAuth();
     const facilityId = (facilityIdOverride ?? currentFacilityId) || '';
@@ -121,9 +123,10 @@ export const LocationInput = React.memo(
     const locationGroupSelectIsDisabled = !existingLocationHasSameFacility;
 
     const LocationAutocompleteInput = isMulti ? MultiAutocompleteInput : AutocompleteInput;
+    const Wrapper = wrapInNoteModalActionBlocker ? NoteModalActionBlocker : React.Fragment;
 
     return (
-      <>
+      <Wrapper>
         {/* Show required asterisk but the field is not actually required */}
         <AutocompleteInput
           label={locationGroupLabel}
@@ -156,7 +159,7 @@ export const LocationInput = React.memo(
           size={size}
           data-testid={`${dataTestId}-location`}
         />
-      </>
+      </Wrapper>
     );
   },
 );

--- a/packages/web/app/forms/LabRequestNoteForm.jsx
+++ b/packages/web/app/forms/LabRequestNoteForm.jsx
@@ -14,6 +14,7 @@ import {
   Field,
 } from '../components';
 import { TranslatedText } from '../components/Translation/TranslatedText';
+import { NoteModalActionBlocker } from '../components/NoteModalActionBlocker';
 
 const Container = styled.div`
   display: flex;
@@ -75,6 +76,10 @@ const buttonStyle = css`
 
 const SubmitNoteButton = styled(FormSubmitButton)`
   ${buttonStyle}
+`;
+
+const ShowAddNoteFormButtonContainer = styled.div`
+  display: inline-block;
 `;
 
 const ShowAddNoteFormButton = styled(Button)`
@@ -162,17 +167,21 @@ export const LabRequestNoteForm = React.memo(({ labRequestId, isReadOnly }) => {
                   />
                 </Box>
               ) : (
-                <ShowAddNoteFormButton
-                  $underline
-                  onClick={() => setActive(true)}
-                  data-testid="showaddnoteformbutton-thpi"
-                >
-                  <TranslatedText
-                    stringId="general.action.addNote"
-                    fallback="Add note"
-                    data-testid="translatedtext-6ric"
-                  />
-                </ShowAddNoteFormButton>
+                <ShowAddNoteFormButtonContainer>
+                  <NoteModalActionBlocker>
+                    <ShowAddNoteFormButton
+                      $underline
+                      onClick={() => setActive(true)}
+                      data-testid="showaddnoteformbutton-thpi"
+                    >
+                      <TranslatedText
+                        stringId="general.action.addNote"
+                        fallback="Add note"
+                        data-testid="translatedtext-6ric"
+                      />
+                    </ShowAddNoteFormButton>
+                  </NoteModalActionBlocker>
+                </ShowAddNoteFormButtonContainer>
               );
             }}
             data-testid="form-7jdi"

--- a/packages/web/app/forms/ProcedureForm/ProcedureForm.jsx
+++ b/packages/web/app/forms/ProcedureForm/ProcedureForm.jsx
@@ -14,6 +14,7 @@ import { TextField, FormGrid } from '@tamanu/ui-components';
 import { MultiAutocompleteField } from '../../components/Field/MultiAutocompleteField';
 import { TranslatedText } from '../../components/Translation/TranslatedText';
 import { useSuggester } from '../../api';
+import { NoteModalActionBlocker } from '../../components/NoteModalActionBlocker';
 
 const Divider = styled(MuiDivider)`
   margin: 10px 0 20px;
@@ -33,30 +34,34 @@ export const ProcedureFormFields = React.memo(({ values }) => {
     <>
       <FormGrid data-testid="formgrid-6sdo">
         <div style={{ gridColumn: 'span 2' }}>
-          <Field
-            name="procedureTypeId"
-            label={<TranslatedText stringId="procedure.procedureType.label" fallback="Procedure" />}
-            required
-            component={AutocompleteField}
-            suggester={procedureSuggester}
-            data-testid="field-87c2"
-          />
+          <NoteModalActionBlocker>
+            <Field
+              name="procedureTypeId"
+              label={<TranslatedText stringId="procedure.procedureType.label" fallback="Procedure" />}
+              required
+              component={AutocompleteField}
+              suggester={procedureSuggester}
+              data-testid="field-87c2"
+            />
+          </NoteModalActionBlocker>
         </div>
-        <Field
-          name="date"
-          label={<TranslatedText stringId="procedure.date.label" fallback="Procedure date" />}
-          saveDateAsString
-          required
-          component={DateField}
-          data-testid="field-3a5v"
-        />
-        <Field
-          name="departmentId"
-          label={<TranslatedText stringId="procedure.department.label" fallback="Department" />}
-          suggester={departmentSuggester}
-          component={AutocompleteField}
-          data-testid="field-3a5v1"
-        />
+        <NoteModalActionBlocker>
+          <Field
+            name="date"
+            label={<TranslatedText stringId="procedure.date.label" fallback="Procedure date" />}
+            saveDateAsString
+            required
+            component={DateField}
+            data-testid="field-3a5v"
+          />
+          <Field
+            name="departmentId"
+            label={<TranslatedText stringId="procedure.department.label" fallback="Department" />}
+            suggester={departmentSuggester}
+            component={AutocompleteField}
+            data-testid="field-3a5v1"
+          />
+        </NoteModalActionBlocker>
         <Field
           locationGroupLabel={
             <TranslatedText stringId="procedure.area.label" fallback="Procedure area" />
@@ -68,129 +73,139 @@ export const ProcedureFormFields = React.memo(({ values }) => {
           enableLocationStatus={false}
           required
           component={LocationField}
+          wrapInNoteModalActionBlocker
           data-testid="field-p4ef"
         />
-        <Field
-          name="physicianId"
-          label={
-            <TranslatedText
-              stringId="general.localisedField.leadClinician.label"
-              fallback="Lead clinician"
+        <NoteModalActionBlocker>
+          <Field
+            name="physicianId"
+            label={
+              <TranslatedText
+                stringId="general.localisedField.leadClinician.label"
+                fallback="Lead clinician"
+              />
+            }
+            required
+            component={AutocompleteField}
+            suggester={physicianSuggester}
+            data-testid="field-lit6"
+          />
+          <Field
+            name="assistantClinicianIds"
+            label={
+              <TranslatedText
+                stringId="procedure.assistantClinicians.label"
+                fallback="Assistant clinicians"
+              />
+            }
+            component={MultiAutocompleteField}
+            suggester={assistantSuggester}
+            data-testid="field-f3l4"
+          />
+          <Field
+            name="anaesthetistId"
+            label={<TranslatedText stringId="procedure.anaesthetist.label" fallback="Anaesthetist" />}
+            component={AutocompleteField}
+            suggester={anaesthetistSuggester}
+            data-testid="field-96eg"
+          />
+          <Field
+            name="assistantAnaesthetistId"
+            label={
+              <TranslatedText
+                stringId="procedure.assistantAnaesthetist.label"
+                fallback="Assistant Anaesthetist"
+              />
+            }
+            component={AutocompleteField}
+            suggester={anaesthetistSuggester}
+            data-testid="field-96eg1"
+          />
+          <Field
+            name="anaestheticId"
+            label={
+              <TranslatedText stringId="procedure.anaesthetic.label" fallback="Anaesthetic type" />
+            }
+            component={AutocompleteField}
+            suggester={anaestheticSuggester}
+            data-testid="field-w9b5"
+          />
+          {/* Empty div to make the time in field start on a new row */}
+          <div />
+          <Field
+            name="timeIn"
+            label={<TranslatedText stringId="procedure.timeIn.label" fallback="Time in" />}
+            component={TimeField}
+            saveDateAsString
+            data-testid="field-khml1"
+          />
+          <Field
+            name="timeOut"
+            label={<TranslatedText stringId="procedure.timeOut.label" fallback="Time out" />}
+            component={TimeField}
+            saveDateAsString
+            data-testid="field-hgzz1"
+          />
+          <Field
+            name="startTime"
+            label={<TranslatedText stringId="procedure.startTime.label" fallback="Time started" />}
+            component={TimeField}
+            saveDateAsString
+            data-testid="field-khml"
+          />
+          <Field
+            name="endTime"
+            label={<TranslatedText stringId="procedure.endTime.label" fallback="Time ended" />}
+            component={TimeField}
+            saveDateAsString
+            data-testid="field-hgzz"
+          />
+        </NoteModalActionBlocker>
+        <div style={{ gridColumn: 'span 2' }}>
+          <NoteModalActionBlocker>
+            <Field
+              name="note"
+              label={
+                <TranslatedText
+                  stringId="procedure.noteOrInstruction.label"
+                  fallback="Notes or additional instructions"
+                />
+              }
+              component={TextField}
+              multiline
+              minRows={4}
+              data-testid="field-7en7"
             />
-          }
-          required
-          component={AutocompleteField}
-          suggester={physicianSuggester}
-          data-testid="field-lit6"
-        />
-        <Field
-          name="assistantClinicianIds"
-          label={
-            <TranslatedText
-              stringId="procedure.assistantClinicians.label"
-              fallback="Assistant clinicians"
-            />
-          }
-          component={MultiAutocompleteField}
-          suggester={assistantSuggester}
-          data-testid="field-f3l4"
-        />
-        <Field
-          name="anaesthetistId"
-          label={<TranslatedText stringId="procedure.anaesthetist.label" fallback="Anaesthetist" />}
-          component={AutocompleteField}
-          suggester={anaesthetistSuggester}
-          data-testid="field-96eg"
-        />
-        <Field
-          name="assistantAnaesthetistId"
-          label={
-            <TranslatedText
-              stringId="procedure.assistantAnaesthetist.label"
-              fallback="Assistant Anaesthetist"
-            />
-          }
-          component={AutocompleteField}
-          suggester={anaesthetistSuggester}
-          data-testid="field-96eg1"
-        />
-        <Field
-          name="anaestheticId"
-          label={
-            <TranslatedText stringId="procedure.anaesthetic.label" fallback="Anaesthetic type" />
-          }
-          component={AutocompleteField}
-          suggester={anaestheticSuggester}
-          data-testid="field-w9b5"
-        />
-        {/* Empty div to make the time in field start on a new row */}
-        <div />
-        <Field
-          name="timeIn"
-          label={<TranslatedText stringId="procedure.timeIn.label" fallback="Time in" />}
-          component={TimeField}
-          saveDateAsString
-          data-testid="field-khml1"
-        />
-        <Field
-          name="timeOut"
-          label={<TranslatedText stringId="procedure.timeOut.label" fallback="Time out" />}
-          component={TimeField}
-          saveDateAsString
-          data-testid="field-hgzz1"
-        />
-        <Field
-          name="startTime"
-          label={<TranslatedText stringId="procedure.startTime.label" fallback="Time started" />}
-          component={TimeField}
-          saveDateAsString
-          data-testid="field-khml"
-        />
-        <Field
-          name="endTime"
-          label={<TranslatedText stringId="procedure.endTime.label" fallback="Time ended" />}
-          component={TimeField}
-          saveDateAsString
-          data-testid="field-hgzz"
-        />
-        <Field
-          name="note"
-          label={
-            <TranslatedText
-              stringId="procedure.noteOrInstruction.label"
-              fallback="Notes or additional instructions"
-            />
-          }
-          component={TextField}
-          multiline
-          minRows={4}
-          style={{ gridColumn: 'span 2' }}
-          data-testid="field-7en7"
-        />
-        <Field
-          name="completed"
-          label={<TranslatedText stringId="general.completed.label" fallback="Completed" />}
-          component={CheckField}
-          data-testid="field-uaz4"
-        />
+          </NoteModalActionBlocker>
+        </div>
+        <NoteModalActionBlocker>
+          <Field
+            name="completed"
+            label={<TranslatedText stringId="general.completed.label" fallback="Completed" />}
+            component={CheckField}
+            data-testid="field-uaz4"
+          />
+        </NoteModalActionBlocker>
         <Collapse
           in={!!values.completed}
           style={{ gridColumn: 'span 2' }}
           data-testid="collapse-e9ow"
         >
-          <Field
-            name="completedNote"
-            label={
-              <TranslatedText
-                stringId="procedure.completedNote.label"
-                fallback="Notes on completed procedure"
-              />
-            }
-            component={TextField}
-            multiline
-            minRows={4}
-            data-testid="field-qrv7"
-          />
+          <NoteModalActionBlocker>
+            <Field
+              name="completedNote"
+              label={
+                <TranslatedText
+                  stringId="procedure.completedNote.label"
+                  fallback="Notes on completed procedure"
+                />
+              }
+              component={TextField}
+              multiline
+              minRows={4}
+              data-testid="field-qrv7"
+            />
+          </NoteModalActionBlocker>
         </Collapse>
       </FormGrid>
       <Divider />

--- a/packages/web/app/views/patients/LabRequestView.jsx
+++ b/packages/web/app/views/patients/LabRequestView.jsx
@@ -49,6 +49,7 @@ import { LabRequestSampleDetailsModal } from './components/LabRequestSampleDetai
 import { LabAttachmentModal } from '../../components/LabAttachmentModal';
 import { ConditionalTooltip } from '../../components/Tooltip';
 import { Colors } from '../../constants';
+import { NoteModalActionBlocker } from '../../components/NoteModalActionBlocker';
 
 const Container = styled.div`
   display: flex;
@@ -164,6 +165,7 @@ const Menu = ({ setModal, status, disabled, canReadLabTestResult }) => {
         />
       ),
       action: () => setModal(MODAL_IDS.CANCEL),
+      wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
     });
   }
 
@@ -247,6 +249,7 @@ export const LabRequestView = () => {
               />
             ),
             action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+            wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
           },
         ]
       : [
@@ -259,6 +262,7 @@ export const LabRequestView = () => {
               />
             ),
             action: () => handleChangeModalId(MODAL_IDS.RECORD_SAMPLE),
+            wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
           },
           {
             label: (
@@ -414,6 +418,7 @@ export const LabRequestView = () => {
                     </ConditionalTooltip>
                   ),
                   action: handleChangeStatus,
+                  wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
                 },
               {
                 label: (
@@ -483,6 +488,7 @@ export const LabRequestView = () => {
                   />
                 ),
                 action: () => handleChangeModalId(MODAL_IDS.CHANGE_LABORATORY),
+                wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
               },
             ]}
             data-testid="tile-eeus"
@@ -519,6 +525,7 @@ export const LabRequestView = () => {
                   />
                 ),
                 action: () => handleChangeModalId(MODAL_IDS.CHANGE_PRIORITY),
+                wrapper: action => <NoteModalActionBlocker>{action}</NoteModalActionBlocker>,
               },
             ]}
             data-testid="tile-phsp"
@@ -540,16 +547,18 @@ export const LabRequestView = () => {
             </Button>
           )}
           {canEnterResults && (
-            <Button
-              onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}
-              data-testid="button-oep6"
-            >
-              <TranslatedText
-                stringId="lab.action.enterResults"
-                fallback="Enter results"
-                data-testid="translatedtext-veq6"
-              />
-            </Button>
+            <NoteModalActionBlocker>
+              <Button
+                onClick={() => handleChangeModalId(MODAL_IDS.ENTER_RESULTS)}
+                data-testid="button-oep6"
+              >
+                <TranslatedText
+                  stringId="lab.action.enterResults"
+                  fallback="Enter results"
+                  data-testid="translatedtext-veq6"
+                />
+              </Button>
+            </NoteModalActionBlocker>
           )}
         </TableButtonRow>
         <LabRequestResultsTable

--- a/packages/web/app/views/patients/imagingRequest/CancelModalButton.jsx
+++ b/packages/web/app/views/patients/imagingRequest/CancelModalButton.jsx
@@ -7,6 +7,7 @@ import { CancelModal } from '../../../components/CancelModal';
 import { useApi } from '../../../api';
 import { useSettings } from '../../../contexts/Settings';
 import { TranslatedText } from '../../../components/Translation/TranslatedText';
+import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 
 function getReasonForCancellationStatus(reasonForCancellation) {
   // these values are set in localisation
@@ -44,13 +45,15 @@ export const CancelModalButton = ({ imagingRequest, onCancel }) => {
 
   return (
     <>
-      <Button variant="text" onClick={() => setIsOpen(true)} data-testid="button-kuzg">
-        <TranslatedText
-          stringId="imaging.action.cancelRequest"
-          fallback="Cancel request"
-          data-testid="translatedtext-xw1p"
-        />
-      </Button>
+      <NoteModalActionBlocker>
+        <Button variant="text" onClick={() => setIsOpen(true)} data-testid="button-kuzg">
+          <TranslatedText
+            stringId="imaging.action.cancelRequest"
+            fallback="Cancel request"
+            data-testid="translatedtext-xw1p"
+          />
+        </Button>
+      </NoteModalActionBlocker>
       <CancelModal
         title={
           <TranslatedText

--- a/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
+++ b/packages/web/app/views/patients/imagingRequest/ImagingRequestView.jsx
@@ -39,6 +39,7 @@ import { TranslatedText } from '../../../components/Translation';
 import { useTranslation } from '../../../contexts/Translation';
 import { useSettings } from '../../../contexts/Settings';
 import { useAuth } from '../../../contexts/Auth';
+import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 
 const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
   const { getLocalisation } = useLocalisation();
@@ -93,39 +94,41 @@ const ImagingRequestSection = ({ currentStatus, imagingRequest }) => {
         disabled
         data-testid="textinput-z6l1"
       />
-      <Field
-        name="status"
-        label={
-          <TranslatedText
-            stringId="general.status.label"
-            fallback="Status"
-            data-testid="translatedtext-jnts"
-          />
-        }
-        component={TranslatedSelectField}
-        enumValues={IMAGING_REQUEST_STATUS_LABELS}
-        transformOptions={options => {
-          return isCancelled
-            ? [
-                {
-                  label: IMAGING_REQUEST_STATUS_LABELS[IMAGING_REQUEST_STATUS_TYPES.CANCELLED],
-                  value: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
-                },
-              ]
-            : options.filter(
-                option =>
-                  ![
-                    IMAGING_REQUEST_STATUS_TYPES.DELETED,
-                    IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
-                    IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
-                  ].includes(option.value),
-              );
-        }}
-        disabled={isCancelled}
-        isClearable={false}
-        required
-        data-testid="field-mfc2"
-      />
+      <NoteModalActionBlocker>
+        <Field
+          name="status"
+          label={
+            <TranslatedText
+              stringId="general.status.label"
+              fallback="Status"
+              data-testid="translatedtext-jnts"
+            />
+          }
+          component={TranslatedSelectField}
+          enumValues={IMAGING_REQUEST_STATUS_LABELS}
+          transformOptions={options => {
+            return isCancelled
+              ? [
+                  {
+                    label: IMAGING_REQUEST_STATUS_LABELS[IMAGING_REQUEST_STATUS_TYPES.CANCELLED],
+                    value: IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+                  },
+                ]
+              : options.filter(
+                  option =>
+                    ![
+                      IMAGING_REQUEST_STATUS_TYPES.DELETED,
+                      IMAGING_REQUEST_STATUS_TYPES.ENTERED_IN_ERROR,
+                      IMAGING_REQUEST_STATUS_TYPES.CANCELLED,
+                    ].includes(option.value),
+                );
+          }}
+          disabled={isCancelled}
+          isClearable={false}
+          required
+          data-testid="field-mfc2"
+        />
+      </NoteModalActionBlocker>
       <DateTimeInput
         value={imagingRequest.requestedDate}
         label={
@@ -208,54 +211,57 @@ const BottomAlignFormGrid = styled(FormGrid)`
 const NewResultSection = ({ disabled = false }) => {
   const practitionerSuggester = useSuggester('practitioner');
   const { getTranslation } = useTranslation();
+  const Wrapper = !disabled ? NoteModalActionBlocker : React.Fragment;
 
   return (
     <FormGrid columns={2} data-testid="formgrid-j2u1">
-      <Field
-        label={
-          <TranslatedText
-            stringId="imaging.completedBy.label"
-            fallback="Completed by"
-            data-testid="translatedtext-wjkc"
-          />
-        }
-        name="newResult.completedById"
-        placeholder={getTranslation('imaging.completedBy.placeholder', 'Search')}
-        component={AutocompleteField}
-        suggester={practitionerSuggester}
-        disabled={disabled}
-        data-testid="field-ta7y"
-      />
-      <Field
-        label={
-          <TranslatedText
-            stringId="imaging.completedDate.label"
-            fallback="Completed"
-            data-testid="translatedtext-iiin"
-          />
-        }
-        name="newResult.completedAt"
-        saveDateAsString
-        component={DateTimeField}
-        disabled={disabled}
-        data-testid="field-wxo5"
-      />
-      <Field
-        label={
-          <TranslatedText
-            stringId="imaging.description.label"
-            fallback="Result description"
-            data-testid="translatedtext-3ezd"
-          />
-        }
-        name="newResult.description"
-        placeholder={getTranslation('imaging.description.placeholder', 'Result description...')}
-        multiline
-        component={TextField}
-        style={{ gridColumn: '1 / -1', minHeight: '3em' }}
-        disabled={disabled}
-        data-testid="field-2pjt"
-      />
+      <Wrapper>
+        <Field
+          label={
+            <TranslatedText
+              stringId="imaging.completedBy.label"
+              fallback="Completed by"
+              data-testid="translatedtext-wjkc"
+            />
+          }
+          name="newResult.completedById"
+          placeholder={getTranslation('imaging.completedBy.placeholder', 'Search')}
+          component={AutocompleteField}
+          suggester={practitionerSuggester}
+          disabled={disabled}
+          data-testid="field-ta7y"
+        />
+        <Field
+          label={
+            <TranslatedText
+              stringId="imaging.completedDate.label"
+              fallback="Completed"
+              data-testid="translatedtext-iiin"
+            />
+          }
+          name="newResult.completedAt"
+          saveDateAsString
+          component={DateTimeField}
+          disabled={disabled}
+          data-testid="field-wxo5"
+        />
+        <Field
+          label={
+            <TranslatedText
+              stringId="imaging.description.label"
+              fallback="Result description"
+              data-testid="translatedtext-3ezd"
+            />
+          }
+          name="newResult.description"
+          placeholder={getTranslation('imaging.description.placeholder', 'Result description...')}
+          multiline
+          component={TextField}
+          style={{ gridColumn: '1 / -1', minHeight: '3em' }}
+          disabled={disabled}
+          data-testid="field-2pjt"
+        />
+      </Wrapper>
     </FormGrid>
   );
 };
@@ -409,16 +415,18 @@ const ImagingRequestInfoPane = React.memo(({ imagingRequest, onSubmit }) => {
             <NewResultSection disabled={!canAddResult} data-testid="newresultsection-poyy" />
             <ButtonRow style={{ marginTop: 20 }} data-testid="buttonrow-52n1">
               {!isCancelled && (
-                <FormSubmitButton
-                  text={
-                    <TranslatedText
-                      stringId="general.action.save"
-                      fallback="Save"
-                      data-testid="translatedtext-wp3m"
-                    />
-                  }
-                  data-testid="formsubmitbutton-nisz"
-                />
+                <NoteModalActionBlocker>
+                  <FormSubmitButton
+                    text={
+                      <TranslatedText
+                        stringId="general.action.save"
+                        fallback="Save"
+                        data-testid="translatedtext-wp3m"
+                      />
+                    }
+                    data-testid="formsubmitbutton-nisz"
+                  />
+                </NoteModalActionBlocker>
               )}
             </ButtonRow>
           </>

--- a/packages/web/app/views/patients/panes/ChartsPane.jsx
+++ b/packages/web/app/views/patients/panes/ChartsPane.jsx
@@ -43,26 +43,19 @@ import { ConditionalTooltip } from '../../../components/Tooltip';
 import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 import { useTranslation } from '../../../contexts/Translation';
 
-const StyledButtonGroup = styled(ButtonGroup)`
-  .MuiButtonGroup-groupedOutlinedHorizontal:not(:first-child) {
-    margin-top: 10px;
-    margin-left: 10px;
-  }
-`;
-
 const TableButtonRowWrapper = styled.div`
   margin-bottom: 15px;
   border-bottom: 1px solid ${Colors.outline};
   overflow-x: auto;
 `;
 
-const AddComplexChartButton = styled.span`
+const AddComplexChartButton = styled.div`
   color: ${Colors.primary};
   font-size: 15px;
   font-weight: 500;
   cursor: pointer;
-  margin-left: 10px;
-  margin-right: 20px;
+  margin: 10px 20px 0 10px;
+  white-space: nowrap;
 `;
 
 const StyledButtonWithPermissionCheck = styled(ButtonWithPermissionCheck)`
@@ -337,7 +330,7 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
             justifyContent="space-between"
             data-testid="tablebuttonrow-lwlu"
           >
-            <StyledButtonGroup data-testid="styledbuttongroup-z992">
+            <ButtonGroup data-testid="styledbuttongroup-z992">
               <ChartDropdown
                 selectedChartTypeId={selectedChartTypeId}
                 setSelectedChartTypeId={setSelectedChartTypeId}
@@ -345,17 +338,19 @@ export const ChartsPane = React.memo(({ patient, encounter }) => {
                 data-testid="chartdropdown-eox5"
               />
               {isComplexChart && canCreateCoreComplexInstance && isCurrentChart ? (
-                <AddComplexChartButton
-                  onClick={() => {
-                    setChartSurveyIdToSubmit(coreComplexChartSurveyId);
-                    setModalOpen(true);
-                  }}
-                  data-testid="addcomplexchartbutton-w4wk"
-                >
-                  + Add
-                </AddComplexChartButton>
+                <NoteModalActionBlocker>
+                  <AddComplexChartButton
+                    onClick={() => {
+                      setChartSurveyIdToSubmit(coreComplexChartSurveyId);
+                      setModalOpen(true);
+                    }}
+                    data-testid="addcomplexchartbutton-w4wk"
+                  >
+                    + Add
+                  </AddComplexChartButton>
+                </NoteModalActionBlocker>
               ) : null}
-            </StyledButtonGroup>
+            </ButtonGroup>
 
             {complexChartInstanceTabs.length && currentComplexChartTab ? (
               <ComplexChartInstancesTab


### PR DESCRIPTION
### Changes

Note: changes look big, but in reality is mostly nesting components inside `NoteModalActionBlocker` thing

Previously, the note modal didn't work if you opened yet a second modal, and that's just what the design asks for. So here I unblocked that issue.

I also covered several missing spots where you could do an edit action when the note modal is open, which shouldn't happen. In some cases, I had to modify components to accept a wrapper or tweak the component tree to avoid screwing up the UI.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables nested modals and wraps key actions/fields with NoteModalActionBlocker across labs, imaging, charts, care plans, and forms; adds wrapper hooks to ButtonRow and LocationField.
> 
> - **Modal behavior**
>   - `BaseModal`: enable nested modals by setting `disableEnforceFocus` on `Dialog`.
> - **UI components**
>   - `ButtonRow`: add `ButtonWrapper` prop to wrap children (used to inject blockers).
>   - `LocationField`: add `wrapInNoteModalActionBlocker` option.
> - **Action blocking integration** (wrap actions/inputs with `NoteModalActionBlocker`):
>   - Care plans: `CarePlanNoteDisplay` (edit/delete), `CarePlanNoteForm` (fields/content/buttons).
>   - Charts: `CoreComplexChartData` (delete), `ChartsPane` (+ Add, Record buttons; minor button layout tweak).
>   - Labs: `LabRequestView` (cancel request, record sample/edit, change status, change laboratory, change priority, enter results), `LabRequestNoteForm` (Add note button).
>   - Imaging: `CancelModalButton` (cancel), `ImagingRequestView` (status field, new result fields, save button).
>   - Procedures: `ProcedureForm` (multiple fields incl. location via `LocationField`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 012fce86e1786048ebbaa7467bbcdf6d834411f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->