### PR TITLE
refactor(user): TAMOC-386: enforce display name uniqueness at database level

### DIFF
--- a/packages/central-server/app/admin/users.js
+++ b/packages/central-server/app/admin/users.js
@@ -29,7 +29,7 @@ function throwIfUserUniqueConstraintError(e) {
   if (fields.some(f => f === 'email' || f === 'users_email_key')) {
     throw new DatabaseDuplicateError('Email must be unique across all users');
   }
-  if (fields.some(f => f === 'display_name' || f === 'users_display_name_unique')) {
+  if (fields.some(f => f === 'display_name' || f === 'lower(display_name)' || f === 'users_display_name_unique')) {
     throw new DatabaseDuplicateError('Display name must be unique across all users');
   }
   throw new DatabaseDuplicateError(e.message);

--- a/packages/central-server/app/admin/users.js
+++ b/packages/central-server/app/admin/users.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { Op } from 'sequelize';
+import { Op, UniqueConstraintError } from 'sequelize';
 import { dateCustomValidation, getCurrentDateString } from '@tamanu/utils/dateTime';
 import { pick } from 'lodash';
 import * as yup from 'yup';
@@ -15,7 +15,6 @@ import {
   NotFoundError,
   ValidationError,
   InvalidOperationError,
-  EditConflictError,
 } from '@tamanu/errors';
 import { isBefore, startOfDay } from 'date-fns';
 import { isBcryptHash } from '@tamanu/utils/password';
@@ -23,6 +22,18 @@ import { subject } from '@casl/ability';
 import z from 'zod';
 
 export const usersRouter = express.Router();
+
+function throwIfUserUniqueConstraintError(e) {
+  if (!(e instanceof UniqueConstraintError)) throw e;
+  const fields = Object.keys(e.fields || {});
+  if (fields.some(f => f === 'email' || f === 'users_email_key')) {
+    throw new DatabaseDuplicateError('Email must be unique across all users');
+  }
+  if (fields.some(f => f === 'display_name' || f === 'users_display_name_unique')) {
+    throw new DatabaseDuplicateError('Display name must be unique across all users');
+  }
+  throw new DatabaseDuplicateError(e.message);
+}
 
 const createUserFilters = (filterParams, models) => {
   const includeDeactivated = filterParams.includeDeactivated !== 'false';
@@ -218,24 +229,6 @@ usersRouter.post(
       throw new NotFoundError('Role not found');
     }
 
-    const existingUserWithSameEmail = await User.findOne({
-      where: {
-        email: fields.email,
-      },
-    });
-    if (existingUserWithSameEmail) {
-      throw new DatabaseDuplicateError('Email must be unique across all users');
-    }
-
-    const existingUserWithSameDisplayName = await User.findOne({
-      where: {
-        displayName: { [Op.iLike]: fields.displayName },
-      },
-    });
-    if (existingUserWithSameDisplayName) {
-      throw new DatabaseDuplicateError('Display name must be unique across all users');
-    }
-
     if (fields.designations && fields.designations.length > 0) {
       // Check if all designation IDs exist and are of type 'designation'
       const existingDesignations = await ReferenceData.findAll({
@@ -276,29 +269,33 @@ usersRouter.post(
       }
     }
 
-    await db.transaction(async () => {
-      const user = await User.create(fields);
+    try {
+      await db.transaction(async () => {
+        const user = await User.create(fields);
 
-      // Add new designations
-      if (fields.designations && fields.designations.length > 0) {
-        const designationRecords = fields.designations.map(designationId => ({
-          userId: user.id,
-          designationId,
-        }));
-        await UserDesignation.bulkCreate(designationRecords);
-      }
+        // Add designations
+        if (fields.designations && fields.designations.length > 0) {
+          const designationRecords = fields.designations.map(designationId => ({
+            userId: user.id,
+            designationId,
+          }));
+          await UserDesignation.bulkCreate(designationRecords);
+        }
 
-      const uniqueFacilityIds = [...new Set(fields.allowedFacilityIds || [])];
-      await UserFacility.bulkCreate(
-        uniqueFacilityIds.map(facilityId => ({
-          userId: user.id,
-          facilityId,
-        })),
-        {
-          ignoreDuplicates: true,
-        },
-      );
-    });
+        const uniqueFacilityIds = [...new Set(fields.allowedFacilityIds || [])];
+        await UserFacility.bulkCreate(
+          uniqueFacilityIds.map(facilityId => ({
+            userId: user.id,
+            facilityId,
+          })),
+          {
+            ignoreDuplicates: true,
+          },
+        );
+      });
+    } catch (e) {
+      throwIfUserUniqueConstraintError(e);
+    }
 
     res.send({ ok: true });
   }),
@@ -409,26 +406,6 @@ usersRouter.put(
       throw new NotFoundError('Role not found');
     }
 
-    const existingUserWithSameEmail = await User.findOne({
-      where: {
-        email: fields.email,
-        id: { [Op.ne]: id },
-      },
-    });
-    if (existingUserWithSameEmail) {
-      throw new EditConflictError('Email must be unique across all users');
-    }
-
-    const existingUserWithSameDisplayName = await User.findOne({
-      where: {
-        displayName: { [Op.iLike]: fields.displayName },
-        id: { [Op.ne]: id },
-      },
-    });
-    if (existingUserWithSameDisplayName) {
-      throw new EditConflictError('Display name must be unique across all users');
-    }
-
     // Validate designations if provided
     if (fields.designations && fields.designations.length > 0) {
       // Check if all designation IDs exist and are of type 'designation'
@@ -465,25 +442,29 @@ usersRouter.put(
       updateFields.password = fields.newPassword;
     }
 
-    await db.transaction(async () => {
-      await user.update(updateFields);
-      // Remove existing designations
-      await UserDesignation.destroy({
-        where: { userId: id },
+    try {
+      await db.transaction(async () => {
+        await user.update(updateFields);
+        // Remove existing designations
+        await UserDesignation.destroy({
+          where: { userId: id },
+        });
+
+        // Add new designations
+        if (fields.designations && fields.designations.length > 0) {
+          const designationRecords = fields.designations.map(designationId => ({
+            userId: id,
+            designationId,
+          }));
+          await UserDesignation.bulkCreate(designationRecords);
+        }
+
+        const uniqueFacilityIds = [...new Set(fields.allowedFacilityIds || [])];
+        await updateUserFacilities(UserFacility, user, uniqueFacilityIds);
       });
-
-      // Add new designations
-      if (fields.designations && fields.designations.length > 0) {
-        const designationRecords = fields.designations.map(designationId => ({
-          userId: id,
-          designationId,
-        }));
-        await UserDesignation.bulkCreate(designationRecords);
-      }
-
-      const uniqueFacilityIds = [...new Set(fields.allowedFacilityIds || [])];
-      await updateUserFacilities(UserFacility, user, uniqueFacilityIds);
-    });
+    } catch (e) {
+      throwIfUserUniqueConstraintError(e);
+    }
 
     res.send({ ok: true });
   }),

--- a/packages/database/src/migrations/1772666758000-addUniqueIndexOnUsersDisplayName.ts
+++ b/packages/database/src/migrations/1772666758000-addUniqueIndexOnUsersDisplayName.ts
@@ -1,0 +1,34 @@
+import { QueryInterface } from 'sequelize';
+
+async function findDuplicateDisplayNames(query: QueryInterface) {
+  const [duplicates] = await query.sequelize.query(`
+    SELECT LOWER(display_name) AS normalized, array_agg(id) AS ids, array_agg(display_name) AS names
+    FROM users
+    GROUP BY LOWER(display_name)
+    HAVING COUNT(*) > 1
+  `);
+  return duplicates as { normalized: string; ids: string[]; names: string[] }[];
+}
+
+export async function up(query: QueryInterface): Promise<void> {
+  const duplicates = await findDuplicateDisplayNames(query);
+  if (duplicates.length > 0) {
+    const details = duplicates
+      .map(d => `  "${d.names.join('", "')}" (ids: ${d.ids.join(', ')})`)
+      .join('\n');
+    throw new Error(
+      `Cannot create unique index on users.display_name — duplicate display names found:\n${details}\n\n` +
+        'Resolve by renaming or merging the duplicate users in the admin panel, then re-run migrations.',
+    );
+  }
+
+  await query.sequelize.query(`
+    CREATE UNIQUE INDEX users_display_name_unique ON users (LOWER(display_name))
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    DROP INDEX IF EXISTS users_display_name_unique
+  `);
+}

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -140,7 +140,6 @@ export class User extends Model {
         displayName: {
           type: DataTypes.STRING,
           allowNull: false,
-          unique: true,
         },
         role: {
           type: DataTypes.STRING,
@@ -170,7 +169,14 @@ export class User extends Model {
             attributes: { include: ['password'] },
           },
         },
-        indexes: [{ fields: ['email'] }],
+        indexes: [
+          { fields: ['email'] },
+          {
+            name: 'users_display_name_unique',
+            unique: true,
+            fields: [Sequelize.fn('LOWER', Sequelize.col('display_name'))],
+          },
+        ],
         syncDirection: SYNC_DIRECTIONS.PULL_FROM_CENTRAL,
         hooks: {
           async beforeUpdate(user: User) {

--- a/packages/database/src/models/User.ts
+++ b/packages/database/src/models/User.ts
@@ -140,6 +140,7 @@ export class User extends Model {
         displayName: {
           type: DataTypes.STRING,
           allowNull: false,
+          unique: true,
         },
         role: {
           type: DataTypes.STRING,


### PR DESCRIPTION
### Changes
Enforce email and display name uniqueness at the database level instead of application-level pre-checks in the user admin routes.

- Add migration with case-insensitive unique index on `users.display_name` (email already had one)
- Remove redundant find-then-check queries from create/update handlers — the DB constraint is now the source of truth
- Catch `UniqueConstraintError` from the transaction and map to friendly `DatabaseDuplicateError` messages
- Migration logs duplicate display names and provides resolution guidance if it can't proceed

Reference data import now gets the same uniqueness validation as the admin panel for free.

**No mobile migration** — users are `PULL_FROM_CENTRAL` only so mobile never creates or edits them. Central enforces uniqueness before data reaches mobile, and a failing migration on-device would silently block the app with no way for the user to resolve it.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
