### PR TITLE
fix(datetime): no-issue: 2.51 fix: time-of-birth field display and date sync

### DIFF
--- a/packages/ui-components/src/components/Field/DateField.jsx
+++ b/packages/ui-components/src/components/Field/DateField.jsx
@@ -33,7 +33,7 @@ import { useTranslation } from '../../contexts/TranslationContext';
 
 const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
-const USER_INPUT_FORMATS = ['dd/MM/yyyy hh:mm a', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy', 'HH:mm'];
+const USER_INPUT_FORMATS = ['dd/MM/yyyy hh:mm a', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy', 'HH:mm', 'HH:mm:ss'];
 
 // Parses a string value to Date, trying storage formats first (ISO 9075),
 // then user-input display formats (dd/MM/yyyy etc) as a fallback for typed input.

--- a/packages/web/app/forms/PatientDetailsForm/layouts/generic/patientFields/GenericBirthFields.jsx
+++ b/packages/web/app/forms/PatientDetailsForm/layouts/generic/patientFields/GenericBirthFields.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useFormikContext } from 'formik';
 
 import {
   ATTENDANT_OF_BIRTH_LABELS,
@@ -17,8 +18,40 @@ import { ConfiguredMandatoryPatientFields } from '../../../ConfiguredMandatoryPa
 import { useSuggester } from '../../../../../api';
 import { TranslatedText } from '../../../../../components/Translation/TranslatedText';
 
+// Strips a date prefix from ISO 8601 ("…T…") or ISO 9075 ("… …") datetime strings.
+// Returns a bare time string, or the original value if it has no date prefix.
+const extractTime = value => value?.replace(/^\d{4}-\d{2}-\d{2}[T ]/, '') ?? '';
+
+const hasDatePrefix = value => /^\d{4}-\d{2}-\d{2}[T ]/.test(value ?? '');
+
 export const GenericBirthFields = ({ filterByMandatory, registeredBirthPlace }) => {
   const facilitySuggester = useSuggester('facility');
+  const { values, setFieldValue } = useFormikContext();
+  const { dateOfBirth, timeOfBirth } = values;
+  const date = dateOfBirth?.slice(0, 10);
+
+  /**
+   * Keeps timeOfBirth in sync with dateOfBirth so the stored value is a full
+   * datetime string (required by dateTimeType on the model). Without this,
+   * TimeField emits a time-only string ("HH:mm:ss") which the server rejects.
+   * Also strips the date prefix back to a bare time when dateOfBirth is cleared.
+   */
+  useEffect(() => {
+    if (!date) {
+      if (hasDatePrefix(timeOfBirth)) {
+        setFieldValue('timeOfBirth', extractTime(timeOfBirth));
+      }
+      return;
+    }
+    if (!timeOfBirth) return;
+    const timePart = extractTime(timeOfBirth);
+    if (!timePart) return;
+    const expected = `${date}T${timePart}`;
+    if (timeOfBirth !== expected) {
+      setFieldValue('timeOfBirth', expected);
+    }
+  }, [date, timeOfBirth, setFieldValue]);
+
   const BIRTH_FIELDS = {
     timeOfBirth: {
       component: TimeField,


### PR DESCRIPTION
Add HH:mm:ss to USER_INPUT_FORMATS so the time picker can round-trip values emitted by OUTPUT_FORMATS.time without reverting to empty.

Add BirthTimeDateSync component to GenericBirthFields to combine timeOfBirth with dateOfBirth into a full datetime string as required by the dateTimeType model field.

Made-with: Cursor

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->
<!-- - [ ] **Run Synthetic Tests (WIP)** **Target URL:** _https://your-target-url_ -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
