### PR TITLE
feat(invoicing): SAV-1098: Show approval after finalised

### DIFF
--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -559,7 +559,10 @@ encounterRelations.get(
     const invoiceRecord = await Invoice.findOne({
       where: { encounterId },
       include: Invoice.getFullReferenceAssociations(invoicePriceListId),
-      order: [[{ model: models.InvoiceItem, as: 'items' }, 'orderDate', 'ASC']],
+      order: [
+        [{ model: models.InvoiceItem, as: 'items' }, 'orderDate', 'ASC'],
+        [{ model: models.InvoiceItem, as: 'items' }, 'createdAt', 'ASC'],
+      ],
     });
     if (!invoiceRecord) {
       // Return null rather than a 404 as it is a valid scenario for there not to be an invoice

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -221,10 +221,6 @@ const updateInvoiceSchema = z
   })
   .strip();
 
-/**
- * Update invoice
- * - Only in progress invoices can be updated
- */
 invoiceRoute.put(
   '/:id/',
   asyncHandler(async (req, res) => {
@@ -234,10 +230,6 @@ invoiceRoute.put(
 
     const foundInvoice = await req.models.Invoice.findByPk(invoiceId);
     if (!foundInvoice) throw new NotFoundError(`Unable to find invoice ${invoiceId}`);
-
-    //* Only in progress invoices can be updated
-    if (foundInvoice.status !== INVOICE_STATUSES.IN_PROGRESS)
-      throw new InvalidOperationError('Only in progress invoices can be updated');
 
     const { data, error } = await updateInvoiceSchema.safeParseAsync(req.body);
     if (error) throw new ValidationError(error.message);

--- a/packages/facility-server/app/routes/apiv1/invoice/invoices.js
+++ b/packages/facility-server/app/routes/apiv1/invoice/invoices.js
@@ -458,10 +458,7 @@ invoiceRoute.put(
     }
 
     // Allow approval changes on both IN_PROGRESS and FINALISED invoices
-    if (
-      invoice.status !== INVOICE_STATUSES.IN_PROGRESS &&
-      invoice.status !== INVOICE_STATUSES.FINALISED
-    ) {
+    if (![INVOICE_STATUSES.IN_PROGRESS, INVOICE_STATUSES.FINALISED].includes(invoice.status)) {
       throw new InvalidOperationError(
         'Approval can only be changed on in-progress or finalised invoices',
       );
@@ -507,10 +504,7 @@ invoiceRoute.put(
     }
 
     // Allow approval changes on both IN_PROGRESS and FINALISED invoices
-    if (
-      invoice.status !== INVOICE_STATUSES.IN_PROGRESS &&
-      invoice.status !== INVOICE_STATUSES.FINALISED
-    ) {
+    if (![INVOICE_STATUSES.IN_PROGRESS, INVOICE_STATUSES.FINALISED].includes(invoice.status)) {
       throw new InvalidOperationError(
         'Approval can only be changed on in-progress or finalised invoices',
       );

--- a/packages/web/app/api/mutations/useInvoiceMutation.js
+++ b/packages/web/app/api/mutations/useInvoiceMutation.js
@@ -88,3 +88,33 @@ export const useInvoiceInsurancePlansMutation = (invoiceId, encounterId) => {
     onError: error => notifyError(error.message),
   });
 };
+
+export const useUpdateInvoiceItemApproval = invoice => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ itemId, approved }) => {
+      await api.put(`invoices/${invoice?.id}/items/${itemId}/approval`, { approved });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([`encounter/${invoice?.encounterId}/invoice`]);
+    },
+    onError: error => notifyError(error.message),
+  });
+};
+
+export const useBulkUpdateInvoiceItemApproval = invoice => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ approved }) => {
+      await api.put(`invoices/${invoice?.id}/items/approval`, { approved });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([`encounter/${invoice?.encounterId}/invoice`]);
+    },
+    onError: error => notifyError(error.message),
+  });
+};

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -13,7 +13,7 @@ import { isInvoiceEditable } from '@tamanu/shared/utils/invoice';
 import { Colors } from '../../../constants/styles';
 import { InvoiceItemRow } from './InvoiceItem';
 import { InvoiceItemHeader } from './InvoiceItemHeader';
-import { useUpdateInvoice } from '../../../api/mutations/useInvoiceMutation';
+import { useUpdateInvoice, useUpdateInvoiceItemApproval } from '../../../api/mutations/useInvoiceMutation';
 import { useAuth } from '../../../contexts/Auth';
 import { invoiceFormSchema } from './invoiceFormSchema';
 
@@ -87,6 +87,7 @@ export const InvoiceForm = ({ invoice, isEditing, setIsEditing }) => {
   const editable = isInvoiceEditable(invoice) && canWriteInvoice;
   const isFinalised = invoice.status === INVOICE_STATUSES.FINALISED;
   const { mutate: updateInvoice, isLoading: isUpdatingInvoice } = useUpdateInvoice(invoice);
+  const { mutate: updateItemApproval } = useUpdateInvoiceItemApproval(invoice);
 
   // Main submit action for the invoice
   const handleSubmit = async data => {
@@ -159,6 +160,7 @@ export const InvoiceForm = ({ invoice, isEditing, setIsEditing }) => {
                           invoiceIsEditable={editable && canWriteInvoice}
                           isEditing={isEditing}
                           onUpdateInvoice={handleUpdateItem}
+                          onUpdateApproval={updateItemApproval}
                           isFinalised={isFinalised}
                         />
                       );

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -2,12 +2,15 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 import { Plus } from 'lucide-react';
+import { FieldArray } from 'formik';
 import { Box, Button as MuiButton } from '@material-ui/core';
+
 import { Form, TranslatedText, FormSubmitButton, FormCancelButton } from '@tamanu/ui-components';
 import { getCurrentDateString } from '@tamanu/utils/dateTime';
-import { Colors } from '../../../constants/styles';
-import { FieldArray } from 'formik';
+import { INVOICE_STATUSES } from '@tamanu/constants';
 import { isInvoiceEditable } from '@tamanu/shared/utils/invoice';
+
+import { Colors } from '../../../constants/styles';
 import { InvoiceItemRow } from './InvoiceItem';
 import { InvoiceItemHeader } from './InvoiceItemHeader';
 import { useUpdateInvoice } from '../../../api/mutations/useInvoiceMutation';
@@ -82,6 +85,7 @@ export const InvoiceForm = ({ invoice, isEditing, setIsEditing }) => {
   const [inProgressItems, setInProgressItems] = useState([]);
   const canWriteInvoice = ability.can('write', 'Invoice');
   const editable = isInvoiceEditable(invoice) && canWriteInvoice;
+  const isFinalised = invoice.status === INVOICE_STATUSES.FINALISED;
   const { mutate: updateInvoice, isLoading: isUpdatingInvoice } = useUpdateInvoice(invoice);
 
   // Main submit action for the invoice
@@ -155,6 +159,7 @@ export const InvoiceForm = ({ invoice, isEditing, setIsEditing }) => {
                           invoiceIsEditable={editable && canWriteInvoice}
                           isEditing={isEditing}
                           onUpdateInvoice={handleUpdateItem}
+                          isFinalised={isFinalised}
                         />
                       );
                     })}

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceForm.jsx
@@ -86,6 +86,7 @@ export const InvoiceForm = ({ invoice, isEditing, setIsEditing }) => {
   const canWriteInvoice = ability.can('write', 'Invoice');
   const editable = isInvoiceEditable(invoice) && canWriteInvoice;
   const isFinalised = invoice.status === INVOICE_STATUSES.FINALISED;
+  const isCancelled = invoice.status === INVOICE_STATUSES.CANCELLED;
   const { mutate: updateInvoice, isLoading: isUpdatingInvoice } = useUpdateInvoice(invoice);
   const { mutate: updateItemApproval } = useUpdateInvoiceItemApproval(invoice);
 
@@ -162,6 +163,7 @@ export const InvoiceForm = ({ invoice, isEditing, setIsEditing }) => {
                           onUpdateInvoice={handleUpdateItem}
                           onUpdateApproval={updateItemApproval}
                           isFinalised={isFinalised}
+                          isCancelled={isCancelled}
                         />
                       );
                     })}

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -232,6 +232,7 @@ export const InvoiceItemRow = ({
           onUpdateInvoice={onUpdateInvoice}
           onUpdateApproval={onUpdateApproval}
           isFinalised={isFinalised}
+          isSaved={isSaved}
         />
       )}
     </StyledItemRow>

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -125,6 +125,7 @@ export const InvoiceItemRow = ({
   onUpdateInvoice,
   onUpdateApproval,
   isFinalised,
+  isCancelled,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const isSaved = item.product?.id;
@@ -222,15 +223,17 @@ export const InvoiceItemRow = ({
         isEditing={isEditing}
       />
 
-      <InvoiceItemActionsMenu
-        index={index}
-        item={item}
-        showActionMenu
-        hidePriceInput={hidePriceInput}
-        onUpdateInvoice={onUpdateInvoice}
-        onUpdateApproval={onUpdateApproval}
-        isFinalised={isFinalised}
-      />
+      {!isCancelled && (
+        <InvoiceItemActionsMenu
+          index={index}
+          item={item}
+          showActionMenu
+          hidePriceInput={hidePriceInput}
+          onUpdateInvoice={onUpdateInvoice}
+          onUpdateApproval={onUpdateApproval}
+          isFinalised={isFinalised}
+        />
+      )}
     </StyledItemRow>
   );
 };

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -123,6 +123,7 @@ export const InvoiceItemRow = ({
   priceListId,
   isEditing,
   onUpdateInvoice,
+  isFinalised,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const isSaved = item.product?.id;
@@ -223,9 +224,10 @@ export const InvoiceItemRow = ({
       <InvoiceItemActionsMenu
         index={index}
         item={item}
-        showActionMenu={isSaved && invoiceIsEditable}
+        showActionMenu
         hidePriceInput={hidePriceInput}
         onUpdateInvoice={onUpdateInvoice}
+        isFinalised={isFinalised}
       />
     </StyledItemRow>
   );

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItem.jsx
@@ -123,6 +123,7 @@ export const InvoiceItemRow = ({
   priceListId,
   isEditing,
   onUpdateInvoice,
+  onUpdateApproval,
   isFinalised,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -227,6 +228,7 @@ export const InvoiceItemRow = ({
         showActionMenu
         hidePriceInput={hidePriceInput}
         onUpdateInvoice={onUpdateInvoice}
+        onUpdateApproval={onUpdateApproval}
         isFinalised={isFinalised}
       />
     </StyledItemRow>

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
@@ -147,31 +147,28 @@ const useInvoiceItemActionsMenu = ({
       disabled: !item.productId,
       hidden: !!item.sourceId || isFinalised,
     },
-    ...(item.approved
-      ? [
-          {
-            label: (
-              <TranslatedText
-                stringId="invoice.editInvoice.removeApproval"
-                fallback="Remove approval"
-                data-testid="translatedtext-y43b"
-              />
-            ),
-            onClick: () => handleApproval(false),
-          },
-        ]
-      : [
-          {
-            label: (
-              <TranslatedText
-                stringId="invoice.editInvoice.markAsApproved"
-                fallback="Mark as approved"
-                data-testid="translatedtext-c3a4"
-              />
-            ),
-            onClick: () => handleApproval(true),
-          },
-        ]),
+    {
+      label: (
+        <TranslatedText
+          stringId="invoice.editInvoice.removeApproval"
+          fallback="Remove approval"
+          data-testid="translatedtext-y43b"
+        />
+      ),
+      onClick: () => handleApproval(false),
+      hidden: !item.approved,
+    },
+    {
+      label: (
+        <TranslatedText
+          stringId="invoice.editInvoice.markAsApproved"
+          fallback="Mark as approved"
+          data-testid="translatedtext-c3a4"
+        />
+      ),
+      onClick: () => handleApproval(true),
+      hidden: item.approved,
+    },
     {
       label: (
         <TranslatedText

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
@@ -15,6 +15,7 @@ const useInvoiceItemActionsMenu = ({
   onUpdateInvoice,
   onUpdateApproval,
   isFinalised,
+  isSaved,
 }) => {
   const [actionModal, setActionModal] = useState();
   const { values } = useFormikContext();
@@ -156,7 +157,7 @@ const useInvoiceItemActionsMenu = ({
         />
       ),
       onClick: () => handleApproval(false),
-      hidden: !item.approved,
+      hidden: !item.approved || !isSaved,
     },
     {
       label: (
@@ -167,7 +168,7 @@ const useInvoiceItemActionsMenu = ({
         />
       ),
       onClick: () => handleApproval(true),
-      hidden: item.approved,
+      hidden: item.approved || !isSaved,
     },
     {
       label: (
@@ -205,6 +206,7 @@ export const InvoiceItemActionsMenu = ({
   onUpdateInvoice,
   onUpdateApproval,
   isFinalised,
+  isSaved,
 }) => {
   const { actionModal, onCloseActionModal, handleAction, menuItems } = useInvoiceItemActionsMenu({
     item,
@@ -213,6 +215,7 @@ export const InvoiceItemActionsMenu = ({
     index,
     hidePriceInput,
     isFinalised,
+    isSaved,
   });
   return (
     <>

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemActionsMenu.jsx
@@ -8,7 +8,7 @@ import { NoteModalActionBlocker } from '../../../components';
 import { InvoiceItemActionModal } from './InvoiceItemActionModal';
 import { ThreeDotMenu } from '../../../components/ThreeDotMenu';
 
-const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoice }) => {
+const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoice, isFinalised }) => {
   const [actionModal, setActionModal] = useState();
   const { values } = useFormikContext();
 
@@ -101,7 +101,7 @@ const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoic
           />
         ),
       onClick: () => handleAction({}, INVOICE_ITEM_ACTION_MODAL_TYPES.REMOVE_DISCOUNT_MARKUP),
-      hidden: !item.discount?.amount,
+      hidden: !item.discount?.amount || isFinalised,
     },
     {
       label: (
@@ -113,7 +113,7 @@ const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoic
       ),
       onClick: () => setActionModal(INVOICE_ITEM_ACTION_MODAL_TYPES.ADD_DISCOUNT),
       disabled: !item.productId,
-      hidden: !!item.discount?.amount || !hidePriceInput,
+      hidden: !!item.discount?.amount || !hidePriceInput || isFinalised,
     },
     {
       label: (
@@ -125,7 +125,7 @@ const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoic
       ),
       onClick: () => setActionModal(INVOICE_ITEM_ACTION_MODAL_TYPES.ADD_MARKUP),
       disabled: !item.productId,
-      hidden: !!item.discount?.amount || !hidePriceInput,
+      hidden: !!item.discount?.amount || !hidePriceInput || isFinalised,
     },
     {
       label: item.note ? (
@@ -143,7 +143,7 @@ const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoic
       ),
       onClick: () => setActionModal(INVOICE_ITEM_ACTION_MODAL_TYPES.ADD_NOTE),
       disabled: !item.productId,
-      hidden: !!item.sourceId,
+      hidden: !!item.sourceId || isFinalised,
     },
     ...item.approved ? [{
       label: (
@@ -176,6 +176,7 @@ const useInvoiceItemActionsMenu = ({ item, index, hidePriceInput, onUpdateInvoic
         />
       ),
       onClick: () => setActionModal(INVOICE_ITEM_ACTION_MODAL_TYPES.DELETE),
+      hidden: isFinalised,
     },
   ];
 
@@ -200,12 +201,14 @@ export const InvoiceItemActionsMenu = ({
   showActionMenu,
   hidePriceInput,
   onUpdateInvoice,
+  isFinalised,
 }) => {
   const { actionModal, onCloseActionModal, handleAction, menuItems } = useInvoiceItemActionsMenu({
     item,
     onUpdateInvoice,
     index,
     hidePriceInput,
+    isFinalised,
   });
   return (
     <>

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -27,7 +27,7 @@ import { useEncounterInvoiceQuery } from '../../../api/queries/useInvoiceQuery';
 import { useAuth } from '../../../contexts/Auth';
 import { NoteModalActionBlocker } from '../../../components';
 import { usePatientDataQuery } from '../../../api/queries';
-import { useCreateInvoice, useUpdateInvoice } from '../../../api/mutations/useInvoiceMutation.js';
+import { useCreateInvoice, useBulkUpdateInvoiceItemApproval } from '../../../api/mutations/useInvoiceMutation.js';
 
 const EmptyPane = styled(ContentPane)`
   text-align: center;
@@ -103,15 +103,14 @@ const InvoiceMenu = ({ encounter, invoice, setInvoiceModalType, setEditing, isEd
   const canDeleteInvoice = ability.can('delete', 'Invoice');
   const cancelable = invoice && isInvoiceEditable(invoice) && canWriteInvoice;
   const deletable = invoice && invoice.status !== INVOICE_STATUSES.FINALISED && canDeleteInvoice;
-  const { mutate: updateInvoice } = useUpdateInvoice(invoice);
+  const { mutate: bulkUpdateApproval } = useBulkUpdateInvoiceItemApproval(invoice);
   const finalisable =
     invoice && isInvoiceEditable(invoice) && canCreateInvoice && encounter.endDate;
 
   const allItemsAreApproved = invoice.items.every(item => item.approved);
 
   const handleAllApprovals = approved => {
-    const updatedInvoiceItems = [...invoice.items].map(item => ({ ...item, approved }));
-    updateInvoice({ ...invoice, items: updatedInvoiceItems });
+    bulkUpdateApproval({ approved });
   };
 
   const ACTIONS = [

--- a/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
+++ b/packages/web/app/views/patients/panes/EncounterInvoicingPane.jsx
@@ -184,11 +184,16 @@ const InvoiceMenu = ({
       hidden: !isInvoiceEditable(invoice),
     });
   }
+
+  const hasVisibleActions = ACTIONS.some(action => !action.hidden);
+
   return (
     <ActionsPane data-testid="actionspane-l9ey">
-      <NoteModalActionBlocker>
-        <ThreeDotMenu items={ACTIONS} data-testid="threedotmenu-5t9u" />
-      </NoteModalActionBlocker>
+      {hasVisibleActions && (
+        <NoteModalActionBlocker>
+          <ThreeDotMenu items={ACTIONS} data-testid="threedotmenu-5t9u" />
+        </NoteModalActionBlocker>
+      )}
       {!isInProgress && (
         <PrintButton
           onClick={() => setInvoiceModalType(INVOICE_MODAL_TYPES.PRINT)}


### PR DESCRIPTION
### Changes
- Show approval after finalised

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new write endpoints that can mutate invoice items on finalised invoices and changes client behavior to use them, which could impact billing workflows if permissions/status checks are wrong.
> 
> **Overview**
> Enables invoice item *approval* to be viewed/changed even after an invoice is **finalised** by introducing dedicated backend endpoints for per-item and bulk approval updates that work for both `IN_PROGRESS` and `FINALISED` invoices.
> 
> The web UI is updated to call these new endpoints (instead of re-saving the whole invoice) and to tighten menu/actions by invoice status (e.g., hide item edits/discount/note/delete actions when finalised, hide action menus when cancelled, and only show relevant top-bar actions including print/insurance). Invoice fetching now adds a secondary `createdAt` sort for stable item ordering when `orderDate` ties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fba8a1e7a019c0eaf02560dac839038b263e0937. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->