### PR TITLE
db: no-issue: backport removeDeviceFkFromUserLoginAttempts migration to 2.45

### DIFF
--- a/packages/database/src/migrations/1768858451324-removeDeviceFkFromUserLoginAttempts.ts
+++ b/packages/database/src/migrations/1768858451324-removeDeviceFkFromUserLoginAttempts.ts
@@ -1,0 +1,31 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    ALTER TABLE user_login_attempts
+    DROP CONSTRAINT IF EXISTS user_login_attempts_device_id_fkey;
+  `);
+  await query.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS user_login_attempts_device_id ON user_login_attempts (device_id);
+  `);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeIndex('user_login_attempts', ['device_id']);
+  await query.sequelize.query(`
+    DELETE FROM user_login_attempts
+    WHERE device_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM devices WHERE devices.id = user_login_attempts.device_id);
+  `);
+  await query.addConstraint('user_login_attempts', {
+    fields: ['device_id'],
+    type: 'foreign key',
+    name: 'user_login_attempts_device_id_fkey',
+    references: {
+      table: 'devices',
+      field: 'id',
+    },
+    onDelete: 'NO ACTION',
+    onUpdate: 'NO ACTION',
+  });
+}


### PR DESCRIPTION
### Changes

Backport the `1768858451324-removeDeviceFkFromUserLoginAttempts` migration to the `release/2.45` branch.

This migration drops the foreign key constraint `user_login_attempts_device_id_fkey` on the `user_login_attempts` table and replaces it with a plain index on `device_id`. The `user_login_attempts` table has existed since v2.45 (migration `1757268197134`), but this FK removal was only introduced in v2.49. Backporting it here ensures older 2.45.x deployments also benefit from decoupling the `user_login_attempts` table from the `devices` table at the constraint level.

The migration uses `DROP CONSTRAINT IF EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it is safe to run even if the constraint was already removed or the index already exists.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._