### PR TITLE
perf(db): no-issue: cherry-pick note type migration perf fix to release/2.50

### DIFF
--- a/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
+++ b/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
@@ -137,6 +137,7 @@ export async function up(query: QueryInterface) {
     },
   });
 
+  const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
   const upCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
     ({ id, code }) => `WHEN '${code}' THEN '${id}'`,
   ).join('\n        ');
@@ -144,6 +145,7 @@ export async function up(query: QueryInterface) {
     UPDATE notes
     SET note_type_id = CASE note_type
         ${upCaseExpression}
+        ELSE '${otherNoteType.id}'
     END
   `);
 
@@ -161,6 +163,7 @@ export async function down(query: QueryInterface) {
     allowNull: true,
   });
 
+  const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
   const downCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
     ({ id, code }) => `WHEN '${id}' THEN '${code}'`,
   ).join('\n        ');
@@ -168,6 +171,7 @@ export async function down(query: QueryInterface) {
     UPDATE notes
     SET note_type = CASE note_type_id
         ${downCaseExpression}
+        ELSE '${otherNoteType.code}'
     END
   `);
 

--- a/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
+++ b/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
@@ -137,18 +137,15 @@ export async function up(query: QueryInterface) {
     },
   });
 
-  await query.sequelize.query(
-    `
+  const upCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
+    ({ id, code }) => `WHEN '${code}' THEN '${id}'`,
+  ).join('\n        ');
+  await query.sequelize.query(`
     UPDATE notes
-    SET note_type_id = reference_data.id
-    FROM reference_data
-    WHERE reference_data.type = :noteType
-      AND reference_data.code = notes.note_type
-    `,
-    {
-      replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },
-    },
-  );
+    SET note_type_id = CASE note_type
+        ${upCaseExpression}
+    END
+  `);
 
   await query.changeColumn('notes', 'note_type_id', {
     type: DataTypes.STRING(255),
@@ -164,18 +161,15 @@ export async function down(query: QueryInterface) {
     allowNull: true,
   });
 
-  await query.sequelize.query(
-    `
+  const downCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
+    ({ id, code }) => `WHEN '${id}' THEN '${code}'`,
+  ).join('\n        ');
+  await query.sequelize.query(`
     UPDATE notes
-    SET note_type = reference_data.code
-    FROM reference_data
-    WHERE reference_data.id = notes.note_type_id
-      AND reference_data.type = :noteType
-    `,
-    {
-      replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },
-    },
-  );
+    SET note_type = CASE note_type_id
+        ${downCaseExpression}
+    END
+  `);
 
   await query.changeColumn('notes', 'note_type', {
     type: DataTypes.STRING(255),
@@ -184,10 +178,7 @@ export async function down(query: QueryInterface) {
 
   await query.removeColumn('notes', 'note_type_id');
 
-  await query.sequelize.query(
-    `DELETE FROM reference_data WHERE type = :noteType`,
-    {
-      replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },
-    },
-  );
+  await query.sequelize.query(`DELETE FROM reference_data WHERE type = :noteType`, {
+    replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },
+  });
 }


### PR DESCRIPTION
### Changes

Cherry-picks two performance commits from `main` (originally merged via PR #9403) into `release/2.50`:

- `f1479b8706` — replaces the join-based `UPDATE` in the note type migration with a single-pass `CASE` expression, significantly reducing query overhead
- `ac0d234d5c` — adds an `ELSE` clause defaulting unmapped note types to `'other'` for safety

The changed file is `packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts`.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->