### PR TITLE
fix(notes): HOTFIX-2.45: Filter out system and mobile note type from create a note dropdown

### DIFF
--- a/packages/constants/src/notes.ts
+++ b/packages/constants/src/notes.ts
@@ -27,6 +27,12 @@ export const NOTE_TYPES = {
   HANDOVER: 'handover',
 };
 
+// Note types that should not be user-editable or creatable via UI
+export const NON_EDITABLE_NOTE_TYPES = [
+  NOTE_TYPES.SYSTEM,
+  NOTE_TYPES.CLINICAL_MOBILE,
+];
+
 export const NOTE_TYPE_LABELS = {
   [NOTE_TYPES.TREATMENT_PLAN]: 'Treatment plan',
   [NOTE_TYPES.ADMISSION]: 'Admission',

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Divider from '@material-ui/core/Divider';
 import Tooltip from '@material-ui/core/Tooltip';
-import { NOTE_TYPES, NOTE_TYPE_LABELS } from '@tamanu/constants';
+import { NOTE_TYPES, NOTE_TYPE_LABELS, NON_EDITABLE_NOTE_TYPES } from '@tamanu/constants';
 import { Box } from '@material-ui/core';
 import { InfoCard, InfoCardItem } from './InfoCard';
 import {
@@ -305,7 +305,7 @@ export const NoteTypeField = ({
     $fontSize={$fontSize}
     transformOptions={types =>
       types
-        .filter(option => !option.hideFromDropdown && ![NOTE_TYPES.SYSTEM, NOTE_TYPES.CLINICAL_MOBILE].includes(option.value))
+        .filter(option => !option.hideFromDropdown && !NON_EDITABLE_NOTE_TYPES.includes(option.value))
         .map(option => ({
           ...option,
           isDisabled:

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -305,7 +305,7 @@ export const NoteTypeField = ({
     $fontSize={$fontSize}
     transformOptions={types =>
       types
-        .filter(option => !option.hideFromDropdown && option.value !== NOTE_TYPES.SYSTEM)
+        .filter(option => !option.hideFromDropdown && ![NOTE_TYPES.SYSTEM, NOTE_TYPES.CLINICAL_MOBILE].includes(option.value))
         .map(option => ({
           ...option,
           isDisabled:

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -305,7 +305,7 @@ export const NoteTypeField = ({
     $fontSize={$fontSize}
     transformOptions={types =>
       types
-        .filter(option => !option.hideFromDropdown)
+        .filter(option => !option.hideFromDropdown && option.value !== NOTE_TYPES.SYSTEM)
         .map(option => ({
           ...option,
           isDisabled:

--- a/packages/web/app/components/NoteTable.jsx
+++ b/packages/web/app/components/NoteTable.jsx
@@ -203,7 +203,7 @@ const NoteContent = ({
         </NoteContentContainer>
         {hasIndividualNotePermission &&
           hasEncounterNoteWritePermission &&
-          note.noteType !== NOTE_TYPES.SYSTEM && (
+          ![NOTE_TYPES.SYSTEM, NOTE_TYPES.CLINICAL_MOBILE].includes(note.noteType) && (
             <NoteModalActionBlocker>
               <StyledEditIcon
                 onClick={() => handleEditNote(note)}

--- a/packages/web/app/components/NoteTable.jsx
+++ b/packages/web/app/components/NoteTable.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react'
 import styled from 'styled-components';
 import EditIcon from '@material-ui/icons/Edit';
 
-import { NOTE_PERMISSION_TYPES, NOTE_TYPES, NOTE_TYPE_LABELS } from '@tamanu/constants';
+import { NOTE_PERMISSION_TYPES, NOTE_TYPES, NOTE_TYPE_LABELS, NON_EDITABLE_NOTE_TYPES } from '@tamanu/constants';
 
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
@@ -203,7 +203,7 @@ const NoteContent = ({
         </NoteContentContainer>
         {hasIndividualNotePermission &&
           hasEncounterNoteWritePermission &&
-          ![NOTE_TYPES.SYSTEM, NOTE_TYPES.CLINICAL_MOBILE].includes(note.noteType) && (
+          !NON_EDITABLE_NOTE_TYPES.includes(note.noteType) && (
             <NoteModalActionBlocker>
               <StyledEditIcon
                 onClick={() => handleEditNote(note)}


### PR DESCRIPTION
System notes are auto-generated and should not be selectable when creating a new note. This aligns the NoteTypeField dropdown with the filtering already applied in NotesPane. I have also removed the option to edit these notes

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
