### PR TITLE
fix(typo): No-issue: Missing full stop on prescriber message

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/PrintMultipleMedicationSelectionForm.jsx
@@ -278,7 +278,7 @@ export const PrintMultipleMedicationSelectionForm = React.memo(({ encounter, onC
             <Box width="147px">
               <TranslatedText
                 stringId="medication.modal.printMultiple.prescriber.tooltip"
-                fallback="This prescriber will appear on the printed prescription"
+                fallback="This prescriber will appear on the printed prescription."
                 data-testid="translatedtext-s7yn"
               />
             </Box>


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string punctuation change in UI fallback text with no behavioral, data, or security impact.
> 
> **Overview**
> Fixes a UI typo in `PrintMultipleMedicationSelectionForm` by adding a missing period to the prescriber tooltip fallback text ("This prescriber will appear on the printed prescription.").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d71fd104e5cdb6883d9f2d01030752d7cf8d06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->