### PR TITLE
fix(mobile): SAV-1143: Ensure we do not drop columns in mobile

### DIFF
--- a/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
+++ b/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
@@ -12,15 +12,7 @@ const getValuePlaceholdersForRows = (rowCount: number, columnsCount: number): st
 const quote = (identifier: string): string => `"${identifier}"`;
 
 // Since sync only sends populated columns, we need to check all rows to get all columns
-const getAllColumns = (rows: DataToPersist[]) => {
-  const columnSet = new Set<string>();
-  for (const row of rows) {
-    for (const key in row) {
-      columnSet.add(key);
-    }
-  }
-  return [...columnSet];
-};
+const getAllColumns = (rows: DataToPersist[]): string[] => [...new Set(rows.flatMap(Object.keys))];
 
 /**
  * Much faster than typeorm bulk insert or save
@@ -77,45 +69,60 @@ export const executePreparedUpdate = async (
 
   const { tableName } = repository.metadata;
 
-  const columns = getAllColumns(rows);
-  const updatableColumns = columns.filter(col => col !== 'id');
-  const updateColumnsQuoted = updatableColumns.map(quote);
-  const cteColumns = [quote('id'), ...updateColumnsQuoted];
+  // Group rows by their column signature so each batch only updates columns present in those rows,
+  // preventing NULL from being written into columns the row doesn't carry.
+  const rowsByColumnSignature = new Map<string, DataToPersist[]>();
+  for (const row of rows) {
+    const signature = Object.keys(row).sort().join(',');
+    const group = rowsByColumnSignature.get(signature);
+    if (group) {
+      group.push(row);
+    } else {
+      rowsByColumnSignature.set(signature, [row]);
+    }
+  }
 
-  const setFragments = updateColumnsQuoted
-    .map(col => `${col} = (SELECT ${col} FROM updates WHERE updates.id = ${tableName}.id)`)
-    .join(', ');
+  for (const groupRows of rowsByColumnSignature.values()) {
+    const columns = Object.keys(groupRows[0]);
+    const updatableColumns = columns.filter(col => col !== 'id');
+    const updateColumnsQuoted = updatableColumns.map(quote);
+    const cteColumns = [quote('id'), ...updateColumnsQuoted];
 
-  // Per row we bind one id plus one parameter per updatable column
-  const chunkSize = getEffectiveBatchSize(maxRecordsPerBatch, cteColumns.length);
+    const setFragments = updateColumnsQuoted
+      .map(col => `${col} = (SELECT ${col} FROM updates WHERE updates.id = ${tableName}.id)`)
+      .join(', ');
 
-  for (const chunkRows of chunk(rows, chunkSize)) {
-    const query = `
+    // Per row we bind one id plus one parameter per updatable column
+    const chunkSize = getEffectiveBatchSize(maxRecordsPerBatch, cteColumns.length);
+
+    for (const chunkRows of chunk(groupRows, chunkSize)) {
+      const query = `
     WITH updates (${cteColumns.join(', ')}) AS (VALUES ${getValuePlaceholdersForRows(chunkRows.length, cteColumns.length)})
     UPDATE ${tableName} SET ${setFragments} WHERE id IN (SELECT id FROM updates)
   `;
 
-    const parameters: any[] = [];
-    for (const row of chunkRows) {
-      parameters.push(row.id);
-      for (const col of updatableColumns) {
-        parameters.push(row[col]);
+      const parameters: any[] = [];
+      for (const row of chunkRows) {
+        parameters.push(row.id);
+        for (const col of updatableColumns) {
+          parameters.push(row[col]);
+        }
       }
-    }
 
-    try {
-      await repository.query(query, parameters);
-    } catch (e: any) {
-      await Promise.all(
-        chunkRows.map(async row => {
-          try {
-            await repository.update({ id: row.id }, row);
-          } catch (error: any) {
-            throw new Error(`Update failed with '${error.message}', recordId: ${row.id}`);
-          }
-        }),
-      );
+      try {
+        await repository.query(query, parameters);
+      } catch (e: any) {
+        await Promise.all(
+          chunkRows.map(async row => {
+            try {
+              await repository.update({ id: row.id }, row);
+            } catch (error: any) {
+              throw new Error(`Update failed with '${error.message}', recordId: ${row.id}`);
+            }
+          }),
+        );
+      }
+      progressCallback(chunkRows.length);
     }
-    progressCallback(chunkRows.length);
   }
 };

--- a/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
+++ b/packages/mobile/App/services/sync/utils/executePreparedQuery.ts
@@ -11,6 +11,17 @@ const getValuePlaceholdersForRows = (rowCount: number, columnsCount: number): st
 
 const quote = (identifier: string): string => `"${identifier}"`;
 
+// Since sync only sends populated columns, we need to check all rows to get all columns
+const getAllColumns = (rows: DataToPersist[]) => {
+  const columnSet = new Set<string>();
+  for (const row of rows) {
+    for (const key in row) {
+      columnSet.add(key);
+    }
+  }
+  return [...columnSet];
+};
+
 /**
  * Much faster than typeorm bulk insert or save
  * Prepare a raw query and execute it with the values
@@ -25,7 +36,7 @@ export const executePreparedInsert = async (
 
   const { tableName } = repository.metadata;
 
-  const columns = Object.keys(rows[0]);
+  const columns = getAllColumns(rows);
   const columnNames = columns.map(quote).join(', ');
 
   const chunkSize = getEffectiveBatchSize(maxRecordsPerBatch, columns.length);
@@ -66,7 +77,7 @@ export const executePreparedUpdate = async (
 
   const { tableName } = repository.metadata;
 
-  const columns = Object.keys(rows[0]);
+  const columns = getAllColumns(rows);
   const updatableColumns = columns.filter(col => col !== 'id');
   const updateColumnsQuoted = updatableColumns.map(quote);
   const cteColumns = [quote('id'), ...updateColumnsQuoted];


### PR DESCRIPTION
### Changes

With this work, we guarantee we will try to save all columns that are passed from central server. It could be possible that some are dropped due to an outdated sync lookup table.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
