### PR TITLE
fix(medication): Hotfix v2.48: Correctly create MAR task on mobile

### DIFF
--- a/packages/mobile/App/models/MedicationAdministrationRecord.ts
+++ b/packages/mobile/App/models/MedicationAdministrationRecord.ts
@@ -223,12 +223,12 @@ export class MedicationAdministrationRecord extends BaseModel {
 
     await Task.createAndSaveOne({
       taskType: TASK_TYPES.MEDICATION_DUE_TASK,
-      encounter: encounter.id,
+      encounterId: encounter.id,
       name: 'Medication Due',
       dueTime: mar.dueAt,
       status: TASK_STATUSES.TODO,
       requestTime: getCurrentDateTimeString(),
-      requestedByUser: SYSTEM_USER_UUID,
+      requestedByUserId: SYSTEM_USER_UUID,
     });
   }
 }


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to task creation payload in mobile; risk is limited to whether downstream code expected the old property names.
> 
> **Overview**
> Fixes `MedicationAdministrationRecord.createMedicationDueTaskForMar` to pass `encounterId` and `requestedByUserId` to `Task.createAndSaveOne` (instead of `encounter` and `requestedByUser`). This aligns task creation with the query/column naming used elsewhere and avoids mis-assigning these relationships when generating medication-due tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1df8039c3ec876fc8ad7906b5452b2b114b2569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->