### PR TITLE
fix(SAST): COOL-47: actions/missing-workflow-permissions

### DIFF
--- a/.github/workflows/cd-down.yml
+++ b/.github/workflows/cd-down.yml
@@ -22,7 +22,7 @@ on:
         required: true
 
 permissions:
-  contents: write # to update the release notes
+  contents: read
   pull-requests: write
   id-token: write # for Tailscale OIDC authentication
 

--- a/.github/workflows/cd-fake-data.yml
+++ b/.github/workflows/cd-fake-data.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
   id-token: write # for Tailscale OIDC authentication
 
 jobs:

--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -8,6 +8,8 @@ on:
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   merge-paused:
     name: Merge paused

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - release/*
+permissions:
+  contents: read
+
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
   NODE_ENV: test
@@ -28,8 +31,6 @@ jobs:
           - "17"
     name: on pg=${{ matrix.postgres }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci-synthetic-test-runner.yml
+++ b/.github/workflows/ci-synthetic-test-runner.yml
@@ -29,6 +29,12 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: read
+  actions: write
+
 jobs:
   validate-and-run:
     name: synthetic-test-run-${{ inputs.pr_number }}-${{ github.run_id }}

--- a/.github/workflows/ci-synthetic-test-trigger.yml
+++ b/.github/workflows/ci-synthetic-test-trigger.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  pull-requests: read
+  actions: write
+
 jobs:
   check-and-trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/cleanup-auto-deploy.yml
+++ b/.github/workflows/cleanup-auto-deploy.yml
@@ -17,9 +17,9 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write # to checkout the repo
-  pull-requests: write # to parse PRs for config and update them
-  issues: write # to parse special deploy issues and update them
+  contents: read
+  pull-requests: write # needed by downstream cd-down.yml for Pulumi PR comments
+  issues: read
   id-token: write # for Tailscale OIDC authentication
 
 jobs:


### PR DESCRIPTION
### Changes

We had a lot of these: https://github.com/beyondessential/tamanu/security/code-scanning?query=is%3Aopen+branch%3Amain+workflow

What was done:
- Added explicit permissions to workflows that had none: ci.yml (contents: read), ci-synthetic-test-runner.yml (contents: read, statuses: write, pull-requests: read, actions: write), ci-synthetic-test-trigger.yml (pull-requests: read, actions: write), check-pr-title.yml and check-label.yml (permissions: {}).
- Reduced scope where permissions were broader than needed: cd-down.yml and cleanup-auto-deploy.yml use contents: read instead of contents: write; cleanup-auto-deploy.yml uses issues: read instead of issues: write; cd-fake-data.yml and ci-e2e.yml no longer request pull-requests: write.
- Moved permissions to workflow level in ci-non-deterministic.yml so all jobs share the same minimal contents: read.