### PR TITLE
fix: EPI-1298: Dropdown list of 'Area' field still displays while the models have been closed

### DIFF
--- a/packages/ui-components/src/components/Field/AutocompleteField.jsx
+++ b/packages/ui-components/src/components/Field/AutocompleteField.jsx
@@ -308,6 +308,9 @@ export class AutocompleteInput extends Component {
 
   clearOptions = () => {
     this.setState({ suggestions: [] });
+    if (this.inputElementNode) {
+      this.inputElementNode.blur();
+    }
   };
 
   onKeyDown = event => {

--- a/packages/ui-components/src/components/Field/AutocompleteField.jsx
+++ b/packages/ui-components/src/components/Field/AutocompleteField.jsx
@@ -295,9 +295,6 @@ export class AutocompleteInput extends Component {
 
   clearOptions = () => {
     this.setState({ suggestions: [] });
-    if (this.inputElementNode) {
-      this.inputElementNode.blur();
-    }
   };
 
   onKeyDown = event => {
@@ -330,6 +327,9 @@ export class AutocompleteInput extends Component {
             const hasSuggestions = this.state.suggestions.length > 0;
             if (!entry.isIntersecting && hasSuggestions) {
               this.clearOptions();
+              if (this.inputElementNode) {
+                this.inputElementNode.blur();
+              }
             }
           },
           { threshold: 0 },

--- a/packages/ui-components/src/components/Field/AutocompleteField.jsx
+++ b/packages/ui-components/src/components/Field/AutocompleteField.jsx
@@ -320,8 +320,9 @@ export class AutocompleteInput extends Component {
     // Store the input element node
     this.inputElementNode = node;
 
-    // Ensure we have a node to observe
-    if (node) {
+    // Ensure we have a node to observe and browser supports IntersectionObserver
+    const supportsIntersectionObserver = 'IntersectionObserver' in window;
+    if (node && supportsIntersectionObserver) {
       // Ensure observer exists
       if (!this.observer) {
         this.observer = new IntersectionObserver(

--- a/packages/web/app/components/Appointments/LocationAssignmentForm/AssignUserDrawer.jsx
+++ b/packages/web/app/components/Appointments/LocationAssignmentForm/AssignUserDrawer.jsx
@@ -442,6 +442,7 @@ export const AssignUserDrawer = ({ open, onClose, initialValues, facilityId }) =
       <Drawer
         open={open}
         onClose={handleClose}
+        unmountOnExit
         title={
           isViewing ? (
             <TranslatedText


### PR DESCRIPTION
### Changes

Add an event listener to the autocomplete field component to detect when the user blurs out, so the suggestion popup can be closed.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
