### PR TITLE
fix(translations): NOTAM-551: 2.48 fix: Translated string admin panel field name was wrong

### DIFF
--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -117,14 +117,26 @@ export async function translatedStringLoader(item, { models, header }) {
   });
   const existingTranslationsMap = new Map(existingTranslations.map(t => [t.language, t]));
   for (const language of languagesInSheet) {
-    if (language === DEFAULT_LANGUAGE_CODE) {
-      continue; // Ignore any edits to the default language
-    }
-
     const text = languages[language];
     const emptyCell = isNil(text) || isEmpty(`${text}`.trim());
+    const existing = existingTranslationsMap.get(language);
+
+    if (language === DEFAULT_LANGUAGE_CODE) {
+      // Allow creation of default language translations, but ignore edits
+      if (!existing && !emptyCell) {
+        rows.push({
+          model: 'TranslatedString',
+          values: {
+            stringId,
+            language,
+            text,
+          },
+        });
+      }
+      continue;
+    }
+
     if (emptyCell) {
-      const existing = existingTranslationsMap.get(language);
       if (existing) {
         // An empty cell means delete the translation for this language
         rows.push({

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -117,26 +117,14 @@ export async function translatedStringLoader(item, { models, header }) {
   });
   const existingTranslationsMap = new Map(existingTranslations.map(t => [t.language, t]));
   for (const language of languagesInSheet) {
-    const text = languages[language];
-    const emptyCell = isNil(text) || isEmpty(`${text}`.trim());
-    const existing = existingTranslationsMap.get(language);
-
     if (language === DEFAULT_LANGUAGE_CODE) {
-      // Allow creation of default language translations, but ignore edits
-      if (!existing && !emptyCell) {
-        rows.push({
-          model: 'TranslatedString',
-          values: {
-            stringId,
-            language,
-            text,
-          },
-        });
-      }
-      continue;
+      continue; // Ignore any edits to the default language
     }
 
+    const text = languages[language];
+    const emptyCell = isNil(text) || isEmpty(`${text}`.trim());
     if (emptyCell) {
+      const existing = existingTranslationsMap.get(language);
       if (existing) {
         // An empty cell means delete the translation for this language
         rows.push({

--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -14,10 +14,9 @@ import {
   LANGUAGE_NAME_STRING_ID,
 } from '@tamanu/constants';
 import { useApi } from '../../../api';
-import { TextField, Form, Button, TranslatedText } from '@tamanu/ui-components';
+import { TextField, Form, Button, TranslatedText, Field } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
 import { SearchInput, TableFormFields } from '../../../components';
-import { AccessorField } from '../../patients/components/AccessorField';
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { ErrorMessage } from '../../../components/ErrorMessage';
 import { ReferenceDataSwitchInput } from './ReferenceDataSwitch';
@@ -153,10 +152,8 @@ const useTranslationMutation = () => {
 };
 
 const TranslationField = ({ stringId, code }) => (
-  // This id format is necessary to avoid formik nesting at . delimiters
-  <AccessorField
-    id={`['${stringId}']`}
-    name={code}
+  <Field
+    name={`['${stringId}']['${code}']`}
     component={TextField}
     multiline
     data-testid="accessorfield-e12n"

--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -153,7 +153,7 @@ const useTranslationMutation = () => {
 
 const TranslationField = ({ stringId, code }) => (
   <Field
-    name={`['${stringId}']['${code}']`}
+    name={`['${stringId}'].${code}`}
     component={TextField}
     multiline
     data-testid="translation-field-e12n"

--- a/packages/web/app/views/administration/translation/TranslationForm.jsx
+++ b/packages/web/app/views/administration/translation/TranslationForm.jsx
@@ -156,7 +156,7 @@ const TranslationField = ({ stringId, code }) => (
     name={`['${stringId}']['${code}']`}
     component={TextField}
     multiline
-    data-testid="accessorfield-e12n"
+    data-testid="translation-field-e12n"
   />
 );
 


### PR DESCRIPTION
### Changes

- Incorrect data being sent: The AccessorField was adding a `labTests.` prefix to field names, causing the form data structure to be wrong. 
- English translations not showing: Since Formik was looking for field values at the wrong path (e.g., `labTests.['welcome.title'].en` instead of `['welcome.title'].en`), it couldn't find the values from initialValues, so the fields appeared empty.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
