### PR TITLE
fix(appointment): Area not passing through to encounter from from appointment popout

### DIFF
--- a/packages/web/app/components/Field/LocationField.jsx
+++ b/packages/web/app/components/Field/LocationField.jsx
@@ -77,7 +77,7 @@ export const LocationInput = React.memo(
     useEffect(() => {
       if (!initialValues) return;
       // Form is reinitialised, reset the state handled group and location values
-      setGroupId('');
+      setGroupId(initialValues?.locationGroup ?? '');
       setLocationId(initialValues[name] ?? '');
     }, [initialValues, name]);
 


### PR DESCRIPTION
### Changes
Reinstate https://github.com/beyondessential/tamanu/pull/8735#top which got removed in unified patient move
Works for all usages I checked

- MoveModal doesn't set initialValues.locationGroup
- EncounterForm doesn't pass groupValue

Will hot fix into 2.49+

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
