### PR TITLE
tweak(cd): use tailscale OIDC

### DIFF
--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -61,11 +61,11 @@ runs:
       with:
         oauth-client-id: ${{ inputs.tailscale-oauth-client-id }}
         audience: api.tailscale.com/${{ inputs.tailscale-oauth-client-id }}
-        tags: ${{ inputs.tailscale-tags }} # must be synced to actual OIDC trust in Tailscale
+        tags: '${{ inputs.tailscale-tags }}'
 
     - name: Configure kubeconfig
       shell: bash
-      run: tailscale configure kubeconfig ${{ inputs.tailscale-k8s-operator-hostname }}
+      run: sudo tailscale configure kubeconfig ${{ inputs.tailscale-k8s-operator-hostname }}
 
     - name: Test kubernetes cluster for readiness
       shell: bash

--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - if: inputs.ops-ssh-key
       name: Checkout ops
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: beyondessential/ops
         ssh-key: ${{ inputs.ops-ssh-key }}
@@ -25,14 +25,14 @@ runs:
 
     - name: Install Node.js for ops
       if: inputs.ops-ssh-key
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version-file: ops/.node-version
         cache: npm
 
     - name: Install Node.js for us
       if: '!inputs.ops-ssh-key'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .node-version
         cache: npm

--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -65,7 +65,9 @@ runs:
 
     - name: Configure kubeconfig
       shell: bash
-      run: sudo tailscale configure kubeconfig ${{ inputs.tailscale-k8s-operator-hostname }}
+      run: |
+        sudo tailscale set --operator=$USER
+        tailscale configure kubeconfig ${{ inputs.tailscale-k8s-operator-hostname }}
 
     - name: Test kubernetes cluster for readiness
       shell: bash

--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -7,6 +7,15 @@ inputs:
   ops-ref:
     description: Ref to checkout in ops repo
     default: main
+  tailscale-oauth-client-id:
+    description: Tailscale OAuth client ID for OIDC authentication
+    required: true
+  tailscale-tags:
+    description: Tailscale tags for the connection (must match OIDC trust configuration)
+    required: true
+  tailscale-k8s-operator-hostname:
+    description: Hostname of the Tailscale Kubernetes operator to configure kubeconfig
+    required: true
 runs:
   using: composite
   steps:
@@ -50,13 +59,13 @@ runs:
     - name: Connect to Tailscale
       uses: tailscale/github-action@v4
       with:
-        oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
-        audience: api.tailscale.com/${{ vars.TS_OAUTH_CLIENT_ID }}
-        tags: ${{ vars.TS_TAGS }} # must be synced to actual OIDC trust in Tailscale
+        oauth-client-id: ${{ inputs.tailscale-oauth-client-id }}
+        audience: api.tailscale.com/${{ inputs.tailscale-oauth-client-id }}
+        tags: ${{ inputs.tailscale-tags }} # must be synced to actual OIDC trust in Tailscale
 
     - name: Configure kubeconfig
       shell: bash
-      run: tailscale configure kubeconfig ${{ vars.TS_K8S_OPERATOR_HOSTNAME }}
+      run: tailscale configure kubeconfig ${{ inputs.tailscale-k8s-operator-hostname }}
 
     - name: Test kubernetes cluster for readiness
       shell: bash

--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -7,17 +7,12 @@ inputs:
   ops-ref:
     description: Ref to checkout in ops repo
     default: main
-  tailscale-oauth:
-    description: Tailscale OAuth key
-    required: true
-  k8s-core:
-    description: K8S core name
 runs:
   using: composite
   steps:
     - if: inputs.ops-ssh-key
       name: Checkout ops
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: beyondessential/ops
         ssh-key: ${{ inputs.ops-ssh-key }}
@@ -30,7 +25,7 @@ runs:
 
     - name: Install Node.js for ops
       if: inputs.ops-ssh-key
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: ops/.node-version
         cache: npm
@@ -55,15 +50,14 @@ runs:
     - name: Connect to Tailscale
       uses: tailscale/github-action@v2
       with:
-        oauth-secret: ${{ inputs.tailscale-oauth }}
-        tags: tag:infra,tag:infra-gha-deploy
+        oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+        audience: api.tailscale.com/${{ vars.TS_OAUTH_CLIENT_ID }}
+        tags: ${{ vars.TS_TAGS }} # must be synced to actual OIDC trust in Tailscale
 
     - name: Configure kubeconfig
-      if: inputs.k8s-core
       shell: bash
-      run: tailscale configure kubeconfig k8s-operator-${{ inputs.k8s-core }}
+      run: tailscale configure kubeconfig ${{ vars.TS_K8S_OPERATOR_HOSTNAME }}
 
     - name: Test kubernetes cluster for readiness
-      if: inputs.k8s-core
       shell: bash
       run: kubectl get namespace/tamanu-system

--- a/.github/actions/setup-cd/action.yml
+++ b/.github/actions/setup-cd/action.yml
@@ -48,7 +48,7 @@ runs:
       uses: pulumi/actions@v5
 
     - name: Connect to Tailscale
-      uses: tailscale/github-action@v2
+      uses: tailscale/github-action@v4
       with:
         oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
         audience: api.tailscale.com/${{ vars.TS_OAUTH_CLIENT_ID }}

--- a/.github/workflows/cd-deploy-dbt-docs.yml
+++ b/.github/workflows/cd-deploy-dbt-docs.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build and deploy docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
          ref: ${{ github.head_ref || github.ref }}
 
@@ -41,7 +41,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install dbt-core dbt-postgres
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: write # to update the release notes
   pull-requests: write
+  id-token: write # for Tailscale OIDC authentication
 
 jobs:
   down:

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -18,8 +18,6 @@ on:
     secrets:
       PULUMI_ACCESS_TOKEN:
         required: true
-      TAILSCALE_OAUTH:
-        required: true
       TAMANU_OPS_SSH:
         required: true
 
@@ -37,8 +35,6 @@ jobs:
         uses: ./.github/actions/setup-cd
         with:
           ops-ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
-          tailscale-oauth: ${{ secrets.TAILSCALE_OAUTH }}
-          k8s-core: ${{ fromJson(inputs.options).k8score }}
 
       - name: Check namespace
         id: check

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -36,6 +36,9 @@ jobs:
         uses: ./.github/actions/setup-cd
         with:
           ops-ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
+          tailscale-oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          tailscale-tags: ${{ vars.TS_TAGS }}
+          tailscale-k8s-operator-hostname: ${{ vars.TS_K8S_OPERATOR_HOSTNAME }}
 
       - name: Check namespace
         id: check

--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -31,7 +31,7 @@ jobs:
     name: Bring down ${{ inputs.deploy-name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: setup
         uses: ./.github/actions/setup-cd
         with:

--- a/.github/workflows/cd-fake-data.yml
+++ b/.github/workflows/cd-fake-data.yml
@@ -21,7 +21,7 @@ jobs:
     name: ${{ inputs.deploy-name }}
     if: fromJson(inputs.options).fakedata != 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-cd
 
       - run: npm ci

--- a/.github/workflows/cd-fake-data.yml
+++ b/.github/workflows/cd-fake-data.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write # for Tailscale OIDC authentication
 
 jobs:
   deploy:

--- a/.github/workflows/cd-fake-data.yml
+++ b/.github/workflows/cd-fake-data.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-cd
+        with:
+          tailscale-oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          tailscale-tags: ${{ vars.TS_TAGS }}
+          tailscale-k8s-operator-hostname: ${{ vars.TS_K8S_OPERATOR_HOSTNAME }}
 
       - run: npm ci
       - run: npm run build-shared

--- a/.github/workflows/cd-fake-data.yml
+++ b/.github/workflows/cd-fake-data.yml
@@ -9,9 +9,6 @@ on:
       options:
         type: string
         required: true
-    secrets:
-      TAILSCALE_OAUTH:
-        required: true
 
 permissions:
   contents: read
@@ -25,9 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-cd
-        with:
-          tailscale-oauth: ${{ secrets.TAILSCALE_OAUTH }}
-          k8s-core: ${{ fromJson(inputs.options).k8score }}
 
       - run: npm ci
       - run: npm run build-shared

--- a/.github/workflows/cd-package-android.yml
+++ b/.github/workflows/cd-package-android.yml
@@ -47,7 +47,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -95,7 +95,7 @@ jobs:
           echo "BRANDING=${{ inputs.branding }}" > .env
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm

--- a/.github/workflows/cd-package-frontend.yml
+++ b/.github/workflows/cd-package-frontend.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           files: '*.tar.zst*'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Post to meta
         if: steps.destination.outputs.result != 'nowhere' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         continue-on-error: true

--- a/.github/workflows/cd-package-servers.yml
+++ b/.github/workflows/cd-package-servers.yml
@@ -25,7 +25,7 @@ jobs:
     name: Pack ${{ matrix.package }} for Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Login to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
@@ -153,10 +153,10 @@ jobs:
     name: Pack ${{ matrix.package }} for Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write # for Tailscale OIDC authentication
 
 jobs:
   deploy:

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ inputs.deploy-name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: setup
         uses: ./.github/actions/setup-cd
         with:

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -21,8 +21,6 @@ on:
     secrets:
       PULUMI_ACCESS_TOKEN:
         required: true
-      TAILSCALE_OAUTH:
-        required: true
       TAMANU_OPS_SSH:
         required: true
 
@@ -41,8 +39,6 @@ jobs:
         with:
           ops-ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           ops-ref: ${{ fromJson(inputs.options).opsref }}
-          tailscale-oauth: ${{ secrets.TAILSCALE_OAUTH }}
-          k8s-core: ${{ fromJson(inputs.options).k8score }}
 
       - name: Create or check namespace
         run: |

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Generate pulumi config
         id: config
         uses: actions/github-script@v7
+        env:
+          K8S_CORE: ${{ vars.K8S_CORE }}
         with:
           script: |
             const cwd = '${{ github.workspace }}';

--- a/.github/workflows/cd-up.yml
+++ b/.github/workflows/cd-up.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           ops-ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
           ops-ref: ${{ fromJson(inputs.options).opsref }}
+          tailscale-oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          tailscale-tags: ${{ vars.TS_TAGS }}
+          tailscale-k8s-operator-hostname: ${{ vars.TS_K8S_OPERATOR_HOSTNAME }}
 
       - name: Create or check namespace
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
     name: Workflow config
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Figure branch ref and sha
         id: ref
         uses: actions/github-script@v7
@@ -61,7 +61,7 @@ jobs:
 
       - name: Checkout the real ref
         if: steps.ref.outputs.result != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.result }}
       - name: Find the real sha
@@ -206,7 +206,7 @@ jobs:
       - name: Login to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.config.outputs.ref }}
 
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Multi-arch for ${{ matrix.repo }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-manifest-tool
       - name: Combine images
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -317,7 +317,6 @@ jobs:
       ref: ${{ needs.config.outputs.ref }}
     secrets:
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      TAILSCALE_OAUTH: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
       TAMANU_OPS_SSH: ${{ secrets.TAMANU_OPS_SSH }}
 
   deploy-down:
@@ -335,7 +334,6 @@ jobs:
       options: ${{ matrix.options }}
     secrets:
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      TAILSCALE_OAUTH: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
       TAMANU_OPS_SSH: ${{ secrets.TAMANU_OPS_SSH }}
 
   fake-data:
@@ -351,8 +349,6 @@ jobs:
     with:
       deploy-name: ${{ matrix.name }}
       options: ${{ matrix.options }}
-    secrets:
-      TAILSCALE_OAUTH: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
 
   package-android-test:
     needs: config

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: check
         uses: actions/github-script@v7
         with:
@@ -37,10 +37,10 @@ jobs:
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -68,10 +68,10 @@ jobs:
       TZ: Pacific/Auckland
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.base_ref }}
@@ -47,7 +47,7 @@ jobs:
           realbase=$(git merge-base ${{ github.base_ref || 'HEAD~1' }} HEAD)
           echo "realbase=$realbase" | tee -a "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm

--- a/.github/workflows/ci-synthetic-test-runner.yml
+++ b/.github/workflows/ci-synthetic-test-runner.yml
@@ -61,14 +61,14 @@ jobs:
       - name: Verify checkbox is still checked
         uses: actions/github-script@v7
         with:
-          script: |    
+          script: |
             const prNumber = parseInt(process.env.PR_NUMBER);
-            
+
             if (isNaN(prNumber)) {
               core.setFailed(`Invalid PR number: ${process.env.PR_NUMBER}`);
               return;
             }
-            
+
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -82,11 +82,11 @@ jobs:
               core.setFailed('Checkbox is no longer checked – skipping test.');
             }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.PR_REF }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -167,4 +167,3 @@ jobs:
             --field pr_number="${{ inputs.pr_number }}" \
             --field pr_ref="${{ inputs.pr_ref }}" \
             --field pr_sha="${{ inputs.pr_sha }}"
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Check node version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
       - name: Check package.json against .node-version
@@ -45,10 +45,10 @@ jobs:
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -96,10 +96,10 @@ jobs:
     name: Test ${{ matrix.package }} ${{ matrix.shard }} (pg=${{ matrix.postgres || 'no' }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -131,10 +131,10 @@ jobs:
     name: Build all packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -151,10 +151,10 @@ jobs:
     name: Lint packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -179,8 +179,8 @@ jobs:
     name: Test storybook
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -211,10 +211,10 @@ jobs:
     name: Test migrations server=${{ matrix.server }} pg=${{ matrix.postgres }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -238,10 +238,10 @@ jobs:
     name: Test mobile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -261,10 +261,10 @@ jobs:
     name: Test the facility server with the central server being down
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -294,10 +294,10 @@ jobs:
     name: Check package-lock.json is up to date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -313,10 +313,10 @@ jobs:
     name: DBT model up to date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -367,10 +367,10 @@ jobs:
     name: DBT model TODOs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: npm
@@ -386,7 +386,7 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check spelling
         uses: crate-ci/typos@v1.36.3
         with:

--- a/.github/workflows/cleanup-auto-deploy.yml
+++ b/.github/workflows/cleanup-auto-deploy.yml
@@ -20,6 +20,7 @@ permissions:
   contents: write # to checkout the repo
   pull-requests: write # to parse PRs for config and update them
   issues: write # to parse special deploy issues and update them
+  id-token: write # for Tailscale OIDC authentication
 
 jobs:
   config:

--- a/.github/workflows/cleanup-auto-deploy.yml
+++ b/.github/workflows/cleanup-auto-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       down: ${{ steps.config.outputs.down }}
       go-down: ${{ steps.config.outputs.go-down == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: setup
         uses: ./.github/actions/setup-cd
         with:

--- a/.github/workflows/cleanup-auto-deploy.yml
+++ b/.github/workflows/cleanup-auto-deploy.yml
@@ -35,6 +35,9 @@ jobs:
         uses: ./.github/actions/setup-cd
         with:
           ops-ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
+          tailscale-oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          tailscale-tags: ${{ vars.TS_TAGS }}
+          tailscale-k8s-operator-hostname: ${{ vars.TS_K8S_OPERATOR_HOSTNAME }}
 
       - name: List all controlled deploys from K8s
         id: list

--- a/.github/workflows/cleanup-auto-deploy.yml
+++ b/.github/workflows/cleanup-auto-deploy.yml
@@ -34,7 +34,6 @@ jobs:
         uses: ./.github/actions/setup-cd
         with:
           ops-ssh-key: ${{ secrets.TAMANU_OPS_SSH }}
-          tailscale-oauth: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
 
       - name: List all controlled deploys from K8s
         id: list
@@ -82,5 +81,4 @@ jobs:
       ref: not needed as check branch is false
     secrets:
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      TAILSCALE_OAUTH: ${{ secrets.TAILSCALE_DBPROXY_ACCESS_OAUTH }}
       TAMANU_OPS_SSH: ${{ secrets.TAMANU_OPS_SSH }}

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: main
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
@@ -29,7 +29,7 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version-file: '.node-version'
 

--- a/.github/workflows/lint-fix-in-pr.yml
+++ b/.github/workflows/lint-fix-in-pr.yml
@@ -49,12 +49,12 @@ jobs:
             pull_number: number,
           });
           return pr.data.head.ref;
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ steps.branch.outputs.result }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: '.node-version'
         cache: npm

--- a/.github/workflows/publish-release-version.yml
+++ b/.github/workflows/publish-release-version.yml
@@ -26,13 +26,13 @@ jobs:
         echo "This workflow can only be run on a release branch"
         exit 1
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         token: ${{ secrets.TAMANU_RELEASE_PAT }}
         fetch-depth: 0 # fetch all history so we can generate release notes
         fetch-tags: true
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version-file: '.node-version'
 

--- a/packages/scripts/src/ghaCdHelpers.mjs
+++ b/packages/scripts/src/ghaCdHelpers.mjs
@@ -60,7 +60,7 @@ const OPTIONS = [
   { key: 'arch', defaultValue: 'arm64' },
   { key: 'opsref', defaultValue: 'main' },
   { key: 'opsstack', defaultValue: 'tamanu/on-k8s' },
-  { key: 'k8score', defaultValue: 'tamanu-internal-main' },
+
   { key: 'pause', defaultValue: false, presence: true },
   { key: 'imagesonly', defaultValue: false, presence: true },
 
@@ -199,9 +199,10 @@ function parseOptions(str, context) {
 }
 
 export function configMap(deployName, imageTag, options) {
+  const k8sCore = process.env.K8S_CORE || 'tamanu-internal-main';
   return Object.fromEntries(
     Object.entries({
-      'k8s-core': `bes/k8s-core/${options.k8score}`,
+      'k8s-core': `bes/k8s-core/${k8sCore}`,
       namespace: `tamanu-${deployName}`,
       externalNamespace: true,
       imageTag,
@@ -425,10 +426,9 @@ export async function findDeploysToCleanUp(controlList, ttl = 24, context, githu
     }
   }
 
-  return todo.map(({ core, ns }) => ({
+  return todo.map(({ ns }) => ({
     name: ns.replace(/^tamanu-/, ''),
     options: JSON.stringify({
-      k8score: core.replace(/^k8s-operator-/, ''),
       opsstack: OPTIONS.find(({ key }) => key === 'opsstack').defaultValue,
     }),
   }));


### PR DESCRIPTION
### Changes

With this, we can eliminate the use of a secret for Tailscale auth of the GHA workers. One less thing to rotate!

The vars have already been set up. The old secret has been rotated, and can be removed altogether in a few months [reminder has been set for March 3rd] once everything has merged this naturally.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
