### PR TITLE
fix(web): HOTFIX-2.47: Add missing symlink for tamanu-manifest.json

### DIFF
--- a/packages/web/public/shared/tamanu-manifest.json
+++ b/packages/web/public/shared/tamanu-manifest.json
@@ -1,0 +1,1 @@
+../tamanu-manifest.json

--- a/packages/web/public/tamanu-manifest.json
+++ b/packages/web/public/tamanu-manifest.json
@@ -6,7 +6,7 @@
     {
       "purpose": "any",
       "sizes": "192x192",
-      "src": "/shared//tamanu-icons/manifest-icon-192.maskable.png",
+      "src": "/shared/tamanu-icons/manifest-icon-192.maskable.png",
       "type": "image/png"
     },
     {


### PR DESCRIPTION
The Install Page as App icon was missing from the browser URL bar because the HTML references /shared/tamanu-manifest.json but there was no symlink for the manifest file in packages/web/public/shared/.

This commit:
- Adds the missing symlink packages/web/public/shared/tamanu-manifest.json
- Fixes a typo (double slash) in the manifest icon path

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
