### PR TITLE
fix(medications): Hotfix 2.49: Correct repeats number

### DIFF
--- a/packages/database/src/models/PharmacyOrderPrescription.ts
+++ b/packages/database/src/models/PharmacyOrderPrescription.ts
@@ -99,16 +99,11 @@ export class PharmacyOrderPrescription extends Model {
     });
   }
 
-  getRemainingRepeats(extraDispenses: number = 0): number {
-    // No repeats will be consumed by an INPATIENT medication request.
+  getRemainingRepeats(): number {
     if (!this.pharmacyOrder?.isDischargePrescription) {
       return 0;
     }
-    // The remaining repeats for OUTPATIENT medication requests is the number of repeats minus the number of dispenses.
-    const repeats = this.repeats || 0;
-    const dispenseCount = (this.medicationDispenses || []).length + extraDispenses;
-    // we subtract 1 from the dispense count because the first dispense is not counted as a repeat
-    return Math.max(0, repeats - Math.max(0, dispenseCount - 1));
+    return this.repeats ?? 0;
   }
 
   static getListReferenceAssociations() {

--- a/packages/database/src/models/PharmacyOrderPrescription.ts
+++ b/packages/database/src/models/PharmacyOrderPrescription.ts
@@ -99,13 +99,6 @@ export class PharmacyOrderPrescription extends Model {
     });
   }
 
-  getRemainingRepeats(): number {
-    if (!this.pharmacyOrder?.isDischargePrescription) {
-      return 0;
-    }
-    return this.repeats ?? 0;
-  }
-
   static getListReferenceAssociations() {
     return ['pharmacyOrder', 'prescription'];
   }

--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -604,7 +604,7 @@ medication.post(
             prescriptionId: prescription.id,
             ongoingPrescriptionId: originalPrescription.id,
             quantity: requestData.quantity,
-            repeats: requestData.repeats ?? originalPrescription.repeats ?? 0,
+            repeats: originalPrescription.repeats ?? 0,
           };
         }),
         { transaction },
@@ -2159,7 +2159,7 @@ medication.get(
               referenceDrug: referenceDrug,
             },
           },
-          remainingRepeats: item.pharmacyOrderPrescription.getRemainingRepeats(),
+          remainingRepeats: item.pharmacyOrderPrescription.repeats ?? 0,
         },
       };
     });
@@ -2329,7 +2329,7 @@ medication.get(
       count: pharmacyOrderPrescriptions.length,
       data: pharmacyOrderPrescriptions.map(pop => ({
         ...pop.toJSON(),
-        remainingRepeats: pop.getRemainingRepeats(),
+        remainingRepeats: pop.repeats ?? 0,
         lastDispensedAt: pop.medicationDispenses?.sort(
           (a, b) => new Date(b.dispensedAt) - new Date(a.dispensedAt),
         )[0]?.dispensedAt,

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -838,7 +838,7 @@ patientRoute.get(
               },
             },
           },
-          remainingRepeats: item.pharmacyOrderPrescription.getRemainingRepeats(),
+          remainingRepeats: item.pharmacyOrderPrescription.repeats ?? 0,
         },
       };
     });


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes medication repeats semantics and removes dispense-based calculation, so client-visible `remainingRepeats` values may shift and should be validated against expected outpatient/inpatient workflows.
> 
> **Overview**
> Fixes repeats reporting by removing `PharmacyOrderPrescription.getRemainingRepeats()` and the API-side dispense-history lookups used to compute it.
> 
> `remainingRepeats` in medication dispense/request responses is now derived directly from `PharmacyOrderPrescription.repeats` (defaulting to `0`), and `send-ongoing-to-pharmacy` now persists `PharmacyOrderPrescription.repeats` from the original ongoing prescription rather than any request override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b64d4c215638f7e0554cd71dfddddc3850967094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->