### PR TITLE
fix(programRegistry): no-issue: 2.52 fix: sort by patient name in program registry table

### DIFF
--- a/packages/facility-server/app/routes/apiv1/programRegistry.js
+++ b/packages/facility-server/app/routes/apiv1/programRegistry.js
@@ -275,6 +275,7 @@ programRegistry.get(
     }
     const sortKeys = {
       displayId: 'patient.display_id',
+      patientName: 'UPPER(patient.last_name)',
       firstName: 'UPPER(patient.first_name)',
       lastName: 'UPPER(patient.last_name)',
       dateOfBirth: 'patient.date_of_birth',


### PR DESCRIPTION
### Changes

The program registry table\'s "Patient name" column sorting was broken — the frontend sends `orderBy: \'patientName\'` but the backend `sortKeys` map had no entry for it, so it silently fell back to `displayId` sorting, making the order appear random. Added `patientName` to the sort keys map, sorting by last name (case-insensitive).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->