### PR TITLE
fix: Release 2.48: Medication timezone issues

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Encounter.test.js
+++ b/packages/facility-server/__tests__/apiv1/Encounter.test.js
@@ -918,9 +918,7 @@ describe('Encounter', () => {
 
         const result = await app.post('/api/medication/import-ongoing').send({
           encounterId: medicationEncounter.id,
-          medications: [
-            { prescriptionId: ongoingPrescription.id, quantity: 10, repeats: 1 },
-          ],
+          medications: [{ prescriptionId: ongoingPrescription.id, quantity: 10, repeats: 1 }],
           prescriberId: app.user.id,
         });
         expect(result).toHaveRequestError();
@@ -997,14 +995,14 @@ describe('Encounter', () => {
         expect(pharmacyOrderPrescriptions[0].repeats).toBe(1);
       });
 
-      it('should return the last ordered timestamp of the medication has been ordered', async () => {
-        const fakeCreatedAt = new Date('2020-01-01T00:00:00.000Z');
-        const pharmacyOrder = await app
+      it('should return the last ordered date time string of the medication has been ordered', async () => {
+        const firstOrderedAt = '2020-01-01 09:00:00';
+        const lastOrderedAt = '2020-01-15 14:30:00';
+
+        const firstOrder = await app
           .post(`/api/encounter/${pharmacyOrderEncounter.id}/pharmacyOrder`)
           .send({
             orderingClinicianId: app.user.id,
-            comments: 'comments',
-            date: getCurrentDateTimeString(),
             facilityId: facilityId,
             pharmacyOrderPrescriptions: [
               {
@@ -1014,16 +1012,37 @@ describe('Encounter', () => {
               },
             ],
           });
+        expect(firstOrder).toHaveSucceeded();
 
-        await models.PharmacyOrderPrescription.update(
-          { createdAt: fakeCreatedAt },
-          { where: { pharmacyOrderId: pharmacyOrder.body.id } },
+        const secondOrder = await app
+          .post(`/api/encounter/${pharmacyOrderEncounter.id}/pharmacyOrder`)
+          .send({
+            orderingClinicianId: app.user.id,
+            facilityId: facilityId,
+            pharmacyOrderPrescriptions: [
+              {
+                prescriptionId: testPrescription.id,
+                quantity: 2,
+                repeats: 1,
+              },
+            ],
+          });
+        expect(secondOrder).toHaveSucceeded();
+
+        await models.PharmacyOrder.update(
+          { date: firstOrderedAt },
+          { where: { id: firstOrder.body.id } },
+        );
+        await models.PharmacyOrder.update(
+          { date: lastOrderedAt },
+          { where: { id: secondOrder.body.id } },
         );
 
         const result = await app.get(`/api/encounter/${pharmacyOrderEncounter.id}/medications`);
         expect(result).toHaveSucceeded();
         const { body } = result;
-        expect(body.data[0].lastOrderedAt).toEqual(fakeCreatedAt.toISOString());
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0].lastOrderedAt).toEqual(lastOrderedAt);
       });
     });
 

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -423,7 +423,9 @@ encounterRelations.get(
         SELECT pop.prescription_id, max(po.date) AS last_ordered_at
         FROM pharmacy_order_prescriptions pop
         INNER JOIN pharmacy_orders po ON po.id = pop.pharmacy_order_id
-        WHERE pop.prescription_id IN (:prescriptionIds) AND pop.deleted_at IS NULL
+        WHERE pop.prescription_id IN (:prescriptionIds)
+          AND pop.deleted_at IS NULL
+          AND po.deleted_at IS NULL
         GROUP BY pop.prescription_id
       `,
         { replacements: { prescriptionIds } },

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -228,7 +228,9 @@ encounter.post(
       attributes: ['id', 'medicationId', 'quantity'],
     });
 
-    const hasSensitive = await models.ReferenceDrug.hasSensitiveMedication(prescriptionRecords.map(p => p.medicationId));
+    const hasSensitive = await models.ReferenceDrug.hasSensitiveMedication(
+      prescriptionRecords.map(p => p.medicationId),
+    );
 
     if (hasSensitive) {
       req.checkPermission('read', 'SensitiveMedication');
@@ -416,19 +418,21 @@ encounterRelations.get(
     let responseData = prescriptions.map(p => p.forResponse());
     if (responseData.length > 0) {
       const prescriptionIds = responseData.map(p => p.id);
-      const [pharmacyOrderPrescriptions] = await db.query(
+      const [lastOrderedRows] = await db.query(
         `
-        SELECT prescription_id, max(created_at) as last_ordered_at
-        FROM pharmacy_order_prescriptions
-        WHERE prescription_id IN (:prescriptionIds) and deleted_at is null GROUP BY prescription_id
+        SELECT pop.prescription_id, max(po.date) AS last_ordered_at
+        FROM pharmacy_order_prescriptions pop
+        INNER JOIN pharmacy_orders po ON po.id = pop.pharmacy_order_id
+        WHERE pop.prescription_id IN (:prescriptionIds) AND pop.deleted_at IS NULL
+        GROUP BY pop.prescription_id
       `,
         { replacements: { prescriptionIds } },
       );
-      const lastOrderedAts = keyBy(pharmacyOrderPrescriptions, 'prescription_id');
+      const lastOrderedAts = keyBy(lastOrderedRows, 'prescription_id');
 
       responseData = responseData.map(p => ({
         ...p,
-        lastOrderedAt: lastOrderedAts[p.id]?.last_ordered_at?.toISOString(),
+        lastOrderedAt: lastOrderedAts[p.id]?.last_ordered_at,
       }));
     }
 

--- a/packages/web/app/components/Medication/MedicationTable.jsx
+++ b/packages/web/app/components/Medication/MedicationTable.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import styled from 'styled-components';
-import { format } from 'date-fns';
 import { Box } from '@material-ui/core';
 import { DRUG_ROUTE_LABELS, MEDICATION_DURATION_DISPLAY_UNITS_LABELS } from '@tamanu/constants';
 import { useLocation, useNavigate } from 'react-router';
@@ -9,7 +8,7 @@ import { Button } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
 
 import { DataFetchingTable } from '../Table';
-import { formatShortest, formatTime } from '../DateDisplay';
+import { formatShortest, formatTime, getDateDisplay } from '../DateDisplay';
 import { TranslatedText, TranslatedReferenceData, TranslatedEnum } from '../Translation';
 import { useTranslation } from '../../contexts/Translation';
 import { formatTimeSlot } from '../../utils/medications';
@@ -219,7 +218,7 @@ const getMedicationColumns = (
           tooltipTitle = (
             <>
               <TranslatedText stringId="medication.table.endsOn.label" fallback="Ends on" />
-              <div>{format(new Date(endDate), 'dd/MM/yy h:mma').toLowerCase()}</div>
+              <div>{getDateDisplay(endDate, { showDate: true, showTime: true })}</div>
             </>
           );
         } else if (isOngoing) {


### PR DESCRIPTION
### Changes

More standardisation of timezones. (Big general fix coming soon in Daniel epic)

Fixes medication date/time inconsistencies by changing GET` /api/encounter/:id/medications` to compute lastOrderedAt from the associated pharmacy_orders.date (joined via pharmacy_order_prescriptions) instead of created_at, and returning the raw stored datetime string rather than converting to ISO.

Updates the facility-server tests to assert the new lastOrderedAt behavior, and updates the web medication table tooltip to use the shared getDateDisplay formatter for end-date timestamps (removing direct date-fns formatting) for consistent timezone-aware rendering.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->