### PR TITLE
fix(sync): no-issue: Rebuild notes in lookup table to correct state after adding note_type_id (hotfix 2.46)

### DIFF
--- a/packages/database/src/migrations/1771806628203-RebuildNotesInLookupTableAfterAddingNoteTypeIdColumn.ts
+++ b/packages/database/src/migrations/1771806628203-RebuildNotesInLookupTableAfterAddingNoteTypeIdColumn.ts
@@ -1,0 +1,12 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // In a previous migration (1759894448776-migrateNoteTypesToReferenceData.ts) we added a note_type_id column to the notes table.
+  // We need to rebuild the notes in the lookup table for the notes table to ensure that lookup table state is correct.
+  // Note that this may take a while on larger deployments, took ~15 mins on Nauru Clone
+  await query.sequelize.query(`SELECT flag_lookup_model_to_rebuild('notes');`);
+}
+
+export async function down(): Promise<void> {
+  // No reverse migration
+}


### PR DESCRIPTION
### Changes

https://beyondessential.slack.com/archives/C0212PJ11DW/p1771562352287319?thread_ts=1771387899.396089&cid=C0212PJ11DW

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
