### PR TITLE
chore: tera compatible templates in alerts

### DIFF
--- a/alerts/fhir-running-job-long.yml
+++ b/alerts/fhir-running-job-long.yml
@@ -24,3 +24,4 @@ send:
       {% if remaining > 0 %}
       - ... and {{ remaining }} more
       {% endif %}
+      

--- a/alerts/fhir-running-job-long.yml
+++ b/alerts/fhir-running-job-long.yml
@@ -24,4 +24,3 @@ send:
       {% if remaining > 0 %}
       - ... and {{ remaining }} more
       {% endif %}
-      

--- a/alerts/fhir-running-job-long.yml
+++ b/alerts/fhir-running-job-long.yml
@@ -17,7 +17,10 @@ send:
       - Alert: {{ filename }}
 
       {% for row in rows | slice(end=5) %}
-      - **{{row.resource}}** {{ row.id }} for {{ row.duration_minutes }} minutes
+      - **{{ row.resource }}** {{ row.id }} for {{ row.duration_minutes }} minutes
       {% endfor %}
-      - ... and {{ rows | length - 5 }} more
+
+      {% set remaining = rows | length - 5 %}
+      {% if remaining > 0 %}
+      - ... and {{ remaining }} more
       {% endif %}

--- a/alerts/fhir-unresolvable-service-requests-labs.yml
+++ b/alerts/fhir-unresolvable-service-requests-labs.yml
@@ -18,7 +18,6 @@ send:
       <ul>
         {% for row in rows | slice(end=5) %}
         <li>
-          <b>{{ row.resource }}</b>
           Lab Request ID: <b>{{ row.lab_request_id }}</b>
           – Unresolved for: <i>{{ row.duration_minutes }} minutes</i>
         </li>

--- a/alerts/fhir-unresolvable-service-requests-labs.yml
+++ b/alerts/fhir-unresolvable-service-requests-labs.yml
@@ -1,9 +1,9 @@
 sql: |
   SELECT
-    lr.display_id as lab_request_id,
+    lr.display_id AS lab_request_id,
     ROUND(EXTRACT(EPOCH FROM (NOW() - fsr.last_updated)) / 60)::text AS duration_minutes
   FROM fhir.service_requests fsr
-  JOIN lab_requests lr on fsr.upstream_id = lr.id
+  JOIN lab_requests lr ON fsr.upstream_id = lr.id
   WHERE fsr.resolved = FALSE
     AND NOW() - fsr.last_updated > INTERVAL '1 hours';
 
@@ -17,9 +17,16 @@ send:
       <h1>Unresolvable FHIR Service Requests (Lab Requests) detected</h1>
       <ul>
         {% for row in rows | slice(end=5) %}
-        <li><b>{{row.resource}}</> Lab Request ID: <b>{{ row.lab_request_id }}</b> - Unresolved for: <i>{{ row.duration_minutes }} minutes</i></li>
+        <li>
+          <b>{{ row.resource }}</b>
+          Lab Request ID: <b>{{ row.lab_request_id }}</b>
+          – Unresolved for: <i>{{ row.duration_minutes }} minutes</i>
+        </li>
         {% endfor %}
-         <li>... and {{ rows | length - 5 }} more</li>
+
+        {% set remaining = rows | length - 5 %}
+        {% if remaining > 0 %}
+        <li>... and {{ remaining }} more</li>
         {% endif %}
       </ul>
       <p>For more information, please check the logs.</p>


### PR DESCRIPTION
### Changes
- Just two alerts on main broke tera syntax
- This is used to read alert template in `alertd`

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
