### PR TITLE
fix(medications): TAMOC-395: Fix 'Missing FROM clause' error in Patients Ongoing Medications table (hotfix 2.48)

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Patient.test.js
+++ b/packages/facility-server/__tests__/apiv1/Patient.test.js
@@ -12,6 +12,7 @@ import { PATIENT_FIELD_DEFINITION_TYPES } from '@tamanu/constants/patientFields'
 import { fake } from '@tamanu/fake-data/fake';
 import { randomLabRequest } from '@tamanu/database/demoData/labRequests';
 import {
+  DRUG_STOCK_STATUSES,
   ENCOUNTER_TYPES,
   LAB_REQUEST_STATUSES,
   REFERENCE_TYPES,
@@ -454,6 +455,120 @@ describe('Patient', () => {
             m => m.medication.id === nonSensitiveMedication.id,
           );
           expect(nonSensitiveResult).toBeDefined();
+        });
+      });
+
+      describe('referenceDrugFacility', () => {
+        it('should not include referenceDrugFacility when facilityId is not provided', async () => {
+          const medication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Drug With Facility',
+            code: 'DRUG_WITH_FACILITY',
+          });
+          const referenceDrug = await models.ReferenceDrug.create({
+            referenceDataId: medication.id,
+            isSensitive: false,
+          });
+          await models.ReferenceDrugFacility.create({
+            referenceDrugId: referenceDrug.id,
+            facilityId,
+            stockStatus: DRUG_STOCK_STATUSES.IN_STOCK,
+          });
+          const prescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: medication.id }),
+          );
+          await models.PatientOngoingPrescription.create({
+            patientId: patient.id,
+            prescriptionId: prescription.id,
+          });
+
+          const result = await app.get(`/api/patient/${patient.id}/ongoing-prescriptions`);
+          expect(result).toHaveSucceeded();
+          const item = result.body.data.find(p => p.id === prescription.id);
+          expect(item).toBeDefined();
+          expect(item).not.toHaveProperty('referenceDrugFacility');
+        });
+
+        it('should include referenceDrugFacility only when facilityId is provided and matches', async () => {
+          const otherFacilityId = 'other-facility-id';
+          await models.Facility.upsert({
+            id: otherFacilityId,
+            name: 'Other Facility',
+            code: 'OTHER_FACILITY',
+          });
+
+          const medicationForThisFacility = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Drug For This Facility',
+            code: 'DRUG_FOR_THIS_FACILITY',
+          });
+          const referenceDrugThis = await models.ReferenceDrug.create({
+            referenceDataId: medicationForThisFacility.id,
+            isSensitive: false,
+          });
+          await models.ReferenceDrugFacility.create({
+            referenceDrugId: referenceDrugThis.id,
+            facilityId,
+            quantity: 100,
+            stockStatus: DRUG_STOCK_STATUSES.IN_STOCK,
+          });
+          const prescriptionThisFacility = await models.Prescription.create(
+            await createDummyPrescription(models, {
+              medicationId: medicationForThisFacility.id,
+            }),
+          );
+          await models.PatientOngoingPrescription.create({
+            patientId: patient.id,
+            prescriptionId: prescriptionThisFacility.id,
+          });
+
+          const medicationOtherFacility = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Drug Only At Other Facility',
+            code: 'DRUG_OTHER_FACILITY',
+          });
+          const referenceDrugOther = await models.ReferenceDrug.create({
+            referenceDataId: medicationOtherFacility.id,
+            isSensitive: false,
+          });
+          await models.ReferenceDrugFacility.create({
+            referenceDrugId: referenceDrugOther.id,
+            facilityId: otherFacilityId,
+            stockStatus: DRUG_STOCK_STATUSES.OUT_OF_STOCK,
+          });
+          const prescriptionOtherFacility = await models.Prescription.create(
+            await createDummyPrescription(models, {
+              medicationId: medicationOtherFacility.id,
+            }),
+          );
+          await models.PatientOngoingPrescription.create({
+            patientId: patient.id,
+            prescriptionId: prescriptionOtherFacility.id,
+          });
+
+          const result = await app.get(
+            `/api/patient/${patient.id}/ongoing-prescriptions?facilityId=${facilityId}`,
+          );
+          expect(result).toHaveSucceeded();
+
+          const itemThisFacility = result.body.data.find(
+            p => p.id === prescriptionThisFacility.id,
+          );
+          expect(itemThisFacility).toBeDefined();
+          expect(itemThisFacility.referenceDrugFacility).toBeDefined();
+          expect(itemThisFacility.referenceDrugFacility.facilityId).toBe(facilityId);
+          expect(itemThisFacility.referenceDrugFacility.referenceDrugId).toBe(
+            referenceDrugThis.id,
+          );
+          expect(itemThisFacility.referenceDrugFacility.stockStatus).toBe(
+            DRUG_STOCK_STATUSES.IN_STOCK,
+          );
+
+          const itemOtherFacility = result.body.data.find(
+            p => p.id === prescriptionOtherFacility.id,
+          );
+          expect(itemOtherFacility).toBeDefined();
+          expect(itemOtherFacility.referenceDrugFacility).toBeUndefined();
         });
       });
     });

--- a/packages/facility-server/__tests__/apiv1/Patient.test.js
+++ b/packages/facility-server/__tests__/apiv1/Patient.test.js
@@ -11,10 +11,16 @@ import {
 import { PATIENT_FIELD_DEFINITION_TYPES } from '@tamanu/constants/patientFields';
 import { fake } from '@tamanu/fake-data/fake';
 import { randomLabRequest } from '@tamanu/database/demoData/labRequests';
-import { ENCOUNTER_TYPES, LAB_REQUEST_STATUSES, REFERENCE_TYPES, SETTINGS_SCOPES } from '@tamanu/constants';
+import {
+  ENCOUNTER_TYPES,
+  LAB_REQUEST_STATUSES,
+  REFERENCE_TYPES,
+  SETTINGS_SCOPES,
+} from '@tamanu/constants';
 import { getCurrentDateString, toDateTimeString } from '@tamanu/utils/dateTime';
 import { CertificateTypes } from '@tamanu/shared/utils/patientCertificates';
 import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
+import { disableHardcodedPermissionsForSuite } from '@tamanu/shared/test-helpers';
 import { createTestContext } from '../utilities';
 
 describe('Patient', () => {
@@ -84,12 +90,12 @@ describe('Patient', () => {
     const encounterOne = await models.Encounter.create({
       ...(await createDummyEncounter(models, { current: true })),
       patientId: patient.id,
-      encounterType: ENCOUNTER_TYPES.ADMISSION
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
     });
     const encounterTwo = await models.Encounter.create({
       ...(await createDummyEncounter(models, { current: true })),
       patientId: patient.id,
-      encounterType: ENCOUNTER_TYPES.ADMISSION
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
     });
     await models.Encounter.create({
       ...(await createDummyEncounter(models, { current: true })),
@@ -363,6 +369,251 @@ describe('Patient', () => {
         where: { value: oldDisplayId },
       });
       expect(secondaryId.typeId).toBe('secondaryIdType-nhn');
+    });
+  });
+
+  describe('Get patient medications', () => {
+    describe('GET /patient/:id/ongoing-prescriptions', () => {
+      it('should return ongoing prescriptions when patient has ongoing prescriptions', async () => {
+        const prescription = await models.Prescription.create(
+          await createDummyPrescription(models),
+        );
+        await models.PatientOngoingPrescription.create({
+          patientId: patient.id,
+          prescriptionId: prescription.id,
+        });
+
+        const result = await app.get(`/api/patient/${patient.id}/ongoing-prescriptions`);
+        expect(result).toHaveSucceeded();
+        expect(result.body.data).toHaveLength(1);
+        expect(result.body.data[0]).toMatchObject({
+          id: prescription.id,
+          medication: expect.any(Object),
+        });
+        expect(result.body.count).toBe(1);
+      });
+
+      it('should reject when user lacks list Medication permission', async () => {
+        const noPermsApp = await baseApp.asRole('base');
+        const result = await noPermsApp.get(`/api/patient/${patient.id}/ongoing-prescriptions`);
+        expect(result).toBeForbidden();
+      });
+
+      describe('when user lacks list SensitiveMedication permission', () => {
+        disableHardcodedPermissionsForSuite();
+
+        it('should not return sensitive medications', async () => {
+          const sensitiveMedication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Sensitive Test Drug',
+            code: 'SENSITIVE_TEST_DRUG',
+          });
+          await models.ReferenceDrug.create({
+            referenceDataId: sensitiveMedication.id,
+            isSensitive: true,
+          });
+
+          const nonSensitiveMedication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Non-Sensitive Test Drug',
+            code: 'NONSENSITIVE_TEST_DRUG',
+          });
+          await models.ReferenceDrug.create({
+            referenceDataId: nonSensitiveMedication.id,
+            isSensitive: false,
+          });
+
+          const sensitivePrescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: sensitiveMedication.id }),
+          );
+          const nonSensitivePrescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: nonSensitiveMedication.id }),
+          );
+
+          await models.PatientOngoingPrescription.create({
+            patientId: patient.id,
+            prescriptionId: sensitivePrescription.id,
+          });
+          await models.PatientOngoingPrescription.create({
+            patientId: patient.id,
+            prescriptionId: nonSensitivePrescription.id,
+          });
+
+          const appWithMedicationOnly = await baseApp.asNewRole([['list', 'Medication']]);
+          const result = await appWithMedicationOnly.get(
+            `/api/patient/${patient.id}/ongoing-prescriptions?page=0&rowsPerPage=10&facilityId=${facilityId}`,
+          );
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.data).toHaveLength(2); // 2 medications, one from previous test and one non-sensitive
+          const sensitiveResult = result.body.data.find(
+            m => m.medication.id === sensitiveMedication.id,
+          );
+          expect(sensitiveResult).toBeUndefined();
+          const nonSensitiveResult = result.body.data.find(
+            m => m.medication.id === nonSensitiveMedication.id,
+          );
+          expect(nonSensitiveResult).toBeDefined();
+        });
+      });
+    });
+
+    describe('GET /patient/:id/dispensed-medications', () => {
+      it('should reject when user lacks read MedicationDispense permission', async () => {
+        const noPermsApp = await baseApp.asRole('base');
+        const result = await noPermsApp.get(`/api/patient/${patient.id}/dispensed-medications`);
+        expect(result).toBeForbidden();
+      });
+
+      describe('when user lacks list SensitiveMedication permission', () => {
+        disableHardcodedPermissionsForSuite();
+
+        it('should not return sensitive medications', async () => {
+          const dispenseUser = await models.User.create({
+            displayName: 'Dispense Test User',
+            email: 'dispense-test@test.test',
+          });
+          const dispensePatient = await models.Patient.create(await createDummyPatient(models));
+          const sensitiveMedication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Sensitive Dispensed Drug',
+            code: 'SENSITIVE_DISPENSED_DRUG',
+          });
+          await models.ReferenceDrug.create({
+            referenceDataId: sensitiveMedication.id,
+            isSensitive: true,
+          });
+          const nonSensitiveMedication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Non-Sensitive Dispensed Drug',
+            code: 'NONSENSITIVE_DISPENSED_DRUG',
+          });
+          await models.ReferenceDrug.create({
+            referenceDataId: nonSensitiveMedication.id,
+            isSensitive: false,
+          });
+
+          const encounter = await models.Encounter.create({
+            ...(await createDummyEncounter(models)),
+            patientId: dispensePatient.id,
+          });
+          const pharmacyOrder = await models.PharmacyOrder.create({
+            encounterId: encounter.id,
+            facilityId,
+            orderingClinicianId: dispenseUser.id,
+            date: new Date().toISOString(),
+            isDischargePrescription: false,
+          });
+          const sensitivePrescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: sensitiveMedication.id }),
+          );
+          const nonSensitivePrescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: nonSensitiveMedication.id }),
+          );
+          const sensitivePop = await models.PharmacyOrderPrescription.create({
+            pharmacyOrderId: pharmacyOrder.id,
+            prescriptionId: sensitivePrescription.id,
+            quantity: 1,
+          });
+          const nonSensitivePop = await models.PharmacyOrderPrescription.create({
+            pharmacyOrderId: pharmacyOrder.id,
+            prescriptionId: nonSensitivePrescription.id,
+            quantity: 1,
+          });
+          await models.MedicationDispense.create({
+            pharmacyOrderPrescriptionId: sensitivePop.id,
+            quantity: 1,
+            dispensedByUserId: dispenseUser.id,
+          });
+          await models.MedicationDispense.create({
+            pharmacyOrderPrescriptionId: nonSensitivePop.id,
+            quantity: 1,
+            dispensedByUserId: dispenseUser.id,
+          });
+
+          const appWithDispenseOnly = await baseApp.asNewRole([['read', 'MedicationDispense']]);
+          const result = await appWithDispenseOnly.get(
+            `/api/patient/${dispensePatient.id}/dispensed-medications`,
+          );
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.data).toHaveLength(1);
+          expect(result.body.data[0].pharmacyOrderPrescription.prescription.id).toBe(
+            nonSensitivePrescription.id,
+          );
+        });
+      });
+    });
+
+    describe('GET /patient/:id/last-inpatient-discharge-medications', () => {
+      it('should reject when user lacks list Medication permission', async () => {
+        const noPermsApp = await baseApp.asRole('base');
+        const result = await noPermsApp.get(
+          `/api/patient/${patient.id}/last-inpatient-discharge-medications`,
+        );
+        expect(result).toBeForbidden();
+      });
+
+      describe('when user lacks list SensitiveMedication permission', () => {
+        disableHardcodedPermissionsForSuite();
+
+        it('should not return sensitive medications', async () => {
+          const dischargePatient = await models.Patient.create(await createDummyPatient(models));
+          const sensitiveMedication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Sensitive Discharge Drug',
+            code: 'SENSITIVE_DISCHARGE_DRUG',
+          });
+          await models.ReferenceDrug.create({
+            referenceDataId: sensitiveMedication.id,
+            isSensitive: true,
+          });
+          const nonSensitiveMedication = await models.ReferenceData.create({
+            type: REFERENCE_TYPES.DRUG,
+            name: 'Non-Sensitive Discharge Drug',
+            code: 'NONSENSITIVE_DISCHARGE_DRUG',
+          });
+          await models.ReferenceDrug.create({
+            referenceDataId: nonSensitiveMedication.id,
+            isSensitive: false,
+          });
+
+          const encounter = await models.Encounter.create({
+            ...(await createDummyEncounter(models, { current: true })),
+            patientId: dischargePatient.id,
+            encounterType: ENCOUNTER_TYPES.ADMISSION,
+          });
+          await encounter.update({
+            endDate: new Date().toISOString(),
+          });
+
+          const sensitivePrescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: sensitiveMedication.id }),
+          );
+          const nonSensitivePrescription = await models.Prescription.create(
+            await createDummyPrescription(models, { medicationId: nonSensitiveMedication.id }),
+          );
+          await models.EncounterPrescription.create({
+            encounterId: encounter.id,
+            prescriptionId: sensitivePrescription.id,
+            isSelectedForDischarge: true,
+          });
+          await models.EncounterPrescription.create({
+            encounterId: encounter.id,
+            prescriptionId: nonSensitivePrescription.id,
+            isSelectedForDischarge: true,
+          });
+
+          const appWithMedicationOnly = await baseApp.asNewRole([['list', 'Medication']]);
+          const result = await appWithMedicationOnly.get(
+            `/api/patient/${dischargePatient.id}/last-inpatient-discharge-medications`,
+          );
+
+          expect(result).toHaveSucceeded();
+          expect(result.body.data).toHaveLength(1);
+          expect(result.body.data[0].id).toBe(nonSensitivePrescription.id);
+        });
+      });
     });
   });
 

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { literal, QueryTypes, Op } from 'sequelize';
-import { snakeCase } from 'lodash';
+import { snakeCase, isNil } from 'lodash';
 import { isBefore } from 'date-fns';
 
 import {
@@ -576,19 +576,43 @@ patientRoute.get(
 
     const { models, params, query, db } = req;
     const patientId = params.id;
-    const { PatientOngoingPrescription, Prescription } = models;
+    const { PatientOngoingPrescription, Prescription, User } = models;
     const { order = 'ASC', orderBy = 'medication.name', page, rowsPerPage, facilityId } = query;
+    const parsedPage = isNil(page) ? undefined : parseInt(page) || 0;
+    const parsedRowsPerPage = isNil(rowsPerPage) ? undefined : parseInt(rowsPerPage) || 10;
 
-    const medicationFilter = {};
     const canListSensitiveMedication = req.ability.can('list', 'SensitiveMedication');
-    if (!canListSensitiveMedication) {
-      medicationFilter['$medication.referenceDrug.is_sensitive$'] = false;
-    }
+
+    // When filtering by sensitive we LEFT JOIN referenceDrug and only exclude prescriptions that
+    // have a referenceDrug record with is_sensitive = true (include when null or false).
+    const filterSensitiveByInclude = !canListSensitiveMedication;
+    const referenceDrugInclude = {
+      model: models.ReferenceDrug,
+      as: 'referenceDrug',
+      attributes: ['referenceDataId', 'isSensitive'],
+      required: false,
+      include: facilityId
+        ? [
+            {
+              model: models.ReferenceDrugFacility,
+              as: 'facilities',
+              where: { facilityId },
+              required: false,
+            },
+          ]
+        : [],
+    };
 
     const baseQuery = {
-      where: medicationFilter,
       include: [
-        ...Prescription.getListReferenceAssociations(),
+        {
+          model: User,
+          as: 'prescriber',
+        },
+        {
+          model: User,
+          as: 'discontinuingClinician',
+        },
         {
           model: PatientOngoingPrescription,
           as: 'patientOngoingPrescription',
@@ -597,47 +621,51 @@ patientRoute.get(
         {
           model: models.ReferenceData,
           as: 'medication',
-          include: {
-            model: models.ReferenceDrug,
-            as: 'referenceDrug',
-            attributes: ['referenceDataId', 'isSensitive'],
-            include: facilityId
-              ? [
-                  {
-                    model: models.ReferenceDrugFacility,
-                    as: 'facilities',
-                    where: { facilityId },
-                    required: false,
-                  },
-                ]
-              : [],
-          },
+          required: true,
+          include: referenceDrugInclude,
         },
       ],
     };
 
+    if (filterSensitiveByInclude) {
+      baseQuery.where = {
+        [Op.or]: [
+          { '$medication.referenceDrug.id$': null },
+          { '$medication.referenceDrug.is_sensitive$': false },
+        ],
+      };
+    }
+
+    const orderClause = [
+      [
+        literal('CASE WHEN "discontinued" IS NULL OR "discontinued" = false THEN 1 ELSE 0 END'),
+        'DESC',
+      ],
+      orderBy === 'route'
+        ? [
+            literal(
+              `CASE "Prescription"."route" ${Object.entries(DRUG_ROUTE_LABELS)
+                .map(([value, label]) => `WHEN '${value}' THEN '${label.replace(/'/g, "''")}'`)
+                .join(' ')} ELSE "Prescription"."route" END`,
+            ),
+            order.toUpperCase(),
+          ]
+        : [...orderBy.split('.'), order.toUpperCase()],
+    ];
+
+    const hasLimitOffset = !isNil(parsedPage) && !isNil(parsedRowsPerPage);
+
+    // When we have both limit/offset and a sensitive filter, use subQuery: false so the filter and
+    // joins stay in the same query instead of being pushed into a subquery where those tables
+    // aren't in the FROM clause.
     const ongoingPrescriptions = await Prescription.findAll({
       ...baseQuery,
-      order: [
-        [
-          literal('CASE WHEN "discontinued" IS NULL OR "discontinued" = false THEN 1 ELSE 0 END'),
-          'DESC',
-        ],
-        orderBy === 'route'
-          ? [
-              literal(
-                `CASE "Prescription"."route" ${Object.entries(DRUG_ROUTE_LABELS)
-                  .map(([value, label]) => `WHEN '${value}' THEN '${label.replace(/'/g, "''")}'`)
-                  .join(' ')} ELSE "Prescription"."route" END`,
-              ),
-              order.toUpperCase(),
-            ]
-          : [...orderBy.split('.'), order.toUpperCase()],
-      ],
-      ...(page && rowsPerPage
+      order: orderClause,
+      ...(hasLimitOffset
         ? {
-            limit: rowsPerPage,
-            offset: page * rowsPerPage,
+            limit: parsedRowsPerPage,
+            offset: parsedPage * parsedRowsPerPage,
+            ...(filterSensitiveByInclude && { subQuery: false }),
           }
         : {}),
     });
@@ -646,7 +674,19 @@ patientRoute.get(
       ...baseQuery,
     });
 
-    let responseData = ongoingPrescriptions.map(p => p.forResponse());
+    let responseData = ongoingPrescriptions.map(p => {
+      const item = p.forResponse();
+      if (facilityId) {
+        const facilityRecord = p.medication?.referenceDrug?.facilities?.[0];
+        if (facilityRecord) {
+          item.referenceDrugFacility =
+            typeof facilityRecord.forResponse === 'function'
+              ? facilityRecord.forResponse()
+              : facilityRecord.dataValues;
+        }
+      }
+      return item;
+    });
     if (responseData.length > 0) {
       const ongoingPrescriptionIds = responseData.map(p => p.id);
 


### PR DESCRIPTION
### Changes

There was a fair bit of finagling to get cursor to do the right thing here, tbf its a pretty awkward issue. Sequelize kept moving parts of the nested `include` into an inner subquery to ensure it fetched the right number of records, but there were missing join clauses.

I think I've got it working right now, and added a bunch of unit tests to confirm

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
