### PR TITLE
fix(adminPanel): no-issue: Fixed invoice product importers missing columns if the first row has no value

### DIFF
--- a/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
+++ b/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
@@ -33,14 +33,16 @@ export function productMatrixByCodeLoaderFactory(config) {
     parentIdCache: new Map(),
   };
 
-  return async (rawItem, { pushError, models }) => {
+  return async (rawItem, { pushError, models, header: sheetHeader }) => {
     // Normalize keys (trim)
-    const item = Object.fromEntries(
-      Object.entries(rawItem).map(([k, v]) => [k?.trim?.() ?? k, v]),
-    );
+    const item = Object.fromEntries(Object.entries(rawItem).map(([k, v]) => [k?.trim?.() ?? k, v]));
 
     if (!state.initialized) {
-      const headers = Object.keys(item);
+      // Use sheet header when available so we get all columns even if the first data row has empty cells
+      const rawHeaders = Array.isArray(sheetHeader)
+        ? sheetHeader.map(h => (typeof h === 'string' ? h.trim() : `${h}`.trim()))
+        : Object.keys(item);
+      const headers = rawHeaders.filter(Boolean);
       const invoiceProductKey = headers.find(h => h.toLowerCase() === 'invoiceproductid');
       if (!invoiceProductKey) {
         pushError('Missing required column: invoiceProductId', itemModel);

--- a/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
+++ b/packages/central-server/app/admin/referenceDataImporter/ProductMatrixByCodeLoaderFactory.js
@@ -39,8 +39,10 @@ export function productMatrixByCodeLoaderFactory(config) {
 
     if (!state.initialized) {
       // Use sheet header when available so we get all columns even if the first data row has empty cells
+      // Note: Excel may parse number-like headers as numbers, so we coerce to string.
+      // Map null/undefined to empty string to avoid literal "null"/"undefined" in headers.
       const rawHeaders = Array.isArray(sheetHeader)
-        ? sheetHeader.map(h => (typeof h === 'string' ? h.trim() : `${h}`.trim()))
+        ? sheetHeader.map(h => (h == null ? '' : String(h).trim()))
         : Object.keys(item);
       const headers = rawHeaders.filter(Boolean);
       const invoiceProductKey = headers.find(h => h.toLowerCase() === 'invoiceproductid');


### PR DESCRIPTION
### Changes

The `rawItem` will only have keys if the cell has values, so we need to parse the header in a different way.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
