### PR TITLE
fix(sync): TAMOC-392: Fix sync performance for Kiribati (HOTFIX 2.42)

### DIFF
--- a/packages/database/src/sync/manageSnapshotTable.ts
+++ b/packages/database/src/sync/manageSnapshotTable.ts
@@ -29,6 +29,10 @@ export const getMarkedForSyncPatientsTableName = (sessionId: string, isFullSync:
 
 export const createSnapshotTable = async (sequelize: Sequelize, sessionId: string) => {
   const tableName = getSnapshotTableName(sessionId);
+  const indexNamePrefix = tableName
+    .replaceAll('.', '_')
+    .replaceAll('"', '')
+    .replaceAll('-', '');     
   await sequelize.query(`
     CREATE TABLE ${tableName} (
       id BIGSERIAL PRIMARY KEY,
@@ -45,10 +49,8 @@ export const createSnapshotTable = async (sequelize: Sequelize, sessionId: strin
     ) WITH (
       autovacuum_enabled = off
     );
-    CREATE INDEX ${tableName
-      .replaceAll('.', '_')
-      .replaceAll('"', '')
-      .replaceAll('-', '')}_direction_index ON ${tableName}(direction);
+    CREATE INDEX ${indexNamePrefix}_dir_id_idx ON ${tableName}(direction, id) INCLUDE (record_type);
+    CREATE INDEX ${indexNamePrefix}_dir_rec_id_idx ON ${tableName}(direction, record_type, id);
   `);
 };
 


### PR DESCRIPTION
### Changes
- Fix performance

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to index creation on ephemeral snapshot tables; primary risk is unexpected index-name collisions or slower table creation, but no changes to sync data semantics.
> 
> **Overview**
> Improves sync snapshot query performance by replacing the single-column `direction` index with two composite indexes over `(direction, id)` and `(direction, record_type, id)` (including `record_type` in one index) when creating snapshot tables.
> 
> Adds an `indexNamePrefix` helper to generate safer, consistent index names derived from the dynamic snapshot table name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e56546f95cae48694e0f88c47fe33f57c1461cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->