### PR TITLE
System notes alignment

### DIFF
--- a/packages/database/src/utils/recordModelChanges.ts
+++ b/packages/database/src/utils/recordModelChanges.ts
@@ -1,0 +1,94 @@
+import { Model } from '../models/Model';
+
+/**
+ * Creates helper functions for recording model changes in update methods.
+ * These functions track changes to model fields and generate system note messages.
+ *
+ * @param modelInstance - The model instance being updated (this)
+ * @param updateData - The data object containing the new values
+ * @param systemNoteRows - Array to collect system note messages
+ * @param changeTypes - Optional array to collect change types for history tracking (soon to be deprecated)
+ * @returns Object containing recordForeignKeyChange and recordTextColumnChange functions
+ */
+export function createChangeRecorders<T extends Model>(
+  modelInstance: T,
+  updateData: Partial<T>,
+  systemNoteRows: string[],
+  changeTypes?: string[],
+) {
+  /**
+   * Records changes to foreign key columns (e.g., locationId, departmentId)
+   * Fetches the related records to get human-readable names for the system note
+   */
+  const onChangeForeignKey = async ({
+    columnName,
+    fieldLabel,
+    model,
+    sequelizeOptions = {},
+    accessor = (record: typeof Model) => record?.name ?? '-',
+    changeType,
+    onChange,
+  }: {
+    columnName: keyof T;
+    fieldLabel: string;
+    model: typeof Model;
+    sequelizeOptions?: any;
+    accessor?: (record: any) => string;
+    changeType?: string;
+    onChange?: () => Promise<void>;
+  }) => {
+    const isChanged =
+      columnName in updateData && updateData[columnName] !== modelInstance[columnName];
+    if (!isChanged) return;
+
+    if (changeType && changeTypes) {
+      changeTypes.push(changeType);
+    }
+
+    const oldRecord = await model.findByPk(modelInstance[columnName] as any, sequelizeOptions);
+    const newRecord = await model.findByPk(updateData[columnName] as any, sequelizeOptions);
+
+    systemNoteRows.push(
+      `Changed ${fieldLabel} from '${accessor(oldRecord)}' to '${accessor(newRecord)}'`,
+    );
+    await onChange?.();
+  };
+
+  /**
+   * Records changes to text/string columns (e.g., encounterType, reasonForEncounter)
+   * Uses the raw values directly since there's no related record to fetch
+   */
+  const onChangeTextColumn = async ({
+    columnName,
+    fieldLabel,
+    formatText = (value: any) => value ?? '-',
+    changeType,
+    onChange,
+  }: {
+    columnName: keyof T;
+    fieldLabel: string;
+    formatText?: (value: any) => string;
+    changeType?: string;
+    onChange?: () => Promise<void>;
+  }) => {
+    const isChanged =
+      columnName in updateData && updateData[columnName] !== modelInstance[columnName];
+    if (!isChanged) return;
+
+    if (changeType && changeTypes) {
+      changeTypes.push(changeType);
+    }
+
+    const oldValue = modelInstance[columnName];
+    const newValue = updateData[columnName];
+    systemNoteRows.push(
+      `Changed ${fieldLabel} from '${formatText(oldValue)}' to '${formatText(newValue)}'`,
+    );
+    await onChange?.();
+  };
+
+  return {
+    onChangeForeignKey,
+    onChangeTextColumn,
+  };
+}


### PR DESCRIPTION
### Changes

This PR addresses NASS-1839 by consolidating system-generated notes for encounter updates into a single, formatted note, aligning with the unified patient move workflow.

Specifically:
- System notes for the **arrival date** (`startDate`) now correctly include both date and time, as per the design and feedback from Klaus.
- System notes for the **estimated discharge date** (`estimatedEndDate`) remain date-only, as time is not captured for this field.
- The encounter update logic has been refactored to use a new `recordModelChanges` utility, ensuring consistent tracking and formatting of all relevant encounter field changes (e.g., location, department, clinician, patient type, referral source, reason for encounter, and diet changes) within a single system note.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [NASS-1839](https://linear.app/bes/issue/NASS-1839/update-system-generated-notes-to-align-with-the-unified-patient-move)

<a href="https://cursor.com/background-agent?bcId=bc-89e68e9e-c330-48c8-be7a-f72fc8477d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89e68e9e-c330-48c8-be7a-f72fc8477d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

