### PR TITLE
fix(notes): TAMOC-384: Floating note modal form state clears on resize

### DIFF
--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -81,9 +81,8 @@ export const withModalFloating = ModalComponent => {
     // Recenter and reset to default size when window is resized
     useEffect(() => {
       const handleResize = () => {
-        const base = baseSizeRef.current;
-        setPosition(calculateDefaultPosition(base.width, base.height));
-        setSize(base);
+        setPosition(calculateDefaultPosition(baseSizeRef.current.width, baseSizeRef.current.height));
+        setSize(baseSizeRef.current);
       };
       window.addEventListener('resize', handleResize);
       return () => window.removeEventListener('resize', handleResize);

--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -11,10 +11,13 @@ import { ResizeVerticalIcon } from './Icons/ResizeVerticalIcon';
 import { Colors } from '../constants';
 
 const calculateDefaultPosition = (baseWidth, baseHeight) => {
-  return {
-    x: Math.max(0, Math.round(window.innerWidth / 2 - Number(baseWidth) / 2)),
-    y: Math.max(0, Math.round(window.innerHeight / 2 - Number(baseHeight) / 2)),
-  };
+  if (typeof window !== 'undefined') {
+    return {
+      x: Math.max(0, Math.round(window.innerWidth / 2 - Number(baseWidth) / 2)),
+      y: Math.max(0, Math.round(window.innerHeight / 2 - Number(baseHeight) / 2)),
+    };
+  }
+  return { x: 0, y: 0 };
 };
 
 export const withModalFloating = ModalComponent => {

--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useMemo } from 'react';
+import React, { useEffect, useRef, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import { Resizable } from 're-resizable';
@@ -52,6 +52,17 @@ export const withModalFloating = ModalComponent => {
     ...modalProps
   }) => {
     const positionRef = useRef({ x: 0, y: 0 });
+    // Capture initial values in refs to prevent PaperComponent from recreating on window resize
+    const initialSizeRef = useRef({ width: baseWidth, height: baseHeight });
+    const initialMinConstraintsRef = useRef(minConstraints);
+    // Store maxConstraints in a ref that we can update dynamically
+    const maxConstraintsRef = useRef(maxConstraints);
+
+    // Update maxConstraints ref when prop changes (for dynamic constraint updates)
+    useEffect(() => {
+      maxConstraintsRef.current = maxConstraints;
+    }, [maxConstraints]);
+
     const defaultPosition = useMemo(() => {
       if (typeof window !== 'undefined') {
         const x = Math.max(0, Math.round(window.innerWidth / 2 - Number(baseWidth) / 2));
@@ -75,11 +86,11 @@ export const withModalFloating = ModalComponent => {
             }}
           >
             <Resizable
-              defaultSize={{ width: baseWidth, height: baseHeight }}
-              minWidth={minConstraints[0]}
-              minHeight={minConstraints[1]}
-              maxWidth={maxConstraints[0]}
-              maxHeight={maxConstraints[1]}
+              defaultSize={initialSizeRef.current}
+              minWidth={initialMinConstraintsRef.current[0]}
+              minHeight={initialMinConstraintsRef.current[1]}
+              maxWidth={maxConstraintsRef.current[0]}
+              maxHeight={maxConstraintsRef.current[1]}
               enable={enableResizeHandle}
               resizeRatio={resizeRatio}
               handleComponent={handleComponent}
@@ -107,10 +118,6 @@ export const withModalFloating = ModalComponent => {
         positionRef,
         draggableHandle,
         draggableBounds,
-        baseWidth,
-        baseHeight,
-        minConstraints,
-        maxConstraints,
         enableResizeHandle,
         handleComponent,
         handleStyles,

--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -61,15 +61,18 @@ export const withModalFloating = ModalComponent => {
     BackdropProps,
     ...modalProps
   }) => {
-    // Store values in refs to prevent PaperComponent from recreating on window resize
-    // Update refs directly in component body to ensure latest values during render
+    // We use both state and refs for position/size:
+    // - State triggers re-renders when window resizes (to recenter modal) and keeps
+    //   react-draggable/re-resizable controlled (they need prop updates to reflect changes)
+    // - Refs provide stable references to the memoized PaperComponent callback, preventing
+    //   it from recreating on every render (which would remount Dialog and reset form state)
+    // Refs are synced from state/props on each render so PaperComponent always reads current values
     const positionRef = useRef({ x: 0, y: 0 });
     const baseSizeRef = useRef({ width: Number(baseWidth), height: Number(baseHeight) });
     const currentSizeRef = useRef({ width: Number(baseWidth), height: Number(baseHeight) });
     const minConstraintsRef = useRef(minConstraints);
     const maxConstraintsRef = useRef(maxConstraints);
 
-    // Controlled position and size so we can recenter and reset size on window resize
     const [position, setPosition] = useState(() =>
       calculateDefaultPosition(baseWidth, baseHeight),
     );

--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -114,6 +114,7 @@ export const withModalFloating = ModalComponent => {
           </Draggable>
         );
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
         positionRef,
         draggableHandle,

--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useRef, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import { Resizable } from 're-resizable';
@@ -52,16 +52,16 @@ export const withModalFloating = ModalComponent => {
     ...modalProps
   }) => {
     const positionRef = useRef({ x: 0, y: 0 });
-    // Capture initial values in refs to prevent PaperComponent from recreating on window resize
-    const initialSizeRef = useRef({ width: baseWidth, height: baseHeight });
-    const initialMinConstraintsRef = useRef(minConstraints);
-    // Store maxConstraints in a ref that we can update dynamically
+    // Store values in refs to prevent PaperComponent from recreating on window resize
+    // Update refs directly in component body to ensure latest values during render
+    const sizeRef = useRef({ width: baseWidth, height: baseHeight });
+    const minConstraintsRef = useRef(minConstraints);
     const maxConstraintsRef = useRef(maxConstraints);
 
-    // Update maxConstraints ref when prop changes (for dynamic constraint updates)
-    useEffect(() => {
-      maxConstraintsRef.current = maxConstraints;
-    }, [maxConstraints]);
+    // Update refs with latest prop values (refs are stable objects, so PaperComponent won't recreate)
+    sizeRef.current = { width: baseWidth, height: baseHeight };
+    minConstraintsRef.current = minConstraints;
+    maxConstraintsRef.current = maxConstraints;
 
     const defaultPosition = useMemo(() => {
       if (typeof window !== 'undefined') {
@@ -86,9 +86,9 @@ export const withModalFloating = ModalComponent => {
             }}
           >
             <Resizable
-              defaultSize={initialSizeRef.current}
-              minWidth={initialMinConstraintsRef.current[0]}
-              minHeight={initialMinConstraintsRef.current[1]}
+              defaultSize={sizeRef.current}
+              minWidth={minConstraintsRef.current[0]}
+              minHeight={minConstraintsRef.current[1]}
               maxWidth={maxConstraintsRef.current[0]}
               maxHeight={maxConstraintsRef.current[1]}
               enable={enableResizeHandle}


### PR DESCRIPTION
### Changes

Resizing the window while editing a note in the floating modal caused the `PaperComponent` inside the floating modal to be recreated because `baseWidth`, `baseHeight`, `minConstraints`, and `maxConstraints` were in the `useCallback` dependency array. This remounted the component and cleared the form state, losing unsaved data. This change stores these values in refs and updates them directly in the component body during render, ensuring the latest values are used while keeping the refs stable. By removing these props from the dependency array and using refs instead, `PaperComponent` no longer recreates on window resize, preserving form state and preventing data loss.

Changes since initial review:
- We now control the position and size using props rather than just setting the default. Previously it would constantly rerender in the correct place thanks to the max and min width changing the default. Now it no longer rerenders and we need to control the size and position

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
