### PR TITLE
feat(centralServer): NASS-1908: pre-check role deletion with dry run

### DIFF
--- a/packages/central-server/app/admin/roles.delete.js
+++ b/packages/central-server/app/admin/roles.delete.js
@@ -1,14 +1,6 @@
 import asyncHandler from 'express-async-handler';
-import { z } from 'zod';
 
 import { DatabaseConstraintError, NotFoundError } from '@tamanu/errors';
-
-const deleteRoleQuerySchema = z.object({
-  dryRun: z
-    .string()
-    .optional()
-    .transform(value => value === '1'),
-});
 
 class InvalidRoleDeletionError extends DatabaseConstraintError {
   constructor(/** @type {string} */ roleId, /** @type {number} */ assignedUserCount) {
@@ -38,8 +30,6 @@ export const assertRoleIsDeletable = async ({ Role, User, roleId }) => {
 export const deleteRoleById = asyncHandler(async (req, res) => {
   req.checkPermission('delete', 'Role');
 
-  const { dryRun } = await deleteRoleQuerySchema.parseAsync(req.query);
-
   const {
     store: {
       models: { Role, User },
@@ -48,9 +38,9 @@ export const deleteRoleById = asyncHandler(async (req, res) => {
     params: { id },
   } = req;
 
-  await sequelize.transaction({ readOnly: dryRun }, async () => {
+  await sequelize.transaction(async () => {
     const role = await assertRoleIsDeletable({ Role, User, roleId: id });
-    if (!dryRun) await role.destroy();
+    await role.destroy();
   });
 
   res.status(204).send();

--- a/packages/central-server/app/admin/roles.delete.js
+++ b/packages/central-server/app/admin/roles.delete.js
@@ -1,0 +1,57 @@
+import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
+import { DatabaseConstraintError, NotFoundError } from '@tamanu/errors';
+
+const deleteRoleQuerySchema = z.object({
+  dryRun: z
+    .string()
+    .optional()
+    .transform(value => value === '1'),
+});
+
+class InvalidRoleDeletionError extends DatabaseConstraintError {
+  constructor(/** @type {string} */ roleId, /** @type {number} */ assignedUserCount) {
+    const isSingular = assignedUserCount === 1;
+    const subject = isSingular ? 'user' : 'users';
+
+    super(
+      `Cannot delete role with ID ‘${roleId}’. ${assignedUserCount} ${subject} assigned to it.`,
+    );
+    this.withExtraData({ assignedUserCount });
+  }
+}
+
+/** @privateRemarks Remember to run this within a transaction. */
+export const assertRoleIsDeletable = async ({ Role, User, roleId }) => {
+  const role = await Role.findByPk(roleId);
+  if (!role) throw new NotFoundError(`No role found with ID ‘${roleId}’`);
+
+  const assignedUserCount = await User.count({
+    where: { role: role.id }, // No FK constraint!
+  });
+  if (assignedUserCount > 0) throw new InvalidRoleDeletionError(roleId, assignedUserCount);
+
+  return role;
+};
+
+export const deleteRoleById = asyncHandler(async (req, res) => {
+  req.checkPermission('delete', 'Role');
+
+  const { dryRun } = await deleteRoleQuerySchema.parseAsync(req.query);
+
+  const {
+    store: {
+      models: { Role, User },
+      sequelize,
+    },
+    params: { id },
+  } = req;
+
+  await sequelize.transaction({ readOnly: dryRun }, async () => {
+    const role = await assertRoleIsDeletable({ Role, User, roleId: id });
+    if (!dryRun) await role.destroy();
+  });
+
+  res.status(204).send();
+});

--- a/packages/central-server/app/admin/roles.get.js
+++ b/packages/central-server/app/admin/roles.get.js
@@ -63,5 +63,5 @@ export const getRoleDeletabilityById = asyncHandler(async (req, res) => {
     await assertRoleIsDeletable({ Role, User, roleId: id });
   });
 
-  res.send({ canDelete: true });
+  res.status(204).send();
 });

--- a/packages/central-server/app/admin/roles.get.js
+++ b/packages/central-server/app/admin/roles.get.js
@@ -1,0 +1,67 @@
+import asyncHandler from 'express-async-handler';
+import { escapeRegExp } from 'lodash';
+import { Op } from 'sequelize';
+
+import { NotFoundError } from '@tamanu/errors';
+import { getResourceList } from '@tamanu/shared/utils/crudHelpers';
+import { assertRoleIsDeletable } from './roles.delete';
+
+export const getRoles = asyncHandler(async (req, res) => {
+  req.checkPermission('list', 'Role');
+
+  const filters = [];
+  const idQuery = req.query.id?.trim();
+  if (idQuery) {
+    filters.push({ id: idQuery });
+  }
+  const nameQuery = req.query.name?.trim();
+  if (nameQuery) {
+    filters.push({
+      name: { [Op.iRegexp]: `\\m${escapeRegExp(nameQuery)}` },
+    });
+  }
+
+  const options = {};
+  if (filters.length > 0) {
+    options.additionalFilters = filters.length === 1 ? filters[0] : { [Op.and]: filters };
+  }
+
+  const response = await getResourceList(req, 'Role', '', options);
+  res.send(response);
+});
+
+export const getRoleById = asyncHandler(async (req, res) => {
+  req.checkPermission('read', 'Role');
+
+  const {
+    store: {
+      models: { Role },
+    },
+    params: { id },
+  } = req;
+
+  const role = await Role.findByPk(id);
+  if (!role) {
+    throw new NotFoundError(`No role found with ID ‘${id}’`);
+  }
+
+  res.send(role);
+});
+
+export const getRoleDeletabilityById = asyncHandler(async (req, res) => {
+  req.checkPermission('delete', 'Role');
+
+  const {
+    store: {
+      models: { Role, User },
+      sequelize,
+    },
+    params: { id },
+  } = req;
+
+  await sequelize.transaction({ readOnly: true }, async () => {
+    await assertRoleIsDeletable({ Role, User, roleId: id });
+  });
+
+  res.send({ canDelete: true });
+});

--- a/packages/central-server/app/admin/roles.js
+++ b/packages/central-server/app/admin/roles.js
@@ -118,7 +118,7 @@ roleRouter.delete(
       params: { id },
     } = req;
 
-    await sequelize.transaction(async () => {
+    await sequelize.transaction({ readOnly: dryRun }, async () => {
       const role = await Role.findByPk(id);
       if (!role) throw new NotFoundError(`No role found with ID ‘${id}’`);
 

--- a/packages/central-server/app/admin/roles.js
+++ b/packages/central-server/app/admin/roles.js
@@ -96,10 +96,19 @@ roleRouter.post(
   }),
 );
 
+const deleteRoleQuerySchema = z.object({
+  dryRun: z
+    .string()
+    .optional()
+    .transform(value => value === '1'),
+});
+
 roleRouter.delete(
   '/:id',
   asyncHandler(async (req, res) => {
     req.checkPermission('delete', 'Role');
+
+    const { dryRun } = await deleteRoleQuerySchema.parseAsync(req.query);
 
     const {
       store: {
@@ -111,27 +120,27 @@ roleRouter.delete(
 
     await sequelize.transaction(async () => {
       const role = await Role.findByPk(id);
-      if (!role) {
-        throw new NotFoundError(`No role found with ID ‘${id}’`);
-      }
+      if (!role) throw new NotFoundError(`No role found with ID ‘${id}’`);
 
       const count = await User.count({
         where: { role: role.id }, // No FK constraint!
       });
       if (count > 0) throw new InvalidRoleDeletionError(id, count);
 
-      await role.destroy();
+      if (!dryRun) await role.destroy();
     });
     res.status(204).send();
   }),
 );
-class InvalidRoleDeletionError extends DatabaseConstraintError {
-  constructor(/** @type {string} */ roleId, /** @type {number} */ count) {
-    const isSingular = count === 1;
-    const subject = isSingular ? 'user' : 'users';
-    const verb = isSingular ? 'is' : 'are';
 
-    super(`Cannot delete role with ID ‘${roleId}’. ${count} ${subject} ${verb} assigned to it.`);
-    this.withExtraData({ roleId, assignedUserCount: count });
+class InvalidRoleDeletionError extends DatabaseConstraintError {
+  constructor(/** @type {string} */ roleId, /** @type {number} */ assignedUserCount) {
+    const isSingular = assignedUserCount === 1;
+    const subject = isSingular ? 'user' : 'users';
+
+    super(
+      `Cannot delete role with ID ‘${roleId}’. ${assignedUserCount} ${subject} assigned to it.`,
+    );
+    this.withExtraData({ assignedUserCount });
   }
 }

--- a/packages/central-server/app/admin/roles.js
+++ b/packages/central-server/app/admin/roles.js
@@ -1,146 +1,17 @@
 import express from 'express';
-import asyncHandler from 'express-async-handler';
-import { escapeRegExp } from 'lodash';
-import { Op, UniqueConstraintError } from 'sequelize';
-import { z } from 'zod';
-
-import { DatabaseConstraintError, DatabaseDuplicateError, NotFoundError } from '@tamanu/errors';
-import { getResourceList } from '@tamanu/shared/utils/crudHelpers';
+import { deleteRoleById } from './roles.delete';
+import { getRoleById, getRoleDeletabilityById, getRoles } from './roles.get';
+import { createRole } from './roles.post';
 
 /** `/admin/role` endpoint for CRUD-ing a single role */
 export const roleRouter = express.Router();
 
+roleRouter.get('/:id/isDeletable', getRoleDeletabilityById);
+roleRouter.get('/:id', getRoleById);
+roleRouter.post('/', createRole);
+roleRouter.delete('/:id', deleteRoleById);
+
 /** `/admin/roles` endpoint for CRUD-ing multiple roles at once */
 export const rolesRouter = express.Router();
 
-rolesRouter.get(
-  '/',
-  asyncHandler(async (req, res) => {
-    req.checkPermission('list', 'Role');
-
-    const filters = [];
-    const idQuery = req.query.id?.trim();
-    if (idQuery) {
-      filters.push({ id: idQuery });
-    }
-    const nameQuery = req.query.name?.trim();
-    if (nameQuery) {
-      filters.push({
-        name: { [Op.iRegexp]: `\\m${escapeRegExp(nameQuery)}` },
-      });
-    }
-
-    const options = {};
-    if (filters.length > 0) {
-      options.additionalFilters = filters.length === 1 ? filters[0] : { [Op.and]: filters };
-    }
-
-    const response = await getResourceList(req, 'Role', '', options);
-    res.send(response);
-  }),
-);
-
-const createRoleSchema = z.object({
-  id: z
-    .string()
-    .trim()
-    .min(1, { message: '`id` must be at least 1 character' })
-    .max(255, { message: '`id` must be no longer than 255 characters' }),
-  name: z
-    .string()
-    .trim()
-    .min(1, { message: '`name` must be at least 1 character' })
-    .max(255, { message: '`name` must be no longer than 255 characters' }),
-});
-
-roleRouter.get(
-  '/:id',
-  asyncHandler(async (req, res) => {
-    req.checkPermission('read', 'Role');
-
-    const {
-      store: {
-        models: { Role },
-      },
-      params: { id },
-    } = req;
-
-    const role = await Role.findByPk(id);
-    if (!role) {
-      throw new NotFoundError(`No role found with ID ‘${id}’`);
-    }
-
-    res.send(role);
-  }),
-);
-
-roleRouter.post(
-  '/',
-  asyncHandler(async (req, res) => {
-    req.checkPermission('create', 'Role');
-
-    const { Role } = req.store.models;
-    const { id, name } = await createRoleSchema.parseAsync(req.body);
-
-    let role;
-    try {
-      role = await Role.create({ id, name });
-    } catch (err) {
-      if (err instanceof UniqueConstraintError) {
-        throw new DatabaseDuplicateError(`A role already exists with ID ‘${id}’`);
-      }
-      throw err;
-    }
-
-    res.status(201).send(role);
-  }),
-);
-
-const deleteRoleQuerySchema = z.object({
-  dryRun: z
-    .string()
-    .optional()
-    .transform(value => value === '1'),
-});
-
-roleRouter.delete(
-  '/:id',
-  asyncHandler(async (req, res) => {
-    req.checkPermission('delete', 'Role');
-
-    const { dryRun } = await deleteRoleQuerySchema.parseAsync(req.query);
-
-    const {
-      store: {
-        models: { Role, User },
-        sequelize,
-      },
-      params: { id },
-    } = req;
-
-    await sequelize.transaction({ readOnly: dryRun }, async () => {
-      const role = await Role.findByPk(id);
-      if (!role) throw new NotFoundError(`No role found with ID ‘${id}’`);
-
-      const count = await User.count({
-        where: { role: role.id }, // No FK constraint!
-      });
-      if (count > 0) throw new InvalidRoleDeletionError(id, count);
-
-      if (!dryRun) await role.destroy();
-    });
-    res.status(204).send();
-  }),
-);
-
-class InvalidRoleDeletionError extends DatabaseConstraintError {
-  constructor(/** @type {string} */ roleId, /** @type {number} */ assignedUserCount) {
-    const isSingular = assignedUserCount === 1;
-    const subject = isSingular ? 'user' : 'users';
-
-    super(
-      `Cannot delete role with ID ‘${roleId}’. ${assignedUserCount} ${subject} assigned to it.`,
-    );
-    this.withExtraData({ assignedUserCount });
-  }
-}
+rolesRouter.get('/', getRoles);

--- a/packages/central-server/app/admin/roles.post.js
+++ b/packages/central-server/app/admin/roles.post.js
@@ -1,0 +1,37 @@
+import asyncHandler from 'express-async-handler';
+import { UniqueConstraintError } from 'sequelize';
+import { z } from 'zod';
+
+import { DatabaseDuplicateError } from '@tamanu/errors';
+
+const createRoleSchema = z.object({
+  id: z
+    .string()
+    .trim()
+    .min(1, { message: '`id` must be at least 1 character' })
+    .max(255, { message: '`id` must be no longer than 255 characters' }),
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: '`name` must be at least 1 character' })
+    .max(255, { message: '`name` must be no longer than 255 characters' }),
+});
+
+export const createRole = asyncHandler(async (req, res) => {
+  req.checkPermission('create', 'Role');
+
+  const { Role } = req.store.models;
+  const { id, name } = await createRoleSchema.parseAsync(req.body);
+
+  let role;
+  try {
+    role = await Role.create({ id, name });
+  } catch (err) {
+    if (err instanceof UniqueConstraintError) {
+      throw new DatabaseDuplicateError(`A role already exists with ID ‘${id}’`);
+    }
+    throw err;
+  }
+
+  res.status(201).send(role);
+});

--- a/packages/central-server/app/admin/roles.post.js
+++ b/packages/central-server/app/admin/roles.post.js
@@ -23,15 +23,13 @@ export const createRole = asyncHandler(async (req, res) => {
   const { Role } = req.store.models;
   const { id, name } = await createRoleSchema.parseAsync(req.body);
 
-  let role;
   try {
-    role = await Role.create({ id, name });
+    const role = await Role.create({ id, name });
+    res.status(201).send(role);
   } catch (err) {
     if (err instanceof UniqueConstraintError) {
       throw new DatabaseDuplicateError(`A role already exists with ID ‘${id}’`);
     }
     throw err;
   }
-
-  res.status(201).send(role);
 });

--- a/packages/ui-components/src/components/Button/ButtonRow.jsx
+++ b/packages/ui-components/src/components/Button/ButtonRow.jsx
@@ -19,8 +19,7 @@ const Row = styled.div`
   // ensure the button row takes up the full width if it's used in a grid context
   grid-column: 1 / -1;
 
-  > button:not(:first-child),
-  > div:not(:first-child) {
+  > :where(button, div, .MuiSkeleton-root):not(:first-child) {
     margin-left: 20px;
   }
 `;
@@ -31,9 +30,7 @@ const ConfirmButton = styled(Button)`
 
 export const ButtonRow = React.memo(({ children, ButtonWrapper = React.Fragment, ...props }) => (
   <Row {...props} data-testid="row-atzb">
-    <ButtonWrapper>
-      {children}
-    </ButtonWrapper>
+    <ButtonWrapper>{children}</ButtonWrapper>
   </Row>
 ));
 

--- a/packages/web/app/components/ConfirmModal.jsx
+++ b/packages/web/app/components/ConfirmModal.jsx
@@ -36,6 +36,7 @@ export const ConfirmModal = ({
   className,
   customContent,
   noteBlockConfirmButton = false,
+  confirmButtonProps,
 }) => (
   <Modal
     className={className}
@@ -58,12 +59,22 @@ export const ConfirmModal = ({
       </OutlinedButton>
       {noteBlockConfirmButton ? (
         <NoteModalActionBlocker>
-          <ConfirmButton variant="contained" onClick={onConfirm} data-testid="confirmbutton-y3tb">
+          <ConfirmButton
+            variant="contained"
+            onClick={onConfirm}
+            data-testid="confirmbutton-y3tb"
+            {...confirmButtonProps}
+          >
             {confirmButtonText}
           </ConfirmButton>
         </NoteModalActionBlocker>
       ) : (
-        <ConfirmButton variant="contained" onClick={onConfirm} data-testid="confirmbutton-y3tb">
+        <ConfirmButton
+          variant="contained"
+          onClick={onConfirm}
+          data-testid="confirmbutton-y3tb"
+          {...confirmButtonProps}
+        >
           {confirmButtonText}
         </ConfirmButton>
       )}

--- a/packages/web/app/components/ConfirmModal.jsx
+++ b/packages/web/app/components/ConfirmModal.jsx
@@ -60,20 +60,20 @@ export const ConfirmModal = ({
       {noteBlockConfirmButton ? (
         <NoteModalActionBlocker>
           <ConfirmButton
+            {...confirmButtonProps}
             variant="contained"
             onClick={onConfirm}
             data-testid="confirmbutton-y3tb"
-            {...confirmButtonProps}
           >
             {confirmButtonText}
           </ConfirmButton>
         </NoteModalActionBlocker>
       ) : (
         <ConfirmButton
+          {...confirmButtonProps}
           variant="contained"
           onClick={onConfirm}
           data-testid="confirmbutton-y3tb"
-          {...confirmButtonProps}
         >
           {confirmButtonText}
         </ConfirmButton>

--- a/packages/web/app/views/administration/users/DeleteRoleModal.jsx
+++ b/packages/web/app/views/administration/users/DeleteRoleModal.jsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import { ERROR_TYPE } from '@tamanu/errors';
 import { Button, ButtonRow, Modal } from '@tamanu/ui-components';
 import { TranslatedText } from '../../../components';
-import { ConfirmModal } from '../../../components/ConfirmModal';
 import { ConfirmRowDivider } from '../../../components/ConfirmRowDivider';
 import { useCanDeleteRoleQuery } from './useCanDeleteRoleQuery';
 import { useRoleDeleteMutation } from './useRoleDeleteMutation';
@@ -19,6 +18,32 @@ const ModalContent = styled.div`
   place-items: center stretch;
 `;
 
+const StyledButtonRow = styled(ButtonRow)`
+  /* Reset style from ButtonRow */
+  > :where(button, div, .MuiSkeleton-root):not(:first-child) {
+    margin-left: unset;
+  }
+
+  flex-direction: row-reverse;
+  gap: 20px;
+  justify-content: flex-start;
+`;
+
+const headingSkeleton = <Skeleton animation="wave" width="16ch" />;
+const bodySkeleton = (
+  <div>
+    <Skeleton animation="wave" width="100%" />
+    <Skeleton animation="wave" width="55%" />
+  </div>
+);
+const buttonSkeleton = (
+  <Skeleton animation="wave" variant="rounded">
+    <Button disabled>
+      <TranslatedText stringId="general.action.delete-role" fallback="Delete role" />
+    </Button>
+  </Skeleton>
+);
+
 const roleNameSkeleton = (
   <Skeleton
     animation="wave"
@@ -27,69 +52,40 @@ const roleNameSkeleton = (
   />
 );
 
-const RoleDeleteErrorModal = ({ open, error, onClose }) => {
-  if (!Error.isError(error)) return null;
+const getAssignedUserCount = error => {
+  const count = Number.parseInt(error?.extra?.get?.('assigned-user-count'), 10);
+  return Number.isSafeInteger(count) ? count : null;
+};
 
-  const _assignedUserCount = Number.parseInt(error?.extra?.get?.('assigned-user-count'), 10);
-  const assignedUserCount = Number.isSafeInteger(_assignedUserCount) ? _assignedUserCount : null;
-
-  const isExpectedError = assignedUserCount != null && assignedUserCount > 0;
+const getErrorModalTitle = error => {
+  const assignedUserCount = getAssignedUserCount(error);
+  const isExpectedError = Boolean(assignedUserCount); // We never expect 0 here
   if (!isExpectedError) {
-    toast.error(
-      error?.detail || error?.message || (
-        <TranslatedText
-          stringId="admin.roles.delete.error.generic"
-          fallback="Couldn’t delete role"
-        />
-      ),
+    return (
+      <TranslatedText
+        stringId="admin.roles.delete.error.generic.presentTense"
+        fallback="Cannot delete role"
+      />
     );
-    return null;
   }
 
-  const isSingular = assignedUserCount === 1;
-  const title = isSingular ? (
+  return assignedUserCount === 1 ? (
     <TranslatedText
       stringId="admin.roles.delete.error.title.singular"
       fallback="User assigned to role"
-      casing="sentence"
     />
   ) : (
     <TranslatedText
       stringId="admin.roles.delete.error.title.plural"
       fallback="Users assigned to role"
-      casing="sentence"
     />
-  );
-
-  return (
-    <Modal open={open} onClose={onClose} title={title}>
-      <ModalContent>
-        <Typography variant="body2">
-          <TranslatedText
-            stringId="admin.roles.delete.error.usersAssigned"
-            fallback="You cannot delete this role as there are currently one or more users assigned to it. Please update the user profiles first in order to delete the role."
-          />
-        </Typography>
-      </ModalContent>
-      <ConfirmRowDivider />
-      <ButtonRow>
-        <Button onClick={onClose}>
-          <TranslatedText stringId="general.action.close" fallback="Close" />
-        </Button>
-      </ButtonRow>
-    </Modal>
   );
 };
 
 export const DeleteRoleModal = ({ onSuccess }) => {
   const deleteMatch = useMatch('/admin/users/roles/delete/:id');
   const roleId = deleteMatch?.params.id;
-  const {
-    data: role,
-    error: roleQueryError,
-    isLoading: isRoleLoading,
-    isFetched: isRoleFetched,
-  } = useRoleQuery(roleId);
+  const { data: role, error: roleQueryError, isLoading: isRoleLoading } = useRoleQuery(roleId);
   const isRoleNotFound = roleQueryError?.status === 404;
 
   const navigate = useNavigate();
@@ -102,25 +98,15 @@ export const DeleteRoleModal = ({ onSuccess }) => {
     error: dryRunError,
     isError: isDryRunError,
     isFetched: isDryRunFetched,
-    isLoading: isDryRunLoading,
-    isSuccess: isDryRunSuccess,
+    isLoading: _isDryRunLoading,
   } = useCanDeleteRoleQuery(roleId);
 
-  const isDryRunConstraintError =
-    isDryRunError && dryRunError?.type === ERROR_TYPE.VALIDATION_CONSTRAINT;
-
-  const showDeleteErrorModal = Boolean(roleId) && isDryRunConstraintError;
-
-  const showConfirmModal =
-    Boolean(roleId) &&
-    !isRoleNotFound &&
-    !showDeleteErrorModal &&
-    (isRoleLoading || isDryRunLoading || isDryRunSuccess);
-
-  const confirmDisabled = isRoleLoading || isDryRunLoading;
+  const isLoadingDeletability = Boolean(roleId) && _isDryRunLoading;
+  const isDeleteRestricted = dryRunError?.type === ERROR_TYPE.VALIDATION_CONSTRAINT;
+  const showModal = Boolean(roleId) && !isRoleNotFound;
 
   useEffect(() => {
-    if (!roleId || !isDryRunFetched || !isDryRunError || isDryRunConstraintError) return;
+    if (!roleId || !isDryRunFetched || !isDryRunError || isDeleteRestricted) return;
     // Not found is surfaced by `useRoleQuery`; dismiss runs in `useLayoutEffect` when that settles.
     if (dryRunError?.status === 404 || dryRunError?.type === ERROR_TYPE.NOT_FOUND) return;
 
@@ -133,7 +119,7 @@ export const DeleteRoleModal = ({ onSuccess }) => {
       ),
     );
     dismiss();
-  }, [dismiss, dryRunError, isDryRunConstraintError, isDryRunError, isDryRunFetched, roleId]);
+  }, [dismiss, dryRunError, isDeleteRestricted, isDryRunError, isDryRunFetched, roleId]);
 
   const { mutate: deleteRole } = useRoleDeleteMutation({
     onSuccess: () => {
@@ -150,7 +136,7 @@ export const DeleteRoleModal = ({ onSuccess }) => {
       toast.error(
         error.detail || error.message || (
           <TranslatedText
-            stringId="admin.roles.delete.error.generic"
+            stringId="admin.roles.delete.error.generic.pastTense"
             fallback="Couldn’t delete role"
           />
         ),
@@ -159,45 +145,67 @@ export const DeleteRoleModal = ({ onSuccess }) => {
   });
 
   useLayoutEffect(() => {
-    if (roleId && isRoleFetched && isRoleNotFound) dismiss();
-  }, [roleId, isRoleFetched, isRoleNotFound, dismiss]);
-
-  const onClose = useCallback(() => {
-    dismiss();
-  }, [dismiss]);
+    if (roleId && isRoleNotFound) dismiss();
+  }, [roleId, isRoleNotFound, dismiss]);
 
   const handleConfirm = useCallback(() => {
     if (roleId) deleteRole(roleId);
   }, [deleteRole, roleId]);
 
-  return (
-    <>
-      <ConfirmModal
-        aria-busy={confirmDisabled}
-        confirmButtonText={
-          <TranslatedText stringId="general.action.delete-role" fallback="Delete role" />
-        }
-        confirmButtonProps={{ disabled: confirmDisabled }}
-        title={<TranslatedText stringId="admin.roles.delete.title" fallback="Delete role" />}
-        customContent={
-          <ModalContent>
-            <Typography variant="body2">
-              <TranslatedText
-                stringId="admin.roles.delete.confirmation"
-                fallback="Are you sure you would like to delete the selected role?"
-              />
-              &nbsp;&ndash;{' '}
-              <strong aria-busy={isRoleLoading}>
-                {isRoleLoading ? roleNameSkeleton : role?.name}
-              </strong>
-            </Typography>
-          </ModalContent>
-        }
-        open={showConfirmModal}
-        onCancel={onClose}
-        onConfirm={handleConfirm}
+  const title = isDeleteRestricted ? (
+    getErrorModalTitle(dryRunError)
+  ) : (
+    <TranslatedText stringId="admin.roles.delete.title" fallback="Delete role" />
+  );
+
+  const body = isDeleteRestricted ? (
+    <Typography variant="body2">
+      <TranslatedText
+        stringId="admin.roles.delete.error.usersAssigned"
+        fallback="You cannot delete this role as there are currently one or more users assigned to it. Please update the user profiles first in order to delete the role."
       />
-      <RoleDeleteErrorModal open={showDeleteErrorModal} error={dryRunError} onClose={onClose} />
-    </>
+    </Typography>
+  ) : (
+    <Typography variant="body2">
+      <TranslatedText
+        stringId="admin.roles.delete.confirmation"
+        fallback="Are you sure you would like to delete the selected role?"
+      />
+      &nbsp;&ndash;{' '}
+      <strong aria-busy={isRoleLoading}>{isRoleLoading ? roleNameSkeleton : role?.name}</strong>
+    </Typography>
+  );
+
+  const primaryButton = isDeleteRestricted ? (
+    <Button onClick={dismiss}>
+      <TranslatedText stringId="general.action.close" fallback="Close" />
+    </Button>
+  ) : (
+    <Button onClick={handleConfirm}>
+      <TranslatedText stringId="general.action.delete-role" fallback="Delete role" />
+    </Button>
+  );
+
+  // Let user dismiss even if pending useCanDeleteRoleQuery result is pending
+  const secondaryButton = isDeleteRestricted ? null : (
+    <Button onClick={dismiss} variant="outlined">
+      <TranslatedText stringId="general.action.cancel" fallback="Cancel" />
+    </Button>
+  );
+
+  return (
+    <Modal
+      aria-busy={isLoadingDeletability}
+      open={showModal}
+      onClose={dismiss}
+      title={isLoadingDeletability ? headingSkeleton : title}
+    >
+      <ModalContent>{isLoadingDeletability ? bodySkeleton : body}</ModalContent>
+      <ConfirmRowDivider />
+      <StyledButtonRow>
+        {isLoadingDeletability ? buttonSkeleton : primaryButton}
+        {secondaryButton}
+      </StyledButtonRow>
+    </Modal>
   );
 };

--- a/packages/web/app/views/administration/users/DeleteRoleModal.jsx
+++ b/packages/web/app/views/administration/users/DeleteRoleModal.jsx
@@ -63,10 +63,8 @@ const RoleDeleteErrorModal = ({ open, error, onClose }) => {
 
   const body = (
     <TranslatedText
-      stringId={'admin.roles.delete.error.assignedUsers'}
-      fallback={
-        'You cannot delete this role as there is currently one or more users assigned to it. Please update the user profile first in order to delete the role.'
-      }
+      stringId="admin.roles.delete.error.assignedUsers"
+      fallback="You cannot delete this role as there is currently one or more users assigned to it. Please update the user profile first in order to delete the role."
     />
   );
 

--- a/packages/web/app/views/administration/users/DeleteRoleModal.jsx
+++ b/packages/web/app/views/administration/users/DeleteRoleModal.jsx
@@ -1,5 +1,5 @@
 import { Skeleton, Typography } from '@mui/material';
-import React, { useCallback, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect } from 'react';
 import { useMatch, useNavigate } from 'react-router';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
@@ -9,6 +9,7 @@ import { Button, ButtonRow, Modal } from '@tamanu/ui-components';
 import { TranslatedText } from '../../../components';
 import { ConfirmModal } from '../../../components/ConfirmModal';
 import { ConfirmRowDivider } from '../../../components/ConfirmRowDivider';
+import { useCanDeleteRoleQuery } from './useCanDeleteRoleQuery';
 import { useRoleDeleteMutation } from './useRoleDeleteMutation';
 import { useRoleQuery } from './useRoleQuery';
 
@@ -29,11 +30,10 @@ const roleNameSkeleton = (
 const RoleDeleteErrorModal = ({ open, error, onClose }) => {
   if (!Error.isError(error)) return null;
 
-  const roleId = error?.extra?.get?.('role-id');
-  const _assignedUserCount = Number.parseInt(error?.extra?.get?.('assigned-user-count'));
+  const _assignedUserCount = Number.parseInt(error?.extra?.get?.('assigned-user-count'), 10);
   const assignedUserCount = Number.isSafeInteger(_assignedUserCount) ? _assignedUserCount : null;
 
-  const isExpectedError = Boolean(roleId && assignedUserCount);
+  const isExpectedError = assignedUserCount != null && assignedUserCount > 0;
   if (!isExpectedError) {
     toast.error(
       error?.detail || error?.message || (
@@ -61,25 +61,19 @@ const RoleDeleteErrorModal = ({ open, error, onClose }) => {
     />
   );
 
-  const detailReplacements = { roleId, count: assignedUserCount?.toLocaleString() };
-  const detail = isSingular ? (
+  const body = (
     <TranslatedText
-      stringId="admin.roles.delete.error.detail.singular"
-      fallback="Cannot delete role with ID ‘:roleId’ as :count user is assigned to it. Please update their profile first to delete the role."
-      replacements={detailReplacements}
-    />
-  ) : (
-    <TranslatedText
-      stringId="admin.roles.delete.error.detail.plural"
-      fallback="Cannot delete role with ID ‘:roleId’ as :count users are assigned to it. Please update their profiles first to delete the role."
-      replacements={detailReplacements}
+      stringId={'admin.roles.delete.error.assignedUsers'}
+      fallback={
+        'You cannot delete this role as there is currently one or more users assigned to it. Please update the user profile first in order to delete the role.'
+      }
     />
   );
 
   return (
-    <Modal open={open} onClose={onClose} width="sm" title={title}>
+    <Modal open={open} onClose={onClose} title={title}>
       <ModalContent>
-        <Typography variant="body2">{detail}</Typography>
+        <Typography variant="body2">{body}</Typography>
       </ModalContent>
       <ConfirmRowDivider />
       <ButtonRow>
@@ -94,7 +88,12 @@ const RoleDeleteErrorModal = ({ open, error, onClose }) => {
 export const DeleteRoleModal = ({ onSuccess }) => {
   const deleteMatch = useMatch('/admin/users/roles/delete/:id');
   const roleId = deleteMatch?.params.id;
-  const { data: role, error: roleQueryError, isLoading: isRoleLoading } = useRoleQuery(roleId);
+  const {
+    data: role,
+    error: roleQueryError,
+    isLoading: isRoleLoading,
+    isFetched: isRoleFetched,
+  } = useRoleQuery(roleId);
   const isRoleNotFound = roleQueryError?.status === 404;
 
   const navigate = useNavigate();
@@ -103,11 +102,45 @@ export const DeleteRoleModal = ({ onSuccess }) => {
     [navigate],
   );
 
-  const [deleteRoleError, setDeleteRoleError] = useState(null);
+  const {
+    error: dryRunError,
+    isError: isDryRunError,
+    isFetched: isDryRunFetched,
+    isLoading: isDryRunLoading,
+    isSuccess: isDryRunSuccess,
+  } = useCanDeleteRoleQuery(roleId);
+
+  const isDryRunConstraintError =
+    isDryRunError && dryRunError?.type === ERROR_TYPE.VALIDATION_CONSTRAINT;
+
+  const showDeleteErrorModal = Boolean(roleId) && isDryRunConstraintError;
+
+  const showConfirmModal =
+    Boolean(roleId) &&
+    !isRoleNotFound &&
+    !showDeleteErrorModal &&
+    (isRoleLoading || isDryRunLoading || isDryRunSuccess);
+
+  const confirmDisabled = isRoleLoading || isDryRunLoading;
+
+  useEffect(() => {
+    if (!roleId || !isDryRunFetched || !isDryRunError || isDryRunConstraintError) return;
+    // Not found is surfaced by `useRoleQuery`; dismiss runs in `useLayoutEffect` when that settles.
+    if (dryRunError?.status === 404 || dryRunError?.type === ERROR_TYPE.NOT_FOUND) return;
+
+    toast.error(
+      dryRunError?.detail || dryRunError?.message || (
+        <TranslatedText
+          stringId="admin.roles.delete.error.generic"
+          fallback="Couldn’t delete role"
+        />
+      ),
+    );
+    dismiss();
+  }, [dismiss, dryRunError, isDryRunConstraintError, isDryRunError, isDryRunFetched, roleId]);
 
   const { mutate: deleteRole } = useRoleDeleteMutation({
     onSuccess: () => {
-      setDeleteRoleError(null);
       dismiss();
       toast.success(
         <>
@@ -118,10 +151,6 @@ export const DeleteRoleModal = ({ onSuccess }) => {
       onSuccess?.();
     },
     onError: error => {
-      if (error.type === ERROR_TYPE.VALIDATION_CONSTRAINT) {
-        setDeleteRoleError(error);
-        return;
-      }
       toast.error(
         error.detail || error.message || (
           <TranslatedText
@@ -134,11 +163,10 @@ export const DeleteRoleModal = ({ onSuccess }) => {
   });
 
   useLayoutEffect(() => {
-    if (roleId && isRoleNotFound) dismiss();
-  }, [roleId, isRoleNotFound, dismiss]);
+    if (roleId && isRoleFetched && isRoleNotFound) dismiss();
+  }, [roleId, isRoleFetched, isRoleNotFound, dismiss]);
 
   const onClose = useCallback(() => {
-    setDeleteRoleError(null);
     dismiss();
   }, [dismiss]);
 
@@ -149,9 +177,11 @@ export const DeleteRoleModal = ({ onSuccess }) => {
   return (
     <>
       <ConfirmModal
+        aria-busy={confirmDisabled}
         confirmButtonText={
           <TranslatedText stringId="general.action.delete-role" fallback="Delete role" />
         }
+        confirmButtonProps={{ disabled: confirmDisabled }}
         title={<TranslatedText stringId="admin.roles.delete.title" fallback="Delete role" />}
         customContent={
           <ModalContent>
@@ -167,15 +197,11 @@ export const DeleteRoleModal = ({ onSuccess }) => {
             </Typography>
           </ModalContent>
         }
-        open={Boolean(roleId) && !isRoleNotFound}
+        open={showConfirmModal}
         onCancel={onClose}
         onConfirm={handleConfirm}
       />
-      <RoleDeleteErrorModal
-        open={deleteRoleError !== null}
-        error={deleteRoleError}
-        onClose={onClose}
-      />
+      <RoleDeleteErrorModal open={showDeleteErrorModal} error={dryRunError} onClose={onClose} />
     </>
   );
 };

--- a/packages/web/app/views/administration/users/DeleteRoleModal.jsx
+++ b/packages/web/app/views/administration/users/DeleteRoleModal.jsx
@@ -122,8 +122,8 @@ export const DeleteRoleModal = ({ onSuccess }) => {
   }, [dismiss, dryRunError, isDeleteRestricted, isDryRunError, isDryRunFetched, roleId]);
 
   const { mutate: deleteRole } = useRoleDeleteMutation({
+    onSettled: () => dismiss(),
     onSuccess: () => {
-      dismiss();
       toast.success(
         <>
           <TranslatedText stringId="admin.roles.delete.success" fallback="Deleted role" />{' '}

--- a/packages/web/app/views/administration/users/DeleteRoleModal.jsx
+++ b/packages/web/app/views/administration/users/DeleteRoleModal.jsx
@@ -61,17 +61,15 @@ const RoleDeleteErrorModal = ({ open, error, onClose }) => {
     />
   );
 
-  const body = (
-    <TranslatedText
-      stringId="admin.roles.delete.error.assignedUsers"
-      fallback="You cannot delete this role as there is currently one or more users assigned to it. Please update the user profile first in order to delete the role."
-    />
-  );
-
   return (
     <Modal open={open} onClose={onClose} title={title}>
       <ModalContent>
-        <Typography variant="body2">{body}</Typography>
+        <Typography variant="body2">
+          <TranslatedText
+            stringId="admin.roles.delete.error.usersAssigned"
+            fallback="You cannot delete this role as there are currently one or more users assigned to it. Please update the user profiles first in order to delete the role."
+          />
+        </Typography>
       </ModalContent>
       <ConfirmRowDivider />
       <ButtonRow>

--- a/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
+++ b/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
@@ -11,7 +11,7 @@ export const useCanDeleteRoleQuery = (roleId, useQueryOptions) => {
     ...useQueryOptions,
     queryKey: ['role', 'canDelete', roleId],
     queryFn: async () =>
-      await api.delete(`${ROLE_ENDPOINT}/${encodeURIComponent(roleId)}`, { dryRun: 1 }),
+      await api.get(`${ROLE_ENDPOINT}/${encodeURIComponent(roleId)}/isDeletable`),
     enabled: Boolean(roleId),
     retry: (failureCount, error) => {
       if (error?.status === 404) return false;

--- a/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
+++ b/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { ERROR_TYPE } from '@tamanu/errors';
+import { useApi } from '../../../api';
+import { ROLE_ENDPOINT } from '../constants';
+
+export const useCanDeleteRoleQuery = (roleId, useQueryOptions) => {
+  const api = useApi();
+
+  return useQuery({
+    ...useQueryOptions,
+    queryKey: ['role', 'canDelete', roleId],
+    queryFn: async () =>
+      await api.delete(`${ROLE_ENDPOINT}/${encodeURIComponent(roleId)}`, { dryRun: 1 }),
+    enabled: Boolean(roleId),
+    retry: (failureCount, error) => {
+      if (error?.status === 404) return false;
+      if (error?.type === ERROR_TYPE.VALIDATION_CONSTRAINT) return false;
+      return failureCount < 3;
+    },
+    refetchOnWindowFocus: false,
+  });
+};

--- a/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
+++ b/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
@@ -9,7 +9,7 @@ export const useCanDeleteRoleQuery = (roleId, useQueryOptions) => {
 
   return useQuery({
     ...useQueryOptions,
-    queryKey: ['role', 'canDelete', roleId],
+    queryKey: ['role', 'isDeletable', roleId],
     queryFn: async () =>
       await api.get(`${ROLE_ENDPOINT}/${encodeURIComponent(roleId)}/isDeletable`),
     enabled: Boolean(roleId),

--- a/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
+++ b/packages/web/app/views/administration/users/useCanDeleteRoleQuery.js
@@ -11,7 +11,9 @@ export const useCanDeleteRoleQuery = (roleId, useQueryOptions) => {
     ...useQueryOptions,
     queryKey: ['role', 'isDeletable', roleId],
     queryFn: async () =>
-      await api.get(`${ROLE_ENDPOINT}/${encodeURIComponent(roleId)}/isDeletable`),
+      await api.get(`${ROLE_ENDPOINT}/${encodeURIComponent(roleId)}/isDeletable`, null, {
+        showUnknownErrorToast: false,
+      }),
     enabled: Boolean(roleId),
     retry: (failureCount, error) => {
       if (error?.status === 404) return false;


### PR DESCRIPTION
### Changes

Previously, when deleting a role, we could

- show the ‘Delete role?’ modal; and if that failed due to a DB constraint,
- follow with the ‘User(s) assigned’ modal

Now, more accurately representing the intended design, we first check if the role can be deleted and try to:

- show the ‘User(s) assigned modal’ if there’s a conflict; and
- show the ‘Delete role?’ confirmation modal if that check passes

Technically, the ‘Delete role?’ confirmation modal still shows first, but in a disabled state, because it first fires off a `DELETE /role` dry run request. We have to wait for that request to settle before we know whether to show the ‘User(s) assigned modal’.

Theoretically, I could add a `deletable` property to the return value from `GET /roles`; but this feels quite data-inefficient and is prone to being out-of-date by the time a role is being deleted.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->
<!-- - [ ] **Run Synthetic Tests (WIP)** **Target URL:** _https://your-target-url_ -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
