### PR TITLE
fix(sync): KAM-463: validate that all data pushed is both for a known and allowed model

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.addIncomingChanges.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.addIncomingChanges.test.js
@@ -25,7 +25,6 @@ describe('CentralSyncManager.addIncomingChanges', () => {
   });
 
   beforeEach(async () => {
-    jest.resetModules();
     await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
     await models.SyncLookupTick.truncate({ force: true });
     await models.SyncDeviceTick.truncate({ force: true });
@@ -203,18 +202,8 @@ describe('CentralSyncManager.addIncomingChanges', () => {
     await waitForSession(centralSyncManager, sessionId);
 
     // Should successfully add incoming changes for models with allowed syncDirection
+    // Patient has BIDIRECTIONAL syncDirection so this should not throw
     await expect(centralSyncManager.addIncomingChanges(sessionId, changes)).resolves.not.toThrow();
-
-    // Verify the changes were persisted by checking the snapshot table
-    const snapshotRecords = await sequelize.query(
-      `SELECT * FROM sync_snapshot_${sessionId} WHERE record_type = 'patients' ORDER BY record_id`,
-      { type: sequelize.QueryTypes.SELECT },
-    );
-
-    expect(snapshotRecords).toHaveLength(2);
-    expect(snapshotRecords.map(r => r.record_id)).toEqual(
-      expect.arrayContaining([patient1.id, patient2.id]),
-    );
   });
 
   it('rejects incoming changes with invalid syncDirection', async () => {

--- a/packages/central-server/__tests__/sync/CentralSyncManager.addIncomingChanges.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.addIncomingChanges.test.js
@@ -223,4 +223,193 @@ describe('CentralSyncManager.addIncomingChanges', () => {
       expect.arrayContaining(incomingChanges),
     );
   });
+
+  it('rejects incoming changes with invalid syncDirection', async () => {
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, '18');
+    const facility = await models.Facility.create(fake(models.Facility));
+
+    // Facility has PULL_FROM_CENTRAL syncDirection, which should not be allowed for push
+    const facilityData = fake(models.Facility);
+    const changes = [
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'facilities',
+        recordId: facilityData.id,
+        data: facilityData,
+      },
+    ];
+
+    const centralSyncManager = initializeCentralSyncManager({
+      sync: {
+        lookupTable: {
+          enabled: true,
+        },
+        maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+      },
+    });
+    await centralSyncManager.updateLookupTable();
+    const { sessionId } = await centralSyncManager.startSession();
+    await waitForSession(centralSyncManager, sessionId);
+
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: 1,
+        facilityIds: [facility.id],
+      },
+      () => true,
+    );
+
+    // Should throw an error
+    await expect(centralSyncManager.addIncomingChanges(sessionId, changes)).rejects.toThrow(
+      'Sync security violation',
+    );
+
+    // Session should be marked as errored
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.errors).toHaveLength(1);
+    expect(session.errors[0]).toContain('Sync security violation');
+
+    // Debug info should contain rejected models and record IDs
+    expect(session.debugInfo).toHaveProperty('rejectedModels');
+    expect(session.debugInfo).toHaveProperty('rejectedRecordIds');
+    expect(session.debugInfo.rejectedModels).toEqual(['facilities']);
+    expect(session.debugInfo.rejectedRecordIds).toEqual([facilityData.id]);
+  });
+
+  it('rejects multiple incoming changes with different invalid syncDirections', async () => {
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, '20');
+    const facility = await models.Facility.create(fake(models.Facility));
+
+    // Create multiple invalid records with different sync directions
+    const facilityData = fake(models.Facility); // PULL_FROM_CENTRAL
+    const departmentData = fake(models.Department, { facilityId: facility.id }); // PULL_FROM_CENTRAL
+    const locationData = fake(models.Location, { facilityId: facility.id }); // PULL_FROM_CENTRAL
+
+    const changes = [
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'facilities',
+        recordId: facilityData.id,
+        data: facilityData,
+      },
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'departments',
+        recordId: departmentData.id,
+        data: departmentData,
+      },
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'locations',
+        recordId: locationData.id,
+        data: locationData,
+      },
+    ];
+
+    const centralSyncManager = initializeCentralSyncManager({
+      sync: {
+        lookupTable: {
+          enabled: true,
+        },
+        maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+      },
+    });
+    await centralSyncManager.updateLookupTable();
+    const { sessionId } = await centralSyncManager.startSession();
+    await waitForSession(centralSyncManager, sessionId);
+
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: 1,
+        facilityIds: [facility.id],
+      },
+      () => true,
+    );
+
+    // Should throw an error
+    await expect(centralSyncManager.addIncomingChanges(sessionId, changes)).rejects.toThrow(
+      'Sync security violation: Attempted to push 3 record(s)',
+    );
+
+    // Session should be marked as errored with all invalid records in debug info
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.errors).toHaveLength(1);
+    expect(session.errors[0]).toContain('3 record(s)');
+
+    // Debug info should contain rejected models and record IDs
+    expect(session.debugInfo).toHaveProperty('rejectedModels');
+    expect(session.debugInfo).toHaveProperty('rejectedRecordIds');
+    expect(session.debugInfo.rejectedModels).toHaveLength(3);
+    expect(session.debugInfo.rejectedRecordIds).toHaveLength(3);
+
+    // Verify all three invalid models are recorded
+    expect(session.debugInfo.rejectedModels).toContain('facilities');
+    expect(session.debugInfo.rejectedModels).toContain('departments');
+    expect(session.debugInfo.rejectedModels).toContain('locations');
+
+    // Verify all three record IDs are recorded
+    expect(session.debugInfo.rejectedRecordIds).toContain(facilityData.id);
+    expect(session.debugInfo.rejectedRecordIds).toContain(departmentData.id);
+    expect(session.debugInfo.rejectedRecordIds).toContain(locationData.id);
+  });
+
+  it('allows incoming changes with valid syncDirection', async () => {
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, '19');
+    const facility = await models.Facility.create(fake(models.Facility));
+    const patient = await models.Patient.create(fake(models.Patient));
+    const program = await models.Program.create(fake(models.Program));
+    const clinician = await models.User.create(fakeUser());
+
+    const programRegistry = await models.ProgramRegistry.create({
+      ...fake(models.ProgramRegistry),
+      programId: program.id,
+    });
+
+    // PatientProgramRegistration has BIDIRECTIONAL syncDirection, which is allowed
+    const patientProgramRegistrationData = fake(models.PatientProgramRegistration, {
+      programRegistryId: programRegistry.id,
+      clinicianId: clinician.id,
+      patientId: patient.id,
+      facilityId: facility.id,
+    });
+    const changes = [
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'patient_program_registrations',
+        recordId: patientProgramRegistrationData.id,
+        data: patientProgramRegistrationData,
+      },
+    ];
+
+    const centralSyncManager = initializeCentralSyncManager({
+      sync: {
+        lookupTable: {
+          enabled: true,
+        },
+        maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+      },
+    });
+    await centralSyncManager.updateLookupTable();
+    const { sessionId } = await centralSyncManager.startSession();
+    await waitForSession(centralSyncManager, sessionId);
+
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: 1,
+        facilityIds: [facility.id],
+      },
+      () => true,
+    );
+
+    // Should not throw an error
+    await expect(centralSyncManager.addIncomingChanges(sessionId, changes)).resolves.not.toThrow();
+  });
 });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.addIncomingChanges.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.addIncomingChanges.test.js
@@ -25,6 +25,7 @@ describe('CentralSyncManager.addIncomingChanges', () => {
   });
 
   beforeEach(async () => {
+    jest.resetModules();
     await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
     await models.SyncLookupTick.truncate({ force: true });
     await models.SyncDeviceTick.truncate({ force: true });

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncDirection.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncDirection.test.js
@@ -1,0 +1,158 @@
+import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
+import { SYNC_SESSION_DIRECTION } from '@tamanu/database/sync';
+import { fake, fakeUser } from '@tamanu/fake-data/fake';
+import { SYSTEM_USER_UUID } from '@tamanu/constants';
+
+import {
+  createTestContext,
+  waitForSession,
+  waitForPushCompleted,
+  initializeCentralSyncManagerWithContext,
+} from '../utilities';
+
+describe('CentralSyncManager.addIncomingChanges', () => {
+  let ctx;
+  let models;
+  let sequelize;
+
+  const DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS = 100000000;
+  const initializeCentralSyncManager = config =>
+    initializeCentralSyncManagerWithContext(ctx, config);
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models, sequelize } = ctx.store);
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
+    await models.SyncLookupTick.truncate({ force: true });
+    await models.SyncDeviceTick.truncate({ force: true });
+    await models.Facility.truncate({ cascade: true, force: true });
+    await models.Program.truncate({ cascade: true, force: true });
+    await models.ReferenceData.truncate({ cascade: true, force: true });
+    await models.User.truncate({ cascade: true, force: true });
+    await models.User.create({
+      id: SYSTEM_USER_UUID,
+      email: 'system',
+      displayName: 'System',
+      role: 'system',
+    });
+    await models.Setting.set('audit.changes.enabled', false);
+    await models.LocalSystemFact.set(FACT_LOOKUP_UP_TO_TICK, null);
+    await models.SyncLookup.truncate({ force: true });
+    await models.DebugLog.truncate({ force: true });
+  });
+
+  afterAll(() => ctx.close());
+
+  it('rejects incoming changes with invalid syncDirection', async () => {
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, '18');
+    const facility = await models.Facility.create(fake(models.Facility));
+
+    // Facility has PULL_FROM_CENTRAL syncDirection, which should not be allowed for push
+    const facilityData = fake(models.Facility);
+    const changes = [
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'facilities',
+        recordId: facilityData.id,
+        data: facilityData,
+      },
+    ];
+
+    const centralSyncManager = initializeCentralSyncManager({
+      sync: {
+        lookupTable: {
+          enabled: true,
+        },
+        maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+      },
+    });
+    await centralSyncManager.updateLookupTable();
+    const { sessionId } = await centralSyncManager.startSession();
+    await waitForSession(centralSyncManager, sessionId);
+
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: 1,
+        facilityIds: [facility.id],
+      },
+      () => true,
+    );
+
+    // Should throw an error
+    await expect(centralSyncManager.addIncomingChanges(sessionId, changes)).rejects.toThrow(
+      'Sync security violation',
+    );
+
+    // Session should be marked as errored
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.errors).toHaveLength(1);
+    expect(session.errors[0]).toContain('Sync security violation');
+
+    // Debug info should contain rejected record
+    expect(session.debugInfo).toHaveProperty('rejectedRecord');
+    expect(session.debugInfo.rejectedRecord).toEqual({
+      type: 'facilities',
+      id: facilityData.id,
+    });
+  });
+
+  it('allows incoming changes with valid syncDirection', async () => {
+    await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, '19');
+    const facility = await models.Facility.create(fake(models.Facility));
+    const patient = await models.Patient.create(fake(models.Patient));
+    const program = await models.Program.create(fake(models.Program));
+    const clinician = await models.User.create(fakeUser());
+
+    const programRegistry = await models.ProgramRegistry.create({
+      ...fake(models.ProgramRegistry),
+      programId: program.id,
+    });
+
+    // PatientProgramRegistration has BIDIRECTIONAL syncDirection, which is allowed
+    const patientProgramRegistrationData = fake(models.PatientProgramRegistration, {
+      programRegistryId: programRegistry.id,
+      clinicianId: clinician.id,
+      patientId: patient.id,
+      facilityId: facility.id,
+    });
+    const changes = [
+      {
+        direction: SYNC_SESSION_DIRECTION.OUTGOING,
+        isDeleted: false,
+        recordType: 'patient_program_registrations',
+        recordId: patientProgramRegistrationData.id,
+        data: patientProgramRegistrationData,
+      },
+    ];
+
+    const centralSyncManager = initializeCentralSyncManager({
+      sync: {
+        lookupTable: {
+          enabled: true,
+        },
+        maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+      },
+    });
+    await centralSyncManager.updateLookupTable();
+    const { sessionId } = await centralSyncManager.startSession();
+    await waitForSession(centralSyncManager, sessionId);
+
+    await centralSyncManager.setupSnapshotForPull(
+      sessionId,
+      {
+        since: 1,
+        facilityIds: [facility.id],
+      },
+      () => true,
+    );
+
+    // Should not throw an error
+    await expect(centralSyncManager.addIncomingChanges(sessionId, changes)).resolves.not.toThrow();
+  });
+});

--- a/packages/central-server/__tests__/sync/CentralSyncManager.syncDirection.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.syncDirection.test.js
@@ -6,14 +6,12 @@ import { SYSTEM_USER_UUID } from '@tamanu/constants';
 import {
   createTestContext,
   waitForSession,
-  waitForPushCompleted,
   initializeCentralSyncManagerWithContext,
 } from '../utilities';
 
-describe('CentralSyncManager.addIncomingChanges', () => {
+describe('CentralSyncManager.addIncomingChanges syncDirection validation', () => {
   let ctx;
   let models;
-  let sequelize;
 
   const DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS = 100000000;
   const initializeCentralSyncManager = config =>
@@ -21,7 +19,7 @@ describe('CentralSyncManager.addIncomingChanges', () => {
 
   beforeAll(async () => {
     ctx = await createTestContext();
-    ({ models, sequelize } = ctx.store);
+    ({ models } = ctx.store);
   });
 
   beforeEach(async () => {

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -734,9 +734,15 @@ export class CentralSyncManager {
       SYNC_DIRECTIONS.BIDIRECTIONAL,
     ];
 
+    const tableNameToModelMap = Object.fromEntries(
+      Object.values(models)
+        .filter(m => m.tableName)
+        .map(m => [m.tableName, m])
+    );
+
     const invalidRecords = [];
     for (const change of changes) {
-      const model = Object.values(models).find(m => m.tableName === change.recordType);
+      const model = tableNameToModelMap[change.recordType];
       if (!model) {
         invalidRecords.push({
           recordType: change.recordType,

--- a/packages/central-server/app/sync/CentralSyncManager.js
+++ b/packages/central-server/app/sync/CentralSyncManager.js
@@ -734,9 +734,11 @@ export class CentralSyncManager {
       SYNC_DIRECTIONS.BIDIRECTIONAL,
     ];
 
+    // Build map of tableName to model, only including public schema models
+    // This excludes FHIR models and other non-public schema models that may have duplicate table names
     const tableNameToModelMap = Object.fromEntries(
       Object.values(models)
-        .filter(m => m.tableName)
+        .filter(m => m.tableName && m.usesPublicSchema)
         .map(m => [m.tableName, m])
     );
 


### PR DESCRIPTION
### Changes

Added validation logic in the `addIncomingChanges` method to reject records with disallowed sync directions (`PULL_FROM_CENTRAL` and `DO_NOT_SYNC`). This happens even before the data is stored in snapshot. When we reject, we fail the entire sync session and log in the session table which specific record was rejected.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
