### PR TITLE
fix(medications): release 2.49: Use correct submit handler

### DIFF
--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -532,7 +532,7 @@ export const PharmacyOrderModal = React.memo(({ encounter, patient, ongoingPresc
           <ConfirmCancelBackRow
             onBack={() => setShowAlreadyOrderedConfirmation(false)}
             onCancel={handleClose}
-            onConfirm={handleSendOrder}
+            onConfirm={submitOrder}
             data-testid="confirmcancelrow-7g3j"
           />
         </SubmitButtonsWrapper>


### PR DESCRIPTION
### Changes

I accidentally used the submit handler that checks for `alreadyOrderedPrescriptions`, returns early and shows this modal. This means the button never does anything. I just needed to swap out for the proper submit handler since there is no need to run validation again.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI handler change limited to the confirmation modal; low risk aside from potentially altering when validation/already-ordered checks run.
> 
> **Overview**
> Fixes the *already-ordered medications* confirmation modal so its **Confirm** action calls `submitOrder` directly instead of re-running `handleSendOrder`.
> 
> This prevents the confirm button from looping back into the already-ordered validation flow and ensures the order is actually submitted after the user confirms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e4f2686429150ea3adcae957537f374928262a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->