### PR TITLE
feat(fhir): NASS-1886: Add FHIR Observation model

### DIFF
--- a/packages/central-server/__tests__/fake/fhir.js
+++ b/packages/central-server/__tests__/fake/fhir.js
@@ -1,4 +1,4 @@
-import { fake, fakeReferenceData } from '@tamanu/fake-data/fake';
+import { fake, fakeReferenceData, fakeString } from '@tamanu/fake-data/fake';
 import { randomLabRequest } from '@tamanu/database/demoData';
 import {
   IMAGING_REQUEST_STATUS_TYPES,
@@ -6,7 +6,7 @@ import {
   FHIR_REQUEST_PRIORITY,
 } from '@tamanu/constants';
 
-export const fakeResourcesOfFhirServiceRequest = async (models) => {
+export const fakeResourcesOfFhirServiceRequest = async models => {
   const {
     Department,
     Encounter,
@@ -120,7 +120,7 @@ export const fakeResourcesOfFhirServiceRequestWithLabRequest = async (
     });
     const testTypes = await fakeTestTypes(10, LabTestType, category.id);
     await Promise.all(
-      testTypes.map((testType) =>
+      testTypes.map(testType =>
         LabTestPanelLabTestTypes.create({
           labTestPanelId: labTestPanel.id,
           labTestTypeId: testType.id,
@@ -154,7 +154,7 @@ export const fakeResourcesOfFhirServiceRequestWithLabRequest = async (
   labRequest = await LabRequest.create(labRequestData);
   const testTypes = await fakeTestTypes(10, LabTestType, category.id);
   await Promise.all(
-    testTypes.map((testType) =>
+    testTypes.map(testType =>
       LabTest.create({
         labRequestId: labRequest.id,
         labTestTypeId: testType.id,
@@ -175,6 +175,9 @@ export const fakeTestTypes = async function (numberOfTests, LabTestType, categor
     const currentLabTest = await LabTestType.create({
       ...fake(LabTestType),
       labTestCategoryId: categoryId,
+    });
+    await currentLabTest.update({
+      externalCode: fakeString(LabTestType, { fieldName: 'externalCode' }, currentLabTest.id),
     });
     testTypes.push(currentLabTest);
   }

--- a/packages/central-server/__tests__/fake/fhir.js
+++ b/packages/central-server/__tests__/fake/fhir.js
@@ -1,10 +1,11 @@
-import { fake, fakeReferenceData, fakeString } from '@tamanu/fake-data/fake';
+import { fake, fakeReferenceData } from '@tamanu/fake-data/fake';
 import { randomLabRequest } from '@tamanu/database/demoData';
 import {
   IMAGING_REQUEST_STATUS_TYPES,
   LAB_REQUEST_STATUSES,
   FHIR_REQUEST_PRIORITY,
 } from '@tamanu/constants';
+import { v4 as uuidv4 } from 'uuid';
 
 export const fakeResourcesOfFhirServiceRequest = async models => {
   const {
@@ -183,9 +184,7 @@ export const fakeTestTypes = async function (numberOfTests, LabTestType, categor
     const currentLabTest = await LabTestType.create({
       ...fake(LabTestType),
       labTestCategoryId: categoryId,
-    });
-    await currentLabTest.update({
-      externalCode: fakeString(LabTestType, { fieldName: 'externalCode' }, currentLabTest.id),
+      externalCode: uuidv4(),
     });
     testTypes.push(currentLabTest);
   }

--- a/packages/central-server/__tests__/fake/fhir.js
+++ b/packages/central-server/__tests__/fake/fhir.js
@@ -136,6 +136,14 @@ export const fakeResourcesOfFhirServiceRequestWithLabRequest = async (
 
     labRequestData = await randomLabRequest(models, requestValues);
     labRequest = await LabRequest.create(labRequestData);
+    await Promise.all(
+      testTypes.map(testType =>
+        LabTest.create({
+          labRequestId: labRequest.id,
+          labTestTypeId: testType.id,
+        }),
+      ),
+    );
 
     return {
       category,

--- a/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
@@ -7,6 +7,7 @@ import {
   fakeResourcesOfFhirServiceRequest,
   fakeResourcesOfFhirServiceRequestWithLabRequest,
 } from '../../fake/fhir';
+import { v4 as uuidv4 } from 'uuid';
 
 describe('Create Observation', () => {
   let ctx;
@@ -156,6 +157,108 @@ describe('Create Observation', () => {
       expect(labTest.result).toBe(result);
     });
 
-    describe('errors', () => {});
+    describe('errors', () => {
+      it('returns invalid value if the ServiceRequest does not exist', async () => {
+        const nonExistentServiceRequestId = uuidv4();
+
+        const body = {
+          resourceType: 'Observation',
+          basedOn: [
+            {
+              type: 'ServiceRequest',
+              reference: `ServiceRequest/${nonExistentServiceRequestId}`,
+            },
+          ],
+          status: FHIR_OBSERVATION_STATUS.FINAL,
+          code: {
+            coding: [
+              {
+                system: config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+                code: 'TEST_CODE',
+              },
+            ],
+          },
+          value: {
+            valueString: '100',
+          },
+        };
+
+        const response = await app.post(endpoint).send(body);
+
+        expect(response.body).toMatchObject({
+          resourceType: 'OperationOutcome',
+          id: expect.any(String),
+          issue: [
+            {
+              severity: 'error',
+              code: 'value',
+              diagnostics: expect.any(String),
+              details: {
+                text: `ServiceRequest '${nonExistentServiceRequestId}' does not exist in Tamanu`,
+              },
+            },
+          ],
+        });
+        expect(response.status).toBe(400);
+      });
+
+      it('returns invalid value if the Observation code does not match any test in the ServiceRequest', async () => {
+        const { FhirServiceRequest } = ctx.store.models;
+        const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+          ctx.store.models,
+          resources,
+          false,
+          {
+            status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+          },
+        );
+        const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+        const serviceRequestId = mat.id;
+        await FhirServiceRequest.resolveUpstreams();
+
+        // Use a code that doesn't exist in the ServiceRequest
+        const invalidCode = 'INVALID_CODE_THAT_DOES_NOT_EXIST';
+
+        const body = {
+          resourceType: 'Observation',
+          basedOn: [
+            {
+              type: 'ServiceRequest',
+              reference: `ServiceRequest/${serviceRequestId}`,
+            },
+          ],
+          status: FHIR_OBSERVATION_STATUS.FINAL,
+          code: {
+            coding: [
+              {
+                system: config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+                code: invalidCode,
+              },
+            ],
+          },
+          value: {
+            valueString: '100',
+          },
+        };
+
+        const response = await app.post(endpoint).send(body);
+
+        expect(response.body).toMatchObject({
+          resourceType: 'OperationOutcome',
+          id: expect.any(String),
+          issue: [
+            {
+              severity: 'error',
+              code: 'value',
+              diagnostics: expect.any(String),
+              details: {
+                text: expect.stringContaining(`No LabTest with code: '${invalidCode}' found for LabRequest: '${labRequest.id}'`),
+              },
+            },
+          ],
+        });
+        expect(response.status).toBe(400);
+      });
+    });
   });
 });

--- a/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
@@ -1,0 +1,161 @@
+import config from 'config';
+
+import { LAB_REQUEST_STATUSES, FHIR_OBSERVATION_STATUS } from '@tamanu/constants';
+
+import { createTestContext } from '../../utilities';
+import {
+  fakeResourcesOfFhirServiceRequest,
+  fakeResourcesOfFhirServiceRequestWithLabRequest,
+} from '../../fake/fhir';
+
+describe('Create Observation', () => {
+  let ctx;
+  let app;
+  let resources;
+  const fhirResources = {
+    fhirPractitioner: null,
+    fhirEncounter: null,
+  };
+  const INTEGRATION_ROUTE = 'fhir/mat';
+  const endpoint = `/v1/integration/${INTEGRATION_ROUTE}/Observation`;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    app = await ctx.baseApp.asRole('practitioner');
+    resources = await fakeResourcesOfFhirServiceRequest(ctx.store.models);
+    const { FhirPractitioner } = ctx.store.models;
+    const fhirPractitioner = await FhirPractitioner.materialiseFromUpstream(
+      resources.practitioner.id,
+    );
+    fhirResources.fhirPractitioner = fhirPractitioner;
+  });
+  afterAll(() => ctx.close());
+
+  describe('create', () => {
+    beforeEach(async () => {
+      const {
+        FhirServiceRequest,
+        ImagingRequest,
+        ImagingRequestArea,
+        LabRequest,
+        LabTestPanel,
+        LabTestPanelRequest,
+        FhirEncounter,
+      } = ctx.store.models;
+      await FhirEncounter.destroy({ where: {} });
+      await FhirServiceRequest.destroy({ where: {} });
+      await ImagingRequest.destroy({ where: {} });
+      await ImagingRequestArea.destroy({ where: {} });
+      await LabRequest.destroy({ where: {} });
+      await LabTestPanel.destroy({ where: {} });
+      await LabTestPanelRequest.destroy({ where: {} });
+      const fhirEncounter = await FhirEncounter.materialiseFromUpstream(resources.encounter.id);
+      fhirResources.fhirEncounter = fhirEncounter;
+    });
+
+    it('post an Observation for a Labs ServiceRequest using the internal code system', async () => {
+      const result = '100';
+
+      const { FhirServiceRequest, LabTest, LabTestType } = ctx.store.models;
+      const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        false,
+        {
+          status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+        },
+      );
+      const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      const serviceRequestId = mat.id;
+      await FhirServiceRequest.resolveUpstreams();
+      const testCode = mat.orderDetail[0];
+      const labTest = await LabTest.findOne({
+        include: [{ model: LabTestType, as: 'labTestType' }],
+        where: {
+          labRequestId: labRequest.id,
+          '$labTestType.code$': testCode.coding.find(
+            ({ system }) => system === config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+          )?.code,
+        },
+      });
+
+      const body = {
+        resourceType: 'Observation',
+        basedOn: [
+          {
+            type: 'ServiceRequest',
+            reference: `ServiceRequest/${serviceRequestId}`,
+          },
+        ],
+        status: FHIR_OBSERVATION_STATUS.FINAL,
+        code: {
+          coding: testCode.coding.filter(
+            ({ system }) => system === config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+          ),
+        },
+        value: {
+          valueString: result,
+        },
+      };
+
+      const response = await app.post(endpoint).send(body);
+      await labTest.reload();
+      expect(response).toHaveSucceeded();
+      expect(labTest.result).toBe(result);
+    });
+
+    it('post an Observation for a Labs ServiceRequest using the external code system', async () => {
+      const result = '100';
+
+      const { FhirServiceRequest, LabTest, LabTestType } = ctx.store.models;
+      const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        false,
+        {
+          status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+        },
+      );
+      const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      const serviceRequestId = mat.id;
+      await FhirServiceRequest.resolveUpstreams();
+      const testCode = mat.orderDetail[0];
+      const labTest = await LabTest.findOne({
+        include: [{ model: LabTestType, as: 'labTestType' }],
+        where: {
+          labRequestId: labRequest.id,
+          '$labTestType.code$': testCode.coding.find(
+            ({ system }) => system === config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+          )?.code,
+        },
+      });
+
+      const body = {
+        resourceType: 'Observation',
+        basedOn: [
+          {
+            type: 'ServiceRequest',
+            reference: `ServiceRequest/${serviceRequestId}`,
+          },
+        ],
+        status: FHIR_OBSERVATION_STATUS.FINAL,
+        code: {
+          coding: testCode.coding.filter(
+            ({ system }) =>
+              system === config.hl7.dataDictionaries.serviceRequestLabTestExternalCodeSystem,
+          ),
+        },
+        value: {
+          valueString: result,
+        },
+      };
+
+      const response = await app.post(endpoint).send(body);
+      await labTest.reload();
+      expect(response).toHaveSucceeded();
+      expect(labTest.result).toBe(result);
+    });
+
+    describe('errors', () => {});
+  });
+});

--- a/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
@@ -68,7 +68,6 @@ describe('Create Observation', () => {
       );
       const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
       const serviceRequestId = mat.id;
-      await FhirServiceRequest.resolveUpstreams();
       const testCode = mat.orderDetail[0];
       const labTest = await LabTest.findOne({
         include: [{ model: LabTestType, as: 'labTestType' }],
@@ -119,7 +118,6 @@ describe('Create Observation', () => {
       );
       const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
       const serviceRequestId = mat.id;
-      await FhirServiceRequest.resolveUpstreams();
       const testCode = mat.orderDetail[0];
       const labTest = await LabTest.findOne({
         include: [{ model: LabTestType, as: 'labTestType' }],
@@ -171,7 +169,6 @@ describe('Create Observation', () => {
       );
       const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
       const serviceRequestId = mat.id;
-      await FhirServiceRequest.resolveUpstreams();
       const labTest = await LabTest.findOne({
         where: {
           labRequestId: labRequest.id,
@@ -264,7 +261,6 @@ describe('Create Observation', () => {
         );
         const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
         const serviceRequestId = mat.id;
-        await FhirServiceRequest.resolveUpstreams();
 
         // Use a code that doesn't exist in the ServiceRequest
         const invalidCode = 'INVALID_CODE_THAT_DOES_NOT_EXIST';

--- a/packages/constants/src/fhir.ts
+++ b/packages/constants/src/fhir.ts
@@ -242,6 +242,13 @@ export const FHIR_IMAGING_STUDY_STATUS = {
   UNKNOWN: 'unknown',
 };
 
+export const FHIR_OBSERVATION_STATUS = {
+  REGISTERED: 'registered',
+  PRELIMINARY: 'preliminary',
+  FINAL: 'final',
+  AMENDED: 'amended',
+};
+
 export const FHIR_ENCOUNTER_CLASS_DISPLAY = {
   IMP: 'inpatient encounter',
   AMB: 'ambulatory encounter',

--- a/packages/database/src/models/fhir/FhirObservation.ts
+++ b/packages/database/src/models/fhir/FhirObservation.ts
@@ -1,0 +1,195 @@
+import config from 'config';
+
+import { DataTypes } from 'sequelize';
+import * as yup from 'yup';
+
+import { FHIR_INTERACTIONS, FHIR_ISSUE_TYPE } from '@tamanu/constants';
+import {
+  FhirCodeableConcept,
+  FhirCoding,
+  FhirQuantity,
+  FhirReference,
+} from '@tamanu/shared/services/fhirTypes';
+import { Invalid } from '@tamanu/shared/utils/fhir';
+import { FhirResource } from './Resource';
+import type { InitOptions, Models } from '../../types/model';
+import type { LabRequest } from '../../models/LabRequest';
+
+const observationValue = yup.object({
+  valueQuantity: FhirQuantity.asYup().optional(),
+  valueCodeableConcept: FhirCodeableConcept.asYup().optional(),
+  valueString: yup.string().optional(),
+});
+
+export class FhirObservation extends FhirResource {
+  declare basedOn: { type: string; reference: string }[];
+  declare status: string;
+  declare code: Record<string, any>;
+  declare value: Record<string, any>;
+
+  static initModel(options: InitOptions, models: Models) {
+    super.initResource(
+      {
+        basedOn: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+        },
+        status: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+        code: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+        },
+        value: {
+          type: DataTypes.JSONB,
+        },
+      },
+      options,
+    );
+
+    this.UpstreamModels = [models.LabTest];
+    this.upstreams = [models.LabTest, models.LabRequest, models.LabTestType];
+  }
+
+  static CAN_DO = new Set([FHIR_INTERACTIONS.TYPE.CREATE]);
+
+  static get INTAKE_SCHEMA() {
+    return yup.object({
+      basedOn: yup.array().of(FhirReference.asYup()).required(),
+      status: yup.string().required(),
+      code: FhirCodeableConcept.asYup().required(),
+      value: yup.object({
+        valueQuantity: FhirQuantity.asYup(),
+        valueCodeableConcept: FhirCodeableConcept.asYup(),
+        valueString: yup.string(),
+      }),
+    });
+  }
+
+  async pushUpstream() {
+    const { FhirServiceRequest, LabRequest } = this.sequelize.models;
+    if (!this.basedOn || !Array.isArray(this.basedOn)) {
+      throw new Invalid('Observation requires basedOn to link to its ServiceRequest', {
+        code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+      });
+    }
+    const { type, reference } = this.basedOn[0]!;
+
+    const ref = reference.split('/');
+    if (type !== 'ServiceRequest' || ref.length < 2 || ref[0] !== 'ServiceRequest') {
+      throw new Invalid(`Invalid ServiceRequest reference`, {
+        code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+      });
+    }
+    const serviceRequestFhirId = ref[1];
+
+    const serviceRequest = await FhirServiceRequest.findOne({
+      where: { id: serviceRequestFhirId },
+    });
+
+    if (!serviceRequest) {
+      throw new Invalid(`ServiceRequest '${serviceRequestFhirId}' does not exist in Tamanu`, {
+        code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+      });
+    }
+
+    const labRequest = await LabRequest.findByPk(serviceRequest.upstreamId);
+    if (!labRequest) {
+      throw new Invalid(
+        `No LabRequest with id: '${serviceRequest.upstreamId}', might be ImagingRequest id`,
+      );
+    }
+
+    const labTest = await this.getLabTestForObservation(labRequest);
+    const value = this.getValue();
+
+    await labTest.update({ result: value });
+    return labTest;
+  }
+
+  async getLabTestForObservation(labRequest: LabRequest) {
+    const { LabTest, LabTestType } = this.sequelize.models;
+    const validatedCode = FhirCodeableConcept.asYup().validateSync(this.code);
+    if (!validatedCode.coding || validatedCode.coding.length === 0) {
+      throw new Invalid('Invalid code, must provide at least one coding', {
+        code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+      });
+    }
+
+    const labTestCode = validatedCode.coding.find(
+      (coding: FhirCoding) =>
+        FhirCoding.asYup().validateSync(coding).system ===
+        config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+    )?.code;
+
+    const labTestExternalCode = validatedCode.coding.find(
+      (coding: FhirCoding) =>
+        FhirCoding.asYup().validateSync(coding).system ===
+        config.hl7.dataDictionaries.serviceRequestLabTestExternalCodeSystem,
+    )?.code;
+
+    if (!labTestCode && !labTestExternalCode) {
+      throw new Invalid('Invalid code, must provide a code of one of the configured systems:', {
+        systems: [
+          config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+          config.hl7.dataDictionaries.serviceRequestLabTestExternalCodeSystem,
+        ],
+      });
+    }
+
+    const labTest =
+      (labTestCode &&
+        (await LabTest.findOne({
+          include: [{ model: LabTestType, as: 'labTestType' }],
+          where: { labRequestId: labRequest.id, '$labTestType.code$': labTestCode },
+        }))) ||
+      (labTestExternalCode &&
+        (await LabTest.findOne({
+          include: [{ model: LabTestType, as: 'labTestType' }],
+          where: {
+            labRequestId: labRequest.id,
+            '$labTestType.external_code$': labTestExternalCode,
+          },
+        })));
+
+    if (!labTest) {
+      throw new Invalid(
+        `No LabTest with code: '${labTestCode}' found for LabRequest: '${labRequest.id}'`,
+        {
+          code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+        },
+      );
+    }
+
+    return labTest;
+  }
+
+  getValue() {
+    const validatedValue = observationValue.validateSync(this.value);
+    if (validatedValue.valueQuantity) {
+      return `${validatedValue.valueQuantity.value}`;
+    }
+
+    if (validatedValue.valueCodeableConcept) {
+      const valueCode = validatedValue.valueCodeableConcept.coding[0]?.code;
+      if (!valueCode) {
+        throw new Invalid('Invalid code, must provide at least one coding', {
+          code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+        });
+      }
+      return valueCode;
+    }
+
+    if (!validatedValue.valueString) {
+      throw new Invalid(
+        'Invalid value, must provide a valueString or valueQuantity or valueCodeableConcept',
+        {
+          code: FHIR_ISSUE_TYPE.INVALID.VALUE,
+        },
+      );
+    }
+    return validatedValue.valueString;
+  }
+}

--- a/packages/database/src/models/fhir/index.ts
+++ b/packages/database/src/models/fhir/index.ts
@@ -1,4 +1,5 @@
 export * from './FhirDiagnosticReport';
+export * from './FhirObservation';
 export * from './FhirEncounter';
 export * from './FhirImagingStudy';
 export * from './FhirImmunization';


### PR DESCRIPTION
### Changes

Introducing the FHIR observation model which will map on to LabTests. For now just a write only model, so we don't materialise observations.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
