### PR TITLE
fix(staticReports): NASS-1488: Remove permissions for all but one static report

### DIFF
--- a/packages/database/src/migrations/1769732592073-removeStaticReportPermissions.ts
+++ b/packages/database/src/migrations/1769732592073-removeStaticReportPermissions.ts
@@ -5,7 +5,8 @@ export async function up(query: QueryInterface): Promise<void> {
       `
         DELETE FROM permissions
         WHERE noun = 'StaticReport'
-          AND (object_id IS NULL OR object_id <> 'generic-survey-export-line-list');
+          AND verb = 'run'
+          AND object_id <> 'generic-survey-export-line-list'
       `,
     );
 }

--- a/packages/database/src/migrations/1769732592073-removeStaticReportPermissions.ts
+++ b/packages/database/src/migrations/1769732592073-removeStaticReportPermissions.ts
@@ -5,7 +5,7 @@ export async function up(query: QueryInterface): Promise<void> {
       `
         DELETE FROM permissions
         WHERE noun = 'StaticReport'
-          AND (object_id IS NULL OR object_id != 'generic-survey-export-line-list');
+          AND (object_id IS NULL OR object_id <> 'generic-survey-export-line-list');
       `,
     );
 }

--- a/packages/database/src/migrations/1769732592073-removeStaticReportPermissions.ts
+++ b/packages/database/src/migrations/1769732592073-removeStaticReportPermissions.ts
@@ -1,0 +1,15 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+    await query.sequelize.query(
+      `
+        DELETE FROM permissions
+        WHERE noun = 'StaticReport'
+          AND (object_id IS NULL OR object_id != 'generic-survey-export-line-list');
+      `,
+    );
+}
+
+export async function down(_query: QueryInterface): Promise<void> {
+  // Cannot restore deleted permissions as we don't have a record of what they were
+}


### PR DESCRIPTION
### Changes

- All but one static report where deleted, causing broken permissions so remove them!

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
