### PR TITLE
UserFacility importer ID type

### DIFF
--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -45,6 +45,10 @@ const existingRecordLoaders = {
     UD.findOne({ where: { userId, designationId }, paranoid: false }),
   UserFacility: (UF, { userId, facilityId }) =>
     UF.findOne({ where: { userId, facilityId }, paranoid: false }),
+  // TODO: COOL-44 - Add existingRecordLoader for LabTestPanelLabTestTypes
+  // Once the ID generation is fixed in loaders.js, add this loader to handle composite key lookups:
+  // LabTestPanelLabTestTypes: (LTPLT, { labTestPanelId, labTestTypeId }) =>
+  //   LTPLT.findOne({ where: { labTestPanelId, labTestTypeId }, paranoid: false }),
   ReferenceDrugFacility: (RDF, { referenceDrugId, facilityId }) =>
     RDF.findOne({ where: { referenceDrugId, facilityId }, paranoid: false }),
   ProcedureTypeSurvey: async (Model, values) => {

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -318,6 +318,10 @@ export function labTestPanelLoader(item) {
       rows.push({
         model: 'LabTestPanelLabTestTypes',
         values: {
+          // TODO: COOL-44 - Remove this manually-set ID to let the database generate UUIDv4
+          // The ID should not be set here as the database has a default UUIDv4 generator.
+          // Also need to add an existingRecordLoader in importRows.js for LabTestPanelLabTestTypes
+          // that looks up records by labTestPanelId and labTestTypeId (similar to UserFacility).
           id: `${id};${testType}`,
           labTestPanelId: id,
           labTestTypeId: testType,
@@ -398,6 +402,10 @@ export async function userLoader(item, { models, pushError }) {
       rows.push({
         model: 'UserFacility',
         values: {
+          // TODO: COOL-44 - Remove this manually-set ID to let the database generate UUIDv4
+          // The ID should not be set here as the database has a default UUIDv4 generator.
+          // The existingRecordLoader in importRows.js already handles finding existing records
+          // by userId and facilityId, so this composite key format is unnecessary and incorrect.
           id: `${id};${facilityId}`,
           userId: id,
           facilityId: facilityId,
@@ -411,6 +419,10 @@ export async function userLoader(item, { models, pushError }) {
     rows.push({
       model: 'UserFacility',
       values: {
+        // TODO: COOL-44 - Remove this manually-set ID to let the database generate UUIDv4
+        // The ID should not be set here as the database has a default UUIDv4 generator.
+        // The existingRecordLoader in importRows.js already handles finding existing records
+        // by userId and facilityId, so this composite key format is unnecessary and incorrect.
         id: `${id};${facilityId}`,
         userId: id,
         facilityId: facilityId,


### PR DESCRIPTION
### Changes

This PR introduces TODO comments to highlight areas that need to be addressed to resolve COOL-44. The comments identify:

*   Instances where `UserFacility` and `LabTestPanelLabTestTypes` IDs are manually set as composite keys (`user_id;facility_id` or `labTestPanelId;labTestTypeId`) instead of allowing the database to generate UUIDv4s.
*   A missing `existingRecordLoader` for `LabTestPanelLabTestTypes` to correctly handle composite key lookups.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [COOL-44](https://linear.app/bes/issue/COOL-44/userfacility-reference-data-importer-sets-user-idfacility-id-as-id)

<p><a href="https://cursor.com/background-agent?bcId=bc-32531447-355c-4414-b3af-08fa9e7ee7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32531447-355c-4414-b3af-08fa9e7ee7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that don’t alter runtime behavior; risk is limited to potential confusion if TODO guidance is misinterpreted later.
> 
> **Overview**
> Adds **TODOs for COOL-44** calling out that reference-data importer loaders are manually setting composite `id` values for `UserFacility` and `LabTestPanelLabTestTypes` instead of relying on DB-generated UUIDv4s.
> 
> Also annotates `importRows.js` to add a future `existingRecordLoader` for `LabTestPanelLabTestTypes` to find existing rows via `(labTestPanelId, labTestTypeId)` once ID generation is corrected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daff29ab7fa57d0b5719d43ca97a5b688800875b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->