### PR TITLE
chore: no-issue: Add CLAUDE.md files for AI assistant guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Tamanu - Development Guidelines for AI Assistants
+
+This file contains rules and patterns that AI assistants should follow when working on this codebase.
+
+## Pull Requests
+
+### Always Use the PR Template
+
+When creating pull requests with `gh pr create`, always use the repository's PR template. Do NOT provide a custom `--body` flag. Instead, let the template populate and fill in the sections:
+
+```bash
+# Correct - uses template
+gh pr create --title "feat(scope): description" --fill
+
+# Wrong - overwrites template
+gh pr create --title "..." --body "custom body"
+```
+
+The PR template (`.github/pull_request_template.md`) contains important elements:
+- **Deploy checkbox**: `<!-- #deploy -->` triggers deployment to Tamanu Internal
+- **E2E checkbox**: `<!-- #e2e -->` triggers end-to-end tests
+- **Reminder checklist**: Important steps like updating docs, adding tests, etc.
+
+After creating the PR, edit it on GitHub to fill in the "Changes" section with a description.
+
+## Package-Specific Guidelines
+
+See also:
+- `packages/database/CLAUDE.md` - Database and migration patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,16 @@ The PR template (`.github/pull_request_template.md`) contains important elements
 
 After creating the PR, edit it on GitHub to fill in the "Changes" section with a description.
 
+## Release Branches
+
+To check releases, look at the `release/2.xx` branches (e.g., `release/2.41`, `release/2.47`).
+The most recent release will be the highest version branch of that form.
+
+Example:
+```bash
+git branch -r | grep 'release/2\.' | sort -V | tail -5
+```
+
 ## Package-Specific Guidelines
 
 See also:

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -55,3 +55,20 @@ export async function up(query: QueryInterface): Promise<void> {
   await query.removeColumn('users', 'old_column');
 }
 ```
+
+### Mark Destructive Down Functions
+
+When a migration's `down` function cannot fully restore the original state (e.g., data loss), add a `// DESTRUCTIVE:` comment explaining what won't be restored:
+
+```typescript
+export async function down(query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: This will not restore the original values - all rows will get default 0
+  await query.addColumn('users', 'some_column', {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  });
+}
+```
+
+This helps developers understand the consequences of rolling back a migration.

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -1,0 +1,57 @@
+# Database Package - Development Guidelines
+
+This file contains patterns and conventions for the database package that should be followed when making changes.
+
+## Migration Patterns
+
+### Never Mix DDL and DML in the Same Migration
+
+**Problem:** PostgreSQL uses deferred constraint triggers for audit logging. When you UPDATE a table, trigger events are queued to fire at transaction commit. If you then try to ALTER TABLE (add/remove columns) in the same transaction, PostgreSQL throws:
+
+```
+error: cannot ALTER TABLE "table_name" because it has pending trigger events
+```
+
+**Solution:** Split migrations that need to both modify data and change schema into separate files:
+
+1. **DDL Migration** - Schema changes only (addColumn, removeColumn, changeColumn)
+2. **DML Migration** - Data changes only (UPDATE, INSERT, DELETE)
+3. **DDL Migration** - Any remaining schema changes
+
+**Example:** Renaming/transforming a column:
+
+```
+1766100000000-addNewColumn.ts        (DDL: add the new column)
+1766100000001-migrateData.ts         (DML: UPDATE to copy/transform data)
+1766100000002-dropOldColumn.ts       (DDL: remove the old column)
+```
+
+Each migration runs in its own transaction, so trigger events are processed between migrations.
+
+**Bad - will fail:**
+```typescript
+// Single migration - DON'T DO THIS
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('users', 'new_column', { type: DataTypes.TEXT });
+  await query.sequelize.query(`UPDATE users SET new_column = old_column`);
+  await query.removeColumn('users', 'old_column'); // FAILS: pending trigger events
+}
+```
+
+**Good - split into separate files:**
+```typescript
+// Migration 1: addNewColumn.ts
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('users', 'new_column', { type: DataTypes.TEXT });
+}
+
+// Migration 2: migrateData.ts
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`UPDATE users SET new_column = old_column`);
+}
+
+// Migration 3: dropOldColumn.ts
+export async function up(query: QueryInterface): Promise<void> {
+  await query.removeColumn('users', 'old_column');
+}
+```


### PR DESCRIPTION
Adds documentation for AI assistants working on the codebase:
- Root CLAUDE.md: PR template rules
- packages/database/CLAUDE.md: Migration patterns (DDL/DML separation)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation to guide AI assistants working in this repo.
> 
> - New `CLAUDE.md` with PR creation rules: always use repo PR template (`--fill`), avoid custom bodies, and note deploy/E2E checkboxes and reminders
> - New `packages/database/CLAUDE.md` detailing migration patterns: never mix DDL and DML in one migration; split into sequential migrations; annotate destructive `down` functions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff9995faf9f279faf805381c036324371f366eda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->