### PR TITLE
fix(notes): HOTFIX-2.46: Filter out system notes

### DIFF
--- a/packages/constants/src/notes.ts
+++ b/packages/constants/src/notes.ts
@@ -19,6 +19,12 @@ export const NOTE_TYPES = {
   HANDOVER: 'notetype-handover',
 };
 
+// Note types that should not be user-editable or creatable via UI
+export const NON_EDITABLE_NOTE_TYPES = [
+  NOTE_TYPES.SYSTEM,
+  NOTE_TYPES.CLINICAL_MOBILE,
+];
+
 export const NOTE_PERMISSION_TYPES = {
   OTHER_PRACTITIONER_ENCOUNTER_NOTE: 'OtherPractitionerEncounterNote',
   TREATMENT_PLAN_NOTE: 'TreatmentPlanNote',

--- a/packages/web/app/components/NoteCommonFields.jsx
+++ b/packages/web/app/components/NoteCommonFields.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import Divider from '@material-ui/core/Divider';
-import { NOTE_TYPES, REFERENCE_TYPES } from '@tamanu/constants';
+import { NOTE_TYPES, REFERENCE_TYPES, NON_EDITABLE_NOTE_TYPES } from '@tamanu/constants';
 import { Box } from '@material-ui/core';
 import { InfoCard, InfoCardItem } from './InfoCard';
 import {
@@ -284,7 +284,7 @@ export const NoteTypeField = ({
 
   const noteTypeOptions = useMemo(() => {
     return noteTypes
-      .filter(noteType => noteType.id !== NOTE_TYPES.SYSTEM)
+      .filter(noteType => !NON_EDITABLE_NOTE_TYPES.includes(noteType.id))
       .map(noteType => ({
         value: noteType.id,
         label: (

--- a/packages/web/app/components/NoteTable.jsx
+++ b/packages/web/app/components/NoteTable.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react'
 import styled from 'styled-components';
 import EditIcon from '@material-ui/icons/Edit';
 
-import { NOTE_PERMISSION_TYPES, NOTE_TYPES, REFERENCE_TYPES } from '@tamanu/constants';
+import { NOTE_PERMISSION_TYPES, NOTE_TYPES, REFERENCE_TYPES, NON_EDITABLE_NOTE_TYPES } from '@tamanu/constants';
 
 import { DataFetchingTable } from './Table';
 import { DateDisplay } from './DateDisplay';
@@ -205,7 +205,7 @@ const NoteContent = ({
         </NoteContentContainer>
         {hasIndividualNotePermission &&
           hasEncounterNoteWritePermission &&
-          note.noteTypeId !== NOTE_TYPES.SYSTEM && (
+          !NON_EDITABLE_NOTE_TYPES.includes(note.noteTypeId) && (
             <NoteModalActionBlocker>
               <StyledEditIcon
                 onClick={() => handleEditNote(note)}


### PR DESCRIPTION
…mobile notes

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only filtering and gating change with minimal blast radius; main risk is inadvertently hiding note types if the list is wrong.
> 
> **Overview**
> Centralizes UI note-type restrictions by introducing `NON_EDITABLE_NOTE_TYPES` (currently `SYSTEM` and `CLINICAL_MOBILE`) in constants.
> 
> Updates the web notes UI to use this shared list: the note-type selector no longer offers non-editable types, and the edit icon/actions are hidden for notes of these types (previously only `SYSTEM` was blocked).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e60ca6326520055c0d66dcc84f2a486a02ec0ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->