### PR TITLE
perf(database): faster `Model.forResponse()`

### DIFF
--- a/packages/database/__tests__/models/Model.forResponse.test.ts
+++ b/packages/database/__tests__/models/Model.forResponse.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { Model } from '../../src/models/Model';
+
+function callForResponse({
+  dataValues,
+  references,
+}: {
+  dataValues: Record<string, unknown>;
+  references?: readonly string[];
+}) {
+  class TestModel extends Model {
+    static getListReferenceAssociations() {
+      return references;
+    }
+  }
+
+  return Model.prototype.forResponse.call({
+    dataValues,
+    sequelize: { models: {} },
+    constructor: TestModel,
+  });
+}
+
+describe('Model.forResponse', () => {
+  it('strips null fields from dataValues', () => {
+    const id = crypto.randomUUID();
+    const response = callForResponse({
+      dataValues: {
+        id,
+        note: 'active',
+        deletedAt: null,
+      },
+    });
+    expect(response).toEqual({
+      id,
+      note: 'active',
+    });
+  });
+
+  it('returns dataValues unchanged when getListReferenceAssociations is undefined', () => {
+    const id = crypto.randomUUID();
+    const response = callForResponse({
+      dataValues: {
+        id,
+        note: 'active',
+      },
+      references: undefined,
+    });
+    expect(response).toEqual({
+      id,
+      note: 'active',
+    });
+  });
+
+  it('transforms loaded associations into camelCase dataValues', () => {
+    const id = crypto.randomUUID();
+    const response = callForResponse({
+      dataValues: {
+        id,
+        Allergy: { dataValues: { id: 'allergy-1', name: 'Peanuts' } },
+      },
+      references: ['Allergy'],
+    });
+    expect(response).toEqual({
+      id,
+      allergy: { id: 'allergy-1', name: 'Peanuts' },
+    });
+  });
+
+  it('transforms reference names from UpperCamelCase to camelCase', () => {
+    const id = crypto.randomUUID();
+    const response = callForResponse({
+      dataValues: {
+        id,
+        Patient: { dataValues: { id: 'patient-1' } },
+        LabTest: { dataValues: { id: 'lab-test-1' } },
+        LabTestType: { dataValues: { id: 'lab-test-type-1' } },
+      },
+      references: ['Patient', 'LabTest', 'LabTestType'],
+    });
+    expect(response).toEqual({
+      id,
+      patient: { id: 'patient-1' },
+      labTest: { id: 'lab-test-1' },
+      labTestType: { id: 'lab-test-type-1' },
+    });
+  });
+
+  it('handles multiple references, transforming loaded ones and omitting falsy ones', () => {
+    const id = crypto.randomUUID();
+    const response = callForResponse({
+      dataValues: {
+        id,
+        Allergy: { dataValues: { id: 'allergy-1', name: 'Peanuts' } },
+        Reaction: null,
+        MissingAssociation: undefined,
+      },
+      references: ['Allergy', 'Reaction', 'MissingAssociation'],
+    });
+    expect(response).toEqual({
+      id,
+      allergy: { id: 'allergy-1', name: 'Peanuts' },
+    });
+  });
+});

--- a/packages/database/__tests__/models/Model.forResponse.test.ts
+++ b/packages/database/__tests__/models/Model.forResponse.test.ts
@@ -23,84 +23,60 @@ function callForResponse({
 }
 
 describe('Model.forResponse', () => {
-  it('strips null fields from dataValues', () => {
-    const id = crypto.randomUUID();
-    const response = callForResponse({
-      dataValues: {
-        id,
-        note: 'active',
-        deletedAt: null,
-      },
-    });
-    expect(response).toEqual({
-      id,
-      note: 'active',
-    });
-  });
-
-  it('returns dataValues unchanged when getListReferenceAssociations is undefined', () => {
-    const id = crypto.randomUUID();
-    const response = callForResponse({
-      dataValues: {
-        id,
-        note: 'active',
-      },
+  it.each([
+    {
+      description: 'strips null fields from dataValues',
+      dataValues: { note: 'active', deletedAt: null },
+      expected: { note: 'active' },
+    },
+    {
+      description: 'returns dataValues unchanged when getListReferenceAssociations is undefined',
+      dataValues: { note: 'active' },
       references: undefined,
-    });
-    expect(response).toEqual({
-      id,
-      note: 'active',
-    });
-  });
-
-  it('transforms loaded associations into camelCase dataValues', () => {
-    const id = crypto.randomUUID();
-    const response = callForResponse({
+      expected: { note: 'active' },
+    },
+    {
+      description: 'transforms loaded associations into camelCase dataValues',
       dataValues: {
-        id,
         Allergy: { dataValues: { id: 'allergy-1', name: 'Peanuts' } },
       },
       references: ['Allergy'],
-    });
-    expect(response).toEqual({
-      id,
-      allergy: { id: 'allergy-1', name: 'Peanuts' },
-    });
-  });
-
-  it('transforms reference names from UpperCamelCase to camelCase', () => {
-    const id = crypto.randomUUID();
-    const response = callForResponse({
+      expected: {
+        allergy: { id: 'allergy-1', name: 'Peanuts' },
+      },
+    },
+    {
+      description: 'transforms reference names from UpperCamelCase to camelCase',
       dataValues: {
-        id,
         Patient: { dataValues: { id: 'patient-1' } },
         LabTest: { dataValues: { id: 'lab-test-1' } },
         LabTestType: { dataValues: { id: 'lab-test-type-1' } },
       },
       references: ['Patient', 'LabTest', 'LabTestType'],
-    });
-    expect(response).toEqual({
-      id,
-      patient: { id: 'patient-1' },
-      labTest: { id: 'lab-test-1' },
-      labTestType: { id: 'lab-test-type-1' },
-    });
-  });
-
-  it('handles multiple references, transforming loaded ones and omitting falsy ones', () => {
-    const id = crypto.randomUUID();
-    const response = callForResponse({
+      expected: {
+        patient: { id: 'patient-1' },
+        labTest: { id: 'lab-test-1' },
+        labTestType: { id: 'lab-test-type-1' },
+      },
+    },
+    {
+      description: 'handles multiple references, transforming loaded ones and omitting falsy ones',
       dataValues: {
-        id,
         Allergy: { dataValues: { id: 'allergy-1', name: 'Peanuts' } },
         Reaction: null,
         MissingAssociation: undefined,
       },
       references: ['Allergy', 'Reaction', 'MissingAssociation'],
+      expected: {
+        allergy: { id: 'allergy-1', name: 'Peanuts' },
+      },
+    },
+  ])('$description', ({ dataValues, references, expected }) => {
+    const id = crypto.randomUUID();
+    const response = callForResponse({
+      dataValues: { id, ...dataValues },
+      references,
     });
-    expect(response).toEqual({
-      id,
-      allergy: { id: 'allergy-1', name: 'Peanuts' },
-    });
+    expect(response).toEqual({ id, ...expected });
   });
 });

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -153,7 +153,10 @@ export class Model<
     // logic here.
     return references.reduce<Record<string, any>>((result, referenceName) => {
       const referenceVal = result[referenceName];
+      delete result[referenceName];
+
       if (!referenceVal) return result;
+
       result[firstLetterLowercase(referenceName)] = referenceVal.dataValues;
       return result;
     }, resultInit);

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -1,16 +1,22 @@
 /* eslint-disable no-unused-vars */
 import {
-  Op,
-  Utils,
-  DataTypes,
   Model as BaseModel,
+  DataTypes,
   type ModelAttributes,
+  Op,
   Sequelize,
+  Utils,
 } from 'sequelize';
+
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
-import { genericBeforeDestroy, genericBeforeBulkDestroy } from '../utils/beforeDestroyHooks';
 import type { InitOptions, Models } from '../types/model';
-import type { SyncHookSnapshotChanges, ModelSanitizeArgs, SessionConfig, SyncSnapshotAttributes } from '../types/sync';
+import type {
+  ModelSanitizeArgs,
+  SessionConfig,
+  SyncHookSnapshotChanges,
+  SyncSnapshotAttributes,
+} from '../types/sync';
+import { genericBeforeBulkDestroy, genericBeforeDestroy } from '../utils/beforeDestroyHooks';
 
 const firstLetterLowercase = (s: string) => (s[0] || '').toLowerCase() + s.slice(1);
 
@@ -34,7 +40,9 @@ export class Model<
     _sessionConfig: SessionConfig,
   ) => string | null;
   declare static adjustDataPostSyncPush?: (ids: string[]) => Promise<void>;
-  declare static incomingSyncHook?: (changes: SyncSnapshotAttributes[]) => Promise<SyncHookSnapshotChanges | undefined>;
+  declare static incomingSyncHook?: (
+    changes: SyncSnapshotAttributes[],
+  ) => Promise<SyncHookSnapshotChanges | undefined>;
 
   static init(
     modelAttributes: ModelAttributes,
@@ -90,7 +98,7 @@ export class Model<
    * Generates a uuid via the database
    */
   static async generateDbUuid() {
-    const result: any  = await this.sequelize.query(`SELECT gen_random_uuid();`);
+    const result: any = await this.sequelize.query(`SELECT gen_random_uuid();`);
     return result[0][0].gen_random_uuid;
   }
 
@@ -128,32 +136,27 @@ export class Model<
     // { id: 12345, field: 'value', referenceObject: { id: 23456, name: 'object' } }
 
     const models = this.sequelize.models;
-    const values = Object.entries(this.dataValues)
+    const resultInit = Object.entries(this.dataValues)
       .filter(([, val]) => val !== null)
-      .reduce(
-        (obj, [key, val]) => ({
-          ...obj,
-          [key]: val,
-        }),
-        {},
-      );
+      .reduce<Record<string, unknown>>((obj, [key, val]) => {
+        obj[key] = val;
+        return obj;
+      }, {});
 
     const references = (this.constructor as typeof Model).getListReferenceAssociations(models);
 
-    if (!references) return values;
+    if (!references) return resultInit;
 
     // Note that we don't call forResponse on the nested object, this is under the assumption that
     // if the structure of a nested object differs significantly from its database representation,
     // it's probably more correct to implement that as a separate endpoint rather than putting the
     // logic here.
-    return references.reduce((allValues: Record<string, any>, referenceName: string) => {
-      const { [referenceName]: referenceVal, ...otherValues } = allValues;
-      if (!referenceVal) return allValues;
-      return {
-        ...otherValues,
-        [firstLetterLowercase(referenceName)]: referenceVal.dataValues,
-      };
-    }, values);
+    return references.reduce((result: Record<string, any>, referenceName: string) => {
+      const referenceVal = result[referenceName];
+      if (!referenceVal) return result;
+      result[firstLetterLowercase(referenceName)] = referenceVal.dataValues;
+      return result;
+    }, resultInit);
   }
 
   toJSON() {

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -138,7 +138,7 @@ export class Model<
     const models = this.sequelize.models;
     const resultInit = Object.entries(this.dataValues)
       .filter(([, val]) => val !== null)
-      .reduce<Record<string, unknown>>((obj, [key, val]) => {
+      .reduce<Record<string, any>>((obj, [key, val]) => {
         obj[key] = val;
         return obj;
       }, {});
@@ -151,7 +151,7 @@ export class Model<
     // if the structure of a nested object differs significantly from its database representation,
     // it's probably more correct to implement that as a separate endpoint rather than putting the
     // logic here.
-    return references.reduce((result: Record<string, any>, referenceName: string) => {
+    return references.reduce<Record<string, any>>((result, referenceName) => {
       const referenceVal = result[referenceName];
       if (!referenceVal) return result;
       result[firstLetterLowercase(referenceName)] = referenceVal.dataValues;
@@ -167,7 +167,7 @@ export class Model<
     return this.constructor.name;
   }
 
-  static getListReferenceAssociations(_models?: Models): any | undefined {
+  static getListReferenceAssociations(_models?: Models): readonly string[] | undefined {
     // List of relations to include when fetching this model
     // as part of a list (eg to display in a table)
     //

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -147,15 +147,14 @@ export class Model<
     // if the structure of a nested object differs significantly from its database representation,
     // it's probably more correct to implement that as a separate endpoint rather than putting the
     // logic here.
-    return references.reduce<Record<string, any>>((result, referenceName) => {
+    const result = resultInit as Record<string, any>;
+    for (const referenceName of references) {
       const referenceVal = result[referenceName];
       delete result[referenceName];
-
-      if (!referenceVal) return result;
-
+      if (!referenceVal) continue;
       result[firstLetterLowercase(referenceName)] = referenceVal.dataValues;
-      return result;
-    }, resultInit);
+    }
+    return result;
   }
 
   toJSON() {

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+import { isNull, omitBy } from 'es-toolkit';
 import {
   Model as BaseModel,
   DataTypes,
@@ -136,12 +137,7 @@ export class Model<
     // { id: 12345, field: 'value', referenceObject: { id: 23456, name: 'object' } }
 
     const models = this.sequelize.models;
-    const resultInit = Object.entries(this.dataValues)
-      .filter(([, val]) => val !== null)
-      .reduce<Record<string, any>>((obj, [key, val]) => {
-        obj[key] = val;
-        return obj;
-      }, {});
+    const resultInit = omitBy(this.dataValues, isNull);
 
     const references = (this.constructor as typeof Model).getListReferenceAssociations(models);
 

--- a/packages/database/src/models/Model.ts
+++ b/packages/database/src/models/Model.ts
@@ -99,7 +99,7 @@ export class Model<
    * Generates a uuid via the database
    */
   static async generateDbUuid() {
-    const result: any = await this.sequelize.query(`SELECT gen_random_uuid();`);
+    const result: any = await this.sequelize.query('SELECT gen_random_uuid();');
     return result[0][0].gen_random_uuid;
   }
 


### PR DESCRIPTION
### Changes

- Refactors `forResponse` method to avoid spreading accumulator in reducer.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
