### PR TITLE
fix(medications): no-issue: Disabled checkbox bug

### DIFF
--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -179,10 +179,6 @@ const buildInstructionText = (prescription, getTranslation, getEnumTranslation) 
   return output.trim();
 };
 
-const isItemDisabled = item => {
-  return item.pharmacyOrder?.isDischargePrescription && (item.remainingRepeats ?? 0) === 0;
-};
-
 const InstructionsInput = memo(({ value: defaultValue, onChange, ...props }) => {
   const [value, setValue] = useState(defaultValue);
   const handleChange = e => {
@@ -256,7 +252,7 @@ export const DispenseMedicationWorkflowModal = memo(
           const { quantity, prescription, instructions } = d;
           return {
             ...d,
-            selected: !isItemDisabled(d), // Don't auto-select disabled items
+            selected: true,
             quantity: quantity ?? 1,
             instructions:
               buildInstructionText(prescription, getTranslation, getEnumTranslation) ||
@@ -284,7 +280,7 @@ export const DispenseMedicationWorkflowModal = memo(
     };
 
     const handleSelectAll = ({ target: { checked } }) => {
-      setItems(prev => prev.map(i => ({ ...i, selected: !isItemDisabled(i) ? checked : false })));
+      setItems(prev => prev.map(i => ({ ...i, selected: checked })));
     };
 
     const handleSelectRow = rowIndex => ({ target: { checked } }) => {
@@ -295,9 +291,7 @@ export const DispenseMedicationWorkflowModal = memo(
       });
     };
 
-    const selectableItems = items.filter(i => !isItemDisabled(i));
-    const selectAllChecked =
-      selectableItems.length > 0 && selectableItems.every(({ selected }) => selected);
+    const selectAllChecked = items.length > 0 && items.every(({ selected }) => selected);
 
     const handleQuantityChange = (rowIndex, { target: { value: rawValue } }) => {
       setItems(prev => {
@@ -442,7 +436,6 @@ export const DispenseMedicationWorkflowModal = memo(
                 onChange={handleSelectRow(rowIndex)}
                 style={{ margin: 'auto' }}
                 data-testid={`dispense-row-checkbox-${rowIndex}`}
-                disabled={isItemDisabled(item)}
               />
             );
           },
@@ -485,7 +478,7 @@ export const DispenseMedicationWorkflowModal = memo(
           accessor: (item, rowIndex) => {
             const { id, quantity, selected } = item;
             const hasQuantityError = itemErrors[id]?.hasQuantityError || false;
-            const disabled = isItemDisabled(item) || !selected;
+            const disabled = !selected;
             return (
               <QuantityInput
                 value={quantity}
@@ -529,7 +522,7 @@ export const DispenseMedicationWorkflowModal = memo(
           accessor: (item, rowIndex) => {
             const { id, instructions, selected } = item;
             const hasInstructionsError = itemErrors[id]?.hasInstructionsError || false;
-            const disabled = isItemDisabled(item) || !selected;
+            const disabled = !selected;
             return (
               <InstructionsInput
                 value={instructions}

--- a/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
+++ b/packages/web/app/components/Medication/DispenseMedicationWorkflowModal.jsx
@@ -478,13 +478,12 @@ export const DispenseMedicationWorkflowModal = memo(
           accessor: (item, rowIndex) => {
             const { id, quantity, selected } = item;
             const hasQuantityError = itemErrors[id]?.hasQuantityError || false;
-            const disabled = !selected;
             return (
               <QuantityInput
                 value={quantity}
                 onChange={e => handleQuantityChange(rowIndex, e)}
                 error={showValidationErrors && hasQuantityError}
-                disabled={disabled}
+                disabled={!selected}
                 InputProps={{ inputProps: { min: 1 } }}
                 data-testid="dispense-quantity"
                 required={selected}
@@ -522,14 +521,13 @@ export const DispenseMedicationWorkflowModal = memo(
           accessor: (item, rowIndex) => {
             const { id, instructions, selected } = item;
             const hasInstructionsError = itemErrors[id]?.hasInstructionsError || false;
-            const disabled = !selected;
             return (
               <InstructionsInput
                 value={instructions}
                 onChange={e => handleInstructionsChange(rowIndex, e)}
                 error={showValidationErrors && hasInstructionsError}
                 required={selected}
-                disabled={disabled}
+                disabled={!selected}
                 testId="dispense-instructions"
                 helperText={
                   showValidationErrors && hasInstructionsError


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only change to selection/disabled logic in a single modal; low risk aside from potentially allowing dispensing items that were previously blocked by the client.
> 
> **Overview**
> Removes the special-case UI disabling for discharge prescriptions with `remainingRepeats === 0` in the dispense workflow.
> 
> All dispensable items are now auto-selected on load, selectable via row and “select all” checkboxes, and only the quantity/instructions inputs are disabled when a row is unselected (not based on repeats/discharge status).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0a984edb3a6498f2c2ddb9d8f2adb1838dac870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->