### PR TITLE
fix(invoicing): Hotfix 2.51: no-issue: revert global ILIKE on suggester lookup

### DIFF
--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -192,7 +192,7 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper, searchColumn,
       const include = includeBuilder?.(req);
 
       const record = await models[modelName].findOne({
-        where: { id: { [Op.iLike]: params.id } },
+        where: { id: params.id },
         include,
         bind: {
           language,

--- a/packages/web/app/constants/invoices.js
+++ b/packages/web/app/constants/invoices.js
@@ -30,4 +30,3 @@ export const INVOICE_DISCOUNT_TYPES = {
   ASSESSMENT: 'assessment',
 };
 
-export const CASH_PAYMENT_METHOD_ID = 'paymentMethod-cash';

--- a/packages/web/app/features/Invoice/PatientPaymentModal.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentModal.jsx
@@ -19,7 +19,7 @@ import { formatDisplayPrice, generateReceiptNumber } from '@tamanu/utils/invoice
 import { TranslatedText } from '../../components/Translation';
 import { ModalFormActionRow } from '../../components/ModalActionRow';
 import { useCreatePatientPayment, useUpdatePatientPayment } from '../../api/mutations';
-import { CASH_PAYMENT_METHOD_ID } from '../../constants';
+import { useDefaultPaymentMethodId } from './useDefaultPaymentMethodId';
 import {
   PaymentFormCard,
   Header,
@@ -129,6 +129,7 @@ export const PatientPaymentModal = ({
   const validationSchema = getValidationSchema(paymentRecord, patientPaymentRemainingBalance);
 
   const paymentMethodSuggester = useSuggester('paymentMethod');
+  const { defaultMethodId, loading: loadingDefaultMethod } = useDefaultPaymentMethodId(paymentMethodSuggester);
   const { mutate: createPatientPayment } = useCreatePatientPayment(invoice);
   const { mutate: updatePatientPayment } = useUpdatePatientPayment(invoice, paymentRecord.id);
 
@@ -161,14 +162,14 @@ export const PatientPaymentModal = ({
       onClose={onClose}
       data-testid="modal-j1bi"
     >
-      <Form
+      {loadingDefaultMethod ? null : <Form
         enableReinitialize
         suppressErrorDialog
         onSubmit={handleSubmit}
         validationSchema={validationSchema}
         initialValues={{
           date: paymentRecord.date || getCurrentDate(),
-          methodId: paymentRecord.patientPayment?.methodId || CASH_PAYMENT_METHOD_ID,
+          methodId: paymentRecord.patientPayment?.methodId ?? defaultMethodId ?? '',
           amount: paymentRecord.amount != null ? paymentRecord.amount : '',
           receiptNumber: paymentRecord.receiptNumber,
         }}
@@ -292,7 +293,7 @@ export const PatientPaymentModal = ({
             </>
           );
         }}
-      />
+      />}
     </StyledModal>
   );
 };

--- a/packages/web/app/features/Invoice/PatientPaymentRefundModal.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentRefundModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import * as yup from 'yup';
 
 import { AutocompleteField, DateDisplay, Field, Form, useSuggester } from '@tamanu/ui-components';
 import { formatDisplayPrice } from '@tamanu/utils/invoice';
@@ -7,7 +8,7 @@ import { formatDisplayPrice } from '@tamanu/utils/invoice';
 import { TranslatedText } from '../../components/Translation';
 import { ModalFormActionRow } from '../../components/ModalActionRow';
 import { useRefundPatientPayment } from '../../api/mutations';
-import { CASH_PAYMENT_METHOD_ID } from '../../constants';
+import { useDefaultPaymentMethodId } from './useDefaultPaymentMethodId';
 import {
   Header,
   Label,
@@ -43,9 +44,16 @@ const RefundAmountValue = styled.span`
   margin-left: 20px;
 `;
 
+const validationSchema = yup.object().shape({
+  methodId: yup
+    .string()
+    .required(<TranslatedText stringId="general.required" fallback="Required" />),
+});
+
 export const PatientPaymentRefundModal = ({ invoice, isOpen, onClose, selectedPaymentRecord }) => {
   const paymentRecord = selectedPaymentRecord ?? {};
   const paymentMethodSuggester = useSuggester('paymentMethod');
+  const { defaultMethodId, loading: loadingDefaultMethod } = useDefaultPaymentMethodId(paymentMethodSuggester);
   const { mutate: refundPatientPayment } = useRefundPatientPayment(invoice, paymentRecord.id);
 
   const handleSubmit = data => {
@@ -61,13 +69,14 @@ export const PatientPaymentRefundModal = ({ invoice, isOpen, onClose, selectedPa
       onClose={onClose}
       data-testid="modal-j1bi"
     >
-      <Form
+      {loadingDefaultMethod ? null : <Form
         enableReinitialize
         suppressErrorDialog
         onSubmit={handleSubmit}
+        validationSchema={validationSchema}
         data-testid="form-xw5y"
         initialValues={{
-          methodId: CASH_PAYMENT_METHOD_ID,
+          methodId: defaultMethodId ?? '',
         }}
         render={() => {
           return (
@@ -133,7 +142,7 @@ export const PatientPaymentRefundModal = ({ invoice, isOpen, onClose, selectedPa
             </>
           );
         }}
-      />
+      />}
     </StyledModal>
   );
 };

--- a/packages/web/app/features/Invoice/useDefaultPaymentMethodId.js
+++ b/packages/web/app/features/Invoice/useDefaultPaymentMethodId.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export const useDefaultPaymentMethodId = (paymentMethodSuggester) => {
+  const [state, setState] = useState({ defaultMethodId: null, loading: true });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    paymentMethodSuggester
+      .fetchSuggestions('cash')
+      .then(results => {
+        if (!cancelled) {
+          setState({
+            defaultMethodId: results.length > 0 ? results[0].value : null,
+            loading: false,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [paymentMethodSuggester]);
+
+  return state;
+};


### PR DESCRIPTION
### Changes

Reverts the `Op.iLike` on the suggester lookup route back to exact ID matching. The ILIKE broke all suggestion endpoints with UUID primary keys (e.g. templates) because Postgres `uuid` type doesn't support the `~~*` operator.

The original ILIKE was added to handle a case-insensitive mismatch for the hardcoded `CASH_PAYMENT_METHOD_ID` constant. Instead of a global ILIKE, this removes the constant entirely and makes both payment modals dynamically fetch the default payment method by searching for 'cash' via the suggester.

Cherry-pick of the fix from main onto release/2.51.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->