### PR TITLE
cursor do not use: prescription request tweaks

### DIFF
--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -2479,15 +2479,9 @@ medication.post(
         { transaction },
       );
 
-      // After dispensing, soft delete all ineligible pharmacy order prescriptions
-      const allCompletedRecords = prescriptionRecords.filter(record => {
-        const remainingRepeats = record.getRemainingRepeats(1);
-        const isDischargePrescription = record.pharmacyOrder?.isDischargePrescription;
-        return remainingRepeats === 0 && !!isDischargePrescription;
-      });
-
-      if (allCompletedRecords.length > 0) {
-        const completedIds = allCompletedRecords.map(r => r.id);
+      // After dispensing, mark all dispensed prescriptions as completed so they disappear from the medication requests list.
+      if (prescriptionRecords.length > 0) {
+        const completedIds = prescriptionRecords.map(r => r.id);
         await PharmacyOrderPrescription.update(
           { isCompleted: true },
           { where: { id: { [Op.in]: completedIds } }, transaction },

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -35,7 +35,6 @@ import { getWhereClausesAndReplacementsFromFilters } from '../../../utils/query'
 import { validate } from '../../../utils/validate';
 import { patientContact } from './patientContact';
 import { patientPortal } from './patientPortal';
-import { isBefore } from 'date-fns';
 
 const patientRoute = express.Router();
 
@@ -823,33 +822,10 @@ patientRoute.get(
       },
     });
 
-    // Fetch all dispenses for the pharmacy order prescriptions to calculate remaining repeats
-    const pharmacyOrderPrescriptionIds = [
-      ...new Set(data.map(item => item.pharmacyOrderPrescription.id)),
-    ];
-
-    const allDispenses = await MedicationDispense.findAll({
-      where: { pharmacyOrderPrescriptionId: { [Op.in]: pharmacyOrderPrescriptionIds } },
-      attributes: ['id', 'pharmacyOrderPrescriptionId', 'dispensedAt'],
-    });
-
-    const dispensesByPrescriptionId = allDispenses.reduce((acc, dispense) => {
-      const id = dispense.pharmacyOrderPrescriptionId;
-      if (!acc[id]) acc[id] = [];
-      acc[id].push(dispense);
-      return acc;
-    }, {});
-
     const result = data.map(item => {
       const referenceDrug = referenceDrugs.find(
         r => r.referenceDataId === item.pharmacyOrderPrescription.prescription.medication.id,
       );
-
-      // Manually set medicationDispenses for getRemainingRepeats calculation
-      // We only want to include dispenses that were dispensed before the current dispense to get remaining repeats at the time of the dispense
-      item.pharmacyOrderPrescription.medicationDispenses = (
-        dispensesByPrescriptionId[item.pharmacyOrderPrescription.id] || []
-      ).filter(d => isBefore(new Date(d.dispensedAt), new Date(item.dispensedAt)));
 
       return {
         ...item.toJSON(),
@@ -869,7 +845,6 @@ patientRoute.get(
               },
             },
           },
-          remainingRepeats: item.pharmacyOrderPrescription.getRemainingRepeats(),
         },
       };
     });

--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -179,9 +179,8 @@ const buildInstructionText = (prescription, getTranslation, getEnumTranslation) 
   return output.trim();
 };
 
-const isItemDisabled = item => {
-  return item.pharmacyOrder?.isDischargePrescription && (item.remainingRepeats ?? 0) === 0;
-};
+// 1 record = 1 dispense; repeats are not used in the dispense workflow
+const isItemDisabled = () => false;
 
 const InstructionsInput = memo(({ value: defaultValue, onChange, ...props }) => {
   const [value, setValue] = useState(defaultValue);
@@ -385,7 +384,6 @@ export const DispenseMedicationWorkflowModal = memo(
         instructions: item.instructions,
         quantity: item.quantity,
         units: item.prescription?.units,
-        remainingRepeats: item.remainingRepeats,
         prescriberName: item.prescription?.prescriber?.displayName,
         requestNumber: item.displayId,
       }));
@@ -503,17 +501,6 @@ export const DispenseMedicationWorkflowModal = memo(
               />
             );
           },
-        },
-        {
-          key: 'remainingRepeats',
-          width: '94px',
-          title: (
-            <TranslatedText
-              stringId="medication.dispense.remainingRepeats"
-              fallback="Remaining repeats"
-            />
-          ),
-          accessor: ({ remainingRepeats }) => remainingRepeats ?? 0,
         },
         {
           key: 'instructions',

--- a/packages/web/app/components/Medication/DispensedMedicationDetailsModal.jsx
+++ b/packages/web/app/components/Medication/DispensedMedicationDetailsModal.jsx
@@ -52,7 +52,6 @@ export const DispensedMedicationDetailsModal = ({ open, onClose, item }) => {
     prescription,
     quantity,
     instructions,
-    remainingRepeats,
     displayId,
     dispensedAt,
     dispensedBy,
@@ -113,15 +112,6 @@ export const DispensedMedicationDetailsModal = ({ open, onClose, item }) => {
     {
       label: <TranslatedText stringId="medication.dispenseDetails.requestNo" fallback="Request no." />,
       value: displayId || '-',
-    },
-    {
-      label: (
-        <TranslatedText
-          stringId="medication.dispenseDetails.remainingRepeats"
-          fallback="Remaining repeats"
-        />
-      ),
-      value: remainingRepeats ?? 0,
     },
   ];
 

--- a/packages/web/app/components/Medication/EditMedicationDispenseModal.jsx
+++ b/packages/web/app/components/Medication/EditMedicationDispenseModal.jsx
@@ -245,7 +245,6 @@ export const EditMedicationDispenseModal = memo(
         instructions: item.instructions,
         quantity: item.quantity,
         units: item.pharmacyOrderPrescription.prescription?.units,
-        remainingRepeats: item.pharmacyOrderPrescription.remainingRepeats,
         prescriberName: item.pharmacyOrderPrescription.prescription?.prescriber?.displayName,
         requestNumber: item.pharmacyOrderPrescription.displayId,
       };
@@ -340,18 +339,6 @@ export const EditMedicationDispenseModal = memo(
               />
             );
           },
-        },
-        {
-          key: 'remainingRepeats',
-          width: '94px',
-          title: (
-            <TranslatedText
-              stringId="medication.editDispensedMedication.remainingRepeats"
-              fallback="Remaining repeats"
-            />
-          ),
-          accessor: ({ pharmacyOrderPrescription }) =>
-            pharmacyOrderPrescription?.remainingRepeats ?? 0,
         },
         {
           key: 'instructions',

--- a/packages/web/app/components/Medication/MedicationDetails.jsx
+++ b/packages/web/app/components/Medication/MedicationDetails.jsx
@@ -9,6 +9,7 @@ import {
   DRUG_ROUTE_LABELS,
   MEDICATION_DURATION_DISPLAY_UNITS_LABELS,
   FORM_TYPES,
+  MAX_REPEATS,
 } from '@tamanu/constants';
 import { formatShortest } from '@tamanu/utils/dateTime';
 import {
@@ -21,7 +22,7 @@ import {
 import { TranslatedText } from '../Translation/TranslatedText';
 import { TextField, Form, Button, OutlinedButton, FormGrid } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
-import { CheckField, Field } from '../Field';
+import { CheckField, Field, NumberField } from '../Field';
 import { FormModal } from '../FormModal';
 import { useAuth } from '../../contexts/Auth';
 import { useApi } from '../../api';
@@ -35,6 +36,7 @@ import { useEncounter } from '../../contexts/Encounter';
 import { MedicationResumeModal } from './MedicationResumeModal';
 import { singularize } from '../../utils';
 import { NoteModalActionBlocker } from '../NoteModalActionBlocker';
+import { preventInvalidRepeatsInput } from '../../utils/utils';
 
 const StyledFormModal = styled(FormModal)`
   .MuiPaper-root {
@@ -220,8 +222,9 @@ export const MedicationDetails = ({
 
   const onSubmit = async data => {
     const payload = { ...data };
-    // Repeats are view-only in this modal; only set when creating an ongoing prescription
-    delete payload.repeats;
+    if (payload.repeats === '') {
+      delete payload.repeats;
+    }
     await api.put(`medication/${medication.id}/details`, {
       ...payload,
     });
@@ -238,7 +241,15 @@ export const MedicationDetails = ({
     onReloadTable();
   };
 
-  const validationSchema = yup.object().shape({});
+  const validationSchema = yup.object().shape({
+    repeats: yup
+      .number()
+      .integer()
+      .min(0)
+      .max(MAX_REPEATS)
+      .nullable()
+      .optional(),
+  });
 
   return (
     <StyledFormModal
@@ -255,6 +266,7 @@ export const MedicationDetails = ({
         initialValues={{
           pharmacyNotes: medication.pharmacyNotes,
           displayPharmacyNotesInMar: medication.displayPharmacyNotesInMar,
+          repeats: medication.repeats ?? 0,
         }}
         render={values => (
           <>
@@ -497,6 +509,29 @@ export const MedicationDetails = ({
                     </Box>
                   </DetailsContainer>
                 </Box>
+                {medication.isOngoing && (
+                  <Box flex={1}>
+                    <DarkestText color={`${Colors.darkText} !important`} mb={0.5}>
+                      <TranslatedText stringId="medication.details.repeats" fallback="Repeats" />
+                    </DarkestText>
+                    <NoteModalActionBlocker>
+                      <Field
+                        name="repeats"
+                        component={NumberField}
+                        min={0}
+                        max={MAX_REPEATS}
+                        step={1}
+                        onInput={preventInvalidRepeatsInput}
+                        disabled={
+                          !canDiscontinueMedication ||
+                          (isSensitive && !canWriteSensitiveMedication) ||
+                          medication.discontinued ||
+                          isPausing
+                        }
+                      />
+                    </NoteModalActionBlocker>
+                  </Box>
+                )}
               </Box>
             </Container>
 

--- a/packages/web/app/components/Medication/MedicationDetails.jsx
+++ b/packages/web/app/components/Medication/MedicationDetails.jsx
@@ -9,7 +9,6 @@ import {
   DRUG_ROUTE_LABELS,
   MEDICATION_DURATION_DISPLAY_UNITS_LABELS,
   FORM_TYPES,
-  MAX_REPEATS,
 } from '@tamanu/constants';
 import { formatShortest } from '@tamanu/utils/dateTime';
 import {
@@ -22,7 +21,7 @@ import {
 import { TranslatedText } from '../Translation/TranslatedText';
 import { TextField, Form, Button, OutlinedButton, FormGrid } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
-import { CheckField, Field, NumberField } from '../Field';
+import { CheckField, Field } from '../Field';
 import { FormModal } from '../FormModal';
 import { useAuth } from '../../contexts/Auth';
 import { useApi } from '../../api';
@@ -36,7 +35,6 @@ import { useEncounter } from '../../contexts/Encounter';
 import { MedicationResumeModal } from './MedicationResumeModal';
 import { singularize } from '../../utils';
 import { NoteModalActionBlocker } from '../NoteModalActionBlocker';
-import { preventInvalidRepeatsInput } from '../../utils/utils';
 
 const StyledFormModal = styled(FormModal)`
   .MuiPaper-root {
@@ -222,9 +220,8 @@ export const MedicationDetails = ({
 
   const onSubmit = async data => {
     const payload = { ...data };
-    if (payload.repeats === '') {
-      delete payload.repeats;
-    }
+    // Repeats are view-only in this modal; only set when creating an ongoing prescription
+    delete payload.repeats;
     await api.put(`medication/${medication.id}/details`, {
       ...payload,
     });
@@ -241,15 +238,7 @@ export const MedicationDetails = ({
     onReloadTable();
   };
 
-  const validationSchema = yup.object().shape({
-    repeats: yup
-      .number()
-      .integer()
-      .min(0)
-      .max(MAX_REPEATS)
-      .nullable()
-      .optional(),
-  });
+  const validationSchema = yup.object().shape({});
 
   return (
     <StyledFormModal
@@ -266,7 +255,6 @@ export const MedicationDetails = ({
         initialValues={{
           pharmacyNotes: medication.pharmacyNotes,
           displayPharmacyNotesInMar: medication.displayPharmacyNotesInMar,
-          repeats: medication.repeats ?? 0,
         }}
         render={values => (
           <>
@@ -509,29 +497,6 @@ export const MedicationDetails = ({
                     </Box>
                   </DetailsContainer>
                 </Box>
-                {medication.isOngoing && (
-                  <Box flex={1}>
-                    <DarkestText color={`${Colors.darkText} !important`} mb={0.5}>
-                      <TranslatedText stringId="medication.details.repeats" fallback="Repeats" />
-                    </DarkestText>
-                    <NoteModalActionBlocker>
-                      <Field
-                        name="repeats"
-                        component={NumberField}
-                        min={0}
-                        max={MAX_REPEATS}
-                        step={1}
-                        onInput={preventInvalidRepeatsInput}
-                        disabled={
-                          !canDiscontinueMedication ||
-                          (isSensitive && !canWriteSensitiveMedication) ||
-                          medication.discontinued ||
-                          isPausing
-                        }
-                      />
-                    </NoteModalActionBlocker>
-                  </Box>
-                )}
               </Box>
             </Container>
 

--- a/packages/web/app/components/Medication/MedicationDetails.jsx
+++ b/packages/web/app/components/Medication/MedicationDetails.jsx
@@ -137,19 +137,19 @@ export const MedicationDetails = ({
     ...(medication.isOngoing || medication.discontinued
       ? []
       : [
-          {
-            label: <TranslatedText stringId="medication.details.duration" fallback="Duration" />,
-            value: medication.durationValue
-              ? `${medication.durationValue} ${singularize(
-                  getEnumTranslation(
-                    MEDICATION_DURATION_DISPLAY_UNITS_LABELS,
-                    medication.durationUnit,
-                  ),
-                  medication.durationValue,
-                ).toLowerCase()}`
-              : '-',
-          },
-        ]),
+        {
+          label: <TranslatedText stringId="medication.details.duration" fallback="Duration" />,
+          value: medication.durationValue
+            ? `${medication.durationValue} ${singularize(
+              getEnumTranslation(
+                MEDICATION_DURATION_DISPLAY_UNITS_LABELS,
+                medication.durationUnit,
+              ),
+              medication.durationValue,
+            ).toLowerCase()}`
+            : '-',
+        },
+      ]),
     {
       label: <TranslatedText stringId="medication.details.indication" fallback="Indication" />,
       value: medication.indication || '-',
@@ -163,10 +163,14 @@ export const MedicationDetails = ({
       ),
       value: medication.quantity ?? '-',
     },
-    {
-      label: <TranslatedText stringId="medication.details.repeats" fallback="Repeats" />,
-      value: medication.repeats ?? 0,
-    },
+    ...(medication.isOngoing
+      ? [
+        {
+          label: <TranslatedText stringId="medication.details.repeats" fallback="Repeats" />,
+          value: medication.repeats ?? 0,
+        },
+      ]
+      : []),
   ];
 
   const rightDetails = [
@@ -188,13 +192,13 @@ export const MedicationDetails = ({
     ...(medication.isOngoing || medication.discontinued || !medication.endDate
       ? []
       : [
-          {
-            label: (
-              <TranslatedText stringId="medication.details.endDate" fallback="End date & time" />
-            ),
-            value: `${formatShortest(medication.endDate)} ${formatTimeSlot(medication.endDate)}`,
-          },
-        ]),
+        {
+          label: (
+            <TranslatedText stringId="medication.details.endDate" fallback="End date & time" />
+          ),
+          value: `${formatShortest(medication.endDate)} ${formatTimeSlot(medication.endDate)}`,
+        },
+      ]),
     {
       label: <TranslatedText stringId="medication.details.prescriber" fallback="Prescriber" />,
       value: medication.prescriber?.displayName || '-',
@@ -505,27 +509,29 @@ export const MedicationDetails = ({
                     </Box>
                   </DetailsContainer>
                 </Box>
-                <Box flex={1}>
-                  <DarkestText color={`${Colors.darkText} !important`} mb={0.5}>
-                    <TranslatedText stringId="medication.details.repeats" fallback="Repeats" />
-                  </DarkestText>
-                  <NoteModalActionBlocker>
-                    <Field
-                      name="repeats"
-                      component={NumberField}
-                      min={0}
-                      max={MAX_REPEATS}
-                      step={1}
-                      onInput={preventInvalidRepeatsInput}
-                      disabled={
-                        !canDiscontinueMedication ||
-                        (isSensitive && !canWriteSensitiveMedication) ||
-                        medication.discontinued ||
-                        isPausing
-                      }
-                    />
-                  </NoteModalActionBlocker>
-                </Box>
+                {medication.isOngoing && (
+                  <Box flex={1}>
+                    <DarkestText color={`${Colors.darkText} !important`} mb={0.5}>
+                      <TranslatedText stringId="medication.details.repeats" fallback="Repeats" />
+                    </DarkestText>
+                    <NoteModalActionBlocker>
+                      <Field
+                        name="repeats"
+                        component={NumberField}
+                        min={0}
+                        max={MAX_REPEATS}
+                        step={1}
+                        onInput={preventInvalidRepeatsInput}
+                        disabled={
+                          !canDiscontinueMedication ||
+                          (isSensitive && !canWriteSensitiveMedication) ||
+                          medication.discontinued ||
+                          isPausing
+                        }
+                      />
+                    </NoteModalActionBlocker>
+                  </Box>
+                )}
               </Box>
             </Container>
 

--- a/packages/web/app/components/Medication/PharmacyOrderMedicationTable.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderMedicationTable.jsx
@@ -7,12 +7,12 @@ import { getMedicationDoseDisplay, getTranslatedFrequency } from '@tamanu/shared
 
 import { TextInput, ConditionalTooltip } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
-import { OuterLabelFieldWrapper, CheckInput, NumberInput } from '../Field';
+import { OuterLabelFieldWrapper, CheckInput } from '../Field';
 import { Table } from '../Table';
 import { useTranslation } from '../../contexts/Translation';
 import { TranslatedText, TranslatedReferenceData } from '../Translation';
-import { MEDICATION_DURATION_DISPLAY_UNITS_LABELS, MAX_REPEATS } from '@tamanu/constants';
-import { preventInvalidRepeatsInput, singularize } from '../../utils';
+import { MEDICATION_DURATION_DISPLAY_UNITS_LABELS } from '@tamanu/constants';
+import { singularize } from '../../utils';
 
 const StyledTable = styled(Table)`
   .MuiTableCell-root {
@@ -99,7 +99,7 @@ const getColumns = (
   onSelectAll,
   selectAllChecked,
   columnsToInclude = Object.values(COLUMN_KEYS),
-  { isOngoingMode = false, canEditRepeats = true, disabledPrescriptionIds = [] } = {},
+  { isOngoingMode = false, disabledPrescriptionIds = [] } = {},
 ) => {
   const allColumns = [
     {
@@ -299,25 +299,9 @@ const getColumns = (
         />
       ),
       sortable: false,
-      accessor: ({ repeats, onChange }) => {
-        // In ongoing mode without edit permission, show read-only value
-        if (isOngoingMode && !canEditRepeats) {
-          return <Box width="89px">{repeats ?? 0}</Box>;
-        }
-        return (
-          <Box width="89px">
-            <NumberInput
-              value={repeats ?? 0}
-              onChange={onChange}
-              min={0}
-              max={MAX_REPEATS}
-              data-testid="selectinput-ld3p"
-              step={1}
-              onInput={preventInvalidRepeatsInput}
-            />
-          </Box>
-        );
-      },
+      accessor: ({ repeats }) => (
+        <Box width="89px">{repeats ?? 0}</Box>
+      ),
     },
   ];
 
@@ -348,7 +332,7 @@ export const PharmacyOrderMedicationTable = ({
         handleSelectAll,
         selectAllChecked,
         columnsToInclude,
-        { isOngoingMode, canEditRepeats, disabledPrescriptionIds },
+        { isOngoingMode, disabledPrescriptionIds },
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -358,7 +342,6 @@ export const PharmacyOrderMedicationTable = ({
       selectAllChecked,
       columnsToInclude,
       isOngoingMode,
-      canEditRepeats,
       disabledIdsKey,
     ],
   );

--- a/packages/web/app/components/Medication/PharmacyOrderMedicationTable.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderMedicationTable.jsx
@@ -7,12 +7,12 @@ import { getMedicationDoseDisplay, getTranslatedFrequency } from '@tamanu/shared
 
 import { TextInput, ConditionalTooltip } from '@tamanu/ui-components';
 import { Colors } from '../../constants/styles';
-import { OuterLabelFieldWrapper, CheckInput } from '../Field';
+import { OuterLabelFieldWrapper, CheckInput, NumberInput } from '../Field';
 import { Table } from '../Table';
 import { useTranslation } from '../../contexts/Translation';
 import { TranslatedText, TranslatedReferenceData } from '../Translation';
-import { MEDICATION_DURATION_DISPLAY_UNITS_LABELS } from '@tamanu/constants';
-import { singularize } from '../../utils';
+import { MEDICATION_DURATION_DISPLAY_UNITS_LABELS, MAX_REPEATS } from '@tamanu/constants';
+import { preventInvalidRepeatsInput, singularize } from '../../utils';
 
 const StyledTable = styled(Table)`
   .MuiTableCell-root {
@@ -99,7 +99,7 @@ const getColumns = (
   onSelectAll,
   selectAllChecked,
   columnsToInclude = Object.values(COLUMN_KEYS),
-  { isOngoingMode = false, disabledPrescriptionIds = [] } = {},
+  { isOngoingMode = false, canEditRepeats = true, disabledPrescriptionIds = [] } = {},
 ) => {
   const allColumns = [
     {
@@ -299,9 +299,25 @@ const getColumns = (
         />
       ),
       sortable: false,
-      accessor: ({ repeats }) => (
-        <Box width="89px">{repeats ?? 0}</Box>
-      ),
+      accessor: ({ repeats, onChange }) => {
+        // In ongoing mode without edit permission, show read-only value
+        if (isOngoingMode && !canEditRepeats) {
+          return <Box width="89px">{repeats ?? 0}</Box>;
+        }
+        return (
+          <Box width="89px">
+            <NumberInput
+              value={repeats ?? 0}
+              onChange={onChange}
+              min={0}
+              max={MAX_REPEATS}
+              data-testid="selectinput-ld3p"
+              step={1}
+              onInput={preventInvalidRepeatsInput}
+            />
+          </Box>
+        );
+      },
     },
   ];
 
@@ -332,7 +348,7 @@ export const PharmacyOrderMedicationTable = ({
         handleSelectAll,
         selectAllChecked,
         columnsToInclude,
-        { isOngoingMode, disabledPrescriptionIds },
+        { isOngoingMode, canEditRepeats, disabledPrescriptionIds },
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -342,6 +358,7 @@ export const PharmacyOrderMedicationTable = ({
       selectAllChecked,
       columnsToInclude,
       isOngoingMode,
+      canEditRepeats,
       disabledIdsKey,
     ],
   );

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -169,9 +169,6 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
 
   const sendViaMSupply = getSetting('features.pharmacyOrder.sendViaMSupply');
 
-  // Permission to edit repeats (only relevant for ongoing mode)
-  const canEditRepeats = ability.can('write', 'Medication');
-
   const [prescriptionType, setPrescriptionType] = useState(
     PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT,
   );
@@ -283,12 +280,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
 
   const cellOnChange = useCallback(
     (event, key, rowIndex) => {
-      if ([COLUMN_KEYS.QUANTITY, COLUMN_KEYS.REPEATS].includes(key)) {
-        // In ongoing mode, only allow repeats change if user has permission
-        if (isOngoingMode && key === COLUMN_KEYS.REPEATS && !canEditRepeats) {
-          return;
-        }
-
+      if (key === COLUMN_KEYS.QUANTITY) {
         const newMedicationData = [...prescriptions];
         const rawValue = event.target.value;
         const value =
@@ -305,7 +297,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
         setPrescriptions(newMedicationData);
       }
     },
-    [prescriptions, isOngoingMode, canEditRepeats],
+    [prescriptions],
   );
 
   const validateForm = useCallback(() => {
@@ -638,7 +630,6 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
         selectAllChecked={selectAllChecked}
         columnsToInclude={mainTableColumns}
         isOngoingMode={isOngoingMode}
-        canEditRepeats={canEditRepeats}
         disabledPrescriptionIds={prescriptions.filter(p => p.isSelectionDisabled).map(p => p.id)}
       />
 

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -169,6 +169,9 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
 
   const sendViaMSupply = getSetting('features.pharmacyOrder.sendViaMSupply');
 
+  // Permission to edit repeats (only relevant for ongoing mode)
+  const canEditRepeats = ability.can('write', 'Medication');
+
   const [prescriptionType, setPrescriptionType] = useState(
     PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT,
   );
@@ -280,7 +283,12 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
 
   const cellOnChange = useCallback(
     (event, key, rowIndex) => {
-      if (key === COLUMN_KEYS.QUANTITY) {
+      if ([COLUMN_KEYS.QUANTITY, COLUMN_KEYS.REPEATS].includes(key)) {
+        // In ongoing mode, only allow repeats change if user has permission
+        if (isOngoingMode && key === COLUMN_KEYS.REPEATS && !canEditRepeats) {
+          return;
+        }
+
         const newMedicationData = [...prescriptions];
         const rawValue = event.target.value;
         const value =
@@ -297,7 +305,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
         setPrescriptions(newMedicationData);
       }
     },
-    [prescriptions],
+    [prescriptions, isOngoingMode, canEditRepeats],
   );
 
   const validateForm = useCallback(() => {
@@ -630,6 +638,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
         selectAllChecked={selectAllChecked}
         columnsToInclude={mainTableColumns}
         isOngoingMode={isOngoingMode}
+        canEditRepeats={canEditRepeats}
         disabledPrescriptionIds={prescriptions.filter(p => p.isSelectionDisabled).map(p => p.id)}
       />
 

--- a/packages/web/app/components/MedicationDispensesTable.jsx
+++ b/packages/web/app/components/MedicationDispensesTable.jsx
@@ -103,7 +103,6 @@ export const MedicationDispensesTable = () => {
         instructions,
         quantity,
         units: prescription?.units,
-        remainingRepeats: pharmacyOrderPrescription?.remainingRepeats,
         prescriberName: prescription?.prescriber?.displayName,
         requestNumber: pharmacyOrderPrescription?.displayId,
         dispensedAt,
@@ -239,37 +238,37 @@ export const MedicationDispensesTable = () => {
     },
     ...(canWriteMedicationDispense
       ? [
-          {
-            key: 'actions',
-            title: '',
-            allowExport: false,
-            accessor: row => {
-              const actions = [
-                {
-                  label: (
-                    <TranslatedText stringId="general.action.printLabel" fallback="Print label" />
-                  ),
-                  action: () => handlePrintLabel(row),
-                },
-                {
-                  label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
-                  action: () => handleEditClick(row),
-                },
-                {
-                  label: <TranslatedText stringId="general.action.cancel" fallback="Cancel" />,
-                  action: () => handleCancelClick(row),
-                },
-              ];
-              return (
-                <div onMouseEnter={() => hoveredRow !== row && setHoveredRow(row.id)}>
-                  <MenuButton actions={actions} />
-                </div>
-              );
-            },
-            sortable: false,
-            dontCallRowInput: true,
+        {
+          key: 'actions',
+          title: '',
+          allowExport: false,
+          accessor: row => {
+            const actions = [
+              {
+                label: (
+                  <TranslatedText stringId="general.action.printLabel" fallback="Print label" />
+                ),
+                action: () => handlePrintLabel(row),
+              },
+              {
+                label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
+                action: () => handleEditClick(row),
+              },
+              {
+                label: <TranslatedText stringId="general.action.cancel" fallback="Cancel" />,
+                action: () => handleCancelClick(row),
+              },
+            ];
+            return (
+              <div onMouseEnter={() => hoveredRow !== row && setHoveredRow(row.id)}>
+                <MenuButton actions={actions} />
+              </div>
+            );
           },
-        ]
+          sortable: false,
+          dontCallRowInput: true,
+        },
+      ]
       : []),
   ];
 
@@ -283,7 +282,6 @@ export const MedicationDispensesTable = () => {
       displayId: dispenseData.pharmacyOrderPrescription?.displayId,
       quantity: dispenseData.quantity,
       instructions: dispenseData.instructions,
-      remainingRepeats: dispenseData.pharmacyOrderPrescription?.remainingRepeats,
       dispensedAt: dispenseData.dispensedAt,
       dispensedBy: dispenseData.dispensedBy,
       prescription: {

--- a/packages/web/app/components/PatientPrinting/modals/MedicationLabelPrintModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/MedicationLabelPrintModal.jsx
@@ -96,7 +96,6 @@ MedicationLabelPrintModal.propTypes = {
       patientName: PropTypes.string.isRequired,
       dispensedAt: PropTypes.string.isRequired,
       quantity: PropTypes.number.isRequired,
-      remainingRepeats: PropTypes.number.isRequired,
       prescriberName: PropTypes.string.isRequired,
       requestNumber: PropTypes.string.isRequired,
       facilityAddress: PropTypes.string,

--- a/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
+++ b/packages/web/app/components/PatientPrinting/printouts/MedicationLabel.jsx
@@ -31,7 +31,7 @@ const Label = styled.div`
 
 const LabelTitle = styled.div`
   font-weight: 700;
-  line-height: ${props => props.$fontSize*1.875}mm;
+  line-height: ${props => props.$fontSize * 1.875}mm;
   text-align: center;
 `;
 
@@ -61,7 +61,7 @@ const LabelInstructions = styled.div`
 const LabelBottomSection = styled.div`
   display: flex;
   justify-content: space-between;
-  line-height: ${props => props.$fontSize*1.125}mm;
+  line-height: ${props => props.$fontSize * 1.125}mm;
 `;
 
 const LabelLeftColumn = styled.div`
@@ -75,7 +75,7 @@ const LabelRightColumn = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.708mm;
-  width: ${props => props.$width*0.478}mm;
+  width: ${props => props.$width * 0.478}mm;
 `;
 
 const LabelPatientName = styled.div`
@@ -127,14 +127,13 @@ export const MedicationLabel = React.memo(({ data }) => {
     dispensedAt,
     quantity,
     units,
-    remainingRepeats,
     prescriberName,
     requestNumber,
     facilityAddress,
     facilityContactNumber,
   } = data;
 
-  const fontSize = labelHeight*0.071;
+  const fontSize = labelHeight * 0.071;
 
   return (
     <Label $width={labelWidth} $height={labelHeight} $fontSize={fontSize}>
@@ -154,13 +153,6 @@ export const MedicationLabel = React.memo(({ data }) => {
             <LabelPatientName>{patientName}</LabelPatientName>
             <LabelRow>
               {getMedicationLabel(quantity, units, getEnumTranslation)}
-            </LabelRow>
-            <LabelRow>
-              <TranslatedText
-                stringId="medication.dispense.numberOfRepeats"
-                fallback="Number of repeats"
-              />
-              : {remainingRepeats}
             </LabelRow>
           </LabelLeftColumn>
           <LabelRightColumn $width={labelWidth}>
@@ -195,7 +187,6 @@ MedicationLabel.propTypes = {
     dispensedAt: PropTypes.string.isRequired,
     quantity: PropTypes.number.isRequired,
     units: PropTypes.string.isRequired,
-    remainingRepeats: PropTypes.number.isRequired,
     prescriberName: PropTypes.string.isRequired,
     requestNumber: PropTypes.string.isRequired,
     facilityAddress: PropTypes.string,

--- a/packages/web/app/forms/DischargeForm.jsx
+++ b/packages/web/app/forms/DischargeForm.jsx
@@ -142,8 +142,8 @@ const TableContainer = styled(Box)`
         padding-right: 0;
       }
       ${({ $isEmpty }) =>
-        $isEmpty &&
-        `
+    $isEmpty &&
+    `
         padding: 0;
         padding-top: 15px;
       `}
@@ -276,9 +276,9 @@ const MedicationAccessor = ({ medication, getTranslation, getEnumTranslation }) 
   const durationDisplay =
     medication.durationValue && translatedUnit
       ? `${medication.durationValue} ${singularize(
-          translatedUnit,
-          medication.durationValue,
-        ).toLowerCase()}`
+        translatedUnit,
+        medication.durationValue,
+      ).toLowerCase()}`
       : null;
   return (
     <Box>
@@ -326,80 +326,83 @@ const MEDICATION_COLUMNS = (
   canUpdateMedication,
   canWriteSensitiveMedication,
 ) => [
-  {
-    key: 'medication',
-    title: (
-      <TranslatedText
-        stringId="discharge.table.column.medication"
-        fallback="Medication"
-        data-testid="translatedtext-qyha"
-      />
-    ),
-    accessor: medication => (
-      <MedicationAccessor
-        medication={medication}
-        getTranslation={getTranslation}
-        getEnumTranslation={getEnumTranslation}
-      />
-    ),
-    width: '250px',
-  },
-  {
-    key: 'quantity',
-    title: (
-      <TranslatedText
-        stringId="discharge.table.column.dischargeQuantity"
-        fallback="Discharge qty"
-        data-testid="translatedtext-8e5k"
-      />
-    ),
-    accessor: ({ id, medication }) => (
-      <Field
-        name={`medications.${id}.quantity`}
-        component={NumberFieldWithoutLabel}
-        data-testid="field-ksmf"
-        disabled={
-          !canUpdateMedication ||
-          (medication?.referenceDrug?.isSensitive && !canWriteSensitiveMedication)
-        }
-      />
-    ),
-    width: '120px',
-  },
-  {
-    key: 'repeats',
-    title: (
-      <TranslatedText
-        stringId="discharge.table.column.repeats"
-        fallback="Repeats"
-        data-testid="translatedtext-opjr"
-      />
-    ),
-    accessor: ({ id, medication }) => (
-      <Field
-        name={`medications.${id}.repeats`}
-        component={NumberFieldWithoutLabel}
-        min={0}
-        max={MAX_REPEATS}
-        data-testid="field-ium3"
-        disabled={
-          !canUpdateMedication ||
-          (medication?.referenceDrug?.isSensitive && !canWriteSensitiveMedication)
-        }
-        step={1}
-        onInput={preventInvalidRepeatsInput}
-      />
-    ),
-    width: '120px',
-  },
-  {
-    key: 'Ongoing',
-    title: <TranslatedText stringId="discharge.table.column.ongoing" fallback="Ongoing" />,
-    accessor: OngoingAccessor,
-    width: '60px',
-  },
-  ...(canUpdateMedication
-    ? [
+    {
+      key: 'medication',
+      title: (
+        <TranslatedText
+          stringId="discharge.table.column.medication"
+          fallback="Medication"
+          data-testid="translatedtext-qyha"
+        />
+      ),
+      accessor: medication => (
+        <MedicationAccessor
+          medication={medication}
+          getTranslation={getTranslation}
+          getEnumTranslation={getEnumTranslation}
+        />
+      ),
+      width: '250px',
+    },
+    {
+      key: 'quantity',
+      title: (
+        <TranslatedText
+          stringId="discharge.table.column.dischargeQuantity"
+          fallback="Discharge qty"
+          data-testid="translatedtext-8e5k"
+        />
+      ),
+      accessor: ({ id, medication }) => (
+        <Field
+          name={`medications.${id}.quantity`}
+          component={NumberFieldWithoutLabel}
+          data-testid="field-ksmf"
+          disabled={
+            !canUpdateMedication ||
+            (medication?.referenceDrug?.isSensitive && !canWriteSensitiveMedication)
+          }
+        />
+      ),
+      width: '120px',
+    },
+    {
+      key: 'repeats',
+      title: (
+        <TranslatedText
+          stringId="discharge.table.column.repeats"
+          fallback="Repeats"
+          data-testid="translatedtext-opjr"
+        />
+      ),
+      accessor: ({ id, medication }) =>
+        medication?.isOngoing ? (
+          <Field
+            name={`medications.${id}.repeats`}
+            component={NumberFieldWithoutLabel}
+            min={0}
+            max={MAX_REPEATS}
+            data-testid="field-ium3"
+            disabled={
+              !canUpdateMedication ||
+              (medication?.referenceDrug?.isSensitive && !canWriteSensitiveMedication)
+            }
+            step={1}
+            onInput={preventInvalidRepeatsInput}
+          />
+        ) : (
+          <Box>-</Box>
+        ),
+      width: '120px',
+    },
+    {
+      key: 'Ongoing',
+      title: <TranslatedText stringId="discharge.table.column.ongoing" fallback="Ongoing" />,
+      accessor: OngoingAccessor,
+      width: '60px',
+    },
+    ...(canUpdateMedication
+      ? [
         {
           key: 'Discontinued',
           title: '',
@@ -415,8 +418,8 @@ const MEDICATION_COLUMNS = (
           width: '75px',
         },
       ]
-    : []),
-];
+      : []),
+  ];
 
 const EncounterOverview = ({
   encounter: { procedures, startDate, examiner, reasonForEncounter, encounterType },
@@ -818,13 +821,13 @@ export const DischargeForm = ({
           !showWarningScreen
             ? DischargeSummaryScreen
             : props => (
-                <UnsavedChangesScreen
-                  {...props}
-                  showWarningScreen={showWarningScreen}
-                  onSubmit={handleSubmit}
-                  data-testid="unsavedchangesscreen-o64o"
-                />
-              )
+              <UnsavedChangesScreen
+                {...props}
+                showWarningScreen={showWarningScreen}
+                onSubmit={handleSubmit}
+                data-testid="unsavedchangesscreen-o64o"
+              />
+            )
         }
         validationSchema={yup.object().shape({
           endDate: yup
@@ -862,12 +865,12 @@ export const DischargeForm = ({
               }),
               note: dischargeNoteMandatory
                 ? foreignKey().translatedLabel(
-                    <TranslatedText
-                      stringId="discharge.notes.label"
-                      fallback="Discharge treatment plan and follow-up notes"
-                      data-testid="translatedtext-208f"
-                    />,
-                  )
+                  <TranslatedText
+                    stringId="discharge.notes.label"
+                    fallback="Discharge treatment plan and follow-up notes"
+                    data-testid="translatedtext-208f"
+                  />,
+                )
                 : yup.string().optional(),
             })
             .required()

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -126,8 +126,8 @@ const validationSchema = yup.object().shape({
     .when('durationValue', (durationValue, schema) =>
       durationValue
         ? schema.required(
-            <TranslatedText stringId="validation.required.inline" fallback="*Required" />,
-          )
+          <TranslatedText stringId="validation.required.inline" fallback="*Required" />,
+        )
         : schema.optional(),
     ),
   prescriberId: foreignKey(
@@ -381,13 +381,13 @@ const MedicationAdministrationForm = ({ frequencyChanged }) => {
       ...values,
       timeSlots: checked
         ? [
-            ...selectedTimeSlots,
-            {
-              index,
-              value: getDefaultIdealTimeFromTimeSlot(slot, index),
-              timeSlot: slot,
-            },
-          ]
+          ...selectedTimeSlots,
+          {
+            index,
+            value: getDefaultIdealTimeFromTimeSlot(slot, index),
+            timeSlot: slot,
+          },
+        ]
         : selectedTimeSlots.filter(s => s.index !== index),
     });
   };
@@ -459,7 +459,7 @@ const MedicationAdministrationForm = ({ frequencyChanged }) => {
             const isDisabled =
               (!checked &&
                 frequenciesAdministrationIdealTimes?.[values.frequency]?.length ===
-                  selectedTimeSlots?.length) ||
+                selectedTimeSlots?.length) ||
               isOneTimeFrequency(values.frequency);
             const selectedTime = selectedTimeSlot
               ? getDateFromTimeString(selectedTimeSlot.value)
@@ -1133,16 +1133,19 @@ export const MedicationForm = ({
                   onInput={preventInvalidNumber}
                   data-testid="medication-field-quantity-6j9m"
                 />
-                <Field
-                  name="repeats"
-                  label={<TranslatedText stringId="medication.repeats.label" fallback="Repeats" />}
-                  component={NumberField}
-                  min={0}
-                  max={MAX_REPEATS}
-                  step={1}
-                  onInput={preventInvalidRepeatsInput}
-                />
               </>
+            )}
+            {(isOngoingPrescription || values?.isOngoing) && (
+              <Field
+                name="repeats"
+                label={<TranslatedText stringId="medication.repeats.label" fallback="Repeats" />}
+                component={NumberField}
+                min={0}
+                max={MAX_REPEATS}
+                step={1}
+                onInput={preventInvalidRepeatsInput}
+                data-testid="medication-field-repeats"
+              />
             )}
             {showPatientWeight && (
               <>

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -36,7 +36,6 @@ export const getMedicationLabelData = ({ items, patient, facility }) => {
     dispensedAt: item.dispensedAt || new Date().toISOString(),
     quantity: item.quantity,
     units: item.units || '',
-    remainingRepeats: item.remainingRepeats,
     prescriberName: item.prescriberName || '-',
     requestNumber: item.requestNumber || '-',
     facilityName: facility?.name || '',

--- a/packages/web/app/views/patients/panes/PatientMedicationPane.jsx
+++ b/packages/web/app/views/patients/panes/PatientMedicationPane.jsx
@@ -277,108 +277,108 @@ const DISPENSED_MEDICATION_COLUMNS = (
   handleEdit,
   handleCancelClick,
 ) => [
-  {
-    key: 'pharmacyOrderPrescription.prescription.medication.name',
-    title: (
-      <TranslatedText stringId="patient.medication.table.column.medication" fallback="Medication" />
-    ),
-    sortable: true,
-    accessor: data => (
-      <TranslatedReferenceData
-        fallback={data?.pharmacyOrderPrescription?.prescription?.medication?.name}
-        value={data?.pharmacyOrderPrescription?.prescription?.medication?.id}
-        category={data?.pharmacyOrderPrescription?.prescription?.medication?.type}
-      />
-    ),
-  },
-  {
-    key: 'dose',
-    title: <TranslatedText stringId="patient.medication.table.column.dose" fallback="Dose" />,
-    accessor: data => {
-      const prescription = data?.pharmacyOrderPrescription?.prescription;
-      if (!prescription) return '';
-      return (
-        <>
-          {getMedicationDoseDisplay(prescription, getTranslation, getEnumTranslation)}
-          {prescription.isPrn && ` ${getTranslation('patient.medication.table.prn', 'PRN')}`}
-        </>
-      );
+    {
+      key: 'pharmacyOrderPrescription.prescription.medication.name',
+      title: (
+        <TranslatedText stringId="patient.medication.table.column.medication" fallback="Medication" />
+      ),
+      sortable: true,
+      accessor: data => (
+        <TranslatedReferenceData
+          fallback={data?.pharmacyOrderPrescription?.prescription?.medication?.name}
+          value={data?.pharmacyOrderPrescription?.prescription?.medication?.id}
+          category={data?.pharmacyOrderPrescription?.prescription?.medication?.type}
+        />
+      ),
     },
-    sortable: false,
-  },
-  {
-    key: 'frequency',
-    title: (
-      <TranslatedText stringId="patient.medication.table.column.frequency" fallback="Frequency" />
-    ),
-    accessor: data => {
-      const frequency = data?.pharmacyOrderPrescription?.prescription?.frequency;
-      return frequency ? getTranslatedFrequency(frequency, getTranslation) : '';
+    {
+      key: 'dose',
+      title: <TranslatedText stringId="patient.medication.table.column.dose" fallback="Dose" />,
+      accessor: data => {
+        const prescription = data?.pharmacyOrderPrescription?.prescription;
+        if (!prescription) return '';
+        return (
+          <>
+            {getMedicationDoseDisplay(prescription, getTranslation, getEnumTranslation)}
+            {prescription.isPrn && ` ${getTranslation('patient.medication.table.prn', 'PRN')}`}
+          </>
+        );
+      },
+      sortable: false,
     },
-    sortable: false,
-  },
-  {
-    key: 'dispensedAt',
-    title: (
-      <TranslatedText
-        stringId="patient.medication.table.column.dateDispensed"
-        fallback="Date dispensed"
-      />
-    ),
-    accessor: data => <DateDisplay date={data?.dispensedAt} timeOnlyTooltip shortYear />,
-    sortable: true,
-  },
-  {
-    key: 'quantity',
-    title: (
-      <TranslatedText
-        stringId="patient.medication.table.column.qtyDispensed"
-        fallback="Qty dispensed"
-      />
-    ),
-    sortable: false,
-    accessor: data => data?.quantity,
-  },
-  {
-    key: 'dispensedBy.displayName',
-    title: (
-      <TranslatedText
-        stringId="patient.medication.table.column.dispensedBy"
-        fallback="Dispensed by"
-      />
-    ),
-    accessor: data => data?.dispensedBy?.displayName ?? '',
-    sortable: true,
-  },
-  {
-    key: 'actions',
-    title: '',
-    allowExport: false,
-    accessor: row => {
-      const actions = [
-        {
-          label: <TranslatedText stringId="general.action.printLabel" fallback="Print label" />,
-          action: () => handlePrintLabel(row),
-        },
-        {
-          label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
-          action: () => handleEdit(row),
-        },
-        {
-          label: <TranslatedText stringId="general.action.cancel" fallback="Cancel" />,
-          action: () => handleCancelClick(row.id),
-        },
-      ];
-      return (
-        <div onMouseEnter={() => hoveredRow !== row && setHoveredRow(row.id)}>
-          <MenuButton actions={actions} />
-        </div>
-      );
+    {
+      key: 'frequency',
+      title: (
+        <TranslatedText stringId="patient.medication.table.column.frequency" fallback="Frequency" />
+      ),
+      accessor: data => {
+        const frequency = data?.pharmacyOrderPrescription?.prescription?.frequency;
+        return frequency ? getTranslatedFrequency(frequency, getTranslation) : '';
+      },
+      sortable: false,
     },
-    sortable: false,
-    dontCallRowInput: true,
-  },
-];
+    {
+      key: 'dispensedAt',
+      title: (
+        <TranslatedText
+          stringId="patient.medication.table.column.dateDispensed"
+          fallback="Date dispensed"
+        />
+      ),
+      accessor: data => <DateDisplay date={data?.dispensedAt} timeOnlyTooltip shortYear />,
+      sortable: true,
+    },
+    {
+      key: 'quantity',
+      title: (
+        <TranslatedText
+          stringId="patient.medication.table.column.qtyDispensed"
+          fallback="Qty dispensed"
+        />
+      ),
+      sortable: false,
+      accessor: data => data?.quantity,
+    },
+    {
+      key: 'dispensedBy.displayName',
+      title: (
+        <TranslatedText
+          stringId="patient.medication.table.column.dispensedBy"
+          fallback="Dispensed by"
+        />
+      ),
+      accessor: data => data?.dispensedBy?.displayName ?? '',
+      sortable: true,
+    },
+    {
+      key: 'actions',
+      title: '',
+      allowExport: false,
+      accessor: row => {
+        const actions = [
+          {
+            label: <TranslatedText stringId="general.action.printLabel" fallback="Print label" />,
+            action: () => handlePrintLabel(row),
+          },
+          {
+            label: <TranslatedText stringId="general.action.edit" fallback="Edit" />,
+            action: () => handleEdit(row),
+          },
+          {
+            label: <TranslatedText stringId="general.action.cancel" fallback="Cancel" />,
+            action: () => handleCancelClick(row.id),
+          },
+        ];
+        return (
+          <div onMouseEnter={() => hoveredRow !== row && setHoveredRow(row.id)}>
+            <MenuButton actions={actions} />
+          </div>
+        );
+      },
+      sortable: false,
+      dontCallRowInput: true,
+    },
+  ];
 
 export const PatientMedicationPane = ({ patient }) => {
   const api = useApi();
@@ -471,7 +471,6 @@ export const PatientMedicationPane = ({ patient }) => {
           instructions,
           quantity,
           units: prescription?.units,
-          remainingRepeats: pharmacyOrderPrescription?.remainingRepeats,
           prescriberName: prescription?.prescriber?.displayName,
           requestNumber: pharmacyOrderPrescription?.displayId,
           dispensedAt,
@@ -535,7 +534,6 @@ export const PatientMedicationPane = ({ patient }) => {
         displayId: pharmacyOrderPrescription?.displayId,
         quantity,
         instructions,
-        remainingRepeats: pharmacyOrderPrescription?.remainingRepeats,
         dispensedAt,
         dispensedBy,
         prescription: {
@@ -556,10 +554,9 @@ export const PatientMedicationPane = ({ patient }) => {
   }, []);
 
   const rowStyle = ({ medication }) => `
-    ${
-      medication?.referenceDrug?.isSensitive && !canViewSensitiveMedications
-        ? 'pointer-events: none;'
-        : ''
+    ${medication?.referenceDrug?.isSensitive && !canViewSensitiveMedications
+      ? 'pointer-events: none;'
+      : ''
     }
     ${isUnavailableAtFacility(medication) ? 'opacity: 0.5; cursor: default !important;' : ''}
   `;


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes medication request/dispense business rules and repeat decrement behavior across API and UI; risk is mainly incorrect repeat counts or request visibility if edge cases weren’t covered.
> 
> **Overview**
> Medication dispensing/request logic is updated to treat each `PharmacyOrderPrescription` as **single-dispense**: the dispense endpoint now blocks any record that already has a dispense, and marks dispensed requests as `isCompleted` so they drop out of the medication requests list.
> 
> Repeat handling is shifted to the **send-to-pharmacy** step: creating a pharmacy order (both encounter and ongoing flows) now decrements `Prescription.repeats` transactionally, and the server/web UI remove `remainingRepeats` calculations/columns and the repeats line from printed medication labels. Repeats inputs/displays are also limited to *ongoing* prescriptions in several medication/discharge forms and modals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b962e00e0b8241bab5e40268c8b8ea7419b6cb74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->