### PR TITLE
fix: Release 2.49: Remove Invoice Price Lists Error

### DIFF
--- a/packages/database/__tests__/models/invoicePriceListMatching.test.ts
+++ b/packages/database/__tests__/models/invoicePriceListMatching.test.ts
@@ -535,31 +535,6 @@ describe('InvoicePriceList.getIdForPatientEncounter', () => {
     expect(id2).toBeNull();
   });
 
-  it('throws an error when multiple price lists match', async () => {
-    const mockEncounter = buildMockEncounter({ facilityId: 'facility-1' });
-
-    const mockFindByPk = vi.fn().mockResolvedValue(mockEncounter);
-    Object.defineProperty(InvoicePriceList, 'sequelize', {
-      value: {
-        models: {
-          Encounter: {
-            findByPk: mockFindByPk,
-          },
-        },
-      },
-      configurable: true,
-    });
-
-    vi.spyOn(InvoicePriceList as any, 'findAll').mockResolvedValue([
-      { id: 'pl-1', code: 'code-1', name: 'Price List One', rules: { facilityId: 'facility-1' } },
-      { id: 'pl-2', code: 'code-2', name: 'Price List Two', rules: { facilityId: 'facility-1' } },
-    ]);
-
-    await expect(InvoicePriceList.getIdForPatientEncounter('encounter-1')).rejects.toThrow(
-      'Multiple price lists match the provided inputs: Price List One, Price List Two',
-    );
-  });
-
   it('returns the matching price list id when only one matches', async () => {
     const mockEncounter = buildMockEncounter({ facilityId: 'facility-1' });
 

--- a/packages/database/src/models/Invoice/InvoicePriceList.ts
+++ b/packages/database/src/models/Invoice/InvoicePriceList.ts
@@ -1,5 +1,6 @@
 import { DataTypes } from 'sequelize';
 import { SYNC_DIRECTIONS, VISIBILITY_STATUSES } from '@tamanu/constants';
+import { log } from '@tamanu/shared/services/logging';
 import { Model } from '../Model';
 import type { InitOptions, Models } from '../../types/model';
 import {
@@ -111,7 +112,7 @@ export class InvoicePriceList extends Model {
     }
 
     if (matches.length > 1) {
-      throw new Error(
+      log.warn(
         `Multiple price lists match the provided inputs: ${matches.map(match => match.name).join(', ')}`,
       );
     }


### PR DESCRIPTION
### Changes

We don't need to error if there are multiple overlapping price lists configured as there is a fallback to the user manually entering prices.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
