### PR TITLE
fix(locations): TAMOC-379: Only show fields that match location hierarchies (HOTFIX 2.47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.36.3
         with:
           config: .typos.toml
 

--- a/packages/web/app/components/Field/HierarchyFields.jsx
+++ b/packages/web/app/components/Field/HierarchyFields.jsx
@@ -16,18 +16,19 @@ const Container = styled(FormGrid)`
 export const HierarchyFields = ({ fields, leafNodeType, relationType }) => {
   const { values } = useFormikContext();
   const { data: hierarchyTypes = [] } = useHierarchyTypesQuery({ leafNodeType, relationType });
-  const configuredFields = hierarchyTypes.filter((type) =>
-    fields.find((f) => f.referenceType === type),
-  );
-  const hierarchyToShow = configuredFields.length > 0 ? configuredFields : [leafNodeType];
 
-  if (fields.length === 0) return null;
+  // Check if the fields to show are in the hierarchy types
+  const fieldsToShow = fields.filter((f) => hierarchyTypes.includes(f.referenceType));
+
+  if (fieldsToShow.length === 0) {
+    return null;
+  }
 
   return (
     <Container data-testid="container-bmjc">
-      {hierarchyToShow.map((type, index) => {
-        const fieldData = fields.find((f) => f.referenceType === type);
-        const parentFieldData = fields.find((f) => f.referenceType === hierarchyToShow[index - 1]);
+      {hierarchyTypes.map((type, index) => {
+        const fieldData = fieldsToShow.find((f) => f.referenceType === type);
+        const parentFieldData = fieldsToShow.find((f) => f.referenceType === hierarchyTypes[index - 1]);
         const parentId = get(values, parentFieldData?.name);
 
         return (

--- a/packages/web/app/components/Field/HierarchyFields.jsx
+++ b/packages/web/app/components/Field/HierarchyFields.jsx
@@ -24,11 +24,20 @@ export const HierarchyFields = ({ fields, leafNodeType, relationType }) => {
     return null;
   }
 
+  // Filter hierarchy types to only include ones we have fields for
+  const matchedHierarchyTypes = hierarchyTypes.filter((type) =>
+    fieldsToShow.some((f) => f.referenceType === type)
+  );
+
+  if (matchedHierarchyTypes.length === 0) {
+    return null;
+  }
+
   return (
     <Container data-testid="container-bmjc">
-      {hierarchyTypes.map((type, index) => {
+      {matchedHierarchyTypes.map((type, index) => {
         const fieldData = fieldsToShow.find((f) => f.referenceType === type);
-        const parentFieldData = fieldsToShow.find((f) => f.referenceType === hierarchyTypes[index - 1]);
+        const parentFieldData = fieldsToShow.find((f) => f.referenceType === matchedHierarchyTypes[index - 1]);
         const parentId = get(values, parentFieldData?.name);
 
         return (


### PR DESCRIPTION
### Changes
- Only show fields that match location hierarchies