### PR TITLE
fix(medications): Hotfix v2.49: Show last dispensed per medication

### DIFF
--- a/packages/facility-server/app/routes/apiv1/medication.js
+++ b/packages/facility-server/app/routes/apiv1/medication.js
@@ -2351,11 +2351,12 @@ medication.get(
     const lastDispensedRows = await PharmacyOrderPrescription.sequelize.query(
       `SELECT p.medication_id AS "medicationId", MAX(md.dispensed_at) AS "lastDispensedAt"
        FROM medication_dispenses md
-       JOIN pharmacy_order_prescriptions pop ON pop.id = md.pharmacy_order_prescription_id
-       JOIN pharmacy_orders po ON po.id = pop.pharmacy_order_id
-       JOIN encounters e ON e.id = po.encounter_id
-       JOIN prescriptions p ON p.id = pop.prescription_id
+       JOIN pharmacy_order_prescriptions pop ON pop.id = md.pharmacy_order_prescription_id AND pop.deleted_at IS NULL
+       JOIN pharmacy_orders po ON po.id = pop.pharmacy_order_id AND po.deleted_at IS NULL
+       JOIN encounters e ON e.id = po.encounter_id AND e.deleted_at IS NULL
+       JOIN prescriptions p ON p.id = pop.prescription_id AND p.deleted_at IS NULL
        WHERE e.patient_id = :patientId
+         AND md.deleted_at IS NULL
        GROUP BY p.medication_id`,
       {
         type: QueryTypes.SELECT,

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -765,9 +765,9 @@ export const MedicationForm = ({
   };
 
   const getStockLevelIcon = () => {
-    if (drugQuantity > 0) return <CircleHelp size={20} color={Colors.safe} />;
+    if (drugQuantity > 0) return <CircleCheck size={20} color={Colors.safe} />;
     if (drugQuantity === 0) return <CircleAlert size={20} color={Colors.alert} />;
-    return <CircleCheck size={20} color={Colors.blue} />;
+    return <CircleHelp size={20} color={Colors.blue} />;
   };
 
   const getStockLevelContent = () => {


### PR DESCRIPTION
### Changes

Another request from Michael. The lastDispensed column was showing the last dispense of that pharmacy order (previous logic where the same order was dispensed multiple times) We actually want to show the last time that drug was dispensed for that patient regardless of source

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new raw SQL aggregation on dispense history, which could affect performance and correctness of medication dispensing lists if joins/filters are off; UI icon swap is low risk.
> 
> **Overview**
> Fixes the `lastDispensedAt` value returned by `GET medication/dispensable-medications` to be the patient’s most recent dispense *per medication across all pharmacy orders/prescriptions*, by computing it via an aggregate SQL query instead of sorting the current request’s `medicationDispenses`.
> 
> Updates the medication form stock-level indicator icons so **in-stock** shows a checkmark and **unknown** shows a help icon (previously swapped).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7883d47afec911c7953f1adcdc9a8bedb50c20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->