### PR TITLE
fix: no-issue: add instance-level permission check in suggester lookup route

### DIFF
--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -201,6 +201,7 @@ function createSuggesterLookupRoute(endpoint, modelName, { mapper, searchColumn,
       });
 
       if (!record) throw new NotFoundError();
+      req.checkPermission('read', record);
 
       res.send(await mapper(record));
     }),


### PR DESCRIPTION
### Changes

Adds an instance-level permission check (`req.checkPermission('read', record)`) to the suggester lookup route (`createSuggesterLookupRoute`). Previously this route only checked model-level `list` permission, which meant any user with the general list permission could look up any record by ID. The new check ensures CASL rules (including objectId constraints) are evaluated against the specific record.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
