### PR TITLE
fix(sync): TAMOC-392: Vacuum after snapshot (HOTFIX 2.42)

### DIFF
--- a/packages/database/src/sync/manageSnapshotTable.ts
+++ b/packages/database/src/sync/manageSnapshotTable.ts
@@ -107,3 +107,9 @@ export const updateSnapshotRecords = async (
     snakeKey(where),
   );
 };
+
+export const vacuumAnalyzeSnapshotTable = async (sequelize: Sequelize, sessionId: string) => {
+  const tableName = getSnapshotTableName(sessionId);
+  // VACUUM cannot run inside an open transaction; caller must ensure autocommit context
+  await sequelize.query(`VACUUM (ANALYZE) ${tableName};`);
+};


### PR DESCRIPTION
### Changes
- Vacuum after snapshot

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an explicit `VACUUM` on dynamically named tables during sync, which can impact database load/locking and must run outside transactions; functional logic change is otherwise small and localized.
> 
> **Overview**
> After completing pull snapshot creation in `CentralSyncManager.setupSnapshotForPull`, the server now runs `VACUUM (ANALYZE)` on the session’s snapshot table *outside* the repeatable-read transaction to refresh stats and enable index-only scans.
> 
> Adds a new `vacuumAnalyzeSnapshotTable(sequelize, sessionId)` helper in `manageSnapshotTable.ts` and wires it into the central-server sync flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edc393716b5ec247f3ea5c8797930b59feab7080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->