### PR TITLE
tweak: COOL-44: Use default UUID4 instead of composite id for userFacility

### DIFF
--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -398,7 +398,6 @@ export async function userLoader(item, { models, pushError }) {
       rows.push({
         model: 'UserFacility',
         values: {
-          id: `${id};${facilityId}`,
           userId: id,
           facilityId: facilityId,
           deletedAt: new Date(),
@@ -411,7 +410,6 @@ export async function userLoader(item, { models, pushError }) {
     rows.push({
       model: 'UserFacility',
       values: {
-        id: `${id};${facilityId}`,
         userId: id,
         facilityId: facilityId,
       },

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -412,6 +412,7 @@ export async function userLoader(item, { models, pushError }) {
       values: {
         userId: id,
         facilityId: facilityId,
+        deletedAt: null,
       },
     });
   });


### PR DESCRIPTION
### Changes

Resolves COOL-44 by removing the manual `id` assignment for `UserFacility` records in the reference data importer. This allows the database to generate UUIDv4 IDs as per its default, aligning with the `user_facilities` table schema.

The `LabTestPanelLabTestTypes` model was investigated and confirmed to intentionally use composite IDs, so no changes were made there.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

---
Linear Issue: [COOL-44](https://linear.app/bes/issue/COOL-44/userfacility-reference-data-importer-sets-user-idfacility-id-as-id)

<p><a href="https://cursor.com/agents/bc-6988788f-0c47-4a98-a883-e45d2f4f64f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6988788f-0c47-4a98-a883-e45d2f4f64f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: importer-only change that removes manual `UserFacility.id` assignment and relies on DB defaults; main risk is unexpected upsert/soft-delete behavior if the importer previously depended on composite IDs.
> 
> **Overview**
> Updates the reference data `userLoader` to no longer set a composite `id` for `UserFacility` rows, allowing the database default (UUID) to be used.
> 
> Also ensures facility assignments imported for a user explicitly clear `deletedAt` (reactivating previously soft-deleted links) while still soft-deleting facilities that are no longer allowed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12ba721c3e004424bfd21d682c4008cce8502681. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->