### PR TITLE
fix(timezones): TAN-2610: Fix date display format in Patient Letters

### DIFF
--- a/packages/central-server/app/localisation.js
+++ b/packages/central-server/app/localisation.js
@@ -44,6 +44,8 @@ const rootLocalisationSchema = yup
         .required(),
     },
     timeZone: yup.string().nullable(),
+    // BCP 47 tag for Intl date formatting (e.g. server-side PDFs). When omitted, en-{country.alpha-2} is used.
+    displayLocale: yup.string().nullable().optional(),
     imagingTypes: imagingTypesSchema,
     // Deprecated: retained so existing configs with this field don't fail noUnknown() validation
     previewUvciFormat: yup.string().oneOf(['tamanu', 'eudcc', 'icao']).optional().strip(),

--- a/packages/central-server/app/utils/makePatientCertificate.jsx
+++ b/packages/central-server/app/utils/makePatientCertificate.jsx
@@ -7,6 +7,7 @@ import ReactPDF from '@react-pdf/renderer';
 import { ASSET_FALLBACK_NAMES, ASSET_NAMES } from '@tamanu/constants';
 import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
 
+import { getDisplayLocaleFromLocalisation } from '@tamanu/utils/dateTime';
 import {
   CovidVaccineCertificate,
   getPatientSurveyResponseAnswer,
@@ -78,6 +79,7 @@ export const makeCovidVaccineCertificate = async ({
   printedDate,
 }) => {
   const [localisation, settingsObj] = await Promise.all([getLocalisation(), settings.getAll()]);
+  const displayLocale = getDisplayLocaleFromLocalisation(localisation);
   const getLocalisationData = key => get(localisation, key);
   const getSettingData = key => get(settingsObj, key);
 
@@ -100,6 +102,7 @@ export const makeCovidVaccineCertificate = async ({
       getLocalisation={getLocalisationData}
       getSetting={getSettingData}
       primaryTimeZone={getPrimaryTimeZone(config)}
+      displayLocale={displayLocale}
       language={language}
     />,
     fileName,
@@ -117,6 +120,7 @@ export const makeVaccineCertificate = async ({
   translations,
 }) => {
   const [localisation, settingsObj] = await Promise.all([getLocalisation(), settings.getAll()]);
+  const displayLocale = getDisplayLocaleFromLocalisation(localisation);
   const getSettingData = key => get(settingsObj, key);
 
   const { title, subTitle } = await settings.get('templates.letterhead');
@@ -146,6 +150,7 @@ export const makeVaccineCertificate = async ({
       healthFacility={healthFacility}
       getSetting={getSettingData}
       primaryTimeZone={getPrimaryTimeZone(config)}
+      displayLocale={displayLocale}
     />,
     fileName,
   );
@@ -159,7 +164,8 @@ export const makeCovidCertificate = async ({
   patient,
   printedBy,
 }) => {
-  const settingsObj = await settings.getAll();
+  const [localisation, settingsObj] = await Promise.all([getLocalisation(), settings.getAll()]);
+  const displayLocale = getDisplayLocaleFromLocalisation(localisation);
   const getSettingData = key => get(settingsObj, key);
 
   const fileName = `covid-${certType}-certificate-${patient.id}.pdf`;
@@ -213,6 +219,7 @@ export const makeCovidCertificate = async ({
       printedBy={printedBy}
       getSetting={getSettingData}
       primaryTimeZone={getPrimaryTimeZone(config)}
+      displayLocale={displayLocale}
       certType={certType}
       language={language}
     />,

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -403,6 +403,8 @@
       // The time zone setting is currently only used for Vaccine Certificates
       // Todo: remove this timeZone once all date fields have been migrated to date_time_strings
       "timeZone": null,
+      // Optional BCP 47 tag for Intl date formatting on server PDFs (e.g. "en-NZ"). If omitted, uses en-{country.alpha-2}.
+      "displayLocale": null,
 
       "disabledReports": [],
       "supportDeskUrl": "https://bes-support.zendesk.com/hc/en-us"

--- a/packages/central-server/config/development.json5
+++ b/packages/central-server/config/development.json5
@@ -14,9 +14,9 @@
     "data": {
       "timeZone": "UTC",
       "country": {
-        "name": "Utopia",
-        "alpha-2": "UT",
-        "alpha-3": "UTO"
+        "name": "New Zealand",
+        "alpha-2": "NZ",
+        "alpha-3": "NZL"
       }
     }
   },

--- a/packages/central-server/config/test.json5
+++ b/packages/central-server/config/test.json5
@@ -52,9 +52,9 @@
     "data": {
       "timeZone": "UTC",
       "country": {
-        "name": "Utopia",
-        "alpha-2": "UT",
-        "alpha-3": "UTO"
+        "name": "New Zealand",
+        "alpha-2": "NZ",
+        "alpha-3": "NZL"
       },
       "imagingTypes": {
         "orthopantomography": { "label": "Orthopantomography" },

--- a/packages/facility-server/app/utils/makePatientLetter.jsx
+++ b/packages/facility-server/app/utils/makePatientLetter.jsx
@@ -6,12 +6,14 @@ import config from 'config';
 import { get } from 'lodash';
 
 import { SETTING_KEYS } from '@tamanu/constants';
+import { getDisplayLocaleFromLocalisation } from '@tamanu/utils/dateTime';
 import { PatientLetter, tmpdir } from '@tamanu/shared/utils';
 import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
 
 export const makePatientLetter = async (req, { id, facilityId, ...data }) => {
   const { getLocalisation, models, language, settings } = req;
   const localisation = await getLocalisation();
+  const displayLocale = getDisplayLocaleFromLocalisation(localisation);
   const getLocalisationData = key => get(localisation, key);
   const settingsObj = await settings[facilityId].getAll();
   const getSettingData = key => get(settingsObj, key);
@@ -40,6 +42,7 @@ export const makePatientLetter = async (req, { id, facilityId, ...data }) => {
       language={language}
       getSetting={getSettingData}
       primaryTimeZone={getPrimaryTimeZone(config)}
+      displayLocale={displayLocale}
     />,
     filePath,
   );

--- a/packages/shared/src/utils/pdf/withDateTimeContext.jsx
+++ b/packages/shared/src/utils/pdf/withDateTimeContext.jsx
@@ -17,7 +17,7 @@ export const useDateTime = () => {
 };
 
 export const withDateTimeContext = Component => props => {
-  const { settings, getSetting: getSettingProp, primaryTimeZone } = props;
+  const { settings, getSetting: getSettingProp, primaryTimeZone, displayLocale } = props;
   const getSetting = getSettingProp ?? (key => get(settings, key));
 
   const facilityTimeZone = getSetting('facilityTimeZone');
@@ -27,11 +27,14 @@ export const withDateTimeContext = Component => props => {
     () => ({
       primaryTimeZone,
       facilityTimeZone,
+      displayLocale,
       getCurrentDate: () => getCurrentDateStringInTimezone(effectiveTimeZone),
       getCurrentDateTime: () => getCurrentDateTimeStringInTimezone(primaryTimeZone),
-      ...mapValues(dateTimeFormatters, fn => date => fn(date, primaryTimeZone, facilityTimeZone)),
+      ...mapValues(dateTimeFormatters, fn => date =>
+        fn(date, primaryTimeZone, facilityTimeZone, displayLocale),
+      ),
     }),
-    [primaryTimeZone, facilityTimeZone, effectiveTimeZone],
+    [primaryTimeZone, facilityTimeZone, effectiveTimeZone, displayLocale],
   );
 
   return (

--- a/packages/utils/src/dateFormatters.ts
+++ b/packages/utils/src/dateFormatters.ts
@@ -6,8 +6,20 @@ const createFormatter =
     fallback: string,
     transform?: (result: string) => string,
   ) =>
-  (date: DateInput, primaryTimeZone: string, facilityTimeZone?: string | null): string => {
-    const result = intlFormatDate(date, formatOptions, fallback, primaryTimeZone, facilityTimeZone);
+  (
+    date: DateInput,
+    primaryTimeZone: string,
+    facilityTimeZone?: string | null,
+    displayLocale?: string | null,
+  ): string => {
+    const result = intlFormatDate(
+      date,
+      formatOptions,
+      fallback,
+      primaryTimeZone,
+      facilityTimeZone,
+      displayLocale,
+    );
     return transform ? transform(result) : result;
   };
 
@@ -70,13 +82,15 @@ export const formatShortDateTime = (
   date: DateInput,
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  displayLocale?: string | null,
 ) =>
-  `${formatShort(date, primaryTimeZone, facilityTimeZone)} ${formatTime(date, primaryTimeZone, facilityTimeZone)}`;
+  `${formatShort(date, primaryTimeZone, facilityTimeZone, displayLocale)} ${formatTime(date, primaryTimeZone, facilityTimeZone, displayLocale)}`;
 
 /** "12/04/24 12:30am" */
 export const formatShortestDateTime = (
   date: DateInput,
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  displayLocale?: string | null,
 ) =>
-  `${formatShortest(date, primaryTimeZone, facilityTimeZone)} ${formatTime(date, primaryTimeZone, facilityTimeZone)}`;
+  `${formatShortest(date, primaryTimeZone, facilityTimeZone, displayLocale)} ${formatTime(date, primaryTimeZone, facilityTimeZone, displayLocale)}`;

--- a/packages/utils/src/dateTime.ts
+++ b/packages/utils/src/dateTime.ts
@@ -200,6 +200,24 @@ export const differenceInMilliseconds = (a: number | string | Date, b: number | 
 
 export const locale = globalThis.navigator?.language ?? 'default';
 
+/**
+ * BCP 47 locale for Intl date formatting on the server (PDFs, reports) where `navigator` is unavailable.
+ * Uses `localisation.displayLocale` when set; otherwise `en-{country.alpha-2}` (e.g. en-NZ → dd/mm/yyyy).
+ */
+export const getDisplayLocaleFromLocalisation = (
+  localisation: {
+    displayLocale?: string | null;
+    country?: { 'alpha-2'?: string };
+  } | null | undefined,
+): string | undefined => {
+  const configured = localisation?.displayLocale?.trim();
+  if (configured) return configured;
+
+  const alpha2 = localisation?.country?.['alpha-2']?.toUpperCase();
+  if (!alpha2 || alpha2.length !== 2) return undefined;
+  return `en-${alpha2}`;
+};
+
 export const isStartOfThisWeek = (date: Date | number) =>
   isSameDay(date, startOfWeek(new Date(), { weekStartsOn: 1 }));
 
@@ -305,13 +323,16 @@ export const intlFormatDate = (
   fallback = 'Unknown',
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  displayLocale?: string | null,
 ) => {
   if (!date) return fallback;
+
+  const formatLocale = displayLocale?.trim() || locale;
 
   try {
     if (date instanceof Date) {
       if (!isValid(date)) return fallback;
-      return date.toLocaleString(locale, formatOptions);
+      return date.toLocaleString(formatLocale, formatOptions);
     }
 
     if (isISO9075DateString(date)) {
@@ -319,9 +340,9 @@ export const intlFormatDate = (
       const timeKeys = ['hour', 'minute', 'second', 'timeStyle', 'dayPeriod'] as const;
       const hasTimeOptions = timeKeys.some(key => key in formatOptions);
       if (hasTimeOptions) {
-        return plainDate.toPlainDateTime().toLocaleString(locale, formatOptions);
+        return plainDate.toPlainDateTime().toLocaleString(formatLocale, formatOptions);
       }
-      return plainDate.toLocaleString(locale, formatOptions);
+      return plainDate.toLocaleString(formatLocale, formatOptions);
     }
 
     const displayTz = getDisplayTimezone(primaryTimeZone, facilityTimeZone);
@@ -331,10 +352,10 @@ export const intlFormatDate = (
       return plain
         .toZonedDateTime(primaryTimeZone)
         .withTimeZone(displayTz)
-        .toLocaleString(locale, formatOptions);
+        .toLocaleString(formatLocale, formatOptions);
     }
 
-    return plain.toLocaleString(locale, formatOptions);
+    return plain.toLocaleString(formatLocale, formatOptions);
   } catch (error) {
     logDateError('intlFormatDate', error, date, primaryTimeZone, facilityTimeZone);
     return fallback;


### PR DESCRIPTION
### Changes

So this is a bit of a change as we're now using the `localisation` config for setting the locale when generating PDFs. Previously we were hard coding `en-NZ` style dates.

Have changed this so that we rely on a configured displayLocale or the localisation country. If neither works we fall back to default (en-US style). 

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->
<!-- - [ ] **Run Synthetic Tests (WIP)** **Target URL:** _https://your-target-url_ -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
