### PR TITLE
feat(fhir): NASS-1871: Allow SENAITE to create reflex tests via the FHIR API

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
@@ -340,7 +340,7 @@ describe('Create Observation', () => {
               diagnostics: expect.any(String),
               details: {
                 text: expect.stringContaining(
-                  `Cannot create reflex test, no lab test type found with code ${invalidCode}`,
+                  `Cannot create reflex test, no lab test type found with code '${invalidCode}'`,
                 ),
               },
             },

--- a/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
@@ -341,7 +341,7 @@ describe('Create Observation', () => {
               diagnostics: expect.any(String),
               details: {
                 text: expect.stringContaining(
-                  `Cannot create reflex test, no lab test type found with code ${invalidCode}`,
+                  `Cannot create reflex test, no lab test type found with code '${invalidCode}'`,
                 ),
               },
             },

--- a/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/Observation.test.js
@@ -7,6 +7,7 @@ import {
   ALL_FHIR_PERMISSIONS,
   fakeResourcesOfFhirServiceRequest,
   fakeResourcesOfFhirServiceRequestWithLabRequest,
+  fakeTestTypes,
 } from '../../fake/fhir';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -199,6 +200,56 @@ describe('Create Observation', () => {
       expect(labTest.result).toBe(result);
     });
 
+    it('Will add a reflex test if the lab test code is not in the original request', async () => {
+      const result = '100';
+
+      const { FhirServiceRequest, LabTest, LabTestType } = ctx.store.models;
+      const { labRequest, category } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
+        ctx.store.models,
+        resources,
+        false,
+        {
+          status: LAB_REQUEST_STATUSES.RESULTS_PENDING,
+        },
+      );
+      const [newTestType] = await fakeTestTypes(10, LabTestType, category.id);
+
+      const mat = await FhirServiceRequest.materialiseFromUpstream(labRequest.id);
+      const serviceRequestId = mat.id;
+
+      const body = {
+        resourceType: 'Observation',
+        basedOn: [
+          {
+            type: 'ServiceRequest',
+            reference: `ServiceRequest/${serviceRequestId}`,
+          },
+        ],
+        status: FHIR_OBSERVATION_STATUS.FINAL,
+        code: {
+          coding: [
+            {
+              system: config.hl7.dataDictionaries.serviceRequestLabTestCodeSystem,
+              code: newTestType.code,
+            },
+          ],
+        },
+        valueString: result,
+      };
+
+      const response = await app.post(endpoint).send(body);
+      expect(response).toHaveSucceeded();
+
+      const labTest = await LabTest.findOne({
+        include: [{ model: LabTestType, as: 'labTestType' }],
+        where: {
+          labRequestId: labRequest.id,
+          '$labTestType.id$': newTestType.id,
+        },
+      });
+      expect(labTest.result).toBe(result);
+    });
+
     describe('errors', () => {
       it('returns invalid value if the ServiceRequest does not exist', async () => {
         const nonExistentServiceRequestId = uuidv4();
@@ -242,7 +293,7 @@ describe('Create Observation', () => {
         expect(response.status).toBe(400);
       });
 
-      it('returns invalid value if the Observation code does not match any test in the ServiceRequest', async () => {
+      it('returns invalid value if the Observation code does not match any test types', async () => {
         const { FhirServiceRequest } = ctx.store.models;
         const { labRequest } = await fakeResourcesOfFhirServiceRequestWithLabRequest(
           ctx.store.models,
@@ -290,7 +341,7 @@ describe('Create Observation', () => {
               diagnostics: expect.any(String),
               details: {
                 text: expect.stringContaining(
-                  `No LabTest with code: '${invalidCode}' found for LabRequest: '${labRequest.id}'`,
+                  `Cannot create reflex test, no lab test type found with code ${invalidCode}`,
                 ),
               },
             },

--- a/packages/database/src/models/fhir/FhirObservation.ts
+++ b/packages/database/src/models/fhir/FhirObservation.ts
@@ -226,8 +226,15 @@ export class FhirObservation extends FhirResource {
           })));
 
       if (!labTestType) {
+        const identifiers = [];
+        if (labTestCode) {
+          identifiers.push(`code '${labTestCode}'`);
+        }
+        if (labTestExternalCode) {
+          identifiers.push(`externalCode '${labTestExternalCode}'`);
+        }
         throw new Invalid(
-          `Cannot create reflex test, no lab test type found with ${labTestCode ? 'code' : 'externalCode'} ${labTestCode || labTestExternalCode}`,
+          `Cannot create reflex test, no lab test type found with ${identifiers.join(' or ')}`,
           {
             code: FHIR_ISSUE_TYPE.INVALID.VALUE,
           },

--- a/packages/database/src/models/fhir/FhirObservation.ts
+++ b/packages/database/src/models/fhir/FhirObservation.ts
@@ -4,7 +4,7 @@ import { DataTypes } from 'sequelize';
 import * as yup from 'yup';
 
 import { FHIR_INTERACTIONS, FHIR_ISSUE_TYPE } from '@tamanu/constants';
-import { getCurrentDateString } from '@tamanu/utils/dateTime';
+import { getCurrentDateString, getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import {
   FhirCodeableConcept,
   FhirCoding,
@@ -158,7 +158,7 @@ export class FhirObservation extends FhirResource {
     const labTest = await this.getLabTestForObservation(labRequest);
     const value = this.getValue();
 
-    await labTest.update({ result: value, completedDate: getCurrentDateString() });
+    await labTest.update({ result: value, completedDate: getCurrentDateTimeString() });
     return labTest;
   }
 


### PR DESCRIPTION
### Changes

Pretty simple change here to instead of rejecting an Observation if it's code isn't in the LabRequest's tests already, just create a new test.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
