### PR TITLE
fix(staticReports): NASS-1488: 2.48 fix: Remove all but 1 static reports permissions

### DIFF
--- a/packages/mobile/App/migrations/1769732592073-removeStaticReportPermissions.ts
+++ b/packages/mobile/App/migrations/1769732592073-removeStaticReportPermissions.ts
@@ -1,0 +1,16 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+    await query.sequelize.query(
+      `
+        DELETE FROM permissions
+        WHERE noun = 'StaticReport'
+          AND verb = 'run'
+          AND object_id <> 'generic-survey-export-line-list'
+      `,
+    );
+}
+
+export async function down(_query: QueryInterface): Promise<void> {
+  // Cannot restore deleted permissions as we don't have a record of what they were
+}


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
