### PR TITLE
fix(dateTime): 2.51 fix: Appointment sidebar time input

### DIFF
--- a/packages/ui-components/src/components/Field/DateField.jsx
+++ b/packages/ui-components/src/components/Field/DateField.jsx
@@ -298,6 +298,7 @@ export const DateInput = ({
   const handleClose = useCallback(() => setOpen(false), []);
   const handleSetToday = useCallback(() => {
     handleChange(getFacilityNowDate?.() ?? new Date());
+    setOpen(false);
   }, [handleChange, getFacilityNowDate]);
 
   const handleClear = useCallback(() => {

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
-import { set as dateFnsSet, parse } from 'date-fns';
+import { set as dateFnsSet, parse, isValid } from 'date-fns';
 import { useDateTime } from '@tamanu/ui-components';
 import { TimeInput } from '../../Field';
 
@@ -20,6 +20,7 @@ export const TimeWithFixedDateField = ({ field, date, ...props }) => {
     }
     const [year, month, day] = date.split('-').map(Number);
     const timeDate = parse(event.target.value, 'HH:mm:ss', getFacilityNowDate() ?? new Date());
+    if (!isValid(timeDate)) return;
     const facilityDateTime = toDateTimeString(
       dateFnsSet(timeDate, {
         year,

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
@@ -9,7 +9,7 @@ import { TimeInput } from '../../Field';
  * The resulting date-time will match the provided `date` (YYYY-MM-DD string) with the time set by the user.
  */
 export const TimeWithFixedDateField = ({ field, date, ...props }) => {
-  const { toFacilityDateTime, toStoredDateTime } = useDateTime();
+  const { toFacilityDateTime, toStoredDateTime, getFacilityNowDate } = useDateTime();
 
   const displayValue = toFacilityDateTime(field.value);
 
@@ -19,7 +19,7 @@ export const TimeWithFixedDateField = ({ field, date, ...props }) => {
       return;
     }
     const [year, month, day] = date.split('-').map(Number);
-    const timeDate = parse(event.target.value, 'HH:mm:ss', new Date());
+    const timeDate = parse(event.target.value, 'HH:mm:ss', getFacilityNowDate() ?? new Date());
     const facilityDateTime = toDateTimeString(
       dateFnsSet(timeDate, {
         year,

--- a/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
+++ b/packages/web/app/components/Appointments/OutpatientsBookingForm/TimeWithFixedDateField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
-import { set as dateFnsSet, parseISO } from 'date-fns';
+import { set as dateFnsSet, parse } from 'date-fns';
 import { useDateTime } from '@tamanu/ui-components';
 import { TimeInput } from '../../Field';
 
@@ -19,14 +19,15 @@ export const TimeWithFixedDateField = ({ field, date, ...props }) => {
       return;
     }
     const [year, month, day] = date.split('-').map(Number);
-    const facilityDateTime = toDateTimeString(  
-      dateFnsSet(parseISO(event.target.value), {
+    const timeDate = parse(event.target.value, 'HH:mm:ss', new Date());
+    const facilityDateTime = toDateTimeString(
+      dateFnsSet(timeDate, {
         year,
         date: day,
         month: month - 1,
       }),
     );
-    const outputValue = toStoredDateTime(facilityDateTime)
+    const outputValue = toStoredDateTime(facilityDateTime);
     field.onChange({ target: { value: outputValue, name: field.name } });
   };
 


### PR DESCRIPTION
### Changes

1. TimeWithFixedDateField.jsx — The MUI TimePicker (introduced in the timezone epic) emits time-only strings like "14:30:00". parseISO() can't parse these (returns Invalid Date), so the end time field in outpatient appointments was completely non-functional. Replaced with parse(value, 'HH:mm:ss', facilityNowDate) which handles the format correctly and respects the facility timezone.

2. DateField.jsx — The "Now"/"Today" action bar button set the value but didn't close the picker (unlike "Clear" which did). Added setOpen(false) so the picker dismisses after clicking.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
