### PR TITLE
fix(appointments): TAMOC-397: Fix 'Admit' button not disabling when a patient had just been admitted via an outpatient appointment (hotfix 2.49)

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -291,6 +291,7 @@ appointments.put(
       } else {
         await appointment.update(appointmentData);
       }
+      await appointment.reload();
       return appointment;
     });
     res.status(200).send(result);

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -21,7 +21,6 @@ import { escapePatternWildcard } from '../../utils/query';
 
 export const appointments = express.Router();
 
-
 const reorderAppointmentSchema = z.object({
   appointments: z
     .array(
@@ -292,7 +291,7 @@ appointments.put(
       } else {
         await appointment.update(appointmentData);
       }
-      return { ok: 'ok' };
+      return appointment;
     });
     res.status(200).send(result);
   }),


### PR DESCRIPTION
### Changes

So the issue here was that previously the `PUT` endpoint for appointments was returning `{ ok: 'ok' }` (weirdly) which meant that we weren't correctly invalidating the `patientCurrentEncounter` query in `useAppointmentMutation` since we didn't have the `patientId` from the response.

I think this change is generally safe, but will check.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
