### PR TITLE
tweak: No-issue: make imaging areas optional

### DIFF
--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1105,6 +1105,14 @@ export const globalSettings = {
       type: imagingPrioritiesSchema,
       defaultValue: imagingPrioritiesDefault,
     },
+    imagingAreasRequired: {
+      name: 'Areas to be imaged required',
+      description:
+        'When enabled, the "Areas to be imaged" field is required when creating an imaging request. When disabled, the field is optional.',
+      exposedToWeb: true,
+      type: yup.boolean(),
+      defaultValue: true,
+    },
     labsCancellationReasons: {
       description: 'Customise the options available for lab request cancellation reasons',
       exposedToWeb: true,

--- a/packages/web/app/forms/ImagingRequestForm.jsx
+++ b/packages/web/app/forms/ImagingRequestForm.jsx
@@ -24,6 +24,7 @@ import { AutocompleteField, DateTimeField, Field, ImagingPriorityField } from '.
 import { TranslatedReferenceData, TranslatedText } from '../components/Translation';
 import { useEncounter } from '../contexts/Encounter';
 import { useLocalisation } from '../contexts/Localisation';
+import { useSettings } from '../contexts/Settings';
 import { useTranslation } from '../contexts/Translation';
 import { reloadImagingRequest } from '../store';
 import { useImagingRequestAreas } from '../utils/useImagingRequestAreas';
@@ -88,9 +89,11 @@ export const ImagingRequestForm = React.memo(
     const { formatShort, getCurrentDateTime } = useDateTime();
     const { getTranslation, getEnumTranslation } = useTranslation();
     const { getLocalisation } = useLocalisation();
+    const { getSetting } = useSettings();
     const { currentUser } = useAuth();
 
     const imagingTypes = getLocalisation('imagingTypes') || {};
+    const imagingAreasRequired = getSetting('imagingAreasRequired') !== false;
 
     const { examiner = {} } = encounter;
     const examinerLabel = examiner.displayName;
@@ -115,20 +118,21 @@ export const ImagingRequestForm = React.memo(
               const imagingAreas = getAreasForImagingType(imagingType);
               return imagingAreas.length > 0;
             },
-            then: yup
-              .string()
-              .min(3, requiredValidationMessage) // Empty input is '[]', so validating that it's got at least one value in the array
-              .required(requiredValidationMessage),
+            then: imagingAreasRequired
+              ? yup
+                  .string()
+                  .min(3, requiredValidationMessage) // Empty input is '[]', so validating that it's got at least one value in the array
+                  .required(requiredValidationMessage)
+              : yup.string(),
           }),
           areaNote: yup.string().when('imagingType', {
             is: imagingType => {
               const imagingAreas = getAreasForImagingType(imagingType);
               return imagingAreas.length === 0;
             },
-            then: yup
-              .string()
-              .trim()
-              .required(requiredValidationMessage),
+            then: imagingAreasRequired
+              ? yup.string().trim().required(requiredValidationMessage)
+              : yup.string().trim(),
           }),
         })}
         showInlineErrorsOnly
@@ -283,7 +287,7 @@ export const ImagingRequestForm = React.memo(
                   }
                   component={MultiselectField}
                   prefix="imaging.property.area"
-                  required
+                  required={imagingAreasRequired}
                   data-testid="field-bsn4"
                 />
               ) : (
@@ -300,7 +304,7 @@ export const ImagingRequestForm = React.memo(
                   multiline
                   style={{ gridColumn: '1 / -1' }}
                   minRows={3}
-                  required
+                  required={imagingAreasRequired}
                   data-testid="field-r8tf"
                 />
               )}


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes imaging request validation behavior based on a new runtime setting, which can affect data completeness and downstream workflows if misconfigured.
> 
> **Overview**
> Adds a new global setting `imagingAreasRequired` (default `true`, exposed to web) to control whether “Areas to be imaged” must be filled when creating an imaging request.
> 
> Updates `ImagingRequestForm` to read this setting and conditionally apply required UI markers and Yup validation for both `areas` (multiselect) and `areaNote` (free-text fallback), allowing the field(s) to become optional when the setting is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 322c8e9c7fc4a7d1d36643ade92cf3206b1509bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->