### PR TITLE
feat(invoicing): SAV-1058: Updates to invoice printout (phase 1)

### DIFF
--- a/packages/shared/__tests__/utils/invoice.test.js
+++ b/packages/shared/__tests__/utils/invoice.test.js
@@ -3,8 +3,8 @@ import {
   getInvoiceItemPrice,
   getInvoiceItemTotalPrice,
   getInvoiceItemTotalDiscountedPrice,
-  getInvoiceItemCoverageValue,
-  getInsuranceCoverageTotal,
+  getInvoiceItemCoveragePercentage,
+  getInsuranceCoverageTotalAmount,
   getInvoiceSummary,
 } from '../../src/utils';
 
@@ -165,13 +165,13 @@ describe('Invoice Utils', () => {
     });
   });
 
-  describe('getInvoiceItemCoverageValue', () => {
+  describe('getInvoiceItemCoveragePercentage', () => {
     it('should return coverageValue when no finalisedInsurances', () => {
       const item = {
         insurancePlanItems: [{ id: 'plan-1', coverageValue: 50 }],
       };
       const insurancePlanItem = { id: 'plan-1', coverageValue: 50 };
-      expect(getInvoiceItemCoverageValue(item, insurancePlanItem)).toEqual(50);
+      expect(getInvoiceItemCoveragePercentage(item, insurancePlanItem)).toEqual(50);
     });
 
     it('should return coverageValue when finalisedInsurances is empty', () => {
@@ -180,7 +180,7 @@ describe('Invoice Utils', () => {
         insurancePlanItems: [{ id: 'plan-1', coverageValue: 50 }],
       };
       const insurancePlanItem = { id: 'plan-1', coverageValue: 50 };
-      expect(getInvoiceItemCoverageValue(item, insurancePlanItem)).toEqual(50);
+      expect(getInvoiceItemCoveragePercentage(item, insurancePlanItem)).toEqual(50);
     });
 
     it('should return coverageValueFinal when finalisedInsurances exists for the plan', () => {
@@ -189,7 +189,7 @@ describe('Invoice Utils', () => {
         insurancePlanItems: [{ id: 'plan-1', coverageValue: 50 }],
       };
       const insurancePlanItem = { id: 'plan-1', coverageValue: 50 };
-      expect(getInvoiceItemCoverageValue(item, insurancePlanItem)).toEqual(60);
+      expect(getInvoiceItemCoveragePercentage(item, insurancePlanItem)).toEqual(60);
     });
 
     it('should return original coverageValue when finalisedInsurances does not match plan', () => {
@@ -198,11 +198,11 @@ describe('Invoice Utils', () => {
         insurancePlanItems: [{ id: 'plan-1', coverageValue: 50 }],
       };
       const insurancePlanItem = { id: 'plan-1', coverageValue: 50 };
-      expect(getInvoiceItemCoverageValue(item, insurancePlanItem)).toEqual(50);
+      expect(getInvoiceItemCoveragePercentage(item, insurancePlanItem)).toEqual(50);
     });
   });
 
-  describe('getInsuranceCoverageTotal', () => {
+  describe('getInsuranceCoverageTotalAmount', () => {
     it('should calculate insurance coverage for single item with one plan', () => {
       const invoiceItems = [
         {
@@ -219,7 +219,7 @@ describe('Invoice Utils', () => {
           },
         },
       ];
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(50);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(50);
     });
 
     it('should calculate insurance coverage for multiple plans', () => {
@@ -236,7 +236,7 @@ describe('Invoice Utils', () => {
           },
         },
       ];
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(50);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(50);
     });
 
     it('should handle items with no insurance', () => {
@@ -247,7 +247,7 @@ describe('Invoice Utils', () => {
           insurancePlanItems: [],
         },
       ];
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(0);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(0);
     });
 
     it('should handle items with missing coverageValue', () => {
@@ -261,7 +261,7 @@ describe('Invoice Utils', () => {
           ],
         },
       ];
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(0);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(0);
     });
 
     it('should calculate insurance coverage on discounted price', () => {
@@ -280,7 +280,7 @@ describe('Invoice Utils', () => {
         },
       ];
       // Price after discount: 90, insurance: 45
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(45);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(45);
     });
 
     it('should handle multiple items', () => {
@@ -303,7 +303,7 @@ describe('Invoice Utils', () => {
         },
       ];
       // Item 1: 50, Item 2: 60, Total: 110
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(110);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(110);
     });
 
     it('should use coverageValueFinal from finalisedInsurances when available', () => {
@@ -319,7 +319,7 @@ describe('Invoice Utils', () => {
         },
       ];
       // Should use 60% instead of 50%
-      expect(getInsuranceCoverageTotal(invoiceItems).toNumber()).toEqual(60);
+      expect(getInsuranceCoverageTotalAmount(invoiceItems).toNumber()).toEqual(60);
     });
   });
 

--- a/packages/shared/src/utils/invoice/invoice.js
+++ b/packages/shared/src/utils/invoice/invoice.js
@@ -1,5 +1,6 @@
-import { INVOICE_ITEMS_DISCOUNT_TYPES, INVOICE_STATUSES } from '@tamanu/constants';
 import Decimal from 'decimal.js';
+import { INVOICE_ITEMS_DISCOUNT_TYPES, INVOICE_STATUSES } from '@tamanu/constants';
+import { formatDisplayPrice } from './display';
 
 /** @typedef {import('@tamanu/database/models').Invoice} Invoice */
 /** @typedef {import('@tamanu/database/models').InvoiceDiscount} InvoiceDiscount */
@@ -66,11 +67,11 @@ export const getInvoiceItemTotalDiscountedPrice = invoiceItem => {
 
 /**
  * Get the display coverage value for an insurance plan item, taking into account finalisedInsurances
- * @param {Object} item - The invoice item containing finalisedInsurances
- * @param {Object} insurancePlanItem - The insurance plan item
+ * @param {InvoiceItem} item - The invoice item containing finalisedInsurances
+ * @param {InsurancePlanItem} insurancePlanItem - The insurance plan item
  * @returns {number} - The coverage value to display (either finalised or default)
  */
-export const getInvoiceItemCoverageValue = (item, insurancePlanItem) => {
+export const getInvoiceItemCoveragePercentage = (item, insurancePlanItem) => {
   const planCoverageValue = insurancePlanItem.coverageValue ?? 0;
 
   if (!item.finalisedInsurances || item.finalisedInsurances.length === 0) {
@@ -93,10 +94,10 @@ export const getInvoiceItemCoverageValue = (item, insurancePlanItem) => {
  * value is capped at the item's discounted price to ensure it does not exceed
  * the discounted amount.
  *
- * @param {Array<Object>} invoiceItems - Array of invoice item objects
+ * @param {Array<InvoiceItem>} invoiceItems - Array of invoice item objects
  * @returns {Decimal} - The total insurance coverage for all invoice items
  */
-export const getInsuranceCoverageTotal = invoiceItems => {
+export const getInsuranceCoverageTotalAmount = invoiceItems => {
   return invoiceItems.reduce((sum, item) => {
     const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
 
@@ -106,8 +107,7 @@ export const getInsuranceCoverageTotal = invoiceItems => {
     }
 
     const totalItemInsurance = item.insurancePlanItems.reduce((itemSum, itemPlan) => {
-      const appliedCoverage = getInvoiceItemCoverageValue(item, itemPlan);
-      const coverageForRow = new Decimal(discountedPrice).times(appliedCoverage / 100).toNumber();
+      const coverageForRow = getItemSingleInsuranceCoverageAmount(discountedPrice, item, itemPlan);
       return itemSum.plus(coverageForRow);
     }, new Decimal(0));
 
@@ -127,7 +127,126 @@ const getInvoiceDiscountDiscountAmount = (discount, total) => {
 };
 
 /**
- * get invoice summary
+ * Calculate the item adjustment amount (difference between original and discounted price)
+ * Returns a negative number for discounts, positive for markups
+ */
+export const getItemAdjustmentAmount = item => {
+  const originalPrice = getInvoiceItemTotalPrice(item) || 0;
+  const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
+  return new Decimal(discountedPrice).minus(originalPrice).toNumber();
+};
+
+/**
+ * Check if an item has any adjustment (markup or discount)
+ */
+export const hasItemAdjustment = item => {
+  return getItemAdjustmentAmount(item) !== 0;
+};
+
+/**
+ * Calculate the total insurance coverage amount (from all insurance plans) for an invoice item
+ * @param {InvoiceItem} item
+ * @returns {number} - The total insurance coverage amount for the item
+ */
+export const getItemTotalInsuranceCoverageAmount = item => {
+  if (!item?.product?.insurable || !item.insurancePlanItems?.length) {
+    return 0;
+  }
+
+  const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
+  const totalCoverage = item.insurancePlanItems.reduce((sum, insurancePlanItem) => {
+    const coverageForRow = getItemSingleInsuranceCoverageAmount(
+      discountedPrice,
+      item,
+      insurancePlanItem,
+    );
+    return sum.plus(coverageForRow);
+  }, new Decimal(0));
+
+  // Cap coverage at the discounted price
+  return Math.min(totalCoverage, discountedPrice);
+};
+
+/**
+ * Calculate the insurance coverage amount for a single insurance plan item
+ * @param {number} discountedPrice - The discounted price of the item
+ * @param {InvoiceItem} item - The invoice item object
+ * @param {InsurancePlanItem} insurancePlanItem - The insurance plan item object
+ * @returns {number} - The insurance coverage amount for the item
+ */
+export const getItemSingleInsuranceCoverageAmount = (discountedPrice, item, insurancePlanItem) => {
+  const appliedCoverage = getInvoiceItemCoveragePercentage(item, insurancePlanItem);
+  return new Decimal(discountedPrice).times(appliedCoverage / 100).toNumber();
+};
+
+/**
+ * Calculate and format the insurance coverage of an invoice item for display in printout
+ * @param {InvoiceItem} item - The invoice item object
+ * @returns {string|number|null} - The insurance coverage of the item
+ */
+export const getFormattedInvoiceItemCoverageAmount = item => {
+  if (!item?.product?.insurable || !item.insurancePlanItems?.length) {
+    return 0;
+  }
+  const coverage = getItemTotalInsuranceCoverageAmount(item);
+  return formatDisplayPrice(coverage);
+};
+
+/**
+ * Calculate and format the net cost of an invoice item for display in printout
+ * @param {InvoiceItem} item - The invoice item object
+ * @returns {string|number|null} - The net cost of the item
+ */
+export const getFormattedInvoiceItemNetCost = item => {
+  const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
+  const insuranceCoverage = getItemTotalInsuranceCoverageAmount(item);
+  const netCost = new Decimal(discountedPrice).minus(insuranceCoverage).toNumber();
+  return formatDisplayPrice(netCost);
+};
+
+// TODO: this is similar to getInsuranceCoverageTotalAmount and could be combined together
+/**
+ * Calculate and format the total coverage amount for each insurance plan across all invoice items for display in printout
+ * @param {Invoice} invoice - The invoice object with items and insurancePlans
+ * @returns {Array<{id: string, name: string, code: string, totalCoverage: number}>}
+ */
+export const getFormattedCoverageAmountPerInsurancePlanForInvoice = invoice => {
+  const insurancePlans = invoice.insurancePlans || [];
+  const items = invoice.items || [];
+
+  return insurancePlans.map(plan => {
+    let totalCoverage = new Decimal(0);
+
+    for (const item of items) {
+      if (!item?.product?.insurable || !item.insurancePlanItems?.length) {
+        continue;
+      }
+
+      const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
+      const planItem = item.insurancePlanItems.find(p => p.id === plan.id);
+
+      if (planItem) {
+        const coverageAmount = getItemSingleInsuranceCoverageAmount(
+          discountedPrice,
+          item,
+          planItem,
+        );
+        totalCoverage = totalCoverage.plus(coverageAmount);
+      }
+    }
+
+    return {
+      id: plan.id,
+      name: plan.name,
+      code: plan.code,
+      totalCoverage: formatDisplayPrice(totalCoverage),
+    };
+  });
+};
+
+// TODO: This could be refactored to use getFormattedInvoiceItemNetCost
+/**
+ * Get the summary of an invoice
  * @param {Invoice} invoice
  * @returns
  */
@@ -139,7 +258,7 @@ export const getInvoiceSummary = invoice => {
     new Decimal(0),
   );
 
-  const insuranceCoverageTotal = getInsuranceCoverageTotal(invoice.items);
+  const insuranceCoverageTotal = getInsuranceCoverageTotalAmount(invoice.items);
 
   const patientSubtotal = invoiceItemsTotal.minus(insuranceCoverageTotal);
   const discountTotal = getInvoiceDiscountDiscountAmount(invoice.discount, patientSubtotal);

--- a/packages/shared/src/utils/invoice/invoice.js
+++ b/packages/shared/src/utils/invoice/invoice.js
@@ -213,35 +213,32 @@ export const getFormattedInvoiceItemNetCost = item => {
 export const getFormattedCoverageAmountPerInsurancePlanForInvoice = invoice => {
   const insurancePlans = invoice.insurancePlans || [];
   const items = invoice.items || [];
+  const planCoverageTotals = new Map(insurancePlans.map(p => [p.id, new Decimal(0)]));
 
-  return insurancePlans.map(plan => {
-    let totalCoverage = new Decimal(0);
+  for (const item of items) {
+    if (!item?.product?.insurable || !item.insurancePlanItems?.length) {
+      continue;
+    }
 
-    for (const item of items) {
-      if (!item?.product?.insurable || !item.insurancePlanItems?.length) {
-        continue;
-      }
-
-      const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
-      const planItem = item.insurancePlanItems.find(p => p.id === plan.id);
-
-      if (planItem) {
+    const discountedPrice = getInvoiceItemTotalDiscountedPrice(item) || 0;
+    for (const planItem of item.insurancePlanItems) {
+      if (planCoverageTotals.has(planItem.id)) {
         const coverageAmount = getItemSingleInsuranceCoverageAmount(
           discountedPrice,
           item,
           planItem,
         );
-        totalCoverage = totalCoverage.plus(coverageAmount);
+        planCoverageTotals.set(planItem.id, planCoverageTotals.get(planItem.id).plus(coverageAmount));
       }
     }
+  }
 
-    return {
-      id: plan.id,
-      name: plan.name,
-      code: plan.code,
-      totalCoverage: formatDisplayPrice(totalCoverage),
-    };
-  });
+  return insurancePlans.map(plan => ({
+    id: plan.id,
+    name: plan.name,
+    code: plan.code,
+    totalCoverage: formatDisplayPrice(planCoverageTotals.get(plan.id)),
+  }));
 };
 
 // TODO: This could be refactored to use getFormattedInvoiceItemNetCost

--- a/packages/shared/src/utils/invoice/invoice.js
+++ b/packages/shared/src/utils/invoice/invoice.js
@@ -182,11 +182,11 @@ export const getItemSingleInsuranceCoverageAmount = (discountedPrice, item, insu
 /**
  * Calculate and format the insurance coverage of an invoice item for display in printout
  * @param {InvoiceItem} item - The invoice item object
- * @returns {string|number|null} - The insurance coverage of the item
+ * @returns {string} - The formatted insurance coverage of the item (e.g., "0.00")
  */
 export const getFormattedInvoiceItemCoverageAmount = item => {
   if (!item?.product?.insurable || !item.insurancePlanItems?.length) {
-    return 0;
+    return formatDisplayPrice(0);
   }
   const coverage = getItemTotalInsuranceCoverageAmount(item);
   return formatDisplayPrice(coverage);
@@ -260,6 +260,12 @@ export const getInvoiceSummary = invoice => {
   const patientSubtotal = invoiceItemsTotal.minus(insuranceCoverageTotal);
   const discountTotal = getInvoiceDiscountDiscountAmount(invoice.discount, patientSubtotal);
 
+  // Calculate item adjustments here to be used in the printout
+  const itemAdjustmentsTotal = invoice.items.reduce(
+    (sum, item) => sum.plus(getItemAdjustmentAmount(item) || 0),
+    new Decimal(0),
+  );
+
   const patientTotal = patientSubtotal.minus(discountTotal);
 
   // Calculate payments as well
@@ -288,6 +294,7 @@ export const getInvoiceSummary = invoice => {
     insuranceCoverageTotal: insuranceCoverageTotal.toNumber(),
     patientTotal: patientTotal.toNumber(),
     discountTotal: discountTotal,
+    itemAdjustmentsTotal: itemAdjustmentsTotal.toNumber(),
     patientSubtotal: patientSubtotal.toNumber(),
     patientPaymentsTotal,
     insurerPaymentsTotal,

--- a/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
@@ -307,6 +307,7 @@ const COLUMNS = {
       title: 'Ordered by',
       accessor: ({ orderedByUser }) => orderedByUser?.displayName,
       style: { width: '24%' },
+      subRowLabel: true 
     },
     {
       key: 'price',
@@ -356,7 +357,7 @@ const COLUMNS = {
     {
       key: 'status',
       title: 'Status',
-      accessor: ({ status }) => status,
+      accessor: ({ status }) => status, // TODO: Waiting for refund/paid status to be added
       style: { width: '21%' },
     },
   ],
@@ -554,11 +555,11 @@ const SummaryPane = ({ invoice }) => {
     <View wrap={false} style={summaryPaneStyles.container}>
       <View style={summaryPaneStyles.item}>
         <P>Invoice total</P>
-        <P>{formatDisplayPrice(invoiceItemsTotal)}</P>
+        <P>{invoiceItemsTotal}</P>
       </View>
       <View style={summaryPaneStyles.item}>
         <P>Item adjustments</P>
-        <P>{formatDisplayPrice(discountTotal)}</P>
+        <P>{discountTotal}</P>
       </View>
       <P bold>Insurance coverage</P>
       {insurancePlanCoverages.length > 0 && (
@@ -566,7 +567,7 @@ const SummaryPane = ({ invoice }) => {
           {insurancePlanCoverages.map(plan => (
             <View key={plan.id} style={summaryPaneStyles.item}>
               <P>{plan.name || plan.code}</P>
-              <P>{formatDisplayPrice(plan.totalCoverage)}</P>
+              <P>{plan.totalCoverage}</P>
             </View>
           ))}
         </>
@@ -574,17 +575,17 @@ const SummaryPane = ({ invoice }) => {
       <HorizontalRule />
       <View style={summaryPaneStyles.item}>
         <P bold>Patient subtotal</P>
-        <P>{formatDisplayPrice(patientSubtotal)}</P>
+        <P>{patientSubtotal}</P>
       </View>
       <HorizontalRule />
       <View style={summaryPaneStyles.item}>
         <P>Patient payments</P>
-        <P>{`-${formatDisplayPrice(patientPaymentsTotal)}`}</P>
+        <P>{`-${patientPaymentsTotal}`}</P>
       </View>
       <HorizontalRule />
       <View style={[summaryPaneStyles.item, { marginVertical: 7.5 }]}>
         <P bold>Patient total due</P>
-        <P bold>{formatDisplayPrice(patientPaymentRemainingBalance)}</P>
+        <P bold>{patientPaymentRemainingBalance}</P>
       </View>
     </View>
   );

--- a/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
@@ -546,8 +546,8 @@ const SummaryPane = ({ invoice }) => {
     invoiceItemsTotal,
     patientPaymentRemainingBalance,
     patientSubtotal,
-    discountTotal,
     patientPaymentsTotal,
+    itemAdjustmentsTotal,
   } = getInvoiceSummaryDisplay(invoice);
   const insurancePlanCoverages = getFormattedCoverageAmountPerInsurancePlanForInvoice(invoice);
 
@@ -559,7 +559,7 @@ const SummaryPane = ({ invoice }) => {
       </View>
       <View style={summaryPaneStyles.item}>
         <P>Item adjustments</P>
-        <P>{discountTotal}</P>
+        <P>{itemAdjustmentsTotal}</P>
       </View>
       <P bold>Insurance coverage</P>
       {insurancePlanCoverages.length > 0 && (

--- a/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
@@ -1,21 +1,28 @@
 import React from 'react';
 import { Document, StyleSheet, View } from '@react-pdf/renderer';
 import { capitalize } from 'lodash';
+
 import { INVOICE_INSURER_PAYMENT_STATUSES } from '@tamanu/constants';
+import { formatShort } from '@tamanu/utils/dateTime';
+
 import { CertificateHeader, Watermark } from './Layout';
 import { LetterheadSection } from './LetterheadSection';
 import { MultiPageHeader } from './printComponents/MultiPageHeader';
 import { getName } from '../patientAccessors';
 import { Footer } from './printComponents/Footer';
-import { formatShort } from '@tamanu/utils/dateTime';
 import { InvoiceDetails } from './printComponents/InvoiceDetails';
 import {
-  getInvoiceItemDiscountPriceDisplay,
   getInvoiceItemPriceDisplay,
   getInvoiceSummaryDisplay,
   getPatientPaymentsWithRemainingBalanceDisplay,
   formatDisplayPrice,
   getInsurerPaymentsWithRemainingBalanceDisplay,
+  getInvoiceItemTotalDiscountedPrice,
+  hasItemAdjustment,
+  getItemAdjustmentAmount,
+  getFormattedInvoiceItemCoverageAmount,
+  getFormattedInvoiceItemNetCost,
+  getFormattedCoverageAmountPerInsurancePlanForInvoice,
 } from '../invoice';
 import { withLanguageContext } from '../pdf/languageContext';
 import { Page } from '../pdf/Page';
@@ -27,7 +34,7 @@ const borderStyle = '1 solid black';
 
 const pageStyles = StyleSheet.create({
   body: {
-    paddingHorizontal: 50,
+    paddingHorizontal: 30,
     paddingTop: 30,
     paddingBottom: 50,
   },
@@ -36,26 +43,34 @@ const pageStyles = StyleSheet.create({
 const textStyles = StyleSheet.create({
   sectionTitle: {
     marginBottom: 3,
-    fontSize: 11,
+    fontSize: 9,
   },
 });
 
-const tableStyles = StyleSheet.create({
+const baseTableStyles = StyleSheet.create({
   table: {
     flexDirection: 'column',
     marginBottom: 5,
+  },
+  heading: {
+    paddingLeft: 13,
+    paddingTop: 5,
+    paddingBottom: 5,
+    borderBottom: 'none',
+    justifyContent: 'flex-start',
   },
   row: {
     flexDirection: 'row',
     justifyContent: 'space-evenly',
     borderTop: borderStyle,
     borderRight: borderStyle,
+    borderLeft: borderStyle,
     borderBottom: borderStyle,
     marginBottom: -1,
   },
   baseCell: {
     flexDirection: 'row',
-    borderLeft: borderStyle,
+    borderLeft: 'none',
     alignItems: 'flex-start',
     padding: 7,
   },
@@ -68,14 +83,46 @@ const tableStyles = StyleSheet.create({
   },
 });
 
-const priceCellStyles = StyleSheet.create({
-  container: {
-    justifyContent: 'space-between',
-    width: '100%',
-    flexDirection: 'row',
+const paymentTableStyles = StyleSheet.create({
+  headerRow: {
+    borderBottom: 'none',
+    borderTop: 'none',
   },
-  crossOutText: {
-    textDecoration: 'line-through',
+  row: {
+    borderBottom: 'none',
+  },
+});
+
+const invoiceItemTableStyles = StyleSheet.create({
+  headerRow: {
+    borderBottom: 'none',
+    borderRight: 'none',
+    borderLeft: 'none',
+  },
+  row: {
+    borderBottom: 'none',
+    borderRight: 'none',
+    borderLeft: 'none',
+  },
+});
+
+const subRowStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+    borderRight: 'none',
+    borderBottom: 'none',
+    marginBottom: -1,
+  },
+  emptyCell: {
+    flexDirection: 'row',
+    borderLeft: 'none',
+    alignItems: 'flex-start',
+    padding: 7,
+  },
+  labelText: {
+    fontSize: 9,
+    color: '#666666',
   },
 });
 
@@ -104,33 +151,88 @@ const HorizontalRule = ({ width = '1px' }) => {
   return <View style={{ borderBottom: `${width} solid black` }} />;
 };
 
-const Table = props => <View style={tableStyles.table} {...props} />;
-const Row = props => <View style={tableStyles.row} {...props} />;
+const Table = props => <View style={baseTableStyles.table} {...props} />;
+const Row = ({ style, ...props }) => <View style={[baseTableStyles.row, style]} {...props} />;
 const P = ({ style = {}, children, bold }) => (
-  <Text bold={bold} style={[tableStyles.p, style]}>
+  <Text bold={bold} style={[baseTableStyles.p, style]}>
     {children}
   </Text>
 );
 
 const Cell = ({ children, style = {} }) => (
-  <View style={[tableStyles.baseCell, style]}>
+  <View style={[baseTableStyles.baseCell, style]}>
     <P>{children}</P>
   </View>
 );
 
 const CustomCellComponent = ({ children, style = {} }) => (
-  <View style={[tableStyles.baseCell, style]}>{children}</View>
+  <View style={[baseTableStyles.baseCell, style]}>{children}</View>
 );
 
 const getPrice = item => {
   const price = getInvoiceItemPriceDisplay(item);
-  const discountPrice = getInvoiceItemDiscountPriceDisplay(item);
+  return <P>{price}</P>;
+};
+
+/**
+ * Renders the adjustment sub-rows (Item adjustment and Cost after adjustment)
+ * These appear below the main invoice item row when there's a markup or discount
+ */
+const InvoiceItemAdjustmentRows = ({ item, columns }) => {
+  if (!hasItemAdjustment(item)) {
+    return null;
+  }
+
+  const adjustmentAmount = getItemAdjustmentAmount(item);
+  const costAfterAdjustment = getInvoiceItemTotalDiscountedPrice(item) || 0;
+
+  // Find the index of orderedBy and price columns to know where to place labels and values
+  const orderedByIndex = columns.findIndex(col => col.key === 'orderedBy');
+  const priceIndex = columns.findIndex(col => col.key === 'price');
+
+  const ItemAdjustmentSubRow = ({ label, value, isLastRow = false }) => (
+    <View style={[subRowStyles.row, isLastRow && { borderBottom: borderStyle }]} wrap={false}>
+      {columns.map((col, index) => {
+        const isFirstColumn = index === 0;
+        const isLastColumn = index === columns.length - 1;
+        const cellStyle = [
+          subRowStyles.emptyCell,
+          isFirstColumn && { borderLeft: 'none' },
+          isLastColumn && { borderRight: 'none' },
+          col.style,
+        ];
+
+        if (index === orderedByIndex) {
+          // Label cell (right-aligned gray text)
+          return (
+            <View key={col.key} style={[...cellStyle, { justifyContent: 'flex-end' }]}>
+              <Text style={subRowStyles.labelText}>{label}</Text>
+            </View>
+          );
+        }
+        if (index === priceIndex) {
+          // Value cell
+          return (
+            <View key={col.key} style={cellStyle}>
+              <Text style={subRowStyles.labelText}>{value}</Text>
+            </View>
+          );
+        }
+        // Empty cell for other columns
+        return <View key={col.key} style={cellStyle} />;
+      })}
+    </View>
+  );
 
   return (
-    <View style={priceCellStyles.container}>
-      <P style={discountPrice ? priceCellStyles.crossOutText : undefined}>{price}</P>
-      {!!discountPrice && <P>{discountPrice}</P>}
-    </View>
+    <>
+      <ItemAdjustmentSubRow label="Item adjustment" value={formatDisplayPrice(adjustmentAmount)} />
+      <ItemAdjustmentSubRow
+        label="Cost after adjustment"
+        value={formatDisplayPrice(costAfterAdjustment)}
+        isLastRow
+      />
+    </>
   );
 };
 
@@ -145,7 +247,7 @@ const getInvoiceItemDetails = item => {
       </View>
       {!!note && (
         <View>
-          <P style={[tableStyles.noteText]}>Note: {note}</P>
+          <P style={[baseTableStyles.noteText]}>Note: {note}</P>
         </View>
       )}
     </View>
@@ -153,7 +255,7 @@ const getInvoiceItemDetails = item => {
 };
 
 const HeaderCell = ({ children, style }) => (
-  <View style={[tableStyles.baseCell, style]}>
+  <View style={[baseTableStyles.baseCell, style]}>
     <P bold>{children}</P>
   </View>
 );
@@ -178,47 +280,59 @@ const COLUMNS = {
     {
       key: 'orderDate',
       title: 'Date',
-      style: { width: '12%' },
+      style: { width: '14%' },
       accessor: ({ orderDate }) => (orderDate ? formatShort(orderDate) : '--/--/----'),
     },
     {
       key: 'productName',
       title: 'Details',
-      style: { width: '34%' },
+      style: { width: '24%' },
       accessor: row => getInvoiceItemDetails(row),
       CellComponent: CustomCellComponent,
     },
     {
-      key: 'productCode',
-      title: 'Code',
-      style: { width: '10%' },
-      accessor: ({ productCode }) => productCode,
-    },
-    {
       key: 'quantity',
       title: 'Quantity',
-      style: { width: '11%' },
+      style: { width: '12%' },
       accessor: ({ quantity }) => quantity,
+    },
+    {
+      key: 'approved',
+      title: 'Approved',
+      style: { width: '13%' },
+      accessor: ({ approved }) => (approved ? 'Y' : ''),
     },
     {
       key: 'orderedBy',
       title: 'Ordered by',
       accessor: ({ orderedByUser }) => orderedByUser?.displayName,
-      style: { width: '14%' },
+      style: { width: '24%' },
     },
     {
       key: 'price',
-      title: 'Price',
+      title: 'Cost',
       accessor: row => getPrice(row),
-      style: { width: '19%' },
+      style: { width: '10%', justifyContent: 'flex-end' },
       CellComponent: CustomCellComponent,
+    },
+    {
+      key: 'insurance',
+      title: 'Insurance',
+      accessor: row => getFormattedInvoiceItemCoverageAmount(row),
+      style: { width: '13%', justifyContent: 'flex-end' },
+    },
+    {
+      key: 'netCost',
+      title: 'Net cost',
+      accessor: row => getFormattedInvoiceItemNetCost(row),
+      style: { width: '12%', justifyContent: 'flex-end' },
     },
   ],
   patientPayments: [
     {
       key: 'date',
       title: 'Date',
-      style: { width: '15%' },
+      style: { width: '14%', paddingLeft: 13 },
       accessor: ({ date }) => (date ? formatShort(date) : '--/--/----'),
     },
     {
@@ -240,9 +354,9 @@ const COLUMNS = {
       style: { width: '21%' },
     },
     {
-      key: 'remainingBalance',
-      title: 'Remaining balance',
-      accessor: ({ remainingBalance }) => remainingBalance,
+      key: 'status',
+      title: 'Status',
+      accessor: ({ status }) => status,
       style: { width: '21%' },
     },
   ],
@@ -250,7 +364,7 @@ const COLUMNS = {
     {
       key: 'date',
       title: 'Date',
-      style: { width: '15%' },
+      style: { width: '15%', paddingLeft: 13 },
       accessor: ({ date }) => (date ? formatShort(date) : '--/--/----'),
     },
     {
@@ -289,104 +403,188 @@ const COLUMNS = {
 const MultipageTableHeading = ({ title, style = textStyles.sectionTitle }) => {
   let firstPageOccurrence = Number.MAX_SAFE_INTEGER;
   return (
-    <Text
-      bold
-      fixed
-      style={style}
-      render={({ pageNumber, subPageNumber }) => {
-        if (pageNumber < firstPageOccurrence && subPageNumber) {
-          firstPageOccurrence = pageNumber;
-        }
-        return pageNumber === firstPageOccurrence ? title : `${title} cont...`;
-      }}
-    />
+    <Row style={baseTableStyles.heading}>
+      <Text
+        bold
+        fixed
+        style={style}
+        render={({ pageNumber, subPageNumber }) => {
+          if (pageNumber < firstPageOccurrence && subPageNumber) {
+            firstPageOccurrence = pageNumber;
+          }
+          return pageNumber === firstPageOccurrence ? title : `${title} cont...`;
+        }}
+      />
+    </Row>
   );
 };
 
-const DataTableHeading = ({ columns, title }) => {
+const DataTableHeadingBorder = () => {
   return (
-    <View fixed>
-      {title && <MultipageTableHeading title={title} />}
-      <Row wrap={false}>
-        {columns.map(({ key, title, style }) => (
-          <HeaderCell key={key} style={style}>
-            {title}
-          </HeaderCell>
-        ))}
-      </Row>
+    <View style={{ paddingLeft: 7, paddingRight: 7 }}>
+      <HorizontalRule />
     </View>
   );
 };
 
-const DataTable = ({ data, columns, title }) => (
-  <Table>
-    <DataTableHeading columns={columns} title={title} />
-    {data.map(row => (
-      <Row key={row.id} wrap={false}>
-        {columns.map(({ key, accessor, style, CellComponent }) => {
-          const displayValue = accessor ? accessor(row) : row[key] || '';
-          if (CellComponent) {
-            return (
-              <CellComponent key={key} style={style}>
-                {displayValue}
-              </CellComponent>
-            );
-          }
+const HeaderRow = ({ columns, style }) => {
+  return (
+    <Row wrap={false} style={style}>
+      {columns.map(({ key, title, style }, colIndex) => (
+        <HeaderCell
+          key={key}
+          style={style}
+          isFirst={colIndex === 0}
+          isLast={colIndex === columns.length - 1}
+        >
+          {title}
+        </HeaderCell>
+      ))}
+    </Row>
+  );
+};
+
+const PaymentDataTableHeading = ({ columns, title }) => {
+  return (
+    <View>
+      {title && <MultipageTableHeading title={title} />}
+      <DataTableHeadingBorder />
+      <HeaderRow columns={columns} style={paymentTableStyles.headerRow} />
+      <DataTableHeadingBorder />
+    </View>
+  );
+};
+
+const InvoiceItemDataTableHeading = ({ columns, title }) => {
+  return (
+    <View>
+      {title && <MultipageTableHeading title={title} />}
+      <HeaderRow columns={columns} style={invoiceItemTableStyles.headerRow} />
+    </View>
+  );
+};
+
+const RowWrapper = ({ row, columns, style, SubRowsComponent }) => (
+  <React.Fragment>
+    <Row wrap={false} style={style}>
+      {columns.map(({ key, accessor, style, CellComponent }, colIndex) => {
+        const displayValue = accessor ? accessor(row) : row[key] || '';
+        const isFirst = colIndex === 0;
+        const isLast = colIndex === columns.length - 1;
+        if (CellComponent) {
           return (
-            <Cell key={key} style={style}>
+            <CellComponent key={key} style={style} isFirst={isFirst} isLast={isLast}>
               {displayValue}
-            </Cell>
+            </CellComponent>
           );
-        })}
-      </Row>
-    ))}
+        }
+        return (
+          <Cell key={key} style={style} isFirst={isFirst} isLast={isLast}>
+            {displayValue}
+          </Cell>
+        );
+      })}
+    </Row>
+    {SubRowsComponent && <SubRowsComponent item={row} columns={columns} />}
+  </React.Fragment>
+);
+
+const InvoiceItemTable = ({ data, columns, title }) => (
+  <Table>
+    <InvoiceItemDataTableHeading columns={columns} title={title} />
+    {data.map(row => {
+      return (
+        <RowWrapper
+          key={row.id}
+          row={row}
+          columns={columns}
+          style={invoiceItemTableStyles.row}
+          SubRowsComponent={InvoiceItemAdjustmentRows}
+        />
+      );
+    })}
   </Table>
 );
 
-const TableSection = ({ title, data, columns, type }) => {
+const PaymentTable = ({ data, columns, title }) => (
+  <Table>
+    <PaymentDataTableHeading columns={columns} title={title} />
+    {data.map((row, rowIndex) => {
+      const isLastRow = rowIndex === data.length - 1;
+      const rowStyle = {
+        borderTop: 'none',
+        borderBottom: isLastRow ? borderStyle : 'none',
+      };
+      return <RowWrapper key={row.id} row={row} columns={columns} style={rowStyle} />;
+    })}
+  </Table>
+);
+
+const InvoiceItemTableSection = ({ title, data, columns }) => {
   return (
     <View>
       <View minPresenceAhead={70} />
-      <DataTable data={data} columns={columns} title={title} type={type} />
+      <InvoiceItemTable data={data} columns={columns} title={title} />
+      <SectionSpacing />
+    </View>
+  );
+};
+
+const PaymentTableSection = ({ title, data, columns }) => {
+  return (
+    <View>
+      <View minPresenceAhead={70} />
+      <PaymentTable data={data} columns={columns} title={title} />
       <SectionSpacing />
     </View>
   );
 };
 
 const SummaryPane = ({ invoice }) => {
-  const { itemsSubtotal, patientSubtotal, discountTotal, patientTotal } =
-    getInvoiceSummaryDisplay(invoice);
+  const {
+    invoiceItemsTotal,
+    patientPaymentRemainingBalance,
+    patientSubtotal,
+    discountTotal,
+    patientPaymentsTotal,
+  } = getInvoiceSummaryDisplay(invoice);
+  const insurancePlanCoverages = getFormattedCoverageAmountPerInsurancePlanForInvoice(invoice);
 
   return (
     <View wrap={false} style={summaryPaneStyles.container}>
-      <HorizontalRule />
       <View style={summaryPaneStyles.item}>
-        <P bold>Total</P>
-        <P bold>{itemsSubtotal ?? '-'}</P>
+        <P>Invoice total</P>
+        <P>{formatDisplayPrice(invoiceItemsTotal)}</P>
       </View>
+      <View style={summaryPaneStyles.item}>
+        <P>Item adjustments</P>
+        <P>{formatDisplayPrice(discountTotal)}</P>
+      </View>
+      <P bold>Insurance coverage</P>
+      {insurancePlanCoverages.length > 0 && (
+        <>
+          {insurancePlanCoverages.map(plan => (
+            <View key={plan.id} style={summaryPaneStyles.item}>
+              <P>{plan.name || plan.code}</P>
+              <P>{formatDisplayPrice(plan.totalCoverage)}</P>
+            </View>
+          ))}
+        </>
+      )}
       <HorizontalRule />
       <View style={summaryPaneStyles.item}>
         <P bold>Patient subtotal</P>
-        <P>{patientSubtotal}</P>
+        <P>{formatDisplayPrice(patientSubtotal)}</P>
       </View>
+      <HorizontalRule />
       <View style={summaryPaneStyles.item}>
-        <P bold>Discount</P>
-        {!!invoice.discount && (
-          <View style={summaryPaneStyles.subItem}>
-            <P>{invoice.discount?.percentage * 100}%</P>
-            <P bold>{typeof discountTotal === 'string' ? `-${discountTotal}` : '-'}</P>
-          </View>
-        )}
+        <P>Patient payments</P>
+        <P>{`-${formatDisplayPrice(patientPaymentsTotal)}`}</P>
       </View>
-      {!!invoice.discount && (
-        <View style={summaryPaneStyles.item}>
-          {invoice.discount?.isManual ? <P>Manual discount</P> : <P>Patient discount applied</P>}
-        </View>
-      )}
       <HorizontalRule />
       <View style={[summaryPaneStyles.item, { marginVertical: 7.5 }]}>
-        <P bold>Patient total</P>
-        <P bold>{patientTotal ?? '-'}</P>
+        <P bold>Patient total due</P>
+        <P bold>{formatDisplayPrice(patientPaymentRemainingBalance)}</P>
       </View>
     </View>
   );
@@ -444,19 +642,23 @@ const InvoiceRecordPrintoutComponent = ({
         />
         <SectionSpacing />
         {invoice?.items?.length > 0 && (
-          <TableSection data={invoice?.items} columns={COLUMNS.invoiceItems} />
+          <InvoiceItemTableSection
+            data={invoice?.items}
+            columns={COLUMNS.invoiceItems}
+            showAdjustmentRows
+          />
         )}
         <SummaryPane invoice={invoice} />
         <SectionSpacing />
         {patientPayments?.length && (
-          <TableSection
+          <PaymentTableSection
             title="Patient payment"
             data={patientPayments}
             columns={COLUMNS.patientPayments}
           />
         )}
         {insurerPayments?.length && (
-          <TableSection
+          <PaymentTableSection
             title="Insurer payment"
             data={insurerPayments}
             columns={COLUMNS.insurerPayments}

--- a/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/InvoiceRecordPrintout.jsx
@@ -307,7 +307,6 @@ const COLUMNS = {
       title: 'Ordered by',
       accessor: ({ orderedByUser }) => orderedByUser?.displayName,
       style: { width: '24%' },
-      subRowLabel: true 
     },
     {
       key: 'price',
@@ -561,9 +560,9 @@ const SummaryPane = ({ invoice }) => {
         <P>Item adjustments</P>
         <P>{itemAdjustmentsTotal}</P>
       </View>
-      <P bold>Insurance coverage</P>
       {insurancePlanCoverages.length > 0 && (
         <>
+          <P bold>Insurance coverage</P>
           {insurancePlanCoverages.map(plan => (
             <View key={plan.id} style={summaryPaneStyles.item}>
               <P>{plan.name || plan.code}</P>

--- a/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/PriceCell.jsx
+++ b/packages/web/app/features/Invoice/InvoiceForm/InvoiceItemCells/PriceCell.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {
   getInvoiceItemTotalDiscountedPrice,
   getInvoiceItemTotalPrice,
-  getInvoiceItemCoverageValue,
+  getInvoiceItemCoveragePercentage,
 } from '@tamanu/shared/utils/invoice';
 import Decimal from 'decimal.js';
 import Collapse from '@material-ui/core/Collapse';
@@ -60,7 +60,7 @@ const InsuranceSection = ({ item, discountedPrice }) => {
   return (
     <Box mt={1}>
       {item.insurancePlanItems.map(insurancePlanItem => {
-        const appliedCoverage = getInvoiceItemCoverageValue(item, insurancePlanItem);
+        const appliedCoverage = getInvoiceItemCoveragePercentage(item, insurancePlanItem);
         const coverageForRow = calculateCoverageValue(discountedPrice, appliedCoverage);
         return (
           <Row key={insurancePlanItem.id}>


### PR DESCRIPTION
Already approved in https://github.com/beyondessential/tamanu/pull/9093, just cherry picking to epic branch of phase 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core invoice total/coverage computations and the PDF output layout, so regressions could affect displayed billing amounts; changes are localized and covered by updated unit tests for renamed/modified helpers.
> 
> **Overview**
> Updates invoice financial calculations and the invoice PDF printout to better surface *item-level adjustments* and *insurance coverage*.
> 
> On the shared invoice utils side, renames insurance helpers (`getInvoiceItemCoverageValue`→`getInvoiceItemCoveragePercentage`, `getInsuranceCoverageTotal`→`getInsuranceCoverageTotalAmount`), factors out per-plan/per-item coverage calculations, and extends `getInvoiceSummary` with `itemAdjustmentsTotal`.
> 
> On the printout, restructures the invoice items table (new columns for Approved/Insurance/Net cost, optional sub-rows showing item adjustment and cost after adjustment) and revamps the summary pane to show invoice total, item adjustments, insurance coverage totals per plan, patient payments, and patient total due; related UI code switches to the renamed coverage-percentage helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f44a19fa9c8e44da8f55c7e004571eadc83c33ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->