### PR TITLE
fix(notes): TAMOC-384: Floating note modal bug (missed fix cherry pick)

### DIFF
--- a/packages/web/app/components/withModalFloating.jsx
+++ b/packages/web/app/components/withModalFloating.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useMemo } from 'react';
+import React, { useRef, useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 import { Resizable } from 're-resizable';
@@ -9,6 +9,16 @@ import { ResizeCornerIcon } from './Icons/ResizeCornerIcon';
 import { ResizeHorizontalIcon } from './Icons/ResizeHorizontalIcon';
 import { ResizeVerticalIcon } from './Icons/ResizeVerticalIcon';
 import { Colors } from '../constants';
+
+const calculateDefaultPosition = (baseWidth, baseHeight) => {
+  if (typeof window !== 'undefined') {
+    return {
+      x: Math.max(0, Math.round(window.innerWidth / 2 - Number(baseWidth) / 2)),
+      y: Math.max(0, Math.round(window.innerHeight / 2 - Number(baseHeight) / 2)),
+    };
+  }
+  return { x: 0, y: 0 };
+};
 
 export const withModalFloating = ModalComponent => {
   const StyledModalComponent = styled(ModalComponent)`
@@ -51,16 +61,46 @@ export const withModalFloating = ModalComponent => {
     BackdropProps,
     ...modalProps
   }) => {
+    // We use both state and refs for position/size:
+    // - State triggers re-renders when window resizes (to recenter modal) and keeps
+    //   react-draggable/re-resizable controlled (they need prop updates to reflect changes)
+    // - Refs provide stable references to the memoized PaperComponent callback, preventing
+    //   it from recreating on every render (which would remount Dialog and reset form state)
+    // Refs are synced from state/props on each render so PaperComponent always reads current values
     const positionRef = useRef({ x: 0, y: 0 });
-    const defaultPosition = useMemo(() => {
-      if (typeof window !== 'undefined') {
-        const x = Math.max(0, Math.round(window.innerWidth / 2 - Number(baseWidth) / 2));
-        const y = Math.max(0, Math.round(window.innerHeight / 2 - Number(baseHeight) / 2));
-        return { x, y };
-      }
-      return { x: 0, y: 0 };
-    }, [baseWidth, baseHeight]);
+    const baseSizeRef = useRef({ width: Number(baseWidth), height: Number(baseHeight) });
+    const currentSizeRef = useRef({ width: Number(baseWidth), height: Number(baseHeight) });
+    const minConstraintsRef = useRef(minConstraints);
+    const maxConstraintsRef = useRef(maxConstraints);
 
+    const [position, setPosition] = useState(() =>
+      calculateDefaultPosition(baseWidth, baseHeight),
+    );
+    const [size, setSize] = useState(() => ({
+      width: Number(baseWidth),
+      height: Number(baseHeight),
+    }));
+
+    // Recenter and reset to default size when window is resized
+    useEffect(() => {
+      const handleResize = () => {
+        setPosition(calculateDefaultPosition(baseSizeRef.current.width, baseSizeRef.current.height));
+        setSize(baseSizeRef.current);
+      };
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    // Update refs with latest prop values so PaperComponent won't recreate
+    baseSizeRef.current = { width: Number(baseWidth), height: Number(baseHeight) };
+    currentSizeRef.current = size;
+    minConstraintsRef.current = minConstraints;
+    maxConstraintsRef.current = maxConstraints;
+    positionRef.current = position;
+
+    // PaperComponent reads position from positionRef so it stays referentially stable
+    // when position changes (e.g. on resize). That avoids Dialog remounting and
+    // resetting form state inside the modal.
     const PaperComponent = useCallback(
       paperProps => {
         const { style, className, children, ...rest } = paperProps;
@@ -68,22 +108,30 @@ export const withModalFloating = ModalComponent => {
           <Draggable
             handle={draggableHandle}
             bounds={draggableBounds}
-            defaultPosition={defaultPosition}
+            position={positionRef.current}
             cancel=".MuiDialogTitle-root button, .MuiDialogActions-root button"
             onStop={(e, data) => {
-              positionRef.current = { x: data.x, y: data.y };
+              const next = { x: data.x, y: data.y };
+              positionRef.current = next;
+              setPosition(next);
             }}
           >
             <Resizable
-              defaultSize={{ width: baseWidth, height: baseHeight }}
-              minWidth={minConstraints[0]}
-              minHeight={minConstraints[1]}
-              maxWidth={maxConstraints[0]}
-              maxHeight={maxConstraints[1]}
+              size={currentSizeRef.current}
+              minWidth={minConstraintsRef.current[0]}
+              minHeight={minConstraintsRef.current[1]}
+              maxWidth={maxConstraintsRef.current[0]}
+              maxHeight={maxConstraintsRef.current[1]}
               enable={enableResizeHandle}
               resizeRatio={resizeRatio}
               handleComponent={handleComponent}
               handleStyles={handleStyles}
+              onResizeStop={(e, direction, ref, d) => {
+                setSize({
+                  width: currentSizeRef.current.width + d.width,
+                  height: currentSizeRef.current.height + d.height,
+                });
+              }}
               className={className}
               style={{ ...style, position: 'absolute', overflow: 'visible', zIndex: 1500 }}
             >
@@ -103,14 +151,10 @@ export const withModalFloating = ModalComponent => {
           </Draggable>
         );
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
-        positionRef,
         draggableHandle,
         draggableBounds,
-        baseWidth,
-        baseHeight,
-        minConstraints,
-        maxConstraints,
         enableResizeHandle,
         handleComponent,
         handleStyles,


### PR DESCRIPTION
…e (#9048)

* Update withModalFloating.jsx

* Update withModalFloating.jsx

* Update withModalFloating.jsx

* Update withModalFloating.jsx

* Update withModalFloating.jsx

* controlled size and position

* Update withModalFloating.jsx

* better comment

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core modal drag/resize behavior and introduces controlled state plus a global `resize` handler, which could impact UX/performance or positioning across consumers if edge cases regress.
> 
> **Overview**
> Fixes the floating modal wrapper (`withModalFloating.jsx`) by switching `react-draggable` and `re-resizable` from *default* (uncontrolled) position/size to *controlled* state, persisting updates on drag/resize.
> 
> Adds a window `resize` listener to recenter the modal and reset it to its base dimensions, while using refs to keep `PaperComponent` referentially stable so the underlying MUI `Dialog` doesn’t remount and wipe in-modal form state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6febc76cf4884417a39d9c0e3d32a195e8deebd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->