### PR TITLE
fix: Release fix v2.51: E2E tests vaccines

### DIFF
--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditVaccineModal.ts
@@ -2,6 +2,11 @@ import { Locator, Page, expect } from '@playwright/test';
 
 import { BasePatientModal } from './BasePatientModal';
 import { editFieldOption } from '@utils/fieldHelpers';
+import {
+  formatForMuiDateTimePicker,
+  getSidebarFacilityDisplayName,
+  normalizeToIsoDate,
+} from '@utils/testHelper';
 import { Vaccine } from 'types/vaccine/Vaccine';
 
 export class EditVaccineModal extends BasePatientModal {
@@ -48,7 +53,7 @@ export class EditVaccineModal extends BasePatientModal {
     this.recordedBy = this.page.getByTestId('displayfield-jkpx-vaccine-translatedtext-e9ru');
     this.facility = this.page.getByTestId('displayfield-jkpx-vaccine-translatedtext-iukb');
     this.batch = this.page.getByTestId('field-865y-input');
-    this.dateGiven = this.page.getByTestId('field-8sou-input').getByRole('textbox');
+    this.dateGiven = this.page.getByTestId('field-8sou').getByRole('textbox');
     this.injectionSite = this.page.getByTestId('field-jz48-select');
     this.area = this.page.getByTestId('field-zrlv-group-input');
     this.areaSearch = this.page
@@ -68,7 +73,7 @@ export class EditVaccineModal extends BasePatientModal {
     this.submitEditsButton = this.page.getByTestId('formsubmitcancelrow-vv8q-confirmButton');
     this.brand = this.page.getByTestId('field-f1vm-input');
     this.disease = this.page.getByTestId('field-gcfk-input');
-    this.reason = this.page.getByTestId('selectinput-phtg-select');
+    this.reason = this.page.getByTestId('selectinput-phtg-select').filter({ visible: true });
     this.notGivenClinician = this.page.getByTestId('field-xycc-input');
     this.closeModalButton = this.page.getByTestId('iconbutton-eull');
     this.areaFieldClearButton = this.page.getByTestId('field-zrlv-group-input-clearbutton');
@@ -121,7 +126,8 @@ export class EditVaccineModal extends BasePatientModal {
     }
 
     if (dateGiven) {
-      await this.dateGiven.fill(dateGiven);
+      await this.dateGiven.fill(formatForMuiDateTimePicker(dateGiven));
+      await this.dateGiven.blur();
       editedFields.dateGiven = dateGiven;
     }
 
@@ -213,7 +219,8 @@ export class EditVaccineModal extends BasePatientModal {
     await expect(this.givenStatus).toContainText(givenStatus);
     await expect(this.recordedBy).toContainText('Initial Admin');
     if (givenStatus !== 'Not given') {
-      await expect(this.facility).toContainText('facility-1');
+      const facilityDisplayName = await getSidebarFacilityDisplayName(this.page);
+      await expect(this.facility).toContainText(facilityDisplayName);
     }
   }
 
@@ -238,7 +245,10 @@ export class EditVaccineModal extends BasePatientModal {
     }
 
     if (dateGiven) {
-      await expect(this.dateGiven).toHaveValue(dateGiven);
+      const displayed = await this.dateGiven.inputValue();
+      await expect(normalizeToIsoDate(displayed)).toBe(
+        normalizeToIsoDate(dateGiven),
+      );
     }
 
     if (injectionSite) {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
@@ -75,6 +75,9 @@ export class RecordVaccineModal extends BasePatientModal {
   readonly consentGivenRequiredError: Locator;
   readonly vaccineNameRequiredError: Locator;
   readonly givenElsewhereCheckbox: Locator;
+  readonly givenElsewhereCircumstancesSection: Locator;
+  readonly givenElsewhereCircumstancesIndicator: Locator;
+  readonly givenElsewhereCountryField: Locator;
   constructor(page: Page) {
     super(page);
 
@@ -122,6 +125,10 @@ export class RecordVaccineModal extends BasePatientModal {
     this.consentGivenRequiredError = this.page.getByTestId('formhelpertext-2d0o');
     this.vaccineNameRequiredError = this.page.getByTestId('field-npct-formhelptertext');
     this.givenElsewhereCheckbox = this.page.getByTestId('field-w50x-controlcheck');
+    this.givenElsewhereCircumstancesSection = this.modal.getByTestId('fullwidthcol-lan5');
+    this.givenElsewhereCircumstancesIndicator =
+      this.givenElsewhereCircumstancesSection.getByTestId('styledindicator-dx40');
+    this.givenElsewhereCountryField = this.modal.getByTestId('field-e5kc-input');
   }
 
   async selectIsVaccineGiven(isVaccineGiven: boolean) {
@@ -348,14 +355,13 @@ export class RecordVaccineModal extends BasePatientModal {
   }
 
   async recordVaccineGivenElsewhere(vaccineGivenElsewhere: string) {
-    const circumstances = this.modal.getByTestId('fullwidthcol-lan5');
-    await circumstances.getByTestId('styledindicator-dx40').click();
+    await this.givenElsewhereCircumstancesIndicator.click();
     await this.page.getByText(vaccineGivenElsewhere, { exact: true }).click();
-    await circumstances.getByTestId('styledindicator-dx40').click({ force: true });
+    await this.givenElsewhereCircumstancesIndicator.click({ force: true });
 
     const givenElsewhereCountry = await selectAutocompleteFieldOption(
       this.page,
-      this.modal.getByTestId('field-e5kc-input'),
+      this.givenElsewhereCountryField,
       {
         selectFirst: true,
         returnOptionText: true,

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
@@ -1,9 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import {
-  formatForMuiDateTimePicker,
-  normalizeToIsoDate,
-} from '@utils/testHelper';
+import { formatForMuiDateTimePicker, normalizeToIsoDate } from '@utils/testHelper';
 import { BasePatientModal } from './BasePatientModal';
 import {
   selectFieldOption,

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
@@ -1,5 +1,9 @@
 import { Locator, Page, expect } from '@playwright/test';
 
+import {
+  formatForMuiDateTimePicker,
+  normalizeToIsoDate,
+} from '@utils/testHelper';
 import { BasePatientModal } from './BasePatientModal';
 import {
   selectFieldOption,
@@ -30,8 +34,8 @@ interface OptionalVaccineFields {
 }
 
 interface GivenElsewhereFields {
-  givenElsewhereCountry?: string;
   givenElsewhereReason?: string;
+  givenElsewhereCountry?: string;
 }
 
 const givenBy = 'Test Doctor';
@@ -73,14 +77,13 @@ export class RecordVaccineModal extends BasePatientModal {
   readonly categoryRequiredError: Locator;
   readonly consentGivenRequiredError: Locator;
   readonly vaccineNameRequiredError: Locator;
-  readonly vaccineGivenElsewhereDropdown: Locator;
   readonly givenElsewhereCheckbox: Locator;
-  readonly countryField: Locator;
-  readonly modalScrollManager: Locator;
   constructor(page: Page) {
     super(page);
 
-    this.modal = this.page.getByTestId('modal-record-vaccine');
+    this.modal = this.page
+      .getByRole('dialog')
+      .filter({ has: this.page.getByRole('heading', { name: 'Record vaccine' }) });
     this.modalHeading = this.page.getByRole('heading', { name: 'Record vaccine' });
     this.categoryRadioGroup = this.page.getByTestId('field-rd4e');
     this.vaccineSelectField = this.page.getByTestId('field-npct-select');
@@ -101,8 +104,10 @@ export class RecordVaccineModal extends BasePatientModal {
     this.vaccineBatchField = this.page.getByTestId('field-865y-input');
     this.injectionSiteField = this.page.getByTestId('field-jz48-select');
     this.consentGivenByField = this.page.getByTestId('field-inc8-input');
-    this.dateField = this.page.getByTestId('field-8sou-input').getByRole('textbox');
-    this.notGivenReasonField = this.page.getByTestId('selectinput-phtg-select');
+    this.dateField = this.page.getByTestId('field-8sou').getByRole('textbox');
+    this.notGivenReasonField = this.page
+      .getByTestId('selectinput-phtg-select')
+      .filter({ visible: true });
     this.notGivenClinicianField = this.page.getByTestId('field-xycc-input');
     this.otherVaccineBrand = this.page.getByTestId('field-f1vm-input');
     this.otherVaccineDisease = this.page.getByTestId('field-gcfk-input');
@@ -119,10 +124,7 @@ export class RecordVaccineModal extends BasePatientModal {
     this.categoryRequiredError = this.page.getByTestId('formhelpertext-sz5u');
     this.consentGivenRequiredError = this.page.getByTestId('formhelpertext-2d0o');
     this.vaccineNameRequiredError = this.page.getByTestId('field-npct-formhelptertext');
-    this.vaccineGivenElsewhereDropdown = this.page.getByTestId('styledindicator-dx40');
     this.givenElsewhereCheckbox = this.page.getByTestId('field-w50x-controlcheck');
-    this.countryField = this.page.getByTestId('field-e5kc-input');
-    this.modalScrollManager = this.page.locator('.css-bp8cua-ScrollManager');
   }
 
   async selectIsVaccineGiven(isVaccineGiven: boolean) {
@@ -244,12 +246,6 @@ export class RecordVaccineModal extends BasePatientModal {
       givenElsewhere = await this.recordVaccineGivenElsewhere(vaccineGivenElsewhere);
     }
 
-    if (specificDate) {
-      await this.dateField.fill(specificDate);
-    }
-
-    const dateGiven = await this.dateField.evaluate((el: HTMLInputElement) => el.value);
-
     if (category !== 'Other') {
       if (recordScheduledVaccine) {
         if (!specificVaccine || !specificScheduleOption) {
@@ -274,10 +270,7 @@ export class RecordVaccineModal extends BasePatientModal {
     let locationGroup: { area: string; location: string; department: string } | undefined;
     if (prefilledLocations) {
       locationGroup = prefilledLocations;
-    } else if (vaccineGivenElsewhere) {
-      //If the vaccine is given elsewhere there is no locationGroup
-      locationGroup = undefined;
-    } else {
+    } else if (!vaccineGivenElsewhere) {
       locationGroup = await this.selectLocationGroup();
     }
 
@@ -290,6 +283,15 @@ export class RecordVaccineModal extends BasePatientModal {
         ? await this.recordOptionalVaccineFieldsGiven(category)
         : await this.recordOptionalVaccineFieldsNotGiven(category);
     }
+
+    // Apply custom date last: selecting vaccine/schedule/category can reset form values to defaults.
+    if (specificDate) {
+      await this.dateField.fill(formatForMuiDateTimePicker(specificDate));
+      await this.dateField.blur();
+    }
+
+    const rawDateGiven = await this.dateField.evaluate((el: HTMLInputElement) => el.value);
+    const dateGiven = normalizeToIsoDate(rawDateGiven);
 
     await this.confirmButton.click();
 
@@ -349,13 +351,27 @@ export class RecordVaccineModal extends BasePatientModal {
   }
 
   async recordVaccineGivenElsewhere(vaccineGivenElsewhere: string) {
-    await this.vaccineGivenElsewhereDropdown.click();
-    await this.page.getByText(vaccineGivenElsewhere).click();
-    await this.modalScrollManager.click(); //Close the dropdown
-    const country = await selectAutocompleteFieldOption(this.page, this.countryField, {
-      returnOptionText: true,
-    });
-    return { givenElsewhereCountry: country, givenElsewhereReason: vaccineGivenElsewhere };
+    const circumstances = this.modal.getByTestId('fullwidthcol-lan5');
+    await circumstances.getByTestId('styledindicator-dx40').click();
+    await this.page.getByText(vaccineGivenElsewhere, { exact: true }).click();
+    await circumstances.getByTestId('styledindicator-dx40').click({ force: true });
+
+    const givenElsewhereCountry = await selectAutocompleteFieldOption(
+      this.page,
+      this.modal.getByTestId('field-e5kc-input'),
+      {
+        selectFirst: true,
+        returnOptionText: true,
+      },
+    );
+    if (!givenElsewhereCountry?.trim()) {
+      throw new Error('Failed to read selected country label after given-elsewhere autocomplete');
+    }
+
+    return {
+      givenElsewhereReason: vaccineGivenElsewhere,
+      givenElsewhereCountry: givenElsewhereCountry.trim(),
+    };
   }
 
   async assertVaccineNotInDropdown(

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/ViewVaccineModal.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, expect } from '@playwright/test';
 
 import { BasePatientModal } from './BasePatientModal';
-import { convertDateFormat } from '../../../../utils/testHelper';
+import { convertDateFormat, getSidebarFacilityDisplayName } from '../../../../utils/testHelper';
 import { Vaccine } from 'types/vaccine/Vaccine';
 
 export class ViewVaccineModal extends BasePatientModal {
@@ -96,10 +96,12 @@ export class ViewVaccineModal extends BasePatientModal {
       throw new Error('Missing required vaccine fields');
     }
 
+    const facilityDisplayName = await getSidebarFacilityDisplayName(this.page);
+
     await expect(this.area).toContainText(area);
     await expect(this.location).toContainText(location);
     await expect(this.department).toContainText(department);
-    await expect(this.facilityLocation).toContainText('facility-1');
+    await expect(this.facilityLocation).toContainText(facilityDisplayName);
     await expect(this.recordedBy).toContainText('Initial Admin');
 
     if (category === 'Other') {
@@ -153,11 +155,13 @@ export class ViewVaccineModal extends BasePatientModal {
   }
 
   async assertGivenElsewhereVaccineModalFields(vaccine: Partial<Vaccine>) {
-    const { vaccineName, givenElsewhereReason, givenElsewhereCountry, dateGiven, category } =
-      vaccine;
+    const { vaccineName, dateGiven, category, givenElsewhereCountry, givenElsewhereReason } = vaccine;
 
-    if (!vaccineName || !givenElsewhereReason || !givenElsewhereCountry) {
-      throw new Error('Missing required given elsewhere fields');
+    if (!vaccineName) {
+      throw new Error('Missing vaccine name for given-elsewhere assertion');
+    }
+    if (!givenElsewhereCountry) {
+      throw new Error('Missing givenElsewhereCountry for given-elsewhere assertion');
     }
 
     if (dateGiven) {
@@ -166,10 +170,14 @@ export class ViewVaccineModal extends BasePatientModal {
       await expect(this.dateGiven).toContainText('--/--/----');
     }
 
-    await expect(this.givenElsewhereReason).toContainText(givenElsewhereReason);
+    const facilityDisplayName = await getSidebarFacilityDisplayName(this.page);
+
+    if (givenElsewhereReason) {
+      await expect(this.givenElsewhereReason).toContainText(givenElsewhereReason);
+    }
     await expect(this.givenElsewhereCountry).toContainText(givenElsewhereCountry);
     await expect(this.status).toContainText('Given elsewhere');
-    await expect(this.givenElsewhereFacility).toContainText('facility-1');
+    await expect(this.givenElsewhereFacility).toContainText(facilityDisplayName);
     await expect(this.recordedBy).toContainText('Initial Admin');
     if (category === 'Other') {
       await expect(this.vaccineNameOther).toContainText(vaccineName);

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientVaccinePane.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientVaccinePane.ts
@@ -5,6 +5,8 @@ import {
   convertDateFormat,
   compareAlphabetically,
   compareByDate,
+  dateTableMatchStrings,
+  getSidebarFacilityDisplayName,
 } from '../../../../utils/testHelper';
 import { ViewVaccineModal } from '../modals/ViewVaccineModal';
 import { EditVaccineModal } from '../modals/EditVaccineModal';
@@ -173,55 +175,84 @@ export class PatientVaccinePane extends BasePatientPane {
       );
     }
 
-    const dateValue = dateGiven ? convertDateFormat(dateGiven) : 'Unknown';
+    const dateCandidates = dateTableMatchStrings(dateGiven);
 
-    const correctDateFound = await this.searchSpecificTableRowForMatch(
-      recordedVaccinesTable,
-      dateValue,
-      'date',
-      count,
-      vaccineName,
-      scheduleOption,
-    );
-
-    if (!correctDateFound) {
-      throw new Error(`Date "${dateValue}" not found in the recorded vaccines table`);
+    let correctDateFound = false;
+    for (const dateValue of dateCandidates) {
+      if (
+        await this.searchSpecificTableRowForMatch(
+          recordedVaccinesTable,
+          dateValue,
+          'date',
+          count,
+          vaccineName,
+          scheduleOption,
+        )
+      ) {
+        correctDateFound = true;
+        break;
+      }
     }
 
-    const givenByValue = givenElsewhereReason ? 'Given elsewhere' : 'Unknown';
+    if (!correctDateFound) {
+      throw new Error(
+        `Date not found in the recorded vaccines table (tried: ${dateCandidates.join(', ')})`,
+      );
+    }
 
+    const expectedGivenBy = given
+      ? givenBy || (givenElsewhereReason ? 'Given elsewhere' : 'Unknown')
+      : 'Not given';
     const correctGivenByFound = await this.searchSpecificTableRowForMatch(
       recordedVaccinesTable,
-      given ? givenBy || givenByValue : 'Not given',
+      expectedGivenBy,
       'givenBy',
       count,
       vaccineName,
       scheduleOption,
     );
     if (!correctGivenByFound) {
-      const expectedValue = given ? givenBy || givenByValue : 'Not given';
-      throw new Error(`Given by "${expectedValue}" not found in the recorded vaccines table`);
+      throw new Error(`Given by "${expectedGivenBy}" not found in the recorded vaccines table`);
     }
 
-    const displayLocationValue = givenElsewhereReason ? givenElsewhereCountry : 'facility-1';
-    if (!displayLocationValue) {
-      throw new Error(
-        'Display location value is not defined - likely the country was not selected',
+    if (givenElsewhereReason) {
+      if (!givenElsewhereCountry) {
+        throw new Error('givenElsewhereCountry is required when givenElsewhereReason is set');
+      }
+      const correctDisplayLocationFound = await this.searchSpecificTableRowForMatch(
+        recordedVaccinesTable,
+        givenElsewhereCountry,
+        'displayLocation',
+        count,
+        vaccineName,
+        scheduleOption,
       );
-    }
+      if (!correctDisplayLocationFound) {
+        throw new Error(
+          `Display location did not contain country "${givenElsewhereCountry}" in the recorded vaccines table`,
+        );
+      }
+    } else {
+      const displayLocationValue = await getSidebarFacilityDisplayName(this.page);
+      if (!displayLocationValue) {
+        throw new Error(
+          'Display location value is not defined - likely the country was not selected',
+        );
+      }
 
-    const correctDisplayLocationFound = await this.searchSpecificTableRowForMatch(
-      recordedVaccinesTable,
-      displayLocationValue,
-      'displayLocation',
-      count,
-      vaccineName,
-      scheduleOption,
-    );
-    if (!correctDisplayLocationFound) {
-      throw new Error(
-        `Display location "${displayLocationValue}" not found in the recorded vaccines table`,
+      const correctDisplayLocationFound = await this.searchSpecificTableRowForMatch(
+        recordedVaccinesTable,
+        displayLocationValue,
+        'displayLocation',
+        count,
+        vaccineName,
+        scheduleOption,
       );
+      if (!correctDisplayLocationFound) {
+        throw new Error(
+          `Display location "${displayLocationValue}" not found in the recorded vaccines table`,
+        );
+      }
     }
   }
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientVaccinePane.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientVaccinePane.ts
@@ -2,7 +2,6 @@ import { Locator, Page, expect } from '@playwright/test';
 import { BasePatientPane } from './BasePatientPane';
 import { RecordVaccineModal } from '../modals/RecordVaccineModal';
 import {
-  convertDateFormat,
   compareAlphabetically,
   compareByDate,
   dateTableMatchStrings,

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientVaccinePane.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientVaccinePane.ts
@@ -235,9 +235,7 @@ export class PatientVaccinePane extends BasePatientPane {
     } else {
       const displayLocationValue = await getSidebarFacilityDisplayName(this.page);
       if (!displayLocationValue) {
-        throw new Error(
-          'Display location value is not defined - likely the country was not selected',
-        );
+        throw new Error('Could not retrieve facility name from sidebar for display location check');
       }
 
       const correctDisplayLocationFound = await this.searchSpecificTableRowForMatch(

--- a/packages/e2e-tests/types/vaccine/Vaccine.ts
+++ b/packages/e2e-tests/types/vaccine/Vaccine.ts
@@ -19,6 +19,8 @@
  * @param disease - The disease the vaccine was given for, e.g. "Tuberculosis"
  * @param notGivenClinician - The name of the clinician who did not give the vaccine, e.g. "Dr. John Doe"
  * @param notGivenReason - The reason the vaccine was not given, e.g. "Patient refused"
+ * @param givenElsewhereReason - Circumstance label when recorded as given elsewhere
+ * @param givenElsewhereCountry - Country label chosen in the given-elsewhere country field
  */
 export interface Vaccine {
   vaccineName: string;

--- a/packages/e2e-tests/utils/fieldHelpers.ts
+++ b/packages/e2e-tests/utils/fieldHelpers.ts
@@ -8,6 +8,10 @@ async function getBaseTestId(field: Locator, suffixToRemove: string): Promise<st
   return rawTestId.replace(suffixToRemove, '');
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export const selectOptionFromPopper = async (
   baseTestId: string,
   popper: Locator,
@@ -17,41 +21,44 @@ export const selectOptionFromPopper = async (
     optionToAvoid = null,
   }: { selectFirst?: boolean; optionToSelect?: string | null; optionToAvoid?: string | null } = {},
 ): Promise<string> => {
-  await popper.waitFor({ state: 'attached', timeout: 5000 });
-
+  const waitMs = 5000;
   const optionLocator = popper.getByTestId(`${baseTestId}-option`);
-  await optionLocator.first().waitFor({ state: 'attached', timeout: 5000 });
+  await optionLocator.first().waitFor({ state: 'attached', timeout: waitMs });
 
-  const options = await optionLocator.all();
-  if (options.length === 0) {
+  const count = await optionLocator.count();
+  if (count === 0) {
     throw new Error(`No options found for ${baseTestId}`);
   }
 
-  const optionTexts = await Promise.all(options.map(option => option.innerText()));
-  
-  let selectedOption: Locator | undefined;
+  let selectedOption: Locator;
 
   if (optionToSelect) {
-    const selectedIndex = optionTexts.findIndex(text => text === optionToSelect);
-    if (selectedIndex === -1) {
-      throw new Error(`Option "${optionToSelect}" not found in popper`);
-    }
-    selectedOption = options[selectedIndex];
+    const exactLabel = new RegExp(`^\\s*${escapeRegExp(optionToSelect)}\\s*$`);
+    selectedOption = optionLocator.filter({ hasText: exactLabel }).first();
+    await expect(selectedOption).toBeAttached({ timeout: waitMs });
   } else if (optionToAvoid) {
-    const filteredOptions = options.filter((_, i) => optionTexts[i] !== optionToAvoid);
-    if (filteredOptions.length === 0) {
+    let found: Locator | undefined;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const opt = optionLocator.nth(Math.floor(Math.random() * count));
+      const text = (await opt.innerText({ timeout: 3000 }).catch(() => '')).trim();
+      if (text && text !== optionToAvoid) {
+        found = opt;
+        break;
+      }
+    }
+    if (!found) {
       throw new Error(`No options found that are not "${optionToAvoid}"`);
     }
-    //Select a random option that is not optionToAvoid
-    selectedOption = filteredOptions[Math.floor(Math.random() * filteredOptions.length)];
+    selectedOption = found;
   } else {
-    selectedOption = selectFirst ? options[0] : options[Math.floor(Math.random() * options.length)];
+    const index = selectFirst ? 0 : Math.floor(Math.random() * count);
+    selectedOption = optionLocator.nth(index);
   }
 
-  const selectedOptionText = await selectedOption.innerText();
-  await selectedOption.click();
+  const selectedOptionText = (await selectedOption.innerText()).trim();
+  await selectedOption.click({ force: true });
 
-  await expect(popper).not.toBeVisible({ timeout: 1000 });
+  await expect(popper).not.toBeVisible({ timeout: 2000 }).catch(() => undefined);
 
   return selectedOptionText;
 };
@@ -131,18 +138,22 @@ export const selectAutocompleteFieldOption = async (
   } = {},
 ) => {
   await expect(field).toBeEnabled();
-  await field.click();
+  await field.scrollIntoViewIfNeeded();
+  const input = field.locator('input');
+  if ((await input.count()) > 0) {
+    await input.click();
+  } else {
+    await field.click();
+  }
 
-  //const input = field.locator('input');
   const testId = await getBaseTestId(field, stripTag ? '-input' : '');
+
   const suggestionsContainer = page.getByTestId(`${testId}-suggestionslist`);
   const selectedOptionText = await selectOptionFromPopper(testId, suggestionsContainer, {
     selectFirst,
     optionToSelect,
     optionToAvoid,
   });
-
-  //await expect(input).toContainText(selectedOptionText, { timeout: 1000 });
 
   if (returnOptionText) {
     return selectedOptionText;

--- a/packages/e2e-tests/utils/fieldHelpers.ts
+++ b/packages/e2e-tests/utils/fieldHelpers.ts
@@ -59,7 +59,7 @@ export const selectOptionFromPopper = async (
   const selectedOptionText = (await selectedOption.innerText()).trim();
   await selectedOption.click({ force: true });
 
-  await expect(popper).not.toBeVisible({ timeout: 2000 }).catch(() => undefined);
+  await expect(popper).not.toBeVisible({ timeout: 1000 });
 
   return selectedOptionText;
 };

--- a/packages/e2e-tests/utils/fieldHelpers.ts
+++ b/packages/e2e-tests/utils/fieldHelpers.ts
@@ -8,10 +8,6 @@ async function getBaseTestId(field: Locator, suffixToRemove: string): Promise<st
   return rawTestId.replace(suffixToRemove, '');
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 export const selectOptionFromPopper = async (
   baseTestId: string,
   popper: Locator,
@@ -33,8 +29,9 @@ export const selectOptionFromPopper = async (
   let selectedOption: Locator;
 
   if (optionToSelect) {
-    const exactLabel = new RegExp(`^\\s*${escapeRegExp(optionToSelect)}\\s*$`);
-    selectedOption = optionLocator.filter({ hasText: exactLabel }).first();
+    selectedOption = optionLocator
+      .filter({ has: popper.page().getByText(optionToSelect, { exact: true }) })
+      .first();
     await expect(selectedOption).toBeAttached({ timeout: waitMs });
   } else if (optionToAvoid) {
     const options = await optionLocator.all();

--- a/packages/e2e-tests/utils/fieldHelpers.ts
+++ b/packages/e2e-tests/utils/fieldHelpers.ts
@@ -37,19 +37,23 @@ export const selectOptionFromPopper = async (
     selectedOption = optionLocator.filter({ hasText: exactLabel }).first();
     await expect(selectedOption).toBeAttached({ timeout: waitMs });
   } else if (optionToAvoid) {
-    let found: Locator | undefined;
-    for (let attempt = 0; attempt < 20; attempt++) {
-      const opt = optionLocator.nth(Math.floor(Math.random() * count));
-      const text = (await opt.innerText({ timeout: 3000 }).catch(() => '')).trim();
-      if (text && text !== optionToAvoid) {
-        found = opt;
-        break;
-      }
-    }
-    if (!found) {
+    const options = await optionLocator.all();
+    const optionTexts = await Promise.all(
+      options.map(async (opt) => {
+        try {
+          return (await opt.innerText({ timeout: 3000 })).trim();
+        } catch {
+          return '';
+        }
+      }),
+    );
+    const eligible = options.filter(
+      (_, i) => optionTexts[i] !== '' && optionTexts[i] !== optionToAvoid,
+    );
+    if (eligible.length === 0) {
       throw new Error(`No options found that are not "${optionToAvoid}"`);
     }
-    selectedOption = found;
+    selectedOption = eligible[Math.floor(Math.random() * eligible.length)];
   } else {
     const index = selectFirst ? 0 : Math.floor(Math.random() * count);
     selectedOption = optionLocator.nth(index);

--- a/packages/e2e-tests/utils/testHelper.ts
+++ b/packages/e2e-tests/utils/testHelper.ts
@@ -3,9 +3,23 @@ import { subYears, addYears, format, parse, isValid } from 'date-fns';
 
 import { SidebarPage } from '../pages/SidebarPage';
 
+/**
+ * Prefix for `data-testid` on cells in the app’s styled data tables (e.g. patient lists).
+ *
+ * Row `i`, column semantic id `columnName` → `getByTestId(\`${STYLED_TABLE_CELL_PREFIX}${i}-${columnName}\`)`.
+ * Keep this in sync with the table implementation if testids change.
+ */
 export const STYLED_TABLE_CELL_PREFIX = 'styledtablecell-2gyy-';
 
-/** Facility column uses `location.facility.name`; match the name shown in the app chrome. */
+/**
+ * Returns the facility name as shown in the sidebar (current facility context).
+ *
+ * Use when a table column or modal shows “facility” and it must match the same string as the app chrome
+ * (e.g. immunisation display location for vaccines given at the current facility).
+ *
+ * @param page — Playwright page (must be on a layout that renders {@link SidebarPage}).
+ * @returns Display name string from the sidebar; may be empty if the facility control is missing or not loaded.
+ */
 export async function getSidebarFacilityDisplayName(page: Page): Promise<string> {
   const sidebar = new SidebarPage(page);
   return sidebar.getFacilityName();
@@ -18,7 +32,20 @@ const DISPLAY_DATE_TIME_PATTERNS = [
 ] as const;
 
 /**
- * Parse date strings as they appear in Tamanu (ISO / ISO-prefix from inputs, MUI-style dd/MM display, etc.).
+ * Parse a date string the way Tamanu / MUI surfaces typically expose it in the browser.
+ *
+ * **Recognized shapes (first match wins)**
+ * 1. **ISO date prefix** — `yyyy-MM-dd` at the start of the string (time or suffix allowed after); calendar date only.
+ * 2. **Display / picker strings** — `date-fns` parse with:
+ *    - `dd/MM/yyyy hh:mm a` / `dd/MM/yyyy h:mm a` / `dd/MM/yyyy` (common MUI-style text).
+ *
+ * **Returns**
+ * - A valid `Date` in local parsing semantics, or `null` if nothing matches or the result is invalid.
+ *
+ * **Typical use** — Building other helpers or custom assertions. Most tests should use the higher-level format
+ * functions below so the intended surface (assertion vs picker vs ISO) stays explicit.
+ *
+ * @param raw — Untrimmed input is trimmed before parsing.
  */
 export function parseTamanuDate(raw: string): Date | null {
   const s = raw.trim();
@@ -38,7 +65,19 @@ export function parseTamanuDate(raw: string): Date | null {
   return null;
 }
 
-// Utility method to convert stored / form dates to MM/dd/yyyy for assertions (US-style)
+/**
+ * Normalize a test or DOM date value to **US-style short date** `MM/dd/yyyy` for text assertions.
+ *
+ * **Used for** `toContainText`, table cell expectations, and anywhere the UI shows month-first short dates.
+ *
+ * **Behaviour**
+ * - `undefined` / missing → `''`.
+ * - `Date` → formatted with `date-fns` if valid, else `''`.
+ * - String → try {@link parseTamanuDate}; if that fails, a naive `yyyy-MM-dd` split → `MM/DD/YYYY`.
+ *
+ * @param dateInput — ISO string, picker output fragment, or `Date` from test data.
+ * @returns `MM/dd/yyyy` or `''` when empty/unparseable.
+ */
 export const convertDateFormat = (dateInput: string | Date | undefined): string => {
   if (!dateInput) return '';
 
@@ -60,7 +99,17 @@ export const convertDateFormat = (dateInput: string | Date | undefined): string 
 };
 
 /**
- * DateDisplay uses locale-specific ordering; the table cell match is substring-based, so try both orderings.
+ * Build candidate strings for **substring** matching a date in a table cell when locale may flip day/month order.
+ *
+ * Some cells render via `DateDisplay` (or similar) so the same calendar day can appear as `MM/dd/yyyy` or
+ * `dd/MM/yyyy`. Playwright checks often use `includes`; passing both strings covers either rendering.
+ *
+ * **Returns**
+ * - No `dateGiven` → `['Unknown']` (placeholder row convention in some specs).
+ * - Parse succeeds → `[ MM/dd/yyyy, dd/MM/yyyy ]`.
+ * - Parse fails → single fallback from {@link convertDateFormat}.
+ *
+ * @param dateGiven — Test data date string; `undefined` triggers the Unknown placeholder path.
  */
 export function dateTableMatchStrings(dateGiven: string | undefined): string[] {
   if (!dateGiven) return ['Unknown'];
@@ -71,7 +120,17 @@ export function dateTableMatchStrings(dateGiven: string | undefined): string[] {
   return [format(parsed, 'MM/dd/yyyy'), format(parsed, 'dd/MM/yyyy')];
 }
 
-/** Normalize raw picker / ISO / display input to yyyy-MM-dd. */
+/**
+ * Normalize picker output, ISO fragments, or display text to **`yyyy-MM-dd`** for value comparisons.
+ *
+ * **Typical use** — Comparing two strings that should represent the same calendar day (e.g. input value vs test
+ * data) when one side came from an MUI field (`dd/MM/…`) and the other from ISO.
+ *
+ * **Behaviour** — If {@link parseTamanuDate} yields a valid date, returns `yyyy-MM-dd`; otherwise returns
+ * `raw` unchanged so callers still see the original string when parsing fails.
+ *
+ * @param raw — Typically `input.value` or a test fixture string.
+ */
 export function normalizeToIsoDate(raw: string): string {
   const parsed = parseTamanuDate(raw);
   if (parsed && isValid(parsed)) {
@@ -80,7 +139,17 @@ export function normalizeToIsoDate(raw: string): string {
   return raw;
 }
 
-/** Format for MUI datetime pickers that expect `dd/MM/yyyy hh:mm a` (plain `yyyy-MM-dd` may not commit). */
+/**
+ * Format a date string for **typing into MUI date-time text fields** (keyboard / `.fill()`).
+ *
+ * Some MUI date-time pickers do not commit or behave correctly when filled with only `yyyy-MM-dd`; the app
+ * expects display-shaped text such as `dd/MM/yyyy hh:mm a`.
+ *
+ * **Behaviour** — Parses via {@link parseTamanuDate}; on failure returns the original string so callers can
+ * still attempt a fill for edge cases.
+ *
+ * @param isoDate — Usually ISO or ISO-like test data; trimmed before parse.
+ */
 export function formatForMuiDateTimePicker(isoDate: string): string {
   const parsed = parseTamanuDate(isoDate.trim());
   if (!parsed || !isValid(parsed)) {
@@ -90,12 +159,16 @@ export function formatForMuiDateTimePicker(isoDate: string): string {
 }
 
 /**
- * Utility method to handle search box suggestions
- * @param searchBox The search box locator
- * @param suggestionList The suggestion list locator
- * @param searchText The text to search for
- * @param timeout Optional timeout in milliseconds (default: 5000)
- * @throws Error if the suggestion is not found in the list
+ * Fill a search field and click a suggestion whose visible text equals `searchText`.
+ *
+ * **Flow** — `fill` → wait for search box visible → `getByText(searchText)` on the suggestion list → click.
+ * **Note** — `getByText` matches by substring; `searchText` should be unique within the suggestion list for the scenario.
+ *
+ * @param searchBox — Input or combobox locator.
+ * @param suggestionList — Popover/list locator containing clickable suggestions.
+ * @param searchText — Label to click (must appear in the list).
+ * @param timeout — Per-step wait budget in ms (default 10000).
+ * @throws Error wrapping the underlying failure if the suggestion never becomes visible or click fails.
  */
 export async function SelectingFromSearchBox(
   searchBox: Locator,
@@ -114,11 +187,15 @@ export async function SelectingFromSearchBox(
   }
 }
 /**
- * Utility method to get table items
- * @param page 
- * @param tableRowCount 
- * @param columnName 
- * @returns An array of table items
+ * Read text from a column across the first `tableRowCount` rows of a styled table.
+ *
+ * Uses {@link STYLED_TABLE_CELL_PREFIX} + row index + `columnName` as the `data-testid` suffix pattern.
+ * Skips empty `textContent` (row may not render a cell or may be loading).
+ *
+ * @param page — Current page.
+ * @param tableRowCount — Number of rows to read (0-based indices `0 .. tableRowCount-1`).
+ * @param columnName — Test id suffix for the column (e.g. `dateOfBirth`).
+ * @returns Array of strings in row order; length may be less than `tableRowCount` if some cells are empty.
  */
 export async function getTableItems(page: Page, tableRowCount: number, columnName: string) {
   const items: string[] = [];
@@ -133,18 +210,24 @@ export async function getTableItems(page: Page, tableRowCount: number, columnNam
 }
 
 /**
- * Formats a date to 'MM/dd/yyyy h:mmam' style (lowercase am/pm, no space) to match the app's display format.
- * @param date - The Date object to format
- * @returns Formatted string (e.g., "02/12/2026 9:31am")
+ * Format a `Date` to match **on-screen datetime copy** in parts of the app: `MM/dd/yyyy` + 12h time with
+ * **lowercase** `am`/`pm` and no space before meridiem (e.g. `02/12/2026 9:31am`).
+ *
+ * @param date — Instant to format (local time per `date-fns` `format`).
  */
 export function formatDateTimeForDisplay(date: Date): string {
   return format(date, 'MM/dd/yyyy h:mm a').replace(' AM', 'am').replace(' PM', 'pm');
 }
 
 /**
- * Converts a dateTime string (format: "2025-12-01T06:11") to table format (format: "6:11am12/01/25")
- * @param dateTimeString - ISO format dateTime string (e.g., "2025-12-01T06:11")
- * @returns Formatted string matching table display format (e.g., "6:11am12/01/25")
+ * Convert an ISO-like datetime string (e.g. `2025-12-01T06:11`) into the **concatenated** table display form
+ * used in some grids: **time** (`h:mm` + lowercase `am`/`pm`, no space) immediately followed by **date** `MM/dd/yy`
+ * (e.g. `6:11am12/01/25`).
+ *
+ * **Parsing** — Uses `new Date(dateTimeString)`; invalid strings produce `Invalid Date` output from `date-fns`
+ * (callers should pass values known to parse in the test environment).
+ *
+ * @param dateTimeString — Typically from a form field or API fixture.
  */
 export function formatDateTimeForTable(dateTimeString: string): string {
   const dateFromForm = new Date(dateTimeString);
@@ -154,9 +237,10 @@ export function formatDateTimeForTable(dateTimeString: string): string {
 }
 
 /**
- * Utility function for sorting alphabetically
- * @param order - The order to sort by, e.g. "asc" or "desc"
- * @returns A function that compares two strings alphabetically
+ * Comparator factory for **locale-aware string sort** (e.g. vaccine names in table order assertions).
+ *
+ * @param order — `'asc'` or `'desc'`.
+ * @returns `(a, b) => number` suitable for `Array.prototype.sort`.
  */
 export function compareAlphabetically(order: 'asc' | 'desc') {
   return (a: string, b: string) =>
@@ -164,9 +248,12 @@ export function compareAlphabetically(order: 'asc' | 'desc') {
 }
 
 /**
- * Utility function for sorting by date
- * @param order - The order to sort by, e.g. "asc" or "desc"
- * @returns A function that compares two dates
+ * Comparator factory for sorting objects with a **`dateGiven`** ISO-like string (e.g. vaccine rows).
+ *
+ * Uses `new Date(...).getTime()`; invalid date strings sort as `NaN` and may behave unpredictably—keep test
+ * data parseable.
+ *
+ * @param order — `'asc'` (oldest first) or `'desc'` (newest first).
  */
 export function compareByDate(order: 'asc' | 'desc') {
   return (a: { dateGiven: string }, b: { dateGiven: string }) => {
@@ -177,11 +264,14 @@ export function compareByDate(order: 'asc' | 'desc') {
 }
 
 /**
- * Utility method to offset a date by a given amount of years and return in YYYY-MM-DD format
- * @param dateToOffset - The date to offset
- * @param offset - The offset to apply ('increase' or 'decrease')
- * @param amountToOffset - The amount of years to offset
- * @returns The date with the offset applied in YYYY-MM-DD format
+ * Shift a calendar date by a whole number of years; returns **`yyyy-MM-dd`** for fixtures and inputs.
+ *
+ * **Use case** — Age boundaries, eligibility windows, “same day next year” vaccine tests.
+ *
+ * @param dateToOffset — Parseable date string (passed to `new Date`).
+ * @param offset — `'increase'` or `'decrease'`.
+ * @param amountToOffset — Non-negative year delta (applied via `date-fns` `addYears` / `subYears`).
+ * @throws Error when `offset` is not `'increase'` or `'decrease'`.
  */
 export function offsetYear(
   dateToOffset: string,
@@ -199,7 +289,16 @@ export function offsetYear(
   return format(newDate, 'yyyy-MM-dd');
 }
 
-// Reusable function to select first option from any dropdown
+/**
+ * Open a generic **MUI listbox** dropdown and select the first `li` option.
+ *
+ * **Assumptions** — `[role="listbox"] li` exists after `input.click()`; not tied to app-specific testids.
+ * Prefer {@link ./fieldHelpers.ts} `selectFieldOption` / `selectAutocompleteFieldOption` for Tamanu fields.
+ *
+ * @param page — Used to scope the listbox query.
+ * @param input — Locator that opens the list on click.
+ * @returns `textContent` of the first option, or `''` if missing.
+ */
 export const selectFirstFromDropdown = async (page: Page, input: Locator): Promise<string> => {
   await input.click();
   const firstOption = page.locator('[role="listbox"] li').first();
@@ -208,10 +307,15 @@ export const selectFirstFromDropdown = async (page: Page, input: Locator): Promi
 };
 
 /**
- * Asserts that a datetime input field contains a recent datetime value
- * @param inputLocator - The locator for the datetime input field
- * @param dateFormat - The format string for parsing the date (e.g., 'yyyy-MM-dd\'T\'HH:mm')
- * @param thresholdMinutes - Optional threshold in minutes for what is considered "recent" (default: 2)
+ * Assert the value of a datetime **input** is within `thresholdMinutes` of “now” (wall clock).
+ *
+ * **Use case** — Fields defaulting to current date/time on open (e.g. new encounter).
+ *
+ * **Parsing** — Uses `date-fns` `parse` with your `dateFormat`; must match the input’s `value` shape exactly.
+ *
+ * @param inputLocator — `input` or element exposing `.inputValue()`.
+ * @param dateFormat — `date-fns` format string matching the input `value` (e.g. ISO-local datetime with a `T` separator).
+ * @param thresholdMinutes — Max absolute difference in minutes (default 2).
  */
 export async function assertRecentDateTime(
   inputLocator: Locator,

--- a/packages/e2e-tests/utils/testHelper.ts
+++ b/packages/e2e-tests/utils/testHelper.ts
@@ -1,25 +1,93 @@
 import { Locator, Page, expect } from '@playwright/test';
-import { subYears, addYears, format, parse } from 'date-fns';
+import { subYears, addYears, format, parse, isValid } from 'date-fns';
+
+import { SidebarPage } from '../pages/SidebarPage';
 
 export const STYLED_TABLE_CELL_PREFIX = 'styledtablecell-2gyy-';
 
-// Utility method to convert YYYY-MM-DD to MM/DD/YYYY format
+/** Facility column uses `location.facility.name`; match the name shown in the app chrome. */
+export async function getSidebarFacilityDisplayName(page: Page): Promise<string> {
+  const sidebar = new SidebarPage(page);
+  return sidebar.getFacilityName();
+}
+
+const DISPLAY_DATE_TIME_PATTERNS = [
+  'dd/MM/yyyy hh:mm a',
+  'dd/MM/yyyy h:mm a',
+  'dd/MM/yyyy',
+] as const;
+
+/**
+ * Parse date strings as they appear in Tamanu (ISO / ISO-prefix from inputs, MUI-style dd/MM display, etc.).
+ */
+export function parseTamanuDate(raw: string): Date | null {
+  const s = raw.trim();
+  if (!s) return null;
+
+  const isoDate = s.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (isoDate) {
+    const d = parse(isoDate[1], 'yyyy-MM-dd', new Date());
+    return isValid(d) ? d : null;
+  }
+
+  for (const pattern of DISPLAY_DATE_TIME_PATTERNS) {
+    const d = parse(s, pattern, new Date());
+    if (isValid(d)) return d;
+  }
+
+  return null;
+}
+
+// Utility method to convert stored / form dates to MM/dd/yyyy for assertions (US-style)
 export const convertDateFormat = (dateInput: string | Date | undefined): string => {
   if (!dateInput) return '';
-  
-  let dateString: string;
-  
+
   if (dateInput instanceof Date) {
-    dateString = dateInput.toISOString().split('T')[0]; // Convert to YYYY-MM-DD format
-  } else {
-    dateString = dateInput;
+    return isValid(dateInput) ? format(dateInput, 'MM/dd/yyyy') : '';
   }
-  
-  if (!dateString) return '';
-  
-  const [year, month, day] = dateString.split('-');
-  return `${month}/${day}/${year}`;
+
+  const parsed = parseTamanuDate(String(dateInput));
+  if (parsed) {
+    return format(parsed, 'MM/dd/yyyy');
+  }
+
+  const s = String(dateInput).trim();
+  const [year, month, day] = s.split('-');
+  if (year && month && day) {
+    return `${month}/${day}/${year}`;
+  }
+  return '';
 };
+
+/**
+ * DateDisplay uses locale-specific ordering; the table cell match is substring-based, so try both orderings.
+ */
+export function dateTableMatchStrings(dateGiven: string | undefined): string[] {
+  if (!dateGiven) return ['Unknown'];
+  const parsed = parseTamanuDate(dateGiven.trim());
+  if (!parsed) {
+    return [convertDateFormat(dateGiven)];
+  }
+  return [format(parsed, 'MM/dd/yyyy'), format(parsed, 'dd/MM/yyyy')];
+}
+
+/** Normalize raw picker / ISO / display input to yyyy-MM-dd. */
+export function normalizeToIsoDate(raw: string): string {
+  const parsed = parseTamanuDate(raw);
+  if (parsed && isValid(parsed)) {
+    return format(parsed, 'yyyy-MM-dd');
+  }
+  return raw;
+}
+
+/** Format for MUI datetime pickers that expect `dd/MM/yyyy hh:mm a` (plain `yyyy-MM-dd` may not commit). */
+export function formatForMuiDateTimePicker(isoDate: string): string {
+  const parsed = parseTamanuDate(isoDate.trim());
+  if (!parsed || !isValid(parsed)) {
+    return isoDate;
+  }
+  return format(parsed, 'dd/MM/yyyy hh:mm a');
+}
 
 /**
  * Utility method to handle search box suggestions

--- a/packages/e2e-tests/utils/vaccineTestHelpers.ts
+++ b/packages/e2e-tests/utils/vaccineTestHelpers.ts
@@ -1,4 +1,5 @@
 import { PatientDetailsPage } from '@pages/patients/PatientDetailsPage';
+import { formatForMuiDateTimePicker } from '@utils/testHelper';
 import { createPatient } from '../utils/apiHelpers';
 import { expect } from '@playwright/test';
 import { Vaccine } from 'types/vaccine/Vaccine';
@@ -109,14 +110,21 @@ export async function triggerDateError(
 
   expect(patientDetailsPage.patientVaccinePane?.recordVaccineModal).toBeDefined();
 
+  const page = patientDetailsPage.patientVaccinePane!.recordVaccineModal!.page;
+  const dateField = patientDetailsPage.patientVaccinePane!.recordVaccineModal!.dateField;
+
   //Attempt to submit a date that should trigger a validation error
-  await patientDetailsPage.patientVaccinePane?.recordVaccineModal?.dateField.fill(date);
+  await dateField.fill(formatForMuiDateTimePicker(date));
+  await dateField.blur();
+
   await patientDetailsPage.patientVaccinePane?.recordVaccineModal?.confirmButton.click();
 
-  //Assert the validation error appears
-  await expect(
-    patientDetailsPage.patientVaccinePane?.recordVaccineModal?.dateFieldIncludingError!,
-  ).toContainText(expectedErrorMessage);
+  const recordVaccineDialog = page
+    .getByTestId('dialog-g9qi')
+    .filter({ visible: true })
+    .filter({ hasText: /Record vaccine/i });
+
+  await expect(recordVaccineDialog.getByText(expectedErrorMessage, { exact: true })).toBeVisible();
 }
 
 /**


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes multiple Playwright locators and form-interaction ordering for vaccine modals, which can cause new E2E flakiness if UI structure/testids differ across deployments. Changes are test-only and don’t affect production behavior.
> 
> **Overview**
> Improves vaccine E2E stability by **normalizing date entry and assertions**: tests now format dates for MUI date-time inputs, blur to commit values, and compare dates via ISO-normalization (plus table matching that tolerates day/month order).
> 
> Reworks vaccine modal/table assertions to be **facility-name agnostic** by reading the current facility display name from the sidebar instead of hardcoding `facility-1`, and tightens “given elsewhere” interactions (new dialog/section locators, deterministic country selection, and clearer validation/errors).
> 
> Hardens dropdown/autocomplete helpers by scrolling/clicking the underlying input when present and making popper option selection more robust (count-based selection, trimming, exact-text targeting, forced clicks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 252c6aa6213ac7711289a0eb35fa6b9240d3f5b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->