### PR TITLE
fix(auditing): Fix broken access logs

### DIFF
--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -131,18 +131,17 @@ export class TamanuApi extends ApiClient {
     });
   }
 
-  setToken(token, refreshToken) {
+  setToken(token) {
     if (token) {
       localStorage.setItem(TOKEN, token);
     } else {
       localStorage.removeItem(TOKEN);
     }
-    return super.setToken(token, refreshToken);
+    return super.setToken(token);
   }
 
   // Overwrite base method to integrate with the facility-server refresh endpoint which just
-  // checks for an apiToken and returns a new one. This should be removed when refresh tokens are
-  // set up in facility-server
+  // checks for an apiToken and returns a new one.
   async refreshToken(config = {}) {
     const response = await this.post(
       'refresh',
@@ -151,8 +150,8 @@ export class TamanuApi extends ApiClient {
       },
       config,
     );
-    const { token, refreshToken: newRefreshToken } = response;
-    this.setToken(token, newRefreshToken);
+    const { token } = response;
+    this.setToken(token);
   }
 
   async restoreSession() {

--- a/packages/web/app/api/TamanuApi.jsx
+++ b/packages/web/app/api/TamanuApi.jsx
@@ -202,7 +202,12 @@ export class TamanuApi extends ApiClient {
   }
 
   async setFacility(facilityId) {
-    const { settings } = await this.post('setFacility', { facilityId });
+    // The setFacility endpoint returns an updated token with facilityId embedded in the JWT claims.
+    // This new token is stored and used for subsequent authenticated requests to facility-scoped endpoints.
+    const { settings, token } = await this.post('setFacility', { facilityId });
+
+    this.setToken(token);
+
     saveToLocalStorage({
       facilityId,
       settings,


### PR DESCRIPTION
### Changes
The facility-server extracts from JWT claims and attaches it to for downstream use (e.g., retrieving facility-specific audit settings). After facility selection, the web client was not storing the updated token returned by , causing subsequent requests to lack the claim and breaking facility-scoped functionality.

The fix is to store the updated JWT token (which includes the claim) returned from the endpoint. This ensures all subsequent authenticated requests include the facility context needed by the middleware.

I don't know why this got into this state but this seems like the obvious solution.


### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
