### PR TITLE
fix(systemNotes): NASS-1939: Duplicate system note fix

### DIFF
--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -366,10 +366,11 @@ export class Encounter extends Model {
           FROM encounters e
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
           WHERE (e.updated_at_sync_tick > :since OR lr.updated_at_sync_tick > :since)
-          ${patientCount > 0
-          ? `AND e.patient_id NOT IN (SELECT patient_id FROM ${markedForSyncPatientsTable}) -- no need to sync if it would be synced anyway`
-          : ''
-        }
+          ${
+            patientCount > 0
+              ? `AND e.patient_id NOT IN (SELECT patient_id FROM ${markedForSyncPatientsTable}) -- no need to sync if it would be synced anyway`
+              : ''
+          }
           GROUP BY e.id
         ) AS encounters_with_labs ON encounters_with_labs.id = encounters.id
       `);
@@ -609,7 +610,8 @@ export class Encounter extends Model {
 
       // Start date is referred to differently in the UI based on the encounter type
       const encounterType = data.encounterType ?? this.encounterType;
-      const noteLabel = encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time';
+      const noteLabel =
+        encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time';
       await onChangeTextColumn({
         columnName: 'startDate',
         noteLabel,

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -571,7 +571,7 @@ export class Encounter extends Model {
 
       await onChangeForeignKey({
         columnName: 'locationId',
-        fieldLabel: 'location',
+        noteLabel: 'location',
         model: Location,
         sequelizeOptions: {
           include: ['locationGroup'],
@@ -586,7 +586,7 @@ export class Encounter extends Model {
       });
       await onChangeTextColumn({
         columnName: 'encounterType',
-        fieldLabel: 'encounter type',
+        noteLabel: 'encounter type',
         formatText: capitalize,
         changeType: EncounterChangeType.EncounterType,
         onChange: async () => {
@@ -595,46 +595,49 @@ export class Encounter extends Model {
       });
       await onChangeForeignKey({
         columnName: 'departmentId',
-        fieldLabel: 'department',
+        noteLabel: 'department',
         model: Department,
         changeType: EncounterChangeType.Department,
       });
       await onChangeForeignKey({
         columnName: 'examinerId',
-        fieldLabel: 'supervising clinician',
+        noteLabel: 'supervising clinician',
         model: User,
         accessor: (record: any) => record?.displayName ?? '-',
         changeType: EncounterChangeType.Examiner,
       });
 
+      // Start date is a special case as it is referred to differently in the UI based on the encounter type
       const encounterType = data.encounterType ?? this.encounterType;
       const isEmergencyEncounter = [ENCOUNTER_TYPES.TRIAGE, ENCOUNTER_TYPES.OBSERVATION, ENCOUNTER_TYPES.EMERGENCY].includes(encounterType);
+      // If emergency encounter, the note is generated from the triage model so we don't need to generate it here
       if (!isEmergencyEncounter) {
+        const noteLabel = encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time';
         await onChangeTextColumn({
           columnName: 'startDate',
-          fieldLabel: ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time',
+          noteLabel,
           formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
         });
       }
 
       await onChangeTextColumn({
         columnName: 'estimatedEndDate',
-        fieldLabel: 'estimated discharge date',
+        noteLabel: 'estimated discharge date',
         formatText: date => (date ? formatShort(date) : '-'),
       });
       await onChangeForeignKey({
         columnName: 'patientBillingTypeId',
-        fieldLabel: 'patient type',
+        noteLabel: 'patient type',
         model: ReferenceData,
       });
       await onChangeForeignKey({
         columnName: 'referralSourceId',
-        fieldLabel: 'referral source',
+        noteLabel: 'referral source',
         model: ReferenceData,
       });
       await onChangeTextColumn({
         columnName: 'reasonForEncounter',
-        fieldLabel: 'reason for encounter',
+        noteLabel: 'reason for encounter',
       });
 
       const { submittedTime, ...encounterData } = data;

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -1,5 +1,5 @@
 import { Op, DataTypes } from 'sequelize';
-import { capitalize, isEqual, lowerCase } from 'lodash';
+import { capitalize, isEqual } from 'lodash';
 
 import {
   ENCOUNTER_TYPE_VALUES,
@@ -12,7 +12,7 @@ import {
 } from '@tamanu/constants';
 import { InvalidOperationError } from '@tamanu/errors';
 import { dischargeOutpatientEncounters } from '@tamanu/shared/utils/dischargeOutpatientEncounters';
-import { formatShort, getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { formatShort, formatTime, getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 import { Model } from './Model';
 import {
@@ -608,22 +608,22 @@ export class Encounter extends Model {
         changeType: EncounterChangeType.Examiner,
       });
 
-      let startDateLabel = 'Date';
+      let startDateLabel = 'date & time';
       switch (data.encounterType ?? this.encounterType) {
         case ENCOUNTER_TYPES.ADMISSION:
-          startDateLabel = 'Admission date';
+          startDateLabel = 'admission date & time';
           break;
         case ENCOUNTER_TYPES.TRIAGE:
         case ENCOUNTER_TYPES.OBSERVATION:
         case ENCOUNTER_TYPES.EMERGENCY:
-          startDateLabel = 'Triage date';
+          startDateLabel = 'triage date & time';
           break;
       }
 
       await onChangeTextColumn({
         columnName: 'startDate',
-        fieldLabel: lowerCase(startDateLabel), 
-        formatText: date => (date ? formatShort(date) : '-'),
+        fieldLabel: startDateLabel, 
+        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await onChangeTextColumn({
         columnName: 'estimatedEndDate',

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -607,18 +607,14 @@ export class Encounter extends Model {
         changeType: EncounterChangeType.Examiner,
       });
 
-      // Start date is a special case as it is referred to differently in the UI based on the encounter type
+      // Start date is referred to differently in the UI based on the encounter type
       const encounterType = data.encounterType ?? this.encounterType;
-      const isEmergencyEncounter = [ENCOUNTER_TYPES.TRIAGE, ENCOUNTER_TYPES.OBSERVATION, ENCOUNTER_TYPES.EMERGENCY].includes(encounterType);
-      // If emergency encounter, the note is generated from the triage model so we don't need to generate it here
-      if (!isEmergencyEncounter) {
-        const noteLabel = encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time';
-        await onChangeTextColumn({
-          columnName: 'startDate',
-          noteLabel,
-          formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
-        });
-      }
+      const noteLabel = encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time';
+      await onChangeTextColumn({
+        columnName: 'startDate',
+        noteLabel,
+        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
+      });
 
       await onChangeTextColumn({
         columnName: 'estimatedEndDate',

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -1,5 +1,5 @@
 import { Op, DataTypes } from 'sequelize';
-import { capitalize, isEqual } from 'lodash';
+import { capitalize, isEqual, lowerCase } from 'lodash';
 
 import {
   ENCOUNTER_TYPE_VALUES,
@@ -622,7 +622,7 @@ export class Encounter extends Model {
 
       await onChangeTextColumn({
         columnName: 'startDate',
-        fieldLabel: startDateLabel,
+        fieldLabel: lowerCase(startDateLabel), 
         formatText: date => (date ? formatShort(date) : '-'),
       });
       await onChangeTextColumn({

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -608,23 +608,16 @@ export class Encounter extends Model {
         changeType: EncounterChangeType.Examiner,
       });
 
-      let startDateLabel = 'date & time';
-      switch (data.encounterType ?? this.encounterType) {
-        case ENCOUNTER_TYPES.ADMISSION:
-          startDateLabel = 'admission date & time';
-          break;
-        case ENCOUNTER_TYPES.TRIAGE:
-        case ENCOUNTER_TYPES.OBSERVATION:
-        case ENCOUNTER_TYPES.EMERGENCY:
-          startDateLabel = 'triage date & time';
-          break;
+      const encounterType = data.encounterType ?? this.encounterType;
+      const isEmergencyEncounter = [ENCOUNTER_TYPES.TRIAGE, ENCOUNTER_TYPES.OBSERVATION, ENCOUNTER_TYPES.EMERGENCY].includes(encounterType);
+      if (!isEmergencyEncounter) {
+        await onChangeTextColumn({
+          columnName: 'startDate',
+          fieldLabel: 'date & time', 
+          formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
+        });
       }
-
-      await onChangeTextColumn({
-        columnName: 'startDate',
-        fieldLabel: startDateLabel, 
-        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
-      });
+      
       await onChangeTextColumn({
         columnName: 'estimatedEndDate',
         fieldLabel: 'estimated discharge date',

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -366,11 +366,10 @@ export class Encounter extends Model {
           FROM encounters e
           INNER JOIN lab_requests lr ON lr.encounter_id = e.id
           WHERE (e.updated_at_sync_tick > :since OR lr.updated_at_sync_tick > :since)
-          ${
-            patientCount > 0
-              ? `AND e.patient_id NOT IN (SELECT patient_id FROM ${markedForSyncPatientsTable}) -- no need to sync if it would be synced anyway`
-              : ''
-          }
+          ${patientCount > 0
+          ? `AND e.patient_id NOT IN (SELECT patient_id FROM ${markedForSyncPatientsTable}) -- no need to sync if it would be synced anyway`
+          : ''
+        }
           GROUP BY e.id
         ) AS encounters_with_labs ON encounters_with_labs.id = encounters.id
       `);
@@ -613,11 +612,11 @@ export class Encounter extends Model {
       if (!isEmergencyEncounter) {
         await onChangeTextColumn({
           columnName: 'startDate',
-          fieldLabel: 'date & time', 
+          fieldLabel: ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time',
           formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
         });
       }
-      
+
       await onChangeTextColumn({
         columnName: 'estimatedEndDate',
         fieldLabel: 'estimated discharge date',

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -636,7 +636,7 @@ export class Encounter extends Model {
         noteLabel: 'reason for encounter',
       });
 
-      const { submittedTime, ...encounterData } = data;
+      const { submittedTime, skipSystemNotes, ...encounterData } = data;
       const updatedEncounter = await super.update({ ...encounterData, ...additionalChanges }, user);
 
       // Create snapshot with array of change types
@@ -648,7 +648,7 @@ export class Encounter extends Model {
         });
       }
 
-      if (systemNoteRows.length > 0) {
+      if (!skipSystemNotes && systemNoteRows.length > 0) {
         const formattedSystemNote = systemNoteRows.map(row => `• ${row}`).join('\n');
         await this.addSystemNote(
           formattedSystemNote,

--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -610,11 +610,10 @@ export class Encounter extends Model {
 
       // Start date is referred to differently in the UI based on the encounter type
       const encounterType = data.encounterType ?? this.encounterType;
-      const noteLabel =
-        encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time';
       await onChangeTextColumn({
         columnName: 'startDate',
-        noteLabel,
+        noteLabel:
+          encounterType === ENCOUNTER_TYPES.ADMISSION ? 'admission date & time' : 'date & time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
 

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -168,6 +168,11 @@ export class Triage extends Model {
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await onChangeTextColumn({
+        columnName: 'triageTime',
+        fieldLabel: 'triage date & time',
+        formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
+      });
+      await onChangeTextColumn({
         columnName: 'score',
         fieldLabel: 'triage score',
       });

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -171,6 +171,16 @@ export class Triage extends Model {
         columnName: 'triageTime',
         noteLabel: 'triage date & time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
+        onChange: async () => {
+          // Sync triageTime to encounter.startDate when triageTime changes
+          // This ensures the encounter's startDate stays in sync with triage time
+          // We use a direct Sequelize update to bypass Encounter.update() which would generate duplicate notes
+          await Encounter.update(
+            { startDate: data.triageTime },
+            { where: { id: this.encounterId } },
+          );
+
+        },
       });
       await onChangeTextColumn({
         columnName: 'score',

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -149,32 +149,32 @@ export class Triage extends Model {
     const updateTriage = async () => {
       await onChangeForeignKey({
         columnName: 'chiefComplaintId',
-        fieldLabel: 'chief complaint',
+        noteLabel: 'chief complaint',
         model: ReferenceData,
       });
       await onChangeForeignKey({
         columnName: 'secondaryComplaintId',
-        fieldLabel: 'secondary complaint',
+        noteLabel: 'secondary complaint',
         model: ReferenceData,
       });
       await onChangeForeignKey({
         columnName: 'arrivalModeId',
-        fieldLabel: 'arrival mode',
+        noteLabel: 'arrival mode',
         model: ReferenceData,
       });
       await onChangeTextColumn({
         columnName: 'arrivalTime',
-        fieldLabel: 'arrival time',
+        noteLabel: 'arrival time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await onChangeTextColumn({
         columnName: 'triageTime',
-        fieldLabel: 'triage date & time',
+        noteLabel: 'triage date & time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
       });
       await onChangeTextColumn({
         columnName: 'score',
-        fieldLabel: 'triage score',
+        noteLabel: 'triage score',
       });
 
       const { submittedTime, ...triageData } = data;

--- a/packages/database/src/models/Triage.ts
+++ b/packages/database/src/models/Triage.ts
@@ -171,16 +171,6 @@ export class Triage extends Model {
         columnName: 'triageTime',
         noteLabel: 'triage date & time',
         formatText: date => (date ? `${formatShort(date)} ${formatTime(date)}` : '-'),
-        onChange: async () => {
-          // Sync triageTime to encounter.startDate when triageTime changes
-          // This ensures the encounter's startDate stays in sync with triage time
-          // We use a direct Sequelize update to bypass Encounter.update() which would generate duplicate notes
-          await Encounter.update(
-            { startDate: data.triageTime },
-            { where: { id: this.encounterId } },
-          );
-
-        },
       });
       await onChangeTextColumn({
         columnName: 'score',

--- a/packages/database/src/utils/recordModelChanges.ts
+++ b/packages/database/src/utils/recordModelChanges.ts
@@ -22,7 +22,7 @@ export function createChangeRecorders<T extends Model>(
    */
   const onChangeForeignKey = async ({
     columnName,
-    fieldLabel,
+    noteLabel,
     model,
     sequelizeOptions = {},
     accessor = (record: typeof Model) => record?.name ?? '-',
@@ -30,7 +30,7 @@ export function createChangeRecorders<T extends Model>(
     onChange,
   }: {
     columnName: keyof T;
-    fieldLabel: string;
+    noteLabel: string;
     model: typeof Model;
     sequelizeOptions?: any;
     accessor?: (record: any) => string;
@@ -49,7 +49,7 @@ export function createChangeRecorders<T extends Model>(
     const newRecord = await model.findByPk(updateData[columnName] as any, sequelizeOptions);
 
     systemNoteRows.push(
-      `Changed ${fieldLabel} from ‘${accessor(oldRecord)}’ to ‘${accessor(newRecord)}’`,
+      `Changed ${noteLabel} from ‘${accessor(oldRecord)}’ to ‘${accessor(newRecord)}’`,
     );
     await onChange?.();
   };
@@ -60,13 +60,13 @@ export function createChangeRecorders<T extends Model>(
    */
   const onChangeTextColumn = async ({
     columnName,
-    fieldLabel,
+    noteLabel,
     formatText = (value: any) => value ?? '-',
     changeType,
     onChange,
   }: {
     columnName: keyof T;
-    fieldLabel: string;
+    noteLabel: string;
     formatText?: (value: any) => string;
     changeType?: string;
     onChange?: () => Promise<void>;
@@ -82,7 +82,7 @@ export function createChangeRecorders<T extends Model>(
     const oldValue = modelInstance[columnName];
     const newValue = updateData[columnName];
     systemNoteRows.push(
-      `Changed ${fieldLabel} from ‘${formatText(oldValue)}’ to ‘${formatText(newValue)}’`,
+      `Changed ${noteLabel} from ‘${formatText(oldValue)}’ to ‘${formatText(newValue)}’`,
     );
     await onChange?.();
   };

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -356,6 +356,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
     estimatedEndDate,
   }) => {
     await writeAndViewEncounter(encounter.id, {
+      submittedTime: getCurrentDateTimeString(),
       startDate,
       referralSourceId,
       patientBillingTypeId,

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -25,6 +25,7 @@ import { TranslatedText } from '../../../components/Translation/TranslatedText';
 import { useEncounter } from '../../../contexts/Encounter';
 import { ENCOUNTER_TYPES } from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { isEmergencyPatient } from '../../../utils/isEmergencyPatient';
 
 const StyledFormGrid = styled(FormGrid)`
   margin-bottom: 20px;
@@ -323,7 +324,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
 
   const triage = encounter.triages?.[0];
 
-  const onSubmit = async values => {
+  const onSubmitTriageForm = async values => {
     const {
       startDate,
       arrivalTime,
@@ -331,25 +332,30 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
       score,
       chiefComplaintId,
       secondaryComplaintId,
+    } = values;
+
+    await api.put(`triage/${triage.id}`, {
+      submittedTime: getCurrentDateTimeString(),
+      encounterId: encounter.id,
+      arrivalTime,
+      triageTime: startDate,
+      arrivalModeId,
+      score,
+      chiefComplaintId,
+      secondaryComplaintId,
+    });
+
+  };
+
+  const onSubmitEncounterForm = async values => {
+    const {
+      startDate,
       referralSourceId,
       patientBillingTypeId,
       dietIds,
       reasonForEncounter,
       estimatedEndDate,
     } = values;
-
-    if (triage) {
-      await api.put(`triage/${triage.id}`, {
-        submittedTime: getCurrentDateTimeString(),
-        encounterId: encounter.id,
-        arrivalTime,
-        triageTime: startDate,
-        arrivalModeId,
-        score,
-        chiefComplaintId,
-        secondaryComplaintId,
-      });
-    }
 
     await writeAndViewEncounter(encounter.id, {
       startDate,
@@ -372,7 +378,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
       <Form
         initialValues={getFormInitialValues({ encounter, triage })}
         formType={FORM_TYPES.EDIT_FORM}
-        onSubmit={onSubmit}
+        onSubmit={isEmergencyPatient(encounter.encounterType) ? onSubmitTriageForm : onSubmitEncounterForm}
         render={({ submitForm }) => (
           <>
             <StyledFormGrid>

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -185,7 +185,7 @@ const TriageFields = () => {
         data-testid="field-admission-time"
       />
       <Field
-        name="triageTime"
+        name="startDate"
         component={DateTimeField}
         label={
           <TranslatedText stringId="triage.triageDateTime.label" fallback="Triage date & time" />
@@ -335,7 +335,6 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
     const {
       startDate,
       arrivalTime,
-      triageTime,
       arrivalModeId,
       score,
       chiefComplaintId,
@@ -352,7 +351,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
         submittedTime: getCurrentDateTimeString(),
         encounterId: encounter.id,
         arrivalTime,
-        triageTime,
+        triageTime: startDate,
         arrivalModeId,
         score,
         chiefComplaintId,
@@ -361,7 +360,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
     }
 
     await writeAndViewEncounter(encounter.id, {
-      startDate: triageTime || startDate,
+      startDate,
       referralSourceId,
       patientBillingTypeId,
       dietIds,

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -361,7 +361,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
     }
 
     await writeAndViewEncounter(encounter.id, {
-      startDate,
+      startDate: triageTime || startDate,
       referralSourceId,
       patientBillingTypeId,
       dietIds,

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -185,7 +185,7 @@ const TriageFields = () => {
         data-testid="field-admission-time"
       />
       <Field
-        name="startDate"
+        name="triageTime"
         component={DateTimeField}
         label={
           <TranslatedText stringId="triage.triageDateTime.label" fallback="Triage date & time" />
@@ -281,7 +281,14 @@ const getFormInitialValues = ({ encounter, triage = {} }) => {
     estimatedEndDate,
   } = encounter;
 
-  const { chiefComplaintId, secondaryComplaintId, arrivalTime, arrivalModeId, score } = triage;
+  const {
+    triageTime,
+    arrivalTime,
+    arrivalModeId,
+    score,
+    chiefComplaintId,
+    secondaryComplaintId,
+  } = triage;
 
   const baseInitialValues = { startDate };
   switch (encounter.encounterType) {
@@ -311,6 +318,7 @@ const getFormInitialValues = ({ encounter, triage = {} }) => {
         arrivalTime,
         arrivalModeId,
         score,
+        triageTime,
       };
     default:
       return {};
@@ -327,6 +335,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
     const {
       startDate,
       arrivalTime,
+      triageTime,
       arrivalModeId,
       score,
       chiefComplaintId,
@@ -343,7 +352,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
         submittedTime: getCurrentDateTimeString(),
         encounterId: encounter.id,
         arrivalTime,
-        triageTime: startDate,
+        triageTime,
         arrivalModeId,
         score,
         chiefComplaintId,

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -325,14 +325,13 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
   const triage = encounter.triages?.[0];
 
   const onSubmitTriageForm = async ({
-      startDate,
-      arrivalTime,
-      arrivalModeId,
-      score,
-      chiefComplaintId,
-      secondaryComplaintId,
+    startDate,
+    arrivalTime,
+    arrivalModeId,
+    score,
+    chiefComplaintId,
+    secondaryComplaintId,
   }) => {
-    
     await api.put(`triage/${triage.id}`, {
       submittedTime: getCurrentDateTimeString(),
       encounterId: encounter.id,
@@ -343,19 +342,17 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
       chiefComplaintId,
       secondaryComplaintId,
     });
-    await writeAndViewEncounter(encounter.id, {
-      startDate,
-    });
+    await writeAndViewEncounter(encounter.id, { startDate, skipSystemNotes: true });
 
   };
 
   const onSubmitEncounterForm = async ({
-      startDate,
-      referralSourceId,
-      patientBillingTypeId,
-      dietIds,
-      reasonForEncounter,
-      estimatedEndDate,
+    startDate,
+    referralSourceId,
+    patientBillingTypeId,
+    dietIds,
+    reasonForEncounter,
+    estimatedEndDate,
   }) => {
     await writeAndViewEncounter(encounter.id, {
       startDate,

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -281,14 +281,7 @@ const getFormInitialValues = ({ encounter, triage = {} }) => {
     estimatedEndDate,
   } = encounter;
 
-  const {
-    triageTime,
-    arrivalTime,
-    arrivalModeId,
-    score,
-    chiefComplaintId,
-    secondaryComplaintId,
-  } = triage;
+  const { arrivalTime, arrivalModeId, score, chiefComplaintId, secondaryComplaintId } = triage;
 
   const baseInitialValues = { startDate };
   switch (encounter.encounterType) {

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -281,7 +281,7 @@ const getFormInitialValues = ({ encounter, triage = {} }) => {
     estimatedEndDate,
   } = encounter;
 
-  const { arrivalTime, arrivalModeId, score, chiefComplaintId, secondaryComplaintId } = triage;
+  const { chiefComplaintId, secondaryComplaintId, arrivalTime, arrivalModeId, score } = triage;
 
   const baseInitialValues = { startDate };
   switch (encounter.encounterType) {

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -324,16 +324,15 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
 
   const triage = encounter.triages?.[0];
 
-  const onSubmitTriageForm = async values => {
-    const {
+  const onSubmitTriageForm = async ({
       startDate,
       arrivalTime,
       arrivalModeId,
       score,
       chiefComplaintId,
       secondaryComplaintId,
-    } = values;
-
+  }) => {
+    
     await api.put(`triage/${triage.id}`, {
       submittedTime: getCurrentDateTimeString(),
       encounterId: encounter.id,
@@ -344,19 +343,20 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
       chiefComplaintId,
       secondaryComplaintId,
     });
+    await writeAndViewEncounter(encounter.id, {
+      startDate,
+    });
 
   };
 
-  const onSubmitEncounterForm = async values => {
-    const {
+  const onSubmitEncounterForm = async ({
       startDate,
       referralSourceId,
       patientBillingTypeId,
       dietIds,
       reasonForEncounter,
       estimatedEndDate,
-    } = values;
-
+  }) => {
     await writeAndViewEncounter(encounter.id, {
       startDate,
       referralSourceId,

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -318,7 +318,6 @@ const getFormInitialValues = ({ encounter, triage = {} }) => {
         arrivalTime,
         arrivalModeId,
         score,
-        triageTime,
       };
     default:
       return {};

--- a/packages/web/app/views/patients/components/EditEncounterModal.jsx
+++ b/packages/web/app/views/patients/components/EditEncounterModal.jsx
@@ -332,7 +332,7 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
     chiefComplaintId,
     secondaryComplaintId,
   }) => {
-    await api.put(`triage/${triage.id}`, {
+    await api.put(`triage/${triage?.id}`, {
       submittedTime: getCurrentDateTimeString(),
       encounterId: encounter.id,
       arrivalTime,
@@ -342,8 +342,9 @@ export const EditEncounterModal = React.memo(({ open, onClose, encounter }) => {
       chiefComplaintId,
       secondaryComplaintId,
     });
-    await writeAndViewEncounter(encounter.id, { startDate, skipSystemNotes: true });
 
+    // Keep the encounter start date in sync with the triage start date when using this form
+    await writeAndViewEncounter(encounter.id, { startDate, skipSystemNotes: true });
   };
 
   const onSubmitEncounterForm = async ({

--- a/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInfoPane.jsx
@@ -387,8 +387,8 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               value={
                 <TranslatedReferenceData
                   category="triageReason"
-                  value={triage?.chiefComplaint.id}
-                  fallback={triage?.chiefComplaint.name}
+                  value={triage?.chiefComplaint?.id}
+                  fallback={triage?.chiefComplaint?.name}
                   placeholder="—"
                 />
               }
@@ -406,8 +406,8 @@ export const EncounterInfoPane = React.memo(({ encounter, getSetting, patientBil
               value={
                 <TranslatedReferenceData
                   category="triageReason"
-                  value={triage?.secondaryComplaint.id}
-                  fallback={triage?.secondaryComplaint.name}
+                  value={triage?.secondaryComplaint?.id}
+                  fallback={triage?.secondaryComplaint?.name}
                   placeholder="—"
                 />
               }


### PR DESCRIPTION
### Changes

Bug Fixes:

- Prevent duplicate system notes: Skip system note creation on the encounter model when updating triage information, as the triage model already handles note creation
- Fix crash on secondary complaint: Add optional chaining to triage?.secondaryComplaint?.id to prevent crashes when secondary complaint data is missing or undefined

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
