### PR TITLE
fix: NOTAM-517: handle deleted survey when viewing referral form response

### DIFF
--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -21,7 +21,7 @@ surveyResponse.get(
     if (!surveyResponseRecord) {
       throw new NotFoundError('Survey response not found');
     }
-    const survey = await surveyResponseRecord.getSurvey({ paranoid: false });
+    const survey = await surveyResponseRecord.getSurvey();
     if (!survey) {
       throw new NotFoundError('Associated survey not found');
     }

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -18,7 +18,13 @@ surveyResponse.get(
     req.checkPermission('read', 'SurveyResponse');
 
     const surveyResponseRecord = await models.SurveyResponse.findByPk(params.id);
-    const survey = await surveyResponseRecord.getSurvey();
+    if (!surveyResponseRecord) {
+      throw new NotFoundError('Survey response not found');
+    }
+    const survey = await surveyResponseRecord.getSurvey({ paranoid: false });
+    if (!survey) {
+      throw new NotFoundError('Associated survey not found');
+    }
 
     req.checkPermission('read', survey);
 

--- a/packages/web/app/api/queries/useSurveyResponseQuery.js
+++ b/packages/web/app/api/queries/useSurveyResponseQuery.js
@@ -1,17 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { cloneDeep } from 'lodash';
-
 import { safeJsonParse } from '@tamanu/utils/safeJsonParse';
 import { PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 import { usePatientDataDisplayValue } from '@tamanu/ui-components';
-
 import { useApi } from '../useApi';
 
-export const useSurveyResponseQuery = surveyResponseId => {
+export const useSurveyResponseQuery = (surveyResponseId, options = {}) => {
   const api = useApi();
   return useQuery(
     ['surveyResponse', surveyResponseId],
-    () => api.get(`surveyResponse/${surveyResponseId}`),
+    () => api.get(`surveyResponse/${surveyResponseId}`, {}, options),
     { enabled: !!surveyResponseId },
   );
 };
@@ -53,10 +51,7 @@ export const useTransformedSurveyResponseQuery = surveyResponseId => {
               ? sourceConfig
               : originalConfig;
 
-          const displayValue = await getDisplayValue(
-            answer.originalBody,
-            safeJsonParse(config),
-          );
+          const displayValue = await getDisplayValue(answer.originalBody, safeJsonParse(config));
           return {
             dataElementId: answer.dataElementId,
             displayValue,

--- a/packages/web/app/components/ReferralTable.jsx
+++ b/packages/web/app/components/ReferralTable.jsx
@@ -33,7 +33,7 @@ const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
 
   useEffect(() => {
     (async () => {
-      const referralByComponent = survey.components.find(({ dataElement }) =>
+      const referralByComponent = survey?.components?.find(({ dataElement }) =>
         fieldNames.includes(dataElement.name),
       );
       if (!referralByComponent) {
@@ -70,7 +70,7 @@ const ReferralBy = ({ surveyResponse: { survey, answers } }) => {
 const getDate = ({ surveyResponse: { submissionDate } }) => {
   return <DateDisplay date={submissionDate} data-testid="datedisplay-qbev" />;
 };
-const getReferralType = ({ surveyResponse: { survey } }) => survey.name;
+const getReferralType = ({ surveyResponse: { survey } }) => survey?.name;
 const getReferralBy = ({ surveyResponse }) => (
   <ReferralBy surveyResponse={surveyResponse} data-testid="referralby-eov4" />
 );

--- a/packages/web/app/components/SurveyResponseDetailsModal.jsx
+++ b/packages/web/app/components/SurveyResponseDetailsModal.jsx
@@ -8,6 +8,7 @@ import { Table } from './Table';
 import { useSurveyResponseQuery } from '../api/queries/useSurveyResponseQuery';
 import { ModalCancelRow } from './ModalActionRow';
 import { SurveyAnswerResult } from './SurveyAnswerResult';
+import { isErrorUnknownAllow404s } from '../api/index.js';
 
 const SectionSpacing = styled.div`
   height: 14px;
@@ -68,34 +69,15 @@ function shouldShow(component) {
 }
 
 export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose, onPrint }) => {
-  const { data: surveyDetails, isLoading, error } = useSurveyResponseQuery(surveyResponseId);
-  if (error) {
-    return (
-      <Modal
-        title={
-          <TranslatedText
-            stringId="surveyResponse.modal.details.title"
-            fallback="Form response"
-            data-testid="translatedtext-y8ns"
-          />
-        }
-        open={!!surveyResponseId}
-        onClose={onClose}
-        data-testid="modal-vzvm"
-      >
-        <h3>
-          <TranslatedText
-            stringId="surveyResponse.modal.details.error.fetchErrorMessage"
-            fallback="Error fetching response details"
-            data-testid="translatedtext-b9js"
-          />
-        </h3>
-        <pre>{error.stack}</pre>
-      </Modal>
-    );
-  }
+  const {
+    data: surveyDetails,
+    isLoading,
+    error,
+  } = useSurveyResponseQuery(surveyResponseId, { isErrorUnknown: isErrorUnknownAllow404s });
 
-  if (isLoading || !surveyDetails) {
+  if (isLoading || !surveyDetails || error) {
+    const isNotFound = error?.status === 404;
+
     return (
       <Modal
         title={
@@ -109,11 +91,27 @@ export const SurveyResponseDetailsModal = ({ surveyResponseId, onClose, onPrint 
         onClose={onClose}
         data-testid="modal-qnfv"
       >
-        <TranslatedText
-          stringId="general.table.loading"
-          fallback="Loading…"
-          data-testid="translatedtext-ec13"
-        />
+        {isNotFound ? (
+          <TranslatedText
+            stringId={
+              isNotFound
+                ? 'surveyResponse.modal.details.error.formDeleted'
+                : 'surveyResponse.modal.details.error.fetchErrorMessage'
+            }
+            fallback={
+              isNotFound
+                ? 'This form has been deleted and is no longer available.'
+                : 'Error fetching response details'
+            }
+            data-testid="translatedtext-b9js"
+          />
+        ) : (
+          <TranslatedText
+            stringId="general.table.loading"
+            fallback="Loading…"
+            data-testid="translatedtext-ec13"
+          />
+        )}
       </Modal>
     );
   }


### PR DESCRIPTION
### Changes

When a referral\'s linked program is deleted, the associated survey is soft-deleted. Viewing the referral form response would crash because the `GET surveyResponse\/:id` endpoint didn\'t handle a null survey. This adds a null check for the survey response record and uses `paranoid: false` on `getSurvey()` so the soft-deleted survey is still retrieved for permission checking.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->