### PR TITLE
feat: No-issue: Make settings searchable

### DIFF
--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -7,10 +7,13 @@ import { getScopedSchema, isSetting } from '@tamanu/settings';
 
 import {
   DynamicSelectField,
+  OuterLabelFieldWrapper,
   TranslatedText,
+  SearchInput,
 } from '../../../components';
 import { SelectInput, OutlinedButton, Button } from '@tamanu/ui-components';
 import { Colors } from '../../../constants/styles';
+import { useTranslation } from '../../../contexts/Translation';
 import { Category } from './components/Category';
 
 const SettingsWrapper = styled.div`
@@ -43,6 +46,77 @@ const CategoriesWrapper = styled.div`
 const ButtonGroup = styled.div`
   display: flex;
   gap: 1rem;
+`;
+
+const SearchWrapper = styled.div`
+  position: relative;
+  width: 18.75rem;
+  padding-right: 1rem;
+`;
+
+const SearchResultsDropdown = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 0.25rem;
+  max-height: 20rem;
+  overflow-y: auto;
+  background: ${Colors.white};
+  border: 1px solid ${Colors.outline};
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1;
+`;
+
+const SearchResultItem = styled.button`
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  &:hover {
+    background: ${Colors.background};
+  }
+  &:not(:last-child) {
+    border-bottom: 1px solid ${Colors.outline};
+  }
+`;
+
+const SearchResultLabel = styled.div`
+  font-weight: 500;
+`;
+
+const SearchResultMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+`;
+
+const SearchResultTypeBadge = styled.span`
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: ${Colors.softText};
+  padding: 0.125rem 0.375rem;
+  background: ${Colors.background};
+  border-radius: 3px;
+`;
+
+const SearchResultBreadcrumb = styled.span`
+  font-size: 11px;
+  color: ${Colors.softText};
+`;
+
+const SearchResultDescription = styled.div`
+  font-size: 12px;
+  color: ${Colors.softText};
+  margin-top: 0.25rem;
 `;
 
 const UNCATEGORISED_KEY = 'uncategorised';
@@ -100,11 +174,10 @@ const getSchemaForCategory = (schema, category, subCategory) => {
 
 const getSubCategoryOptions = (schema, category) => {
   const categorySchema = schema.properties[category];
-  if (!categorySchema) return null;
+  if (!categorySchema?.properties) return null;
   const subCategories = omitBy(categorySchema.properties, isSetting);
-  return Object.keys(subCategories).length > 1
-    ? getCategoryOptions({ properties: subCategories })
-    : null;
+  const keys = Object.keys(subCategories);
+  return keys.length >= 1 ? getCategoryOptions({ properties: subCategories }) : null;
 };
 
 const getCategoryOptions = (schema) =>
@@ -114,6 +187,62 @@ const getCategoryOptions = (schema) =>
       label: formatSettingName(value.name, key),
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
+
+const SEARCH_RESULTS_LIMIT = 20;
+
+const getEntryType = (path, isLeaf) => {
+  if (isLeaf) return 'setting';
+  const segmentCount = path.split('.').length;
+  return segmentCount === 1 ? 'category' : 'subcategory';
+};
+
+const formatPathBreadcrumb = (path) =>
+  path
+    .split('.')
+    .map((segment) => capitalize(startCase(segment)))
+    .join(' › ');
+
+const buildSearchIndex = (schema) => {
+  if (!schema?.properties) return [];
+  const entries = [];
+
+  const walk = (properties, pathPrefix = '') => {
+    Object.entries(properties).forEach(([key, value]) => {
+      const path = pathPrefix ? `${pathPrefix}.${key}` : key;
+      const label = formatSettingName(value.name, key);
+      const description = value?.description ?? '';
+      const isLeaf = isSetting(value);
+      const type = getEntryType(path, isLeaf);
+      const pathBreadcrumb = formatPathBreadcrumb(path);
+
+      if (isLeaf) {
+        entries.push({ path, label, description, type, pathBreadcrumb });
+      } else {
+        entries.push({ path, label, description, type, pathBreadcrumb });
+        if (value?.properties) {
+          walk(value.properties, path);
+        }
+      }
+    });
+  };
+
+  walk(schema.properties);
+  return entries;
+};
+
+const filterSearchIndex = (index, query) => {
+  if (!query || query.trim().length < 2) return [];
+  const q = query.trim().toLowerCase();
+  return index
+    .filter(
+      (entry) =>
+        entry.type === 'setting' &&
+        (entry.label?.toLowerCase().includes(q) ||
+          entry.description?.toLowerCase().includes(q) ||
+          entry.path?.toLowerCase().includes(q)),
+    )
+    .slice(0, SEARCH_RESULTS_LIMIT);
+};
 
 export const EditorView = memo(
   ({
@@ -128,10 +257,17 @@ export const EditorView = memo(
     scope,
   }) => {
     const { facilityId } = values;
+    const { getTranslation } = useTranslation();
     const [category, setCategory] = useState(null);
     const [subCategory, setSubCategory] = useState(null);
+    const [searchQuery, setSearchQuery] = useState('');
 
     const scopedSchema = useMemo(() => prepareSchema(scope), [scope]);
+    const searchIndex = useMemo(() => buildSearchIndex(scopedSchema), [scopedSchema]);
+    const searchResults = useMemo(
+      () => filterSearchIndex(searchIndex, searchQuery),
+      [searchIndex, searchQuery],
+    );
     const categoryOptions = useMemo(() => getCategoryOptions(scopedSchema), [scopedSchema]);
     const subCategoryOptions = useMemo(
       () => getSubCategoryOptions(scopedSchema, category),
@@ -145,9 +281,34 @@ export const EditorView = memo(
     const handleChangeScope = () => {
       setSubCategory(null);
       setCategory(null);
+      setSearchQuery('');
     };
 
     useEffect(handleChangeScope, [scope]);
+
+    const handleSelectResult = async (entry) => {
+      const pathParts = entry.path.split('.');
+      const newCategory = pathParts[0];
+      const categorySchema = scopedSchema?.properties?.[newCategory];
+      const secondSegment = pathParts.length >= 2 ? pathParts[1] : null;
+      const isSecondSegmentSubCategory =
+        secondSegment &&
+        categorySchema?.properties?.[secondSegment] &&
+        !isSetting(categorySchema.properties[secondSegment]);
+      const newSubCategory = secondSegment && isSecondSegmentSubCategory ? secondSegment : null;
+
+      if (newCategory !== category || newSubCategory !== subCategory) {
+        if (dirty) {
+          const dismissChanges = await handleShowWarningModal();
+          if (!dismissChanges) return;
+          await resetForm();
+        }
+        setCategory(newCategory);
+        setSubCategory(newSubCategory);
+      }
+
+      setSearchQuery('');
+    };
 
     const handleChangeCategory = async (e) => {
       const newCategory = e.target.value;
@@ -165,8 +326,7 @@ export const EditorView = memo(
     };
 
     const getSettingPath = (path) =>
-      `${category === UNCATEGORISED_KEY ? '' : `${category}.`}${
-        subCategory ? `${subCategory}.` : ''
+      `${category === UNCATEGORISED_KEY ? '' : `${category}.`}${subCategory ? `${subCategory}.` : ''
       }${path}`;
 
     const handleChangeSetting = (path, value) => {
@@ -192,7 +352,52 @@ export const EditorView = memo(
       <>
         <SettingsWrapper data-testid="settingswrapper-bfnb">
           <CategoryOptions p={2} data-testid="categoryoptions-0h2x">
-            <Box display="flex" alignItems="center" data-testid="box-e25e">
+            <Box display="flex" alignItems="center" gap={2} data-testid="box-e25e">
+              <SearchWrapper data-testid="search-wrapper">
+                <OuterLabelFieldWrapper
+                  label={
+                    <TranslatedText
+                      stringId="admin.settings.search.placeholder"
+                      fallback="Search settings"
+                      data-testid="translatedtext-search-label"
+                    />
+                  }
+                  data-testid="settings-search-label-wrapper"
+                >
+                  <SearchInput
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onClear={() => setSearchQuery('')}
+                    data-testid="settings-search-input"
+                  />
+                {searchResults.length > 0 && (
+                  <SearchResultsDropdown data-testid="settings-search-results">
+                    {searchResults.map((entry) => (
+                      <SearchResultItem
+                        key={entry.path}
+                        type="button"
+                        onClick={() => handleSelectResult(entry)}
+                        data-testid={`settings-search-result-${entry.path.replace(/\./g, '-')}`}
+                      >
+                        <SearchResultLabel>{entry.label}</SearchResultLabel>
+                        <SearchResultMeta>
+                          <SearchResultTypeBadge>
+                            {getTranslation(
+                              `admin.settings.search.type.${entry.type}`,
+                              entry.type.charAt(0).toUpperCase() + entry.type.slice(1),
+                            )}
+                          </SearchResultTypeBadge>
+                          <SearchResultBreadcrumb>{entry.pathBreadcrumb}</SearchResultBreadcrumb>
+                        </SearchResultMeta>
+                        {entry.description ? (
+                          <SearchResultDescription>{entry.description}</SearchResultDescription>
+                        ) : null}
+                      </SearchResultItem>
+                    ))}
+                  </SearchResultsDropdown>
+                )}
+                </OuterLabelFieldWrapper>
+              </SearchWrapper>
               <StyledSelectInput
                 required
                 placeholder=""
@@ -209,22 +414,20 @@ export const EditorView = memo(
                 data-testid="styledselectinput-kvyx"
               />
               {subCategoryOptions && (
-                <Box ml={2} data-testid="box-o82k">
-                  <StyledDynamicSelectField
-                    label={
-                      <TranslatedText
-                        stringId="admin.settings.subCategory.label"
-                        fallback="Select sub-category"
-                        data-testid="translatedtext-i0zl"
-                      />
-                    }
-                    placeholder=""
-                    value={subCategory}
-                    onChange={handleChangeSubcategory}
-                    options={subCategoryOptions}
-                    data-testid="styleddynamicselectfield-d62r"
-                  />
-                </Box>
+                <StyledDynamicSelectField
+                  label={
+                    <TranslatedText
+                      stringId="admin.settings.subCategory.label"
+                      fallback="Select sub-category"
+                      data-testid="translatedtext-i0zl"
+                    />
+                  }
+                  placeholder=""
+                  value={subCategory}
+                  onChange={handleChangeSubcategory}
+                  options={subCategoryOptions}
+                  data-testid="styleddynamicselectfield-d62r"
+                />
               )}
             </Box>
             <ButtonGroup data-testid="buttongroup-oe3l">

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -188,20 +188,28 @@ const getCategoryOptions = (schema) =>
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
 
+// --- Settings search: index and filter ---
+// We build a flat list of all schema nodes (categories, subcategories, settings) so we can
+// search by label/description/path. Only leaf settings are shown in results; type and
+// breadcrumb are still displayed for context. Selecting a result sets category/subcategory
+// so the editor shows the right section.
+
 const SEARCH_RESULTS_LIMIT = 20;
 
+/** Classify a schema node for display: 'category' (top-level), 'subcategory', or 'setting' (leaf). */
 const getEntryType = (path, isLeaf) => {
   if (isLeaf) return 'setting';
-  const segmentCount = path.split('.').length;
-  return segmentCount === 1 ? 'category' : 'subcategory';
+  return path.split('.').length === 1 ? 'category' : 'subcategory';
 };
 
+/** Turn a dot path into a readable breadcrumb, e.g. "audit.changes.enabled" → "Audit › Changes › Enabled". */
 const formatPathBreadcrumb = (path) =>
   path
     .split('.')
     .map((segment) => capitalize(startCase(segment)))
     .join(' › ');
 
+/** Recursively walk the schema and build a flat list of entries with path, label, description, type, pathBreadcrumb. */
 const buildSearchIndex = (schema) => {
   if (!schema?.properties) return [];
   const entries = [];
@@ -209,19 +217,17 @@ const buildSearchIndex = (schema) => {
   const walk = (properties, pathPrefix = '') => {
     Object.entries(properties).forEach(([key, value]) => {
       const path = pathPrefix ? `${pathPrefix}.${key}` : key;
-      const label = formatSettingName(value.name, key);
-      const description = value?.description ?? '';
       const isLeaf = isSetting(value);
-      const type = getEntryType(path, isLeaf);
-      const pathBreadcrumb = formatPathBreadcrumb(path);
-
-      if (isLeaf) {
-        entries.push({ path, label, description, type, pathBreadcrumb });
-      } else {
-        entries.push({ path, label, description, type, pathBreadcrumb });
-        if (value?.properties) {
-          walk(value.properties, path);
-        }
+      const entry = {
+        path,
+        label: formatSettingName(value.name, key),
+        description: value?.description ?? '',
+        type: getEntryType(path, isLeaf),
+        pathBreadcrumb: formatPathBreadcrumb(path),
+      };
+      entries.push(entry);
+      if (!isLeaf && value?.properties) {
+        walk(value.properties, path);
       }
     });
   };
@@ -230,18 +236,33 @@ const buildSearchIndex = (schema) => {
   return entries;
 };
 
+/** Return settings that match the query (label, description, or path). Only leaf settings are included. */
 const filterSearchIndex = (index, query) => {
-  if (!query || query.trim().length < 2) return [];
-  const q = query.trim().toLowerCase();
-  return index
-    .filter(
-      (entry) =>
-        entry.type === 'setting' &&
-        (entry.label?.toLowerCase().includes(q) ||
-          entry.description?.toLowerCase().includes(q) ||
-          entry.path?.toLowerCase().includes(q)),
-    )
-    .slice(0, SEARCH_RESULTS_LIMIT);
+  const q = query?.trim();
+  if (!q || q.length < 2) return [];
+  const lower = q.toLowerCase();
+  const matches = (entry) =>
+    entry.type === 'setting' &&
+    (entry.label?.toLowerCase().includes(lower) ||
+      entry.description?.toLowerCase().includes(lower) ||
+      entry.path?.toLowerCase().includes(lower));
+  return index.filter(matches).slice(0, SEARCH_RESULTS_LIMIT);
+};
+
+/**
+ * Derive category and subcategory from a setting path and schema.
+ * Path like "audit.changes.enabled" → category "audit", subcategory "changes".
+ * The second segment is only used as subcategory if it's a nested category (has properties), not a leaf.
+ */
+const getCategoryAndSubCategoryFromPath = (path, schema) => {
+  const parts = path.split('.');
+  const category = parts[0];
+  const categorySchema = schema?.properties?.[category];
+  const secondSegment = parts.length >= 2 ? parts[1] : null;
+  const secondSegmentSchema = secondSegment && categorySchema?.properties?.[secondSegment];
+  const isSubCategory = secondSegmentSchema && !isSetting(secondSegmentSchema);
+  const subCategory = isSubCategory ? secondSegment : null;
+  return { category, subCategory };
 };
 
 export const EditorView = memo(
@@ -263,6 +284,8 @@ export const EditorView = memo(
     const [searchQuery, setSearchQuery] = useState('');
 
     const scopedSchema = useMemo(() => prepareSchema(scope), [scope]);
+
+    // Search: flat index of schema nodes, filtered to matching settings only
     const searchIndex = useMemo(() => buildSearchIndex(scopedSchema), [scopedSchema]);
     const searchResults = useMemo(
       () => filterSearchIndex(searchIndex, searchQuery),
@@ -281,21 +304,17 @@ export const EditorView = memo(
     const handleChangeScope = () => {
       setSubCategory(null);
       setCategory(null);
-      setSearchQuery('');
+      setSearchQuery(''); // Clear search when scope changes so results stay relevant
     };
 
     useEffect(handleChangeScope, [scope]);
 
+    /** Navigate to the category/subcategory that contains the selected setting; prompt to discard changes if form is dirty. */
     const handleSelectResult = async (entry) => {
-      const pathParts = entry.path.split('.');
-      const newCategory = pathParts[0];
-      const categorySchema = scopedSchema?.properties?.[newCategory];
-      const secondSegment = pathParts.length >= 2 ? pathParts[1] : null;
-      const isSecondSegmentSubCategory =
-        secondSegment &&
-        categorySchema?.properties?.[secondSegment] &&
-        !isSetting(categorySchema.properties[secondSegment]);
-      const newSubCategory = secondSegment && isSecondSegmentSubCategory ? secondSegment : null;
+      const { category: newCategory, subCategory: newSubCategory } = getCategoryAndSubCategoryFromPath(
+        entry.path,
+        scopedSchema,
+      );
 
       if (newCategory !== category || newSubCategory !== subCategory) {
         if (dirty) {
@@ -353,6 +372,7 @@ export const EditorView = memo(
         <SettingsWrapper data-testid="settingswrapper-bfnb">
           <CategoryOptions p={2} data-testid="categoryoptions-0h2x">
             <Box display="flex" alignItems="center" gap={2} data-testid="box-e25e">
+              {/* Search settings by name/description; results show type + breadcrumb, only settings are selectable */}
               <SearchWrapper data-testid="search-wrapper">
                 <OuterLabelFieldWrapper
                   label={
@@ -384,7 +404,7 @@ export const EditorView = memo(
                           <SearchResultTypeBadge>
                             {getTranslation(
                               `admin.settings.search.type.${entry.type}`,
-                              entry.type.charAt(0).toUpperCase() + entry.type.slice(1),
+                              capitalize(entry.type),
                             )}
                           </SearchResultTypeBadge>
                           <SearchResultBreadcrumb>{entry.pathBreadcrumb}</SearchResultBreadcrumb>

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -123,7 +123,7 @@ const UNCATEGORISED_KEY = 'uncategorised';
 
 export const formatSettingName = (name, path) => name || capitalize(startCase(path));
 
-const recursiveJsonParse = (obj) => {
+const recursiveJsonParse = obj => {
   if (typeof obj !== 'object') return obj;
   if (Array.isArray(obj)) return obj.map(recursiveJsonParse);
   return Object.entries(obj).reduce((acc, [key, value]) => {
@@ -141,7 +141,7 @@ const recursiveJsonParse = (obj) => {
   }, {});
 };
 
-const prepareSchema = (scope) => {
+const prepareSchema = scope => {
   const schema = getScopedSchema(scope);
   const uncategorised = pickBy(schema.properties, isSetting);
   // If there are any top-level settings, move them to an uncategorised category
@@ -180,7 +180,7 @@ const getSubCategoryOptions = (schema, category) => {
   return keys.length >= 1 ? getCategoryOptions({ properties: subCategories }) : null;
 };
 
-const getCategoryOptions = (schema) =>
+const getCategoryOptions = schema =>
   Object.entries(schema.properties)
     .map(([key, value]) => ({
       value: key,
@@ -203,14 +203,14 @@ const getEntryType = (path, isLeaf) => {
 };
 
 /** Turn a dot path into a readable breadcrumb, e.g. "audit.changes.enabled" → "Audit › Changes › Enabled". */
-const formatPathBreadcrumb = (path) =>
+const formatPathBreadcrumb = path =>
   path
     .split('.')
-    .map((segment) => capitalize(startCase(segment)))
+    .map(segment => capitalize(startCase(segment)))
     .join(' › ');
 
 /** Recursively walk the schema and build a flat list of entries with path, label, description, type, pathBreadcrumb. */
-const buildSearchIndex = (schema) => {
+const buildSearchIndex = schema => {
   if (!schema?.properties) return [];
   const entries = [];
 
@@ -241,7 +241,7 @@ const filterSearchIndex = (index, query) => {
   const q = query?.trim();
   if (!q || q.length < 2) return [];
   const lower = q.toLowerCase();
-  const matches = (entry) =>
+  const matches = entry =>
     entry.type === 'setting' &&
     (entry.label?.toLowerCase().includes(lower) ||
       entry.description?.toLowerCase().includes(lower) ||
@@ -310,14 +310,12 @@ export const EditorView = memo(
     useEffect(handleChangeScope, [scope]);
 
     /** Navigate to the category/subcategory that contains the selected setting; prompt to discard changes if form is dirty. */
-    const handleSelectResult = async (entry) => {
-      const { category: newCategory, subCategory: newSubCategory } = getCategoryAndSubCategoryFromPath(
-        entry.path,
-        scopedSchema,
-      );
+    const handleSelectResult = async entry => {
+      const { category: newCategory, subCategory: newSubCategory } =
+        getCategoryAndSubCategoryFromPath(entry.path, scopedSchema);
 
       if (newCategory !== category || newSubCategory !== subCategory) {
-        if (dirty) {
+        if (newCategory !== category && dirty) {
           const dismissChanges = await handleShowWarningModal();
           if (!dismissChanges) return;
           await resetForm();
@@ -329,7 +327,7 @@ export const EditorView = memo(
       setSearchQuery('');
     };
 
-    const handleChangeCategory = async (e) => {
+    const handleChangeCategory = async e => {
       const newCategory = e.target.value;
       if (newCategory !== category && dirty) {
         const dismissChanges = await handleShowWarningModal();
@@ -340,12 +338,13 @@ export const EditorView = memo(
       setCategory(newCategory);
     };
 
-    const handleChangeSubcategory = (e) => {
+    const handleChangeSubcategory = e => {
       setSubCategory(e.target.value);
     };
 
-    const getSettingPath = (path) =>
-      `${category === UNCATEGORISED_KEY ? '' : `${category}.`}${subCategory ? `${subCategory}.` : ''
+    const getSettingPath = path =>
+      `${category === UNCATEGORISED_KEY ? '' : `${category}.`}${
+        subCategory ? `${subCategory}.` : ''
       }${path}`;
 
     const handleChangeSetting = (path, value) => {
@@ -354,9 +353,9 @@ export const EditorView = memo(
       setFieldValue('settings', updatedSettings);
     };
 
-    const getSettingValue = (path) => get(values.settings, getSettingPath(path));
+    const getSettingValue = path => get(values.settings, getSettingPath(path));
 
-    const saveSettings = async (event) => {
+    const saveSettings = async event => {
       // Need to parse json string objects stored in keys
       const parsedSettings = recursiveJsonParse(values.settings);
       delete parsedSettings.uncategorised;
@@ -386,36 +385,36 @@ export const EditorView = memo(
                 >
                   <SearchInput
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={e => setSearchQuery(e.target.value)}
                     onClear={() => setSearchQuery('')}
                     data-testid="settings-search-input"
                   />
-                {searchResults.length > 0 && (
-                  <SearchResultsDropdown data-testid="settings-search-results">
-                    {searchResults.map((entry) => (
-                      <SearchResultItem
-                        key={entry.path}
-                        type="button"
-                        onClick={() => handleSelectResult(entry)}
-                        data-testid={`settings-search-result-${entry.path.replace(/\./g, '-')}`}
-                      >
-                        <SearchResultLabel>{entry.label}</SearchResultLabel>
-                        <SearchResultMeta>
-                          <SearchResultTypeBadge>
-                            {getTranslation(
-                              `admin.settings.search.type.${entry.type}`,
-                              capitalize(entry.type),
-                            )}
-                          </SearchResultTypeBadge>
-                          <SearchResultBreadcrumb>{entry.pathBreadcrumb}</SearchResultBreadcrumb>
-                        </SearchResultMeta>
-                        {entry.description ? (
-                          <SearchResultDescription>{entry.description}</SearchResultDescription>
-                        ) : null}
-                      </SearchResultItem>
-                    ))}
-                  </SearchResultsDropdown>
-                )}
+                  {searchResults.length > 0 && (
+                    <SearchResultsDropdown data-testid="settings-search-results">
+                      {searchResults.map(entry => (
+                        <SearchResultItem
+                          key={entry.path}
+                          type="button"
+                          onClick={() => handleSelectResult(entry)}
+                          data-testid={`settings-search-result-${entry.path.replace(/\./g, '-')}`}
+                        >
+                          <SearchResultLabel>{entry.label}</SearchResultLabel>
+                          <SearchResultMeta>
+                            <SearchResultTypeBadge>
+                              {getTranslation(
+                                `admin.settings.search.type.${entry.type}`,
+                                capitalize(entry.type),
+                              )}
+                            </SearchResultTypeBadge>
+                            <SearchResultBreadcrumb>{entry.pathBreadcrumb}</SearchResultBreadcrumb>
+                          </SearchResultMeta>
+                          {entry.description ? (
+                            <SearchResultDescription>{entry.description}</SearchResultDescription>
+                          ) : null}
+                        </SearchResultItem>
+                      ))}
+                    </SearchResultsDropdown>
+                  )}
                 </OuterLabelFieldWrapper>
               </SearchWrapper>
               <StyledSelectInput

--- a/packages/web/app/views/administration/settings/EditorView.jsx
+++ b/packages/web/app/views/administration/settings/EditorView.jsx
@@ -196,12 +196,6 @@ const getCategoryOptions = schema =>
 
 const SEARCH_RESULTS_LIMIT = 20;
 
-/** Classify a schema node for display: 'category' (top-level), 'subcategory', or 'setting' (leaf). */
-const getEntryType = (path, isLeaf) => {
-  if (isLeaf) return 'setting';
-  return path.split('.').length === 1 ? 'category' : 'subcategory';
-};
-
 /** Turn a dot path into a readable breadcrumb, e.g. "audit.changes.enabled" → "Audit › Changes › Enabled". */
 const formatPathBreadcrumb = path =>
   path
@@ -217,16 +211,13 @@ const buildSearchIndex = schema => {
   const walk = (properties, pathPrefix = '') => {
     Object.entries(properties).forEach(([key, value]) => {
       const path = pathPrefix ? `${pathPrefix}.${key}` : key;
-      const isLeaf = isSetting(value);
-      const entry = {
-        path,
-        label: formatSettingName(value.name, key),
-        description: value?.description ?? '',
-        type: getEntryType(path, isLeaf),
-        pathBreadcrumb: formatPathBreadcrumb(path),
-      };
-      entries.push(entry);
-      if (!isLeaf && value?.properties) {
+
+      if (isSetting(value)) {
+        const label = formatSettingName(value.name, key);
+        const description = value?.description ?? '';
+        const pathBreadcrumb = formatPathBreadcrumb(path);
+        entries.push({ path, label, description, type: 'setting', pathBreadcrumb });
+      } else if (value?.properties) {
         walk(value.properties, path);
       }
     });
@@ -343,8 +334,7 @@ export const EditorView = memo(
     };
 
     const getSettingPath = path =>
-      `${category === UNCATEGORISED_KEY ? '' : `${category}.`}${
-        subCategory ? `${subCategory}.` : ''
+      `${category === UNCATEGORISED_KEY ? '' : `${category}.`}${subCategory ? `${subCategory}.` : ''
       }${path}`;
 
     const handleChangeSetting = (path, value) => {


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI-only, but it changes settings navigation and interacts with the dirty-form discard/reset flow, so regressions could cause unexpected loss of unsaved edits or mis-navigation.
> 
> **Overview**
> Adds a settings search box to the administration settings editor, building a flat index of schema settings and showing a dropdown of matches (name/description/path) with breadcrumb context.
> 
> Selecting a search result navigates to the corresponding category/subcategory (respecting the existing unsaved-changes warning/reset flow) and clears the search; scope changes now also clear the search query. Also tweaks subcategory option handling to be more defensive when schema properties are missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 966ce6e9beebf6be9b51c9a8567be9a9636a2704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->