### PR TITLE
fix(invoicing): SAV-1097: Prevent user from removing insurance plan from patient details if it is being used for an invoice

### DIFF
--- a/packages/database/src/migrations/1769038631127-addPatientInvoiceInsurancePlanTable.ts
+++ b/packages/database/src/migrations/1769038631127-addPatientInvoiceInsurancePlanTable.ts
@@ -38,10 +38,11 @@ export async function up(query: QueryInterface): Promise<void> {
     name: `idx_patient_invoice_insurance_plans_patient_id`,
   });
 
-  await query.addIndex('patient_invoice_insurance_plans', ['patient_id', 'invoice_insurance_plan_id'], {
-    name: `idx_patient_invoice_insurance_plans_patient_id_invoice_insurance_plan_id`,
-    unique: true,
-  });
+  await query.sequelize.query(`
+    CREATE UNIQUE INDEX idx_patient_invoice_insurance_plans_patient_id_invoice_insurance_plan_id
+    ON patient_invoice_insurance_plans (patient_id, invoice_insurance_plan_id)
+    WHERE deleted_at IS NULL;
+  `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {

--- a/packages/database/src/models/PatientInvoiceInsurancePlan.ts
+++ b/packages/database/src/models/PatientInvoiceInsurancePlan.ts
@@ -34,7 +34,6 @@ export class PatientInvoiceInsurancePlan extends Model {
         syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
         indexes: [
           { fields: ['patientId'] },
-          { unique: true, fields: ['patientId', 'invoiceInsurancePlanId'] },
         ],
       },
     );

--- a/packages/facility-server/__tests__/apiv1/PatientInvoiceInsurancePlan.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientInvoiceInsurancePlan.test.js
@@ -49,7 +49,7 @@ describe('PatientInvoiceInsurancePlan', () => {
   afterAll(() => ctx.close());
 
   beforeEach(async () => {
-    await models.PatientInvoiceInsurancePlan.truncate();
+    await models.PatientInvoiceInsurancePlan.truncate({ force: true });
   });
 
   it('should create new patient invoice insurance plan if it is in the list of insurance plans and not exist before', async () => {

--- a/packages/facility-server/__tests__/apiv1/PatientInvoiceInsurancePlan.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientInvoiceInsurancePlan.test.js
@@ -96,8 +96,8 @@ describe('PatientInvoiceInsurancePlan', () => {
     expect(secondPatientInvoiceInsurancePlans.filter(p => !p.deletedAt).map(p => p.invoiceInsurancePlanId)).toEqual([insurancePlan1.id]);
   });
 
-  it('should restore patient invoice insurance plan if it is in the list of insurance plans and it is previously deleted', async () => {
-    // Create the patient invoice insurance plan
+  it('should create new patient invoice insurance plans when re-adding previously deleted plans', async () => {
+    // Create the patient invoice insurance plans
     const firstUpdateResult = await app.put(`/api/patient/${patient.id}`).send({
       invoiceInsurancePlanId: JSON.stringify([insurancePlan1.id, insurancePlan2.id, insurancePlan3.id]),
       facilityId,
@@ -110,7 +110,7 @@ describe('PatientInvoiceInsurancePlan', () => {
     expect(firstPatientInvoiceInsurancePlans).toHaveLength(3);
     expect(firstPatientInvoiceInsurancePlans.map(p => p.invoiceInsurancePlanId).sort()).toEqual([insurancePlan1.id, insurancePlan2.id, insurancePlan3.id].sort());
 
-    // Soft delete the patient invoice insurance plan
+    // Soft delete two of the plans
     const secondUpdateResult = await app.put(`/api/patient/${patient.id}`).send({
       invoiceInsurancePlanId: JSON.stringify([insurancePlan1.id]),
       facilityId,
@@ -125,19 +125,20 @@ describe('PatientInvoiceInsurancePlan', () => {
     expect(secondPatientInvoiceInsurancePlans.filter(p => p.deletedAt).map(p => p.invoiceInsurancePlanId).sort()).toEqual([insurancePlan2.id, insurancePlan3.id].sort());
     expect(secondPatientInvoiceInsurancePlans.filter(p => !p.deletedAt).map(p => p.invoiceInsurancePlanId)).toEqual([insurancePlan1.id]);
 
-    // Restore the patient invoice insurance plan
+    // Re-add the deleted plans — creates new records instead of restoring
     const thirdUpdateResult = await app.put(`/api/patient/${patient.id}`).send({
       invoiceInsurancePlanId: JSON.stringify([insurancePlan1.id, insurancePlan2.id, insurancePlan3.id]),
       facilityId,
     });
     expect(thirdUpdateResult).toHaveSucceeded();
 
+    // Should have 3 active records and 2 soft-deleted ones (old plan2 and plan3)
     const thirdPatientInvoiceInsurancePlans = await models.PatientInvoiceInsurancePlan.findAll({
       where: { patientId: patient.id },
       paranoid: false,
     });
-    expect(thirdPatientInvoiceInsurancePlans).toHaveLength(3);
-    expect(thirdPatientInvoiceInsurancePlans.filter(p => p.deletedAt).map(p => p.invoiceInsurancePlanId)).toEqual([]);
+    expect(thirdPatientInvoiceInsurancePlans).toHaveLength(5);
+    expect(thirdPatientInvoiceInsurancePlans.filter(p => p.deletedAt)).toHaveLength(2);
     expect(thirdPatientInvoiceInsurancePlans.filter(p => !p.deletedAt).map(p => p.invoiceInsurancePlanId).sort()).toEqual([insurancePlan1.id, insurancePlan2.id, insurancePlan3.id].sort());
   });
 

--- a/packages/facility-server/app/routes/apiv1/encounter.js
+++ b/packages/facility-server/app/routes/apiv1/encounter.js
@@ -256,6 +256,7 @@ encounter.post(
       isDischargePrescription,
       pharmacyOrderPrescriptions,
       facilityId,
+      date,
     } = body;
 
     const prescriptionRecords = await models.Prescription.findAll({
@@ -277,7 +278,7 @@ encounter.post(
         encounterId: id,
         comments,
         isDischargePrescription,
-        date: getCurrentDateTimeString(),
+        date: date || getCurrentDateTimeString(),
         facilityId,
       });
 

--- a/packages/facility-server/app/routes/apiv1/patient/patientInsurancePlans.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patientInsurancePlans.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import { INVOICE_STATUSES } from '@tamanu/constants';
 
 export const patientInsurancePlans = express.Router();
 
@@ -18,5 +19,53 @@ patientInsurancePlans.get(
     });
 
     res.send(insurancePlans);
+  }),
+);
+
+patientInsurancePlans.get(
+  '/:id/insurancePlans/inUse',
+  asyncHandler(async (req, res) => {
+    const { models, params } = req;
+
+    req.checkPermission('read', 'Patient');
+
+    const inUsePlans = await models.InvoicesInvoiceInsurancePlan.findAll({
+      attributes: ['invoiceInsurancePlanId'],
+      include: [
+        {
+          model: models.Invoice,
+          as: 'invoice',
+          attributes: [],
+          where: { status: INVOICE_STATUSES.IN_PROGRESS },
+          required: true,
+          include: [
+            {
+              model: models.Encounter,
+              as: 'encounter',
+              attributes: [],
+              where: { patientId: params.id },
+              required: true,
+            },
+          ],
+        },
+        {
+          model: models.InvoiceInsurancePlan,
+          as: 'invoiceInsurancePlan',
+          attributes: ['id', 'name'],
+        },
+      ],
+    });
+
+    const uniquePlans = new Map();
+    for (const plan of inUsePlans) {
+      if (!uniquePlans.has(plan.invoiceInsurancePlanId)) {
+        uniquePlans.set(plan.invoiceInsurancePlanId, {
+          invoiceInsurancePlanId: plan.invoiceInsurancePlanId,
+          name: plan.invoiceInsurancePlan?.name || plan.invoiceInsurancePlanId,
+        });
+      }
+    }
+
+    res.send([...uniquePlans.values()]);
   }),
 );

--- a/packages/facility-server/app/routes/apiv1/patient/utils/patientInsurancePlans.js
+++ b/packages/facility-server/app/routes/apiv1/patient/utils/patientInsurancePlans.js
@@ -22,23 +22,12 @@ export const savePatientInsurancePlans = async (PatientInvoiceInsurancePlanModel
 
   const existingPlans = await PatientInvoiceInsurancePlanModel.findAll({
     where: { patientId },
-    paranoid: false,
   });
 
   const desiredPlanIds = new Set(invoiceInsurancePlanIds);
-  const activePlanIds = new Set();
-  const deletedPlanIds = new Set();
+  const activePlanIds = new Set(existingPlans.map(plan => plan.invoiceInsurancePlanId));
 
-  for (const plan of existingPlans) {
-    if (plan.deletedAt) {
-      deletedPlanIds.add(plan.invoiceInsurancePlanId);
-    } else {
-      activePlanIds.add(plan.invoiceInsurancePlanId);
-    }
-  }
-
-  const toCreate = invoiceInsurancePlanIds.filter(id => !activePlanIds.has(id) && !deletedPlanIds.has(id));
-  const toRestore = invoiceInsurancePlanIds.filter(id => deletedPlanIds.has(id));
+  const toCreate = invoiceInsurancePlanIds.filter(id => !activePlanIds.has(id));
   const toDelete = [...activePlanIds].filter(id => !desiredPlanIds.has(id));
 
   const promises = [];
@@ -51,12 +40,6 @@ export const savePatientInsurancePlans = async (PatientInvoiceInsurancePlanModel
   if (toDelete.length > 0) {
     promises.push(PatientInvoiceInsurancePlanModel.destroy({
       where: { patientId, invoiceInsurancePlanId: { [Op.in]: toDelete } },
-    }));
-  }
-
-  if (toRestore.length > 0) {
-    promises.push(PatientInvoiceInsurancePlanModel.restore({
-      where: { patientId, invoiceInsurancePlanId: { [Op.in]: toRestore } },
     }));
   }
 

--- a/packages/web/app/api/mutations/useInvoiceMutation.js
+++ b/packages/web/app/api/mutations/useInvoiceMutation.js
@@ -37,6 +37,7 @@ export const useCancelInvoice = invoice => {
     mutationFn: async () => {
       await api.put(`invoices/${invoice?.id}/cancel`);
       await queryClient.invalidateQueries([`encounter/${invoice?.encounterId}/invoice`]);
+      await queryClient.invalidateQueries(['insurancePlansInUse', invoice?.encounter?.patientId]);
     },
     onError: error => notifyError(error.message),
   });
@@ -53,6 +54,7 @@ export const useFinaliseInvoice = invoice => {
       await queryClient.invalidateQueries({
         queryKey: [`patient/${invoice.encounter?.patientId}/invoices/totalOutstandingBalance`],
       });
+      await queryClient.invalidateQueries(['insurancePlansInUse', invoice?.encounter?.patientId]);
     },
     onError: error => notifyError(error.message),
   });
@@ -70,11 +72,14 @@ export const useDeleteInvoice = invoice => {
       await queryClient.invalidateQueries([`encounter/${invoice?.encounterId}/invoice`]);
       queryClient.removeQueries([`encounter/${invoice?.encounterId}/invoice`]);
     },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['insurancePlansInUse', invoice?.encounter?.patientId]);
+    },
     onError: error => notifyError(error.message),
   });
 };
 
-export const useInvoiceInsurancePlansMutation = (invoiceId, encounterId) => {
+export const useInvoiceInsurancePlansMutation = (invoiceId, encounterId, patientId) => {
   const api = useApi();
   const queryClient = useQueryClient();
 
@@ -84,6 +89,7 @@ export const useInvoiceInsurancePlansMutation = (invoiceId, encounterId) => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries([`encounter/${encounterId}/invoice`]);
+      await queryClient.invalidateQueries(['insurancePlansInUse', patientId]);
     },
     onError: error => notifyError(error.message),
   });

--- a/packages/web/app/api/queries/index.js
+++ b/packages/web/app/api/queries/index.js
@@ -35,3 +35,4 @@ export * from './usePatientDataQuery.js';
 export { useSurveyQuery } from './useSurveyQuery';
 export { useFacilityQuery } from './useFacilityQuery';
 export { usePatientInsurancePlansQuery } from './usePatientInsurancePlansQuery';
+export { usePatientInsurancePlansInUseQuery } from './usePatientInsurancePlansInUseQuery';

--- a/packages/web/app/api/queries/usePatientInsurancePlansInUseQuery.js
+++ b/packages/web/app/api/queries/usePatientInsurancePlansInUseQuery.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { useApi } from '../useApi';
+
+export const usePatientInsurancePlansInUseQuery = ({ patientId }) => {
+  const api = useApi();
+  return useQuery(
+    ['insurancePlansInUse', patientId],
+    () => api.get(`patient/${patientId}/insurancePlans/inUse`),
+    { enabled: Boolean(patientId) },
+  );
+};

--- a/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
+++ b/packages/web/app/features/Invoice/InvoiceInsuranceModal.jsx
@@ -31,7 +31,7 @@ export const InvoiceInsuranceModal = ({ open, onClose, invoice }) => {
   const patientId = invoice?.encounter?.patientId;
   const defaultValues = invoice?.insurancePlans?.map(({ id }) => id) || [];
   const [selectedPlans, setSelectedPlans] = useState(defaultValues);
-  const { mutate } = useInvoiceInsurancePlansMutation(invoice.id, invoice.encounterId);
+  const { mutate } = useInvoiceInsurancePlansMutation(invoice.id, invoice.encounterId, patientId);
   const {
     data: insurancePlans = [],
     isLoading: isLoadingInsurancePlans,

--- a/packages/web/app/forms/NewPatientForm.jsx
+++ b/packages/web/app/forms/NewPatientForm.jsx
@@ -234,7 +234,6 @@ export const NewPatientForm = memo(
           patientRegistryType,
           getSetting,
           getTranslation,
-          getSetting,
         )}
         data-testid="form-60mo"
       />

--- a/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
@@ -12,6 +12,7 @@ import { NoteModalActionBlocker } from '../../components';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { useLayoutComponents } from './useLayoutComponents';
 import { usePatientFieldDefinitionQuery } from '../../api/queries/usePatientFieldDefinitionQuery';
+import { usePatientInsurancePlansInUseQuery } from '../../api/queries/usePatientInsurancePlansInUseQuery';
 import { useTranslation } from '../../contexts/Translation';
 import { useSettings } from '../../contexts/Settings';
 
@@ -103,6 +104,10 @@ export const PatientDetailsForm = ({ patient, additionalData, birthData, insuran
     enabled: Boolean(patient.id),
   });
 
+  const {
+    data: insurancePlansInUse,
+  } = usePatientInsurancePlansInUseQuery({ patientId: patient.id });
+
   const errors = [fieldDefError, fieldValError].filter(e => Boolean(e));
   if (errors.length > 0) {
     return <pre>{errors.map(e => e.stack).join('\n')}</pre>;
@@ -162,7 +167,7 @@ export const PatientDetailsForm = ({ patient, additionalData, birthData, insuran
         patientRegistryType,
         getSetting,
         getTranslation,
-        getSetting,
+        insurancePlansInUse,
       )}
       data-testid="form-9v1j"
     />

--- a/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/PatientDetailsForm.jsx
@@ -106,9 +106,10 @@ export const PatientDetailsForm = ({ patient, additionalData, birthData, insuran
 
   const {
     data: insurancePlansInUse,
+    error: insurancePlansInUseError,
   } = usePatientInsurancePlansInUseQuery({ patientId: patient.id });
 
-  const errors = [fieldDefError, fieldValError].filter(e => Boolean(e));
+  const errors = [fieldDefError, fieldValError, insurancePlansInUseError].filter(e => Boolean(e));
   if (errors.length > 0) {
     return <pre>{errors.map(e => e.stack).join('\n')}</pre>;
   }

--- a/packages/web/app/validations/patientDetailValidations.jsx
+++ b/packages/web/app/validations/patientDetailValidations.jsx
@@ -40,7 +40,7 @@ const requiredBirthFieldWhenConfiguredMandatory = (
     otherwise: baseType,
   });
 
-export const getPatientDetailsValidation = (patientRegistryType, getSetting, getTranslation) => {
+export const getPatientDetailsValidation = (patientRegistryType, getSetting, getTranslation, insurancePlansInUse = []) => {
   const patientDetailsValidationSchema = yup.object().shape({
     firstName: yup
       .string()
@@ -787,7 +787,39 @@ export const getPatientDetailsValidation = (patientRegistryType, getSetting, get
       getSetting,
       getTranslation,
       'invoiceInsurancePlanId',
-      yup.array().of(yup.string()),
+      yup
+        .array()
+        .of(yup.string())
+        .test(
+          'insurance-plan-not-in-use',
+          '',
+          function testInsurancePlanNotInUse(value) {
+            if (!insurancePlansInUse?.length) {
+              return true;
+            }
+
+            const currentPlanIds = value || [];
+            const removedInUsePlans = insurancePlansInUse.filter(
+              plan => !currentPlanIds.includes(plan.invoiceInsurancePlanId),
+            );
+            if (removedInUsePlans.length === 0) {
+              return true;
+            }
+            const planNames = removedInUsePlans.map(plan => plan.name).join(', ');
+            const message = removedInUsePlans.length > 1
+              ? getTranslation(
+                  'patient.validation.insurancePlansInUse',
+                  ':planNames have been added to one or more in-progress invoices. Please remove the insurance plans from the invoices first.',
+                )
+              : getTranslation(
+                  'patient.validation.insurancePlanInUse',
+                  ':planNames has been added to one or more in-progress invoices. Please remove the insurance plan from the invoices first.',
+                );
+            return this.createError({
+              message: message.replace(':planNames', planNames),
+            });
+          },
+        ),
       'Insurance plan',
     ),
   });


### PR DESCRIPTION
### Changes
- Prevent user from removing insurance plan from patient details if it is being used for an invoice

<img width="631" height="272" alt="Screenshot 2026-02-17 at 6 11 16 pm" src="https://github.com/user-attachments/assets/0e467c3d-04e4-4da5-b619-4699976dcac4" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invoicing/patient insurance plan data integrity and adds a new query path used for UI validation; primary risk is incorrect filtering/index behavior causing plans to be incorrectly blocked or allowed.
> 
> **Overview**
> Prevents users from removing a patient’s insurance plan when it’s already attached to an *in-progress* invoice by adding a new `GET /api/patient/:id/insurancePlans/inUse` endpoint and using it in patient detail form validation.
> 
> Updates the patient insurance plan persistence rules to **not restore** soft-deleted links; re-adding a plan now creates a new row, backed by a DB-level **partial unique index** `(patient_id, invoice_insurance_plan_id) WHERE deleted_at IS NULL` and corresponding test updates/coverage.
> 
> Ensures the UI stays consistent by adding a `usePatientInsurancePlansInUseQuery` hook and invalidating this cache when invoices are cancelled/finalised/deleted or when invoice insurance plans are updated; also allows pharmacy order creation to accept an optional `date` override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 149e13f0c92b5411267ca07ca0b3914450e45ab3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->