### PR TITLE
feat(fhir): TAN-2589: Disallow mixed standard + fhir permissions

### DIFF
--- a/packages/constants/src/fhir.ts
+++ b/packages/constants/src/fhir.ts
@@ -402,3 +402,10 @@ export const FHIR_INTEGRATION_PERMISSIONS: Record<
     write: [],
   },
 };
+
+export const FHIR_PERMISSION_NOUNS: ReadonlySet<string> = new Set([
+  ...Object.values(FHIR_RESOURCE_TO_PERMISSION_NOUN),
+  ...Object.values(SERVICE_REQUEST_PERMISSION_NOUNS),
+  ...Object.keys(FHIR_INTEGRATION_PERMISSIONS),
+  ...Object.values(FHIR_INTEGRATION_PERMISSIONS).flatMap(c => [...c.read, ...c.write]),
+]);

--- a/packages/shared/src/permissions/buildAbility.js
+++ b/packages/shared/src/permissions/buildAbility.js
@@ -1,4 +1,5 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
+import { FHIR_PERMISSION_NOUNS, FHIR_INTEGRATION_VERB } from '@tamanu/constants';
 
 export function buildAbility(permissions, options = {}) {
   const { can, build } = new AbilityBuilder(Ability);
@@ -26,10 +27,29 @@ export function buildAdminAbility() {
   ]);
 }
 
+function isFhirPermission({ verb, noun }) {
+  return verb === FHIR_INTEGRATION_VERB || FHIR_PERMISSION_NOUNS.has(noun);
+}
+
+function validateNoMixedPermissions(permissions) {
+  const hasFhir = permissions.some(isFhirPermission);
+  const hasRegular = permissions.some(p => !isFhirPermission(p));
+  if (hasFhir && hasRegular) {
+    const fhir = permissions.filter(isFhirPermission).map(p => `${p.verb}:${p.noun}`);
+    const regular = permissions.filter(p => !isFhirPermission(p)).map(p => `${p.verb}:${p.noun}`);
+    throw new Error(
+      `Role mixes FHIR and regular permissions. ` +
+      `FHIR: ${fhir.join(', ')}. Regular: ${regular.join(', ')}`,
+    );
+  }
+}
+
 export function buildAbilityForUser(user, permissions) {
   if (user.role === 'admin') {
     return buildAdminAbility();
   }
+
+  validateNoMixedPermissions(permissions);
 
   return buildAbility([
     ...permissions,

--- a/packages/shared/src/permissions/buildAbility.js
+++ b/packages/shared/src/permissions/buildAbility.js
@@ -32,11 +32,15 @@ function isFhirPermission({ verb, noun }) {
 }
 
 function validateNoMixedPermissions(permissions) {
-  const hasFhir = permissions.some(isFhirPermission);
-  const hasRegular = permissions.some(p => !isFhirPermission(p));
-  if (hasFhir && hasRegular) {
-    const fhir = permissions.filter(isFhirPermission).map(p => `${p.verb}:${p.noun}`);
-    const regular = permissions.filter(p => !isFhirPermission(p)).map(p => `${p.verb}:${p.noun}`);
+  const { fhir, regular } = permissions.reduce(
+    (acc, p) => {
+      acc[isFhirPermission(p) ? 'fhir' : 'regular'].push(`${p.verb}:${p.noun}`);
+      return acc;
+    },
+    { fhir: [], regular: [] },
+  );
+
+  if (fhir.length > 0 && regular.length > 0) {
     throw new Error(
       `Role mixes FHIR and regular permissions. ` +
       `FHIR: ${fhir.join(', ')}. Regular: ${regular.join(', ')}`,

--- a/packages/shared/src/permissions/buildAbility.js
+++ b/packages/shared/src/permissions/buildAbility.js
@@ -32,15 +32,11 @@ function isFhirPermission({ verb, noun }) {
 }
 
 function validateNoMixedPermissions(permissions) {
-  const { fhir, regular } = permissions.reduce(
-    (acc, p) => {
-      acc[isFhirPermission(p) ? 'fhir' : 'regular'].push(`${p.verb}:${p.noun}`);
-      return acc;
-    },
-    { fhir: [], regular: [] },
-  );
-
-  if (fhir.length > 0 && regular.length > 0) {
+  const hasFhir = permissions.some(isFhirPermission);
+  const hasRegular = permissions.some(p => !isFhirPermission(p));
+  if (hasFhir && hasRegular) {
+    const fhir = permissions.filter(isFhirPermission).map(p => `${p.verb}:${p.noun}`);
+    const regular = permissions.filter(p => !isFhirPermission(p)).map(p => `${p.verb}:${p.noun}`);
     throw new Error(
       `Role mixes FHIR and regular permissions. ` +
       `FHIR: ${fhir.join(', ')}. Regular: ${regular.join(', ')}`,


### PR DESCRIPTION
### Changes
Bonus from ticket: Validate no mixed permissions (fhir + standard) in a role 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
