### PR TITLE
Survey selector search logic

### DIFF
--- a/INVESTIGATION_NOTES.md
+++ b/INVESTIGATION_NOTES.md
@@ -1,0 +1,74 @@
+# COOL-35: SurveySelector Search Logic Investigation
+
+## Problem
+PR #8783 made all SelectInput fields searchable by setting `isSearchable={true}`. This broke SurveySelector and potentially other select fields that use JSX elements (like `<TranslatedReferenceData>`) as option labels, because react-select cannot extract searchable text from JSX elements.
+
+## Solution Implemented
+
+### Backend Changes
+**File: `packages/shared/src/services/suggestions/suggestions.js`**
+- Extended the survey suggester to support `surveyType` filtering parameter
+- Now supports both `programId` and `surveyType` query parameters
+- This enables proper server-side translation handling
+
+### Frontend Changes
+
+**File: `packages/web/app/views/programs/SurveySelector.jsx`**
+- Replaced `SelectInput` with `DynamicSelectField`
+- Now accepts a `suggester` prop instead of `surveys` array
+- Removed dependency on manually fetched and mapped survey data
+- Added support for optional `label` prop
+
+**File: `packages/web/app/views/programs/ProgramsView.jsx`**
+- Added `useSuggester` hook to create a survey suggester with `programId` filter
+- Removed manual API call to fetch surveys (`/program/${programId}/surveys`)
+- Removed manual mapping of surveys with TranslatedReferenceData labels
+- Simplified `selectProgram` callback (no longer needs to fetch surveys)
+- Updated SurveySelector usage to pass suggester instead of surveys array
+
+**File: `packages/web/app/views/referrals/ReferralsView.jsx`**
+- Added `useSuggester` hook to create a survey suggester with `surveyType: REFERRAL` filter
+- Removed manual API call to fetch referral surveys
+- Removed manual mapping of survey options
+- Updated SurveySelector usage to pass suggester instead of surveys array
+
+## Benefits
+1. **Proper Translation Support**: Server-side translation handling via suggester API
+2. **Searchable Surveys**: Users can now search surveys by translated names
+3. **Consistent Pattern**: Using the same suggester pattern as other fields
+4. **Reduced Code**: Eliminated manual API calls and data mapping
+5. **Better UX**: Automatic switching between dropdown and autocomplete based on list size
+
+## Other Select Fields with Potential Issues
+
+### 1. Program Selector in ProgramsView.jsx (Line 154-169)
+**Status**: ⚠️ Potential Issue
+**Description**: Uses `SelectInput` with `TranslatedReferenceData` labels
+```javascript
+options={programs.map(p => ({
+  value: p.id,
+  label: <TranslatedReferenceData category="program" value={p.id} fallback={p.name} />,
+}))}
+```
+**Severity**: Low - Programs are typically a small list (< 10 items), so search functionality may not be critical
+**Recommendation**: Monitor for user complaints. If needed, create a program suggester endpoint.
+
+### 2. Other Fields Investigated
+- **PatientProgramRegistrationSelectSurvey.jsx**: ✅ OK - Uses plain string labels (`x.name`)
+- **UserProfileModal.jsx**: ✅ OK - Only 2 status options (Active/Deactivated)
+- **ReportGeneratorForm.jsx**: ✅ OK - Uses plain string labels
+- Various other SelectFields with TranslatedText in labels were found but are for menu options (buttons), not searchable dropdowns
+
+## Testing Recommendations
+1. Test survey selection in Programs tab with translated UI language
+2. Test referral survey selection with translated UI language
+3. Verify search functionality works with translated survey names
+4. Test with both small (< 7) and large (> 7) survey lists
+5. Verify program selector still works (though search may not work with translations)
+
+## Migration Notes
+- The SurveySelector component API has changed:
+  - Old: `<SurveySelector surveys={array} ... />`
+  - New: `<SurveySelector suggester={suggesterInstance} ... />`
+- Any other components using SurveySelector will need to be updated
+- The backend suggester now supports filtering by `surveyType` in addition to `programId`

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -723,13 +723,23 @@ createNameSuggester('bookableLocationGroup', 'LocationGroup', ({ endpoint, model
       }),
 }));
 
-createNameSuggester('survey', 'Survey', ({ search, query: { programId } }) => ({
-  name: { [Op.iLike]: search },
-  ...(programId ? { programId } : programId),
-  surveyType: {
-    [Op.notIn]: [SURVEY_TYPES.OBSOLETE, SURVEY_TYPES.VITALS],
-  },
-}));
+createNameSuggester('survey', 'Survey', ({ search, query: { programId, surveyType } }) => {
+  const where = {
+    name: { [Op.iLike]: search },
+    ...(programId ? { programId } : {}),
+  };
+
+  // If surveyType is provided, use it; otherwise exclude obsolete and vitals
+  if (surveyType) {
+    where.surveyType = surveyType;
+  } else {
+    where.surveyType = {
+      [Op.notIn]: [SURVEY_TYPES.OBSOLETE, SURVEY_TYPES.VITALS],
+    };
+  }
+
+  return where;
+});
 
 createSuggester(
   'practitioner',

--- a/packages/web/app/views/programs/SurveySelector.jsx
+++ b/packages/web/app/views/programs/SurveySelector.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { SelectInput, Button, TextButton, ButtonRow } from '@tamanu/ui-components';
+import { Button, TextButton, ButtonRow } from '@tamanu/ui-components';
 import { SendFormToPatientPortalModal } from '../patients/components/SendFormToPatientPortalModal';
-import { TranslatedText } from '../../components';
+import { TranslatedText, DynamicSelectField } from '../../components';
 import { SendIcon } from '../../components/Icons/SendIcon';
 import { useSettings } from '../../contexts/Settings';
 import { useAuth } from '../../contexts/Auth.jsx';
@@ -42,41 +42,46 @@ const SendFormToPatientPortalModalButton = ({ setOpen, isDisabled }) => {
   );
 };
 
-export const SurveySelector = React.memo(({ value, onChange, onSubmit, surveys, buttonText }) => {
-  const [open, setOpen] = useState(false);
+export const SurveySelector = React.memo(
+  ({ value, onChange, onSubmit, suggester, buttonText, label }) => {
+    const [open, setOpen] = useState(false);
 
-  const handleChange = event => {
-    const surveyId = event.target.value;
-    onChange(surveyId);
-  };
+    const handleChange = event => {
+      const surveyId = event.target.value;
+      onChange(surveyId);
+    };
 
-  const handleSubmit = () => {
-    onSubmit(value);
-  };
+    const handleSubmit = () => {
+      onSubmit(value);
+    };
 
-  return (
-    <>
-      <SelectInput
-        name="survey"
-        options={surveys}
-        value={value ?? ''}
-        onChange={handleChange}
-        data-testid="selectinput-4g3c"
-      />
-      <StyledButtonRow data-testid="styledbuttonrow-nem0">
-        <SendFormToPatientPortalModalButton setOpen={setOpen} isDisabled={!value} />
-        <Button
-          onClick={handleSubmit}
-          disabled={!value}
-          variant="contained"
-          color="primary"
-          data-testid="button-qsbg"
-          style={{ marginLeft: 'auto' }}
-        >
-          {buttonText}
-        </Button>
-      </StyledButtonRow>
-      <SendFormToPatientPortalModal formId={value} open={open} setOpen={setOpen} />
-    </>
-  );
-});
+    return (
+      <>
+        <DynamicSelectField
+          field={{
+            name: 'survey',
+            value: value ?? '',
+            onChange: handleChange,
+          }}
+          suggester={suggester}
+          label={label}
+          data-testid="selectinput-4g3c"
+        />
+        <StyledButtonRow data-testid="styledbuttonrow-nem0">
+          <SendFormToPatientPortalModalButton setOpen={setOpen} isDisabled={!value} />
+          <Button
+            onClick={handleSubmit}
+            disabled={!value}
+            variant="contained"
+            color="primary"
+            data-testid="button-qsbg"
+            style={{ marginLeft: 'auto' }}
+          >
+            {buttonText}
+          </Button>
+        </StyledButtonRow>
+        <SendFormToPatientPortalModal formId={value} open={open} setOpen={setOpen} />
+      </>
+    );
+  },
+);

--- a/packages/web/app/views/referrals/ReferralsView.jsx
+++ b/packages/web/app/views/referrals/ReferralsView.jsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { SURVEY_TYPES } from '@tamanu/constants';
-import { getAnswersFromData, FormGrid } from '@tamanu/ui-components';
+import { getAnswersFromData, FormGrid, useSuggester } from '@tamanu/ui-components';
 
 import { useApi } from '../../api';
 import { reloadPatient } from '../../store/patient';
@@ -24,16 +24,15 @@ const ReferralFlow = ({ patient, currentUser }) => {
   const { facilityId } = useAuth();
   const { navigateToPatient } = usePatientNavigation();
   const [referralSurvey, setReferralSurvey] = useState(null);
-  const [referralSurveys, setReferralSurveys] = useState(null);
   const [selectedSurveyId, setSelectedSurveyId] = useState(null);
   const [startTime, setStartTime] = useState(null);
 
-  useEffect(() => {
-    (async () => {
-      const response = await api.get(`survey`, { type: SURVEY_TYPES.REFERRAL });
-      setReferralSurveys(response.surveys.map(x => ({ value: x.id, label: x.name })));
-    })();
-  }, [api]);
+  // Create a suggester for referral surveys
+  const referralSurveySuggester = useSuggester('survey', {
+    baseQueryParameters: {
+      surveyType: SURVEY_TYPES.REFERRAL,
+    },
+  });
 
   const setSelectedReferral = useCallback(
     async id => {
@@ -90,7 +89,7 @@ const ReferralFlow = ({ patient, currentUser }) => {
             onSubmit={setSelectedReferral}
             onChange={setSelectedSurveyId}
             value={selectedSurveyId}
-            surveys={referralSurveys}
+            suggester={referralSurveySuggester}
             buttonText={
               <TranslatedText
                 stringId="referral.action.begin"


### PR DESCRIPTION
### Changes

This PR fixes the broken search logic for `SurveySelector` by refactoring it to use `DynamicSelectField` with a backend suggester.

Specifically:
*   **Backend:** Extended the survey suggester to support `surveyType` filtering.
*   **Frontend:**
    *   `SurveySelector` now uses `DynamicSelectField` and the updated survey suggester.
    *   `ProgramsView` and `ReferralsView` were updated to use the new suggester pattern for fetching surveys.

This ensures search functionality works correctly with translations and aligns with modern form field implementations.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [COOL-35](https://linear.app/bes/issue/COOL-35/fix-search-logic-for-surveyselector)

<p><a href="https://cursor.com/background-agent?bcId=bc-fee902b8-fe1e-4c30-9ad8-c96b4617ba35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fee902b8-fe1e-4c30-9ad8-c96b4617ba35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared suggester query logic and changes `SurveySelector` props/behavior, which can impact survey/referral flows if filtering or option loading differs from the previous manual fetch.
> 
> **Overview**
> Fixes broken survey search (especially with translated/JSX labels) by moving survey selection to the suggester-driven `DynamicSelectField`.
> 
> Backend `survey` suggester now accepts an optional `surveyType` filter (otherwise continues excluding obsolete/vitals). Frontend updates `SurveySelector` API from `surveys` to `suggester`, and refactors `ProgramsView` and `ReferralsView` to use `useSuggester` instead of manually fetching/mapping survey option lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c89269d7346405892c8f6359b763213ca91dc26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->