### PR TITLE
feat(fhir): NASS-1885: Added FHIR /Bundle endpoint

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/transactionBundle.test.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/transactionBundle.test.js
@@ -201,7 +201,10 @@ describe(`FHIR API - Transaction Bundle`, () => {
 
       // assert
       expect(response).toHaveSucceeded();
-      expect(response.status).toBe(201);
+      expect(response.status).toBe(200);
+      expect(response.body.resourceType).toBe('Bundle');
+      expect(response.body.type).toBe('transaction-response');
+      expect(response.body.response.status).toBe('201');
       const ires = await ImagingResult.findOne({
         where: { externalCode: 'ACCESSION' },
       });

--- a/packages/central-server/__tests__/hl7fhir/routeHandlersTests/transactionBundle.test.js
+++ b/packages/central-server/__tests__/hl7fhir/routeHandlersTests/transactionBundle.test.js
@@ -1,0 +1,350 @@
+/* eslint-disable no-unused-expressions */
+
+import { fake, fakeReferenceData } from '@tamanu/fake-data/fake';
+
+import { createTestContext } from '../../utilities';
+import {
+  FHIR_DIAGNOSTIC_REPORT_STATUS,
+  IMAGING_REQUEST_STATUS_TYPES,
+  LAB_REQUEST_STATUSES,
+} from '@tamanu/constants';
+import { fakeResourcesOfFhirServiceRequestWithLabRequest } from '../../fake/fhir';
+
+const PATH = '/api/integration/fhir/mat/Bundle';
+
+describe(`FHIR API - Transaction Bundle`, () => {
+  let ctx;
+  let app;
+  let resources;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    app = await ctx.baseApp.asRole('practitioner');
+
+    const {
+      Department,
+      Facility,
+      ImagingAreaExternalCode,
+      Location,
+      Patient,
+      ReferenceData,
+      User,
+      FhirPatient,
+      Encounter,
+    } = ctx.store.models;
+
+    const [practitioner, patient, area1, area2, facility] = await Promise.all([
+      User.create(fake(User)),
+      Patient.create(fake(Patient)),
+      ReferenceData.create({ ...fakeReferenceData('xRay'), type: 'xRayImagingArea' }),
+      ReferenceData.create({ ...fakeReferenceData('xRay'), type: 'xRayImagingArea' }),
+      Facility.create(fake(Facility)),
+    ]);
+
+    const location = await Location.create(fake(Location, { facilityId: facility.id }));
+    const department = await Department.create(
+      fake(Department, { locationId: location.id, facilityId: facility.id }),
+    );
+
+    const [extCode1, extCode2, pat] = await Promise.all([
+      ImagingAreaExternalCode.create(fake(ImagingAreaExternalCode, { areaId: area1.id })),
+      ImagingAreaExternalCode.create(fake(ImagingAreaExternalCode, { areaId: area2.id })),
+      FhirPatient.materialiseFromUpstream(patient.id),
+    ]);
+
+    const encounter = await Encounter.create(
+      fake(Encounter, {
+        patientId: patient.id,
+        locationId: location.id,
+        departmentId: department.id,
+        examinerId: practitioner.id,
+      }),
+    );
+
+    resources = {
+      encounter,
+      practitioner,
+      patient,
+      area1,
+      area2,
+      facility,
+      location,
+      department,
+      extCode1,
+      extCode2,
+      pat,
+    };
+  });
+  afterAll(() => ctx.close());
+
+  describe('success', () => {
+    beforeEach(async () => {
+      const {
+        FhirServiceRequest,
+        FhirWriteLog,
+        ImagingRequest,
+        ImagingRequestArea,
+        ImagingResult,
+        LabRequest,
+        LabTestPanel,
+        LabTestPanelRequest,
+      } = ctx.store.models;
+      await FhirWriteLog.destroy({ where: {} });
+      await FhirServiceRequest.destroy({ where: {} });
+      await ImagingRequest.destroy({ where: {} });
+      await ImagingRequestArea.destroy({ where: {} });
+      await ImagingResult.destroy({ where: {} });
+      await FhirServiceRequest.destroy({ where: {} });
+      await ImagingRequest.destroy({ where: {} });
+      await ImagingRequestArea.destroy({ where: {} });
+      await LabRequest.destroy({ where: {} });
+      await LabTestPanel.destroy({ where: {} });
+      await LabTestPanelRequest.destroy({ where: {} });
+    });
+
+    it('Can multiple resources in a transaction bundle', async () => {
+      // arrange
+      const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
+      const ir = await ImagingRequest.create(
+        fake(ImagingRequest, {
+          requestedById: resources.practitioner.id,
+          encounterId: resources.encounter.id,
+          locationId: resources.location.id,
+          status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+          priority: 'routine',
+          requestedDate: '2022-03-04 15:30:00',
+        }),
+      );
+      await ir.setAreas([resources.area1.id, resources.area2.id]);
+      await ir.reload();
+      const irMat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+      await FhirServiceRequest.resolveUpstreams();
+      const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        {
+          isWithPanels: true,
+        },
+        {
+          status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+        },
+      );
+      const labMat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      await FhirServiceRequest.resolveUpstreams();
+
+      // act
+      const body = {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            resource: {
+              resourceType: 'ImagingStudy',
+              status: 'final',
+              identifier: [
+                {
+                  system: 'http://data-dictionary.tamanu-fiji.org/ris-accession-number.html',
+                  value: 'ACCESSION',
+                },
+              ],
+              basedOn: [
+                {
+                  type: 'ServiceRequest',
+                  reference: `ServiceRequest/${irMat.id}`,
+                },
+              ],
+              note: [{ text: 'This is an okay note' }, { text: 'This is another note' }],
+            },
+            request: {
+              method: 'POST',
+              url: `/api/integration/fhir/mat/ImagingStudy`,
+            },
+          },
+          {
+            resource: {
+              resourceType: 'DiagnosticReport',
+              basedOn: [
+                {
+                  type: 'ServiceRequest',
+                  reference: `ServiceRequest/${labMat.id}`,
+                },
+              ],
+              status: FHIR_DIAGNOSTIC_REPORT_STATUS.FINAL,
+              category: [
+                {
+                  coding: [
+                    {
+                      code: '108252007',
+                      system: 'http://snomed.info/sct',
+                    },
+                  ],
+                },
+              ],
+              code: {
+                coding: [
+                  {
+                    system: 'http://loinc.org',
+                    code: '42191-7',
+                    display: 'Hepatitis Panel',
+                  },
+                ],
+              },
+            },
+            request: {
+              method: 'POST',
+              url: `/api/integration/fhir/mat/DiagnosticReport`,
+            },
+          },
+        ],
+      };
+      const response = await app.post(PATH).send(body);
+
+      // assert
+      expect(response).toHaveSucceeded();
+      expect(response.status).toBe(201);
+      const ires = await ImagingResult.findOne({
+        where: { externalCode: 'ACCESSION' },
+      });
+      expect(ires).toBeTruthy();
+      expect(ires.description).toEqual('This is an okay note\n\nThis is another note');
+
+      await labRequest.reload();
+      expect(labRequest.status).toBe(LAB_REQUEST_STATUSES.VERIFIED);
+    });
+  });
+
+  describe('errors', () => {
+    beforeEach(async () => {
+      const {
+        FhirServiceRequest,
+        FhirWriteLog,
+        ImagingRequest,
+        ImagingRequestArea,
+        ImagingResult,
+        LabRequest,
+        LabTestPanel,
+        LabTestPanelRequest,
+      } = ctx.store.models;
+      await FhirWriteLog.destroy({ where: {} });
+      await FhirServiceRequest.destroy({ where: {} });
+      await ImagingRequest.destroy({ where: {} });
+      await ImagingRequestArea.destroy({ where: {} });
+      await ImagingResult.destroy({ where: {} });
+      await FhirServiceRequest.destroy({ where: {} });
+      await ImagingRequest.destroy({ where: {} });
+      await ImagingRequestArea.destroy({ where: {} });
+      await LabRequest.destroy({ where: {} });
+      await LabTestPanel.destroy({ where: {} });
+      await LabTestPanelRequest.destroy({ where: {} });
+    });
+
+    it('will treat transactions as atomic and will not create a resource if one of the resources is invalid', async () => {
+      // arrange
+      const { FhirServiceRequest, ImagingRequest, ImagingResult } = ctx.store.models;
+      const ir = await ImagingRequest.create(
+        fake(ImagingRequest, {
+          requestedById: resources.practitioner.id,
+          encounterId: resources.encounter.id,
+          locationId: resources.location.id,
+          status: IMAGING_REQUEST_STATUS_TYPES.PENDING,
+          priority: 'routine',
+          requestedDate: '2022-03-04 15:30:00',
+        }),
+      );
+      await ir.setAreas([resources.area1.id, resources.area2.id]);
+      await ir.reload();
+      const irMat = await FhirServiceRequest.materialiseFromUpstream(ir.id);
+      await FhirServiceRequest.resolveUpstreams();
+      const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        {
+          isWithPanels: true,
+        },
+        {
+          status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+        },
+      );
+      const labMat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      await FhirServiceRequest.resolveUpstreams();
+
+      // act
+      const body = {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            resource: {
+              resourceType: 'ImagingStudy',
+              status: 'final',
+              identifier: [
+                {
+                  system: 'http://data-dictionary.tamanu-fiji.org/ris-accession-number.html',
+                  value: 'ACCESSION',
+                },
+              ],
+              basedOn: [
+                {
+                  type: 'ServiceRequest',
+                  reference: `ServiceRequest/${irMat.id}`,
+                },
+              ],
+              note: [{ text: 'This is an okay note' }, { text: 'This is another note' }],
+            },
+            request: {
+              method: 'POST',
+              url: `/api/integration/fhir/mat/ImagingStudy`,
+            },
+          },
+          {
+            resource: {
+              resourceType: 'DiagnosticReport',
+              basedOn: [
+                {
+                  type: 'ServiceRequest',
+                  reference: `ServiceRequest/${labMat.id}`,
+                },
+              ],
+              status: 'invalid_status_that_does_not_exist',
+              category: [
+                {
+                  coding: [
+                    {
+                      code: '108252007',
+                      system: 'http://snomed.info/sct',
+                    },
+                  ],
+                },
+              ],
+              code: {
+                coding: [
+                  {
+                    system: 'http://loinc.org',
+                    code: '42191-7',
+                    display: 'Hepatitis Panel',
+                  },
+                ],
+              },
+            },
+            request: {
+              method: 'POST',
+              url: `/api/integration/fhir/mat/DiagnosticReport`,
+            },
+          },
+        ],
+      };
+      const response = await app.post(PATH).send(body);
+
+      // assert
+      expect(response).not.toHaveSucceeded();
+      expect(response.status).toBe(400); // the request should be rejected because the diagnostic report is invalid
+      const ires = await ImagingResult.findAll({
+        where: { externalCode: 'ACCESSION' },
+      });
+      expect(ires.length).toBe(0); // no imaging result should be created because the diagnostic report is invalid
+
+      await labRequest.reload();
+      expect(labRequest.status).toBe(LAB_REQUEST_STATUSES.RESULTS_PENDING); // the lab request should not be updated because the diagnostic report is invalid
+    });
+  });
+});

--- a/packages/central-server/app/hl7fhir/materialised/BundleResponse.js
+++ b/packages/central-server/app/hl7fhir/materialised/BundleResponse.js
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 
 import { getBaseUrl, getHL7Link } from '../utils';
 
-export class Bundle {
+export class BundleResponse {
   included = [];
 
   issues = [];

--- a/packages/central-server/app/hl7fhir/materialised/bundle/index.js
+++ b/packages/central-server/app/hl7fhir/materialised/bundle/index.js
@@ -1,0 +1,1 @@
+export { transactionBundleHandler } from './transactionBundle';

--- a/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
+++ b/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
@@ -4,6 +4,7 @@ import { FhirTransactionBundle } from '@tamanu/shared/services/fhirTypes';
 import { OperationOutcome } from '@tamanu/shared/utils/fhir';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { createResource } from '../create';
+import { InvalidOperationError } from '@tamanu/errors';
 
 export const transactionBundleHandler = () => {
   return asyncHandler(async (req, res) => {
@@ -18,20 +19,22 @@ export const transactionBundleHandler = () => {
     const createableResources = resourcesThatCanDo(store.models, FHIR_INTERACTIONS.TYPE.CREATE);
 
     // Run all operations in a database transaction to ensure atomicity
-    await store.sequelize.transaction(async () => {
-      for (const { resource: rawResource } of validatedBundle.entry) {
-        const FhirResource = createableResources.find(r => r.fhirName === rawResource.resourceType);
-        if (!FhirResource) {
-          return res
-            .status(400)
-            .send(
-              OperationOutcome.fromMessage(`Resource type ${rawResource.resourceType} not found`),
-            );
-        }
+    try {
+      await store.sequelize.transaction(async () => {
+        for (const { resource: rawResource } of validatedBundle.entry) {
+          const FhirResource = createableResources.find(
+            r => r.fhirName === rawResource.resourceType,
+          );
+          if (!FhirResource) {
+            throw new InvalidOperationError(`Resource type ${rawResource.resourceType} not found`);
+          }
 
-        await createResource(store, FhirResource, rawResource, req.user?.id, settings);
-      }
-    });
+          await createResource(store, FhirResource, rawResource, req.user?.id, settings);
+        }
+      });
+    } catch (err) {
+      return res.status(400).send(new OperationOutcome([err]));
+    }
 
     // TODO: generate ID here, and return it (if resource can be materialised)
     res.status(201).send();

--- a/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
+++ b/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
@@ -1,0 +1,39 @@
+import asyncHandler from 'express-async-handler';
+import { FHIR_INTERACTIONS } from '@tamanu/constants';
+import { FhirTransactionBundle } from '@tamanu/shared/services/fhirTypes';
+import { OperationOutcome } from '@tamanu/shared/utils/fhir';
+import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
+import { createResource } from '../create';
+
+export const transactionBundleHandler = () => {
+  return asyncHandler(async (req, res) => {
+    const { settings, store } = req;
+    let validatedBundle;
+    try {
+      validatedBundle = await FhirTransactionBundle.SCHEMA().validate(req.body);
+    } catch (err) {
+      return res.status(400).send(OperationOutcome.fromYupError(err));
+    }
+
+    const createableResources = resourcesThatCanDo(store.models, FHIR_INTERACTIONS.TYPE.CREATE);
+
+    // Run all operations in a database transaction to ensure atomicity
+    await store.sequelize.transaction(async () => {
+      for (const { resource: rawResource } of validatedBundle.entry) {
+        const FhirResource = createableResources.find(r => r.fhirName === rawResource.resourceType);
+        if (!FhirResource) {
+          return res
+            .status(400)
+            .send(
+              OperationOutcome.fromMessage(`Resource type ${rawResource.resourceType} not found`),
+            );
+        }
+
+        await createResource(store, FhirResource, rawResource, req.user?.id, settings);
+      }
+    });
+
+    // TODO: generate ID here, and return it (if resource can be materialised)
+    res.status(201).send();
+  });
+};

--- a/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
+++ b/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
@@ -16,13 +16,13 @@ export const transactionBundleHandler = () => {
       return res.status(400).send(OperationOutcome.fromYupError(err));
     }
 
-    const createableResources = resourcesThatCanDo(store.models, FHIR_INTERACTIONS.TYPE.CREATE);
+    const creatableResources = resourcesThatCanDo(store.models, FHIR_INTERACTIONS.TYPE.CREATE);
 
     // Run all operations in a database transaction to ensure atomicity
     try {
       await store.sequelize.transaction(async () => {
         for (const { resource: rawResource } of validatedBundle.entry) {
-          const FhirResource = createableResources.find(
+          const FhirResource = creatableResources.find(
             r => r.fhirName === rawResource.resourceType,
           );
           if (!FhirResource) {

--- a/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
+++ b/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
@@ -36,7 +36,7 @@ export const transactionBundleHandler = () => {
         }
       });
     } catch (err) {
-      return res.status(400).send(new OperationOutcome([err]));
+      return res.status(400).send(new OperationOutcome([err]).asFhir());
     }
 
     const responseBundle = new FhirTransactionResponseBundle({

--- a/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
+++ b/packages/central-server/app/hl7fhir/materialised/bundle/transactionBundle.js
@@ -1,6 +1,9 @@
 import asyncHandler from 'express-async-handler';
-import { FHIR_INTERACTIONS } from '@tamanu/constants';
-import { FhirTransactionBundle } from '@tamanu/shared/services/fhirTypes';
+import { FHIR_BUNDLE_TYPES, FHIR_INTERACTIONS } from '@tamanu/constants';
+import {
+  FhirTransactionBundle,
+  FhirTransactionResponseBundle,
+} from '@tamanu/shared/services/fhirTypes';
 import { OperationOutcome } from '@tamanu/shared/utils/fhir';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { createResource } from '../create';
@@ -36,7 +39,13 @@ export const transactionBundleHandler = () => {
       return res.status(400).send(new OperationOutcome([err]));
     }
 
-    // TODO: generate ID here, and return it (if resource can be materialised)
-    res.status(201).send();
+    const responseBundle = new FhirTransactionResponseBundle({
+      resourceType: 'Bundle',
+      type: FHIR_BUNDLE_TYPES.TRANSACTION_RESPONSE,
+      response: {
+        status: '201',
+      },
+    });
+    res.status(200).send(responseBundle);
   });
 };

--- a/packages/central-server/app/hl7fhir/materialised/create.js
+++ b/packages/central-server/app/hl7fhir/materialised/create.js
@@ -12,35 +12,38 @@ async function mapErr(promise, fn) {
   }
 }
 
+export const createResource = async (store, FhirResource, data, requesterId, settings) => {
+  const { FhirJob } = store.models;
+  const validated = await mapErr(
+    FhirResource.INTAKE_SCHEMA.shape({
+      resourceType: yup
+        .string()
+        .test(
+          'is-same-as-route',
+          `must be '${FhirResource.fhirName}'`,
+          t => t === FhirResource.fhirName,
+        )
+        .required(),
+    }).validate(data, { stripUnknown: true }),
+    err => OperationOutcome.fromYupError(err),
+  );
+
+  const resource = new FhirResource(validated);
+  const upstream = await resource.pushUpstream({
+    settings,
+    requesterId,
+  });
+  if (FhirResource.CAN_DO.has(FHIR_INTERACTIONS.INTERNAL.MATERIALISE)) {
+    FhirJob.submit(JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM, {
+      resource: FhirResource.fhirName,
+      upstreamId: upstream.id,
+    });
+  }
+};
+
 export function createHandler(FhirResource) {
   return asyncHandler(async (req, res) => {
-    const { settings, store } = req;
-    const { FhirJob } = store.models;
-    const validated = await mapErr(
-      FhirResource.INTAKE_SCHEMA.shape({
-        resourceType: yup
-          .string()
-          .test(
-            'is-same-as-route',
-            `must be '${FhirResource.fhirName}'`,
-            t => t === FhirResource.fhirName,
-          )
-          .required(),
-      }).validate(req.body, { stripUnknown: true }),
-      err => OperationOutcome.fromYupError(err),
-    );
-
-    const resource = new FhirResource(validated);
-    const upstream = await resource.pushUpstream({
-      settings,
-      requesterId: req.user?.id,
-    });
-    if (FhirResource.CAN_DO.has(FHIR_INTERACTIONS.INTERNAL.MATERIALISE)) {
-      FhirJob.submit(JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM, {
-        resource: FhirResource.fhirName,
-        upstreamId: upstream.id,
-      });
-    }
+    await createResource(req.store, FhirResource, req.body, req.user?.id, req.settings);
 
     // in spec, we should Location: to the resource, but we don't have it yet
     // TODO: generate ID here, and return it (if resource can be materialised)

--- a/packages/central-server/app/hl7fhir/materialised/handlers.js
+++ b/packages/central-server/app/hl7fhir/materialised/handlers.js
@@ -12,6 +12,7 @@ import { patientSummaryHandler } from './patientSummary';
 import { readHandler } from './read';
 import { searchHandler } from './search';
 import { createHandler } from './create';
+import { transactionBundleHandler } from './bundle';
 
 export function fhirRoutes(ctx, { requireClientHeaders } = {}) {
   const routes = Router();
@@ -50,6 +51,8 @@ export function fhirRoutes(ctx, { requireClientHeaders } = {}) {
   for (const Resource of resourcesThatCanDo(models, FHIR_INTERACTIONS.TYPE.CREATE)) {
     routes.post(`/${Resource.fhirName}`, createHandler(Resource));
   }
+
+  routes.post(`/Bundle`, transactionBundleHandler());
 
   routes.use((err, _req, res, next) => {
     if (res.headersSent) {

--- a/packages/central-server/app/hl7fhir/materialised/search/SearchBundleResponse.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/SearchBundleResponse.js
@@ -57,8 +57,8 @@ export class SearchBundleResponse {
     }
 
     bundleData.entry = this.resources
-      .map(r => resourceToEntry(r, this.isSearchResult ? 'match' : null))
-      .concat(this.included.map(r => resourceToEntry(r, this.isSearchResult ? 'include' : null)));
+      .map(r => resourceToEntry(r, 'match'))
+      .concat(this.included.map(r => resourceToEntry(r, 'include')));
 
     if (this.issues.length > 0) {
       const oo = new OperationOutcome(this.issues);
@@ -70,14 +70,12 @@ export class SearchBundleResponse {
   }
 }
 
-function resourceToEntry(resource, searchMode = null) {
+function resourceToEntry(resource, searchMode) {
   const entry = { resource: resource.asFhir() };
 
-  if (searchMode) {
-    entry.search = {
-      mode: searchMode,
-    };
-  }
+  entry.search = {
+    mode: searchMode,
+  };
 
   return entry;
 }

--- a/packages/central-server/app/hl7fhir/materialised/search/search.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/search.js
@@ -8,7 +8,7 @@ import {
   Unsupported,
 } from '@tamanu/shared/utils/fhir';
 
-import { Bundle } from '../bundle';
+import { BundleResponse } from '../BundleResponse';
 import { pushToQuery } from './common';
 import { resolveIncludes, retrieveIncludes } from './include';
 import { buildSearchQuery } from './query';
@@ -33,7 +33,7 @@ export function searchHandler(FhirResource) {
       FhirResource,
     );
 
-    const bundle = new Bundle(FHIR_BUNDLE_TYPES.SEARCHSET, records, {
+    const bundle = new BundleResponse(FHIR_BUNDLE_TYPES.SEARCHSET, records, {
       total,
     });
 

--- a/packages/central-server/app/hl7fhir/materialised/search/search.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/search.js
@@ -1,6 +1,5 @@
 import asyncHandler from 'express-async-handler';
 import { ValidationError } from 'yup';
-import { FHIR_BUNDLE_TYPES } from '@tamanu/constants';
 import {
   Invalid,
   normaliseParameters,
@@ -8,7 +7,7 @@ import {
   Unsupported,
 } from '@tamanu/shared/utils/fhir';
 
-import { BundleResponse } from '../BundleResponse';
+import { SearchBundleResponse } from './SearchBundleResponse';
 import { pushToQuery } from './common';
 import { resolveIncludes, retrieveIncludes } from './include';
 import { buildSearchQuery } from './query';
@@ -33,7 +32,7 @@ export function searchHandler(FhirResource) {
       FhirResource,
     );
 
-    const bundle = new BundleResponse(FHIR_BUNDLE_TYPES.SEARCHSET, records, {
+    const bundle = new SearchBundleResponse(records, {
       total,
     });
 

--- a/packages/shared/src/services/fhirTypes/bundle.js
+++ b/packages/shared/src/services/fhirTypes/bundle.js
@@ -1,0 +1,59 @@
+import * as yup from 'yup';
+
+import { FhirBaseType } from './baseType';
+import { FHIR_BUNDLE_TYPES } from '@tamanu/constants';
+
+export class FhirBundle extends FhirBaseType {
+  static SCHEMA() {
+    return yup.object({
+      type: yup.string().oneOf(Object.values(FHIR_BUNDLE_TYPES)).required(),
+    });
+  }
+}
+
+export class FhirTransactionBundle extends FhirBundle {
+  static SCHEMA() {
+    return yup.object({
+      type: yup.string().oneOf([FHIR_BUNDLE_TYPES.TRANSACTION]).required(),
+      entry: yup
+        .array()
+        .of(
+          yup.object({
+            resource: yup.object({ resourceType: yup.string().required() }).required(),
+            request: yup
+              .object({
+                // For now just supporting POST as we only support create transactions
+                method: yup.string().oneOf(['POST']).required(),
+                url: yup.string().required(),
+              })
+              .required(),
+          }),
+        )
+        .required(),
+    });
+  }
+}
+
+export class FhirSearchSetBundle extends FhirBundle {
+  static SCHEMA() {
+    return yup.object({
+      type: yup.string().oneOf([FHIR_BUNDLE_TYPES.SEARCHSET]).required(),
+      total: yup.number(),
+      timestamp: yup.string().required(),
+      link: yup.array().of(
+        yup.object({
+          relation: yup.string().oneOf(['self', 'next', 'previous']).required(),
+          url: yup.string().required(),
+        }),
+      ),
+      entry: yup.array().of(
+        yup.object({
+          resource: yup.object().required(),
+          search: yup.object({
+            mode: yup.string().oneOf(['match', 'include', 'outcome']),
+          }),
+        }),
+      ),
+    });
+  }
+}

--- a/packages/shared/src/services/fhirTypes/bundle.js
+++ b/packages/shared/src/services/fhirTypes/bundle.js
@@ -6,6 +6,7 @@ import { FHIR_BUNDLE_TYPES } from '@tamanu/constants';
 export class FhirBundle extends FhirBaseType {
   static SCHEMA() {
     return yup.object({
+      resourceType: yup.string().oneOf(['Bundle']).required(),
       type: yup.string().oneOf(Object.values(FHIR_BUNDLE_TYPES)).required(),
     });
   }
@@ -14,6 +15,7 @@ export class FhirBundle extends FhirBaseType {
 export class FhirTransactionBundle extends FhirBundle {
   static SCHEMA() {
     return yup.object({
+      resourceType: yup.string().oneOf(['Bundle']).required(),
       type: yup.string().oneOf([FHIR_BUNDLE_TYPES.TRANSACTION]).required(),
       entry: yup
         .array()
@@ -34,9 +36,24 @@ export class FhirTransactionBundle extends FhirBundle {
   }
 }
 
+export class FhirTransactionResponseBundle extends FhirBundle {
+  static SCHEMA() {
+    return yup.object({
+      resourceType: yup.string().oneOf(['Bundle']).required(),
+      type: yup.string().oneOf([FHIR_BUNDLE_TYPES.TRANSACTION_RESPONSE]).required(),
+      response: yup
+        .object({
+          status: yup.string().required(),
+        })
+        .required(),
+    });
+  }
+}
+
 export class FhirSearchSetBundle extends FhirBundle {
   static SCHEMA() {
     return yup.object({
+      resourceType: yup.string().oneOf(['Bundle']).required(),
       type: yup.string().oneOf([FHIR_BUNDLE_TYPES.SEARCHSET]).required(),
       total: yup.number(),
       timestamp: yup.string().required(),

--- a/packages/shared/src/services/fhirTypes/index.js
+++ b/packages/shared/src/services/fhirTypes/index.js
@@ -1,5 +1,6 @@
 export { FhirAddress } from './address';
 export { FhirAnnotation } from './annotation';
+export { FhirBundle, FhirTransactionBundle, FhirSearchSetBundle } from './bundle';
 export { FhirCoding } from './coding';
 export { FhirCodeableConcept } from './codeableConcept';
 export { FhirContactPoint } from './contactPoint';

--- a/packages/shared/src/services/fhirTypes/index.js
+++ b/packages/shared/src/services/fhirTypes/index.js
@@ -1,6 +1,11 @@
 export { FhirAddress } from './address';
 export { FhirAnnotation } from './annotation';
-export { FhirBundle, FhirTransactionBundle, FhirSearchSetBundle } from './bundle';
+export {
+  FhirBundle,
+  FhirTransactionBundle,
+  FhirTransactionResponseBundle,
+  FhirSearchSetBundle,
+} from './bundle';
 export { FhirCoding } from './coding';
 export { FhirCodeableConcept } from './codeableConcept';
 export { FhirContactPoint } from './contactPoint';


### PR DESCRIPTION
### Changes

Added a new `POST /Bundle` endpoint to the FHIR API which accepts transaction bundles of multiple API operations.

For now just adding the ability to handle multiple FHIR POST operations. In the future we may add support for other operations.

Next step will be to implement a POST Observation endpoint. 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
