### PR TITLE
fix(medications): Hotfix v2.49: Checkbox styling on new prescription form

### DIFF
--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -165,7 +165,7 @@ const StyledCheckField = styled(CheckField)`
   background-color: ${Colors.white};
   border: 1px solid
     ${({ $checked, $isLocked }) => {
-    if ($isLocked) return Colors.midText;
+    if ($isLocked && $isChecked) return Colors.midText;
     if ($checked) return Colors.primary;
     return Colors.outline;
   }};

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -163,7 +163,12 @@ const StyledCheckField = styled(CheckField)`
   cursor: pointer;
   width: 100%;
   background-color: ${Colors.white};
-  border: 1px solid ${({ $checked }) => ($checked ? Colors.primary : Colors.outline)};
+  border: 1px solid
+    ${({ $checked, $isLocked }) => {
+    if ($isLocked) return Colors.midText;
+    if ($checked) return Colors.primary;
+    return Colors.outline;
+  }};
   border-radius: 3px;
   .MuiFormControlLabel-root {
     padding: 10px 2px;
@@ -934,9 +939,15 @@ export const MedicationForm = ({
                           setValues({ ...values, durationValue: '', durationUnit: '' });
                         }
                       }}
-                      checkedIcon={<StyledIcon className="far fa-check-square" $color={Colors.midText} />}
+                      checkedIcon={
+                        <StyledIcon
+                          className="far fa-check-square"
+                          $color={isOngoingPrescription ? Colors.midText : Colors.primary}
+                        />
+                      }
                       data-testid="medication-field-isOngoing-7j2p"
                       $checked={values.isOngoing || isOngoingPrescription}
+                      $isLocked={isOngoingPrescription}
                     />
                   </ConditionalTooltip>
                 </CheckboxRowItem>

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -164,9 +164,9 @@ const StyledCheckField = styled(CheckField)`
   width: 100%;
   background-color: ${Colors.white};
   border: 1px solid
-    ${({ $checked, $locked }) => {
-    if ($locked && $checked) return Colors.midText;
-    if ($checked) return Colors.primary;
+    ${({ $isChecked, $isLocked }) => {
+    if ($isLocked && $isChecked) return Colors.midText;
+    if ($isChecked) return Colors.primary;
     return Colors.outline;
   }};
   border-radius: 3px;
@@ -946,8 +946,8 @@ export const MedicationForm = ({
                         />
                       }
                       data-testid="medication-field-isOngoing-7j2p"
-                      $checked={values.isOngoing || isOngoingPrescription}
-                      $locked={isOngoingPrescription}
+                      $isChecked={values.isOngoing || isOngoingPrescription}
+                      $isLocked={isOngoingPrescription}
                     />
                   </ConditionalTooltip>
                 </CheckboxRowItem>
@@ -959,7 +959,7 @@ export const MedicationForm = ({
                     }
                     component={StyledCheckField}
                     data-testid="medication-field-isPrn-9n4q"
-                    $checked={values.isPrn}
+                    $isChecked={values.isPrn}
                   />
                 </CheckboxRowItem>
               </CheckboxRow>
@@ -983,7 +983,7 @@ export const MedicationForm = ({
                   }
                 }}
                 data-testid="medication-field-isVariableDose-5h8x"
-                $checked={values.isVariableDose}
+                $isChecked={values.isVariableDose}
               />
             </VariableDoseFieldWrapper>
             <Field

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -164,8 +164,8 @@ const StyledCheckField = styled(CheckField)`
   width: 100%;
   background-color: ${Colors.white};
   border: 1px solid
-    ${({ $checked, $isLocked }) => {
-    if ($isLocked && $isChecked) return Colors.midText;
+    ${({ $checked, $locked }) => {
+    if ($locked && $checked) return Colors.midText;
     if ($checked) return Colors.primary;
     return Colors.outline;
   }};
@@ -947,7 +947,7 @@ export const MedicationForm = ({
                       }
                       data-testid="medication-field-isOngoing-7j2p"
                       $checked={values.isOngoing || isOngoingPrescription}
-                      $isLocked={isOngoingPrescription}
+                      $locked={isOngoingPrescription}
                     />
                   </ConditionalTooltip>
                 </CheckboxRowItem>

--- a/packages/web/app/forms/MedicationForm.jsx
+++ b/packages/web/app/forms/MedicationForm.jsx
@@ -165,7 +165,7 @@ const StyledCheckField = styled(CheckField)`
   background-color: ${Colors.white};
   border: 1px solid
     ${({ $checked, $isLocked }) => {
-    if ($isLocked && $isChecked) return Colors.midText;
+    if ($isLocked && $checked) return Colors.midText;
     if ($checked) return Colors.primary;
     return Colors.outline;
   }};


### PR DESCRIPTION
### Changes

Part of a small batch of hotfixes to medication being merged short after release. This fixes the checkbox styling on the "New prescription form". After we changed the design last sprint there were a few weird styling quirks. This just corrects the styling of the checkboxes to have consistent border and icon colour based on state.

- Locked + checked = dark grey
- Checked = primary
- Unchecked = light grey

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only changes to checkbox presentation with minimal functional impact; risk is limited to potential visual regressions in the medication form.
> 
> **Overview**
> Adjusts checkbox styling in `MedicationForm` to render consistent border and check icon colours across *unchecked*, *checked*, and *locked+checked* states.
> 
> `StyledCheckField` now derives its border color from new props (`$isChecked`, `$isLocked`), and the "Ongoing medication" checkbox’s `checkedIcon` color is updated to show grey when locked (ongoing prescription) vs primary when user-checked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea77b3c77636827260c81a6ab6f837bf1102bd5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->