### PR TITLE
fix(sync): COOL-36: Prevent duplicate patient_ongoing_prescriptions when an encounter is discharged on facility and central

### DIFF
--- a/database/model/public/patient_ongoing_prescriptions.yml
+++ b/database/model/public/patient_ongoing_prescriptions.yml
@@ -16,7 +16,7 @@ sources:
               - set_patient_ongoing_prescriptions_updated_at_sync_tick
         columns:
           - name: id
-            data_type: uuid
+            data_type: text
             description: "{{ doc('generic__id') }} in patient_ongoing_prescriptions."
             data_tests:
               - unique

--- a/packages/central-server/__tests__/sync/CentralSyncManager.edgeCases.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.edgeCases.test.js
@@ -1,8 +1,17 @@
+import { sub } from 'date-fns';
 import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
 import { SYNC_SESSION_DIRECTION } from '@tamanu/database/sync';
-import { fake } from '@tamanu/fake-data/fake';
-import { APPOINTMENT_STATUSES, REPEAT_FREQUENCY, SYSTEM_USER_UUID } from '@tamanu/constants';
+import { fake, fakeUser } from '@tamanu/fake-data/fake';
+import {
+  APPOINTMENT_STATUSES,
+  NOTE_TYPES,
+  REFERENCE_TYPES,
+  REPEAT_FREQUENCY,
+  SYSTEM_USER_UUID,
+} from '@tamanu/constants';
 import { settingsCache } from '@tamanu/settings';
+import { ENCOUNTER_TYPES } from '@tamanu/constants/encounters';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 
 import {
   createTestContext,
@@ -10,6 +19,7 @@ import {
   waitForPushCompleted,
   initializeCentralSyncManagerWithContext,
 } from '../utilities';
+import { OutpatientDischarger } from '../../dist/tasks/OutpatientDischarger';
 
 describe('CentralSyncManager Edge Cases', () => {
   let ctx;
@@ -28,6 +38,14 @@ describe('CentralSyncManager Edge Cases', () => {
     await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, 2);
     await models.SyncLookupTick.truncate({ force: true });
     await models.SyncDeviceTick.truncate({ force: true });
+    await models.PatientOngoingPrescription.truncate({ cascade: true, force: true });
+    await models.EncounterPrescription.truncate({ cascade: true, force: true });
+    await models.Prescription.truncate({ cascade: true, force: true });
+    await models.Encounter.truncate({ cascade: true, force: true });
+    await models.Location.truncate({ cascade: true, force: true });
+    await models.Department.truncate({ cascade: true, force: true });
+    await models.PatientFacility.truncate({ cascade: true, force: true });
+    await models.Patient.truncate({ cascade: true, force: true });
     await models.Facility.truncate({ cascade: true, force: true });
     await models.ReferenceData.truncate({ cascade: true, force: true });
     await models.User.truncate({ cascade: true, force: true });
@@ -202,6 +220,147 @@ describe('CentralSyncManager Edge Cases', () => {
           }),
         ]),
       );
+    });
+  });
+
+  describe('deterministic patient ongoing prescription id', () => {
+    it('results in a single patient ongoing prescription and a valid sync_lookup when the same encounter is manually discharged on facility and auto-discharged on central then facility syncs', async () => {
+      const CURRENT_SYNC_TICK = '20';
+      await models.LocalSystemFact.set(FACT_CURRENT_SYNC_TICK, CURRENT_SYNC_TICK);
+
+      const facility = await models.Facility.create(fake(models.Facility));
+      const patient = await models.Patient.create(fake(models.Patient));
+      await models.PatientFacility.create({
+        patientId: patient.id,
+        facilityId: facility.id,
+      });
+      const examiner = await models.User.create(fakeUser());
+      const department = await models.Department.create({
+        ...fake(models.Department),
+        facilityId: facility.id,
+      });
+      const location = await models.Location.create({
+        ...fake(models.Location),
+        facilityId: facility.id,
+      });
+      const medicationReference = await models.ReferenceData.create(
+        fake(models.ReferenceData, { type: 'drug' }),
+      );
+
+      await models.ReferenceData.create({
+        id: NOTE_TYPES.SYSTEM,
+        code: 'system',
+        name: 'System',
+        type: REFERENCE_TYPES.NOTE_TYPE,
+        visibilityStatus: 'current',
+        systemRequired: true,
+      });
+
+      const encounter = await models.Encounter.create({
+        ...fake(models.Encounter, {
+          patientId: patient.id,
+          departmentId: department.id,
+          locationId: location.id,
+          examinerId: examiner.id,
+          encounterType: ENCOUNTER_TYPES.CLINIC,
+          startDate: toDateTimeString(sub(new Date(), { days: 2 })),
+          endDate: null,
+        }),
+      });
+
+      const prescription = await models.Prescription.create(
+        fake(models.Prescription, {
+          medicationId: medicationReference.id,
+          isOngoing: true,
+          discontinued: false,
+        }),
+      );
+
+      await models.EncounterPrescription.create({
+        ...fake(models.EncounterPrescription, {
+          encounterId: encounter.id,
+          prescriptionId: prescription.id,
+        }),
+      });
+
+      // Central auto-discharger runs and creates PatientOngoingPrescription
+      const discharger = new OutpatientDischarger(ctx, {
+        schedule: '',
+        suppressInitialRun: true,
+        batchSleepAsyncDurationInMilliseconds: 1,
+      });
+      await discharger.run();
+
+      const centralCreatedPop = await models.PatientOngoingPrescription.findOne({
+        where: { patientId: patient.id, prescriptionId: prescription.id },
+      });
+      expect(centralCreatedPop).not.toBeNull();
+
+      // Facility would have the same deterministic id when it manually discharged. Use the
+      // same formula as the DB so that without deterministic ids (central has random id)
+      // we send a different id and get two rows → test fails.
+      const deterministicId = `${patient.id.replace(/;/g, ':')};${prescription.id.replace(/;/g, ':')}`;
+
+      const facilityChangePayload = {
+        ...centralCreatedPop.get({ plain: true }),
+        id: deterministicId,
+        updatedAtSyncTick: parseInt(CURRENT_SYNC_TICK, 10),
+      };
+      const changes = [
+        {
+          direction: SYNC_SESSION_DIRECTION.OUTGOING,
+          isDeleted: false,
+          recordType: 'patient_ongoing_prescriptions',
+          recordId: deterministicId,
+          data: facilityChangePayload,
+        },
+      ];
+
+      const centralSyncManager = initializeCentralSyncManager({
+        sync: {
+          lookupTable: {
+            enabled: true,
+          },
+          maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
+        },
+      });
+      await centralSyncManager.updateLookupTable();
+      const { sessionId } = await centralSyncManager.startSession();
+      await waitForSession(centralSyncManager, sessionId);
+
+      await centralSyncManager.setupSnapshotForPull(
+        sessionId,
+        {
+          since: 1,
+          facilityIds: [facility.id],
+        },
+        () => true,
+      );
+
+      await centralSyncManager.addIncomingChanges(sessionId, changes);
+      await centralSyncManager.completePush(sessionId, facility.id, [
+        'patient_ongoing_prescriptions',
+      ]);
+      await waitForPushCompleted(centralSyncManager, sessionId);
+
+      const count = await models.PatientOngoingPrescription.count({
+        where: { patientId: patient.id, prescriptionId: prescription.id },
+      });
+      expect(count).toBe(1);
+
+      // Bump the sync tick on the prescription to trigger a sync lookup update, which would error if there were multiple patient ongoing prescriptions for the same patient and prescription.
+      await prescription.update({
+        updatedAtSyncTick: parseInt(CURRENT_SYNC_TICK, 10),
+      });
+      await expect(centralSyncManager.updateLookupTable()).resolves.not.toThrow();
+
+      const lookupRows = await models.SyncLookup.findAll({
+        where: {
+          recordType: 'patient_ongoing_prescriptions',
+          recordId: deterministicId,
+        },
+      });
+      expect(lookupRows).toHaveLength(1);
     });
   });
 });

--- a/packages/database/src/migrations/1770250000001-makePatientOngoingPrescriptionIdDeterministic.ts
+++ b/packages/database/src/migrations/1770250000001-makePatientOngoingPrescriptionIdDeterministic.ts
@@ -1,0 +1,73 @@
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Deterministic id from (patient_id, prescription_id), same pattern as patient_facilities.
+// REPLACE avoids collisions if ';' appears in ids. Updates logs.changes and sync_lookup so audit and sync stay consistent.
+
+export async function up(query: QueryInterface): Promise<void> {
+  const duplicates = await query.sequelize.query<{
+    patient_id: string;
+    prescription_id: string;
+    count: string;
+  }>(
+    `
+    SELECT patient_id, prescription_id, COUNT(*)::text as count
+    FROM patient_ongoing_prescriptions
+    GROUP BY patient_id, prescription_id
+    HAVING COUNT(*) > 1
+    `,
+    { type: QueryTypes.SELECT },
+  );
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Cannot run migration: found ${duplicates.length} duplicate (patient_id, prescription_id) pair(s) in patient_ongoing_prescriptions. ` +
+        `Clean up duplicates manually before running this migration. Duplicates: ${JSON.stringify(duplicates)}`,
+    );
+  }
+
+  await query.sequelize.query(`
+    ALTER TABLE patient_ongoing_prescriptions
+      ADD COLUMN id_new TEXT GENERATED ALWAYS AS (REPLACE("patient_id", ';', ':') || ';' || REPLACE("prescription_id", ';', ':')) STORED;
+
+    UPDATE logs.changes
+    SET record_id = pop.id_new
+    FROM patient_ongoing_prescriptions pop
+    WHERE logs.changes.record_id = pop.id::text
+      AND logs.changes.table_name = 'patient_ongoing_prescriptions';
+
+    UPDATE logs.changes
+    SET record_data = jsonb_set(record_data, '{id}', to_jsonb(record_id::text))
+    WHERE table_name = 'patient_ongoing_prescriptions'
+      AND record_id != record_data->>'id';
+
+    UPDATE sync_lookup
+    SET record_id = pop.id_new
+    FROM patient_ongoing_prescriptions pop
+    WHERE sync_lookup.record_id = pop.id::text
+      AND sync_lookup.record_type = 'patient_ongoing_prescriptions';
+
+    UPDATE sync_lookup
+    SET data = jsonb_set(data::jsonb, '{id}', to_jsonb(record_id))
+    WHERE record_type = 'patient_ongoing_prescriptions'
+      AND (data::jsonb->>'id') IS DISTINCT FROM record_id;
+
+    ALTER TABLE patient_ongoing_prescriptions DROP CONSTRAINT patient_ongoing_prescriptions_pkey;
+    ALTER TABLE patient_ongoing_prescriptions DROP COLUMN id;
+    ALTER TABLE patient_ongoing_prescriptions RENAME COLUMN id_new TO id;
+    ALTER TABLE patient_ongoing_prescriptions ADD CONSTRAINT patient_ongoing_prescriptions_id_key UNIQUE (id);
+    ALTER TABLE patient_ongoing_prescriptions ALTER COLUMN id SET NOT NULL;
+    ALTER TABLE patient_ongoing_prescriptions ADD PRIMARY KEY (patient_id, prescription_id);
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: Cannot restore original UUID ids or logs.changes record_id values
+  await query.sequelize.query(`
+    ALTER TABLE patient_ongoing_prescriptions DROP CONSTRAINT patient_ongoing_prescriptions_pkey;
+    ALTER TABLE patient_ongoing_prescriptions ADD COLUMN id_old UUID DEFAULT gen_random_uuid();
+    UPDATE patient_ongoing_prescriptions SET id_old = gen_random_uuid();
+    ALTER TABLE patient_ongoing_prescriptions DROP COLUMN id;
+    ALTER TABLE patient_ongoing_prescriptions RENAME COLUMN id_old TO id;
+    ALTER TABLE patient_ongoing_prescriptions ADD PRIMARY KEY (id);
+  `);
+}

--- a/packages/database/src/migrations/1770250000001-makePatientOngoingPrescriptionIdDeterministic.ts
+++ b/packages/database/src/migrations/1770250000001-makePatientOngoingPrescriptionIdDeterministic.ts
@@ -64,10 +64,9 @@ export async function down(query: QueryInterface): Promise<void> {
   // DESTRUCTIVE: Cannot restore original UUID ids or logs.changes record_id values
   await query.sequelize.query(`
     ALTER TABLE patient_ongoing_prescriptions DROP CONSTRAINT patient_ongoing_prescriptions_pkey;
-    ALTER TABLE patient_ongoing_prescriptions ADD COLUMN id_old UUID DEFAULT gen_random_uuid();
-    UPDATE patient_ongoing_prescriptions SET id_old = gen_random_uuid();
+    ALTER TABLE patient_ongoing_prescriptions DROP CONSTRAINT patient_ongoing_prescriptions_id_key;
     ALTER TABLE patient_ongoing_prescriptions DROP COLUMN id;
-    ALTER TABLE patient_ongoing_prescriptions RENAME COLUMN id_old TO id;
+    ALTER TABLE patient_ongoing_prescriptions ADD COLUMN id UUID NOT NULL DEFAULT gen_random_uuid();
     ALTER TABLE patient_ongoing_prescriptions ADD PRIMARY KEY (id);
   `);
 }

--- a/packages/database/src/migrations/1770250000001-makePatientOngoingPrescriptionIdDeterministic.ts
+++ b/packages/database/src/migrations/1770250000001-makePatientOngoingPrescriptionIdDeterministic.ts
@@ -55,12 +55,18 @@ export async function up(query: QueryInterface): Promise<void> {
 }
 
 export async function down(query: QueryInterface): Promise<void> {
-  // DESTRUCTIVE: Cannot restore original UUID ids or logs.changes record_id values
+  // Revert to primary key on id. Id stays TEXT (existing deterministic values unchanged); default gen_random_uuid() for new rows.
+  // logs.changes and sync_lookup are unchanged.
   await query.sequelize.query(`
+    ALTER TABLE patient_ongoing_prescriptions
+      ADD COLUMN id_new TEXT NOT NULL DEFAULT gen_random_uuid()::text;
+
+    UPDATE patient_ongoing_prescriptions SET id_new = id;
+
     ALTER TABLE patient_ongoing_prescriptions DROP CONSTRAINT patient_ongoing_prescriptions_pkey;
     ALTER TABLE patient_ongoing_prescriptions DROP CONSTRAINT patient_ongoing_prescriptions_id_key;
     ALTER TABLE patient_ongoing_prescriptions DROP COLUMN id;
-    ALTER TABLE patient_ongoing_prescriptions ADD COLUMN id UUID NOT NULL DEFAULT gen_random_uuid();
+    ALTER TABLE patient_ongoing_prescriptions RENAME COLUMN id_new TO id;
     ALTER TABLE patient_ongoing_prescriptions ADD PRIMARY KEY (id);
   `);
 }


### PR DESCRIPTION
### Changes

This is a common enough bug, as if sync is failing for some reason encounters often get discharged both on central by the automatic discharger, and on the facility manually. If discharge prescriptions were created, duplicates end up in the system which ends up breaking the logic to build the sync lookup table.

There's a few ways we could resolve this, but I like making the ids deterministic as its an established pattern for merging sync records, and also ensures that we now have a constraint to prevent multiple pops for the same patient/prescription. 

This does however require changing the id of live records. I've added logic to fix up the audit logs, and the sync lookup table, but still a little wary of this.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
