### PR TITLE
fix(invoicing): SAV-1111: Fix refund not changing payment status

### DIFF
--- a/packages/utils/src/invoice/payments.ts
+++ b/packages/utils/src/invoice/payments.ts
@@ -1,4 +1,5 @@
 import Decimal from 'decimal.js';
+import { customAlphabet } from 'nanoid';
 import {
   INVOICE_INSURER_PAYMENT_STATUSES,
   INVOICE_PATIENT_PAYMENT_STATUSES,
@@ -6,6 +7,12 @@ import {
 import { getInvoiceSummary } from './invoice';
 import { formatDisplayPrice, round } from './display';
 import type { Invoice, Payment } from './types';
+
+const RECEIPT_NUMBER_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789';
+const RECEIPT_NUMBER_LENGTH = 8;
+
+export const generateReceiptNumber = (): string =>
+  customAlphabet(RECEIPT_NUMBER_ALPHABET, RECEIPT_NUMBER_LENGTH)();
 
 export const getInvoicePatientPaymentStatus = (paidAmount: number, owingAmount: number): string => {
   const roundedPaidAmount = round(paidAmount, 2);

--- a/packages/web/app/features/Invoice/PatientPaymentModal.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentModal.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import * as yup from 'yup';
 import Decimal from 'decimal.js';
-import { customAlphabet } from 'nanoid';
-
 import { getCurrentDateString } from '@tamanu/utils/dateTime';
 import { FORM_TYPES } from '@tamanu/constants';
 import {
@@ -16,7 +14,7 @@ import {
   TAMANU_COLORS,
   TextButton,
 } from '@tamanu/ui-components';
-import { formatDisplayPrice } from '@tamanu/utils/invoice';
+import { formatDisplayPrice, generateReceiptNumber } from '@tamanu/utils/invoice';
 
 import { TranslatedText } from '../../components/Translation';
 import { ModalFormActionRow } from '../../components/ModalActionRow';
@@ -31,8 +29,6 @@ import {
   Text,
 } from './PatientPaymentStyledComponents';
 
-const RECEIPT_NUMBER_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789';
-const RECEIPT_NUMBER_LENGTH = 8;
 const DECIMAL_PLACES = 2;
 
 const Total = styled.div`
@@ -58,9 +54,6 @@ const PayBalanceButton = styled(TextButton)`
     text-decoration: underline;
   }
 `;
-
-const generateReceiptNumber = () =>
-  customAlphabet(RECEIPT_NUMBER_ALPHABET, RECEIPT_NUMBER_LENGTH)();
 
 const calculateMaxAllowedAmount = (editingPayment, patientPaymentRemainingBalance) => {
   const editingAmount = editingPayment?.amount


### PR DESCRIPTION
### Changes
- Fix refund not changing payment status

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invoicing payment/refund flow and recalculates `Invoice.patientPaymentStatus` inside the refund transaction; mistakes here could misstate what a patient owes. Changes are scoped and covered by new refund status tests, keeping risk moderate.
> 
> **Overview**
> Refunding a patient payment now also recalculates and persists the invoice’s `patientPaymentStatus` (e.g. `PAID` → `UNPAID`/`PARTIAL`) within the refund transaction.
> 
> Receipt number generation is centralized by adding `generateReceiptNumber` to `@tamanu/utils/invoice` and switching the web modal and server tests to use it instead of ad-hoc `Date.now()`/local nanoid logic.
> 
> Adds tests covering `patientPaymentStatus` transitions when fully/partially refunded, alongside minor test cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ab8968b8fed7b3f9f6a12826c8035049158b1f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->