### PR TITLE
tweak(ci): shard tests to 8 parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,22 +71,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { package: "@tamanu/facility-server", shard: 1/6, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 2/6, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 3/6, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 4/6, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 5/6, postgres: 16 }
-          - { package: "@tamanu/facility-server", shard: 6/6, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 1/6, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 2/6, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 3/6, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 4/6, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 5/6, postgres: 16 }
-          - { package: "@tamanu/central-server",  shard: 6/6, postgres: 16 }
+          - { package: "@tamanu/facility-server", shard: 1/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 2/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 3/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 4/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 5/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 6/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 7/8, postgres: 17 }
+          - { package: "@tamanu/facility-server", shard: 8/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 1/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 2/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 3/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 4/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 5/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 6/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 7/8, postgres: 17 }
+          - { package: "@tamanu/central-server",  shard: 8/8, postgres: 17 }
           - { package: "@tamanu/database",                    postgres: 12 }
           - { package: "@tamanu/database",                    postgres: 14 }
           - { package: "@tamanu/database",                    postgres: 16 }
           - { package: "@tamanu/database",                    postgres: 17 }
+          - { package: "@tamanu/database",                    postgres: 18 }
           - { package: "@tamanu/settings"                                  }
           - { package: "@tamanu/shared"                                    }
           - { package: "@tamanu/upgrade"                                   }


### PR DESCRIPTION
### Changes

- shard facility and central test suites to 8 parts
- update tests to use postgres 17
- add postgres 18 to the database test matrix

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

