### PR TITLE
fix(medication): v2.49: Use frequency value for comparison instead of translated label

### DIFF
--- a/packages/mobile/App/ui/components/FrequencySearchField/FrequencySearchField.tsx
+++ b/packages/mobile/App/ui/components/FrequencySearchField/FrequencySearchField.tsx
@@ -51,10 +51,6 @@ const FrequencySearchInput: React.FC<FrequencySearchFieldProps> = ({
   const [displayLabel, setDisplayLabel] = useState<string | null>(null);
   const frequenciesEnabled: any = getSetting(`medications.frequenciesEnabled`);
 
-  // Build suggestion objects for the autocomplete field.
-  // value: the original untranslated frequency string (e.g. 'Daily') stored in the database
-  // label: the translated display name with its first synonym (e.g. 'Daily (D)')
-  // synonyms: translated alternative search terms (e.g. 'mane' for 'Daily in the morning')
   const frequencySuggester = useMemo(() => {
     const suggestions = Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS)
       .filter(([frequency]) => !frequenciesEnabled || frequenciesEnabled[frequency])

--- a/packages/mobile/App/ui/helpers/medicationHelpers.ts
+++ b/packages/mobile/App/ui/helpers/medicationHelpers.ts
@@ -9,8 +9,8 @@ import { addDays, format, isSameDay, set } from 'date-fns';
 export const getTranslatedFrequencySynonyms = (
   frequenciesEnabled: Record<string, boolean> | undefined,
   getTranslation: (key: string, fallback: string) => string,
-): Record<string, string[]> => {
-  const result: Record<string, string[]> = {};
+): Record<string, { label: string; synonyms: string[] }> => {
+  const result: Record<string, { label: string; synonyms: string[] }> = {};
 
   Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS).forEach(([frequency, synonyms]) => {
     // If frequenciesEnabled is provided, filter out disabled frequencies
@@ -18,30 +18,28 @@ export const getTranslatedFrequencySynonyms = (
       return;
     }
 
-    // Use the frequency itself as the key/label
-    const labelKey = getTranslation(
+    const translatedLabel = getTranslation(
       `medication.frequency.${camelCase(frequency)}.label`,
       frequency,
     );
 
-    // Translate synonyms (for now, just use the synonyms as-is since mobile doesn't have complex translation setup)
     const translatedSynonyms = synonyms.map((synonym, index) =>
       getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, synonym),
     );
 
-    result[labelKey] = translatedSynonyms;
+    result[frequency] = { label: translatedLabel, synonyms: translatedSynonyms };
   });
 
   return result;
 };
 
 export const getFrequencySuggestions = (
-  synonyms: Record<string, string[]>,
+  synonyms: Record<string, { label: string; synonyms: string[] }>,
 ): FrequencySuggestion[] => {
-  return Object.entries(synonyms).map(([key, value]) => ({
-    label: `${key} (${value[0]})`,
+  return Object.entries(synonyms).map(([key, { label, synonyms: syn }]) => ({
+    label: `${label} (${syn[0]})`,
     value: key,
-    synonyms: value,
+    synonyms: syn,
   }));
 };
 

--- a/packages/mobile/App/ui/helpers/medicationHelpers.ts
+++ b/packages/mobile/App/ui/helpers/medicationHelpers.ts
@@ -1,47 +1,7 @@
 import {
-  ADMINISTRATION_FREQUENCY_SYNONYMS,
   MEDICATION_ADMINISTRATION_TIME_SLOTS,
 } from '~/constants/medications';
-import { FrequencySuggestion } from './frequencySuggester';
-import { camelCase } from 'lodash';
 import { addDays, format, isSameDay, set } from 'date-fns';
-
-export const getTranslatedFrequencySynonyms = (
-  frequenciesEnabled: Record<string, boolean> | undefined,
-  getTranslation: (key: string, fallback: string) => string,
-): Record<string, { label: string; synonyms: string[] }> => {
-  const result: Record<string, { label: string; synonyms: string[] }> = {};
-
-  Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS).forEach(([frequency, synonyms]) => {
-    // If frequenciesEnabled is provided, filter out disabled frequencies
-    if (frequenciesEnabled && !frequenciesEnabled[frequency]) {
-      return;
-    }
-
-    const translatedLabel = getTranslation(
-      `medication.frequency.${camelCase(frequency)}.label`,
-      frequency,
-    );
-
-    const translatedSynonyms = synonyms.map((synonym, index) =>
-      getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, synonym),
-    );
-
-    result[frequency] = { label: translatedLabel, synonyms: translatedSynonyms };
-  });
-
-  return result;
-};
-
-export const getFrequencySuggestions = (
-  synonyms: Record<string, { label: string; synonyms: string[] }>,
-): FrequencySuggestion[] => {
-  return Object.entries(synonyms).map(([key, { label, synonyms: syn }]) => ({
-    label: `${label} (${syn[0]})`,
-    value: key,
-    synonyms: syn,
-  }));
-};
 
 export const getDateFromTimeString = (time: string, initialDate = new Date()) => {
   if (typeof time !== 'string' || !time?.includes?.(':')) {

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -7,10 +7,10 @@ import { getTranslatedFrequencySynonyms } from '../../utils/medications';
 import { useSettings } from '../../contexts/Settings';
 
 const getFrequencySuggestions = synonyms => {
-  return Object.entries(synonyms).map(([key, value]) => ({
-    label: `${key} (${value[0]})`,
+  return Object.entries(synonyms).map(([key, { label, synonyms: syn }]) => ({
+    label: `${label} (${syn[0]})`,
     value: key,
-    synonyms: value,
+    synonyms: syn,
   }));
 };
 

--- a/packages/web/app/components/Medication/FrequencySearchInput.jsx
+++ b/packages/web/app/components/Medication/FrequencySearchInput.jsx
@@ -1,27 +1,35 @@
 import React from 'react';
+import { ADMINISTRATION_FREQUENCY_SYNONYMS } from '@tamanu/constants';
+import { camelCase } from 'lodash';
 import { AutocompleteInput } from '../Field';
 import { FrequencySuggester } from './frequencySuggester';
 import { TranslatedText } from '../Translation/TranslatedText';
 import { useTranslation } from '../../contexts/Translation';
-import { getTranslatedFrequencySynonyms } from '../../utils/medications';
 import { useSettings } from '../../contexts/Settings';
-
-const getFrequencySuggestions = synonyms => {
-  return Object.entries(synonyms).map(([key, { label, synonyms: syn }]) => ({
-    label: `${label} (${syn[0]})`,
-    value: key,
-    synonyms: syn,
-  }));
-};
 
 export const FrequencySearchInput = ({ ...props }) => {
   const { getTranslation } = useTranslation();
   const { getSetting } = useSettings();
   const frequenciesEnabled = getSetting(`medications.frequenciesEnabled`);
 
-  const translatedFrequencySynonyms = getTranslatedFrequencySynonyms(frequenciesEnabled, getTranslation);
+  const frequencySuggestions = Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS)
+    .filter(([frequency]) => frequenciesEnabled?.[frequency])
+    .map(([frequency, synonyms]) => {
+      const translatedLabel = getTranslation(
+        `medication.frequency.${camelCase(frequency)}.label`,
+        frequency,
+      );
 
-  const frequencySuggestions = getFrequencySuggestions(translatedFrequencySynonyms);
+      const translatedSynonyms = synonyms.map((synonym, index) =>
+        getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, synonym),
+      );
+
+      return {
+        value: frequency,
+        label: `${translatedLabel} (${translatedSynonyms[0]})`,
+        synonyms: translatedSynonyms,
+      };
+    });
   const frequencySuggester = new FrequencySuggester(frequencySuggestions);
 
   return (

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -687,6 +687,7 @@ export const MedicationForm = ({
   }, [awaitingPrint, submittedMedication]);
 
   const onSubmit = async data => {
+    console.log('data', data);
     const defaultIdealTimes = frequenciesAdministrationIdealTimes?.[data.frequency];
     if (!isOneTimeFrequency(data.frequency) && data.timeSlots.length < defaultIdealTimes?.length) {
       setIdealTimesErrorOpen(true);

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -687,7 +687,6 @@ export const MedicationForm = ({
   }, [awaitingPrint, submittedMedication]);
 
   const onSubmit = async data => {
-    console.log('data', data);
     const defaultIdealTimes = frequenciesAdministrationIdealTimes?.[data.frequency];
     if (!isOneTimeFrequency(data.frequency) && data.timeSlots.length < defaultIdealTimes?.length) {
       setIdealTimesErrorOpen(true);

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -45,25 +45,6 @@ export const getMedicationLabelData = ({ items, patient, facility }) => {
   }));
 };
 
-export const getTranslatedFrequencySynonyms = (frequenciesEnabled, getTranslation) => {
-  const result = {};
-  Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS).forEach(([frequency, synonyms]) => {
-    if (!frequenciesEnabled?.[frequency]) return;
-    const translatedLabel = getTranslation(
-      `medication.frequency.${camelCase(frequency)}.label`,
-      frequency,
-    );
-
-    const translatedSynonyms = synonyms.map((synonym, index) =>
-      getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, synonym),
-    );
-
-    result[frequency] = { label: translatedLabel, synonyms: translatedSynonyms };
-  });
-
-  return result;
-};
-
 export const getTranslatedFrequencySynonym = (synonyms, index, getTranslation) => {
   const frequency = synonyms[index];
   return getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, frequency);

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import {
-  ADMINISTRATION_FREQUENCY_SYNONYMS,
   DRUG_STOCK_STATUS_LABELS,
   DRUG_STOCK_STATUSES,
 } from '@tamanu/constants';

--- a/packages/web/app/utils/medications.jsx
+++ b/packages/web/app/utils/medications.jsx
@@ -49,7 +49,7 @@ export const getTranslatedFrequencySynonyms = (frequenciesEnabled, getTranslatio
   const result = {};
   Object.entries(ADMINISTRATION_FREQUENCY_SYNONYMS).forEach(([frequency, synonyms]) => {
     if (!frequenciesEnabled?.[frequency]) return;
-    const labelKey = getTranslation(
+    const translatedLabel = getTranslation(
       `medication.frequency.${camelCase(frequency)}.label`,
       frequency,
     );
@@ -58,7 +58,7 @@ export const getTranslatedFrequencySynonyms = (frequenciesEnabled, getTranslatio
       getTranslation(`medication.frequency.${camelCase(frequency)}.synonym.${index}`, synonym),
     );
 
-    result[labelKey] = translatedSynonyms;
+    result[frequency] = { label: translatedLabel, synonyms: translatedSynonyms };
   });
 
   return result;


### PR DESCRIPTION
### Changes
Frequency search/autocomplete on **mobile** (`FrequencySearchField`) and **web** (`FrequencySearchInput`) now builds suggestions directly from `ADMINISTRATION_FREQUENCY_SYNONYMS`, using the *canonical frequency key* as the `value` and translating only the displayed `label`/`synonyms`.

Removes the intermediate `getTranslatedFrequencySynonyms`/`getFrequencySuggestions` utilities from mobile `medicationHelpers.ts` and web `utils/medications.jsx`, consolidating suggestion construction at the call sites and relying on `medications.frequenciesEnabled` to filter available options.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect medication frequency selection and how stored values map to UI labels; incorrect filtering or translation keys could lead to missing options or mismatched selections across locales.
> 
> **Overview**
> Frequency search/autocomplete on **mobile** (`FrequencySearchField`) and **web** (`FrequencySearchInput`) now builds suggestion lists directly from `ADMINISTRATION_FREQUENCY_SYNONYMS`, using the canonical frequency key as `value` while translating only the displayed `label` and `synonyms`.
> 
> The intermediate translation/suggestion helper functions have been removed from `mobile/ui/helpers/medicationHelpers.ts` and `web/utils/medications.jsx`, consolidating this logic at the call sites and filtering options via `medications.frequenciesEnabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2adf8c6696e229d424583a367bd01c83cfffdb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->