### PR TITLE
fix(encounters): Release v2.49: Missing modal declaration

### DIFF
--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -10,6 +10,7 @@ import { NoteModalActionBlocker } from '../../../components';
 import { EncounterRecordModal } from '../../../components/PatientPrinting/modals/EncounterRecordModal';
 import { ThreeDotMenu } from '../../../components/ThreeDotMenu';
 import { useAuth } from '../../../contexts/Auth';
+import { useEncounterDischargeQuery } from '../../../api/queries/useEncounterDischargeQuery';
 
 const ENCOUNTER_MODALS = {
   NONE: 'none',
@@ -51,6 +52,8 @@ export const EncounterActions = React.memo(({ encounter }) => {
   const onClose = () => setOpenModal(ENCOUNTER_MODALS.NONE);
   const onViewSummary = () => navigateToSummary();
 
+  const { data: discharge } = useEncounterDischargeQuery(encounter)
+
   const canWriteEncounter = ability.can('write', 'Encounter');
 
   if (encounter.endDate) {
@@ -59,7 +62,7 @@ export const EncounterActions = React.memo(({ encounter }) => {
     // need this extra check here to only show encounter/discharge summary actions when
     // the encounter is actually discharged (discharge record exists).
     return (
-      <>
+      discharge && <>
         <ActionsContainer data-testid="actionscontainer-w92z">
           <StyledButton
             size="small"

--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -59,33 +59,41 @@ export const EncounterActions = React.memo(({ encounter }) => {
     // need this extra check here to only show encounter/discharge summary actions when
     // the encounter is actually discharged (discharge record exists).
     return (
-      <ActionsContainer data-testid="actionscontainer-w92z">
-        <StyledButton
-          size="small"
-          variant="outlined"
-          onClick={() => setOpenModal(ENCOUNTER_MODALS.ENCOUNTER_PROGRESS_RECORD)}
-          data-testid="styledbutton-00iz"
-        >
-          <TranslatedText
-            stringId="patient.encounter.action.encounterSummary"
-            fallback="Encounter summary"
-            data-testid="translatedtext-ftbh"
-          />
-        </StyledButton>
-        <br />
-        <StyledButton
-          size="small"
-          color="primary"
-          onClick={onViewSummary}
-          data-testid="styledbutton-0m1p"
-        >
-          <TranslatedText
-            stringId="patient.encounter.action.dischargeSummary"
-            fallback="Discharge summary"
-            data-testid="translatedtext-0hzq"
-          />
-        </StyledButton>
-      </ActionsContainer>
+      <>
+        <ActionsContainer data-testid="actionscontainer-w92z">
+          <StyledButton
+            size="small"
+            variant="outlined"
+            onClick={() => setOpenModal(ENCOUNTER_MODALS.ENCOUNTER_PROGRESS_RECORD)}
+            data-testid="styledbutton-00iz"
+          >
+            <TranslatedText
+              stringId="patient.encounter.action.encounterSummary"
+              fallback="Encounter summary"
+              data-testid="translatedtext-ftbh"
+            />
+          </StyledButton>
+          <br />
+          <StyledButton
+            size="small"
+            color="primary"
+            onClick={onViewSummary}
+            data-testid="styledbutton-0m1p"
+          >
+            <TranslatedText
+              stringId="patient.encounter.action.dischargeSummary"
+              fallback="Discharge summary"
+              data-testid="translatedtext-0hzq"
+            />
+          </StyledButton>
+        </ActionsContainer>
+        <EncounterRecordModal
+          encounter={encounter}
+          open={openModal === ENCOUNTER_MODALS.ENCOUNTER_PROGRESS_RECORD}
+          onClose={onClose}
+          data-testid="encounterrecordmodal-discharged"
+        />
+      </>
     );
   }
 


### PR DESCRIPTION
### Changes

Fixes the discharged-encounter action block in EncounterActions.jsx by mounting EncounterRecordModal alongside the Encounter/Discharge summary buttons.

This ensures clicking Encounter summary on a discharged encounter opens the Encounter Progress Record modal (using the existing openModal state).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI logic change gated by an existing discharge query; limited scope and no sensitive logic changes.
> 
> **Overview**
> For ended encounters, the action block now fetches the discharge record via `useEncounterDischargeQuery` and **only renders** the Encounter/Discharge summary buttons when a discharge exists.
> 
> It also mounts `EncounterRecordModal` alongside these buttons so clicking *Encounter summary* on a discharged encounter actually opens the modal (using the existing `openModal` state), instead of having no modal mounted in this branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea9d12aed5f5eec6baf4bbe860a5d8dcd4d316be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->