### PR TITLE
tweak(fhir): Add prescription endDate to the FHIR MedicationRequest.dispenseRequest.validityPeriod

### DIFF
--- a/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
@@ -115,6 +115,7 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
       const { FhirMedicationRequest, PharmacyOrder, PharmacyOrderPrescription, Prescription } =
         ctx.store.models;
 
+      const prescriptionStartDate = new Date('2026-01-01T00:00:00.000Z').toISOString();
       const prescription = await Prescription.create(
         fake(Prescription, {
           medicationId: resources.drug1.id,
@@ -125,8 +126,12 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
           route: DRUG_ROUTES.oral,
           prescriberId: resources.practitioner.id,
           isVariableDose: false,
+          startDate: prescriptionStartDate,
+          durationValue: 165,
+          durationUnit: 'days',
         }),
       );
+      await prescription.reload();
       const pharmacyOrder = await PharmacyOrder.create(
         fake(PharmacyOrder, {
           encounterId: resources.encounter.id,
@@ -250,6 +255,10 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
         dispenseRequest: {
           quantity: pharmacyOrderPrescription.quantity,
           numberOfRepeatsAllowed: pharmacyOrderPrescription.repeats,
+          validityPeriod: {
+            start: formatFhirDate(prescription.startDate),
+            end: formatFhirDate(prescription.endDate),
+          },
         },
         authoredOn: pharmacyOrder.createdAt.toISOString(),
         note: [

--- a/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
+++ b/packages/central-server/__tests__/hl7fhir/materialised/MedicationRequest.test.js
@@ -116,6 +116,7 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
         ctx.store.models;
 
       const prescriptionStartDate = new Date('2026-01-01T00:00:00.000Z').toISOString();
+      const prescriptionNote = 'Take with food';
       const prescription = await Prescription.create(
         fake(Prescription, {
           medicationId: resources.drug1.id,
@@ -129,6 +130,7 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
           startDate: prescriptionStartDate,
           durationValue: 165,
           durationUnit: 'days',
+          notes: prescriptionNote,
         }),
       );
       await prescription.reload();
@@ -265,8 +267,14 @@ describe(`Materialised FHIR - MedicationRequest`, () => {
           {
             text: pharmacyOrder.comments,
           },
+          {
+            text: prescriptionNote,
+          },
         ],
       });
+      expect(response.body.note).toHaveLength(2);
+      expect(response.body.note[0].text).toBe(pharmacyOrder.comments);
+      expect(response.body.note[1].text).toBe(prescriptionNote);
       expect(response.headers['last-modified']).toBe(formatRFC7231(new Date(mat.lastUpdated)));
       expect(response).toHaveSucceeded();
     });

--- a/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
+++ b/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
@@ -68,7 +68,7 @@ export async function getValues(upstream: PharmacyOrderPrescription, models: Mod
     requester,
     subject,
     encounter,
-    note: note(pharmacyOrder, recorder),
+    note: note(pharmacyOrder, prescription, recorder),
     resolved:
       requester.isResolved() &&
       recorder.isResolved() &&
@@ -233,15 +233,29 @@ function category(pharmacyOrder: PharmacyOrder) {
   return null;
 }
 
-function note(pharmacyOrder: PharmacyOrder, recorder: FhirReference) {
+function note(
+  pharmacyOrder: PharmacyOrder,
+  prescription: Prescription | null,
+  recorder: FhirReference,
+) {
+  const annotations: FhirAnnotation[] = [];
+
   if (pharmacyOrder.comments) {
-    return [
+    annotations.push(
       new FhirAnnotation({
         author: recorder,
         text: pharmacyOrder.comments,
       }),
-    ];
+    );
   }
 
-  return null;
+  if (prescription?.notes?.trim()) {
+    annotations.push(
+      new FhirAnnotation({
+        text: prescription.notes.trim(),
+      }),
+    );
+  }
+
+  return annotations.length > 0 ? annotations : null;
 }

--- a/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
+++ b/packages/database/src/utils/fhir/MedicationRequest/getValues.ts
@@ -10,7 +10,9 @@ import {
   FhirDosageInstruction,
   FhirTiming,
   FhirDoseAndRate,
+  FhirPeriod,
 } from '@tamanu/shared/services/fhirTypes';
+import { formatFhirDate } from '@tamanu/shared/utils/fhir';
 import type { Models } from '../../../types/model';
 import type { PharmacyOrder, PharmacyOrderPrescription, Prescription } from '../../../models';
 import { getMedicationDoseDisplay, getTranslatedFrequency } from '@tamanu/shared/utils/medication';
@@ -28,6 +30,10 @@ export async function getValues(upstream: PharmacyOrderPrescription, models: Mod
   const requester = await requesterRef(pharmacyOrder, models);
   const subject = await subjectRef(pharmacyOrder, models);
   const encounter = await FhirReference.to(models.FhirEncounter, pharmacyOrder.encounterId);
+  const prescription = await models.Prescription.findOne({
+    where: { id: upstream.prescriptionId },
+  });
+
   return {
     lastUpdated: new Date(),
     identifier: [
@@ -51,6 +57,12 @@ export async function getValues(upstream: PharmacyOrderPrescription, models: Mod
     dispenseRequest: {
       quantity: upstream.quantity,
       numberOfRepeatsAllowed: upstream.repeats,
+      ...(prescription?.endDate && {
+        validityPeriod: new FhirPeriod({
+          start: formatFhirDate(prescription.startDate),
+          end: formatFhirDate(prescription.endDate),
+        }),
+      }),
     },
     recorder,
     requester,

--- a/packages/shared/src/services/fhirTypes/period.js
+++ b/packages/shared/src/services/fhirTypes/period.js
@@ -8,18 +8,15 @@ export class FhirPeriod extends FhirBaseType {
   static SCHEMA() {
     return yup
       .object({
-        start: yup
-          .string()
-          .nullable()
-          .default(null),
+        start: yup.string().nullable().default(null),
         end: yup
           .string()
           .when('start', (start, schema) =>
             start
               ? schema.test(
                   'is-later-than-start',
-                  'end must be later than start',
-                  end => end === null || end > start,
+                  'end must be later than or equal to start',
+                  end => end === null || end >= start,
                 )
               : schema,
           )


### PR DESCRIPTION
### Changes

Will be useful to display the expiry date of the prescription in mSupply

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
