### PR TITLE
fix(e2e): no-issue: Add refresh auth token flow for e2e tests

### DIFF
--- a/packages/e2e-tests/config/auth.ts
+++ b/packages/e2e-tests/config/auth.ts
@@ -1,0 +1,3 @@
+import path from 'path';
+
+export const AUTH_STATE_PATH = path.join(__dirname, '..', '.auth', 'user.json');

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup } from '../../fixtures/baseFixture';
-import path from 'path';
+
+import { AUTH_STATE_PATH } from '../../config/auth';
 
 setup('authenticate', async ({ loginPage }) => {
   await loginPage.goto();
@@ -16,7 +17,5 @@ setup('authenticate', async ({ loginPage }) => {
   // Ensure state is persisted
   await loginPage.page.waitForTimeout(1000);
 
-  // Save page context
-  const authStatePath = path.join(__dirname, '../../.auth/user.json');
-  await loginPage.page.context().storageState({ path: authStatePath });
+  await loginPage.page.context().storageState({ path: AUTH_STATE_PATH });
 });

--- a/packages/e2e-tests/utils/apiHelpers.ts
+++ b/packages/e2e-tests/utils/apiHelpers.ts
@@ -6,8 +6,10 @@ import { getItemFromLocalStorage } from './localStorage';
 import { Patient, User } from '@tamanu/database';
 import { generateNHN } from './generateNewPatient';
 import { testData } from './testData';
+import { ensureValidToken } from './auth';
 
 export const createApiContext = async ({ page }: { page: Page }) => {
+  await ensureValidToken(page);
   const token = await getItemFromLocalStorage(page, 'apiToken');
 
   return request.newContext({

--- a/packages/e2e-tests/utils/auth.ts
+++ b/packages/e2e-tests/utils/auth.ts
@@ -1,0 +1,51 @@
+import { Page } from '@playwright/test';
+
+import { LoginPage } from '../pages/LoginPage';
+import { getItemFromLocalStorage } from './localStorage';
+import { AUTH_STATE_PATH } from '../config/auth';
+
+const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
+
+function isTokenExpired(token: string, bufferSeconds = TOKEN_EXPIRY_BUFFER_SECONDS): boolean {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return true;
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+    const exp = payload.exp as number | undefined;
+    if (!exp) return true;
+    return Date.now() / 1000 >= exp - bufferSeconds;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Ensures the page has a valid auth token. If the token is missing or expired,
+ * performs login and persists the new storage state so subsequent tests get fresh auth.
+ * Call this before creating API contexts or using token from localStorage in long-running e2e runs (e.g. CI).
+ */
+export async function ensureValidToken(page: Page): Promise<void> {
+  let token: string | null = null;
+  try {
+    token = await getItemFromLocalStorage(page, 'apiToken');
+  } catch {
+    // No token in storage
+  }
+
+  if (token && !isTokenExpired(token)) {
+    return;
+  }
+
+  const email = process.env.TEST_EMAIL;
+  const password = process.env.TEST_PASSWORD;
+  if (!email || !password) {
+    throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set to re-authenticate');
+  }
+
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.login(email, password);
+  await page.waitForTimeout(1000);
+
+  await page.context().storageState({ path: AUTH_STATE_PATH });
+}

--- a/packages/e2e-tests/utils/generateNewPatient.ts
+++ b/packages/e2e-tests/utils/generateNewPatient.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 import { AllPatientsPage } from '../pages/patients/AllPatientsPage';
 import { constructFacilityUrl } from './navigation';
 import { testData } from '../utils/testData';
+import { ensureValidToken } from './auth';
 
 export function generateNHN() {
   const letters = faker.string.alpha({ length: 4, casing: 'upper' });
@@ -29,6 +30,7 @@ export async function createPatientViaApi(allPatientsPage: AllPatientsPage) {
   const patientData = generatePatientData();
   allPatientsPage.setPatientData(patientData);
 
+  await ensureValidToken(allPatientsPage.page);
   const token = await getItemFromLocalStorage(allPatientsPage, 'apiToken');
   const userData = await getCurrentUser(token);
   const currentFacilityId = await getItemFromLocalStorage(allPatientsPage, 'facilityId');


### PR DESCRIPTION
### Changes

Tests kept failing with invalid token errors that seemed to be caused by token expiring.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
