### PR TITLE
fix(suggestions): Hotfix 2.49: no-issue: Revert Op.iLike on suggestion lookup id

### DIFF
--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -173,7 +173,7 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper, searchColumn,
       const include = includeBuilder?.(req);
 
       const record = await models[modelName].findOne({
-        where: { id: { [Op.iLike]: params.id } },
+        where: { id: params.id },
         include,
         bind: {
           language,


### PR DESCRIPTION
This reverts commit cfe310ae461fc24b1b9df553f84612ea3882a5a1.

I haven't been able to determine the exact use case for that change, so will only merge this once that's known, but thought it was worth putting up for review in the meantime
