### PR TITLE
fix: NASS-1839: Duplicate system note generation

### DIFF
--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -162,11 +162,6 @@ export class Triage extends Model {
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await onChangeTextColumn({
-        columnName: 'triageTime',
-        fieldLabel: 'triage time',
-        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
-      });
-      await onChangeTextColumn({
         columnName: 'score',
         fieldLabel: 'triage score',
       });


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses duplicate system notes by adjusting triage update logging.
> 
> - Removes `onChangeTextColumn` for `triageTime` in `Triage.update`; changes to triage time no longer create system note entries
> - Change tracking for `arrivalTime`, `score`, and foreign keys remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d21cad8168a63031e7025579f39a5807fc7c6ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->