### PR TITLE
fix(patientDetails): No issue: Show duplicate NHN error when editing patient details

### DIFF
--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -114,10 +114,10 @@ patientRoute.put(
     await db.transaction(async () => {
       // First check if displayId changed to create a secondaryId record
       if (validatedBody.displayId && validatedBody.displayId !== patient.displayId) {
-        const existingPatient = await Patient.findOne({
+        const existingPatientCount = await Patient.count({
           where: { displayId: validatedBody.displayId },
         });
-        if (existingPatient) {
+        if (existingPatientCount > 0) {
           throw new ValidationError(
             `Display ID ${validatedBody.displayId} is already in use by another patient`,
           );

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -7,12 +7,7 @@ import {
   createPatientSchema,
   updatePatientSchema,
 } from '@tamanu/shared/schemas/facility/requests/createPatient.schema';
-import {
-  NotFoundError,
-  InvalidParameterError,
-  DatabaseDuplicateError,
-  ValidationError,
-} from '@tamanu/errors';
+import { NotFoundError, InvalidParameterError, ValidationError } from '@tamanu/errors';
 import {
   PATIENT_REGISTRY_TYPES,
   VISIBILITY_STATUSES,

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -7,7 +7,12 @@ import {
   createPatientSchema,
   updatePatientSchema,
 } from '@tamanu/shared/schemas/facility/requests/createPatient.schema';
-import { NotFoundError, InvalidParameterError } from '@tamanu/errors';
+import {
+  NotFoundError,
+  InvalidParameterError,
+  DatabaseDuplicateError,
+  ValidationError,
+} from '@tamanu/errors';
 import {
   PATIENT_REGISTRY_TYPES,
   VISIBILITY_STATUSES,
@@ -114,6 +119,15 @@ patientRoute.put(
     await db.transaction(async () => {
       // First check if displayId changed to create a secondaryId record
       if (validatedBody.displayId && validatedBody.displayId !== patient.displayId) {
+        const existingPatient = await Patient.findOne({
+          where: { displayId: validatedBody.displayId },
+        });
+        if (existingPatient) {
+          throw new ValidationError(
+            `Display ID ${validatedBody.displayId} is already in use by another patient`,
+          );
+        }
+
         const oldDisplayIdType =
           isGeneratedDisplayId(patient.displayId) ||
           isGeneratedIdFromPattern(patient.displayId, patientDisplayIdPattern)

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -114,10 +114,10 @@ patientRoute.put(
     await db.transaction(async () => {
       // First check if displayId changed to create a secondaryId record
       if (validatedBody.displayId && validatedBody.displayId !== patient.displayId) {
-        const existingPatientCount = await Patient.count({
+        const existingPatients = await Patient.count({
           where: { displayId: validatedBody.displayId },
         });
-        if (existingPatientCount > 0) {
+        if (existingPatients > 0) {
           throw new ValidationError(
             `Display ID ${validatedBody.displayId} is already in use by another patient`,
           );


### PR DESCRIPTION
### Changes

This shows up as a generic "Validation error" and was causing some confusion on a support issue. This just adds a clear message for this situation (Attempting to edit a patient to a duplicate NHN)

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
