### PR TITLE
feat(datetime): TAN-2585: Autocomplete facilityTimeZone field using Intl available options

### DIFF
--- a/packages/constants/src/suggesters.ts
+++ b/packages/constants/src/suggesters.ts
@@ -31,4 +31,5 @@ export const SUGGESTER_ENDPOINTS = [
   'role',
   'encounter',
   'reportDefinition',
+  'timeZone',
 ];

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -84,6 +84,7 @@ export const facilitySettings = {
       description: 'Time zone in IANA format',
       type: yup.string().nullable(),
       defaultValue: null,
+      suggesterEndpoint: 'timeZone',
     },
     patientDisplayIdPattern: {
       highRisk: true,

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1174,6 +1174,30 @@ createSuggester('reportDefinition', 'ReportDefinition', ({ search }) => ({
   name: { [Op.iLike]: search },
 }));
 
+const TIME_ZONES = Intl.supportedValuesOf('timeZone').map(tz => ({ id: tz, name: tz }));
+
+suggestions.get(
+  '/timeZone$',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const searchQuery = (req.query.q || '').trim().toLowerCase();
+    const filtered = searchQuery
+      ? TIME_ZONES.filter(tz => tz.name.toLowerCase().includes(searchQuery))
+      : TIME_ZONES;
+    res.send(filtered.slice(0, DEFAULT_LIMIT));
+  }),
+);
+
+suggestions.get(
+  '/timeZone/:id',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const tz = TIME_ZONES.find(t => t.id === req.params.id);
+    if (!tz) throw new NotFoundError();
+    res.send(tz);
+  }),
+);
+
 const routerEndpoints = suggestions.stack.map(layer => {
   const path = layer.route.path.replace('/', '').replaceAll('$', '');
   const root = path.split('/')[0];

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1174,7 +1174,9 @@ createSuggester('reportDefinition', 'ReportDefinition', ({ search }) => ({
   name: { [Op.iLike]: search },
 }));
 
-const TIME_ZONES = Intl.supportedValuesOf('timeZone').map(tz => ({ id: tz, name: tz }));
+const timeZoneValues = Intl.supportedValuesOf('timeZone');
+const TIME_ZONES = timeZoneValues.map(tz => ({ id: tz, name: tz }));
+const TIME_ZONES_LOWER = timeZoneValues.map(tz => tz.toLowerCase());
 
 suggestions.get(
   '/timeZone$',
@@ -1182,7 +1184,7 @@ suggestions.get(
     req.flagPermissionChecked();
     const searchQuery = (req.query.q || '').trim().toLowerCase();
     const filtered = searchQuery
-      ? TIME_ZONES.filter(tz => tz.name.toLowerCase().includes(searchQuery))
+      ? TIME_ZONES.filter((_tz, i) => TIME_ZONES_LOWER[i].includes(searchQuery))
       : TIME_ZONES;
     res.send(filtered.slice(0, DEFAULT_LIMIT));
   }),

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1174,7 +1174,8 @@ createSuggester('reportDefinition', 'ReportDefinition', ({ search }) => ({
   name: { [Op.iLike]: search },
 }));
 
-const timeZoneValues = Intl.supportedValuesOf('timeZone');
+const timeZoneValues =
+  typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : ['UTC'];
 const TIME_ZONES = timeZoneValues.map(tz => ({ id: tz, name: tz }));
 const TIME_ZONES_LOWER = timeZoneValues.map(tz => tz.toLowerCase());
 


### PR DESCRIPTION
### Changes
Changes `facilityTimeZone` admin panel settings field from a free text timezone input to an autocomplete
- Remove human error of incorrectly formed timezone string
- Requires no extra package, using Intl built in class
<img width="1028" height="369" alt="Screenshot 2026-02-19 at 10 29 17 AM" src="https://github.com/user-attachments/assets/5c9fbaeb-79ed-475f-bf52-fbca0794b3bf" />


### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
