### PR TITLE
fix: Release v2.48: Medication tweaks

### DIFF
--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -2479,20 +2479,14 @@ medication.post(
         { transaction },
       );
 
-      // After dispensing, soft delete all ineligible pharmacy order prescriptions
-      const allCompletedRecords = prescriptionRecords.filter(record => {
-        const remainingRepeats = record.getRemainingRepeats(1);
-        const isDischargePrescription = record.pharmacyOrder?.isDischargePrescription;
-        return remainingRepeats === 0 && !!isDischargePrescription;
-      });
-
-      if (allCompletedRecords.length > 0) {
-        const completedIds = allCompletedRecords.map(r => r.id);
-        await PharmacyOrderPrescription.update(
-          { isCompleted: true },
-          { where: { id: { [Op.in]: completedIds } }, transaction },
-        );
-      }
+      // Mark all dispensed pharmacy order prescriptions as completed so they no longer
+      // appear in the Active medication requests table (same behaviour for all encounter types).
+      // If another dispense is needed, a new order must be sent.
+      const dispensedIds = prescriptionRecords.map(r => r.id);
+      await PharmacyOrderPrescription.update(
+        { isCompleted: true },
+        { where: { id: { [Op.in]: dispensedIds } }, transaction },
+      );
 
       return dispenseRecords;
     });

--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -9,7 +9,7 @@ import { Button } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
 
 import { DataFetchingTable } from '../Table';
-import { formatShortest } from '../DateDisplay';
+import { formatShortest, formatTime } from '../DateDisplay';
 import { TranslatedText, TranslatedReferenceData, TranslatedEnum } from '../Translation';
 import { useTranslation } from '../../contexts/Translation';
 import { formatTimeSlot } from '../../utils/medications';
@@ -299,16 +299,15 @@ const getMedicationColumns = (
           );
         }
 
-        const orderDate = new Date(lastOrderedAt);
         return (
           <NoWrapCell
             color={isPausing ? Colors.softText : 'inherit'}
             fontStyle={isPausing ? 'italic' : 'normal'}
           >
             <Box>
-              {formatShortest(orderDate)}
+              {formatShortest(lastOrderedAt)}
               <Box fontSize="12px" color={Colors.softText}>
-                {format(orderDate, 'h:mma').toLowerCase()}
+                {formatTime(lastOrderedAt).toLowerCase()}
               </Box>
             </Box>
           </NoWrapCell>
@@ -365,10 +364,9 @@ export const EncounterMedicationTable = ({
 
   const rowStyle = ({ discontinued, medication }) => `
     ${discontinued ? 'text-decoration: line-through;' : ''}
-    ${
-      medication.referenceDrug.isSensitive && !canViewSensitiveMedications
-        ? 'pointer-events: none;'
-        : ''
+    ${medication.referenceDrug.isSensitive && !canViewSensitiveMedications
+      ? 'pointer-events: none;'
+      : ''
     }
   `;
 

--- a/packages/web/app/components/Medication/PharmacyOrderMedicationTable.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderMedicationTable.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { Box } from '@material-ui/core';
 
-import { formatShortest } from '@tamanu/utils/dateTime';
+import { formatShortest, formatTime } from '@tamanu/utils/dateTime';
 import { getMedicationDoseDisplay, getTranslatedFrequency } from '@tamanu/shared/utils/medication';
 
 import { TextInput, ConditionalTooltip } from '@tamanu/ui-components';
@@ -11,7 +11,6 @@ import { OuterLabelFieldWrapper, CheckInput, NumberInput } from '../Field';
 import { Table } from '../Table';
 import { useTranslation } from '../../contexts/Translation';
 import { TranslatedText, TranslatedReferenceData } from '../Translation';
-import { format } from 'date-fns';
 import { MEDICATION_DURATION_DISPLAY_UNITS_LABELS, MAX_REPEATS } from '@tamanu/constants';
 import { preventInvalidRepeatsInput, singularize } from '../../utils';
 
@@ -246,13 +245,12 @@ const getColumns = (
           );
         }
 
-        const orderDate = new Date(lastOrderedAt);
         return (
           <NoWrapCell color={'inherit'} fontStyle={'normal'}>
             <Box>
-              {formatShortest(orderDate)}
+              {formatShortest(lastOrderedAt)}
               <Box fontSize="12px" color={Colors.softText}>
-                {format(orderDate, 'h:mma').toLowerCase()}
+                {formatTime(lastOrderedAt).toLowerCase()}
               </Box>
             </Box>
           </NoWrapCell>

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -80,7 +80,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
 
   if (encounter.endDate) {
     return (
-      discharge ? (
+      discharge && (
         <ActionsContainer data-testid="actionscontainer-w92z">
           <StyledButton
             size="small"
@@ -108,7 +108,7 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
             />
           </StyledButton>
         </ActionsContainer>
-      ) : <></>)
+      ))
   }
 
   const progression = {

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -79,6 +79,10 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
   const onChangeDiet = () => setOpenModal(ENCOUNTER_MODALS.CHANGE_DIET);
 
   if (encounter.endDate) {
+    // Ideally we would have a dedicated encounter type for discharged encounters and filter
+    // at the same level as the other encounter types. Because discharge uses clinic data we
+    // need this extra check here to only show encounter/discharge summary actions when
+    // the encounter is actually discharged (discharge record exists).
     return (
       discharge && (
         <ActionsContainer data-testid="actionscontainer-w92z">

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -18,6 +18,7 @@ import { ChangeReasonModal } from '../../../components/ChangeReasonModal';
 import { ChangeDietModal } from '../../../components/ChangeDietModal';
 import { isInpatient } from '../../../utils/isInpatient';
 import { useSettings } from '../../../contexts/Settings';
+import { useEncounterDischargeQuery } from '../../../api/queries/useEncounterDischargeQuery';
 
 const ActionsContainer = styled.div`
   display: flex;
@@ -57,6 +58,7 @@ const StyledDropdownButton = styled(DropdownButton)`
 const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType }) => {
   const { navigateToSummary } = usePatientNavigation();
   const { getSetting } = useSettings();
+  const { data: discharge } = useEncounterDischargeQuery(encounter);
 
   const onChangeEncounterType = type => {
     setNewEncounterType(type);
@@ -78,34 +80,35 @@ const EncounterActionDropdown = ({ encounter, setOpenModal, setNewEncounterType 
 
   if (encounter.endDate) {
     return (
-      <ActionsContainer data-testid="actionscontainer-w92z">
-        <StyledButton
-          size="small"
-          variant="outlined"
-          onClick={onViewEncounterRecord}
-          data-testid="styledbutton-00iz"
-        >
-          <TranslatedText
-            stringId="patient.encounter.action.encounterSummary"
-            fallback="Encounter summary"
-            data-testid="translatedtext-ftbh"
-          />
-        </StyledButton>
-        <br />
-        <StyledButton
-          size="small"
-          color="primary"
-          onClick={onViewSummary}
-          data-testid="styledbutton-0m1p"
-        >
-          <TranslatedText
-            stringId="patient.encounter.action.dischargeSummary"
-            fallback="Discharge summary"
-            data-testid="translatedtext-0hzq"
-          />
-        </StyledButton>
-      </ActionsContainer>
-    );
+      discharge ? (
+        <ActionsContainer data-testid="actionscontainer-w92z">
+          <StyledButton
+            size="small"
+            variant="outlined"
+            onClick={onViewEncounterRecord}
+            data-testid="styledbutton-00iz"
+          >
+            <TranslatedText
+              stringId="patient.encounter.action.encounterSummary"
+              fallback="Encounter summary"
+              data-testid="translatedtext-ftbh"
+            />
+          </StyledButton>
+          <br />
+          <StyledButton
+            size="small"
+            color="primary"
+            onClick={onViewSummary}
+            data-testid="styledbutton-0m1p"
+          >
+            <TranslatedText
+              stringId="patient.encounter.action.dischargeSummary"
+              fallback="Discharge summary"
+              data-testid="translatedtext-0hzq"
+            />
+          </StyledButton>
+        </ActionsContainer>
+      ) : <></>)
   }
 
   const progression = {


### PR DESCRIPTION
### Changes

Overview
Standardises the “Last sent” timestamp display in medication tables by using shared formatTime/formatShortest helpers (and removing ad-hoc date-fns parsing/formatting) in both MedicationTable and PharmacyOrderMedicationTable.

Updates encounter action rendering so that when an encounter has endDate, the Encounter/Discharge summary buttons only appear if discharge data is available via useEncounterDischargeQuery

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI-level formatting and conditional rendering, but it changes when discharge/summary actions appear and adds a new discharge fetch that could affect workflows if the query behavior differs from expectations.
> 
> **Overview**
> Standardises the “Last sent” timestamp rendering in `MedicationTable` and `PharmacyOrderMedicationTable` by using shared `formatShortest`/`formatTime` helpers instead of local `Date`/`date-fns` formatting.
> 
> Updates `EncounterActions` so that when an encounter has an `endDate`, the Encounter/Discharge summary buttons only render if a discharge record is available via `useEncounterDischargeQuery` (avoiding showing discharge actions for ended-but-not-discharged encounters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81dc749e107d4e94d05e9b1c66da7f2a2a6c3288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->