### PR TITLE
fix: TAMOC-407: Drug suggester "all" route bug

### DIFF
--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -483,8 +483,8 @@ REFERENCE_TYPE_VALUES.forEach(typeName => {
 
       return baseWhere;
     },
-    (() => {
-      const includeBuilderFn = req => {
+    {
+      includeBuilder: req => {
         const {
           models: {
             ReferenceData,
@@ -549,31 +549,27 @@ REFERENCE_TYPE_VALUES.forEach(typeName => {
         ].filter(Boolean);
 
         return result.length > 0 ? result : null;
-      };
-
-      return {
-        includeBuilder: includeBuilderFn,
-        queryOptions:
-          typeName === REFERENCE_TYPES.MEDICATION_SET || typeName === REFERENCE_TYPES.DRUG
-            ? { subQuery: false }
-            : {},
-        creatingBodyBuilder: req => referenceDataBodyBuilder({ type: typeName, name: req.body.name }),
-        afterCreated: afterCreatedReferenceData,
-        mapper: item => item,
-        orderBuilder: () => {
-          if (typeName === REFERENCE_TYPES.NOTE_TYPE) {
-            return [
-              // Prioritize treatment plan at the top
-              Sequelize.literal(`
+      },
+      queryOptions:
+        typeName === REFERENCE_TYPES.MEDICATION_SET || typeName === REFERENCE_TYPES.DRUG
+          ? { subQuery: false }
+          : {},
+      creatingBodyBuilder: req => referenceDataBodyBuilder({ type: typeName, name: req.body.name }),
+      afterCreated: afterCreatedReferenceData,
+      mapper: item => item,
+      orderBuilder: () => {
+        if (typeName === REFERENCE_TYPES.NOTE_TYPE) {
+          return [
+            // Prioritize treatment plan at the top
+            Sequelize.literal(`
               CASE "ReferenceData"."id" WHEN '${NOTE_TYPES.TREATMENT_PLAN}' THEN 0 ELSE 1 END
               `),
-            ];
-          }
-        },
-        shouldSkipDefaultOrder: req =>
-          req.query.parentId || typeName === REFERENCE_TYPES.MEDICATION_SET,
-      };
-    })(),
+          ];
+        }
+      },
+      shouldSkipDefaultOrder: req =>
+        req.query.parentId || typeName === REFERENCE_TYPES.MEDICATION_SET,
+    },
     true,
   );
 });

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -217,7 +217,7 @@ function createAllRecordsRoute(
     extraReplacementsBuilder,
     allRecordsIncludeBuilder,
     includeBuilder,
-    queryOptions = {},
+    queryOptions,
   },
 ) {
   suggestions.get(

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -215,6 +215,7 @@ function createAllRecordsRoute(
     mapper,
     searchColumn,
     extraReplacementsBuilder,
+    allRecordsIncludeBuilder,
     includeBuilder,
     queryOptions = {},
   },
@@ -229,7 +230,7 @@ function createAllRecordsRoute(
       const model = models[modelName];
       const where = whereBuilder({ search: '%', query, req, endpoint, modelName, searchColumn });
 
-      const include = includeBuilder?.(req);
+      const include = allRecordsIncludeBuilder?.(req) ?? includeBuilder?.(req);
 
       const results = await model.findAll({
         include,
@@ -722,6 +723,7 @@ createSuggester(
   'InvoiceInsurancePlan',
   ({ endpoint, modelName }) => DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
   {
+    allRecordsIncludeBuilder: invoiceInsurancePlanIncludeBuilder,
     includeBuilder: invoiceInsurancePlanIncludeBuilder,
   },
 );

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -211,7 +211,7 @@ function createAllRecordsRoute(
   endpoint,
   modelName,
   whereBuilder,
-  { mapper, searchColumn, extraReplacementsBuilder, allRecordsIncludeBuilder },
+  { mapper, searchColumn, extraReplacementsBuilder, includeBuilder },
 ) {
   suggestions.get(
     `/${endpoint}/all$`,
@@ -223,7 +223,7 @@ function createAllRecordsRoute(
       const model = models[modelName];
       const where = whereBuilder({ search: '%', query, req, endpoint, modelName, searchColumn });
 
-      const include = allRecordsIncludeBuilder?.(req);
+      const include = includeBuilder?.(req);
 
       const results = await model.findAll({
         include,
@@ -483,8 +483,8 @@ REFERENCE_TYPE_VALUES.forEach(typeName => {
 
       return baseWhere;
     },
-    {
-      includeBuilder: req => {
+    (() => {
+      const includeBuilderFn = req => {
         const {
           models: {
             ReferenceData,
@@ -549,27 +549,31 @@ REFERENCE_TYPE_VALUES.forEach(typeName => {
         ].filter(Boolean);
 
         return result.length > 0 ? result : null;
-      },
-      queryOptions:
-        typeName === REFERENCE_TYPES.MEDICATION_SET || typeName === REFERENCE_TYPES.DRUG
-          ? { subQuery: false }
-          : {},
-      creatingBodyBuilder: req => referenceDataBodyBuilder({ type: typeName, name: req.body.name }),
-      afterCreated: afterCreatedReferenceData,
-      mapper: item => item,
-      orderBuilder: () => {
-        if (typeName === REFERENCE_TYPES.NOTE_TYPE) {
-          return [
-            // Prioritize treatment plan at the top
-            Sequelize.literal(`
+      };
+
+      return {
+        includeBuilder: includeBuilderFn,
+        queryOptions:
+          typeName === REFERENCE_TYPES.MEDICATION_SET || typeName === REFERENCE_TYPES.DRUG
+            ? { subQuery: false }
+            : {},
+        creatingBodyBuilder: req => referenceDataBodyBuilder({ type: typeName, name: req.body.name }),
+        afterCreated: afterCreatedReferenceData,
+        mapper: item => item,
+        orderBuilder: () => {
+          if (typeName === REFERENCE_TYPES.NOTE_TYPE) {
+            return [
+              // Prioritize treatment plan at the top
+              Sequelize.literal(`
               CASE "ReferenceData"."id" WHEN '${NOTE_TYPES.TREATMENT_PLAN}' THEN 0 ELSE 1 END
-            `),
-          ];
-        }
-      },
-      shouldSkipDefaultOrder: req =>
-        req.query.parentId || typeName === REFERENCE_TYPES.MEDICATION_SET,
-    },
+              `),
+            ];
+          }
+        },
+        shouldSkipDefaultOrder: req =>
+          req.query.parentId || typeName === REFERENCE_TYPES.MEDICATION_SET,
+      };
+    })(),
     true,
   );
 });
@@ -715,7 +719,6 @@ createSuggester(
   'InvoiceInsurancePlan',
   ({ endpoint, modelName }) => DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
   {
-    allRecordsIncludeBuilder: invoiceInsurancePlanIncludeBuilder,
     includeBuilder: invoiceInsurancePlanIncludeBuilder,
   },
 );

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -215,7 +215,6 @@ function createAllRecordsRoute(
     mapper,
     searchColumn,
     extraReplacementsBuilder,
-    allRecordsIncludeBuilder,
     includeBuilder,
     queryOptions,
   },
@@ -230,7 +229,7 @@ function createAllRecordsRoute(
       const model = models[modelName];
       const where = whereBuilder({ search: '%', query, req, endpoint, modelName, searchColumn });
 
-      const include = allRecordsIncludeBuilder?.(req) ?? includeBuilder?.(req);
+      const include = includeBuilder?.(req);
 
       const results = await model.findAll({
         include,
@@ -723,7 +722,6 @@ createSuggester(
   'InvoiceInsurancePlan',
   ({ endpoint, modelName }) => DEFAULT_WHERE_BUILDER({ endpoint, modelName }),
   {
-    allRecordsIncludeBuilder: invoiceInsurancePlanIncludeBuilder,
     includeBuilder: invoiceInsurancePlanIncludeBuilder,
   },
 );

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -217,7 +217,7 @@ function createAllRecordsRoute(
     extraReplacementsBuilder,
     allRecordsIncludeBuilder,
     includeBuilder,
-    queryOptions,
+    queryOptions = {},
   },
 ) {
   suggestions.get(

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -211,7 +211,14 @@ function createAllRecordsRoute(
   endpoint,
   modelName,
   whereBuilder,
-  { mapper, searchColumn, extraReplacementsBuilder, allRecordsIncludeBuilder },
+  {
+    mapper,
+    searchColumn,
+    extraReplacementsBuilder,
+    allRecordsIncludeBuilder,
+    includeBuilder,
+    queryOptions,
+  },
 ) {
   suggestions.get(
     `/${endpoint}/all$`,
@@ -223,7 +230,7 @@ function createAllRecordsRoute(
       const model = models[modelName];
       const where = whereBuilder({ search: '%', query, req, endpoint, modelName, searchColumn });
 
-      const include = allRecordsIncludeBuilder?.(req);
+      const include = allRecordsIncludeBuilder?.(req) ?? includeBuilder?.(req);
 
       const results = await model.findAll({
         include,
@@ -235,6 +242,7 @@ function createAllRecordsRoute(
           searchQuery: '%',
           ...extraReplacementsBuilder(query),
         },
+        ...queryOptions,
       });
       // Allow for async mapping functions (currently only used by location suggester)
       res.send(await Promise.all(results.map(mapper)));

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -211,14 +211,7 @@ function createAllRecordsRoute(
   endpoint,
   modelName,
   whereBuilder,
-  {
-    mapper,
-    searchColumn,
-    extraReplacementsBuilder,
-    allRecordsIncludeBuilder,
-    includeBuilder,
-    queryOptions,
-  },
+  { mapper, searchColumn, extraReplacementsBuilder, allRecordsIncludeBuilder },
 ) {
   suggestions.get(
     `/${endpoint}/all$`,
@@ -230,7 +223,7 @@ function createAllRecordsRoute(
       const model = models[modelName];
       const where = whereBuilder({ search: '%', query, req, endpoint, modelName, searchColumn });
 
-      const include = allRecordsIncludeBuilder?.(req) ?? includeBuilder?.(req);
+      const include = allRecordsIncludeBuilder?.(req);
 
       const results = await model.findAll({
         include,
@@ -242,7 +235,6 @@ function createAllRecordsRoute(
           searchQuery: '%',
           ...extraReplacementsBuilder(query),
         },
-        ...queryOptions,
       });
       // Allow for async mapping functions (currently only used by location suggester)
       res.send(await Promise.all(results.map(mapper)));


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing/options change limited to suggestion endpoints; low risk aside from potentially altering query joins for `/all` responses.
> 
> **Overview**
> Fixes suggester `/all` routes to use the standard `includeBuilder` option (renaming the previous `allRecordsIncludeBuilder` hook), so endpoints like `invoiceInsurancePlan` get the correct includes when fetching all records.
> 
> Also includes a minor formatting tweak in the `NOTE_TYPE` ordering literal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5de24c38bb0cedd1384fe917123a131ea17faebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->