### PR TITLE
tweak(fhir): no-issue: Reduce default fhir worker concurrency

### DIFF
--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -366,7 +366,7 @@
       "enabled": false, // the HTTP routes
       "worker": {
         "enabled": true, // the materialisation worker
-        "concurrency": 100,
+        "concurrency": 10,
         "resourceMaterialisationEnabled": {
           "Patient": true,
           "Encounter": false,


### PR DESCRIPTION
### Changes

With the new FHIR queue processing logic, we run the risk of using up the whole sequelize connection pool if the concurrency exceeds the connection pool size (10 by default).

100 seems pretty over the top anyway, and the new processing logic is faster so having less concurrency shouldn't affect queue processing times much.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
