### PR TITLE
tweak: educate apostrophe in “Today’s appointments”

### DIFF
--- a/packages/web/app/views/dashboard/components/TodayAppointmentsPane.jsx
+++ b/packages/web/app/views/dashboard/components/TodayAppointmentsPane.jsx
@@ -104,13 +104,13 @@ export const TodayAppointmentsPane = ({ showTasks }) => {
   const navigate = useNavigate();
   const { currentUser, facilityId } = useAuth();
   const { getCurrentDate, getDayBoundaries } = useDateTime();
-  
+
   // Get today's date boundaries in facility timezone, converted to primary timezone for query
-  const todayFacility = getCurrentDate(); 
+  const todayFacility = getCurrentDate();
   const boundaries = getDayBoundaries(todayFacility);
   const start = boundaries?.start;
   const end = boundaries?.end;
-  
+
   const appointments =
     useAutoUpdatingQuery(
       'appointments',
@@ -138,7 +138,7 @@ export const TodayAppointmentsPane = ({ showTasks }) => {
         <Heading4 margin={0} data-testid="heading4-14lj">
           <TranslatedText
             stringId="dashboard.appointments.todayAppointments.title"
-            fallback="Today's appointments"
+            fallback="Today’s appointments"
             data-testid="translatedtext-5ugr"
           />
         </Heading4>


### PR DESCRIPTION
### Changes

Today's appointments → Today’s appointments

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
