### PR TITLE
fix(invoicing): no-issue: Fixed data table exports broken due to missing dateTime context

### DIFF
--- a/packages/ui-components/src/contexts/DateTimeContext.tsx
+++ b/packages/ui-components/src/contexts/DateTimeContext.tsx
@@ -44,7 +44,8 @@ interface DateTimeProviderProps {
   facilityTimeZone?: string | null;
 }
 
-const DateTimeProviderContext = createContext<DateTimeContextValue | null>(null);
+/** Exported so consumers can inject a datetime value (e.g. when rendering in an isolated root for export). */
+export const DateTimeProviderContext = createContext<DateTimeContextValue | null>(null);
 
 export const useDateTime = (): DateTimeContextValue => {
   const context = useContext(DateTimeProviderContext);

--- a/packages/web/app/components/Table/DownloadDataButton.jsx
+++ b/packages/web/app/components/Table/DownloadDataButton.jsx
@@ -4,6 +4,7 @@ import * as XLSX from 'xlsx';
 import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import {
   ApiContext,
+  DateTimeProviderContext,
   TranslationContext,
   useTranslation,
   GreyOutlinedButton,
@@ -16,7 +17,8 @@ import { TranslatedText } from '../Translation';
 import { ExportProvider } from '../../contexts/ExportContext';
 
 export function DownloadDataButton({ exportName, columns, data, ExportButton }) {
-  const { getCurrentDate } = useDateTime();
+  const dateTimeContext = useDateTime();
+  const { getCurrentDate } = dateTimeContext;
   const queryClient = useQueryClient();
   const api = useApi();
   const translationContext = useTranslation();
@@ -28,7 +30,9 @@ export function DownloadDataButton({ exportName, columns, data, ExportButton }) 
         <QueryClientProvider client={queryClient} data-testid="queryclientprovider-k086">
           <ApiContext.Provider value={api} data-testid="provider-72ic">
             <TranslationContext.Provider value={translationContext} data-testid="provider-c9xv">
-              {element}
+              <DateTimeProviderContext.Provider value={dateTimeContext}>
+                {element}
+              </DateTimeProviderContext.Provider>
             </TranslationContext.Provider>
           </ApiContext.Provider>
         </QueryClientProvider>


### PR DESCRIPTION
### Changes

We need to wrap the the `safelyRenderToText` function in the `DataDownloadButton` with all the required contexts. Looks like the `DateTimeContext` was missing.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
