### PR TITLE
fix(importer): Hotfix 2.49: TAMOC-400: Detect changes to decimal fields on re-import

### DIFF
--- a/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
+++ b/packages/central-server/__tests__/importers/invoicePriceListLoader.test.js
@@ -244,6 +244,64 @@ describe('Invoice price list item import', () => {
     expect(didntSendReason).toEqual('validationFailed');
   });
 
+  it('should detect updated decimal values on re-import', async () => {
+    const { InvoiceProduct, InvoicePriceList, InvoicePriceListItem } = models;
+
+    await InvoiceProduct.create({ ...fake(InvoiceProduct), id: 'prod-1' });
+    await InvoicePriceList.create({ ...fake(InvoicePriceList), code: 'PL_A' });
+
+    const headers = ['invoiceProductId', 'PL_A'];
+    const initialRows = [{ invoiceProductId: 'prod-1', PL_A: 100 }];
+    const initialBuffer = buildWorkbookBuffer(headers, initialRows);
+
+    const { errors: createErrors, stats: createStats } = await doImport(ctx, {
+      buffer: initialBuffer,
+    });
+    expect(createErrors).toBeEmpty();
+    expect(createStats).toMatchObject({
+      InvoicePriceListItem: { created: 1 },
+    });
+
+    // Re-import with a changed price
+    const updatedRows = [{ invoiceProductId: 'prod-1', PL_A: 200 }];
+    const updatedBuffer = buildWorkbookBuffer(headers, updatedRows);
+
+    const { errors: updateErrors, stats: updateStats } = await doImport(ctx, {
+      buffer: updatedBuffer,
+    });
+    expect(updateErrors).toBeEmpty();
+    expect(updateStats).toMatchObject({
+      InvoicePriceListItem: { updated: 1 },
+    });
+
+    const items = await InvoicePriceListItem.findAll({
+      where: { invoiceProductId: 'prod-1' },
+    });
+    expect(items).toHaveLength(1);
+    expect(Number(items[0].price)).toBe(200);
+  });
+
+  it('should skip unchanged decimal values on re-import', async () => {
+    const { InvoiceProduct, InvoicePriceList } = models;
+
+    await InvoiceProduct.create({ ...fake(InvoiceProduct), id: 'prod-1' });
+    await InvoicePriceList.create({ ...fake(InvoicePriceList), code: 'PL_A' });
+
+    const headers = ['invoiceProductId', 'PL_A'];
+    const rows = [{ invoiceProductId: 'prod-1', PL_A: 100 }];
+    const buffer = buildWorkbookBuffer(headers, rows);
+
+    const { errors: createErrors } = await doImport(ctx, { buffer });
+    expect(createErrors).toBeEmpty();
+
+    // Re-import with the same price
+    const { errors: reimportErrors, stats: reimportStats } = await doImport(ctx, { buffer });
+    expect(reimportErrors).toBeEmpty();
+    expect(reimportStats).toMatchObject({
+      InvoicePriceListItem: { skipped: 1, updated: 0 },
+    });
+  });
+
   it('should error if invoiceProductId column is missing', async () => {
     const { InvoicePriceList } = models;
 

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -78,6 +78,8 @@ function checkForChanges(existing, normalizedValues, model) {
   return Object.keys(normalizedValues)
     .filter(key => !ignoredFields?.includes(key))
     .some(key => {
+      // At this point, we already updated the existing row with the normalized values
+      // so we need to check the previous data values to see if there was a change
       const existingValue = existing._previousDataValues[key];
       const normalizedValue = normalizedValues[key];
 

--- a/packages/central-server/app/admin/importer/importRows.js
+++ b/packages/central-server/app/admin/importer/importRows.js
@@ -1,5 +1,5 @@
 import { camelCase, lowerCase, lowerFirst, startCase, upperFirst } from 'lodash';
-import { AggregateError, Op } from 'sequelize';
+import { AggregateError, DataTypes, Op } from 'sequelize';
 import { ValidationError as YupValidationError } from 'yup';
 import config from 'config';
 
@@ -78,14 +78,21 @@ function checkForChanges(existing, normalizedValues, model) {
   return Object.keys(normalizedValues)
     .filter(key => !ignoredFields?.includes(key))
     .some(key => {
-      // At this point, we already updated the existing row with the normalized values
-      // so we need to check the previous data values to see if there was a change
       const existingValue = existing._previousDataValues[key];
       const normalizedValue = normalizedValues[key];
 
-      if (typeof existingValue === 'number') {
-        return isNaN(normalizedValue) ? false : Number(normalizedValue) !== existingValue;
+      const attrType = existing.constructor.rawAttributes[key]?.type;
+      if (attrType instanceof DataTypes.NUMBER) {
+        if (existingValue == null || normalizedValue == null) {
+          return (existingValue == null) !== (normalizedValue == null);
+        }
+        const existingNum = Number(existingValue);
+        const normalizedNum = Number(normalizedValue);
+        if (Number.isNaN(normalizedNum)) return false;
+        if (Number.isNaN(existingNum)) return true;
+        return existingNum !== normalizedNum;
       }
+
       return existing.changed(key);
     });
 }


### PR DESCRIPTION
Use instanceof DataTypes.NUMBER instead of typeof to identify numeric fields, so DECIMAL values (returned as strings by Sequelize) are correctly compared during import change detection.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
