### PR TITLE
mui helper

### DIFF
--- a/packages/e2e-tests/pages/patients/AllPatientsPage.ts
+++ b/packages/e2e-tests/pages/patients/AllPatientsPage.ts
@@ -2,7 +2,7 @@ import { Locator, Page } from '@playwright/test';
 import { routes } from '../../config/routes';
 import { BasePatientListPage, BaseSearchCriteria } from './BasePatientListPage';
 import { selectAutocompleteFieldOption } from '../../utils/fieldHelpers';
-import { muiDateTextbox, fillDateField } from '../../utils/dateFieldHelpers';
+import { fillDateField } from '../../utils/dateFieldHelpers';
 import { RecentlyViewedPatientsList } from './RecentlyViewedPatientsList';
 import { expect } from '../../fixtures/baseFixture';
 import { convertDateFormat, STYLED_TABLE_CELL_PREFIX } from '../../utils/testHelper';
@@ -127,11 +127,11 @@ export class AllPatientsPage extends BasePatientListPage {
     this.searchResultsPaginationOneOfOne = page
       .getByTestId('pagerecordcount-m8ne')
       .filter({ hasText: '1–1 of 1' });
-    this.DOBInput = muiDateTextbox(page.getByTestId('field-qk60-input'));
+    this.DOBInput = page.getByTestId('field-qk60-input');
     this.newPatientVillageSearchBox = page.getByTestId('localisedfield-rpma-input').locator('input');
     this.villageSuggestionList = page.getByTestId('villagelocalisedfield-mcri-suggestionslist').locator('ul').locator('li');
-    this.DOBFromTxt = muiDateTextbox(page.getByTestId('joinedfield-swzm-input'));
-    this.DOBToTxt = muiDateTextbox(page.getByTestId('field-aax5-input'));
+    this.DOBFromTxt = page.getByTestId('joinedfield-swzm-input');
+    this.DOBToTxt = page.getByTestId('field-aax5-input');
     this.patientPageRecordCount25 = page.getByTestId('styledmenuitem-fkrw-undefined').getByText('25');
     this.patientPageRecordCount50 = page.getByTestId('styledmenuitem-fkrw-undefined').getByText('50');
     this.patientPage2 = page.getByTestId('paginationitem-c5vg').getByText('2');

--- a/packages/e2e-tests/pages/patients/AllPatientsPage.ts
+++ b/packages/e2e-tests/pages/patients/AllPatientsPage.ts
@@ -2,6 +2,7 @@ import { Locator, Page } from '@playwright/test';
 import { routes } from '../../config/routes';
 import { BasePatientListPage, BaseSearchCriteria } from './BasePatientListPage';
 import { selectAutocompleteFieldOption } from '../../utils/fieldHelpers';
+import { muiDateTextbox, fillDateField } from '../../utils/dateFieldHelpers';
 import { RecentlyViewedPatientsList } from './RecentlyViewedPatientsList';
 import { expect } from '../../fixtures/baseFixture';
 import { convertDateFormat, STYLED_TABLE_CELL_PREFIX } from '../../utils/testHelper';
@@ -126,11 +127,11 @@ export class AllPatientsPage extends BasePatientListPage {
     this.searchResultsPaginationOneOfOne = page
       .getByTestId('pagerecordcount-m8ne')
       .filter({ hasText: '1–1 of 1' });
-    this.DOBInput = page.getByTestId('field-qk60-input').locator('input[type="date"]');
+    this.DOBInput = muiDateTextbox(page.getByTestId('field-qk60-input'));
     this.newPatientVillageSearchBox = page.getByTestId('localisedfield-rpma-input').locator('input');
     this.villageSuggestionList = page.getByTestId('villagelocalisedfield-mcri-suggestionslist').locator('ul').locator('li');
-    this.DOBFromTxt = page.getByTestId('joinedfield-swzm-input').locator('input[type="date"]');
-    this.DOBToTxt = page.getByTestId('field-aax5-input').locator('input[type="date"]');
+    this.DOBFromTxt = muiDateTextbox(page.getByTestId('joinedfield-swzm-input'));
+    this.DOBToTxt = muiDateTextbox(page.getByTestId('field-aax5-input'));
     this.patientPageRecordCount25 = page.getByTestId('styledmenuitem-fkrw-undefined').getByText('25');
     this.patientPageRecordCount50 = page.getByTestId('styledmenuitem-fkrw-undefined').getByText('50');
     this.patientPage2 = page.getByTestId('paginationitem-c5vg').getByText('2');
@@ -163,8 +164,7 @@ export class AllPatientsPage extends BasePatientListPage {
     await this.NewPatientFirstName.fill(firstName);
     await this.NewPatientLastName.fill(lastName);
 
-    await this.NewPatientDOBtxt.click();
-    await this.NewPatientDOBtxt.fill(dob);
+    await fillDateField(this.NewPatientDOBtxt, dob);
 
     if (gender === 'female') {
       await this.NewPatientFemaleChk.check();
@@ -189,7 +189,7 @@ export class AllPatientsPage extends BasePatientListPage {
       await this.lastNameInput.fill(searchCriteria.lastName);
     }
     if (searchCriteria.DOB) {
-      await this.DOBInput.fill(searchCriteria.DOB);
+      await fillDateField(this.DOBInput, searchCriteria.DOB);
     }
     if (searchCriteria.culturalName) {
       await this.culturalNameInput.fill(searchCriteria.culturalName);
@@ -209,10 +209,10 @@ export class AllPatientsPage extends BasePatientListPage {
       await this.includeDeceasedChk.check();
     }
     if (searchCriteria.DOBFrom) {
-      await this.DOBFromTxt.fill(searchCriteria.DOBFrom);
+      await fillDateField(this.DOBFromTxt, searchCriteria.DOBFrom);
     }
     if (searchCriteria.DOBTo) {
-      await this.DOBToTxt.fill(searchCriteria.DOBTo);
+      await fillDateField(this.DOBToTxt, searchCriteria.DOBTo);
     }
     
     await this.searchBtn.click();

--- a/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
+++ b/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectFieldOption } from '../../../../utils/fieldHelpers';
+import { muiDateTextbox, fillDateTimeField } from '../../../../utils/dateFieldHelpers';
 
 export interface SimpleChartFormValues {
     dateTime?: string;
@@ -53,7 +54,7 @@ export class SimpleChartModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    this.dateTimeInput = this.form.getByText('Date & time').locator('..').locator('input');
+    this.dateTimeInput = this.form.getByText('Date & time').locator('..').getByRole('textbox');
     this.gcsEyeOpeningSelect = this.form.getByText('GCS Eye opening').locator('..').getByTestId('wrapperfieldcomponent-mkjr-select');
     this.gcsVerbalResponseSelect = this.form.getByText('GCS Verbal response').locator('..').getByTestId('wrapperfieldcomponent-mkjr-select');
     this.gcsMotorResponseSelect = this.form.getByText('GCS Motor response').locator('..').getByTestId('wrapperfieldcomponent-mkjr-select');
@@ -98,7 +99,7 @@ export class SimpleChartModal {
     let leftPupilsReaction: string | undefined;
 
     if (values.dateTime) {
-      await this.dateTimeInput.fill(values.dateTime);
+      await fillDateTimeField(this.dateTimeInput, values.dateTime);
     }
     if (values.gcsEyeOpening) {
       gcsEyeOpening = await selectFieldOption(this.page, this.gcsEyeOpeningSelect, {

--- a/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
+++ b/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectFieldOption } from '../../../../utils/fieldHelpers';
-import { muiDateTextbox, fillDateTimeField } from '../../../../utils/dateFieldHelpers';
+import { fillDateTimeField } from '../../../../utils/dateFieldHelpers';
 
 export interface SimpleChartFormValues {
     dateTime?: string;

--- a/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
+++ b/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption, selectFieldOption } from '../../../../utils/fieldHelpers';
+import { muiDateTextbox, fillDateTimeField } from '../../../../utils/dateFieldHelpers';
 
 export interface ImagingRequestFormValues {
   orderDateTime?: string;
@@ -53,7 +54,7 @@ export class NewImagingRequestModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    this.orderDateTimeInput = this.orderDateTimeField.locator('input');
+    this.orderDateTimeInput = muiDateTextbox(this.orderDateTimeField);
     this.requestingClinicianInput = this.requestingClinicianField.locator('input');
     this.finaliseButton = this.page.getByTestId('formgrid-4uzw').getByTestId('mainbuttoncomponent-06gp');
     this.areasToBeImagedSelect = this.page.getByText('Areas to be imaged').locator('..').getByTestId('multiselectinput-dvij');
@@ -76,7 +77,7 @@ export class NewImagingRequestModal {
     } = values;
 
     if (orderDateTime) {
-      await this.orderDateTimeInput.fill(orderDateTime);
+      await fillDateTimeField(this.orderDateTimeInput, orderDateTime);
     }
 
     let selectedRequestingClinician: string | undefined;

--- a/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
+++ b/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption, selectFieldOption } from '../../../../utils/fieldHelpers';
-import { muiDateTextbox, fillDateTimeField } from '../../../../utils/dateFieldHelpers';
+import { fillDateTimeField } from '../../../../utils/dateFieldHelpers';
 
 export interface ImagingRequestFormValues {
   orderDateTime?: string;
@@ -54,7 +54,7 @@ export class NewImagingRequestModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    this.orderDateTimeInput = muiDateTextbox(this.orderDateTimeField);
+    this.orderDateTimeInput = this.orderDateTimeField;
     this.requestingClinicianInput = this.requestingClinicianField.locator('input');
     this.finaliseButton = this.page.getByTestId('formgrid-4uzw').getByTestId('mainbuttoncomponent-06gp');
     this.areasToBeImagedSelect = this.page.getByText('Areas to be imaged').locator('..').getByTestId('multiselectinput-dvij');

--- a/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
@@ -1,5 +1,6 @@
 import { Page, Locator, expect } from '@playwright/test';
 import { format } from 'date-fns';
+import { fillDateTimeField } from '@utils/dateFieldHelpers';
 import { RecordSampleModal } from './modals/RecordSampleModal';
 import { StatusLogModal } from './modals/StatusLogModal';
 import { ChangeLaboratoryModal } from './modals/ChangeLaboratoryModal';
@@ -293,7 +294,7 @@ export class LabRequestDetailsPage {
     await this.enterResultsModal.selectLabTestMethod(labTestMethod);
     await this.enterResultsModal.verificationFirstRow.fill(verification);
     const dateToUse = completedDate || format(new Date(), "yyyy-MM-dd'T'HH:mm");
-    await this.enterResultsModal.completedDateFirstRow.fill(dateToUse);
+    await fillDateTimeField(this.enterResultsModal.completedDateFirstRow, dateToUse);
     await this.enterResultsModal.confirmButton.click();
   }
 }

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/EnterResultsModal.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from '@playwright/test';
+import { muiDateTextbox } from '@utils/dateFieldHelpers';
 
 export class EnterResultsModal {
   readonly page: Page;
@@ -46,7 +47,7 @@ export class EnterResultsModal {
     this.labTestMethodFirstRow = page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-labTestMethodId`).locator('input').locator('..').locator('div');
     this.labTestMethodFirstRowIcon = this.page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-labTestMethodId`).getByTestId('selectinput-phtg-expandmoreicon-h115');
     this.verificationFirstRow = page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-verification`).locator('input');
-    this.completedDateFirstRow = page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-completedDate`).locator('input');
+    this.completedDateFirstRow = muiDateTextbox(page.getByTestId(`${this.STYLED_TABLE_CELL_PREFIX}-0-completedDate`));
     
     // Dropdown option locators
     this.resultOptions = page.getByTestId('styledfield-h653-option');

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
@@ -2,7 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { PatientDetailsPage } from '@pages/patients/PatientDetailsPage';
 import { createApiContext, getUser } from '../../../../utils/apiHelpers';
 import { format } from 'date-fns';
-import { muiDateTextbox, fillDateTimeField, formatDateTimeForInput } from '../../../../utils/dateFieldHelpers';
+import { fillDateTimeField, formatDateTimeForInput } from '../../../../utils/dateFieldHelpers';
 import { getTableItems } from '../../../../utils/testHelper';
 
 const CATEGORY_TEXT_TEST_ID = 'categorytext-jno3';
@@ -127,7 +127,7 @@ export class LabRequestModalBase {
     
     // Special cases that need additional processing
     this.requestingClinicianInput = page.getByTestId('field-z6gb-input').locator('input');
-    this.requestDateTimeInput = muiDateTextbox(page.getByTestId('field-y6ku-input'));
+    this.requestDateTimeInput = page.getByTestId('field-y6ku-input');
     this.departmentInput = page.getByTestId('field-wobc-input').locator('input');
     // Scope prioritySelect to the visible form grid to avoid strict mode violations
     this.prioritySelect = page.getByTestId('formgrid-wses').getByTestId('selectinput-phtg-select');
@@ -247,7 +247,7 @@ export class LabRequestModalBase {
    * @param index - The index of the input to set
    */
   async setDateTimeCollected(dateTime: string, index: number = 0) {
-    const input = muiDateTextbox(this.dateTimeCollectedInputs.nth(index));
+    const input = this.dateTimeCollectedInputs.nth(index);
     await input.waitFor({ state: 'visible' });
     await fillDateTimeField(input, dateTime);
   }

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
@@ -2,6 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { PatientDetailsPage } from '@pages/patients/PatientDetailsPage';
 import { createApiContext, getUser } from '../../../../utils/apiHelpers';
 import { format } from 'date-fns';
+import { muiDateTextbox, fillDateTimeField, formatDateTimeForInput } from '../../../../utils/dateFieldHelpers';
 import { getTableItems } from '../../../../utils/testHelper';
 
 const CATEGORY_TEXT_TEST_ID = 'categorytext-jno3';
@@ -126,7 +127,7 @@ export class LabRequestModalBase {
     
     // Special cases that need additional processing
     this.requestingClinicianInput = page.getByTestId('field-z6gb-input').locator('input');
-    this.requestDateTimeInput = page.getByTestId('field-y6ku-input').locator('input');
+    this.requestDateTimeInput = muiDateTextbox(page.getByTestId('field-y6ku-input'));
     this.departmentInput = page.getByTestId('field-wobc-input').locator('input');
     // Scope prioritySelect to the visible form grid to avoid strict mode violations
     this.prioritySelect = page.getByTestId('formgrid-wses').getByTestId('selectinput-phtg-select');
@@ -154,7 +155,8 @@ export class LabRequestModalBase {
 
   async validateRequestedDateTimeIsToday() {
     const todayString = this.getCurrentDateTime();
-    await expect(this.requestDateTimeInput).toHaveValue(todayString);
+    const displayValue = formatDateTimeForInput(todayString);
+    await expect(this.requestDateTimeInput).toHaveValue(displayValue);
     return todayString;
   }
 
@@ -245,10 +247,9 @@ export class LabRequestModalBase {
    * @param index - The index of the input to set
    */
   async setDateTimeCollected(dateTime: string, index: number = 0) {
-    const input = this.dateTimeCollectedInputs.locator('input').nth(index);
-    await input.click();
+    const input = muiDateTextbox(this.dateTimeCollectedInputs.nth(index));
     await input.waitFor({ state: 'visible' });
-    await input.fill(dateTime);
+    await fillDateTimeField(input, dateTime);
   }
   
   /**

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { selectFirstFromDropdown } from '@utils/testHelper';
+import { muiDateTextbox } from '@utils/dateFieldHelpers';
 
 export class RecordSampleModal {
   readonly page: Page;
@@ -41,7 +42,7 @@ export class RecordSampleModal {
     }
 
     // Special cases that need additional processing
-    this.dateTimeCollectedInput = page.getByTestId('styledfield-dmjl-input').locator('input');
+    this.dateTimeCollectedInput = muiDateTextbox(page.getByTestId('styledfield-dmjl-input'));
     this.collectedByInput = page.getByTestId('styledfield-v88m-input').locator('input');
     this.specimenTypeInput = page.getByTestId('styledfield-0950-input').locator('input');
     // Scope siteInputDropdownIcon to the record sample form to avoid matching elements in other forms

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
@@ -1,6 +1,5 @@
 import { Page, Locator } from '@playwright/test';
 import { selectFirstFromDropdown } from '@utils/testHelper';
-import { muiDateTextbox } from '@utils/dateFieldHelpers';
 
 export class RecordSampleModal {
   readonly page: Page;
@@ -42,7 +41,7 @@ export class RecordSampleModal {
     }
 
     // Special cases that need additional processing
-    this.dateTimeCollectedInput = muiDateTextbox(page.getByTestId('styledfield-dmjl-input'));
+    this.dateTimeCollectedInput = page.getByTestId('styledfield-dmjl-input');
     this.collectedByInput = page.getByTestId('styledfield-v88m-input').locator('input');
     this.specimenTypeInput = page.getByTestId('styledfield-0950-input').locator('input');
     // Scope siteInputDropdownIcon to the record sample form to avoid matching elements in other forms

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
@@ -1,5 +1,4 @@
 import { Page, Locator } from '@playwright/test';
-import { muiDateTextbox } from '../../../../../utils/dateFieldHelpers';
 
 export abstract class BaseNoteModal {
   readonly page: Page;
@@ -28,7 +27,7 @@ export abstract class BaseNoteModal {
     
     // Special cases that need additional processing
     this.writtenByInput = page.getByTestId('field-ar9q-input').locator('input');
-    this.dateTimeInput = muiDateTextbox(page.getByTestId('field-nwwl-input'));
+    this.dateTimeInput = page.getByTestId('field-nwwl-input');
     this.noteContentTextarea = page.getByTestId('field-wxzr').locator('textarea').nth(0);
     this.cancelButton = page.getByRole('dialog').getByTestId('outlinedbutton-8rnr');
   }

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from '@playwright/test';
+import { muiDateTextbox } from '../../../../../utils/dateFieldHelpers';
 
 export abstract class BaseNoteModal {
   readonly page: Page;
@@ -27,7 +28,7 @@ export abstract class BaseNoteModal {
     
     // Special cases that need additional processing
     this.writtenByInput = page.getByTestId('field-ar9q-input').locator('input');
-    this.dateTimeInput = page.getByTestId('field-nwwl-input').locator('input');
+    this.dateTimeInput = muiDateTextbox(page.getByTestId('field-nwwl-input'));
     this.noteContentTextarea = page.getByTestId('field-wxzr').locator('textarea').nth(0);
     this.cancelButton = page.getByRole('dialog').getByTestId('outlinedbutton-8rnr');
   }

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/updateTreatmentPlanModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/updateTreatmentPlanModal.ts
@@ -2,6 +2,7 @@ import { Page, Locator } from '@playwright/test';
 import { BaseNoteModal } from './BaseModals/BaseNoteModal';
 import { format } from 'date-fns';
 import * as fieldHelpers from '@utils/fieldHelpers';
+import { fillDateTimeField } from '@utils/dateFieldHelpers';
 
 export class UpdateTreatmentPlanModal extends BaseNoteModal {
   // Additional fields specific to update treatment plan
@@ -36,7 +37,7 @@ export class UpdateTreatmentPlanModal extends BaseNoteModal {
       optionToSelect: updatedBy,
     });
     const updatedDateTime = format(new Date(), 'yyyy-MM-dd\'T\'HH:mm');
-    await this.dateTimeInput.fill(updatedDateTime);
+    await fillDateTimeField(this.dateTimeInput, updatedDateTime);
     await this.noteContentTextarea.fill(updatedContent);
     await this.confirmButton.click();
     await this.waitForModalToClose();

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -2,6 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { Patient } from '@tamanu/database';
 import { constructFacilityUrl } from '@utils/navigation';
 import { routes } from '@config/routes';
+import { fillDateField } from '@utils/dateFieldHelpers';
 import { BasePatientPage } from '../BasePatientPage';
 import { PatientVaccinePane } from './panes/PatientVaccinePane';
 import { CarePlanModal } from './modals/CarePlanModal';
@@ -460,7 +461,7 @@ export class PatientDetailsPage extends BasePatientPage {
     await this.initiateNewFamilyHistoryAddButton.click();
     await this.familyHistoryDiagnosisField.fill(familyHistoryCondition);
     await this.page.getByRole('menuitem', { name: familyHistoryCondition, exact: true }).click();
-    await this.familyHistoryDateRecordedField.fill(dateRecorded);
+    await fillDateField(this.familyHistoryDateRecordedField, dateRecorded);
     await this.familyHistoryRelationshipField.fill(relationship);
     await this.familyHistoryClinicianField.click();
     await this.page.getByRole('menuitem', { name: clinicianName, exact: true }).click();

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDiagnosisModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDiagnosisModal.ts
@@ -32,8 +32,8 @@ export class AddDiagnosisModal {
     for (const [key, testId] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(testId);
     }
-    this.dateInput= page.getByTestId('field-fszu-input').locator('input');
-    this.clinicianInput= page.getByTestId('field-af83-input').locator('input');
+    this.dateInput = page.getByTestId('field-fszu-input');
+    this.clinicianInput = page.getByTestId('field-af83-input').locator('input');
   }
 
   async waitForModalToLoad(): Promise<void> {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddReferralModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddReferralModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption, selectFieldOption } from '@utils/fieldHelpers';
+import { fillDateField } from '@utils/dateFieldHelpers';
 
 export class AddReferralModal {
   readonly page: Page;
@@ -26,7 +27,7 @@ export class AddReferralModal {
     this.referralFormGrid = this.page.getByTestId('formgrid-prtu');
     this.surveySelector = this.referralFormGrid.getByTestId('selectinput-4g3c-select');
     this.formFields = this.page.getByTestId('formgrid-h378');
-    this.referralDateInput = this.formFields.getByText('Referral date').locator('..').getByTestId('wrapperfieldcomponent-mkjr-input').locator('input');
+    this.referralDateInput = this.formFields.getByText('Referral date').locator('..').getByTestId('wrapperfieldcomponent-mkjr-input');
     this.referralHealthFacility = this.formFields.getByText('Referring health facility').locator('..').getByTestId('autocompletefield-efuf-input');
     this.referralCompletedBy = this.formFields.getByText('Referral completed by').locator('..').getByTestId('autocompletefield-efuf-input');
     this.reasonForReferral = this.formFields.getByText('Reason for referral').locator('..').getByTestId('wrapperfieldcomponent-mkjr-input');
@@ -69,7 +70,7 @@ export class AddReferralModal {
     referralReason?: string;
     relevantScreeningHistory?: string;
   }> {
-    await this.referralDateInput.fill(values.referralDate);
+    await fillDateField(this.referralDateInput, values.referralDate);
     
     const selectedReferralHealthFacility = values.referralHealthFacility
       ? await selectAutocompleteFieldOption(this.page, this.referralHealthFacility, {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditVaccineModal.ts
@@ -2,6 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 
 import { BasePatientModal } from './BasePatientModal';
 import { editFieldOption } from '@utils/fieldHelpers';
+import { fillDateField, formatDateForInput } from '@utils/dateFieldHelpers';
 import { Vaccine } from 'types/vaccine/Vaccine';
 
 export class EditVaccineModal extends BasePatientModal {
@@ -121,7 +122,7 @@ export class EditVaccineModal extends BasePatientModal {
     }
 
     if (dateGiven) {
-      await this.dateGiven.fill(dateGiven);
+      await fillDateField(this.dateGiven, dateGiven);
       editedFields.dateGiven = dateGiven;
     }
 
@@ -238,7 +239,7 @@ export class EditVaccineModal extends BasePatientModal {
     }
 
     if (dateGiven) {
-      await expect(this.dateGiven).toHaveValue(dateGiven);
+      await expect(this.dateGiven).toHaveValue(formatDateForInput(dateGiven));
     }
 
     if (injectionSite) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { selectFieldOption, selectAutocompleteFieldOption } from '@utils/fieldHelpers';
+import { muiDateTextbox, fillDateTimeField } from '@utils/dateFieldHelpers';
 import { RecordVitalsModal } from '../../VitalsPage/modals/RecordVitalsModal';
 
 export class EmergencyTriageModal {
@@ -159,7 +160,7 @@ export class EmergencyTriageModal {
     triageClinician?: string;
   }> {
     if (options.arrivalDateTime) {
-      await this.arrivalDateTimeInput.locator('input').fill(options.arrivalDateTime);
+      await fillDateTimeField(muiDateTextbox(this.arrivalDateTimeInput), options.arrivalDateTime);
     }
     
     const area = await selectAutocompleteFieldOption(this.page, this.areaField, {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
@@ -1,6 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { selectFieldOption, selectAutocompleteFieldOption } from '@utils/fieldHelpers';
-import { muiDateTextbox, fillDateTimeField } from '@utils/dateFieldHelpers';
+import { fillDateTimeField } from '@utils/dateFieldHelpers';
 import { RecordVitalsModal } from '../../VitalsPage/modals/RecordVitalsModal';
 
 export class EmergencyTriageModal {
@@ -160,7 +160,7 @@ export class EmergencyTriageModal {
     triageClinician?: string;
   }> {
     if (options.arrivalDateTime) {
-      await fillDateTimeField(muiDateTextbox(this.arrivalDateTimeInput), options.arrivalDateTime);
+      await fillDateTimeField(this.arrivalDateTimeInput, options.arrivalDateTime);
     }
     
     const area = await selectAutocompleteFieldOption(this.page, this.areaField, {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
@@ -6,6 +6,7 @@ import {
   selectAutocompleteFieldOption,
   returnAllOptionsFromDropdown,
 } from '@utils/fieldHelpers';
+import { fillDateField, readDateFieldValue, parseDateDisplayToIso } from '@utils/dateFieldHelpers';
 
 interface RecordVaccineOptions {
   specificVaccine?: string;
@@ -245,10 +246,11 @@ export class RecordVaccineModal extends BasePatientModal {
     }
 
     if (specificDate) {
-      await this.dateField.fill(specificDate);
+      await fillDateField(this.dateField, specificDate);
     }
 
-    const dateGiven = await this.dateField.evaluate((el: HTMLInputElement) => el.value);
+    const dateGivenDisplay = await readDateFieldValue(this.dateField);
+    const dateGiven = parseDateDisplayToIso(dateGivenDisplay) ?? dateGivenDisplay;
 
     if (category !== 'Other') {
       if (recordScheduledVaccine) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage.ts
@@ -2,7 +2,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePatientPane } from './BasePatientPane';
 import { selectAutocompleteFieldOption, selectFieldOption } from '../../../../utils/fieldHelpers';
-import { muiDateTextbox, fillDateField } from '../../../../utils/dateFieldHelpers';
+import { fillDateField } from '../../../../utils/dateFieldHelpers';
 
 
 export interface PatientDetails {
@@ -180,7 +180,7 @@ export class PatientDetailsTabPage extends BasePatientPane {
       await this.culturalNameInput.fill(patientDetails.culturalName);
     }
     if (patientDetails.dateOfBirth) {
-      await fillDateField(muiDateTextbox(this.dateOfBirthInput), patientDetails.dateOfBirth);
+      await fillDateField(this.dateOfBirthInput, patientDetails.dateOfBirth);
     }
     if (patientDetails.sex) {
       if (patientDetails.sex === 'female') {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage.ts
@@ -2,6 +2,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePatientPane } from './BasePatientPane';
 import { selectAutocompleteFieldOption, selectFieldOption } from '../../../../utils/fieldHelpers';
+import { muiDateTextbox, fillDateField } from '../../../../utils/dateFieldHelpers';
 
 
 export interface PatientDetails {
@@ -179,7 +180,7 @@ export class PatientDetailsTabPage extends BasePatientPane {
       await this.culturalNameInput.fill(patientDetails.culturalName);
     }
     if (patientDetails.dateOfBirth) {
-      await this.dateOfBirthInput.locator('input').fill(patientDetails.dateOfBirth);
+      await fillDateField(muiDateTextbox(this.dateOfBirthInput), patientDetails.dateOfBirth);
     }
     if (patientDetails.sex) {
       if (patientDetails.sex === 'female') {

--- a/packages/e2e-tests/pages/patients/PatientTable.ts
+++ b/packages/e2e-tests/pages/patients/PatientTable.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { expect } from '../../fixtures/baseFixture';
 import { convertDateFormat, SelectingFromSearchBox ,STYLED_TABLE_CELL_PREFIX} from '../../utils/testHelper';
+import { muiDateTextbox } from '../../utils/dateFieldHelpers';
 import { routes } from '../../config/routes';
 import { Patient } from '../../types/Patient'; 
 import { TWO_COLUMNS_FIELD_TEST_ID } from './AllPatientsPage';
@@ -101,10 +102,10 @@ export class PatientTable {
       .locator('svg');
     this.villageSortButton = page.getByTestId('tablesortlabel-0qxx-villageName').locator('svg');
     this.dobSortButton = page.getByTestId('tablesortlabel-0qxx-dateOfBirth').locator('svg');
-    this.DOBTxt = page.getByTestId('field-qk60-input').locator('input[type="date"]');
+    this.DOBTxt = muiDateTextbox(page.getByTestId('field-qk60-input'));
     this.villageSearchBox = page.getByTestId('villagelocalisedfield-mcri-input').locator('input');
-    this.DOBFromTxt = page.getByTestId('joinedfield-swzm-input').locator('input[type="date"]');
-    this.DOBToTxt = page.getByTestId('field-aax5-input').locator('input[type="date"]');
+    this.DOBFromTxt = muiDateTextbox(page.getByTestId('joinedfield-swzm-input'));
+    this.DOBToTxt = muiDateTextbox(page.getByTestId('field-aax5-input'));
     this.pageRecordCountDropDown = page.getByTestId('styledselectfield-lunn').locator('div');
     this.patientPageRecordCount25 = page
       .getByTestId('styledmenuitem-fkrw-undefined')

--- a/packages/e2e-tests/pages/patients/PatientTable.ts
+++ b/packages/e2e-tests/pages/patients/PatientTable.ts
@@ -1,7 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { expect } from '../../fixtures/baseFixture';
 import { convertDateFormat, SelectingFromSearchBox ,STYLED_TABLE_CELL_PREFIX} from '../../utils/testHelper';
-import { muiDateTextbox } from '../../utils/dateFieldHelpers';
 import { routes } from '../../config/routes';
 import { Patient } from '../../types/Patient'; 
 import { TWO_COLUMNS_FIELD_TEST_ID } from './AllPatientsPage';
@@ -102,10 +101,10 @@ export class PatientTable {
       .locator('svg');
     this.villageSortButton = page.getByTestId('tablesortlabel-0qxx-villageName').locator('svg');
     this.dobSortButton = page.getByTestId('tablesortlabel-0qxx-dateOfBirth').locator('svg');
-    this.DOBTxt = muiDateTextbox(page.getByTestId('field-qk60-input'));
+    this.DOBTxt = page.getByTestId('field-qk60-input');
     this.villageSearchBox = page.getByTestId('villagelocalisedfield-mcri-input').locator('input');
-    this.DOBFromTxt = muiDateTextbox(page.getByTestId('joinedfield-swzm-input'));
-    this.DOBToTxt = muiDateTextbox(page.getByTestId('field-aax5-input'));
+    this.DOBFromTxt = page.getByTestId('joinedfield-swzm-input');
+    this.DOBToTxt = page.getByTestId('field-aax5-input');
     this.pageRecordCountDropDown = page.getByTestId('styledselectfield-lunn').locator('div');
     this.patientPageRecordCount25 = page
       .getByTestId('styledmenuitem-fkrw-undefined')

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePage } from '../../../BasePage';
 import { selectAutocompleteFieldOption } from '../../../../utils/fieldHelpers';
+import { muiDateTextbox, fillTimeField } from '../../../../utils/dateFieldHelpers';
 import { UnsavedChangesModal } from './UnsavedChangesModal';
 
 /**
@@ -118,10 +119,10 @@ export class NewProcedureModal extends BasePage {
     const notes = 'This is a test note';
     const completedNotes = 'This is a test completed note';
 
-    await this.timeInInput.locator('input').fill(timeIn);
-    await this.timeOutInput.locator('input').fill(timeOut);
-    await this.timeStartedInput.locator('input').fill(timeStarted);
-    await this.timeEndedInput.locator('input').fill(timeEnded);
+    await fillTimeField(muiDateTextbox(this.timeInInput), `1970-01-01T${timeIn}`);
+    await fillTimeField(muiDateTextbox(this.timeOutInput), `1970-01-01T${timeOut}`);
+    await fillTimeField(muiDateTextbox(this.timeStartedInput), `1970-01-01T${timeStarted}`);
+    await fillTimeField(muiDateTextbox(this.timeEndedInput), `1970-01-01T${timeEnded}`);
     await this.notesInput.fill(notes);
     await this.completedCheckbox.check();
     await this.completedNotesInput.fill(completedNotes);

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePage } from '../../../BasePage';
 import { selectAutocompleteFieldOption } from '../../../../utils/fieldHelpers';
-import { muiDateTextbox, fillTimeField } from '../../../../utils/dateFieldHelpers';
+import { fillTimeField } from '../../../../utils/dateFieldHelpers';
 import { UnsavedChangesModal } from './UnsavedChangesModal';
 
 /**
@@ -119,10 +119,10 @@ export class NewProcedureModal extends BasePage {
     const notes = 'This is a test note';
     const completedNotes = 'This is a test completed note';
 
-    await fillTimeField(muiDateTextbox(this.timeInInput), `1970-01-01T${timeIn}`);
-    await fillTimeField(muiDateTextbox(this.timeOutInput), `1970-01-01T${timeOut}`);
-    await fillTimeField(muiDateTextbox(this.timeStartedInput), `1970-01-01T${timeStarted}`);
-    await fillTimeField(muiDateTextbox(this.timeEndedInput), `1970-01-01T${timeEnded}`);
+    await fillTimeField(this.timeInInput, `1970-01-01T${timeIn}`);
+    await fillTimeField(this.timeOutInput, `1970-01-01T${timeOut}`);
+    await fillTimeField(this.timeStartedInput, `1970-01-01T${timeStarted}`);
+    await fillTimeField(this.timeEndedInput, `1970-01-01T${timeEnded}`);
     await this.notesInput.fill(notes);
     await this.completedCheckbox.check();
     await this.completedNotesInput.fill(completedNotes);

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/AddTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/AddTaskModal.ts
@@ -1,6 +1,5 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption, selectFieldOption } from '@utils/fieldHelpers';
-
 export class AddTaskModal {
   readonly page: Page;
 
@@ -45,9 +44,9 @@ export class AddTaskModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    // Fields that need nested locators
-    this.startDateTimeInput = this.startDateTimeField.locator('input');
-    this.requestDateTimeInput = this.requestDateTimeField.locator('input');
+    // DateTime pickers: test ids end with -input on the actual textbox
+    this.startDateTimeInput = this.startDateTimeField;
+    this.requestDateTimeInput = this.requestDateTimeField;
     this.requestedByInput = this.requestedByField.locator('input');
     this.notesInput = this.notesField.locator('textarea').first();
     this.frequencyValueInput = this.frequencyValueField.locator('input');

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption } from '@utils/fieldHelpers';
-import { muiDateTextbox, fillDateTimeField } from '@utils/dateFieldHelpers';
+import { fillDateTimeField } from '@utils/dateFieldHelpers';
 
 export class DeleteTaskModal {
   readonly page: Page;
@@ -27,7 +27,7 @@ export class DeleteTaskModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    this.recordDateTimeInput = muiDateTextbox(this.recordDateTimeField);
+    this.recordDateTimeInput = this.recordDateTimeField;
   }
 
   async waitForModalToLoad(): Promise<void> {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption } from '@utils/fieldHelpers';
+import { muiDateTextbox, fillDateTimeField } from '@utils/dateFieldHelpers';
 
 export class DeleteTaskModal {
   readonly page: Page;
@@ -26,8 +27,7 @@ export class DeleteTaskModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    // Field that needs nested locator
-    this.recordDateTimeInput = this.recordDateTimeField.locator('input');
+    this.recordDateTimeInput = muiDateTextbox(this.recordDateTimeField);
   }
 
   async waitForModalToLoad(): Promise<void> {
@@ -48,7 +48,7 @@ export class DeleteTaskModal {
     }
 
     if (values.recordDateTime) {
-      await this.recordDateTimeInput.fill(values.recordDateTime);
+      await fillDateTimeField(this.recordDateTimeInput, values.recordDateTime);
     }
 
     if (values.reasonForDeletion) {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
@@ -1,6 +1,4 @@
 import { Locator, Page } from '@playwright/test';
-import { muiDateTextbox } from '@utils/dateFieldHelpers';
-
 export class MarkAsCompletedModal {
   readonly page: Page;
 
@@ -26,7 +24,7 @@ export class MarkAsCompletedModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    this.completedDateTimeInput = muiDateTextbox(this.completedDateTimeField);
+    this.completedDateTimeInput = this.completedDateTimeField;
   }
 
   async waitForModalToLoad(): Promise<void> {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from '@playwright/test';
+import { muiDateTextbox } from '@utils/dateFieldHelpers';
 
 export class MarkAsCompletedModal {
   readonly page: Page;
@@ -25,8 +26,7 @@ export class MarkAsCompletedModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    // Field that needs nested locator
-    this.completedDateTimeInput = this.completedDateTimeField.locator('input');
+    this.completedDateTimeInput = muiDateTextbox(this.completedDateTimeField);
   }
 
   async waitForModalToLoad(): Promise<void> {

--- a/packages/e2e-tests/pages/patients/VitalsPage/modals/RecordVitalsModal.ts
+++ b/packages/e2e-tests/pages/patients/VitalsPage/modals/RecordVitalsModal.ts
@@ -47,8 +47,8 @@ export class RecordVitalsModal {
       (this as any)[key] = page.getByTestId(id);
     }
 
-    // Inputs (by name attributes or specific selectors from provided HTML)
-    this.dateInput = page.locator('input[type="datetime-local"]');
+    // Inputs (by name attributes)
+    this.dateInput = page.locator('input[name="pde-PatientVitalsDate"]');
     this.sbpInput = page.locator('input[name="pde-PatientVitalsSBP"]');
     this.dbpInput = page.locator('input[name="pde-PatientVitalsDBP"]');
     this.heartRateInput = page.locator('input[name="pde-PatientVitalsHeartRate"]');

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -2,7 +2,7 @@ import { EmergencyPatientsPage } from '@pages/patients/EmergencyPatientsPage';
 import { test } from '../../fixtures/baseFixture';
 import { expect } from '@playwright/test';
 import { assertRecentDateTime, convertDateFormat, getTableItems, formatDateTimeForTable } from '@utils/testHelper';
-import { muiDateTextbox, expectDateFieldValue } from '@utils/dateFieldHelpers';
+import { expectDateFieldValue, formatDateForInput } from '@utils/dateFieldHelpers';
 import { VitalsPage } from '@pages/patients/VitalsPage/panes/VitalsPage';
 import { generateNHN } from '@utils/generateNewPatient';
 import type { PatientDetails } from '@pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage';
@@ -172,7 +172,7 @@ test.describe('Basic tests', () => {
 
      await expect(patientDetailsTabPage2.firstNameInput).toHaveValue(patientDetails.firstName as string);
      await expect(patientDetailsTabPage2.lastNameInput).toHaveValue(patientDetails.lastName as string);
-     await expectDateFieldValue(muiDateTextbox(patientDetailsTabPage2.dateOfBirthInput), '1990-01-01');
+     await expectDateFieldValue(patientDetailsTabPage2.dateOfBirthInput, '1990-01-01');
      if ((patientDetails.sex) === 'female') {
        await expect(patientDetailsTabPage2.sexFemaleRadio).toBeChecked();
      } else if ((patientDetails.sex ) === 'male') {
@@ -327,7 +327,7 @@ test.describe('Basic tests', () => {
     await patientDetailsPage.addDiagnosisButton.click();
     const diagnosisModal = patientDetailsPage.getAddDiagnosisModal();
     await diagnosisModal.waitForModalToLoad();  
-    expect(await diagnosisModal.dateInput.inputValue()).toBe(format(new Date(), 'yyyy-MM-dd'));
+    expect(await diagnosisModal.dateInput.inputValue()).toBe(formatDateForInput(format(new Date(), 'yyyy-MM-dd')));
     expect(await diagnosisModal.clinicianInput.inputValue()).toBe(currentUserDisplayName);
     const formValues = await diagnosisModal.fillForm(true);
     await diagnosisModal.confirmButton.click();

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -2,6 +2,7 @@ import { EmergencyPatientsPage } from '@pages/patients/EmergencyPatientsPage';
 import { test } from '../../fixtures/baseFixture';
 import { expect } from '@playwright/test';
 import { assertRecentDateTime, convertDateFormat, getTableItems, formatDateTimeForTable } from '@utils/testHelper';
+import { muiDateTextbox, expectDateFieldValue } from '@utils/dateFieldHelpers';
 import { VitalsPage } from '@pages/patients/VitalsPage/panes/VitalsPage';
 import { generateNHN } from '@utils/generateNewPatient';
 import type { PatientDetails } from '@pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage';
@@ -171,7 +172,7 @@ test.describe('Basic tests', () => {
 
      await expect(patientDetailsTabPage2.firstNameInput).toHaveValue(patientDetails.firstName as string);
      await expect(patientDetailsTabPage2.lastNameInput).toHaveValue(patientDetails.lastName as string);
-     await expect(patientDetailsTabPage2.dateOfBirthInput.locator('input')).toHaveValue('1990-01-01');
+     await expectDateFieldValue(muiDateTextbox(patientDetailsTabPage2.dateOfBirthInput), '1990-01-01');
      if ((patientDetails.sex) === 'female') {
        await expect(patientDetailsTabPage2.sexFemaleRadio).toBeChecked();
      } else if ((patientDetails.sex ) === 'male') {

--- a/packages/e2e-tests/tests/patients/patientSideBar.spec.ts
+++ b/packages/e2e-tests/tests/patients/patientSideBar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../fixtures/baseFixture';
+import { fillDateField, fillDateTimeField, expectDateFieldValue, expectDateTimeFieldValue } from '@utils/dateFieldHelpers';
 
 test.describe('Patient Side Bar', () => {
   test.beforeEach(async ({ patientDetailsPage, newPatient }) => {
@@ -177,7 +178,7 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Hair alopecia');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue(currentBrowserDate);
+    await expectDateFieldValue(patientDetailsPage.savedFamilyHistoryDateRecorded, currentBrowserDate);
   });
 
   test('[T-0044][AT-0106]Add family history with all fields', async ({ patientDetailsPage }) => {
@@ -194,7 +195,7 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Ear burn');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue('2025-05-26');
+    await expectDateFieldValue(patientDetailsPage.savedFamilyHistoryDateRecorded, '2025-05-26');
     await expect(patientDetailsPage.savedFamilyHistoryRelationship).toHaveValue('Mother');
     await expect(patientDetailsPage.savedFamilyClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedFamilyHistoryNote).toHaveValue('Family history note');
@@ -205,7 +206,7 @@ test.describe('Patient Side Bar', () => {
 
     await patientDetailsPage.firstListItem.click();
 
-    await patientDetailsPage.savedFamilyHistoryDateRecorded.fill('2025-05-25');
+    await fillDateField(patientDetailsPage.savedFamilyHistoryDateRecorded, '2025-05-25');
     await patientDetailsPage.savedFamilyHistoryRelationship.fill('Mother');
     await patientDetailsPage.savedFamilyClinician.click();
     await patientDetailsPage.page.getByRole('menuitem', { name: 'Initial Admin' }).click();
@@ -215,7 +216,7 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Hair alopecia');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue('2025-05-25');
+    await expectDateFieldValue(patientDetailsPage.savedFamilyHistoryDateRecorded, '2025-05-25');
     await expect(patientDetailsPage.savedFamilyHistoryRelationship).toHaveValue('Mother');
     await expect(patientDetailsPage.savedFamilyClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedFamilyHistoryNote).toHaveValue('First edit to note');
@@ -226,7 +227,7 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Hair alopecia');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue('2025-05-25');
+    await expectDateFieldValue(patientDetailsPage.savedFamilyHistoryDateRecorded, '2025-05-25');
     await expect(patientDetailsPage.savedFamilyHistoryRelationship).toHaveValue('Mother');
     await expect(patientDetailsPage.savedFamilyClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedFamilyHistoryNote).toHaveValue('Second edit to note');
@@ -248,7 +249,7 @@ test.describe('Patient Side Bar', () => {
 
     await expect(patientDetailsPage.savedIssueType).toContainText('Issue');
     await expect(patientDetailsPage.savedOtherPatientIssueNote).toHaveValue('New issue note');
-    await expect(patientDetailsPage.savedOtherPatientIssueDate).toHaveValue(currentBrowserDate);
+    await expectDateFieldValue(patientDetailsPage.savedOtherPatientIssueDate, currentBrowserDate);
   });
 
   test('[T-0045][AT-0109]Add other patient issue: warning', async ({ patientDetailsPage }) => {
@@ -290,7 +291,7 @@ test.describe('Patient Side Bar', () => {
     await expect(patientDetailsPage.savedOtherPatientIssueNote).toHaveValue('Test warning');
 
     await patientDetailsPage.savedOtherPatientIssueNote.fill('Edited warning');
-    await patientDetailsPage.savedOtherPatientIssueDate.fill('2025-09-17');
+    await fillDateField(patientDetailsPage.savedOtherPatientIssueDate, '2025-09-17');
     await patientDetailsPage.getOtherPatientIssuesEditSubmitButton().click();
 
     await patientDetailsPage.firstListItem.click();
@@ -393,7 +394,7 @@ test.describe('Patient Side Bar', () => {
     await additionalNoteKebabMenu.click();
     await completedCarePlanModal.additionalNoteEditButton.click();
 
-    await completedCarePlanModal.additionalNoteSavedDate.fill('2025-04-26T15:40');
+    await fillDateTimeField(completedCarePlanModal.additionalNoteSavedDate, '2025-04-26T15:40');
     await completedCarePlanModal.editableNoteContent.fill('Edited note');
     await completedCarePlanModal.getSaveButton().click();
 

--- a/packages/e2e-tests/utils/dateFieldHelpers.ts
+++ b/packages/e2e-tests/utils/dateFieldHelpers.ts
@@ -1,0 +1,148 @@
+import { Locator, Page, expect } from '@playwright/test';
+import { format, parse, isValid } from 'date-fns';
+
+// Must match DISPLAY_FORMATS in packages/ui-components/src/components/Field/DateField.jsx
+const DATE_DISPLAY_FORMAT = 'dd/MM/yyyy';
+const DATETIME_DISPLAY_FORMAT = 'dd/MM/yyyy hh:mm a';
+const TIME_DISPLAY_FORMAT = 'hh:mm a';
+
+/**
+ * Resolve the MUI textbox input inside a date field container.
+ * Works for DatePicker, DateTimePicker, and TimePicker fields.
+ */
+export function muiDateTextbox(fieldRoot: Locator): Locator {
+  return fieldRoot.getByRole('textbox');
+}
+
+export function muiDateTextboxByTestId(page: Page, testId: string): Locator {
+  return muiDateTextbox(page.getByTestId(testId));
+}
+
+// ---------------------------------------------------------------------------
+// Format conversion — ISO ↔ MUI display strings
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an ISO date string (yyyy-MM-dd) to the display format the MUI
+ * DatePicker shows in its text field (dd/MM/yyyy).
+ */
+export function formatDateForInput(isoDate: string): string {
+  const date = parseIsoish(isoDate);
+  return format(date, DATE_DISPLAY_FORMAT);
+}
+
+/**
+ * Convert an ISO-ish datetime string to the display format the MUI
+ * DateTimePicker shows (dd/MM/yyyy hh:mm a).
+ *
+ * Accepted inputs: yyyy-MM-dd'T'HH:mm, yyyy-MM-dd HH:mm:ss, Date objects.
+ */
+export function formatDateTimeForInput(isoDateTime: string | Date): string {
+  const date = isoDateTime instanceof Date ? isoDateTime : parseIsoish(isoDateTime);
+  return format(date, DATETIME_DISPLAY_FORMAT);
+}
+
+/**
+ * Convert an ISO-ish time or datetime string to the display format the MUI
+ * TimePicker shows (hh:mm a).
+ */
+export function formatTimeForInput(isoTime: string | Date): string {
+  const date = isoTime instanceof Date ? isoTime : parseIsoish(isoTime);
+  return format(date, TIME_DISPLAY_FORMAT);
+}
+
+/**
+ * Parse a MUI display-format date string back to ISO yyyy-MM-dd.
+ * Returns null if the string is not a valid date.
+ */
+export function parseDateDisplayToIso(display: string): string | null {
+  const date = parse(display.trim(), DATE_DISPLAY_FORMAT, new Date());
+  return isValid(date) ? format(date, 'yyyy-MM-dd') : null;
+}
+
+// ---------------------------------------------------------------------------
+// Interaction helpers — fill MUI date/datetime/time fields from ISO values
+// ---------------------------------------------------------------------------
+
+/**
+ * Fill a MUI DatePicker textbox with an ISO date string (yyyy-MM-dd).
+ * Converts to display format, types it in, and blurs to commit the value.
+ */
+export async function fillDateField(textbox: Locator, isoDate: string): Promise<void> {
+  const display = formatDateForInput(isoDate);
+  await clearAndType(textbox, display);
+}
+
+/**
+ * Fill a MUI DateTimePicker textbox with an ISO-ish datetime string.
+ * Converts to display format, types it in, and blurs to commit the value.
+ */
+export async function fillDateTimeField(textbox: Locator, isoDateTime: string | Date): Promise<void> {
+  const display = formatDateTimeForInput(isoDateTime);
+  await clearAndType(textbox, display);
+}
+
+/**
+ * Fill a MUI TimePicker textbox with an ISO-ish time string.
+ * Converts to display format, types it in, and blurs to commit the value.
+ */
+export async function fillTimeField(textbox: Locator, isoTime: string | Date): Promise<void> {
+  const display = formatTimeForInput(isoTime);
+  await clearAndType(textbox, display);
+}
+
+/**
+ * Read the raw input value from a MUI date/datetime/time textbox.
+ */
+export async function readDateFieldValue(textbox: Locator): Promise<string> {
+  return textbox.inputValue();
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that a MUI date textbox currently holds a value matching the given
+ * ISO date string (compared via display format).
+ */
+export async function expectDateFieldValue(textbox: Locator, expectedIso: string): Promise<void> {
+  const expectedDisplay = formatDateForInput(expectedIso);
+  await expect(textbox).toHaveValue(expectedDisplay);
+}
+
+/**
+ * Assert that a MUI datetime textbox currently holds a value matching the
+ * given ISO datetime string (compared via display format).
+ */
+export async function expectDateTimeFieldValue(textbox: Locator, expectedIso: string | Date): Promise<void> {
+  const expectedDisplay = formatDateTimeForInput(expectedIso);
+  await expect(textbox).toHaveValue(expectedDisplay);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function clearAndType(textbox: Locator, displayValue: string): Promise<void> {
+  await textbox.click();
+  await textbox.press('ControlOrMeta+a');
+  await textbox.fill(displayValue);
+  await textbox.press('Tab');
+}
+
+function parseIsoish(value: string): Date {
+  // Try native Date first (handles ISO 8601 and yyyy-MM-dd'T'HH:mm)
+  let date = new Date(value);
+  if (isValid(date)) return date;
+
+  // Fallback: yyyy-MM-dd HH:mm:ss (ISO 9075 / SQL style)
+  date = parse(value, 'yyyy-MM-dd HH:mm:ss', new Date());
+  if (isValid(date)) return date;
+
+  // Fallback: plain date
+  date = parse(value, 'yyyy-MM-dd', new Date());
+  if (isValid(date)) return date;
+
+  throw new Error(`Cannot parse date value: "${value}"`);
+}

--- a/packages/e2e-tests/utils/vaccineTestHelpers.ts
+++ b/packages/e2e-tests/utils/vaccineTestHelpers.ts
@@ -3,6 +3,7 @@ import { createPatient } from '../utils/apiHelpers';
 import { expect } from '@playwright/test';
 import { Vaccine } from 'types/vaccine/Vaccine';
 import { addWeeks, startOfWeek, format } from 'date-fns';
+import { fillDateField } from './dateFieldHelpers';
 
 interface AddVaccineOptions {
   specificVaccine?: string | null;
@@ -110,7 +111,7 @@ export async function triggerDateError(
   expect(patientDetailsPage.patientVaccinePane?.recordVaccineModal).toBeDefined();
 
   //Attempt to submit a date that should trigger a validation error
-  await patientDetailsPage.patientVaccinePane?.recordVaccineModal?.dateField.fill(date);
+  await fillDateField(patientDetailsPage.patientVaccinePane?.recordVaccineModal?.dateField!, date);
   await patientDetailsPage.patientVaccinePane?.recordVaccineModal?.confirmButton.click();
 
   //Assert the validation error appears

--- a/packages/ui-components/src/components/Field/TextField.jsx
+++ b/packages/ui-components/src/components/Field/TextField.jsx
@@ -137,6 +137,7 @@ export const TextInput = ({
   return (
     <OuterLabelFieldWrapper label={label} data-testid={dataTestId} {...props}>
       <StyledTextField
+        {...props}
         value={value}
         variant="outlined"
         onPaste={onPaste}
@@ -147,7 +148,6 @@ export const TextInput = ({
           ...props.inputProps,
           'data-testid': `${dataTestId}-input`,
         }}
-        {...props}
       />
     </OuterLabelFieldWrapper>
   );


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [x] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactors E2E selectors and input helpers, but it also changes `ui-components` `TextField` prop spread order, which could subtly affect runtime field behavior/overrides.
> 
> **Overview**
> Adds a new `e2e-tests` `dateFieldHelpers` utility that normalizes interacting with MUI Date/DateTime/Time pickers by converting ISO values to MUI display strings, typing/blur-committing them, and providing matching assertion helpers.
> 
> Migrates multiple patient E2E page objects and specs (patients list/search, charts, imaging, lab requests, notes, referrals, triage, vaccines, procedures, tasks) to use these helpers and more robust `getByRole('textbox')`-based locators instead of targeting raw `input[type=date|datetime-local]` elements.
> 
> Updates the shared `ui-components` `TextField` to spread `{...props}` before explicit props, affecting which values/handlers win when both are provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61d4e56a46f9ca7f2564452628702ab7c34b5747. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->