### PR TITLE
Install app icon missing

### DIFF
--- a/packages/web/public/shared/tamanu-manifest.json
+++ b/packages/web/public/shared/tamanu-manifest.json
@@ -1,0 +1,1 @@
+../tamanu-manifest.json

--- a/packages/web/public/tamanu-manifest.json
+++ b/packages/web/public/tamanu-manifest.json
@@ -6,7 +6,7 @@
     {
       "purpose": "any",
       "sizes": "192x192",
-      "src": "/shared//tamanu-icons/manifest-icon-192.maskable.png",
+      "src": "/shared/tamanu-icons/manifest-icon-192.maskable.png",
       "type": "image/png"
     },
     {


### PR DESCRIPTION
### Changes

Resolves NASS-1890 by ensuring the PWA manifest is correctly served. This was achieved by creating a missing symlink for `tamanu-manifest.json` in `packages/web/public/shared/` and correcting a double slash in an icon path within the manifest. This allows browsers to detect the web app as a PWA and display the "Install App" icon.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- [ ] ...write or update tests
- [ ] ...add UI screenshots and **testing notes** to the Linear issue
- [ ] ...add any **manual upgrade steps** to the Linear issue
- [ ] ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- [ ] ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [NASS-1890](https://linear.app/bes/issue/NASS-1890/bug-request-install-page-as-app-icon-mssing)

<a href="https://cursor.com/background-agent?bcId=bc-a9bbc30a-e2e2-44f6-9540-7a97bfaff530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9bbc30a-e2e2-44f6-9540-7a97bfaff530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

