### PR TITLE
fix(translations): no-issue: Fix newline char parsing in translations

### DIFF
--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -25,7 +25,7 @@ export const TranslatedText = ({
   const { debugMode, getTranslation } = useTranslation();
   const translation = useMemo(
     () =>
-      getTranslation(stringId, fallback, { replacements, casing })?.replace(/\\n/g, '\n') ?? '',
+      getTranslation(stringId, fallback, { replacements, casing })?.replace(/\\n/g, '\n'),
     [getTranslation, stringId, fallback, replacements, casing],
   );
 

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -24,7 +24,8 @@ export const TranslatedText = ({
 }: TranslatedTextProps): ReactElement => {
   const { debugMode, getTranslation } = useTranslation();
   const translation = useMemo(
-    () => getTranslation(stringId, fallback?.split('\\n').join('\n'), { replacements, casing }),
+    () =>
+      getTranslation(stringId, fallback, { replacements, casing })?.split('\\n')?.join('\n') ?? '',
     [getTranslation, stringId, fallback, replacements, casing],
   );
 

--- a/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
+++ b/packages/mobile/App/ui/components/Translations/TranslatedText.tsx
@@ -25,7 +25,7 @@ export const TranslatedText = ({
   const { debugMode, getTranslation } = useTranslation();
   const translation = useMemo(
     () =>
-      getTranslation(stringId, fallback, { replacements, casing })?.split('\\n')?.join('\n') ?? '',
+      getTranslation(stringId, fallback, { replacements, casing })?.replace(/\\n/g, '\n') ?? '',
     [getTranslation, stringId, fallback, replacements, casing],
   );
 

--- a/packages/ui-components/src/components/Translation/TranslatedText.jsx
+++ b/packages/ui-components/src/components/Translation/TranslatedText.jsx
@@ -17,7 +17,8 @@ export const TranslatedText = ({ stringId, fallback, replacements, casing }) => 
   const { getTranslation } = useTranslation();
 
   const translation = useMemo(
-    () => getTranslation(stringId, fallback?.split('\\n').join('\n'), { replacements, casing }),
+    () =>
+      getTranslation(stringId, fallback, { replacements, casing })?.split('\\n')?.join('\n') ?? '',
     [getTranslation, stringId, fallback, replacements, casing],
   );
 

--- a/packages/ui-components/src/components/Translation/TranslatedText.jsx
+++ b/packages/ui-components/src/components/Translation/TranslatedText.jsx
@@ -18,7 +18,7 @@ export const TranslatedText = ({ stringId, fallback, replacements, casing }) => 
 
   const translation = useMemo(
     () =>
-      getTranslation(stringId, fallback, { replacements, casing })?.split('\\n')?.join('\n') ?? '',
+      getTranslation(stringId, fallback, { replacements, casing })?.replace(/\\n/g, '\n') ?? '',
     [getTranslation, stringId, fallback, replacements, casing],
   );
 

--- a/packages/ui-components/src/components/Translation/TranslatedText.jsx
+++ b/packages/ui-components/src/components/Translation/TranslatedText.jsx
@@ -17,8 +17,7 @@ export const TranslatedText = ({ stringId, fallback, replacements, casing }) => 
   const { getTranslation } = useTranslation();
 
   const translation = useMemo(
-    () =>
-      getTranslation(stringId, fallback, { replacements, casing })?.replace(/\\n/g, '\n') ?? '',
+    () => getTranslation(stringId, fallback, { replacements, casing })?.replace(/\\n/g, '\n'),
     [getTranslation, stringId, fallback, replacements, casing],
   );
 


### PR DESCRIPTION
### Changes

We were handling newline chars in the fallback, but not in the translations themselves.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
