### PR TITLE
Medication repeats logic

### DIFF
--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -180,7 +180,9 @@ const buildInstructionText = (prescription, getTranslation, getEnumTranslation) 
 };
 
 const isItemDisabled = item => {
-  return item.pharmacyOrder?.isDischargePrescription && (item.remainingRepeats ?? 0) === 0;
+  // Active requests can always be dispensed once they are in the table
+  // Repeats only apply when sending from ongoing medications to pharmacy
+  return false;
 };
 
 const InstructionsInput = memo(({ value: defaultValue, onChange, ...props }) => {

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -197,8 +197,8 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
           quantity: prescription.quantity ?? undefined,
           repeats: prescription.repeats ?? 0,
           selected: false,
-          // Disable selection if no repeats remaining
-          isSelectionDisabled: (prescription.repeats ?? 0) === 0,
+          // Disable selection if no repeats remaining and user cannot edit repeats
+          isSelectionDisabled: !canEditRepeats && (prescription.repeats ?? 0) === 0,
         }));
     }
     // Use encounter medications from query
@@ -212,7 +212,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
           selected: false,
         })) || []
     );
-  }, [data, isOngoingMode, ongoingPrescriptions]);
+  }, [data, isOngoingMode, ongoingPrescriptions, canEditRepeats]);
 
   const [prescriptions, setPrescriptions] = useState(initialPrescriptions);
 


### PR DESCRIPTION
### Changes

This PR implements the clarified medication repeat logic from NASS-1892.

*   **Ongoing Medications**: Require at least 1 repeat to be sent to pharmacy, unless the user has permission to edit repeats.
*   **Active Requests**: Can always be dispensed once, regardless of remaining repeats on the original ongoing prescription. Each active request can only be dispensed a single time.
*   **Repeat Decrement**: Outpatient dispensing of medications originating from ongoing prescriptions will now decrement the original ongoing prescription's repeats by one. Inpatient dispensing does not affect repeats.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- [ ] ...write or update tests
- [ ] ...add UI screenshots and **testing notes** to the Linear issue
- [ ] ...add any **manual upgrade steps** to the Linear issue
- [ ] ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- [ ] ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [NASS-1892](https://linear.app/bes/issue/NASS-1892/logic-for-medication-repeats)

<p><a href="https://cursor.com/background-agent?bcId=bc-c5f938bb-5cfa-4a32-a4fa-6ce16a6f1e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5f938bb-5cfa-4a32-a4fa-6ce16a6f1e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches medication dispensing and repeat-decrement business logic across backend and UI; risk is mainly incorrect repeat updates or blocking/allowing dispensing incorrectly for outpatient requests.
> 
> **Overview**
> Updates dispensing rules so **each pharmacy request can only be dispensed once**: the `/apiv1/medication/dispense` endpoint now blocks any `PharmacyOrderPrescription` that already has a dispense, and marks *all* dispensed requests as `isCompleted`.
> 
> Adds repeat consumption behavior for outpatient/discharge requests: when dispensing discharge prescriptions, the server attempts to find the matching ongoing prescription for the patient and decrements its `repeats` by 1.
> 
> Adjusts UI to match the clarified logic: `DispenseMedicationWorkflowModal` no longer disables dispensing based on `remainingRepeats`, and `PharmacyOrderModal` only disables selecting ongoing prescriptions with `0` repeats when the user lacks permission to edit repeats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737f37730a6c6e678de657af3709d6bacf9015fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->