### PR TITLE
FHIR jobs resource index

### DIFF
--- a/packages/database/src/migrations/1771203955260-addIndexToFhirJobsResourceColumn.ts
+++ b/packages/database/src/migrations/1771203955260-addIndexToFhirJobsResourceColumn.ts
@@ -1,0 +1,14 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    CREATE INDEX job_payload_resource_idx ON fhir.jobs
+    USING btree ((payload->>'resource'))
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    DROP INDEX IF EXISTS fhir.job_payload_resource_idx
+  `);
+}

--- a/packages/database/src/migrations/1771203955260-addIndexToFhirJobsResourceColumn.ts
+++ b/packages/database/src/migrations/1771203955260-addIndexToFhirJobsResourceColumn.ts
@@ -2,7 +2,7 @@ import { QueryInterface } from 'sequelize';
 
 export async function up(query: QueryInterface): Promise<void> {
   await query.sequelize.query(`
-    CREATE INDEX job_payload_resource_idx ON fhir.jobs
+    CREATE INDEX IF NOT EXISTS job_payload_resource_idx ON fhir.jobs
     USING btree ((payload->>'resource'))
   `);
 }


### PR DESCRIPTION
### Changes

Adds a database migration to create a B-tree index on the `payload->>'resource'` column of the `fhir.jobs` table. This improves query performance when filtering or grouping FHIR jobs by resource type.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- [ ] ...write or update tests
- [ ] ...add UI screenshots and **testing notes** to the Linear issue
- [ ] ...add any **manual upgrade steps** to the Linear issue
- [ ] ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- [ ] ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [COOL-43](https://linear.app/bes/issue/COOL-43/add-index-to-resource-column-of-fhir-jobs-table)

<p><a href="https://cursor.com/background-agent?bcId=bc-c2ef6d02-167b-47f7-95d9-a1a73649350b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2ef6d02-167b-47f7-95d9-a1a73649350b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: migration-only change that adds/drops an index; primary concern is potential lock/time to build the index on large `fhir.jobs` tables during deployment.
> 
> **Overview**
> Adds a new database migration that creates a B-tree expression index `job_payload_resource_idx` on `fhir.jobs` for `(payload->>'resource')`, improving performance for queries that filter/group jobs by resource type.
> 
> Includes a rollback that drops the index (`DROP INDEX IF EXISTS fhir.job_payload_resource_idx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fba92d2d6483f074a5a9f6eb536452bc6614f588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->