### PR TITLE
fix(facility): no-issue: Start facility ASAP

### DIFF
--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -74,7 +74,6 @@ export class CentralServerConnection extends TamanuApi {
   }
 
   async connect(backoff = config.sync.backoff, timeout = this.timeout) {
-    console.log('connect', backoff);
     try {
       await this.refreshToken({
         retryAuth: false,

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -54,7 +54,7 @@ export class CentralServerConnection extends TamanuApi {
     }
 
     if (retryAuth && !this.hasToken()) {
-      await this.connect();
+      await this.connect(options.preserveBackoffForAuthAttempt && options.backoff);
     }
 
     try {
@@ -74,6 +74,7 @@ export class CentralServerConnection extends TamanuApi {
   }
 
   async connect(backoff = config.sync.backoff, timeout = this.timeout) {
+    console.log('connect', backoff);
     try {
       await this.refreshToken({
         retryAuth: false,

--- a/packages/facility-server/app/sync/CentralServerConnection.js
+++ b/packages/facility-server/app/sync/CentralServerConnection.js
@@ -54,7 +54,7 @@ export class CentralServerConnection extends TamanuApi {
     }
 
     if (retryAuth && !this.hasToken()) {
-      await this.connect(options.preserveBackoffForAuthAttempt && options.backoff);
+      await this.connect(options.preserveBackoffForAuthAttempt ? options.backoff : undefined);
     }
 
     try {

--- a/packages/shared/src/utils/timeZoneCheck.js
+++ b/packages/shared/src/utils/timeZoneCheck.js
@@ -23,7 +23,13 @@ async function getDatabaseTimeZone(sequelize) {
 // otherwise ignore that one
 async function getRemoteTimeZone(remote) {
   try {
-    const health = await remote.fetch('health', { timeout: 2000, backoff: { maxAttempts: 1 }, preserveBackoffForAuthAttempt: true });
+    const health = await remote.fetch('health',
+      {
+        timeout: 2000,
+        backoff: { maxAttempts: 1 },
+        preserveBackoffForAuthAttempt: true,
+      },
+    );
     const { countryTimeZone } = health.config;
     return countryTimeZone;
   } catch (error) {

--- a/packages/shared/src/utils/timeZoneCheck.js
+++ b/packages/shared/src/utils/timeZoneCheck.js
@@ -23,7 +23,7 @@ async function getDatabaseTimeZone(sequelize) {
 // otherwise ignore that one
 async function getRemoteTimeZone(remote) {
   try {
-    const health = await remote.fetch('health', { timeout: 2000, backoff: { maxAttempts: 1 } });
+    const health = await remote.fetch('health', { timeout: 2000, backoff: { maxAttempts: 1 }, preserveBackoffForAuthAttempt: true });
     const { countryTimeZone } = health.config;
     return countryTimeZone;
   } catch (error) {


### PR DESCRIPTION
### Changes

This has been something that annoyed me for a bit. Facility is not accessible until it waits to make a connection to the central server, which is a tad inconvenient for dev work, but seems very much undesirable on production IMO. The connection we are waiting is to get the central server time zone and we do not perform any action on the result, other than a log.

Currently, with defaults, it takes the facility server an extra 76 seconds to start (backoff attempts in milliseconds are: 300 * 2 + 600 + 900 + 1500 + 2400 + 3900 + 6300 + 10000 * 6).

With this change, we'll just wait for login to fail once if central server is unavailable at time of request.

I believe that ever since we implemented the facility server being able to come up online without connecting to central this should've been the behavior anyway, but a couple of refactors made it so that we didn't respect the backoff specified for auth retries. Lastly, I'm not confident enough that we should preserve the specified backoff every time, but for this particular check it should be okay - hence my approach here.

PS: this seems a bit tough to test, so if whoever is reviewing thinks it's needed, spin up a dev server and check the facility is immediately available. Otherwise I'll just merge as is
