### PR TITLE
fix(appointments): Race condition crash on outpatient appointments page

### DIFF
--- a/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
+++ b/packages/web/app/views/scheduling/outpatientBookings/useOutpatientAppointmentsCalendarData.js
@@ -47,10 +47,11 @@ export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate })
   const combinedQuery = combineQueries([locationGroupsQuery, usersQuery, appointmentsQuery]);
 
   combinedQuery.data = useMemo(() => {
-    if (!appointmentsData?.data || appointmentsData.data.length === 0) return {};
+    if (!appointmentsData?.data || !usersData || !locationGroupData) return {};
+    if (appointmentsData.data.length === 0) return {};
 
     const cellData = lodashGroupBy(
-      appointmentsData?.data,
+      appointmentsData.data,
       (appointment) => appointment[groupBy] || 'unknown',
     );
 
@@ -63,7 +64,7 @@ export const useOutpatientAppointmentsCalendarData = ({ groupBy, selectedDate })
     if (groupBy === APPOINTMENT_GROUP_BY.LOCATION_GROUP) {
       return {
         cellData,
-        headData: locationGroupData?.filter((group) => !!cellData[group.id]),
+        headData: locationGroupData.filter((group) => !!cellData[group.id]),
       };
     }
     if (!groupBy) {


### PR DESCRIPTION
### Changes
usersData could be undefined when the appointments query resolves before the users query, causing Cannot read properties of undefined (reading 'filter'). Added optional chaining to match the existing pattern used for locationGroupData on the next line.

Noticed in FSM
<img width="2058" height="1435" alt="image (12)" src="https://github.com/user-attachments/assets/eba5aedb-92c3-457d-9a22-f3f00a32e33c" />


### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
