### PR TITLE
fix(invoicing): Hotfix 2.49: no-issue: revert global ILIKE on suggester lookup

### DIFF
--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -173,7 +173,7 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper, searchColumn,
       const include = includeBuilder?.(req);
 
       const record = await models[modelName].findOne({
-        where: { id: { [Op.iLike]: params.id } },
+        where: { id: params.id },
         include,
         bind: {
           language,

--- a/packages/web/app/constants/invoices.js
+++ b/packages/web/app/constants/invoices.js
@@ -28,4 +28,3 @@ export const INVOICE_DISCOUNT_TYPES = {
   ASSESSMENT: 'assessment',
 };
 
-export const CASH_PAYMENT_METHOD_ID = 'paymentmethod-cash';

--- a/packages/web/app/features/Invoice/PatientPaymentModal.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentModal.jsx
@@ -20,7 +20,7 @@ import { Modal } from '../../components/Modal';
 import { TranslatedText } from '../../components/Translation';
 import { ModalFormActionRow } from '../../components/ModalActionRow';
 import { useCreatePatientPayment, useUpdatePatientPayment } from '../../api/mutations';
-import { CASH_PAYMENT_METHOD_ID } from '../../constants';
+import { useDefaultPaymentMethodId } from './useDefaultPaymentMethodId';
 
 const RECEIPT_NUMBER_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789';
 const RECEIPT_NUMBER_LENGTH = 8;
@@ -175,6 +175,7 @@ export const PatientPaymentModal = ({
   const validationSchema = getValidationSchema(paymentRecord, patientPaymentRemainingBalance);
 
   const paymentMethodSuggester = useSuggester('paymentMethod');
+  const { defaultMethodId, loading: loadingDefaultMethod } = useDefaultPaymentMethodId(paymentMethodSuggester);
   const { mutate: createPatientPayment } = useCreatePatientPayment(invoice);
   const { mutate: updatePatientPayment } = useUpdatePatientPayment(invoice, paymentRecord.id);
 
@@ -207,14 +208,14 @@ export const PatientPaymentModal = ({
       onClose={onClose}
       data-testid="modal-j1bi"
     >
-      <Form
+      {loadingDefaultMethod ? null : <Form
         enableReinitialize
         suppressErrorDialog
         onSubmit={handleSubmit}
         validationSchema={validationSchema}
         initialValues={{
           date: paymentRecord.date || getCurrentDateString(),
-          methodId: paymentRecord.patientPayment?.methodId || CASH_PAYMENT_METHOD_ID,
+          methodId: paymentRecord.patientPayment?.methodId ?? defaultMethodId ?? '',
           amount: paymentRecord.amount != null ? paymentRecord.amount : '',
           receiptNumber: paymentRecord.receiptNumber,
         }}
@@ -342,7 +343,7 @@ export const PatientPaymentModal = ({
             </>
           );
         }}
-      />
+      />}
     </StyledModal>
   );
 };

--- a/packages/web/app/features/Invoice/useDefaultPaymentMethodId.js
+++ b/packages/web/app/features/Invoice/useDefaultPaymentMethodId.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export const useDefaultPaymentMethodId = (paymentMethodSuggester) => {
+  const [state, setState] = useState({ defaultMethodId: null, loading: true });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    paymentMethodSuggester
+      .fetchSuggestions('cash')
+      .then(results => {
+        if (!cancelled) {
+          setState({
+            defaultMethodId: results.length > 0 ? results[0].value : null,
+            loading: false,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [paymentMethodSuggester]);
+
+  return state;
+};


### PR DESCRIPTION
### Changes

Reverts the `Op.iLike` on the suggester lookup route back to exact ID matching. The ILIKE broke all suggestion endpoints with UUID primary keys (e.g. templates) because Postgres `uuid` type doesn't support the `~~*` operator.

The original ILIKE was added to handle a case-insensitive mismatch for the hardcoded `CASH_PAYMENT_METHOD_ID` constant. Instead of a global ILIKE, this removes the constant entirely and makes the payment modal dynamically fetch the default payment method by searching for 'cash' via the suggester.

Cherry-pick of the fix from main onto release/2.49. Note: `PatientPaymentRefundModal` does not exist on this branch.

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->