### PR TITLE
tweak(sync): no-issue: Disable mobile sync -> useUnsafeSchemaForInitialSync by default

### DIFF
--- a/packages/mobile/App/services/sync/MobileSyncManager.ts
+++ b/packages/mobile/App/services/sync/MobileSyncManager.ts
@@ -388,7 +388,7 @@ export class MobileSyncManager {
       this.updateProgress(recordTotal, totalSaved, `Saving changes (${totalSaved}/${recordTotal})`);
     };
 
-    const { useUnsafeSchemaForInitialSync = true } = this.syncSettings;
+    const { useUnsafeSchemaForInitialSync = false } = this.syncSettings;
     if (useUnsafeSchemaForInitialSync) {
       await Database.setUnsafePragma();
     }


### PR DESCRIPTION
### Changes

In a recent deployment issue, we noticed that the unsafe pragma meant that we can't rollback the persist transaction during an initial sync. This means that if that sync fails for some reason, the device is stuck in an invalid state and needs to manually have its app data cleared.

Still a useful setting as it really speeds up sync, but best to be off by default.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
