### PR TITLE
fix(translations): PHX-303: Update medication label translations (and more)

### DIFF
--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -2265,7 +2265,7 @@ medication.get(
           include: [
             {
               association: 'medication',
-              attributes: ['id', 'name'],
+              attributes: ['id', 'name', 'type'],
               include: [
                 {
                   model: models.ReferenceDrug,

--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -272,7 +272,7 @@ export const DispenseMedicationWorkflowModal = memo(
         });
       setItems(nextItems);
       setItemErrors({});
-    }, [open, dispensableResponse]);
+    }, [open, dispensableResponse, getTranslation, getEnumTranslation]);
 
     const handleClose = () => {
       setItems([]);

--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -83,7 +83,7 @@ const PrintContainer = styled.div`
 const PrintDescription = styled(Box)`
   margin-bottom: 16px;
   font-size: 14px;
-  color: Colors.midText;
+  color: ${Colors.midText};
 
   @media print {
     display: none;

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
@@ -110,7 +110,8 @@ const LabelFooterText = styled.div`
 
 export const getMedicationLabel = (quantity, units, getEnumTranslation) => {
   if (!quantity || !units) return;
-  const translatedUnit = quantity > 1 ? pluralize(getEnumTranslation(DRUG_UNIT_LABELS, units)) : getEnumTranslation(DRUG_UNIT_LABELS, units);
+  const enumTranslation = getEnumTranslation(DRUG_UNIT_LABELS, units);
+  const translatedUnit = quantity > 1 ? pluralize(enumTranslation) : enumTranslation;
   return `${quantity} ${translatedUnit.toLowerCase()}`;
 };
 

--- a/packages/web/app/contexts/Translation.jsx
+++ b/packages/web/app/contexts/Translation.jsx
@@ -4,8 +4,8 @@ import { LOCAL_STORAGE_KEYS } from '../constants';
 import { useTranslationsQuery } from '../api/queries/useTranslationsQuery';
 import { translationFactory } from '@tamanu/shared/utils/translation/translationFactory';
 import { getCurrentLanguageCode } from '../utils/translation';
-import { getEnumPrefix } from '@tamanu/shared/utils/enumRegistry';
 import { getReferenceDataStringId } from '@tamanu/shared/utils/translation';
+import { getEnumStringId } from '../components/Translation/TranslatedEnum';
 
 export { useTranslation };
 
@@ -34,7 +34,7 @@ export const TranslationProvider = ({ children, value }) => {
 
   const getEnumTranslation = (enumValues, currentValue) => {
     const fallback = enumValues[currentValue];
-    const stringId = `${getEnumPrefix(enumValues)}.${currentValue}`;
+    const stringId = getEnumStringId(currentValue ?? '', enumValues);
     const { value } = translationFunc(stringId, fallback);
     return value;
   };

--- a/packages/web/app/contexts/Translation.jsx
+++ b/packages/web/app/contexts/Translation.jsx
@@ -39,17 +39,17 @@ export const TranslationProvider = ({ children, value }) => {
       : placeholder;
   }, [getTranslation]);
 
-  // In the case of mocking the translation context, we can pass in the value directly
-  if (value) {
-    return <TranslationContext.Provider value={value}>{children}</TranslationContext.Provider>;
-  }
-
   const updateStoredLanguage = newLanguage => {
     // Save the language in local state so that it updates the react component tree on change
     setStoredLanguage(newLanguage);
     // Save the language in local storage so that it persists between sessions
     localStorage.setItem(LOCAL_STORAGE_KEYS.LANGUAGE, newLanguage);
   };
+
+  // In the case of mocking the translation context, we can pass in the value directly
+  if (value) {
+    return <TranslationContext.Provider value={value}>{children}</TranslationContext.Provider>;
+  }
 
   return (
     <TranslationContext.Provider


### PR DESCRIPTION
### Changes

So we had something a bit whack going on in a couple of places.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared translation lookup behavior and medication dispensing UI data requirements, which could cause widespread label/enum translation regressions if string IDs or enum mappings differ from expectations.
> 
> **Overview**
> Fixes medication dispensing/label translation issues by changing `getEnumTranslation` to build enum string IDs via `getEnumStringId` (from `TranslatedEnum`) and by updating dependent UI code to react to translation function changes.
> 
> Medication dispensing responses now include `medication.type` (alongside `id`/`name`) so the web app can correctly translate medication reference data, and medication label unit translation/pluralisation is refactored to avoid double-calling `getEnumTranslation` and improve correctness/readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f67a9202a3cb3ebdbf51840818eaf5509932fe0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->