### PR TITLE
fix(mobile): TAMOC-389 AutocompleteModalField empty on selection

### DIFF
--- a/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
+++ b/packages/mobile/App/ui/components/AutocompleteModal/SurveyQuestionAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Suggester } from '~/ui/helpers/suggester';
 import { useFacility } from '~/ui/contexts/FacilityContext';
 import { useBackend } from '~/ui/hooks';
@@ -14,14 +14,15 @@ function getNameColumnForModel(modelName: string): string {
   }
 }
 
+const EMPTY_FILTER: Record<string, never> = {};
+
 const useFilterByResource = ({ source, scope }: SurveyScreenConfig): object => {
   const { facilityId } = useFacility();
-
-  if (source === 'LocationGroup' && scope !== 'allFacilities') {
-    return { facility: facilityId };
-  }
-
-  return {};
+  const hasFacilityFilter = source === 'LocationGroup' && scope !== 'allFacilities';
+  return useMemo(
+    () => (hasFacilityFilter ? { facility: facilityId } : EMPTY_FILTER),
+    [hasFacilityFilter, facilityId],
+  );
 };
 
 const useWhere = ({
@@ -31,20 +32,18 @@ const useWhere = ({
   where?: {
     type: string;
   };
-}) => {
-  if (source === 'ReferenceData' && where?.type === 'icd10')
-    // Continue to support existing surveys with deprecated icd10 type by treating as diagnosis
-    return {
-      ...where,
-      type: 'diagnosis',
-    };
-  return where;
-};
+}) =>
+  useMemo(() => {
+    if (source === 'ReferenceData' && where?.type === 'icd10') {
+      return { ...where, type: 'diagnosis' };
+    }
+    return where;
+  }, [source, where]);
 
 const useSurveyAutocompleteWhere = (config: SurveyScreenConfig) => {
   const where = useWhere(config);
   const filter = useFilterByResource(config);
-  return { ...where, ...filter };
+  return useMemo(() => ({ ...where, ...filter }), [where, filter]);
 };
 
 export const SurveyQuestionAutocomplete = (props): JSX.Element => {
@@ -52,13 +51,17 @@ export const SurveyQuestionAutocomplete = (props): JSX.Element => {
   const where = useSurveyAutocompleteWhere(props.config);
   const { source } = props.config;
 
-  const suggester = new Suggester({
-    model: models[source],
-    options: {
-      where,
-      column: getNameColumnForModel(source),
-    },
-  });
+  const suggester = useMemo(
+    () =>
+      new Suggester({
+        model: models[source],
+        options: {
+          where,
+          column: getNameColumnForModel(source),
+        },
+      }),
+    [models, source, where],
+  );
 
   return (
     <AutocompleteModalField

--- a/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/LabRequestForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { ReactElement, useCallback, useMemo, useState } from 'react';
 import { FormValidationMessage } from '/components/Forms/FormValidationMessage';
 import { Field } from '/components/Forms/FormField';
 import { FormScreenView } from '/components/Forms/FormScreenView';
@@ -21,43 +21,63 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
   const [labTestTypes, setLabTestTypes] = useState([]);
   const { models } = useBackend();
 
-  const labRequestCategorySuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.LabTestCategory,
-      },
-    },
-  });
-  const labRequestPrioritySuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.LabTestPriority,
-      },
-    },
-  });
-  const labSampleSiteSuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.LabSampleSite,
-      },
-    },
-  });
-  const specimenTypeSuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.SpecimenType,
-      },
-    },
-  });
+  const labRequestCategorySuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.LabTestCategory,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
+  const labRequestPrioritySuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.LabTestPriority,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
+  const labSampleSiteSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.LabSampleSite,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
+  const specimenTypeSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.SpecimenType,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
 
-  const practitionerSuggester = new Suggester({
-    model: models.User,
-    options: { column: 'displayName' },
-  });
+  const practitionerSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.User,
+        options: { column: 'displayName' },
+      }),
+    [models.User],
+  );
 
   const handleLabRequestTypeSelected = useCallback(async (selectedValue) => {
     const where: any = {
@@ -96,6 +116,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
       <Field
         component={DateField}
         label={<TranslatedText stringId="general.requestDate.label" fallback="Request date" />}
+        labelFontSize="14"
         required
         mode="date"
         name="requestedDate"
@@ -103,6 +124,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
       <Field
         component={DateField}
         label={<TranslatedText stringId="lab.requestTime.label" fallback="Request time" />}
+        labelFontSize="14"
         mode="time"
         name="requestedTime"
       />
@@ -138,6 +160,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
       <Field
         component={DateField}
         label={<TranslatedText stringId="lab.sampleDate.label" fallback="Sample date" />}
+        labelFontSize="14"
         required
         mode="date"
         name="sampleDate"
@@ -145,6 +168,7 @@ export const LabRequestForm = ({ errors, handleSubmit, navigation }): ReactEleme
       <Field
         component={DateField}
         label={<TranslatedText stringId="lab.sampleTime.label" fallback="Sample time" />}
+        labelFontSize="14"
         required
         mode="time"
         name="sampleTime"

--- a/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
+++ b/packages/mobile/App/ui/components/Forms/NewPatientForm/PatientPersonalInfoForm/LocationDetailsSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/core';
 
 import { LocalisedField } from '~/ui/components/Forms/LocalisedField';
@@ -16,14 +16,18 @@ export const LocationDetailsSection = (): ReactElement => {
   const { getTranslation } = useTranslation();
   const { getSetting } = useSettings();
 
-  const villageSuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.Village,
-      },
-    },
-  });
+  const villageSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.Village,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
 
   return (
     <LocalisedField

--- a/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/VaccineForms/VaccineCommonFields.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { NavigationProp } from '@react-navigation/native';
 
 import { DateField } from '../../DateField/DateField';
@@ -22,6 +22,7 @@ const InjectionSiteDropdown = ({ value, label, onChange, selectPlaceholderText }
     options={INJECTION_SITE_OPTIONS}
     onChange={onChange}
     label={label}
+    labelFontSize="14"
     selectPlaceholderText={selectPlaceholderText}
   />
 );
@@ -46,7 +47,15 @@ export const DateGivenField = ({
   min,
   max,
 }: LabelledFieldProps & DateGivenFieldProps): JSX.Element => (
-  <Field component={DateField} name="date" label={label} required={required} min={min} max={max} />
+  <Field
+    component={DateField}
+    name="date"
+    label={label}
+    labelFontSize="14"
+    required={required}
+    min={min}
+    max={max}
+  />
 );
 
 export const BatchField = (): JSX.Element => (
@@ -95,14 +104,18 @@ export const DepartmentField = ({ navigation }: NavigationFieldProps): JSX.Eleme
   const { models } = useBackend();
   const { facilityId } = useFacility();
 
-  const departmentSuggester = new Suggester({
-    model: models.Department,
-    options: {
-      where: {
-        facility: facilityId,
-      },
-    },
-  });
+  const departmentSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.Department,
+        options: {
+          where: {
+            facility: facilityId,
+          },
+        },
+      }),
+    [models.Department, facilityId],
+  );
 
   return (
     <Field

--- a/packages/mobile/App/ui/components/HierarchyFieldItem.tsx
+++ b/packages/mobile/App/ui/components/HierarchyFieldItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormikContext } from 'formik';
 import { AutocompleteModalField } from './AutocompleteModal/AutocompleteModalField';
 import { Field } from './Forms/FormField';
@@ -17,22 +17,26 @@ export const HierarchyFieldItem = ({
   const { models } = useBackend();
   const { setFieldValue, dirty } = useFormikContext();
 
-  const suggesterInstance = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: referenceType,
-      },
-      relations: ['parents'],
-    },
-    filter: (item: IReferenceData) => {
-      if (isFirstLevel || !parentId) {
-        return true;
-      }
-      const parent = item.parents[0];
-      return parent?.referenceDataParentId === parentId && parent?.type === relationType;
-    },
-  });
+  const suggesterInstance = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: referenceType,
+          },
+          relations: ['parents'],
+        },
+        filter: (item: IReferenceData) => {
+          if (isFirstLevel || !parentId) {
+            return true;
+          }
+          const parent = item.parents[0];
+          return parent?.referenceDataParentId === parentId && parent?.type === relationType;
+        },
+      }),
+    [models.ReferenceData, referenceType, isFirstLevel, parentId, relationType],
+  );
 
   // Clear the value of the field when the parent field changes
   useEffect(() => {

--- a/packages/mobile/App/ui/components/LocationField.tsx
+++ b/packages/mobile/App/ui/components/LocationField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormikContext } from 'formik';
 import { NavigationProp } from '@react-navigation/native';
 
@@ -20,24 +20,32 @@ export const LocationField: React.FC<LocationFieldProps> = ({ navigation, requir
   const { models } = useBackend();
   const { facilityId } = useFacility();
 
-  const locationGroupSuggester = new Suggester({
-    model: models.LocationGroup,
-    options: {
-      where: {
-        facility: facilityId,
-      },
-    },
-  });
+  const locationGroupSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.LocationGroup,
+        options: {
+          where: {
+            facility: facilityId,
+          },
+        },
+      }),
+    [models.LocationGroup, facilityId],
+  );
 
-  const locationSuggester = new Suggester({
-    model: models.Location,
-    options: {
-      where: {
-        facility: facilityId,
-        locationGroup: values.locationGroupId,
-      },
-    },
-  });
+  const locationSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.Location,
+        options: {
+          where: {
+            facility: facilityId,
+            locationGroup: values.locationGroupId,
+          },
+        },
+      }),
+    [models.Location, facilityId, values.locationGroupId],
+  );
 
   useEffect(() => {
     if (values.locationId && !values.locationGroupId) {

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/ProgramRegistrySection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/core';
 import { subject } from '@casl/ability';
 
@@ -25,15 +25,19 @@ export const ProgramRegistrySection = (): ReactElement => {
   const { ability } = useAuth();
   const { getTranslation } = useTranslation();
 
-  const ProgramRegistrySuggester = new Suggester({
-    model: models.ProgramRegistry,
-    options: {
-      where: {
-        visibilityStatus: VisibilityStatus.Current,
-      },
-    },
-    filter: ({ entity_id }) => ability.can('read', subject('ProgramRegistry', { id: entity_id })),
-  });
+  const ProgramRegistrySuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ProgramRegistry,
+        options: {
+          where: {
+            visibilityStatus: VisibilityStatus.Current,
+          },
+        },
+        filter: ({ entity_id }) => ability.can('read', subject('ProgramRegistry', { id: entity_id })),
+      }),
+    [models.ProgramRegistry, ability],
+  );
 
   const [programRegistries, programRegistryError, isProgramRegistryLoading] = useBackendEffect(
     async ({ models }) => {

--- a/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
+++ b/packages/mobile/App/ui/navigation/screens/PatientSearch/PatientSearchTabs/PatientFilterScreen/CustomComponents/VillageSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/core';
 
 //Components
@@ -16,14 +16,18 @@ export const VillageSection = (): ReactElement => {
   const navigation = useNavigation();
   const { models } = useBackend();
 
-  const villageSuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.Village,
-      },
-    },
-  });
+  const villageSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.Village,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
 
   // uses new IdRelation decorator on model, so the field is `villageId` and not `village`
   return (

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/AddIllnessDetails.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/AddIllnessDetails.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useMemo } from 'react';
 import { compose } from 'redux';
 import { useSelector } from 'react-redux';
 import { Formik } from 'formik';
@@ -78,14 +78,18 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
     [],
   );
 
-  const diagnosisSuggester = new Suggester({
-    model: models.ReferenceData,
-    options: {
-      where: {
-        type: ReferenceDataType.Diagnosis,
-      },
-    },
-  });
+  const diagnosisSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ReferenceData,
+        options: {
+          where: {
+            type: ReferenceDataType.Diagnosis,
+          },
+        },
+      }),
+    [models.ReferenceData],
+  );
 
   return (
     <FullView background={theme.colors.BACKGROUND_GREY}>
@@ -128,16 +132,19 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
                 <StyledView justifyContent="space-between">
                   <Field
                     component={AutocompleteModalField}
-                    label={<TranslatedText stringId="general.action.select" fallback="Select" />}
-                    placeholder={
+                    label={
                       <TranslatedText
                         stringId="general.form.diagnosis.label"
                         fallback="Diagnosis"
                       />
                     }
+                    placeholder={
+                      <TranslatedText stringId="general.action.search" fallback="Search" />
+                    }
                     navigation={navigation}
                     suggester={diagnosisSuggester}
                     name="diagnosis"
+                    labelFontSize="14"
                   />
                   <Spacer height="24px" />
                   <Field
@@ -150,6 +157,7 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
                         fallback="Certainty"
                       />
                     }
+                    labelFontSize="14"
                     disabled={!values?.diagnosis}
                   />
                   <Spacer height="24px" />
@@ -157,12 +165,13 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
                     component={TextField}
                     name="clinicalNote"
                     multiline
-                    placeholder={
+                    label={
                       <TranslatedText
                         stringId="diagnosis.form.clinicalNote.label"
                         fallback="Clinical Note"
                       />
                     }
+                    labelFontSize="14"
                   />
                   <Spacer height="24px" />
                   <CurrentUserField
@@ -173,6 +182,7 @@ export const DumbAddIllnessScreen = ({ selectedPatient, navigation }): ReactElem
                         fallback="Recorded By"
                       />
                     }
+                    labelFontSize="14"
                   />
                   <Button
                     marginTop={screenPercentageToDP(1.22, Orientation.Height)}

--- a/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
+++ b/packages/mobile/App/ui/navigation/screens/diagnosisAndTreatment/PrescribeMedication.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useCallback, useEffect, useState } from 'react';
+import React, { Fragment, ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import { compose } from 'redux';
 import { useSelector } from 'react-redux';
 import { Formik } from 'formik';
@@ -151,33 +151,41 @@ export const DumbPrescribeMedicationScreen = ({ selectedPatient, navigation }): 
   }, []);
 
   const canCreateSensitiveMedication = ability.can('create', 'SensitiveMedication');
-  const medicationSuggester = new Suggester({
-    model: ReferenceData,
-    options: {
-      column: 'name',
-      where: {
-        type: ReferenceDataType.Drug,
-      },
-      relations: ['referenceDrug'],
-    },
-    formatter: (record: any) => ({
-      label: record.entity_display_label,
-      value: record.entity_id,
-      ...record,
-    }),
-    filter: (data: any) => {
-      const isSensitive = data.referenceDrug_isSensitive;
-      return !isSensitive || canCreateSensitiveMedication;
-    },
-  });
+  const medicationSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: ReferenceData,
+        options: {
+          column: 'name',
+          where: {
+            type: ReferenceDataType.Drug,
+          },
+          relations: ['referenceDrug'],
+        },
+        formatter: (record: any) => ({
+          label: record.entity_display_label,
+          value: record.entity_id,
+          ...record,
+        }),
+        filter: (data: any) => {
+          const isSensitive = data.referenceDrug_isSensitive;
+          return !isSensitive || canCreateSensitiveMedication;
+        },
+      }),
+    [canCreateSensitiveMedication],
+  );
 
-  const practitionerSuggester = new Suggester({
-    model: models.User,
-    options: {
-      column: 'displayName',
-      where: {},
-    },
-  });
+  const practitionerSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.User,
+        options: {
+          column: 'displayName',
+          where: {},
+        },
+      }),
+    [models.User],
+  );
 
   // Convert constants to dropdown options
   const unitOptions = Object.entries(DRUG_UNIT_LABELS).map(([value, label]) => ({

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationConditionsField.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationConditionsField.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, FC, useState, useEffect, useCallback } from 'react';
+import React, { ReactElement, FC, useState, useEffect, useCallback, useMemo } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { StyledView, StyledText, StyledTouchableOpacity } from '/styled/common';
@@ -251,18 +251,22 @@ export const PatientProgramRegistrationConditionsField = ({
     getTranslation,
   );
 
-  const conditionSuggester = new Suggester({
-    model: models.ProgramRegistryCondition,
-    options: {
-      where: {
-        programRegistry: programRegistryId,
-      },
-    },
-    filter: ({ entity_id }) => {
-      // hide previously selected conditions
-      return !conditions.map((value) => value?.condition?.value).includes(entity_id);
-    },
-  });
+  const conditionSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.ProgramRegistryCondition,
+        options: {
+          where: {
+            programRegistry: programRegistryId,
+          },
+        },
+        filter: ({ entity_id }) => {
+          // hide previously selected conditions
+          return !conditions.map((value) => value?.condition?.value).includes(entity_id);
+        },
+      }),
+    [models.ProgramRegistryCondition, programRegistryId, conditions],
+  );
 
   const addItem = (newValue: ConditionAndCategory) => {
     onChange([...conditions, newValue]);

--- a/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
+++ b/packages/mobile/App/ui/navigation/screens/patientProgramRegistration/form/PatientProgramRegistrationDetailsForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import * as yup from 'yup';
 import { AutocompleteModalField } from '~/ui/components/AutocompleteModal/AutocompleteModalField';
 import { DateField } from '~/ui/components/DateField/DateField';
@@ -33,18 +33,26 @@ export const PatientProgramRegistrationDetailsForm = ({ navigation, route }: Bas
   const { programRegistry, editedObject, selectedPatient } = route.params;
   const { getTranslation } = useTranslation();
   const { models } = useBackend();
-  const practitionerSuggester = new Suggester({
-    model: models.User,
-    options: { column: 'displayName' },
-  });
-  const facilitySuggester = new Suggester({
-    model: models.Facility,
-    options: {
-      where: {
-        visibilityStatus: VisibilityStatus.Current,
-      },
-    },
-  });
+  const practitionerSuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.User,
+        options: { column: 'displayName' },
+      }),
+    [models.User],
+  );
+  const facilitySuggester = useMemo(
+    () =>
+      new Suggester({
+        model: models.Facility,
+        options: {
+          where: {
+            visibilityStatus: VisibilityStatus.Current,
+          },
+        },
+      }),
+    [models.Facility],
+  );
 
   const [clinicalStatusOptions] = useBackendEffect(
     async ({ models }) => {


### PR DESCRIPTION
### Changes
Reviewed in
[fix(mobile): TAMOC-389: 2.47 hotfix: AutocompleteModalField empty on selection](https://github.com/beyondessential/tamanu/pull/9114#top)

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
