### PR TITLE
fix: no-issue: Update duplicate patient checking logic

### DIFF
--- a/packages/database/src/migrations/1766091436057-updateDuplicateCheckFunctionV2.ts
+++ b/packages/database/src/migrations/1766091436057-updateDuplicateCheckFunctionV2.ts
@@ -1,0 +1,75 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;`);
+
+  await query.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS patients_last_name_soundex_index ON patients(soundex(last_name));`,
+  );
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS patients_deleted_at_index ON patients(deleted_at) WHERE deleted_at IS NULL;
+  `);
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS patients_date_of_birth_index ON patients(date_of_birth);
+  `);
+
+  // Update function
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION public.find_potential_patient_duplicates(patient_data json)
+      RETURNS SETOF patients
+      LANGUAGE plpgsql
+      STABLE PARALLEL SAFE
+    AS $function$
+        BEGIN      
+          RETURN QUERY
+        SELECT 
+          p.*
+        FROM patients p
+        WHERE p.deleted_at IS NULL
+          AND soundex(p.last_name) = soundex(patient_data->>'lastName')
+          AND levenshtein(
+            lower(concat(p.last_name, p.first_name)), 
+            lower(concat(patient_data->>'lastName', patient_data->>'firstName'))
+          ) <= 6
+          AND (levenshtein(
+            p.date_of_birth, 
+            (patient_data->>'dateOfBirth')
+          ) <= 1
+          OR p.date_of_birth = concat_ws('-', 
+            substring(patient_data->>'dateOfBirth', 1, 4), 
+            substring(patient_data->>'dateOfBirth', 9, 2), 
+            substring(patient_data->>'dateOfBirth', 6, 2)))
+        LIMIT 5;
+        END;
+        $function$
+    ;
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE OR REPLACE FUNCTION find_potential_patient_duplicates(
+      patient_data JSON
+    )
+    RETURNS SETOF patients AS $$
+    BEGIN      
+      RETURN QUERY
+      SELECT 
+        p.*
+      FROM 
+        patients p
+      WHERE 
+        lower(p.first_name) = lower(patient_data->>'firstName') 
+        AND lower(p.last_name) = lower(patient_data->>'lastName') 
+        AND p.date_of_birth = patient_data->>'dateOfBirth'
+        AND p.deleted_at IS NULL;
+    END;
+    $$ LANGUAGE plpgsql STABLE PARALLEL SAFE;
+  `);
+
+  await query.sequelize.query(`DROP INDEX IF EXISTS patients_date_of_birth_index;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS patients_deleted_at_index;`);
+  await query.sequelize.query(`DROP INDEX IF EXISTS patients_last_name_soundex_index;`);
+
+  // Note: We don't drop the extension as it might be used by other functions
+}


### PR DESCRIPTION
### Changes

Just adding a migration to use the V2 duplicate function from here: https://beyond-essential.slab.com/public/posts/library-of-duplicate-patient-alert-functions-g3ify9cn?shr=ehzs2hxwhoguejpijzlhobqn#ha0i0-v-1-phonetic-last-name-levenshtein-distance-name

Have dev tested 🙏 

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a migration that replaces duplicate-patient detection with soundex/Levenshtein-based logic and adds supporting indexes; down migration restores exact-match logic and drops indexes.
> 
> - **Database Migration** (`packages/database/src/migrations/1766091436057-updateDuplicateCheckFunctionV2.ts`):
>   - **Function update**: `find_potential_patient_duplicates` now uses `soundex` on last name, `levenshtein` on concatenated names (<= 6), and tolerant DOB matching (levenshtein <= 1 or reordered format), limited to 5 results.
>   - **Indexes**:
>     - `patients_last_name_soundex_index` on `soundex(last_name)`.
>     - `patients_deleted_at_index` partial index where `deleted_at IS NULL`.
>     - `patients_date_of_birth_index` on `date_of_birth`.
>   - **Extension**: Ensure `fuzzystrmatch` is installed.
>   - **Down**: Restore prior exact-match function and drop the new indexes (retain extension).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d08dae10b66cb207d749769df109ae79dc3b12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->