### PR TITLE
fix(appointments): no-issue: 2.52 fix: use primary timezone for upcoming appointments query

### DIFF
--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -16,6 +16,9 @@ import {
 import { NotFoundError, EditConflictError, InvalidOperationError } from '@tamanu/errors';
 import { replaceInTemplate } from '@tamanu/utils/replaceInTemplate';
 import { datetimeCustomValidation } from '@tamanu/utils/dateTime';
+import config from 'config';
+import { getPrimaryTimeZone } from '@tamanu/shared/utils/timeZoneCheck';
+import { getCurrentPrimaryTimeZoneDateTimeString } from '@tamanu/shared/utils/primaryDateTime';
 
 import { escapePatternWildcard } from '../../utils/query';
 
@@ -615,7 +618,7 @@ appointments.get(
         }
         WHERE patient_id = :patientId
           AND status != :cancelledStatus
-          AND start_time < NOW()::date_time_string
+          AND start_time < (NOW() AT TIME ZONE :primaryTimeZone)::date_time_string
           AND ${type === 'outpatient' ? 'location_groups.facility_id = :facilityId' : 'locations.facility_id = :facilityId'}
         LIMIT 1
       ) as "hasPastAppointment"
@@ -626,6 +629,7 @@ appointments.get(
           facilityId,
           cancelledStatus: APPOINTMENT_STATUSES.CANCELLED,
           typeColumn: type === 'outpatient' ? 'location_group_id' : 'location_id',
+          primaryTimeZone: getPrimaryTimeZone(config),
         },
         type: QueryTypes.SELECT,
       },
@@ -667,7 +671,7 @@ appointments.get(
       where: {
         patientId,
         status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED },
-        startTime: { [Op.gt]: literal("NOW()::date_time_string") },
+        startTime: { [Op.gt]: getCurrentPrimaryTimeZoneDateTimeString() },
         ...getAppointmentTypeWhereQuery(type, facilityId),
       },
       include: [

--- a/packages/facility-server/app/routes/apiv1/appointments.js
+++ b/packages/facility-server/app/routes/apiv1/appointments.js
@@ -667,7 +667,7 @@ appointments.get(
       where: {
         patientId,
         status: { [Op.not]: APPOINTMENT_STATUSES.CANCELLED },
-        startTime: { [Op.gt]: new Date() },
+        startTime: { [Op.gt]: literal("NOW()::date_time_string") },
         ...getAppointmentTypeWhereQuery(type, facilityId),
       },
       include: [


### PR DESCRIPTION
### Changes

The upcoming appointments endpoint on patient view was comparing `startTime` (stored as a timezone-naive string in the primary timezone) against JS `new Date()` (UTC). In non-UTC deployments (e.g. Pacific Islands at UTC+12/+13), this created a window where past appointments still appeared in the future appointments table. Fixed by using `NOW()::date_time_string`, matching the pattern already used by the `hasPastAppointments` endpoint.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->