### PR TITLE
chore: no-issue: avoid command substitution in PR creation rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ lints.md
 /dockercfg
 /docker-volumes/
 
+# Claude Code
+.claude/tmp/
+
 # IDEs
 .idea
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,8 @@ lints.md
 /dockercfg
 /docker-volumes/
 
-# Claude Code
-.claude/tmp/
+# Claude Code temp files
+.tmp/
 
 # IDEs
 .idea

--- a/llm/project-rules/pull-requests.md
+++ b/llm/project-rules/pull-requests.md
@@ -60,10 +60,10 @@ The summary should give reviewers context — what changed, why, and any notable
 4. Pass the temp file to `gh pr create --body-file`
 
 ```bash
-# Step 1-3: Read template with Read tool, construct body, write to temp file (.claude/tmp/ is gitignored)
+# Step 1-3: Read template with Read tool, construct body, write to temp file (.tmp/ is gitignored)
 # Step 4: Create PR using the temp file, then clean up
-gh pr create --title "feat(scope): TICKET-123: description" --body-file .claude/tmp/pr-body.md
-rm .claude/tmp/pr-body.md
+gh pr create --title "feat(scope): TICKET-123: description" --body-file .tmp/pr-body.md
+rm .tmp/pr-body.md
 ```
 
 **Don't:**

--- a/llm/project-rules/pull-requests.md
+++ b/llm/project-rules/pull-requests.md
@@ -52,11 +52,18 @@ Read `.github/pull_request_template.md` **from the target branch** (templates ma
 
 The summary should give reviewers context — what changed, why, and any notable details. Keep it concise (a short paragraph is fine).
 
+**Important:** Do NOT use command substitution (`$(...)`) in `gh pr create` — it triggers permission prompts. Instead, use separate steps:
+
+1. Read the template using the Read tool (path: `.github/pull_request_template.md`)
+2. Replace the placeholder text with your summary
+3. Write the final body to a temp file
+4. Pass the temp file to `gh pr create --body-file`
+
 ```bash
-# Read the template from the target branch, replace the placeholder, and create the PR
-TEMPLATE="$(git show origin/<base-branch>:.github/pull_request_template.md)"
-BODY="${TEMPLATE/_Add a brief description of the changes in this PR to help give the reviewer context._/Your summary here.}"
-gh pr create --title "feat(scope): TICKET-123: description" --body "$BODY"
+# Step 1-3: Read template with Read tool, construct body, write to temp file (.claude/tmp/ is gitignored)
+# Step 4: Create PR using the temp file, then clean up
+gh pr create --title "feat(scope): TICKET-123: description" --body-file .claude/tmp/pr-body.md
+rm .claude/tmp/pr-body.md
 ```
 
 **Don't:**


### PR DESCRIPTION
### Changes

Updates the PR creation instructions in the LLM rules to avoid command substitution (`$(...)`), which triggers permission prompts in Claude Code. Instead, the rule now uses a temp file approach with `--body-file`. Also adds `.tmp/` to `.gitignore` for scratch files.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
