### PR TITLE
fix(charts): no-issue: use primary/facility timezone for chart date range and axis labels

### DIFF
--- a/packages/facility-server/app/routeHandlers/charts/getGraphData.js
+++ b/packages/facility-server/app/routeHandlers/charts/getGraphData.js
@@ -1,9 +1,6 @@
 import asyncHandler from 'express-async-handler';
-import config from 'config';
 import { Op } from 'sequelize';
 import { subject } from '@casl/ability';
-import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
-import { toStoredDateTime } from '@tamanu/utils/dateTime';
 
 export const fetchGraphData = (options = {}) =>
   asyncHandler(async (req, res) => {
@@ -40,14 +37,9 @@ export const fetchGraphData = (options = {}) =>
   });
 
 async function getGraphData(req, options = {}) {
-  const { models, query, settings, facilityId } = req;
+  const { models, query } = req;
   const { encounterId, patientId, dateDataElementId, dataElementId } = options;
   const { startDate, endDate } = query;
-
-  const primaryTimeZone = getPrimaryTimeZone(config);
-  const facilityTimeZone = await settings[facilityId]?.get('facilityTimeZone');
-  const storedStartDate = toStoredDateTime(startDate, primaryTimeZone, facilityTimeZone) ?? startDate;
-  const storedEndDate = toStoredDateTime(endDate, primaryTimeZone, facilityTimeZone) ?? endDate;
   const { SurveyResponse, SurveyResponseAnswer, Encounter } = models;
 
   const dateAnswersQuery = {
@@ -78,8 +70,8 @@ async function getGraphData(req, options = {}) {
     where: {
       dataElementId: dateDataElementId,
       body: {
-        [Op.gte]: storedStartDate,
-        [Op.lte]: storedEndDate,
+        [Op.gte]: startDate,
+        [Op.lte]: endDate,
       },
     },
   };

--- a/packages/facility-server/app/routeHandlers/charts/getGraphData.js
+++ b/packages/facility-server/app/routeHandlers/charts/getGraphData.js
@@ -1,6 +1,9 @@
 import asyncHandler from 'express-async-handler';
+import config from 'config';
 import { Op } from 'sequelize';
 import { subject } from '@casl/ability';
+import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
+import { toStoredDateTime } from '@tamanu/utils/dateTime';
 
 export const fetchGraphData = (options = {}) =>
   asyncHandler(async (req, res) => {
@@ -37,9 +40,14 @@ export const fetchGraphData = (options = {}) =>
   });
 
 async function getGraphData(req, options = {}) {
-  const { models, query } = req;
+  const { models, query, settings, facilityId } = req;
   const { encounterId, patientId, dateDataElementId, dataElementId } = options;
   const { startDate, endDate } = query;
+
+  const primaryTimeZone = getPrimaryTimeZone(config);
+  const facilityTimeZone = await settings[facilityId]?.get('facilityTimeZone');
+  const storedStartDate = toStoredDateTime(startDate, primaryTimeZone, facilityTimeZone) ?? startDate;
+  const storedEndDate = toStoredDateTime(endDate, primaryTimeZone, facilityTimeZone) ?? endDate;
   const { SurveyResponse, SurveyResponseAnswer, Encounter } = models;
 
   const dateAnswersQuery = {
@@ -70,8 +78,8 @@ async function getGraphData(req, options = {}) {
     where: {
       dataElementId: dateDataElementId,
       body: {
-        [Op.gte]: startDate,
-        [Op.lte]: endDate,
+        [Op.gte]: storedStartDate,
+        [Op.lte]: storedEndDate,
       },
     },
   };

--- a/packages/web/app/api/queries/useGraphDataQuery.js
+++ b/packages/web/app/api/queries/useGraphDataQuery.js
@@ -26,7 +26,7 @@ export const useGraphDataQuery = (encounterId, vitalDataElementId, dateRange, is
         { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     {
-      enabled: Boolean(encounterId),
+      enabled: Boolean(encounterId) && Boolean(startDate) && Boolean(endDate),
     },
   );
 

--- a/packages/web/app/api/queries/useProgramRegistryGraphDataQuery.js
+++ b/packages/web/app/api/queries/useProgramRegistryGraphDataQuery.js
@@ -25,7 +25,7 @@ export const useProgramRegistryGraphDataQuery = (patientId, dataElementId, dateR
         { isErrorUnknown: isErrorUnknownAllow404s },
       ),
     {
-      enabled: Boolean(patientId),
+      enabled: Boolean(patientId) && Boolean(startDate) && Boolean(endDate),
     },
   );
 

--- a/packages/web/app/components/Charts/components/CustomisedTick.jsx
+++ b/packages/web/app/components/Charts/components/CustomisedTick.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { isValid } from 'date-fns';
 import { useDateTime } from '@tamanu/ui-components';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { Colors } from '../../../constants';
@@ -17,7 +18,9 @@ export const CustomisedXAxisTick = (props) => {
   const { formatShortest, formatTime } = useDateTime();
   const { x, y, payload } = props;
   const { value } = payload;
-  const dateString = toDateTimeString(new Date(value));
+  const date = new Date(value);
+  if (!isValid(date)) return null;
+  const dateString = toDateTimeString(date);
 
   return (
     <g transform={`translate(${x},${y})`}>

--- a/packages/web/app/components/Charts/components/CustomisedTick.jsx
+++ b/packages/web/app/components/Charts/components/CustomisedTick.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useDateTime } from '@tamanu/ui-components';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
 import { Colors } from '../../../constants';
 
 const TextFontSize = 11;
@@ -16,12 +17,12 @@ export const CustomisedXAxisTick = (props) => {
   const { formatShortest, formatTime } = useDateTime();
   const { x, y, payload } = props;
   const { value } = payload;
-  const date = new Date(value);
+  const dateString = toDateTimeString(new Date(value));
 
   return (
     <g transform={`translate(${x},${y})`}>
       <Text x={0} y={9} textAnchor="middle" fill={Colors.darkText} data-testid="text-ch4x">
-        {formatShortest(date)}
+        {formatShortest(dateString)}
       </Text>
       <Text
         x={0}
@@ -30,7 +31,7 @@ export const CustomisedXAxisTick = (props) => {
         fill={Colors.midText}
         data-testid="text-cydx"
       >
-        {formatTime(date)}
+        {formatTime(dateString)}
       </Text>
     </g>
   );

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { debounce } from 'lodash';
 import { addDays, parseISO, startOfDay } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
+import { useDateTimeIfAvailable } from '@tamanu/ui-components';
 
 import { DateInput as DateInputComponent } from '../../Field';
 import { SelectInput as SelectInputComponent } from '@tamanu/ui-components';
@@ -26,30 +27,36 @@ const DateInput = styled(DateInputComponent)`
 const CUSTOM_DATE = 'Custom Date';
 const DATE_FORMAT = 'yyyy-MM-dd';
 
-const options = [
-    {
-      value: 'Last 24 hours',
-      label: 'Last 24 hours',
-      getDefaultStartDate: () => addDays(new Date(), -1),
-    },
-    {
-      value: 'Last 48 hours',
-      label: 'Last 48 hours',
-      getDefaultStartDate: () => addDays(new Date(), -2),
-    },
-    {
-      value: CUSTOM_DATE,
-      label: 'Custom Date',
-      getDefaultStartDate: () => startOfDay(new Date()),
-      getDefaultEndDate: () => addDays(startOfDay(new Date()), 1),
-    },
-  ];
+const OPTIONS = [
+  {
+    value: 'Last 24 hours',
+    label: 'Last 24 hours',
+    getDefaultStartDate: getNow => addDays(getNow(), -1),
+  },
+  {
+    value: 'Last 48 hours',
+    label: 'Last 48 hours',
+    getDefaultStartDate: getNow => addDays(getNow(), -2),
+  },
+  {
+    value: CUSTOM_DATE,
+    label: 'Custom Date',
+    getDefaultStartDate: getNow => startOfDay(getNow()),
+    getDefaultEndDate: getNow => addDays(startOfDay(getNow()), 1),
+  },
+];
 
 export const DateTimeSelector = (props) => {
   const { dateRange, setDateRange } = props;
   const [startDateString] = dateRange;
-  
-  const [value, setValue] = useState(options[0].value);
+
+  const dateTime = useDateTimeIfAvailable();
+  const getNow = useCallback(
+    () => dateTime?.getFacilityNowDate() ?? new Date(),
+    [dateTime],
+  );
+
+  const [value, setValue] = useState(OPTIONS[0].value);
 
   const formatAndSetDateRange = useCallback(
     (newStartDate, newEndDate) => {
@@ -61,19 +68,19 @@ export const DateTimeSelector = (props) => {
   );
 
   useEffect(() => {
-    const { getDefaultStartDate, getDefaultEndDate } = options.find(
+    const { getDefaultStartDate, getDefaultEndDate } = OPTIONS.find(
       (option) => option.value === value,
     );
-    const newStartDate = getDefaultStartDate ? getDefaultStartDate() : new Date();
-    const newEndDate = getDefaultEndDate ? getDefaultEndDate() : new Date();
+    const newStartDate = getDefaultStartDate ? getDefaultStartDate(getNow) : getNow();
+    const newEndDate = getDefaultEndDate ? getDefaultEndDate(getNow) : getNow();
 
     formatAndSetDateRange(newStartDate, newEndDate);
-  }, [value, formatAndSetDateRange]);
+  }, [value, formatAndSetDateRange, getNow]);
 
   return (
     <Wrapper data-testid="wrapper-onhu">
       <SelectInput
-        options={options}
+        options={OPTIONS}
         value={value}
         isClearable={false}
         onChange={(v) => {

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -4,7 +4,7 @@ import { debounce } from 'lodash';
 import { addDays, parseISO, startOfDay } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
 import {
-  useDateTimeIfAvailable,
+  useDateTime,
   SelectInput as SelectInputComponent,
   DateInput as DateInputComponent,
 } from '@tamanu/ui-components';
@@ -52,8 +52,8 @@ export const DateTimeSelector = props => {
   const { dateRange, setDateRange } = props;
   const [startDateString] = dateRange;
 
-  const dateTime = useDateTimeIfAvailable();
-  const getNow = useCallback(() => dateTime?.getFacilityNowDate() ?? new Date(), [dateTime]);
+  const { getCurrentDateTime } = useDateTime();
+  const getNow = useCallback(() => parseISO(getCurrentDateTime().replace(' ', 'T')), [getCurrentDateTime]);
 
   const [value, setValue] = useState(OPTIONS[0].value);
 

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -53,7 +53,10 @@ export const DateTimeSelector = props => {
   const [startDateString] = dateRange;
 
   const { getCurrentDateTime } = useDateTime();
-  const getNow = useCallback(() => parseISO(getCurrentDateTime().replace(' ', 'T')), [getCurrentDateTime]);
+  const getNow = useCallback(
+    () => new Date(getCurrentDateTime().replace(' ', 'T')),
+    [getCurrentDateTime],
+  );
 
   const [value, setValue] = useState(OPTIONS[0].value);
 

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -3,9 +3,12 @@ import styled from 'styled-components';
 import { debounce } from 'lodash';
 import { addDays, parseISO, startOfDay } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
+import {
+  useDateTime,
+  SelectInput as SelectInputComponent,
+  DateInput as DateInputComponent,
+} from '@tamanu/ui-components';
 
-import { DateInput as DateInputComponent } from '../../Field';
-import { SelectInput as SelectInputComponent } from '@tamanu/ui-components';
 import { Y_AXIS_WIDTH } from '../constants';
 
 const Wrapper = styled.div`
@@ -26,30 +29,33 @@ const DateInput = styled(DateInputComponent)`
 const CUSTOM_DATE = 'Custom Date';
 const DATE_FORMAT = 'yyyy-MM-dd';
 
-const options = [
-    {
-      value: 'Last 24 hours',
-      label: 'Last 24 hours',
-      getDefaultStartDate: () => addDays(new Date(), -1),
-    },
-    {
-      value: 'Last 48 hours',
-      label: 'Last 48 hours',
-      getDefaultStartDate: () => addDays(new Date(), -2),
-    },
-    {
-      value: CUSTOM_DATE,
-      label: 'Custom Date',
-      getDefaultStartDate: () => startOfDay(new Date()),
-      getDefaultEndDate: () => addDays(startOfDay(new Date()), 1),
-    },
-  ];
+const OPTIONS = [
+  {
+    value: 'Last 24 hours',
+    label: 'Last 24 hours',
+    getDefaultStartDate: getNow => addDays(getNow(), -1),
+  },
+  {
+    value: 'Last 48 hours',
+    label: 'Last 48 hours',
+    getDefaultStartDate: getNow => addDays(getNow(), -2),
+  },
+  {
+    value: CUSTOM_DATE,
+    label: 'Custom Date',
+    getDefaultStartDate: getNow => startOfDay(getNow()),
+    getDefaultEndDate: getNow => addDays(startOfDay(getNow()), 1),
+  },
+];
 
-export const DateTimeSelector = (props) => {
+export const DateTimeSelector = props => {
   const { dateRange, setDateRange } = props;
   const [startDateString] = dateRange;
-  
-  const [value, setValue] = useState(options[0].value);
+
+  const { getCurrentDateTime } = useDateTime();
+  const getNow = useCallback(() => parseISO(getCurrentDateTime()), [getCurrentDateTime]);
+
+  const [value, setValue] = useState(OPTIONS[0].value);
 
   const formatAndSetDateRange = useCallback(
     (newStartDate, newEndDate) => {
@@ -61,22 +67,22 @@ export const DateTimeSelector = (props) => {
   );
 
   useEffect(() => {
-    const { getDefaultStartDate, getDefaultEndDate } = options.find(
-      (option) => option.value === value,
+    const { getDefaultStartDate, getDefaultEndDate } = OPTIONS.find(
+      option => option.value === value,
     );
-    const newStartDate = getDefaultStartDate ? getDefaultStartDate() : new Date();
-    const newEndDate = getDefaultEndDate ? getDefaultEndDate() : new Date();
+    const newStartDate = getDefaultStartDate ? getDefaultStartDate(getNow) : getNow();
+    const newEndDate = getDefaultEndDate ? getDefaultEndDate(getNow) : getNow();
 
     formatAndSetDateRange(newStartDate, newEndDate);
-  }, [value, formatAndSetDateRange]);
+  }, [value, formatAndSetDateRange, getNow]);
 
   return (
     <Wrapper data-testid="wrapper-onhu">
       <SelectInput
-        options={options}
+        options={OPTIONS}
         value={value}
         isClearable={false}
-        onChange={(v) => {
+        onChange={v => {
           setValue(v.target.value);
         }}
         size="small"
@@ -88,7 +94,7 @@ export const DateTimeSelector = (props) => {
           // set format so we can safely use parseISO
           format={DATE_FORMAT}
           value={startDateString}
-          onChange={debounce((newValue) => {
+          onChange={debounce(newValue => {
             const { value: dateString } = newValue.target;
             if (dateString) {
               const selectedDayDate = parseISO(dateString);

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -54,7 +54,7 @@ export const DateTimeSelector = props => {
 
   const { getCurrentDateTime } = useDateTime();
   const getNow = useCallback(
-    () => new Date(getCurrentDateTime().replace(' ', 'T')),
+    () => parseISO(getCurrentDateTime()),
     [getCurrentDateTime],
   );
 

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -3,10 +3,12 @@ import styled from 'styled-components';
 import { debounce } from 'lodash';
 import { addDays, parseISO, startOfDay } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
-import { useDateTimeIfAvailable } from '@tamanu/ui-components';
+import {
+  useDateTimeIfAvailable,
+  SelectInput as SelectInputComponent,
+  DateInput as DateInputComponent,
+} from '@tamanu/ui-components';
 
-import { DateInput as DateInputComponent } from '../../Field';
-import { SelectInput as SelectInputComponent } from '@tamanu/ui-components';
 import { Y_AXIS_WIDTH } from '../constants';
 
 const Wrapper = styled.div`
@@ -46,15 +48,12 @@ const OPTIONS = [
   },
 ];
 
-export const DateTimeSelector = (props) => {
+export const DateTimeSelector = props => {
   const { dateRange, setDateRange } = props;
   const [startDateString] = dateRange;
 
   const dateTime = useDateTimeIfAvailable();
-  const getNow = useCallback(
-    () => dateTime?.getFacilityNowDate() ?? new Date(),
-    [dateTime],
-  );
+  const getNow = useCallback(() => dateTime?.getFacilityNowDate() ?? new Date(), [dateTime]);
 
   const [value, setValue] = useState(OPTIONS[0].value);
 
@@ -69,7 +68,7 @@ export const DateTimeSelector = (props) => {
 
   useEffect(() => {
     const { getDefaultStartDate, getDefaultEndDate } = OPTIONS.find(
-      (option) => option.value === value,
+      option => option.value === value,
     );
     const newStartDate = getDefaultStartDate ? getDefaultStartDate(getNow) : getNow();
     const newEndDate = getDefaultEndDate ? getDefaultEndDate(getNow) : getNow();
@@ -83,7 +82,7 @@ export const DateTimeSelector = (props) => {
         options={OPTIONS}
         value={value}
         isClearable={false}
-        onChange={(v) => {
+        onChange={v => {
           setValue(v.target.value);
         }}
         size="small"
@@ -95,7 +94,7 @@ export const DateTimeSelector = (props) => {
           // set format so we can safely use parseISO
           format={DATE_FORMAT}
           value={startDateString}
-          onChange={debounce((newValue) => {
+          onChange={debounce(newValue => {
             const { value: dateString } = newValue.target;
             if (dateString) {
               const selectedDayDate = parseISO(dateString);

--- a/packages/web/app/components/Charts/components/DateTimeSelector.jsx
+++ b/packages/web/app/components/Charts/components/DateTimeSelector.jsx
@@ -53,10 +53,7 @@ export const DateTimeSelector = props => {
   const [startDateString] = dateRange;
 
   const { getCurrentDateTime } = useDateTime();
-  const getNow = useCallback(
-    () => parseISO(getCurrentDateTime()),
-    [getCurrentDateTime],
-  );
+  const getNow = useCallback(() => parseISO(getCurrentDateTime()), [getCurrentDateTime]);
 
   const [value, setValue] = useState(OPTIONS[0].value);
 

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { addDays } from 'date-fns';
-import { toDateTimeString } from '@tamanu/utils/dateTime';
+
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,
   visualisationConfigQueryArgs = [],
@@ -11,10 +10,7 @@ export const GraphDataProviderFactory = ({
   const [chartKeys, setChartKeys] = useState([]);
   const [isInMultiChartsView, setIsInMultiChartsView] = useState(false);
   const [modalTitle, setModalTitle] = useState(null);
-  const [dateRange, setDateRange] = useState([
-    toDateTimeString(addDays(new Date(), -1)),
-    toDateTimeString(new Date()),
-  ]);
+  const [dateRange, setDateRange] = useState([null, null]);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
   const { data } = visualisationConfigQueryFn(...visualisationConfigQueryArgs);
   const { visualisationConfigs, allGraphedChartKeys } = data;

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -1,7 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { addDays, parseISO } from 'date-fns';
-import { toDateTimeString } from '@tamanu/utils/dateTime';
-import { useDateTime } from '@tamanu/ui-components';
 
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { addDays } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
-import { useDateTimeIfAvailable } from '@tamanu/ui-components';
-
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,
   visualisationConfigQueryArgs = [],
@@ -10,15 +8,12 @@ export const GraphDataProviderFactory = ({
   isVital = false,
   children,
 }) => {
-  const dateTime = useDateTimeIfAvailable();
-  const getNow = () => dateTime?.getFacilityNowDate() ?? new Date();
-
   const [chartKeys, setChartKeys] = useState([]);
   const [isInMultiChartsView, setIsInMultiChartsView] = useState(false);
   const [modalTitle, setModalTitle] = useState(null);
   const [dateRange, setDateRange] = useState([
-    toDateTimeString(addDays(getNow(), -1)),
-    toDateTimeString(getNow()),
+    toDateTimeString(addDays(new Date(), -1)),
+    toDateTimeString(new Date()),
   ]);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
   const { data } = visualisationConfigQueryFn(...visualisationConfigQueryArgs);

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -1,4 +1,7 @@
 import React, { useState, useMemo } from 'react';
+import { addDays, parseISO } from 'date-fns';
+import { toDateTimeString } from '@tamanu/utils/dateTime';
+import { useDateTime } from '@tamanu/ui-components';
 
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,
@@ -10,7 +13,7 @@ export const GraphDataProviderFactory = ({
   const [chartKeys, setChartKeys] = useState([]);
   const [isInMultiChartsView, setIsInMultiChartsView] = useState(false);
   const [modalTitle, setModalTitle] = useState(null);
-  const [dateRange, setDateRange] = useState([null, null]);
+  const [dateRange, setDateRange] = useState(['', '']);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
   const { data } = visualisationConfigQueryFn(...visualisationConfigQueryArgs);
   const { visualisationConfigs, allGraphedChartKeys } = data;

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -1,6 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { addDays } from 'date-fns';
-import { toDateTimeString } from '@tamanu/utils/dateTime';
 
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,
@@ -12,10 +10,7 @@ export const GraphDataProviderFactory = ({
   const [chartKeys, setChartKeys] = useState([]);
   const [isInMultiChartsView, setIsInMultiChartsView] = useState(false);
   const [modalTitle, setModalTitle] = useState(null);
-  const [dateRange, setDateRange] = useState([
-    toDateTimeString(addDays(new Date(), -1)),
-    toDateTimeString(new Date()),
-  ]);
+  const [dateRange, setDateRange] = useState(['', '']);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
   const { data } = visualisationConfigQueryFn(...visualisationConfigQueryArgs);
   const { visualisationConfigs, allGraphedChartKeys } = data;

--- a/packages/web/app/contexts/GraphData.jsx
+++ b/packages/web/app/contexts/GraphData.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { addDays } from 'date-fns';
 import { toDateTimeString } from '@tamanu/utils/dateTime';
+import { useDateTimeIfAvailable } from '@tamanu/ui-components';
 
 export const GraphDataProviderFactory = ({
   visualisationConfigQueryFn,
@@ -9,12 +10,15 @@ export const GraphDataProviderFactory = ({
   isVital = false,
   children,
 }) => {
+  const dateTime = useDateTimeIfAvailable();
+  const getNow = () => dateTime?.getFacilityNowDate() ?? new Date();
+
   const [chartKeys, setChartKeys] = useState([]);
   const [isInMultiChartsView, setIsInMultiChartsView] = useState(false);
   const [modalTitle, setModalTitle] = useState(null);
   const [dateRange, setDateRange] = useState([
-    toDateTimeString(addDays(new Date(), -1)),
-    toDateTimeString(new Date()),
+    toDateTimeString(addDays(getNow(), -1)),
+    toDateTimeString(getNow()),
   ]);
   const [vitalChartModalOpen, setVitalChartModalOpen] = useState(false);
   const { data } = visualisationConfigQueryFn(...visualisationConfigQueryArgs);

--- a/packages/web/app/views/charts/VitalChartLineChart.jsx
+++ b/packages/web/app/views/charts/VitalChartLineChart.jsx
@@ -19,15 +19,16 @@ export const VitalChartLineChart = props => {
     location.pathname,
   );
 
+  const useProgramRegistry = !isVital && isProgramRegistryRoute;
   const encounterGraphQuery = useGraphDataQuery(encounter?.id, chartKey, dateRange, isVital);
   const programRegistryGraphQuery = useProgramRegistryGraphDataQuery(
     patient?.id,
     chartKey,
-    dateRange,
+    useProgramRegistry ? dateRange : ['', ''],
   );
 
   const { data: chartData, isLoading } =
-    !isVital && isProgramRegistryRoute ? programRegistryGraphQuery : encounterGraphQuery;
+    useProgramRegistry ? programRegistryGraphQuery : encounterGraphQuery;
   const chartProps = getVitalChartProps({
     visualisationConfig,
     dateRange,


### PR DESCRIPTION
### Changes
fix(charts): Use primary timezone for chart date range queries

The chart date range was computed using browser-local time (new Date()), but vitals data is stored in the primary timezone. When the user's browser timezone differs from the primary timezone, "Last 24 hours" produced a date window that didn't match any stored records. Now uses getCurrentDateTime() from the DateTime context to compute ranges in primary timezone. Also prevents wasteful programRegistry queries from firing on vitals pages, and guards chart queries from executing before valid dates are available.
Also one last thing - fix the x axis dates, they where in browser timezone

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->
<!-- - [ ] **Run Synthetic Tests (WIP)** **Target URL:** _https://your-target-url_ -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
