### PR TITLE
fix(sync): COOL-38: Prevent exceeding maxConcurrentSyncSessions when multiple syncs are requested at the same time

### DIFF
--- a/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
+++ b/packages/central-server/__tests__/sync/SyncQueuedDevice.test.js
@@ -236,7 +236,7 @@ const MAX_CONCURRENT_SESSIONS = 1;
       try {
         const results = await Promise.all(
           sessions.map(async (device, index) => {
-            await sleepAsync(10 + index * 500);
+            await sleepAsync((index + 1) * 500);
             const result = await requestSyncUnchecked(device);
             flagSessionAttempted(); // If request has completed, we need to flag that we've attempted the session
             return result;

--- a/packages/central-server/app/sync/buildSyncRoutes.js
+++ b/packages/central-server/app/sync/buildSyncRoutes.js
@@ -119,7 +119,6 @@ export const buildSyncRoutes = ctx => {
         return;
       }
 
-      let result;
       try {
         // remove our place in the queue before starting sync
         // (if the resulting sync has an error, we'll be knocked to the back of the queue
@@ -128,18 +127,16 @@ export const buildSyncRoutes = ctx => {
         // lastSyncedTick)
         await queueRecord.destroy();
 
-        result = await syncManager.startSession({
+        const { sessionId, tick } = await syncManager.startSession({
           userId: user.id,
           deviceId: device.id,
           facilityIds,
           isMobile,
         });
+
+        res.json({ status: 'goodToGo', sessionId, tick });
       } finally {
         await releaseCreateSessionLock();
-      }
-
-      if (result) {
-        res.json({ status: 'goodToGo', sessionId: result.sessionId, tick: result.tick });
       }
     }),
   );

--- a/packages/central-server/app/sync/buildSyncRoutes.js
+++ b/packages/central-server/app/sync/buildSyncRoutes.js
@@ -112,10 +112,9 @@ export const buildSyncRoutes = ctx => {
         return;
       }
 
-      // Grab create-session lock, and startSession in a single transaction so we don't race with other devices
-      const safeToCreateSession = await syncManager.takeCreateSessionLock();
-      if (!safeToCreateSession) {
-        // Another session is already creating, so we're not allowed to create one
+      const releaseCreateSessionLock = await syncManager.takeCreateSessionLock();
+      if (!releaseCreateSessionLock) {
+        // Couldn't acquire lock, another session is being created
         res.send({ status: 'activeSync' });
         return;
       }
@@ -136,7 +135,7 @@ export const buildSyncRoutes = ctx => {
           isMobile,
         });
       } finally {
-        await syncManager.releaseCreateSessionLock();
+        await releaseCreateSessionLock();
       }
 
       if (result) {

--- a/packages/shared/src/utils/index.js
+++ b/packages/shared/src/utils/index.js
@@ -3,6 +3,7 @@ export * from './getMetaServerHosts';
 export * from './getPatientAdditionalData';
 export * from './getPatientSurveyResponseAnswer';
 export * from './getResponseJsonSafely';
+export * from './stringToStableInteger';
 export * from './uuidToFairlyUniqueInteger';
 export * from './patientCertificates';
 export * from './patientAccessors';

--- a/packages/shared/src/utils/stringToStableInteger.js
+++ b/packages/shared/src/utils/stringToStableInteger.js
@@ -7,4 +7,4 @@ import crypto from 'crypto';
  * @returns {number}
  */
 export const stringToStableInteger = text =>
-  Number(`0x${crypto.createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 12)}`);
+  crypto.createHash('sha256').update(text, 'utf8').digest().subarray(-6).readUIntBE(0, 6);

--- a/packages/shared/src/utils/stringToStableInteger.js
+++ b/packages/shared/src/utils/stringToStableInteger.js
@@ -1,0 +1,10 @@
+import crypto from 'crypto';
+
+/**
+ * Maps a string to a stable integer (e.g. for PostgreSQL advisory lock keys).
+ * Stays within JS safe integer range. Same string always yields the same number.
+ * @param {string} text
+ * @returns {number}
+ */
+export const stringToStableInteger = text =>
+  Number(`0x${crypto.createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 12)}`);


### PR DESCRIPTION
### Changes

Decided to go with the approach here of adding an `advisory lock` that guards creating a sync session, so that only a single sync session can be created at once. We use the number of sync sessions to determine if we've hit the limit, so if we ensure we take the lock before, and only release once we've created the session, we should never be able to exceed the limit.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
