### PR TITLE
tweak(cd): use subnamespaceanchors so that we can have strict permissions for GHA auto-deploys

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -99,6 +99,7 @@ jobs:
       - # if the pulumi destroy had failed, then the namespace delete will have deleted the
         # actual resources, but we run pulumi destroy again to clean up the pulumi state
         if: always() && steps.down.outcome != 'success'
+        continue-on-error: true
         name: Down again!
         uses: pulumi/actions@v5
         with:

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -85,18 +85,20 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
-      - # if down fails but namespace existed, try to hard-delete the namespace
-        if: failure() && steps.down.outcome != 'success'
-        id: hard-delete
-        name: Delete namespace outright
+      - # we always need to delete the namespace anchor as pulumi is configured not to manage it
+        # additionally, if the pulumi destroy failed, this will hard-delete all the resources
+        if: always()
+        name: Delete namespace
         run: |
           NS_NAME="tamanu-${{ inputs.deploy-name }}"
           if kubectl -n tamanu-super get subnamespaceanchor "$NS_NAME" 2>/dev/null; then
-            echo "Deleting namespace hard"
+            echo "Deleting namespace"
             kubectl -n tamanu-super delete subnamespaceanchor "$NS_NAME" --wait=true
           fi
-      - # run pulumi destroy again to clean up any resources that might have been left behind
-        if: always() && steps.hard-delete.outcome == 'success'
+
+      - # if the pulumi destroy had failed, then the namespace delete will have deleted the
+        # actual resources, but we run pulumi destroy again to clean up the pulumi state
+        if: always() && steps.down.outcome != 'success'
         name: Down again!
         uses: pulumi/actions@v5
         with:

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -44,11 +44,12 @@ jobs:
         id: check
         continue-on-error: true # so a false check doesn't make the workflow fail
         run: |
-          if kubectl get namespace tamanu-${{ inputs.deploy-name }} 2>/dev/null; then
+          NS_NAME="tamanu-${{ inputs.deploy-name }}"
+          if kubectl -n tamanu-super get subnamespaceanchor "$NS_NAME" 2>/dev/null; then
             echo "Namespace exists"
             if ${{ inputs.check-branch }}; then
               echo "Checking it's matched to this branch"
-              if kubectl -n tamanu-${{ inputs.deploy-name }} \
+              if kubectl -n "$NS_NAME" \
                 get configmap auto-deploy -o json \
                 | tee -a /dev/stderr \
                 | jq -e '.data | [.repo == "${{ github.repository }}", .ref == "${{ inputs.ref }}"] | all | not'
@@ -89,9 +90,10 @@ jobs:
         id: hard-delete
         name: Delete namespace outright
         run: |
-          if kubectl get namespace tamanu-${{ inputs.deploy-name }} 2>/dev/null; then
+          NS_NAME="tamanu-${{ inputs.deploy-name }}"
+          if kubectl -n tamanu-super get subnamespaceanchor "$NS_NAME" 2>/dev/null; then
             echo "Deleting namespace hard"
-            kubectl delete namespace tamanu-${{ inputs.deploy-name }}
+            kubectl -n tamanu-super delete subnamespaceanchor "$NS_NAME" --wait=true
           fi
       - # run pulumi destroy again to clean up any resources that might have been left behind
         if: always() && steps.hard-delete.outcome == 'success'

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -46,25 +46,41 @@ jobs:
 
       - name: Create or check namespace
         run: |
-          if kubectl get namespace tamanu-${{ inputs.deploy-name }} 2>/dev/null; then
+          NS_NAME="tamanu-${{ inputs.deploy-name }}"
+
+          # Check if subnamespace anchor exists
+          if kubectl -n tamanu-super get subnamespaceanchor "$NS_NAME" 2>/dev/null; then
             echo "Namespace exists, checking it's matched to this branch"
-            kubectl -n tamanu-${{ inputs.deploy-name }} \
+            kubectl -n "$NS_NAME" \
               get configmap auto-deploy -o json \
               | tee -a /dev/stderr \
               | jq -e '.data | [.repo == "${{ github.repository }}", .ref == "${{ inputs.ref }}"] | all'
           else
-            kubectl create namespace tamanu-${{ inputs.deploy-name }}
-            kubectl -n tamanu-${{ inputs.deploy-name }} \
+            # Create SubnamespaceAnchor - HNC will create the namespace
+            kubectl apply -f - <<EOF
+          apiVersion: hnc.x-k8s.io/v1alpha2
+          kind: SubnamespaceAnchor
+          metadata:
+            name: $NS_NAME
+            namespace: tamanu-super
+          EOF
+
+            # Wait for namespace to be created by HNC
+            kubectl wait --for=condition=Ready subnamespaceanchor/"$NS_NAME" \
+              -n tamanu-super --timeout=30s || true
+
+            # Create tracking configmap
+            kubectl -n "$NS_NAME" \
               create configmap auto-deploy \
               --from-literal=repo=${{ github.repository }} \
               --from-literal=ref=${{ inputs.ref }}
           fi
 
-          kubectl -n tamanu-${{ inputs.deploy-name }} \
+          kubectl -n "$NS_NAME" \
             patch configmap auto-deploy \
             -p '{"data":{"control":"${{ inputs.control }}"}}'
 
-          kubectl -n tamanu-${{ inputs.deploy-name }} \
+          kubectl -n "$NS_NAME" \
             patch configmap auto-deploy \
             -p '{"data":{"imageTag":"${{ inputs.image-tag }}"}}'
 

--- a/packages/scripts/src/ghaCdHelpers.mjs
+++ b/packages/scripts/src/ghaCdHelpers.mjs
@@ -44,7 +44,7 @@ function intBounds(input, [low, high]) {
 }
 
 const OPTIONS = [
-  { key: 'facilities', defaultValue: 2, parse: (input) => intBounds(input, [0, 5]) },
+  { key: 'facilities', defaultValue: 2, parse: input => intBounds(input, [0, 5]) },
   {
     key: 'config',
     defaultValue: (_options, { ref, eventName }) => {
@@ -55,8 +55,8 @@ const OPTIONS = [
   },
   { key: 'env', defaultValue: 'staging' },
   { key: 'timezone', defaultValue: 'Pacific/Auckland' },
-  { key: 'ip', defaultValue: null, parse: (input) => input.split(',').map((s) => s.trim()) },
-  { key: 'dbstorage', defaultValue: 10, parse: (input) => intBounds(input, [10, 100]) },
+  { key: 'ip', defaultValue: null, parse: input => input.split(',').map(s => s.trim()) },
+  { key: 'dbstorage', defaultValue: 10, parse: input => intBounds(input, [10, 100]) },
   { key: 'arch', defaultValue: 'arm64' },
   { key: 'opsref', defaultValue: 'main' },
   { key: 'opsstack', defaultValue: 'tamanu/on-k8s' },
@@ -64,54 +64,54 @@ const OPTIONS = [
   { key: 'pause', defaultValue: false, presence: true },
   { key: 'imagesonly', defaultValue: false, presence: true },
 
-  { key: 'apis', defaultValue: 2, parse: (input) => intBounds(input, [0, 5]) },
+  { key: 'apis', defaultValue: 2, parse: input => intBounds(input, [0, 5]) },
   {
     key: 'centralapis',
-    defaultValue: (options) => intBounds(options.apis, [0, 5]),
-    parse: (input) => intBounds(input, [0, 5]),
+    defaultValue: options => intBounds(options.apis, [0, 5]),
+    parse: input => intBounds(input, [0, 5]),
   },
   {
     key: 'facilityapis',
-    defaultValue: (options) => intBounds(options.apis, [0, 5]),
-    parse: (input) => intBounds(input, [0, 5]),
+    defaultValue: options => intBounds(options.apis, [0, 5]),
+    parse: input => intBounds(input, [0, 5]),
   },
 
-  { key: 'tasks', defaultValue: 1, parse: (input) => intBounds(input, [0, 1]) },
+  { key: 'tasks', defaultValue: 1, parse: input => intBounds(input, [0, 1]) },
   {
     key: 'centraltasks',
-    defaultValue: (options) => intBounds(options.tasks, [0, 1]),
-    parse: (input) => intBounds(input, [0, 1]),
+    defaultValue: options => intBounds(options.tasks, [0, 1]),
+    parse: input => intBounds(input, [0, 1]),
   },
   {
     key: 'facilitytasks',
-    defaultValue: (options) => intBounds(options.tasks, [0, 1]),
-    parse: (input) => intBounds(input, [0, 1]),
+    defaultValue: options => intBounds(options.tasks, [0, 1]),
+    parse: input => intBounds(input, [0, 1]),
   },
 
-  { key: 'webs', defaultValue: 2, parse: (input) => intBounds(input, [0, 5]) },
+  { key: 'webs', defaultValue: 2, parse: input => intBounds(input, [0, 5]) },
   {
     key: 'centralwebs',
-    defaultValue: (options) => intBounds(options.webs, [0, 5]),
-    parse: (input) => intBounds(input, [0, 5]),
+    defaultValue: options => intBounds(options.webs, [0, 5]),
+    parse: input => intBounds(input, [0, 5]),
   },
   {
     key: 'facilitywebs',
-    defaultValue: (options) => intBounds(options.webs, [0, 5]),
-    parse: (input) => intBounds(input, [0, 5]),
+    defaultValue: options => intBounds(options.webs, [0, 5]),
+    parse: input => intBounds(input, [0, 5]),
   },
 
-  { key: 'patientportals', defaultValue: 1, parse: (input) => intBounds(input, [0, 5]) },
+  { key: 'patientportals', defaultValue: 1, parse: input => intBounds(input, [0, 5]) },
 
-  { key: 'dbs', defaultValue: 2, parse: (input) => intBounds(input, [2, 3]) },
+  { key: 'dbs', defaultValue: 2, parse: input => intBounds(input, [2, 3]) },
   {
     key: 'centraldbs',
-    defaultValue: (options) => intBounds(options.dbs, [2, 3]),
-    parse: (input) => intBounds(input, [2, 3]),
+    defaultValue: options => intBounds(options.dbs, [2, 3]),
+    parse: input => intBounds(input, [2, 3]),
   },
   {
     key: 'facilitydbs',
-    defaultValue: (options) => intBounds(options.dbs, [2, 3]),
-    parse: (input) => intBounds(input, [2, 3]),
+    defaultValue: options => intBounds(options.dbs, [2, 3]),
+    parse: input => intBounds(input, [2, 3]),
   },
   {
     /*
@@ -123,7 +123,7 @@ const OPTIONS = [
      */
     key: 'mobile',
     defaultValue: 'normal',
-    parse: (input) => (['normal', 'always', 'never'].includes(input) ? input : 'normal'),
+    parse: input => (['normal', 'always', 'never'].includes(input) ? input : 'normal'),
   },
   {
     /*
@@ -133,7 +133,7 @@ const OPTIONS = [
      */
     key: 'branding',
     defaultValue: 'tamanu',
-    parse: (input) => (['tamanu'].includes(input) ? input : 'tamanu'),
+    parse: input => (['tamanu'].includes(input) ? input : 'tamanu'),
   },
   {
     key: 'serviceaccountarn',
@@ -146,7 +146,7 @@ const OPTIONS = [
      */
     key: 'facilitynames',
     defaultValue: null,
-    parse: (input) => input.split(','),
+    parse: input => input.split(','),
   },
   {
     /*
@@ -154,7 +154,7 @@ const OPTIONS = [
      */
     key: 'fakedata',
     defaultValue: 0,
-    parse: (input) => intBounds(input, [0, 100]),
+    parse: input => intBounds(input, [0, 100]),
   },
 ];
 
@@ -167,7 +167,7 @@ function parseOptions(str, context) {
   const inputs = new Map(
     str
       .split(/\s+/)
-      .map((opt) => opt.trim().split('='))
+      .map(opt => opt.trim().split('='))
       .map(([key, value]) => [stripPercent(key.toLowerCase()), value])
       .filter(([key]) => !!key),
   );
@@ -203,6 +203,7 @@ export function configMap(deployName, imageTag, options) {
     Object.entries({
       'k8s-core': `bes/k8s-core/${options.k8score}`,
       namespace: `tamanu-${deployName}`,
+      externalNamespace: true,
       imageTag,
 
       architecture: options.arch,
@@ -258,7 +259,7 @@ export function parseBranchConfig(context) {
 
   if (
     context.eventName === 'issues' &&
-    context.payload.issue?.labels?.some((label) => label.name === 'auto-deploy') &&
+    context.payload.issue?.labels?.some(label => label.name === 'auto-deploy') &&
     context.payload.issue?.title.startsWith('Auto-deploy:')
   ) {
     console.log('Using auto-deploy issue body');
@@ -315,7 +316,7 @@ export async function findControlText(context, github) {
     console.log(
       'PRs for branch:',
       prs.data.length,
-      prs.data.map((pr) => pr.number),
+      prs.data.map(pr => pr.number),
     );
     // ...and ignore if that's the case (as the PR event will take care of it)
     if (prs.data.length) {
@@ -333,9 +334,9 @@ export async function findControlText(context, github) {
     console.log(
       'Control issues:',
       issues.data.length,
-      issues.data.map((issue) => issue.title),
+      issues.data.map(issue => issue.title),
     );
-    const issue = issues.data.find((issue) => issue.title === `Auto-deploy: ${branch}`);
+    const issue = issues.data.find(issue => issue.title === `Auto-deploy: ${branch}`);
     if (issue) {
       console.log('Found control issue matching branch:', issue.number);
 
@@ -365,7 +366,7 @@ export async function findDeploysToCleanUp(controlList, ttl = 24, context, githu
   const controls = controlList
     .split(/\s+/)
     .filter(Boolean)
-    .map((control) => control.split('='))
+    .map(control => control.split('='))
     .map(([core, ns, type, number]) => ({ core, ns, type, number }));
 
   const todo = [];


### PR DESCRIPTION
### Changes

This lets us restrict the GHA workers to only have deploy and undeploy permissions for tamanu workspaces in Kubernetes, and not be allowed outside that at all.

Until this is applied to main, the permissions remain very wide, so that the rest of all the PRs etc continue to work. The PR was tested under specific conditions that ensured the restricted permission set works. Once in main, the permission will be changed, and then PRs and epics can update from main or can cherry-pick the change into their branch to regain deployability.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
