### PR TITLE
db: no-issue: split pharmacy orders migration to avoid pending trigger events

### DIFF
--- a/packages/database/src/migrations/1764976539675-addDateAndFacilityIdToPharmacyOrders.ts
+++ b/packages/database/src/migrations/1764976539675-addDateAndFacilityIdToPharmacyOrders.ts
@@ -1,4 +1,7 @@
-import { DataTypes, QueryInterface, QueryTypes } from 'sequelize';
+import { DataTypes, QueryInterface } from 'sequelize';
+
+// Migration 1 of 3: Add columns only (DDL)
+// Data backfill is in a separate migration to avoid "pending trigger events" error
 
 export async function up(query: QueryInterface): Promise<void> {
   await query.addColumn('pharmacy_orders', 'date', {
@@ -13,46 +16,6 @@ export async function up(query: QueryInterface): Promise<void> {
       model: 'facilities',
       key: 'id',
     },
-  });
-
-  // Backfill date and facility_id columns using a single bulk UPDATE query
-  await query.sequelize.query(
-    `
-    UPDATE pharmacy_orders
-    SET
-      date = SUBSTRING(pharmacy_orders.created_at::TEXT, 1, 19),
-      facility_id = locations.facility_id
-    FROM
-      encounters
-    INNER JOIN
-      locations ON locations.id = encounters.location_id
-    WHERE
-      pharmacy_orders.encounter_id = encounters.id;
-    `,
-  );
-
-  // Check if there are any rows with NULL facility_id before making the column non-nullable
-  const nullCountResult: any = await query.sequelize.query(
-    `SELECT COUNT(*) as count FROM pharmacy_orders WHERE facility_id IS NULL;`,
-    { type: QueryTypes.SELECT },
-  );
-
-  const nullCount = parseInt(nullCountResult[0].count, 10);
-  if (nullCount > 0) {
-    throw new Error(
-      `Cannot make facility_id non-nullable: ${nullCount} pharmacy order(s) have NULL facility_id. ` +
-      `These orders may be missing encounters or encounters may be missing locations.`,
-    );
-  }
-
-  await query.changeColumn('pharmacy_orders', 'date', {
-    type: DataTypes.DATETIMESTRING,
-    allowNull: false,
-  });
-
-  await query.changeColumn('pharmacy_orders', 'facility_id', {
-    type: DataTypes.STRING,
-    allowNull: false,
   });
 }
 

--- a/packages/database/src/migrations/1764976539676-backfillPharmacyOrdersDateAndFacilityId.ts
+++ b/packages/database/src/migrations/1764976539676-backfillPharmacyOrdersDateAndFacilityId.ts
@@ -1,0 +1,41 @@
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Migration 2 of 3: Backfill data (DML)
+// Separated from schema changes to avoid "pending trigger events" error
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Backfill date and facility_id columns using a single bulk UPDATE query
+  await query.sequelize.query(
+    `
+    UPDATE pharmacy_orders
+    SET
+      date = SUBSTRING(pharmacy_orders.created_at::TEXT, 1, 19),
+      facility_id = locations.facility_id
+    FROM
+      encounters
+    INNER JOIN
+      locations ON locations.id = encounters.location_id
+    WHERE
+      pharmacy_orders.encounter_id = encounters.id;
+    `,
+  );
+
+  // Check if there are any rows with NULL facility_id before the next migration makes the column non-nullable
+  const nullCountResult: any = await query.sequelize.query(
+    `SELECT COUNT(*) as count FROM pharmacy_orders WHERE facility_id IS NULL;`,
+    { type: QueryTypes.SELECT },
+  );
+
+  const nullCount = parseInt(nullCountResult[0].count, 10);
+  if (nullCount > 0) {
+    throw new Error(
+      `Cannot make facility_id non-nullable: ${nullCount} pharmacy order(s) have NULL facility_id. ` +
+        `These orders may be missing encounters or encounters may be missing locations.`,
+    );
+  }
+}
+
+export async function down(_query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: Data backfill cannot be reversed - the columns will remain but values will be lost
+  // when the previous migration removes the columns
+}

--- a/packages/database/src/migrations/1764976539677-makePharmacyOrdersDateAndFacilityIdNonNullable.ts
+++ b/packages/database/src/migrations/1764976539677-makePharmacyOrdersDateAndFacilityIdNonNullable.ts
@@ -1,0 +1,28 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+// Migration 3 of 3: Make columns non-nullable (DDL)
+// Separated from data backfill to avoid "pending trigger events" error
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.changeColumn('pharmacy_orders', 'date', {
+    type: DataTypes.DATETIMESTRING,
+    allowNull: false,
+  });
+
+  await query.changeColumn('pharmacy_orders', 'facility_id', {
+    type: DataTypes.STRING,
+    allowNull: false,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.changeColumn('pharmacy_orders', 'facility_id', {
+    type: DataTypes.STRING,
+    allowNull: true,
+  });
+
+  await query.changeColumn('pharmacy_orders', 'date', {
+    type: DataTypes.DATETIMESTRING,
+    allowNull: true,
+  });
+}


### PR DESCRIPTION
PostgreSQL deferred constraint triggers for audit logging queue events during
UPDATE operations. Subsequent ALTER TABLE fails with "pending trigger events"
error. Split into 3 migrations: DDL (add columns), DML (backfill data), DDL
(make non-nullable) so each runs in its own transaction.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
