### PR TITLE
fix(suggestions): Hotfix 2.50: no-issue: Revert Op.iLike on suggestion lookup id

### DIFF
--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -173,7 +173,7 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper, searchColumn,
       const include = includeBuilder?.(req);
 
       const record = await models[modelName].findOne({
-        where: { id: { [Op.iLike]: params.id } },
+        where: { id: params.id },
         include,
         bind: {
           language,


### PR DESCRIPTION
Using Op.iLike (ILIKE) on a uuid column fails in Postgres with:
  operator does not exist: uuid ~~* unknown

UUID primary keys are always lowercase so case-insensitive matching
adds no value and breaks every /api/suggestions/:endpoint/:id lookup.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
