### PR TITLE
feat(invoicing): SAV-1054: Palau sliding scale discounts

### DIFF
--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -370,6 +370,11 @@ export const globalSettings = {
               type: yup.boolean(),
               defaultValue: false,
             },
+            slidingFeeScale: {
+              description: 'This setting allows sliding fee scale to be applied to invoices.',
+              type: yup.boolean(),
+              defaultValue: true,
+            },
           },
         },
         labRequest: {

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -373,7 +373,7 @@ export const globalSettings = {
             slidingFeeScale: {
               description: 'This setting allows sliding fee scale to be applied to invoices.',
               type: yup.boolean(),
-              defaultValue: true,
+              defaultValue: false,
             },
           },
         },

--- a/packages/shared/src/utils/invoice/invoice.js
+++ b/packages/shared/src/utils/invoice/invoice.js
@@ -118,6 +118,15 @@ export const getInsuranceCoverageTotal = invoiceItems => {
 };
 
 /**
+ * Get the discount amount of an invoice discount
+ * @param {InvoiceDiscount} discount
+ * @param {number} total
+ */
+const getInvoiceDiscountDiscountAmount = (discount, total) => {
+  return discountAmount(total || 0, discount?.percentage || 0);
+};
+
+/**
  * get invoice summary
  * @param {Invoice} invoice
  * @returns
@@ -131,7 +140,11 @@ export const getInvoiceSummary = invoice => {
   );
 
   const insuranceCoverageTotal = getInsuranceCoverageTotal(invoice.items);
-  const patientTotal = invoiceItemsTotal.minus(insuranceCoverageTotal);
+
+  const patientSubtotal = invoiceItemsTotal.minus(insuranceCoverageTotal);
+  const discountTotal = getInvoiceDiscountDiscountAmount(invoice.discount, patientSubtotal);
+
+  const patientTotal = patientSubtotal.minus(discountTotal);
 
   // Calculate payments as well
   const payments = invoice?.payments || [];
@@ -156,9 +169,10 @@ export const getInvoiceSummary = invoice => {
 
   return {
     invoiceItemsTotal: invoiceItemsTotal.toNumber(),
-    patientSubtotal: invoiceItemsTotal.toNumber(),
     insuranceCoverageTotal: insuranceCoverageTotal.toNumber(),
     patientTotal: patientTotal.toNumber(),
+    discountTotal: discountTotal,
+    patientSubtotal: patientSubtotal.toNumber(),
     patientPaymentsTotal,
     insurerPaymentsTotal,
     paymentsTotal,

--- a/packages/web/app/features/Invoice/InvoiceDiscountModal/InvoiceDiscountModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceDiscountModal/InvoiceDiscountModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Modal, TranslatedText } from '@tamanu/ui-components';
 import { InvoiceDiscountAssessmentForm } from './InvoiceDiscountAssessmentForm';
 
-export const InvoiceDiscountModal = ({ open, onClose, invoice }) => {
+export const InvoiceDiscountModal = ({ open, onClose, handleUpdateDiscount }) => {
   return (
     <Modal
       width="sm"
@@ -15,7 +15,10 @@ export const InvoiceDiscountModal = ({ open, onClose, invoice }) => {
       open={open}
       onClose={onClose}
     >
-      <InvoiceDiscountAssessmentForm onClose={onClose} invoice={invoice} />
+      <InvoiceDiscountAssessmentForm
+        onClose={onClose}
+        handleUpdateDiscount={handleUpdateDiscount}
+      />
     </Modal>
   );
 };

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -71,6 +71,10 @@ export const InvoiceForm = ({ invoice }) => {
     setDiscountModalOpen(false);
   };
 
+  const handleRemoveDiscount = () => {
+    updateInvoice({ ...invoice, discount: null });
+  };
+
   const handleShowErrorDialog = errors => {
     return Object.keys(errors).length === 1 && errors['totalInsurerPercentage'];
   };
@@ -152,7 +156,9 @@ export const InvoiceForm = ({ invoice }) => {
                         )}
                         <InvoiceSummaryPanel
                           invoiceItems={values.invoiceItems}
+                          invoiceDiscount={invoice.discount}
                           openDiscountModal={() => setDiscountModalOpen(true)}
+                          handleRemoveDiscount={handleRemoveDiscount}
                         />
                         <InvoiceDiscountModal
                           open={discountModalOpen}

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 import { Plus } from 'lucide-react';
@@ -14,6 +14,7 @@ import { useAuth } from '../../../contexts/Auth';
 import { invoiceFormSchema } from './invoiceFormSchema';
 import { InvoiceSummaryPanel } from '../InvoiceSummaryPanel';
 import { getCurrentDateString } from '@tamanu/utils/dateTime';
+import { InvoiceDiscountModal } from '../InvoiceDiscountModal/InvoiceDiscountModal.jsx';
 
 const AddButton = styled(MuiButton)`
   font-size: 14px;
@@ -47,6 +48,7 @@ const FormFooter = styled.div`
 const getDefaultRow = () => ({ id: uuidv4(), quantity: 1, orderDate: getCurrentDateString() });
 
 export const InvoiceForm = ({ invoice }) => {
+  const [discountModalOpen, setDiscountModalOpen] = useState(false);
   const { ability } = useAuth();
   const canWriteInvoice = ability.can('write', 'Invoice');
   const editable = isInvoiceEditable(invoice) && canWriteInvoice;
@@ -62,6 +64,11 @@ export const InvoiceForm = ({ invoice }) => {
         percentage: insurer.percentage / 100,
       })),
     });
+  };
+
+  const handleUpdateDiscount = discountData => {
+    updateInvoice({ ...invoice, discount: discountData });
+    setDiscountModalOpen(false);
   };
 
   const handleShowErrorDialog = errors => {
@@ -143,7 +150,15 @@ export const InvoiceForm = ({ invoice }) => {
                             </SubmitButton>
                           </Box>
                         )}
-                        <InvoiceSummaryPanel invoiceItems={values.invoiceItems} />
+                        <InvoiceSummaryPanel
+                          invoiceItems={values.invoiceItems}
+                          openDiscountModal={() => setDiscountModalOpen(true)}
+                        />
+                        <InvoiceDiscountModal
+                          open={discountModalOpen}
+                          onClose={() => setDiscountModalOpen(false)}
+                          handleUpdateDiscount={handleUpdateDiscount}
+                        />
                       </Box>
                     </FormFooter>
                   )}

--- a/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
+++ b/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Divider } from '@material-ui/core';
+import { Divider, Button } from '@material-ui/core';
 import { getInvoiceSummary } from '@tamanu/shared/utils/invoice';
 import { Colors } from '../../constants';
 import { TranslatedText } from '../../components/Translation';
@@ -18,38 +18,94 @@ const Container = styled.div`
   margin-left: auto;
 `;
 
-const CardItem = styled.div`
+const Row = styled.div`
   display: flex;
   font-size: 14px;
   justify-content: space-between;
   align-items: flex-start;
+  margin-left: ${props => (props.$indent ? '16px' : 0)};
 `;
 
-const TotalCardItem = styled(CardItem)`
-  font-size: 16px;
+const TotalRow = styled(Row)`
+  font-size: ${({ $fontSize = '16px' }) => $fontSize};
   font-weight: 500;
 `;
 
-export const InvoiceSummaryPanel = ({ invoiceItems }) => {
+const AddButton = styled(Button)`
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-left: -8px;
+  text-transform: none;
+  font-weight: 500;
+  font-size: 14px;
+  color: ${props => props.theme.palette.primary.main};
+`;
+
+const RemoveButton = styled(Button)`
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-left: -8px;
+  text-transform: none;
+  font-weight: 400;
+  font-size: 14px;
+  text-decoration: underline;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const SlidingFeeScaleSection = ({ openDiscountModal }) => {
+  const feeScaleAdjustment = '-1.00';
+  const patientSubtotal = '10.00';
+
+  return (
+    <>
+      <TotalRow $fontSize="14px">
+        <TranslatedText stringId="invoice.summary.patientSubtotal" fallback="Patient subtotal" />
+        <Price price={patientSubtotal} data-testid="patient-subtotal" />
+      </TotalRow>
+      <Divider />
+      <Row $indent>
+        <TranslatedText
+          stringId="invoice.summary.feeScaleAdjustment"
+          fallback="Fee scale adjustment"
+        />
+        <Price price={feeScaleAdjustment} data-testid="fee-scale-adjustment" />
+      </Row>
+      <Row $indent>
+        <AddButton onClick={openDiscountModal}>
+          <TranslatedText
+            stringId="invoice.summary.removeSlidingFeeScale"
+            fallback="Remove sliding fee scale"
+          />
+        </AddButton>
+      </Row>
+      <Divider />
+    </>
+  );
+};
+
+export const InvoiceSummaryPanel = ({ invoiceItems, openDiscountModal }) => {
   const { invoiceItemsTotal, insuranceCoverageTotal, patientTotal } = getInvoiceSummary({
     items: invoiceItems,
   });
   const coverageDisplay = insuranceCoverageTotal * -1;
   return (
     <Container>
-      <CardItem>
+      <Row>
         <TranslatedText stringId="invoice.summary.invoiceTotal" fallback="Invoice total" />
         <Price price={invoiceItemsTotal} data-testid="translatedtext-828s" />
-      </CardItem>
-      <CardItem>
+      </Row>
+      <Row>
         <TranslatedText stringId="invoice.summary.insuranceTotal" fallback="Insurance coverage" />
         <Price price={coverageDisplay} data-testid="translatedtext-qedx" />
-      </CardItem>
+      </Row>
       <Divider />
-      <TotalCardItem>
+      <SlidingFeeScaleSection openDiscountModal={openDiscountModal} />
+      <TotalRow>
         <TranslatedText stringId="invoice.summary.patientTotal" fallback="Patient total due" />
         <Price price={patientTotal} data-testid="translatedtext-nst0" />
-      </TotalCardItem>
+      </TotalRow>
     </Container>
   );
 };

--- a/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
+++ b/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
@@ -31,7 +31,7 @@ const TotalRow = styled(Row)`
   font-weight: 500;
 `;
 
-const AddButton = styled(Button)`
+const AddDiscountButton = styled(Button)`
   padding-top: 0;
   padding-bottom: 0;
   margin-left: -8px;
@@ -41,7 +41,7 @@ const AddButton = styled(Button)`
   color: ${props => props.theme.palette.primary.main};
 `;
 
-const RemoveButton = styled(Button)`
+const RemoveDiscountButton = styled(Button)`
   padding-top: 0;
   padding-bottom: 0;
   margin-left: -8px;
@@ -54,10 +54,14 @@ const RemoveButton = styled(Button)`
   }
 `;
 
-const SlidingFeeScaleSection = ({ openDiscountModal }) => {
-  const feeScaleAdjustment = '-1.00';
-  const patientSubtotal = '10.00';
-
+const SlidingFeeScaleSection = ({
+  openDiscountModal,
+  handleRemoveDiscount,
+  discountTotal,
+  patientSubtotal,
+  discountPercentage,
+}) => {
+  const discountDisplay = discountTotal > 0 ? discountTotal * -1 : 0;
   return (
     <>
       <TotalRow $fontSize="14px">
@@ -66,30 +70,55 @@ const SlidingFeeScaleSection = ({ openDiscountModal }) => {
       </TotalRow>
       <Divider />
       <Row $indent>
-        <TranslatedText
-          stringId="invoice.summary.feeScaleAdjustment"
-          fallback="Fee scale adjustment"
-        />
-        <Price price={feeScaleAdjustment} data-testid="fee-scale-adjustment" />
+        <span>
+          <TranslatedText
+            stringId="invoice.summary.feeScaleAdjustment"
+            fallback="Fee scale adjustment"
+          />
+          {discountPercentage && <span> - {discountPercentage * 10}%</span>}
+        </span>
+        <Price price={discountDisplay} data-testid="fee-scale-adjustment" />
       </Row>
       <Row $indent>
-        <AddButton onClick={openDiscountModal}>
-          <TranslatedText
-            stringId="invoice.summary.removeSlidingFeeScale"
-            fallback="Remove sliding fee scale"
-          />
-        </AddButton>
+        {discountTotal ? (
+          <RemoveDiscountButton onClick={handleRemoveDiscount}>
+            <TranslatedText
+              stringId="invoice.summary.removeSlidingFeeScale"
+              fallback="Remove sliding fee scale"
+            />
+          </RemoveDiscountButton>
+        ) : (
+          <AddDiscountButton onClick={openDiscountModal}>
+            <TranslatedText
+              stringId="invoice.summary.applySlidingFeeScale"
+              fallback="Apply sliding fee scale"
+            />
+          </AddDiscountButton>
+        )}
       </Row>
       <Divider />
     </>
   );
 };
 
-export const InvoiceSummaryPanel = ({ invoiceItems, openDiscountModal }) => {
-  const { invoiceItemsTotal, insuranceCoverageTotal, patientTotal } = getInvoiceSummary({
+export const InvoiceSummaryPanel = ({
+  invoiceItems,
+  openDiscountModal,
+  invoiceDiscount,
+  handleRemoveDiscount,
+}) => {
+  const {
+    invoiceItemsTotal,
+    insuranceCoverageTotal,
+    patientTotal,
+    patientSubtotal,
+    discountTotal,
+  } = getInvoiceSummary({
     items: invoiceItems,
+    discount: invoiceDiscount,
   });
-  const coverageDisplay = insuranceCoverageTotal * -1;
+  const coverageDisplay = insuranceCoverageTotal > 0 ? insuranceCoverageTotal * -1 : 0;
+
   return (
     <Container>
       <Row>
@@ -101,7 +130,13 @@ export const InvoiceSummaryPanel = ({ invoiceItems, openDiscountModal }) => {
         <Price price={coverageDisplay} data-testid="translatedtext-qedx" />
       </Row>
       <Divider />
-      <SlidingFeeScaleSection openDiscountModal={openDiscountModal} />
+      <SlidingFeeScaleSection
+        openDiscountModal={openDiscountModal}
+        patientSubtotal={patientSubtotal}
+        discountTotal={discountTotal}
+        handleRemoveDiscount={handleRemoveDiscount}
+        discountPercentage={invoiceDiscount?.percentage}
+      />
       <TotalRow>
         <TranslatedText stringId="invoice.summary.patientTotal" fallback="Patient total due" />
         <Price price={patientTotal} data-testid="translatedtext-nst0" />

--- a/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
+++ b/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
@@ -109,7 +109,7 @@ export const InvoiceSummaryPanel = ({
   handleRemoveDiscount,
 }) => {
   const { getSetting } = useSettings();
-  const slidingFeeScaleEnabled = getSetting('features.slidingFeeScale');
+  const slidingFeeScaleEnabled = getSetting('features.invoicing.slidingFeeScale');
 
   const {
     invoiceItemsTotal,

--- a/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
+++ b/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { Divider, Button } from '@material-ui/core';
 import { getInvoiceSummary } from '@tamanu/shared/utils/invoice';
+import { useSettings } from '@tamanu/ui-components';
 import { Colors } from '../../constants';
 import { TranslatedText } from '../../components/Translation';
 import { Price } from './Price';
-import { useSettings } from '@tamanu/ui-components';
 
 const Container = styled.div`
   align-self: start;
@@ -76,7 +76,7 @@ const SlidingFeeScaleSection = ({
             stringId="invoice.summary.feeScaleAdjustment"
             fallback="Fee scale adjustment"
           />
-          {discountPercentage && <span> - {discountPercentage * 10}%</span>}
+          {discountPercentage && ` - ${discountPercentage * 100}%`}
         </span>
         <Price price={discountDisplay} data-testid="fee-scale-adjustment" />
       </Row>

--- a/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
+++ b/packages/web/app/features/Invoice/InvoiceSummaryPanel.jsx
@@ -5,6 +5,7 @@ import { getInvoiceSummary } from '@tamanu/shared/utils/invoice';
 import { Colors } from '../../constants';
 import { TranslatedText } from '../../components/Translation';
 import { Price } from './Price';
+import { useSettings } from '@tamanu/ui-components';
 
 const Container = styled.div`
   align-self: start;
@@ -107,6 +108,9 @@ export const InvoiceSummaryPanel = ({
   invoiceDiscount,
   handleRemoveDiscount,
 }) => {
+  const { getSetting } = useSettings();
+  const slidingFeeScaleEnabled = getSetting('features.slidingFeeScale');
+
   const {
     invoiceItemsTotal,
     insuranceCoverageTotal,
@@ -115,7 +119,7 @@ export const InvoiceSummaryPanel = ({
     discountTotal,
   } = getInvoiceSummary({
     items: invoiceItems,
-    discount: invoiceDiscount,
+    discount: slidingFeeScaleEnabled ? invoiceDiscount : null,
   });
   const coverageDisplay = insuranceCoverageTotal > 0 ? insuranceCoverageTotal * -1 : 0;
 
@@ -130,13 +134,15 @@ export const InvoiceSummaryPanel = ({
         <Price price={coverageDisplay} data-testid="translatedtext-qedx" />
       </Row>
       <Divider />
-      <SlidingFeeScaleSection
-        openDiscountModal={openDiscountModal}
-        patientSubtotal={patientSubtotal}
-        discountTotal={discountTotal}
-        handleRemoveDiscount={handleRemoveDiscount}
-        discountPercentage={invoiceDiscount?.percentage}
-      />
+      {slidingFeeScaleEnabled && (
+        <SlidingFeeScaleSection
+          openDiscountModal={openDiscountModal}
+          patientSubtotal={patientSubtotal}
+          discountTotal={discountTotal}
+          handleRemoveDiscount={handleRemoveDiscount}
+          discountPercentage={invoiceDiscount?.percentage}
+        />
+      )}
       <TotalRow>
         <TranslatedText stringId="invoice.summary.patientTotal" fallback="Patient total due" />
         <Price price={patientTotal} data-testid="translatedtext-nst0" />


### PR DESCRIPTION
### Changes

**New Global Setting for Sliding Fee Scale**
Add new global setting, features.slidingFeeScale which controls whether the sliding fee scale can be applied to invoices.

**Invoice Summary Calculation Logic Update**
The getInvoiceSummary utility function has been enhanced to correctly calculate and apply discounts. It now first determines the patientSubtotal (total items minus insurance coverage) and then applies any invoice.discount to derive the final patientTotal.

**Re-Introduce Invoice Discount Modal**
The InvoiceDiscountAssessmentForm and InvoiceDiscountModal components have been updated to support the new sliding fee scale.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
