### PR TITLE
feat(fhir): TAN-2532: Realtime update of fhir worker settings

### DIFF
--- a/packages/central-server/__tests__/tasks/FhirQueueManager.test.js
+++ b/packages/central-server/__tests__/tasks/FhirQueueManager.test.js
@@ -104,7 +104,7 @@ describe('FhirQueueManager', () => {
 
     beforeEach(async () => {
       logger = jest.fn();
-      queueManager = new FhirQueueManager(ctx.store, makeLogger(logger));
+      queueManager = new FhirQueueManager(ctx.store, ctx.settings, makeLogger(logger));
       queueManager.testMode = true;
       await queueManager.start();
       await queueManager.setHandler('test', testHandler);
@@ -155,7 +155,7 @@ describe('FhirQueueManager', () => {
         await models.FhirJob.truncate();
 
         logger = jest.fn();
-        queueManager = new FhirQueueManager(ctx.store, makeLogger(logger));
+        queueManager = new FhirQueueManager(ctx.store, ctx.settings, makeLogger(logger));
         queueManager.testMode = true;
         queueManager._concurrency = 1;
         await queueManager.setHandler('test1', testHandler);

--- a/packages/central-server/app/hl7fhir/materialised/search/query.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/query.js
@@ -1,7 +1,5 @@
 import { last } from 'lodash';
 
-import { FHIR_MAX_RESOURCES_PER_PAGE } from '@tamanu/constants';
-
 import { pushToQuery } from './common';
 import { generateWhereClause } from './where';
 import { generateOrderClause } from './order';
@@ -10,13 +8,10 @@ import { generateOrderClause } from './order';
  * @param {*} query The request query Map (normalised)
  * @param {*} parameters The search parameters for the resource
  * @param {*} FhirResource The resource model
- * @param {ReadSettings} settings The settings reader
  */
-export async function buildSearchQuery(query, parameters, FhirResource, settings) {
-  const countDefault =
-    (await settings.get('fhir.parameters._count.default')) || FHIR_MAX_RESOURCES_PER_PAGE;
+export function buildSearchQuery(query, parameters, FhirResource) {
   const sql = {
-    limit: countDefault,
+    limit: parameters.get('_count').parameterSchema.getDefault(),
   };
 
   if (query.has('_sort')) {

--- a/packages/central-server/app/hl7fhir/materialised/search/query.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/query.js
@@ -1,6 +1,6 @@
 import { last } from 'lodash';
 
-import { getFhirCountSettingsDefault } from '@tamanu/shared/utils/fhir/parameters';
+import { FHIR_MAX_RESOURCES_PER_PAGE } from '@tamanu/constants';
 
 import { pushToQuery } from './common';
 import { generateWhereClause } from './where';
@@ -10,10 +10,13 @@ import { generateOrderClause } from './order';
  * @param {*} query The request query Map (normalised)
  * @param {*} parameters The search parameters for the resource
  * @param {*} FhirResource The resource model
+ * @param {ReadSettings} settings The settings reader
  */
-export function buildSearchQuery(query, parameters, FhirResource) {
+export async function buildSearchQuery(query, parameters, FhirResource, settings) {
+  const countDefault =
+    (await settings.get('fhir.parameters._count.default')) || FHIR_MAX_RESOURCES_PER_PAGE;
   const sql = {
-    limit: getFhirCountSettingsDefault(),
+    limit: countDefault,
   };
 
   if (query.has('_sort')) {

--- a/packages/central-server/app/hl7fhir/materialised/search/search.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/search.js
@@ -22,7 +22,7 @@ export function searchHandler(FhirResource) {
       includes = resolveIncludes(req.store.models, query, parameters, FhirResource);
     }
 
-    const sqlQuery = await buildSearchQuery(query, parameters, FhirResource, req.settings);
+    const sqlQuery = buildSearchQuery(query, parameters, FhirResource);
     const total = await FhirResource.count(sqlQuery);
     const records = await FhirResource.findAll(sqlQuery);
     const { included, errors } = await retrieveIncludes(

--- a/packages/central-server/app/hl7fhir/materialised/search/search.js
+++ b/packages/central-server/app/hl7fhir/materialised/search/search.js
@@ -14,7 +14,7 @@ import { buildSearchQuery } from './query';
 
 export function searchHandler(FhirResource) {
   return asyncHandler(async (req, res) => {
-    const parameters = normaliseParameters(FhirResource);
+    const parameters = await normaliseParameters(FhirResource, req.settings);
     const query = await parseRequest(req, parameters);
 
     let includes = null;
@@ -22,7 +22,7 @@ export function searchHandler(FhirResource) {
       includes = resolveIncludes(req.store.models, query, parameters, FhirResource);
     }
 
-    const sqlQuery = buildSearchQuery(query, parameters, FhirResource);
+    const sqlQuery = await buildSearchQuery(query, parameters, FhirResource, req.settings);
     const total = await FhirResource.count(sqlQuery);
     const records = await FhirResource.findAll(sqlQuery);
     const { included, errors } = await retrieveIncludes(

--- a/packages/central-server/app/integrations/fhir/config.js
+++ b/packages/central-server/app/integrations/fhir/config.js
@@ -1,14 +1,14 @@
 import config from 'config';
 import { log } from '@tamanu/shared/services/logging';
-import { getFhirCountSettings } from '@tamanu/shared/utils/fhir/fhirSettings';
 
-export function checkFhirConfig() {
+export async function checkFhirConfig(settings) {
   const fhirEnabled = config?.integrations?.fhir?.enabled;
   if (fhirEnabled) {
-    const countSettings = getFhirCountSettings();
-    if (countSettings.default && countSettings.max && countSettings.default > countSettings.max) {
+    const countDefault = await settings.get('fhir.parameters._count.default');
+    const countMax = await settings.get('fhir.parameters._count.max');
+    if (countDefault && countMax && countDefault > countMax) {
       log.warn(
-        `FHIR _count config default value is bigger than the max (default=${countSettings.default}, max=${countSettings.max})`,
+        `FHIR _count config default value is bigger than the max (default=${countDefault}, max=${countMax})`,
       );
     }
   }

--- a/packages/central-server/app/integrations/index.js
+++ b/packages/central-server/app/integrations/index.js
@@ -44,6 +44,6 @@ export const initIntegrations = async ctx => {
   }
 };
 
-export function checkIntegrationsConfig() {
-  checkFhirConfig();
+export async function checkIntegrationsConfig(settings) {
+  await checkFhirConfig(settings);
 }

--- a/packages/central-server/app/subCommands/provision.js
+++ b/packages/central-server/app/subCommands/provision.js
@@ -14,6 +14,7 @@ import {
 } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 
+import { ReadSettings } from '@tamanu/settings';
 import { initDatabase } from '../database';
 import { checkIntegrationsConfig } from '../integrations';
 import { loadSettingFile } from '../utils/loadSettingFile';
@@ -104,7 +105,7 @@ export async function provision(provisioningFile, { skipIfNotNeeded }) {
     throw new Error(`Found ${userCount} users already in the database, aborting provision`);
   }
 
-  checkIntegrationsConfig();
+  await checkIntegrationsConfig(new ReadSettings(store.models));
 
   const {
     users = {},

--- a/packages/central-server/app/subCommands/startFhirWorker.js
+++ b/packages/central-server/app/subCommands/startFhirWorker.js
@@ -21,7 +21,7 @@ export const startFhirWorker = async ({ name, skipMigrationCheck, topics }) => {
     log.info(`FHIR worker restricted to topics: ${topics.join(', ')}`);
   }
 
-  const worker = await startFhirWorkerTasks({ store: context.store, topics });
+  const worker = await startFhirWorkerTasks({ store: context.store, settings: context.settings, topics });
 
   for (const sig of ['SIGINT', 'SIGTERM']) {
     process.once(sig, async () => {

--- a/packages/central-server/app/tasks/fhir/index.js
+++ b/packages/central-server/app/tasks/fhir/index.js
@@ -7,8 +7,8 @@ import { entireResource } from './refresh/entireResource';
 import { fromUpstream } from './refresh/fromUpstream';
 import { resolver } from './resolver';
 
-export async function startFhirWorkerTasks({ store, topics }) {
-  const queueManager = new FhirQueueManager(store, log);
+export async function startFhirWorkerTasks({ store, settings, topics }) {
+  const queueManager = new FhirQueueManager(store, settings, log);
   await queueManager.start();
 
   const setHandler = async (topic, handler) => {

--- a/packages/settings/src/schema/definitions/fhir.ts
+++ b/packages/settings/src/schema/definitions/fhir.ts
@@ -91,7 +91,6 @@ export const fhirExtensionsSchema = {
 export const fhirWorkerConcurrencySchema = {
   name: 'Concurrency',
   description: 'Maximum number of FHIR jobs processed simultaneously by the worker',
-  requiresRestart: true,
   type: yup.number().integer().positive(),
   defaultValue: 10,
 };
@@ -99,7 +98,6 @@ export const fhirWorkerConcurrencySchema = {
 export const fhirCountParametersSchema = {
   name: 'Parameters',
   description: 'FHIR search parameter configuration',
-  requiresRestart: true,
   properties: {
     _count: {
       name: 'Count',

--- a/packages/shared/src/tasks/FhirQueueManager.js
+++ b/packages/shared/src/tasks/FhirQueueManager.js
@@ -4,7 +4,6 @@ import ms from 'ms';
 import { hostname } from 'os';
 
 import { getTracer } from '../services/logging';
-import { getFhirWorkerSettings } from '../utils/fhir/fhirSettings';
 import { FhirTopicQueueProcessor } from './FhirTopicQueueProcessor';
 
 export class FhirQueueManager {
@@ -21,14 +20,15 @@ export class FhirQueueManager {
   // in "testMode" it's disabled.
   testMode = false;
 
-  constructor(context, log) {
+  constructor(context, settings, log) {
     this.models = context.models;
     this.sequelize = context.sequelize;
+    this.settings = settings;
     this.log = log;
   }
 
   async start() {
-    const { FhirJobWorker, Setting } = this.models;
+    const { FhirJobWorker } = this.models;
     const { enabled } = this.config;
 
     if (!enabled) {
@@ -36,7 +36,7 @@ export class FhirQueueManager {
       return;
     }
 
-    const heartbeatInterval = await Setting.get('fhir.worker.heartbeat');
+    const heartbeatInterval = await this.settings.get('fhir.worker.heartbeat');
     this.log.debug('FhirQueueManager: got raw heartbeat interval', { heartbeatInterval });
     const heartbeat = Math.round(ms(heartbeatInterval) * (1 + Math.random() * 0.2 - 0.1)); // +/- 10%
     this.log.debug('FhirQueueManager: added some jitter to the heartbeat', { heartbeat });
@@ -113,8 +113,10 @@ export class FhirQueueManager {
    *
    * @returns {number} Total capacity of the queue manager.
    */
-  totalCapacity() {
-    return Math.max(0, this._concurrency ?? getFhirWorkerSettings().concurrency);
+  async totalCapacity() {
+    if (this._concurrency != null) return Math.max(0, this._concurrency);
+    const concurrency = await this.settings.get('fhir.worker.concurrency');
+    return Math.max(0, concurrency);
   }
 
   /**
@@ -126,10 +128,11 @@ export class FhirQueueManager {
    *
    * @returns {number} Amount of jobs to run in parallel for a topic.
    */
-  parallelisationPerTopic() {
+  async parallelisationPerTopic() {
+    const capacity = await this.totalCapacity();
     return Math.max(
-      this.totalCapacity() > 0 ? 1 : 0, // return at least 1 if there's any capacity
-      Math.floor(this.totalCapacity() / this.queueProcessors.size), // otherwise divide the capacity evenly among the topics
+      capacity > 0 ? 1 : 0, // return at least 1 if there's any capacity
+      Math.floor(capacity / this.queueProcessors.size), // otherwise divide the capacity evenly among the topics
     );
   }
 
@@ -155,7 +158,7 @@ export class FhirQueueManager {
         });
 
         try {
-          if (this.totalCapacity() === 0) {
+          if ((await this.totalCapacity()) === 0) {
             this.log.debug('FhirQueueManager: no capacity');
             return;
           }

--- a/packages/shared/src/tasks/FhirQueueManager.js
+++ b/packages/shared/src/tasks/FhirQueueManager.js
@@ -114,8 +114,8 @@ export class FhirQueueManager {
    * @returns {number} Total capacity of the queue manager.
    */
   async totalCapacity() {
-    if (this._concurrency != null) return Math.max(0, this._concurrency);
-    const concurrency = await this.settings.get('fhir.worker.concurrency');
+    const concurrency =
+      this._concurrency ?? (await this.settings.get('fhir.worker.concurrency')) ?? 0;
     return Math.max(0, concurrency);
   }
 
@@ -126,13 +126,14 @@ export class FhirQueueManager {
    * Every topic can run at least 1 job (regardless of total capacity), and the remaining capacity
    * is divided evenly among the topics.
    *
+   * @param {number} [capacity] - Pre-fetched capacity to avoid a redundant settings read.
    * @returns {number} Amount of jobs to run in parallel for a topic.
    */
-  async parallelisationPerTopic() {
-    const capacity = await this.totalCapacity();
+  async parallelisationPerTopic(capacity) {
+    const cap = capacity ?? (await this.totalCapacity());
     return Math.max(
-      capacity > 0 ? 1 : 0, // return at least 1 if there's any capacity
-      Math.floor(capacity / this.queueProcessors.size), // otherwise divide the capacity evenly among the topics
+      cap > 0 ? 1 : 0, // return at least 1 if there's any capacity
+      Math.floor(cap / this.queueProcessors.size), // otherwise divide the capacity evenly among the topics
     );
   }
 
@@ -158,7 +159,8 @@ export class FhirQueueManager {
         });
 
         try {
-          if ((await this.totalCapacity()) === 0) {
+          const capacity = await this.totalCapacity();
+          if (capacity === 0) {
             this.log.debug('FhirQueueManager: no capacity');
             return;
           }
@@ -169,7 +171,7 @@ export class FhirQueueManager {
             return;
           }
 
-          await this.queueProcessors.get(topic).processQueue();
+          await queueProcessor.processQueue(capacity);
         } catch (err) {
           this.log.debug('Trouble retrieving the backlog');
           span.recordException(err);

--- a/packages/shared/src/tasks/FhirTopicQueueProcessor.js
+++ b/packages/shared/src/tasks/FhirTopicQueueProcessor.js
@@ -16,7 +16,7 @@ export class FhirTopicQueueProcessor {
     this.handler = handler;
   }
 
-  processQueue() {
+  processQueue(capacity) {
     this.isRunning = true;
     return getTracer().startActiveSpan(
       `FhirTopicQueueProcessor.processQueue`,
@@ -36,7 +36,7 @@ export class FhirTopicQueueProcessor {
         }
 
         // Start as many job runs as we have capacity
-        const parallelisation = await this.manager.parallelisationPerTopic();
+        const parallelisation = await this.manager.parallelisationPerTopic(capacity);
         for (let i = this.jobRuns.size; i < parallelisation; i++) {
           this.startJobRun();
         }

--- a/packages/shared/src/tasks/FhirTopicQueueProcessor.js
+++ b/packages/shared/src/tasks/FhirTopicQueueProcessor.js
@@ -36,7 +36,8 @@ export class FhirTopicQueueProcessor {
         }
 
         // Start as many job runs as we have capacity
-        for (let i = this.jobRuns.size; i < this.manager.parallelisationPerTopic(); i++) {
+        const parallelisation = await this.manager.parallelisationPerTopic();
+        for (let i = this.jobRuns.size; i < parallelisation; i++) {
           this.startJobRun();
         }
 

--- a/packages/shared/src/utils/fhir/fhirSettings.js
+++ b/packages/shared/src/utils/fhir/fhirSettings.js
@@ -5,9 +5,6 @@ import { log } from '../../services/logging';
 const fhirDefaults = globalDefaults.fhir;
 const DEFAULTS = {
   resourceMaterialisationEnabled: fhirDefaults.worker.resourceMaterialisationEnabled,
-  countDefault: fhirDefaults.parameters._count.default,
-  countMax: fhirDefaults.parameters._count.max,
-  concurrency: fhirDefaults.worker.concurrency,
   extensions: fhirDefaults.extensions,
   nullLastNameValue: fhirDefaults.nullLastNameValue,
   assigners: fhirDefaults.assigners,
@@ -53,9 +50,6 @@ export async function initFhirSettingsFromDb(globalSettings, facilitySettings = 
 
     settings = { // eslint-disable-line require-atomic-updates
       resourceMaterialisationEnabled: mergedMatEnabled,
-      countDefault: fhir.parameters._count.default,
-      countMax: fhir.parameters._count.max,
-      concurrency: fhir.worker.concurrency,
       extensions: fhir.extensions,
       nullLastNameValue: fhir.nullLastNameValue,
       assigners: fhir.assigners,
@@ -71,15 +65,7 @@ export async function initFhirSettingsFromDb(globalSettings, facilitySettings = 
 export function getFhirWorkerSettings() {
   return {
     enabled: config?.integrations?.fhir?.worker?.enabled ?? false,
-    concurrency: settings.concurrency,
     resourceMaterialisationEnabled: settings.resourceMaterialisationEnabled,
-  };
-}
-
-export function getFhirCountSettings() {
-  return {
-    default: settings.countDefault,
-    max: settings.countMax,
   };
 }
 

--- a/packages/shared/src/utils/fhir/parameters.js
+++ b/packages/shared/src/utils/fhir/parameters.js
@@ -8,15 +8,15 @@ import {
 } from '@tamanu/constants';
 
 import { DEFAULT_SCHEMA_FOR_TYPE, INCLUDE_SCHEMA } from './schemata';
-import { getFhirCountSettings } from './fhirSettings';
 
-export function getFhirCountSettingsDefault() {
-  return getFhirCountSettings().default || FHIR_MAX_RESOURCES_PER_PAGE;
-}
-
-function getFhirCountSettingsMax() {
-  const { max } = getFhirCountSettings();
-  return Math.max(max || 0, getFhirCountSettingsDefault());
+async function getCountSettings(settings) {
+  const countDefault =
+    (await settings.get('fhir.parameters._count.default')) || FHIR_MAX_RESOURCES_PER_PAGE;
+  const countMax = Math.max(
+    (await settings.get('fhir.parameters._count.max')) || 0,
+    countDefault,
+  );
+  return { default: countDefault, max: countMax };
 }
 
 export function normaliseParameter([key, param], overrides = {}) {
@@ -43,7 +43,8 @@ export function normaliseParameter([key, param], overrides = {}) {
   return [key, norm];
 }
 
-function getResultParameters() {
+async function getResultParameters(settings) {
+  const count = await getCountSettings(settings);
   return {
     _total: {
       type: FHIR_SEARCH_PARAMETERS.SPECIAL,
@@ -59,8 +60,8 @@ function getResultParameters() {
         .number()
         .integer()
         .min(0) // equivalent to _summary=count
-        .max(getFhirCountSettingsMax())
-        .default(getFhirCountSettingsDefault()),
+        .max(count.max)
+        .default(count.default),
     },
     _page: {
       type: FHIR_SEARCH_PARAMETERS.SPECIAL,
@@ -117,16 +118,10 @@ function sortParameter(sortableParameters) {
   };
 }
 
-const cache = new Map();
-
-export function normaliseParameters(FhirResource) {
+export async function normaliseParameters(FhirResource, settings) {
   const cacheKey = FhirResource.fhirName;
   if (!cacheKey) {
     throw new Error('DEV: not a proper Resource');
-  }
-
-  if (cache.has(cacheKey)) {
-    return cache.get(cacheKey);
   }
 
   const resourceParameters = Object.entries(FhirResource.searchParameters()).map(
@@ -137,7 +132,7 @@ export function normaliseParameters(FhirResource) {
 
   const resultParameters = Object.entries({
     ...sortParameter(sortableParameters),
-    ...getResultParameters(),
+    ...(await getResultParameters(settings)),
   }).map(param =>
     normaliseParameter(param, {
       path: [],
@@ -145,7 +140,5 @@ export function normaliseParameters(FhirResource) {
     }),
   );
 
-  const parameters = new Map([...resourceParameters, ...resultParameters]);
-  cache.set(cacheKey, parameters);
-  return parameters;
+  return new Map([...resourceParameters, ...resultParameters]);
 }

--- a/packages/shared/src/utils/fhir/parameters.js
+++ b/packages/shared/src/utils/fhir/parameters.js
@@ -43,6 +43,8 @@ export function normaliseParameter([key, param], overrides = {}) {
   return [key, norm];
 }
 
+const RESULT_PARAMETER_NAMES = ['_total', '_summary', '_count', '_page', '_include', '_revinclude'];
+
 async function getResultParameters(settings) {
   const count = await getCountSettings(settings);
   return {
@@ -79,7 +81,7 @@ async function getResultParameters(settings) {
 }
 
 export function getResultParameterNames() {
-  return ['_sort', '_total', '_summary', '_count', '_page', '_include', '_revinclude'];
+  return ['_sort', ...RESULT_PARAMETER_NAMES];
 }
 
 function sortParameter(sortableParameters) {

--- a/packages/shared/src/utils/fhir/parameters.js
+++ b/packages/shared/src/utils/fhir/parameters.js
@@ -10,13 +10,11 @@ import {
 import { DEFAULT_SCHEMA_FOR_TYPE, INCLUDE_SCHEMA } from './schemata';
 
 async function getCountSettings(settings) {
-  const countDefault =
-    (await settings.get('fhir.parameters._count.default')) || FHIR_MAX_RESOURCES_PER_PAGE;
-  const countMax = Math.max(
-    (await settings.get('fhir.parameters._count.max')) || 0,
-    countDefault,
-  );
-  return { default: countDefault, max: countMax };
+  const { default: settingsDefault, max: settingsMax } = await settings.get('fhir.parameters._count');
+  return {
+    default: settingsDefault || FHIR_MAX_RESOURCES_PER_PAGE,
+    max: Math.max(settingsMax || 0, settingsDefault || FHIR_MAX_RESOURCES_PER_PAGE),
+  };
 }
 
 export function normaliseParameter([key, param], overrides = {}) {
@@ -120,17 +118,21 @@ function sortParameter(sortableParameters) {
   };
 }
 
+const resourceParamCache = new Map();
+
 export async function normaliseParameters(FhirResource, settings) {
   const cacheKey = FhirResource.fhirName;
   if (!cacheKey) {
     throw new Error('DEV: not a proper Resource');
   }
 
-  const resourceParameters = Object.entries(FhirResource.searchParameters()).map(
-    normaliseParameter,
-  );
-  // eslint-disable-next-line no-unused-vars
-  const sortableParameters = resourceParameters.filter(([_, v]) => v.sortable);
+  let { resourceParameters, sortableParameters } = resourceParamCache.get(cacheKey) ?? {};
+  if (!resourceParameters) {
+    resourceParameters = Object.entries(FhirResource.searchParameters()).map(normaliseParameter);
+    // eslint-disable-next-line no-unused-vars
+    sortableParameters = resourceParameters.filter(([_, v]) => v.sortable);
+    resourceParamCache.set(cacheKey, { resourceParameters, sortableParameters });
+  }
 
   const resultParameters = Object.entries({
     ...sortParameter(sortableParameters),

--- a/packages/shared/src/utils/fhir/parameters.js
+++ b/packages/shared/src/utils/fhir/parameters.js
@@ -79,7 +79,7 @@ async function getResultParameters(settings) {
 }
 
 export function getResultParameterNames() {
-  return ['_sort', ...Object.keys(getResultParameters())];
+  return ['_sort', '_total', '_summary', '_count', '_page', '_include', '_revinclude'];
 }
 
 function sortParameter(sortableParameters) {


### PR DESCRIPTION
### Changes
- Make FHIR worker concurrency setting real-time by reading from settings reader instead of cached startup value
- Make FHIR _count parameters real-time by reading from settings reader in search handlers
- Remove requiresRestart flag from fhirWorkerConcurrencySchema and fhirCountParametersSchema
- Thread ReadSettings instance through FhirQueueManager, buildSearchQuery, and normaliseParameters

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
