### PR TITLE
fix(medications): hotfix 2.49: Save pharmacyOrders with appropriate repeats

### DIFF
--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -543,6 +543,16 @@ medication.post(
       for (const originalPrescription of ongoingPrescriptions) {
         const requestData = prescriptionMap.get(originalPrescription.id);
 
+        // Decrement repeats on the ongoing prescriptions (repeats = remaining "send to pharmacy" count)
+        // Only decrement if the prescription has been ordered before (has a lastOrderedAt)
+        const { repeats = 0 } = originalPrescription;
+        const lastOrderedAt = lastOrderedAts[originalPrescription.id]?.last_ordered_at;
+
+        // We only start decrementing repeats after the first send.
+        if (lastOrderedAt && repeats > 0) {
+          await originalPrescription.update({ repeats: repeats - 1 }, { transaction });
+        }
+
         // Create a new prescription with the original details but updated quantity and repeats
         const newPrescription = await Prescription.create(
           {
@@ -551,7 +561,7 @@ medication.post(
             date: currentDateTime,
             startDate: currentDateTime,
             quantity: requestData.quantity,
-            repeats: requestData.repeats ?? originalPrescription.repeats ?? 0,
+            repeats: originalPrescription.repeats ?? 0,
             prescriberId: orderingClinicianId,
           },
           { transaction },
@@ -582,18 +592,6 @@ medication.post(
         },
         { transaction },
       );
-
-      // Decrement repeats on the ongoing prescriptions (repeats = remaining "send to pharmacy" count)
-      // Only decrement if the prescription has been ordered before (has a lastOrderedAt)
-      for (const originalPrescription of ongoingPrescriptions) {
-        const { repeats = 0 } = originalPrescription;
-        const lastOrderedAt = lastOrderedAts[originalPrescription.id]?.last_ordered_at;
-
-        // We only start decrementing repeats after the first send.
-        if (lastOrderedAt && repeats > 0) {
-          await originalPrescription.update({ repeats: repeats - 1 }, { transaction });
-        }
-      }
 
       await PharmacyOrderPrescription.bulkCreate(
         newPrescriptions.map((prescription, index) => {

--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -551,7 +551,7 @@ medication.post(
             date: currentDateTime,
             startDate: currentDateTime,
             quantity: requestData.quantity,
-            repeats: requestData.repeats ?? originalPrescription.repeats ?? 0,
+            repeats: originalPrescription.repeats ?? 0,
             prescriberId: orderingClinicianId,
           },
           { transaction },

--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -604,7 +604,7 @@ medication.post(
             prescriptionId: prescription.id,
             ongoingPrescriptionId: originalPrescription.id,
             quantity: requestData.quantity,
-            repeats: requestData.repeats ?? originalPrescription.repeats ?? 0,
+            repeats: originalPrescription.repeats ?? 0,
           };
         }),
         { transaction },

--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -551,7 +551,7 @@ medication.post(
             date: currentDateTime,
             startDate: currentDateTime,
             quantity: requestData.quantity,
-            repeats: originalPrescription.repeats ?? 0,
+            repeats: requestData.repeats ?? originalPrescription.repeats ?? 0,
             prescriberId: orderingClinicianId,
           },
           { transaction },


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches medication ordering state (`repeats`) and affects how pharmacy orders and cloned prescriptions are persisted; mistakes could cause incorrect remaining-repeat counts.
> 
> **Overview**
> Fixes repeat-count handling when using `POST /send-ongoing-to-pharmacy`.
> 
> Repeats are now decremented *per ongoing prescription* before cloning it, and both the newly created encounter `Prescription` and the saved `PharmacyOrderPrescription` explicitly use the (possibly decremented) `originalPrescription.repeats` rather than any client-supplied `requestData.repeats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66943ca198fb8ed9ca7ce8345ea031cfa1adcd0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->