### PR TITLE
tweak: use true figure dashes for empty date strings

### DIFF
--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
@@ -163,7 +163,7 @@ export class ViewVaccineModal extends BasePatientModal {
     if (dateGiven) {
       await expect(this.dateGiven).toContainText(convertDateFormat(dateGiven));
     } else {
-      await expect(this.dateGiven).toContainText('--/--/----');
+      await expect(this.dateGiven).toContainText('‒‒/‒‒/‒‒‒‒' /* Figure dashes U+2012 */);
     }
 
     await expect(this.givenElsewhereReason).toContainText(givenElsewhereReason);

--- a/packages/patient-portal/src/utils/format.ts
+++ b/packages/patient-portal/src/utils/format.ts
@@ -17,11 +17,12 @@ const dateTimeFormatter = new Intl.DateTimeFormat(locale, {
 });
 
 export const formatDate = (dateString: string | null | undefined) => {
-  if (!dateString) return '--/--/----';
+  const emptyDate = '‒‒/‒‒/‒‒‒‒'; // Figure dashes U+2012
+  if (!dateString) return emptyDate;
   try {
     return dateFormatter.format(parseISO(dateString));
   } catch {
-    return '--/--/----';
+    return emptyDate;
   }
 };
 

--- a/packages/utils/src/dateFormatters.ts
+++ b/packages/utils/src/dateFormatters.ts
@@ -16,13 +16,13 @@ const compactTime = (s: string) => s.replace(' ', '').toLowerCase();
 /** "12/04/24" */
 export const formatShortest = createFormatter(
   { month: '2-digit', day: '2-digit', year: '2-digit' },
-  '--/--',
+  '‒‒/‒‒', // Figure dashes U+2012
 );
 
 /** "12/04/2020" */
 export const formatShort = createFormatter(
   { day: '2-digit', month: '2-digit', year: 'numeric' },
-  '--/--/----',
+  '‒‒/‒‒/‒‒‒‒', // Figure dashes U+2012
 );
 
 /** "12:30 am" */


### PR DESCRIPTION
### Changes

Replace hyphen-minus typographic approximations with figure dashes U+2012

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
