### PR TITLE
tweak: NASS-1815: Update encounter summary pane for emergency encounters

### DIFF
--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -48,10 +48,12 @@ export class Triage extends Model {
 
     this.belongsTo(models.ReferenceData, {
       foreignKey: 'chiefComplaintId',
+      as: 'chiefComplaint',
     });
 
     this.belongsTo(models.ReferenceData, {
       foreignKey: 'secondaryComplaintId',
+      as: 'secondaryComplaint',
     });
 
     this.belongsTo(models.ReferenceData, {
@@ -67,6 +69,10 @@ export class Triage extends Model {
         recordType: this.name,
       },
     });
+  }
+
+  static getListReferenceAssociations() {
+    return ['chiefComplaint', 'secondaryComplaint'];
   }
 
   static buildPatientSyncFilter(patientCount: number, markedForSyncPatientsTable: string) {

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -202,6 +202,8 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
   const [isEstimatedDischargeModalOpen, setIsEstimatedDischargeModalOpen] = useState(false);
   const canWriteEncounter = ability.can('write', 'Encounter');
 
+  const triage = triage;
+
   return (
     <InfoCard inlineValues contentPadding={25} paddingTop={0} data-testid="infocard-o4i8">
       <InfoCardFirstColumn data-testid="infocardfirstcolumn-u3u3">
@@ -383,15 +385,12 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
                 />
               }
               value={
-                encounter.triages?.[0]?.chiefComplaint ? (
-                  <TranslatedReferenceData
-                    category="triageReason"
-                    value={encounter.triages[0].chiefComplaint.id}
-                    fallback={encounter.triages[0].chiefComplaint.name}
-                  />
-                ) : (
-                  '—'
-                )
+                <TranslatedReferenceData
+                  category="triageReason"
+                  value={triage.chiefComplaint.id}
+                  fallback={triage.chiefComplaint.name}
+                  placeholder="—"
+                />
               }
               icon={reasonForEncounterIcon}
               data-testid="infocarditem-chiefComplaint"
@@ -405,15 +404,12 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
                 />
               }
               value={
-                encounter.triages?.[0]?.secondaryComplaint ? (
-                  <TranslatedReferenceData
-                    category="triageReason"
-                    value={encounter.triages[0].secondaryComplaint.id}
-                    fallback={encounter.triages[0].secondaryComplaint.name}
-                  />
-                ) : (
-                  '—'
-                )
+                <TranslatedReferenceData
+                  category="triageReason"
+                  value={triage.secondaryComplaint.id}
+                  fallback={triage.secondaryComplaint.name}
+                  placeholder="—"
+                />
               }
               icon={reasonForEncounterIcon}
               data-testid="infocarditem-secondaryComplaint"

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -242,7 +242,7 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
                 data-testid="translatedtext-l4wd"
               />
             }
-            value={encounter.triages?.[0]?.score || '—'}
+            value={triage.score || '—'}
             icon={triageScoreIcon}
             data-testid="infocarditem-p5t5"
           />

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -202,7 +202,7 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
   const [isEstimatedDischargeModalOpen, setIsEstimatedDischargeModalOpen] = useState(false);
   const canWriteEncounter = ability.can('write', 'Encounter');
 
-  const triage = triage;
+  const triage = encounter.triages?.[0];
 
   return (
     <InfoCard inlineValues contentPadding={25} paddingTop={0} data-testid="infocard-o4i8">

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -372,19 +372,68 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
             data-testid="infocarditem-n7q6"
           />
         )}
-        <InfoCardItem
-          label={
-            <TranslatedText
-              stringId="encounter.reasonForEncounter.label"
-              fallback="Reason for encounter"
-              data-testid="translatedtext-3602"
+        {isEmergencyPatient(encounter.encounterType) ? (
+          <>
+            <InfoCardItem
+              label={
+                <TranslatedText
+                  stringId="triage.chiefComplaint.label"
+                  fallback="Chief complaint"
+                  data-testid="translatedtext-3602"
+                />
+              }
+              value={
+                encounter.triages?.[0]?.chiefComplaint ? (
+                  <TranslatedReferenceData
+                    category="triageReason"
+                    value={encounter.triages[0].chiefComplaint.id}
+                    fallback={encounter.triages[0].chiefComplaint.name}
+                  />
+                ) : (
+                  '—'
+                )
+              }
+              icon={reasonForEncounterIcon}
+              data-testid="infocarditem-chiefComplaint"
             />
-          }
-          value={encounter.reasonForEncounter}
-          icon={reasonForEncounterIcon}
-          $whiteSpace="normal"
-          data-testid="infocarditem-axjq"
-        />
+            <InfoCardItem
+              label={
+                <TranslatedText
+                  stringId="triage.secondaryComplaint.label"
+                  fallback="Secondary complaint"
+                  data-testid="translatedtext-3602"
+                />
+              }
+              value={
+                encounter.triages?.[0]?.secondaryComplaint ? (
+                  <TranslatedReferenceData
+                    category="triageReason"
+                    value={encounter.triages[0].secondaryComplaint.id}
+                    fallback={encounter.triages[0].secondaryComplaint.name}
+                  />
+                ) : (
+                  '—'
+                )
+              }
+              icon={reasonForEncounterIcon}
+              data-testid="infocarditem-secondaryComplaint"
+            />
+          </>
+        ) : (
+          <InfoCardItem
+            label={
+              <TranslatedText
+                stringId="encounter.reasonForEncounter.label"
+                fallback="Reason for encounter"
+                data-testid="translatedtext-3602"
+              />
+            }
+            value={encounter.reasonForEncounter}
+            icon={reasonForEncounterIcon}
+            $whiteSpace="normal"
+            data-testid="infocarditem-axjq"
+          />
+        )}
       </InfoCardSecondColumn>
     </InfoCard>
   );

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -242,7 +242,7 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
                 data-testid="translatedtext-l4wd"
               />
             }
-            value={triage.score || '—'}
+            value={triage?.score || '—'}
             icon={triageScoreIcon}
             data-testid="infocarditem-p5t5"
           />
@@ -387,8 +387,8 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               value={
                 <TranslatedReferenceData
                   category="triageReason"
-                  value={triage.chiefComplaint.id}
-                  fallback={triage.chiefComplaint.name}
+                  value={triage?.chiefComplaint.id}
+                  fallback={triage?.chiefComplaint.name}
                   placeholder="—"
                 />
               }
@@ -406,8 +406,8 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               value={
                 <TranslatedReferenceData
                   category="triageReason"
-                  value={triage.secondaryComplaint.id}
-                  fallback={triage.secondaryComplaint.name}
+                  value={triage?.secondaryComplaint.id}
+                  fallback={triage?.secondaryComplaint.name}
                   placeholder="—"
                 />
               }


### PR DESCRIPTION
### Changes

Small design change to show the Chief and Secondary complaint instead of encounter reason in the summary pane for emergency type encounters.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows triage complaints in encounter summary and exposes related associations.
> 
> - UI: In `EncounterInfoPane.jsx`, for emergency encounters display `triage.chiefComplaint` and `triage.secondaryComplaint` (via `TranslatedReferenceData`) instead of `reasonForEncounter`; non-emergency still shows `reasonForEncounter`.
> - Model: In `Triage.ts`, add `as: 'chiefComplaint'` and `as: 'secondaryComplaint'` for reference associations and introduce `getListReferenceAssociations()` returning these fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d73623a9cd041b3f314cfb88fa862dad0c8bb68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->