### PR TITLE
chore: trigger tamanu-source-dbt upgrade on cut release

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -81,7 +81,7 @@ jobs:
       env:
         NEW_BRANCH_NAME: ${{ steps.branchname.outputs.result }}
       run: |
-        curl -X POST \
+        curl -fsSL -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.DBT_REPO_DISPATCH_PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -76,3 +76,16 @@ jobs:
         version=$(jq -r .version package.json)
         git commit -am "release: Bump version to $version"
         git push
+
+    - name: Trigger tamanu-source-dbt upgrade workflow
+      env:
+        NEW_BRANCH_NAME: ${{ steps.branchname.outputs.result }}
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.DBT_REPO_DISPATCH_PAT }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/beyondessential/tamanu-source-dbt/dispatches \
+          -d "{\"event_type\":\"tamanu-release-created\",\"client_payload\":{\"branch\":\"$NEW_BRANCH_NAME\"}}"
+
+        echo "✅ Triggered tamanu-source-dbt upgrade workflow for $NEW_BRANCH_NAME"


### PR DESCRIPTION
### Changes

When the cut off workflow is run, it will trigger an update on tamanu-source-dbt repo.
Companion [PR](https://github.com/beyondessential/tamanu-source-dbt/pull/335) in tamanu-source-dbt repo
- Requires a PAT to be setup (DBT_REPO_DISPATCH_PAT).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
