### PR TITLE
feat: Add tooltip for hospital encounters containing both triage and admission dates

### DIFF
--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -196,6 +196,7 @@ export class Encounter extends Model {
         association: 'triages',
         include: ['chiefComplaint', 'secondaryComplaint'],
       },
+      'encounterHistory',
     ];
   }
 

--- a/packages/web/app/utils/getHospitalAdmissionDate.js
+++ b/packages/web/app/utils/getHospitalAdmissionDate.js
@@ -1,0 +1,28 @@
+import { ENCOUNTER_TYPES, EncounterChangeType } from '@tamanu/constants';
+
+/**
+ * Gets the hospital admission date from encounter history for encounters
+ * that were transferred from emergency status to hospital admission.
+ *
+ * @param {Object} encounter - The encounter object
+ * @returns {string|null} - The hospital admission date or null if not applicable
+ */
+export const getHospitalAdmissionDate = encounter => {
+  if (!encounter || encounter.encounterType !== ENCOUNTER_TYPES.ADMISSION) {
+    return null;
+  }
+
+  const encounterHistory = encounter.encounterHistory || [];
+  if (encounterHistory.length === 0) {
+    return null;
+  }
+
+  // Find the history record where the encounter type changed to ADMISSION
+  const admissionHistory = encounterHistory.find(
+    history =>
+      history.encounterType === ENCOUNTER_TYPES.ADMISSION &&
+      history.changeType?.includes(EncounterChangeType.EncounterType),
+  );
+
+  return admissionHistory?.date || null;
+};

--- a/packages/web/app/utils/getHospitalAdmissionDate.test.js
+++ b/packages/web/app/utils/getHospitalAdmissionDate.test.js
@@ -1,0 +1,115 @@
+import { ENCOUNTER_TYPES, EncounterChangeType } from '@tamanu/constants';
+import { getHospitalAdmissionDate } from './getHospitalAdmissionDate';
+
+describe('getHospitalAdmissionDate', () => {
+  it('should return null for non-admission encounters', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.TRIAGE,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBeNull();
+  });
+
+  it('should return null for admission encounters without history', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBeNull();
+  });
+
+  it('should return null for admission encounters without encounter type change', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBeNull();
+  });
+
+  it('should return the admission date for encounters transferred from emergency status', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-02-01 09:35:00',
+          changeType: [EncounterChangeType.EncounterType],
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBe('2020-02-01 09:35:00');
+  });
+
+  it('should return null if encounter is null', () => {
+    expect(getHospitalAdmissionDate(null)).toBeNull();
+  });
+
+  it('should return null if encounter is undefined', () => {
+    expect(getHospitalAdmissionDate(undefined)).toBeNull();
+  });
+
+  it('should handle encounters with multiple type changes', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.EMERGENCY,
+          date: '2020-01-31 15:00:00',
+          changeType: [EncounterChangeType.EncounterType],
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-02-01 09:35:00',
+          changeType: [EncounterChangeType.EncounterType],
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBe('2020-02-01 09:35:00');
+  });
+
+  it('should handle encounters with location changes mixed with type changes', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 12:00:00',
+          changeType: [EncounterChangeType.Location],
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-02-01 09:35:00',
+          changeType: [EncounterChangeType.EncounterType, EncounterChangeType.Location],
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBe('2020-02-01 09:35:00');
+  });
+});

--- a/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
+++ b/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
@@ -16,11 +16,13 @@ import {
   TranslatedReferenceData,
   TranslatedText,
 } from '../../../components/Translation';
-import { ENCOUNTER_TYPE_LABELS } from '@tamanu/constants';
+import { ENCOUNTER_TYPE_LABELS, ENCOUNTER_TYPES } from '@tamanu/constants';
 import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 import { getEncounterStartDateLabel } from '../../../utils/getEncounterStartDateLabel';
 import { useAuth } from '../../../contexts/Auth';
 import { isEmergencyPatient } from '../../../utils/isEmergencyPatient';
+import { getHospitalAdmissionDate } from '../../../utils/getHospitalAdmissionDate';
+import { ThemedTooltip } from '../../../components/Tooltip';
 
 const Border = css`
   border: 1px solid ${Colors.outline};
@@ -439,7 +441,57 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckIn })
             {getEncounterStartDateLabel(encounterType)}:
           </ContentLabel>
           <ContentText data-testid="contenttext-nw17">
-            <DateDisplay date={startDate} data-testid="datedisplay-5hsh" />
+            {(() => {
+              const hospitalAdmissionDate = getHospitalAdmissionDate(encounter);
+              const shouldShowTooltip =
+                encounterType === ENCOUNTER_TYPES.ADMISSION && hospitalAdmissionDate;
+
+              const dateDisplay = (
+                <DateDisplay date={startDate} data-testid="datedisplay-5hsh" />
+              );
+
+              if (!shouldShowTooltip) {
+                return dateDisplay;
+              }
+
+              return (
+                <ThemedTooltip
+                  title={
+                    <Box>
+                      <Box fontWeight="500">
+                        <TranslatedText
+                          stringId="encounter.triageDate.label"
+                          fallback="Triage date"
+                        />
+                        {': '}
+                        <DateDisplay
+                          date={startDate}
+                          format="short"
+                          timeFormat="default"
+                          noTooltip
+                        />
+                      </Box>
+                      <Box fontWeight="500">
+                        <TranslatedText
+                          stringId="encounter.hospitalAdmissionDate.label"
+                          fallback="Hospital admission date"
+                        />
+                        {': '}
+                        <DateDisplay
+                          date={hospitalAdmissionDate}
+                          format="short"
+                          timeFormat="default"
+                          noTooltip
+                        />
+                      </Box>
+                    </Box>
+                  }
+                  data-testid="themedtooltip-encounter-dates"
+                >
+                  {dateDisplay}
+                </ThemedTooltip>
+              );
+            })()}
           </ContentText>
         </ContentItem>
         {isEmergencyPatient(encounterType) ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changes

This PR implements a tooltip on the encounter summary pane that displays both the triage start date and the hospital admission date for encounters that were transferred from an emergency status (Triage, Active ED care, or Emergency short stay) to hospital admission.

**Implementation details:**
- Updated the `Encounter` model to include `encounterHistory` in the full reference associations
- Created a utility function `getHospitalAdmissionDate` to extract the hospital admission date from encounter history
- Modified `PatientEncounterSummary` to display a tooltip when hovering over the admission date for encounters that have both a triage date and a hospital admission date
- The tooltip shows:
  - **Triage date & time:** [original encounter start date]
  - **Hospital admission date & time:** [date when encounter type changed to admission]

**When the tooltip appears:**
- Only for encounters with `encounterType === 'admission'`
- Only when there is a corresponding encounter history record showing the type change from emergency status to admission

**Testing:**
- Added comprehensive unit tests for the `getHospitalAdmissionDate` utility function
- All 8 test cases pass successfully
- No linting errors introduced

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [x] Unit tests added and passing
- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->

### Remember to...

- [x] ...write or update tests
- [ ] ...add UI screenshots and **testing notes** to the Linear issue
- [ ] ...add any **manual upgrade steps** to the Linear issue
- [ ] ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- [ ] ...call out additions or changes to **config files** for the deployment team to take note of

**Resolves:** NASS-1853
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NASS-1853](https://linear.app/bes/issue/NASS-1853/add-tooltip-for-hospital-encounters-containing-both-a-triage-and)

<div><a href="https://cursor.com/agents/bc-4565c714-0cfc-482d-80fc-5c4dfbfa6761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4565c714-0cfc-482d-80fc-5c4dfbfa6761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

