### PR TITLE
fix: No-issue: E2E fix and standardise dateTime handling

### DIFF
--- a/.github/scripts/e2e-test-setup.sh
+++ b/.github/scripts/e2e-test-setup.sh
@@ -17,6 +17,10 @@ e2e_test_setup_setup_central() {
     cat <<- EOF > packages/central-server/config/local.json5
     {
         "port": "3000",
+        "countryTimeZone": "Pacific/Auckland",
+        "auth": {
+            "tokenDuration": "24h"
+        },
         "db": {
             "host": "localhost",
             "name": "central",
@@ -36,7 +40,7 @@ e2e_test_setup_setup_central() {
                     "alpha-2": "UT",
                     "alpha-3": "UTO"
                 },
-                "timeZone": "UTC",
+                "timeZone": "Pacific/Auckland",
                 "imagingTypes": {
                     "orthopantomography": { "label": "Orthopantomography" },
                     "xRay": { "label": "X-Ray" },
@@ -130,6 +134,10 @@ e2e_test_setup_setup_facility() {
 	cat <<- EOF > packages/facility-server/config/local.json5
 	{
 	    "port": "4000",
+	    "countryTimeZone": "Pacific/Auckland",
+	    "auth": {
+	        "tokenDuration": "24h"
+	    },
 	    "serverFacilityIds": ["facility-1"],
 	    "sync": {
 	        "email": "facility-1@tamanu.io",

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -44,19 +44,26 @@ jobs:
           node-version-file: '.node-version'
           cache: npm
       - uses: actions/cache/restore@v3
+        id: cache
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
-      - run: npm ci
-      - uses: actions/cache/save@v3
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
         with:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
   e2e:
     needs: node_modules_cache
-    name: E2E Tests
+    name: E2E Tests ${{ matrix.shard }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
     env:
       FACILITY_FRONTEND_URL: http://localhost:5173
       ADMIN_FRONTEND_URL: http://localhost:5174
@@ -79,8 +86,10 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           path: ${{ env.NODE_MODULES_PATHS }}
 
-      - run: npm ci
-      - run: npm run build
+      - run: npm i
+      - run: npm run build-shared
+      - run: npm run --workspace @tamanu/central-server build
+      - run: npm run --workspace @tamanu/facility-server build
 
       - name: Setup postgres dbs
         run: |
@@ -95,13 +104,12 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
-        run: npm run e2e-test
-      - name: Upload test results
-        if: failure()
+        run: npx playwright test --shard=${{ matrix.shard }}
+        working-directory: packages/e2e-tests
+      - name: Upload blob report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: |
-            packages/e2e-tests/playwright-report/
-            packages/e2e-tests/test-results/
-          retention-days: 30
+          name: blob-report-${{ strategy.job-index }}
+          path: packages/e2e-tests/blob-report/
+          retention-days: 7

--- a/packages/e2e-tests/pages/patients/AllPatientsPage.ts
+++ b/packages/e2e-tests/pages/patients/AllPatientsPage.ts
@@ -4,7 +4,11 @@ import { BasePatientListPage, BaseSearchCriteria } from './BasePatientListPage';
 import { selectAutocompleteFieldOption } from '../../utils/fieldHelpers';
 import { RecentlyViewedPatientsList } from './RecentlyViewedPatientsList';
 import { expect } from '../../fixtures/baseFixture';
-import { convertDateFormat, STYLED_TABLE_CELL_PREFIX } from '../../utils/testHelper';
+import {
+  convertDateFormat,
+  fillMuiDateField,
+  STYLED_TABLE_CELL_PREFIX,
+} from '../../utils/testHelper';
 import { ERROR_RED_RGB } from '@utils/testColors';
 
 export const TWO_COLUMNS_FIELD_TEST_ID = 'twocolumnsfield-wg4x';
@@ -62,7 +66,7 @@ export class AllPatientsPage extends BasePatientListPage {
   constructor(page: Page) {
     super(page, routes.patients.all);
     this.recentlyViewedPatientsList = new RecentlyViewedPatientsList(page);
-    
+
     // TestId mapping for AllPatients page elements
     const testIds = {
       // Override base locators with AllPatients-specific test IDs
@@ -75,7 +79,7 @@ export class AllPatientsPage extends BasePatientListPage {
       nhnInput: 'localisedfield-dzml-input',
       firstNameInput: 'localisedfield-i9br-input',
       lastNameInput: 'localisedfield-ngsn-input',
-      
+
       // AllPatients-specific locators
       addNewPatientBtn: 'component-enxe',
       NewPatientFirstName: 'localisedfield-cqua-input',
@@ -89,7 +93,7 @@ export class AllPatientsPage extends BasePatientListPage {
       nhnResultCell: 'styledtablecell-2gyy-0-displayId',
       secondNHNResultCell: 'styledtablecell-2gyy-1-displayId',
       NHNInput: 'localisedfield-dzml-input',
-      DOBInput: 'field-qk60-input',
+      DOBInput: 'field-qk60',
       culturalNameInput: 'localisedfield-epbq-input',
       villageSearchBox: 'villagelocalisedfield-mcri-input',
       newPatientVillageSearchBox: 'localisedfield-rpma-input',
@@ -99,8 +103,8 @@ export class AllPatientsPage extends BasePatientListPage {
       villageSuggestionList: 'villagelocalisedfield-mcri-suggestionslist',
       sexDropDownIcon: 'sexlocalisedfield-7lm9-expandmoreicon-h115',
       sexDropDownCrossIcon: 'stylediconbutton-6vh3',
-      DOBFromTxt: 'joinedfield-swzm-input',
-      DOBToTxt: 'field-aax5-input',
+      DOBFromTxt: 'joinedfield-swzm',
+      DOBToTxt: 'field-aax5',
       clearSearchBtn: 'clearbutton-z9x3',
       patientPageRecordCount25: 'styledmenuitem-fkrw-undefined',
       patientPageRecordCount50: 'styledmenuitem-fkrw-undefined',
@@ -116,7 +120,7 @@ export class AllPatientsPage extends BasePatientListPage {
     for (const [key, id] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(id);
     }
-    
+
     // Override specific locators that need additional processing
     this.tableRows = page.getByTestId('styledtablebody-a0jz').locator('tr');
     this.NewPatientDOBtxt = page.getByTestId('localisedfield-oafl-input').getByRole('textbox');
@@ -126,17 +130,28 @@ export class AllPatientsPage extends BasePatientListPage {
     this.searchResultsPaginationOneOfOne = page
       .getByTestId('pagerecordcount-m8ne')
       .filter({ hasText: '1–1 of 1' });
-    this.DOBInput = page.getByTestId('field-qk60-input').locator('input[type="date"]');
-    this.newPatientVillageSearchBox = page.getByTestId('localisedfield-rpma-input').locator('input');
-    this.villageSuggestionList = page.getByTestId('villagelocalisedfield-mcri-suggestionslist').locator('ul').locator('li');
-    this.DOBFromTxt = page.getByTestId('joinedfield-swzm-input').locator('input[type="date"]');
-    this.DOBToTxt = page.getByTestId('field-aax5-input').locator('input[type="date"]');
-    this.patientPageRecordCount25 = page.getByTestId('styledmenuitem-fkrw-undefined').getByText('25');
-    this.patientPageRecordCount50 = page.getByTestId('styledmenuitem-fkrw-undefined').getByText('50');
+    this.DOBInput = page.getByTestId('field-qk60').getByRole('textbox');
+    this.newPatientVillageSearchBox = page
+      .getByTestId('localisedfield-rpma-input')
+      .locator('input');
+    this.villageSuggestionList = page
+      .getByTestId('villagelocalisedfield-mcri-suggestionslist')
+      .locator('ul')
+      .locator('li');
+    this.DOBFromTxt = page.getByTestId('joinedfield-swzm').getByRole('textbox');
+    this.DOBToTxt = page.getByTestId('field-aax5').getByRole('textbox');
+    this.patientPageRecordCount25 = page
+      .getByTestId('styledmenuitem-fkrw-undefined')
+      .getByText('25');
+    this.patientPageRecordCount50 = page
+      .getByTestId('styledmenuitem-fkrw-undefined')
+      .getByText('50');
     this.patientPage2 = page.getByTestId('paginationitem-c5vg').getByText('2');
     this.firstNameSortButton = page.getByTestId('tablesortlabel-0qxx-firstName').locator('svg');
     this.lastNameSortButton = page.getByTestId('tablesortlabel-0qxx-lastName').locator('svg');
-    this.culturalNameSortButton = page.getByTestId('tablesortlabel-0qxx-culturalName').locator('svg');
+    this.culturalNameSortButton = page
+      .getByTestId('tablesortlabel-0qxx-culturalName')
+      .locator('svg');
     this.villageSortButton = page.getByTestId('tablesortlabel-0qxx-villageName').locator('svg');
     this.dobSortButton = page.getByTestId('tablesortlabel-0qxx-dateOfBirth').locator('svg');
   }
@@ -164,7 +179,7 @@ export class AllPatientsPage extends BasePatientListPage {
     await this.NewPatientLastName.fill(lastName);
 
     await this.NewPatientDOBtxt.click();
-    await this.NewPatientDOBtxt.fill(dob);
+    await fillMuiDateField(this.NewPatientDOBtxt, dob);
 
     if (gender === 'female') {
       await this.NewPatientFemaleChk.check();
@@ -189,32 +204,33 @@ export class AllPatientsPage extends BasePatientListPage {
       await this.lastNameInput.fill(searchCriteria.lastName);
     }
     if (searchCriteria.DOB) {
-      await this.DOBInput.fill(searchCriteria.DOB);
+      await fillMuiDateField(this.DOBInput, searchCriteria.DOB);
     }
     if (searchCriteria.culturalName) {
       await this.culturalNameInput.fill(searchCriteria.culturalName);
     }
     if (searchCriteria.village) {
-      await selectAutocompleteFieldOption(
-        this.page,
-        this.villageSearchBox,
-        { optionToSelect: searchCriteria.village }
-      );
+      await selectAutocompleteFieldOption(this.page, this.villageSearchBox, {
+        optionToSelect: searchCriteria.village,
+      });
     }
-    if (searchCriteria.sex){
+    if (searchCriteria.sex) {
       await this.sexDropDownIcon.click();
-      await this.page.getByTestId(TWO_COLUMNS_FIELD_TEST_ID).getByText(new RegExp(`^${searchCriteria.sex}$`, 'i')).click();
+      await this.page
+        .getByTestId(TWO_COLUMNS_FIELD_TEST_ID)
+        .getByText(new RegExp(`^${searchCriteria.sex}$`, 'i'))
+        .click();
     }
     if (searchCriteria.deceased) {
       await this.includeDeceasedChk.check();
     }
     if (searchCriteria.DOBFrom) {
-      await this.DOBFromTxt.fill(searchCriteria.DOBFrom);
+      await fillMuiDateField(this.DOBFromTxt, searchCriteria.DOBFrom);
     }
     if (searchCriteria.DOBTo) {
-      await this.DOBToTxt.fill(searchCriteria.DOBTo);
+      await fillMuiDateField(this.DOBToTxt, searchCriteria.DOBTo);
     }
-    
+
     await this.searchBtn.click();
   }
 
@@ -236,7 +252,7 @@ export class AllPatientsPage extends BasePatientListPage {
     const lowerExpectedText = expectedText.toLowerCase();
     for (let i = 0; i < rowCount; i++) {
       const row = this.tableRows.nth(i);
-      const locatorText = STYLED_TABLE_CELL_PREFIX + i + "-" + columnName;
+      const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-' + columnName;
       const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
       const cellText = await cellLocator.textContent();
       const actualText = cellText || '';
@@ -253,7 +269,7 @@ export class AllPatientsPage extends BasePatientListPage {
     const row = this.tableRows.nth(rowIndex);
     const cells = row.locator('td');
     const cellCount = await cells.count();
-    
+
     for (let i = 1; i < cellCount; i++) {
       const cell = cells.nth(i);
       await expect(cell).toHaveCSS('color', ERROR_RED_RGB);
@@ -263,11 +279,11 @@ export class AllPatientsPage extends BasePatientListPage {
   // Validate date in all rows for a specific column
   async validateAllRowsDateMatches(expectedDate: string) {
     const rowCount = await this.tableRows.count();
-    const convertedExpectedDate = await convertDateFormat(expectedDate);  
-    
+    const convertedExpectedDate = await convertDateFormat(expectedDate);
+
     for (let i = 0; i < rowCount; i++) {
       const row = await this.tableRows.nth(i);
-      const locatorText = STYLED_TABLE_CELL_PREFIX + i + "-dateOfBirth";
+      const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-dateOfBirth';
       const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
       await expect(cellLocator).toHaveText(convertedExpectedDate);
     }
@@ -286,47 +302,50 @@ export class AllPatientsPage extends BasePatientListPage {
   }
 
   async validateSortOrder(isAscending: boolean, columnName: string) {
-    const rowCount = await this.tableRows.count();
-    const Values: string[] = [];
-    
-    for (let i = 0; i < rowCount; i++) {
-      const row = this.tableRows.nth(i);
-      const locatorText = STYLED_TABLE_CELL_PREFIX + i + "-"+columnName;
-      const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
-      const cellText = await cellLocator.textContent();
-      if (cellText) Values.push(cellText);
-    }
+    await expect(async () => {
+      const rowCount = await this.tableRows.count();
+      const Values: string[] = [];
 
-    const sortedValues = [...Values].sort((a, b) => {
-      return isAscending ? a.localeCompare(b) : b.localeCompare(a);
-    });
+      for (let i = 0; i < rowCount; i++) {
+        const row = this.tableRows.nth(i);
+        const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-' + columnName;
+        const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
+        const cellText = await cellLocator.textContent();
+        if (cellText) Values.push(cellText);
+      }
 
-    expect(Values).toEqual(sortedValues);
+      const sortedValues = [...Values].sort((a, b) => {
+        return isAscending ? a.localeCompare(b) : b.localeCompare(a);
+      });
+
+      expect(Values).toEqual(sortedValues);
+    }).toPass({ timeout: 10000 });
   }
 
   async validateDateSortOrder(isAscending: boolean) {
-    const rowCount = await this.tableRows.count();
-    const dateValues: string[] = [];
-    
-    for (let i = 0; i < rowCount; i++) {
-      const row = this.tableRows.nth(i);
-      const locatorText = STYLED_TABLE_CELL_PREFIX + i + "-dateOfBirth";
-      const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
-      const cellText = await cellLocator.textContent();
-      if (cellText) dateValues.push(cellText);
-    }
+    await expect(async () => {
+      const rowCount = await this.tableRows.count();
+      const dateValues: string[] = [];
 
-    const sortedValues = [...dateValues].sort((a, b) => {
-      // Convert MM/DD/YYYY to YYYY-MM-DD for proper date comparison
-      const [monthA, dayA, yearA] = a.split('/');
-      const [monthB, dayB, yearB] = b.split('/');
-      const dateA = `${yearA}-${monthA.padStart(2, '0')}-${dayA.padStart(2, '0')}`;
-      const dateB = `${yearB}-${monthB.padStart(2, '0')}-${dayB.padStart(2, '0')}`;
-      return isAscending 
-        ? new Date(dateA).getTime() - new Date(dateB).getTime()
-        : new Date(dateB).getTime() - new Date(dateA).getTime();
-    });
-    expect(dateValues).toEqual(sortedValues);
+      for (let i = 0; i < rowCount; i++) {
+        const row = this.tableRows.nth(i);
+        const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-dateOfBirth';
+        const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
+        const cellText = await cellLocator.textContent();
+        if (cellText) dateValues.push(cellText);
+      }
+
+      const sortedValues = [...dateValues].sort((a, b) => {
+        const [monthA, dayA, yearA] = a.split('/');
+        const [monthB, dayB, yearB] = b.split('/');
+        const dateA = `${yearA}-${monthA.padStart(2, '0')}-${dayA.padStart(2, '0')}`;
+        const dateB = `${yearB}-${monthB.padStart(2, '0')}-${dayB.padStart(2, '0')}`;
+        return isAscending
+          ? new Date(dateA).getTime() - new Date(dateB).getTime()
+          : new Date(dateB).getTime() - new Date(dateA).getTime();
+      });
+      expect(dateValues).toEqual(sortedValues);
+    }).toPass({ timeout: 10000 });
   }
   async searchForAndSelectPatientByNHN(nhn: string, maxAttempts = 100) {
     let attempts = 0;

--- a/packages/e2e-tests/pages/patients/BasePatientListPage.ts
+++ b/packages/e2e-tests/pages/patients/BasePatientListPage.ts
@@ -129,10 +129,9 @@ export abstract class BasePatientListPage extends BasePage {
     await this.patientTable.waitForTableToLoad();
   }
 
-  // Validate that at least one row is displayed after search
+  // Validate that at least one data row is displayed (not an empty/loading status row)
   async validateAtLeastOneSearchResult() {
-    const count = await this.tableRows.count();
-    await expect(count).toBeGreaterThanOrEqual(1);
+    await expect(this.tableBody.getByTestId(`${STYLED_TABLE_CELL_PREFIX}0-displayId`)).toBeVisible();
   }
 
   // Abstract method for field validation - each page has different fields
@@ -182,60 +181,63 @@ export abstract class BasePatientListPage extends BasePage {
 
   // Validate that a specific row appears
   async validateFirstRowContainsNHN(expectedText: string) {
-    const firstRowNHN = this.page.getByTestId(`${STYLED_TABLE_CELL_PREFIX}0-displayId`);
+    const firstRowNHN = this.tableBody.getByTestId(`${STYLED_TABLE_CELL_PREFIX}0-displayId`);
     await expect(firstRowNHN).toHaveText(expectedText);
   }
 
-  // Validate that there is only one row displayed after search
+  // Validate that there is only one data row displayed after search
   async validateOneSearchResult() {
-    const rowCount = await this.tableRows.count();
-    await expect(rowCount).toBe(1);
+    await expect(this.tableBody.getByTestId(`${STYLED_TABLE_CELL_PREFIX}0-displayId`)).toBeVisible();
+    await expect(this.tableRows).toHaveCount(1);
   }
 
   async validateSortOrder(isAscending: boolean, columnName: string) {
-    const rowCount = await this.tableRows.count();
-    const Values: string[] = [];
+    await expect(async () => {
+      const rowCount = await this.tableRows.count();
+      const Values: string[] = [];
 
-    for (let i = 0; i < rowCount; i++) {
-      const row = this.tableRows.nth(i);
-      const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-' + columnName;
-      const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
-      const cellText = await cellLocator.textContent();
-      if (cellText) Values.push(cellText);
-    }
+      for (let i = 0; i < rowCount; i++) {
+        const row = this.tableRows.nth(i);
+        const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-' + columnName;
+        const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
+        const cellText = await cellLocator.textContent();
+        if (cellText) Values.push(cellText);
+      }
 
-    const sortedValues = [...Values].sort((a, b) => {
-      return isAscending ? a.localeCompare(b) : b.localeCompare(a);
-    });
+      const sortedValues = [...Values].sort((a, b) => {
+        return isAscending ? a.localeCompare(b) : b.localeCompare(a);
+      });
 
-    expect(Values).toEqual(sortedValues);
+      expect(Values).toEqual(sortedValues);
+    }).toPass({ timeout: 10000 });
   }
 
   async validateDateSortOrder(isAscending: boolean) {
-    const rowCount = await this.tableRows.count();
-    const dateValues: string[] = [];
+    await expect(async () => {
+      const rowCount = await this.tableRows.count();
+      const dateValues: string[] = [];
 
-    for (let i = 0; i < rowCount; i++) {
-      const row = this.tableRows.nth(i);
-      const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-dateOfBirth';
-      const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
-      const cellText = await cellLocator.textContent();
-      if (cellText) dateValues.push(cellText);
-    }
+      for (let i = 0; i < rowCount; i++) {
+        const row = this.tableRows.nth(i);
+        const locatorText = STYLED_TABLE_CELL_PREFIX + i + '-dateOfBirth';
+        const cellLocator = row.locator(`[data-testid="${locatorText}"]`);
+        const cellText = await cellLocator.textContent();
+        if (cellText) dateValues.push(cellText);
+      }
 
-    const sortedValues = [...dateValues].sort((a, b) => {
-      // Convert MM/DD/YYYY to YYYY-MM-DD for proper date comparison
-      const [monthA, dayA, yearA] = a.split('/');
-      const [monthB, dayB, yearB] = b.split('/');
-      const dateA = new Date(
-        `${yearA}-${monthA.padStart(2, '0')}-${dayA.padStart(2, '0')}`,
-      ).getTime();
-      const dateB = new Date(
-        `${yearB}-${monthB.padStart(2, '0')}-${dayB.padStart(2, '0')}`,
-      ).getTime();
-      return isAscending ? dateA - dateB : dateB - dateA;
-    });
-    expect(dateValues).toEqual(sortedValues);
+      const sortedValues = [...dateValues].sort((a, b) => {
+        const [monthA, dayA, yearA] = a.split('/');
+        const [monthB, dayB, yearB] = b.split('/');
+        const dateA = new Date(
+          `${yearA}-${monthA.padStart(2, '0')}-${dayA.padStart(2, '0')}`,
+        ).getTime();
+        const dateB = new Date(
+          `${yearB}-${monthB.padStart(2, '0')}-${dayB.padStart(2, '0')}`,
+        ).getTime();
+        return isAscending ? dateA - dateB : dateB - dateA;
+      });
+      expect(dateValues).toEqual(sortedValues);
+    }).toPass({ timeout: 10000 });
   }
 
   async searchForAndSelectPatientByNHN(nhn: string, maxAttempts = 100) {

--- a/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
+++ b/packages/e2e-tests/pages/patients/ChartsPage/modals/SimpleChartModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectFieldOption } from '../../../../utils/fieldHelpers';
+import { fillMuiDateTimeField } from '@utils/testHelper';
 
 export interface SimpleChartFormValues {
     dateTime?: string;
@@ -98,7 +99,7 @@ export class SimpleChartModal {
     let leftPupilsReaction: string | undefined;
 
     if (values.dateTime) {
-      await this.dateTimeInput.fill(values.dateTime);
+      await fillMuiDateTimeField(this.dateTimeInput, values.dateTime);
     }
     if (values.gcsEyeOpening) {
       gcsEyeOpening = await selectFieldOption(this.page, this.gcsEyeOpeningSelect, {

--- a/packages/e2e-tests/pages/patients/ChartsPage/panes/ChartsPane.ts
+++ b/packages/e2e-tests/pages/patients/ChartsPage/panes/ChartsPane.ts
@@ -13,14 +13,10 @@ export class ChartsPane {
   constructor(page: Page) {
     this.page = page;
 
-    const testIds = {
-      recordChartButton: 'component-enxe',
-      chartTypeSelect: 'styledtranslatedselectfield-vwze-select',
-    } as const;
-
-    for (const [key, id] of Object.entries(testIds)) {
-      (this as any)[key] = page.getByTestId(id);
-    }
+    this.chartTypeSelect = page.getByTestId('styledtranslatedselectfield-vwze-select');
+    this.recordChartButton = page
+      .getByTestId('tablebuttonrowwrapper-srjx')
+      .getByRole('button', { name: 'Record' });
   }
 
   async waitForPageToLoad(): Promise<void> {
@@ -58,7 +54,7 @@ async getLatestValuesFromChartsTable(page: Page, fieldKeys: readonly string[]): 
   if (!dateTimeColumn) throw new Error(`Could not extract date/time from header: ${headerTestId}`);
   
   // Format dateTime
-  const dateTimeFormatted = format(parse(dateTimeColumn, 'yyyy-MM-dd HH:mm:ss', new Date()), 'yyyy-MM-dd\'T\'HH:mm');
+  const dateTimeFormatted = format(parse(dateTimeColumn, 'yyyy-MM-dd HH:mm:ss', new Date()), 'dd/MM/yyyy hh:mm a');
   
   // Field mappings
   const measureNameMap: Record<string, string> = {

--- a/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
+++ b/packages/e2e-tests/pages/patients/ImagingRequestPage/modals/NewImagingRequestModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption, selectFieldOption } from '../../../../utils/fieldHelpers';
+import { fillMuiDateTimeField } from '@utils/testHelper';
 
 export interface ImagingRequestFormValues {
   orderDateTime?: string;
@@ -36,7 +37,7 @@ export class NewImagingRequestModal {
 
     const testIds = {
       imagingRequestCodeInput: 'field-6jew-input',
-      orderDateTimeField: 'field-xsta-input',
+      orderDateTimeField: 'field-xsta',
       supervisingClinicianInput: 'textinput-3wnq-input',
       requestingClinicianField: 'field-g6kl-input',
       requestingClinicianClearButton: 'field-g6kl-input-clearbutton',
@@ -76,7 +77,7 @@ export class NewImagingRequestModal {
     } = values;
 
     if (orderDateTime) {
-      await this.orderDateTimeInput.fill(orderDateTime);
+      await fillMuiDateTimeField(this.orderDateTimeInput, orderDateTime);
     }
 
     let selectedRequestingClinician: string | undefined;

--- a/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/LabRequestDetailsPage.ts
@@ -1,5 +1,6 @@
 import { Page, Locator, expect } from '@playwright/test';
 import { format } from 'date-fns';
+import { fillMuiDateTimeField } from '../../../utils/testHelper';
 import { RecordSampleModal } from './modals/RecordSampleModal';
 import { StatusLogModal } from './modals/StatusLogModal';
 import { ChangeLaboratoryModal } from './modals/ChangeLaboratoryModal';
@@ -112,7 +113,7 @@ export class LabRequestDetailsPage {
     this.backButton = page.getByTestId('backbutton-1n40');
     this.testCategoryValue = page.getByTestId('fixedtilerow-xxmq').locator('[data-testid="container-uk3i"]').first().getByTestId('main-vs6r');
     this.statusValue = page.getByTestId('fixedtilerow-xxmq').locator('[data-testid="container-uk3i"]').nth(1).getByTestId('tiletag-zdg8');
-    this.sampleCollectedValue = page.getByTestId('fixedtilerow-xxmq').locator('[data-testid="container-uk3i"]').nth(2).getByTestId('tooltip-b4e8');
+    this.sampleCollectedValue = page.getByTestId('fixedtilerow-xxmq').locator('[data-testid="container-uk3i"]').nth(2).getByTestId('datedisplay-h6el');
     this.laboratoryValue = page.getByTestId('fixedtilerow-xxmq').locator('[data-testid="container-uk3i"]').nth(3).getByTestId('main-vs6r');
     this.priorityValue = page.getByTestId('fixedtilerow-xxmq').locator('[data-testid="container-uk3i"]').nth(4).getByTestId('main-vs6r');
 
@@ -293,7 +294,7 @@ export class LabRequestDetailsPage {
     await this.enterResultsModal.selectLabTestMethod(labTestMethod);
     await this.enterResultsModal.verificationFirstRow.fill(verification);
     const dateToUse = completedDate || format(new Date(), "yyyy-MM-dd'T'HH:mm");
-    await this.enterResultsModal.completedDateFirstRow.fill(dateToUse);
+    await fillMuiDateTimeField(this.enterResultsModal.completedDateFirstRow, dateToUse);
     await this.enterResultsModal.confirmButton.click();
   }
 }

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/LabRequestModalBase.ts
@@ -1,8 +1,7 @@
 import { Locator, Page, expect } from '@playwright/test';
 import { PatientDetailsPage } from '@pages/patients/PatientDetailsPage';
 import { createApiContext, getUser } from '../../../../utils/apiHelpers';
-import { format } from 'date-fns';
-import { getTableItems } from '../../../../utils/testHelper';
+import { fillMuiDateTimeField, getTableItems, normalizeToIsoDateTimeMinute } from '../../../../utils/testHelper';
 
 const CATEGORY_TEXT_TEST_ID = 'categorytext-jno3';
 
@@ -77,7 +76,7 @@ export class LabRequestModalBase {
       heading: 'heading3-keat',
       description: 'styledbodytext-8egc',
       requestingClinicianInput: 'field-z6gb-input',
-      requestDateTimeInput: 'field-y6ku-input',
+      requestDateTimeField: 'field-y6ku',
       departmentInput: 'field-wobc-input',
       prioritySelect: 'selectinput-phtg-select',
       panelRadioButton: 'radio-il3t-panel',
@@ -126,7 +125,7 @@ export class LabRequestModalBase {
     
     // Special cases that need additional processing
     this.requestingClinicianInput = page.getByTestId('field-z6gb-input').locator('input');
-    this.requestDateTimeInput = page.getByTestId('field-y6ku-input').locator('input');
+    this.requestDateTimeInput = page.getByTestId('field-y6ku').locator('input');
     this.departmentInput = page.getByTestId('field-wobc-input').locator('input');
     // Scope prioritySelect to the visible form grid to avoid strict mode violations
     this.prioritySelect = page.getByTestId('formgrid-wses').getByTestId('selectinput-phtg-select');
@@ -135,9 +134,9 @@ export class LabRequestModalBase {
     this.selectedItemsList = page.getByTestId('testitemwrapper-o7ha').getByTestId('labeltext-6stl');
     this.listItems = page.getByTestId('selectortable-dwrp').getByTestId('labeltext-6stl');
     this.selectedCategoryList = page.getByTestId('testitemwrapper-o7ha').getByTestId('categorytext-jno3');
-    this.collectedByInputs = page.getByTestId('styledfield-wifm-input').locator('input');
-    this.specimenTypeInputs = page.getByTestId('styledfield-8g4b-input').locator('input');
-    this.siteInputs = page.getByTestId('styledfield-mog8-input').locator('input');
+    this.collectedByInputs = page.getByTestId('styledfield-wifm-input');
+    this.specimenTypeInputs = page.getByTestId('styledfield-8g4b-input');
+    this.siteInputs = page.getByTestId('styledfield-mog8-input');
     this.requestingClinicianLabel = page.getByTestId('cardlabel-6kys').filter({ hasText: 'Requesting clinician' });
     this.requestingClinicianValue = this.requestingClinicianLabel.locator('..').getByTestId('cardvalue-lcni');
     this.requestDateTimeLabel = page.getByTestId('cardlabel-6kys').filter({ hasText: 'Request date & time' });
@@ -153,8 +152,9 @@ export class LabRequestModalBase {
   }
 
   async validateRequestedDateTimeIsToday() {
-    const todayString = this.getCurrentDateTime();
-    await expect(this.requestDateTimeInput).toHaveValue(todayString);
+    const todayString = await this.getCurrentDateTime();
+    const actual = normalizeToIsoDateTimeMinute(await this.requestDateTimeInput.inputValue());
+    expect(actual).toBe(todayString);
     return todayString;
   }
 
@@ -177,8 +177,12 @@ export class LabRequestModalBase {
     return currentUser;
   }
 
-  getCurrentDateTime(): string {
-    return format(new Date(), "yyyy-MM-dd'T'HH:mm");
+  async getCurrentDateTime(): Promise<string> {
+    return this.page.evaluate(() => {
+      const now = new Date();
+      const pad = (n: number) => n.toString().padStart(2, '0');
+      return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+    });
   }
 
   /**
@@ -245,10 +249,10 @@ export class LabRequestModalBase {
    * @param index - The index of the input to set
    */
   async setDateTimeCollected(dateTime: string, index: number = 0) {
-    const input = this.dateTimeCollectedInputs.locator('input').nth(index);
+    const input = this.dateTimeCollectedInputs.nth(index);
     await input.click();
     await input.waitFor({ state: 'visible' });
-    await input.fill(dateTime);
+    await fillMuiDateTimeField(input, dateTime);
   }
   
   /**

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/PanelLabRequestModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/PanelLabRequestModal.ts
@@ -74,7 +74,7 @@ export class PanelLabRequestModal extends LabRequestModalBase {
     const noteToAdd = 'This is a test note';
     await this.addNotes(noteToAdd);
     await this.nextButton.click();
-    const currentDateTime = this.getCurrentDateTime();
+    const currentDateTime = await this.getCurrentDateTime();
     await this.setDateTimeCollected(currentDateTime);
     await this.selectFirstCollectedBy(0);
     await this.selectFirstSpecimenType(0);

--- a/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
+++ b/packages/e2e-tests/pages/patients/LabRequestPage/modals/RecordSampleModal.ts
@@ -41,9 +41,9 @@ export class RecordSampleModal {
     }
 
     // Special cases that need additional processing
-    this.dateTimeCollectedInput = page.getByTestId('styledfield-dmjl-input').locator('input');
-    this.collectedByInput = page.getByTestId('styledfield-v88m-input').locator('input');
-    this.specimenTypeInput = page.getByTestId('styledfield-0950-input').locator('input');
+    this.dateTimeCollectedInput = page.getByTestId('styledfield-dmjl-input');
+    this.collectedByInput = page.getByTestId('styledfield-v88m-input');
+    this.specimenTypeInput = page.getByTestId('styledfield-0950-input');
     // Scope siteInputDropdownIcon to the record sample form to avoid matching elements in other forms
     this.siteInputDropdownIcon = page.getByTestId('formgrid-3btd').getByTestId('selectinput-phtg-expandmoreicon-h115');
   }

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseChangeLogModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseChangeLogModal.ts
@@ -24,7 +24,7 @@ export abstract class BaseChangeLogModal {
     
     // Special cases that need additional processing
     this.noteTypeLabel = page.getByTestId('cardbody-3iyj').getByTestId('cardcell-8efu').first().getByTestId('cardvalue-lcni');
-    this.changelogInfoDates = this.changeLogInfoWrappers.getByTestId('tooltip-b4e8');
+    this.changelogInfoDates = this.changeLogInfoWrappers.getByTestId('datedisplay-o9yj');
     this.changelogTextContents = this.page.getByRole('dialog').getByTestId('stylednotechangeloginfowrapper-zbh3').locator('+ span');
   }
 

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/BaseModals/BaseNoteModal.ts
@@ -27,7 +27,7 @@ export abstract class BaseNoteModal {
     
     // Special cases that need additional processing
     this.writtenByInput = page.getByTestId('field-ar9q-input').locator('input');
-    this.dateTimeInput = page.getByTestId('field-nwwl-input').locator('input');
+    this.dateTimeInput = page.getByTestId('field-nwwl').locator('input');
     this.noteContentTextarea = page.getByTestId('field-wxzr').locator('textarea').nth(0);
     this.cancelButton = page.getByRole('dialog').getByTestId('outlinedbutton-8rnr');
   }

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/ChangeLogModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/ChangeLogModal.ts
@@ -6,19 +6,9 @@ export class ChangeLogModal extends BaseChangeLogModal {
 
   constructor(page: Page) {
     super(page);
-    
-    // TestId mapping for ChangeLogModal elements
-    const testIds = {
-      dateLabel: 'cardvalue-lcni',
-    } as const;
 
-    // Create locators using the testId mapping
-    for (const [key, id] of Object.entries(testIds)) {
-      (this as any)[key] = page.getByTestId(id);
-    }
-    
-    // Special cases that need additional processing
-    this.dateLabel = page.getByTestId('cardvalue-lcni').getByTestId('tooltip-b4e8');
+    // Date & time in header is `DateDisplay` in `NoteInfoSection` (`datedisplay-cfwj`), not `tooltip-b4e8`.
+    this.dateLabel = page.getByRole('dialog').getByTestId('datedisplay-cfwj');
   }
 
 }

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/editNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/editNoteModal.ts
@@ -1,5 +1,6 @@
 import { Page } from '@playwright/test';
 import { BaseNoteModal } from './BaseModals/BaseNoteModal';
+import { normalizeToIsoDateTimeMinute } from '@utils/testHelper';
 
 export class EditNoteModal extends BaseNoteModal {
   constructor(page: Page) {
@@ -10,7 +11,7 @@ export class EditNoteModal extends BaseNoteModal {
   async editNote(updatedContent: string): Promise<string> {
     await this.waitForModalToLoad();
     await this.noteContentTextarea.fill(updatedContent);
-    const secondDateTime = await this.dateTimeInput.inputValue();
+    const secondDateTime = normalizeToIsoDateTimeMinute(await this.dateTimeInput.inputValue());
     await this.confirmButton.click();
     await this.waitForModalToClose();
     return secondDateTime;

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/newNoteModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/newNoteModal.ts
@@ -2,6 +2,7 @@ import { Page, Locator } from '@playwright/test';
 import { DiscardNoteModal } from './discardNoteModal';
 import { BaseNoteModal } from './BaseModals/BaseNoteModal';
 import { format } from 'date-fns';
+import { normalizeToIsoDateTimeMinute } from '@utils/testHelper';
 
 export class NewNoteModal extends BaseNoteModal {
   readonly discardNoteModal: DiscardNoteModal;
@@ -48,7 +49,7 @@ export class NewNoteModal extends BaseNoteModal {
   }
 
   async getDateTimeValue(): Promise<string> {
-    return await this.dateTimeInput.inputValue();
+    return normalizeToIsoDateTimeMinute(await this.dateTimeInput.inputValue());
   }
 
   // Helper method to create a basic note

--- a/packages/e2e-tests/pages/patients/NotesPage/modals/updateTreatmentPlanModal.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/modals/updateTreatmentPlanModal.ts
@@ -2,6 +2,7 @@ import { Page, Locator } from '@playwright/test';
 import { BaseNoteModal } from './BaseModals/BaseNoteModal';
 import { format } from 'date-fns';
 import * as fieldHelpers from '@utils/fieldHelpers';
+import { fillMuiDateTimeField } from '@utils/testHelper';
 
 export class UpdateTreatmentPlanModal extends BaseNoteModal {
   // Additional fields specific to update treatment plan
@@ -36,7 +37,7 @@ export class UpdateTreatmentPlanModal extends BaseNoteModal {
       optionToSelect: updatedBy,
     });
     const updatedDateTime = format(new Date(), 'yyyy-MM-dd\'T\'HH:mm');
-    await this.dateTimeInput.fill(updatedDateTime);
+    await fillMuiDateTimeField(this.dateTimeInput, updatedDateTime);
     await this.noteContentTextarea.fill(updatedContent);
     await this.confirmButton.click();
     await this.waitForModalToClose();

--- a/packages/e2e-tests/pages/patients/NotesPage/panes/notesPane.ts
+++ b/packages/e2e-tests/pages/patients/NotesPage/panes/notesPane.ts
@@ -43,7 +43,6 @@ export class NotesPane {
     const testIds = {
       notesTab: 'styledtab-ccs8-notes',
       noteTypeSelect: 'styledtranslatedselectfield-oy9y-input-outerlabelfieldwrapper',
-      newNoteButton: 'component-enxe',
       readMoreButton: 'readmorespan-dpwv',
       showLessButton: 'showlessspan-7kuw',
       editIcons: 'styledediticon-nmdz',
@@ -58,7 +57,11 @@ export class NotesPane {
     for (const [key, id] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(id);
     }
-    
+
+    // `withPermissionCheck` forces `data-testid="component-enxe"` on permission buttons (same as Prepare discharge, etc.).
+    // The notes toolbar is `row-v55c` (note-type filter + New note).
+    this.newNoteButton = page.getByTestId('row-v55c').getByRole('button', { name: 'New note' });
+
     // Special cases that need additional processing
     this.noteRows = page.getByTestId('styledtable-1dlu').locator('tbody').locator('tr');
     this.noteHeaderTexts = page.getByTestId('styledtablebody-a0jz').getByTestId('noteheadertext-e3kq');

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/PatientDetailsPage.ts
@@ -8,6 +8,7 @@ import { CarePlanModal } from './modals/CarePlanModal';
 import { LabRequestPane } from '../LabRequestPage/panes/LabRequestPane';
 import { ProcedurePane } from '../ProcedurePage/Panes/ProcedurePane';
 import { format } from 'date-fns';
+import { fillMuiDateField } from '@utils/testHelper';
 import { NotesPane } from '../NotesPage/panes/notesPane';
 import { PrepareDischargeModal } from './modals/PrepareDischargeModal';
 import { CreateEncounterModal } from './modals/CreateEncounterModal';
@@ -134,9 +135,7 @@ export class PatientDetailsPage extends BasePatientPage {
     this.ongoingConditionNameField = this.page
       .getByTestId('field-j30y-input')
       .getByRole('textbox', { name: 'Search...' });
-    this.ongoingConditionDateRecordedField = this.page
-      .getByTestId('field-2775-input')
-      .getByRole('textbox');
+    this.ongoingConditionDateRecordedField = this.page.getByTestId('field-2775').locator('input');
     this.ongoingConditionClinicianField = this.page.getByTestId('field-9miu-input');
     this.ongoingConditionNotes = this.page.getByTestId('field-e52k-input');
     this.savedOnGoingConditionName = this.page
@@ -145,8 +144,8 @@ export class PatientDetailsPage extends BasePatientPage {
       .getByRole('textbox');
     this.savedOnGoingConditionDate = this.page
       .getByTestId('collapse-0a33')
-      .getByTestId('field-2775-input')
-      .getByRole('textbox');
+      .getByTestId('field-2775')
+      .locator('input');
     this.savedOnGoingConditionClinician = this.page
       .getByTestId('collapse-0a33')
       .getByTestId('field-9miu-input')
@@ -174,8 +173,8 @@ export class PatientDetailsPage extends BasePatientPage {
       .getByRole('textbox');
     this.savedAllergyDate = this.page
       .getByTestId('collapse-0a33')
-      .getByTestId('field-gmf8-input')
-      .getByRole('textbox');
+      .getByTestId('field-gmf8')
+      .locator('input');
     this.savedAllergyNote = this.page.getByTestId('collapse-0a33').getByTestId('field-dayn-input');
     this.submitNewAllergyAddButton = this.page
       .getByTestId('formsubmitcancelrow-nx2z-confirmButton')
@@ -188,9 +187,7 @@ export class PatientDetailsPage extends BasePatientPage {
     this.familyHistoryDiagnosisField = this.page
       .getByTestId('field-3b4u-input')
       .getByRole('textbox', { name: 'Search...' });
-    this.familyHistoryDateRecordedField = this.page
-      .getByTestId('field-wrp3-input')
-      .getByRole('textbox');
+    this.familyHistoryDateRecordedField = this.page.getByTestId('field-wrp3').locator('input');
     this.familyHistoryRelationshipField = this.page.getByTestId('field-t0k5-input');
     this.familyHistoryClinicianField = this.page.getByTestId('field-kbwi-input');
     this.familyHistoryNotes = this.page.getByTestId('field-mgiu-input');
@@ -200,8 +197,8 @@ export class PatientDetailsPage extends BasePatientPage {
 
     this.savedFamilyHistoryDateRecorded = this.page
       .getByTestId('collapse-0a33')
-      .getByTestId('field-wrp3-input')
-      .getByRole('textbox');
+      .getByTestId('field-wrp3')
+      .locator('input');
     this.savedFamilyHistoryRelationship = this.page
       .getByTestId('collapse-0a33')
       .getByTestId('field-t0k5-input');
@@ -222,8 +219,8 @@ export class PatientDetailsPage extends BasePatientPage {
     this.otherPatientIssueNote = this.page.getByTestId('field-nj3s-input');
     this.savedOtherPatientIssueDate = this.page
       .getByTestId('collapse-0a33')
-      .getByTestId('field-urg2-input')
-      .getByRole('textbox');
+      .getByTestId('field-urg2')
+      .locator('input');
     this.savedOtherPatientIssueNote = this.page
       .getByTestId('collapse-0a33')
       .getByTestId('field-nj3s-input');
@@ -417,7 +414,7 @@ export class PatientDetailsPage extends BasePatientPage {
     await this.initiateNewOngoingConditionAddButton.click();
     await this.ongoingConditionNameField.fill(conditionName);
     await this.page.getByRole('menuitem', { name: conditionName, exact: true }).click();
-    await this.ongoingConditionDateRecordedField.fill(dateRecorded);
+    await fillMuiDateField(this.ongoingConditionDateRecordedField, dateRecorded);
     await this.ongoingConditionClinicianField.click();
     await this.page.getByRole('menuitem', { name: clinicianName, exact: true }).click();
     await this.ongoingConditionNotes.fill(notes);
@@ -460,7 +457,7 @@ export class PatientDetailsPage extends BasePatientPage {
     await this.initiateNewFamilyHistoryAddButton.click();
     await this.familyHistoryDiagnosisField.fill(familyHistoryCondition);
     await this.page.getByRole('menuitem', { name: familyHistoryCondition, exact: true }).click();
-    await this.familyHistoryDateRecordedField.fill(dateRecorded);
+    await fillMuiDateField(this.familyHistoryDateRecordedField, dateRecorded);
     await this.familyHistoryRelationshipField.fill(relationship);
     await this.familyHistoryClinicianField.click();
     await this.page.getByRole('menuitem', { name: clinicianName, exact: true }).click();

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDiagnosisModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddDiagnosisModal.ts
@@ -32,7 +32,7 @@ export class AddDiagnosisModal {
     for (const [key, testId] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(testId);
     }
-    this.dateInput= page.getByTestId('field-fszu-input').locator('input');
+    this.dateInput = this.dateField.locator('input');
     this.clinicianInput= page.getByTestId('field-af83-input').locator('input');
   }
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddReferralModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/AddReferralModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption, selectFieldOption } from '@utils/fieldHelpers';
+import { fillMuiDateField } from '@utils/testHelper';
 
 export class AddReferralModal {
   readonly page: Page;
@@ -26,7 +27,7 @@ export class AddReferralModal {
     this.referralFormGrid = this.page.getByTestId('formgrid-prtu');
     this.surveySelector = this.referralFormGrid.getByTestId('selectinput-4g3c-select');
     this.formFields = this.page.getByTestId('formgrid-h378');
-    this.referralDateInput = this.formFields.getByText('Referral date').locator('..').getByTestId('wrapperfieldcomponent-mkjr-input').locator('input');
+    this.referralDateInput = this.formFields.getByText('Referral date').locator('..').getByTestId('wrapperfieldcomponent-mkjr-input');
     this.referralHealthFacility = this.formFields.getByText('Referring health facility').locator('..').getByTestId('autocompletefield-efuf-input');
     this.referralCompletedBy = this.formFields.getByText('Referral completed by').locator('..').getByTestId('autocompletefield-efuf-input');
     this.reasonForReferral = this.formFields.getByText('Reason for referral').locator('..').getByTestId('wrapperfieldcomponent-mkjr-input');
@@ -69,7 +70,7 @@ export class AddReferralModal {
     referralReason?: string;
     relevantScreeningHistory?: string;
   }> {
-    await this.referralDateInput.fill(values.referralDate);
+    await fillMuiDateField(this.referralDateInput, values.referralDate);
     
     const selectedReferralHealthFacility = values.referralHealthFacility
       ? await selectAutocompleteFieldOption(this.page, this.referralHealthFacility, {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/CarePlanModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/CarePlanModal.ts
@@ -29,7 +29,7 @@ export class CarePlanModal extends BasePatientModal {
     this.carePlanDropdown = this.page
       .getByTestId('field-uc7w-input')
       .getByRole('textbox', { name: 'Search...' });
-    this.carePlanDate = this.page.getByTestId('field-764k-input').getByRole('textbox');
+    this.carePlanDate = this.page.getByTestId('field-764k').locator('input');
     this.carePlanClinicianDropdown = this.page
       .getByTestId('field-kb54-input')
       .getByRole('textbox', { name: 'Search...' });
@@ -62,8 +62,8 @@ export class CarePlanModal extends BasePatientModal {
     this.additionalNoteEditButton = this.page.getByTestId('item-8ybn-0');
     this.additionalNoteSavedDate = this.page
       .getByTestId('editablenoteformcontainer-mx3i')
-      .getByTestId('field-qouz-input')
-      .getByRole('textbox');
+      .getByTestId('field-qouz')
+      .locator('input');
     this.additionalNoteDeleteButton = this.page.getByTestId('item-8ybn-1');
   }
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EditVaccineModal.ts
@@ -3,7 +3,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { BasePatientModal } from './BasePatientModal';
 import { editFieldOption } from '@utils/fieldHelpers';
 import {
-  formatForMuiDateTimePicker,
+  fillMuiDateTimeField,
   getSidebarFacilityDisplayName,
   normalizeToIsoDate,
 } from '@utils/testHelper';
@@ -126,8 +126,7 @@ export class EditVaccineModal extends BasePatientModal {
     }
 
     if (dateGiven) {
-      await this.dateGiven.fill(formatForMuiDateTimePicker(dateGiven));
-      await this.dateGiven.blur();
+      await fillMuiDateTimeField(this.dateGiven, dateGiven);
       editedFields.dateGiven = dateGiven;
     }
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/EmergencyTriageModal.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { selectFieldOption, selectAutocompleteFieldOption } from '@utils/fieldHelpers';
+import { fillMuiDateTimeField } from '@utils/testHelper';
 import { RecordVitalsModal } from '../../VitalsPage/modals/RecordVitalsModal';
 
 export class EmergencyTriageModal {
@@ -71,9 +72,7 @@ export class EmergencyTriageModal {
       // Form fields
       form: 'styledform-5o5i',
       arrivalDateTimeField: 'field-mhav',
-      arrivalDateTimeInput: 'field-mhav-input',
       triageDateTimeField: 'field-9hxy',
-      triageDateTimeInput: 'field-9hxy-input',
       areaField: 'field-ipih-group-input',
       locationField: 'field-ipih-location-input',
       arrivalModeSelect: 'selectinput-phtg-select',
@@ -100,7 +99,9 @@ export class EmergencyTriageModal {
     for (const [key, id] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(id);
     }
-    this.arrivalModeSelect=page.getByRole('dialog').getByTestId('selectinput-phtg-select');
+    this.arrivalDateTimeInput = this.arrivalDateTimeField.locator('input');
+    this.triageDateTimeInput = this.triageDateTimeField.locator('input');
+    this.arrivalModeSelect = page.getByRole('dialog').getByTestId('selectinput-phtg-select');
   }
 
   async waitForModalToLoad() {
@@ -159,7 +160,7 @@ export class EmergencyTriageModal {
     triageClinician?: string;
   }> {
     if (options.arrivalDateTime) {
-      await this.arrivalDateTimeInput.locator('input').fill(options.arrivalDateTime);
+      await fillMuiDateTimeField(this.arrivalDateTimeInput, options.arrivalDateTime);
     }
     
     const area = await selectAutocompleteFieldOption(this.page, this.areaField, {

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/HospitalAdmissionModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/HospitalAdmissionModal.ts
@@ -55,6 +55,7 @@ export class HospitalAdmissionModal {
 
   async waitForModalToLoad(): Promise<void> {
     await this.modalTitle.waitFor({ state: 'visible' });
+    await this.formGrid.waitFor({ state: 'visible' });
     await this.checkInDateInput.waitFor({ state: 'visible' });
     await this.page.waitForLoadState('networkidle', { timeout: 10000 });
   }

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/modals/RecordVaccineModal.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-import { formatForMuiDateTimePicker, normalizeToIsoDate } from '@utils/testHelper';
+import { fillMuiDateTimeField, normalizeToIsoDate } from '@utils/testHelper';
 import { BasePatientModal } from './BasePatientModal';
 import {
   selectFieldOption,
@@ -290,12 +290,11 @@ export class RecordVaccineModal extends BasePatientModal {
 
     // Apply custom date last: selecting vaccine/schedule/category can reset form values to defaults.
     if (specificDate) {
-      await this.dateField.fill(formatForMuiDateTimePicker(specificDate));
-      await this.dateField.blur();
+      await fillMuiDateTimeField(this.dateField, specificDate);
     }
 
     const rawDateGiven = await this.dateField.evaluate((el: HTMLInputElement) => el.value);
-    const dateGiven = normalizeToIsoDate(rawDateGiven);
+    const dateGiven = rawDateGiven ? normalizeToIsoDate(rawDateGiven) : '';
 
     await this.confirmButton.click();
 

--- a/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage.ts
+++ b/packages/e2e-tests/pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage.ts
@@ -2,6 +2,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePatientPane } from './BasePatientPane';
 import { selectAutocompleteFieldOption, selectFieldOption } from '../../../../utils/fieldHelpers';
+import { fillMuiDateField } from '@utils/testHelper';
 
 
 export interface PatientDetails {
@@ -179,7 +180,7 @@ export class PatientDetailsTabPage extends BasePatientPane {
       await this.culturalNameInput.fill(patientDetails.culturalName);
     }
     if (patientDetails.dateOfBirth) {
-      await this.dateOfBirthInput.locator('input').fill(patientDetails.dateOfBirth);
+      await fillMuiDateField(this.dateOfBirthInput, patientDetails.dateOfBirth);
     }
     if (patientDetails.sex) {
       if (patientDetails.sex === 'female') {

--- a/packages/e2e-tests/pages/patients/PatientTable.ts
+++ b/packages/e2e-tests/pages/patients/PatientTable.ts
@@ -1,8 +1,13 @@
 import { Locator, Page } from '@playwright/test';
 import { expect } from '../../fixtures/baseFixture';
-import { convertDateFormat, SelectingFromSearchBox ,STYLED_TABLE_CELL_PREFIX} from '../../utils/testHelper';
+import {
+  convertDateFormat,
+  fillMuiDateField,
+  SelectingFromSearchBox,
+  STYLED_TABLE_CELL_PREFIX,
+} from '../../utils/testHelper';
 import { routes } from '../../config/routes';
-import { Patient } from '../../types/Patient'; 
+import { Patient } from '../../types/Patient';
 import { TWO_COLUMNS_FIELD_TEST_ID } from './AllPatientsPage';
 type PatientTableRow = Locator & {
   getPatientInfo(): Promise<Patient>;
@@ -45,7 +50,7 @@ export class PatientTable {
 
   constructor(page: Page) {
     this.page = page;
-    
+
     // TestId mapping for PatientTable elements
     const testIds = {
       loadingCell: 'statustablecell-rwkq',
@@ -63,15 +68,15 @@ export class PatientTable {
       NHNTxt: 'localisedfield-dzml-input',
       firstNameTxt: 'localisedfield-i9br-input',
       lastNameTxt: 'localisedfield-ngsn-input',
-      DOBTxt: 'field-qk60-input',
+      DOBTxt: 'field-qk60',
       CulturalNameTxt: 'localisedfield-epbq-input',
       villageSearchBox: 'villagelocalisedfield-mcri-input',
       includeDeceasedChk: 'field-ngy7-controlcheck',
       advanceSearchIcon: 'iconbutton-zrkv',
       sexDropDownIcon: 'sexlocalisedfield-7lm9-expandmoreicon-h115',
       sexDropDownCrossIcon: 'stylediconbutton-6vh3',
-      DOBFromTxt: 'joinedfield-swzm-input',
-      DOBToTxt: 'field-aax5-input',
+      DOBFromTxt: 'joinedfield-swzm',
+      DOBToTxt: 'field-aax5',
       downloadBtn: 'download-data-button',
       pageRecordCountDropDown: 'styledselectfield-lunn',
       pageRecordCountDropDownOptions: 'styledmenuitem-fkrw-undefined',
@@ -85,7 +90,7 @@ export class PatientTable {
     for (const [key, id] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(id);
     }
-    
+
     // Special cases that need additional processing
     this.table = page.getByRole('table');
     this.loadingCell = page.getByTestId('statustablecell-rwkq').filter({ hasText: 'Loading' });
@@ -101,10 +106,10 @@ export class PatientTable {
       .locator('svg');
     this.villageSortButton = page.getByTestId('tablesortlabel-0qxx-villageName').locator('svg');
     this.dobSortButton = page.getByTestId('tablesortlabel-0qxx-dateOfBirth').locator('svg');
-    this.DOBTxt = page.getByTestId('field-qk60-input').locator('input[type="date"]');
+    this.DOBTxt = page.getByTestId('field-qk60').getByRole('textbox');
     this.villageSearchBox = page.getByTestId('villagelocalisedfield-mcri-input').locator('input');
-    this.DOBFromTxt = page.getByTestId('joinedfield-swzm-input').locator('input[type="date"]');
-    this.DOBToTxt = page.getByTestId('field-aax5-input').locator('input[type="date"]');
+    this.DOBFromTxt = page.getByTestId('joinedfield-swzm').getByRole('textbox');
+    this.DOBToTxt = page.getByTestId('field-aax5').getByRole('textbox');
     this.pageRecordCountDropDown = page.getByTestId('styledselectfield-lunn').locator('div');
     this.patientPageRecordCount25 = page
       .getByTestId('styledmenuitem-fkrw-undefined')
@@ -120,12 +125,14 @@ export class PatientTable {
       await this.loadingCell.waitFor({ state: 'detached' });
       await this.page.waitForLoadState('networkidle', { timeout: 10000 });
     } catch (error) {
-      throw new Error(`Failed to wait for table to load: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to wait for table to load: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
   async waitForTableRowCount(expectedRowCount: number, timeout: number = 50000) {
-  /**  try {
+    /**  try {
       await this.page.waitForFunction(
         (count) => {
           const table = document.querySelector('table');
@@ -141,7 +148,7 @@ export class PatientTable {
         `Table did not reach expected row count of ${expectedRowCount} within ${timeout}ms. ${error instanceof Error ? error.message : String(error)}`,
       );
     }*/
-      await expect(async () => {
+    await expect(async () => {
       expect(await this.rows.count()).toBe(expectedRowCount);
     }).toPass({ timeout });
   }
@@ -253,7 +260,6 @@ export class PatientTable {
     console.log('result', dateValues);
     console.log('expected', sortedValues);
     expect(dateValues).toEqual(sortedValues);
-    
   }
 
   async searchTable(searchCriteria: {
@@ -283,7 +289,7 @@ export class PatientTable {
       await this.lastNameTxt.fill(searchCriteria.lastName);
     }
     if (searchCriteria.DOB) {
-      await this.DOBTxt.fill(searchCriteria.DOB);
+      await fillMuiDateField(this.DOBTxt, searchCriteria.DOB);
     }
     if (searchCriteria.culturalName) {
       await this.CulturalNameTxt.fill(searchCriteria.culturalName);
@@ -306,10 +312,10 @@ export class PatientTable {
       await this.includeDeceasedChk.check();
     }
     if (searchCriteria.DOBFrom) {
-      await this.DOBFromTxt.fill(searchCriteria.DOBFrom);
+      await fillMuiDateField(this.DOBFromTxt, searchCriteria.DOBFrom);
     }
     if (searchCriteria.DOBTo) {
-      await this.DOBToTxt.fill(searchCriteria.DOBTo);
+      await fillMuiDateField(this.DOBToTxt, searchCriteria.DOBTo);
     }
 
     await this.searchBtn.click();
@@ -335,19 +341,18 @@ export class PatientTable {
     try {
       // Click on the page record count dropdown
       await this.pageRecordCountDropDown.click();
-      
+
       // Select the specified number of records per page
-      await this.pageRecordCountDropDownOptions
-        .getByText(recordsPerPage.toString())
-        .click();
-      
+      await this.pageRecordCountDropDownOptions.getByText(recordsPerPage.toString()).click();
+
       // Wait for the table to reload with the new page size
       await this.waitForTableToLoad();
       // Verify the page size has been changed by checking the page record count
       await expect(this.pageRecordCount).toContainText(recordsPerPage.toString());
-      
     } catch (error) {
-      throw new Error(`Failed to change page size to ${recordsPerPage}: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to change page size to ${recordsPerPage}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
@@ -360,54 +365,58 @@ export class PatientTable {
     const rowLocator = this.rows.nth(index);
     return Object.assign(rowLocator, {
       async getPatientInfo(): Promise<Patient> {
-        const firstName = await rowLocator.locator('[data-testid*="-firstName"]').textContent() || '';
-        const lastName = await rowLocator.locator('[data-testid*="-lastName"]').textContent() || '';
-        const nhn = await rowLocator.locator('[data-testid*="-displayId"]').textContent() || '';
-        const sex = await rowLocator.locator('[data-testid*="-sex"]').textContent() || '';
-        const dateOfBirth = await rowLocator.locator('[data-testid*="-dateOfBirth"]').textContent() || '';
-        
+        const firstName =
+          (await rowLocator.locator('[data-testid*="-firstName"]').textContent()) || '';
+        const lastName =
+          (await rowLocator.locator('[data-testid*="-lastName"]').textContent()) || '';
+        const nhn = (await rowLocator.locator('[data-testid*="-displayId"]').textContent()) || '';
+        const sex = (await rowLocator.locator('[data-testid*="-sex"]').textContent()) || '';
+        const dateOfBirth =
+          (await rowLocator.locator('[data-testid*="-dateOfBirth"]').textContent()) || '';
+
         return {
           firstName,
           lastName,
           nhn,
           sex,
-          dateOfBirth
+          dateOfBirth,
         };
-      }
+      },
     }) as PatientTableRow;
   }
 
   async getAllPatientInfo(): Promise<Patient[]> {
     const rowCount = await this.getTotalRowCount();
     const patients: Patient[] = [];
-    
+
     for (let i = 0; i < rowCount; i++) {
       const row = this.getRow(i);
       const patientInfo = await row.getPatientInfo();
       patients.push(patientInfo);
     }
-    
+
     return patients;
   }
 
   async clickOnRow(rowIndex: number) {
     try {
       await this.waitForTableToLoad();
-      
+
       // Get the row at the specified index (0-based)
       const targetRow = this.rows.nth(rowIndex);
-      
+
       // Wait for the row to be visible
       await targetRow.waitFor({ state: 'visible' });
-      
+
       // Click on the row
       await targetRow.click();
-      
+
       // Wait for navigation to patient details page
       await this.page.waitForURL(`**/*${routes.patients.patientDetails}`);
-      
     } catch (error) {
-      throw new Error(`Failed to click on row ${rowIndex}: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to click on row ${rowIndex}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 }

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Modals/NewProcedureModal.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePage } from '../../../BasePage';
 import { selectAutocompleteFieldOption } from '../../../../utils/fieldHelpers';
+import { fillMuiTimeField, formatForMuiTimePicker } from '../../../../utils/testHelper';
 import { UnsavedChangesModal } from './UnsavedChangesModal';
 
 /**
@@ -39,9 +40,11 @@ export class NewProcedureModal extends BasePage {
   constructor(page: Page) {
     super(page);
     
+    // DateField / TimeField pass data-testid to the MUI TextField root (see ui-components DateField).
+    // AutocompleteField uses `${dataTestId}-input` on the text input (see ui-components AutocompleteField).
     const testIds = {
       procedureInput: 'field-87c2-input',
-      procedureDateInput: 'field-3a5v-input',
+      procedureDateInput: 'field-3a5v',
       procedureAreaInput: 'field-p4ef-group-input',
       procedureLocationInput: 'field-p4ef-location-input',
       leadClinicianInput: 'field-lit6-input',
@@ -49,10 +52,10 @@ export class NewProcedureModal extends BasePage {
       anaesthetistInput: 'field-96eg-input',
       assistantAnaesthetistInput: 'field-96eg1-input',
       anaestheticTypeInput: 'field-w9b5-input',
-      timeInInput: 'field-khml1-input',
-      timeOutInput: 'field-hgzz1-input',
-      timeStartedInput: 'field-khml-input',
-      timeEndedInput: 'field-hgzz-input',
+      timeInInput: 'field-khml1',
+      timeOutInput: 'field-hgzz1',
+      timeStartedInput: 'field-khml',
+      timeEndedInput: 'field-hgzz',
       notesInput: 'field-7en7-input',
       completedNotesInput: 'field-qrv7-input',
       assistantCliniciansInput: 'styledformcontrol-td30', 
@@ -111,17 +114,22 @@ export class NewProcedureModal extends BasePage {
       returnOptionText: true
     });
 
-    const timeIn = '09:00';
-    const timeOut = '10:00';
-    const timeStarted = '09:00';
-    const timeEnded = '10:00';
+    const timeInRaw = '09:00';
+    const timeOutRaw = '10:00';
+    const timeStartedRaw = '09:00';
+    const timeEndedRaw = '10:00';
+    const timeIn = formatForMuiTimePicker(timeInRaw);
+    const timeOut = formatForMuiTimePicker(timeOutRaw);
+    const timeStarted = formatForMuiTimePicker(timeStartedRaw);
+    const timeEnded = formatForMuiTimePicker(timeEndedRaw);
     const notes = 'This is a test note';
     const completedNotes = 'This is a test completed note';
 
-    await this.timeInInput.locator('input').fill(timeIn);
-    await this.timeOutInput.locator('input').fill(timeOut);
-    await this.timeStartedInput.locator('input').fill(timeStarted);
-    await this.timeEndedInput.locator('input').fill(timeEnded);
+    const timeInput = (fieldRoot: Locator) => fieldRoot.locator('input');
+    await fillMuiTimeField(timeInput(this.timeInInput), timeInRaw);
+    await fillMuiTimeField(timeInput(this.timeOutInput), timeOutRaw);
+    await fillMuiTimeField(timeInput(this.timeStartedInput), timeStartedRaw);
+    await fillMuiTimeField(timeInput(this.timeEndedInput), timeEndedRaw);
     await this.notesInput.fill(notes);
     await this.completedCheckbox.check();
     await this.completedNotesInput.fill(completedNotes);

--- a/packages/e2e-tests/pages/patients/ProcedurePage/Panes/ProcedurePane.ts
+++ b/packages/e2e-tests/pages/patients/ProcedurePage/Panes/ProcedurePane.ts
@@ -43,7 +43,6 @@ export class ProcedurePane extends BasePatientPane {
     const testIds = {
       tabPane: 'tabpane-q1xp',
       styledForm: 'styledform-5o5i',
-      newProcedureButton: 'component-enxe',
       tableContainer: 'styledtablecontainer-3ttp',
       table: 'styledtable-1dlu',
       tableHead: 'styledtablehead-ays3',
@@ -70,6 +69,11 @@ export class ProcedurePane extends BasePatientPane {
     for (const [key, id] of Object.entries(testIds)) {
       (this as any)[key] = this.page.getByTestId(id);
     }
+
+    // `withPermissionCheck` forces `data-testid="component-enxe"` (same as Prepare discharge / Move patient).
+    this.newProcedureButton = this.page
+      .getByTestId('tabpane-q1xp')
+      .getByRole('button', { name: 'New procedure' });
   }
 
   /**

--- a/packages/e2e-tests/pages/patients/RecentlyViewedPatientsList.ts
+++ b/packages/e2e-tests/pages/patients/RecentlyViewedPatientsList.ts
@@ -27,7 +27,7 @@ export class RecentlyViewedPatientsList {
     }
     
     // Special cases that need additional processing
-    this.firstRecentlyViewedBirthDate = page.getByTestId('cardtext-i2bu-0').getByTestId('tooltip-b4e8');
+    this.firstRecentlyViewedBirthDate = page.getByTestId('cardtext-i2bu-0').getByTestId('datedisplay-tw5s-0');
   }
 
   static formatDateForRecentlyViewed(dateOfBirth: string): string {
@@ -51,7 +51,7 @@ export class RecentlyViewedPatientsList {
       name: this.page.getByTestId(`cardtitle-qqhk-${index}`),
       nhn: this.page.getByTestId(`cardtext-iro1-${index}`),
       gender: this.page.getByTestId(`capitalizedcardtext-zu58-${index}`),
-      birthDate: this.page.getByTestId(`cardtext-i2bu-${index}`).getByTestId('tooltip-b4e8')
+      birthDate: this.page.getByTestId(`cardtext-i2bu-${index}`).getByTestId(`datedisplay-tw5s-${index}`)
     };
 
     return {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/AddTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/AddTaskModal.ts
@@ -27,8 +27,8 @@ export class AddTaskModal {
     this.page = page;
 
     const testIds = {
-      startDateTimeField: 'field-om46-input',
-      requestDateTimeField: 'field-yduo-input',
+      startDateTimeField: 'field-om46',
+      requestDateTimeField: 'field-yduo',
       requestedByField: 'field-xhot-input',
       notesField: 'field-e475',
       taskInput: 'field-hp09-input',

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/DeleteTaskModal.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { selectAutocompleteFieldOption } from '@utils/fieldHelpers';
+import { fillMuiDateTimeField } from '@utils/testHelper';
 
 export class DeleteTaskModal {
   readonly page: Page;
@@ -16,7 +17,7 @@ export class DeleteTaskModal {
 
     const testIds = {
       recordedByInput: 'field-2l6f-input',
-      recordDateTimeField: 'field-bnve-input',
+      recordDateTimeField: 'field-bnve',
       reasonForDeletionInput: 'field-4x58-input',
       confirmButton: 'formsubmitcancelrow-0v1x-confirmButton',
       cancelButton: 'outlinedbutton-8rnr',
@@ -48,7 +49,7 @@ export class DeleteTaskModal {
     }
 
     if (values.recordDateTime) {
-      await this.recordDateTimeInput.fill(values.recordDateTime);
+      await fillMuiDateTimeField(this.recordDateTimeInput, values.recordDateTime);
     }
 
     if (values.reasonForDeletion) {

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsCompletedModal.ts
@@ -15,7 +15,7 @@ export class MarkAsCompletedModal {
 
     const testIds = {
       completedByInput: 'field-4r4u-input',
-      completedDateTimeField: 'field-el3t-input',
+      completedDateTimeField: 'field-el3t',
       notesInput: 'field-kvze-input',
       confirmButton: 'formsubmitcancelrow-v41o-confirmButton',
       cancelButton: 'outlinedbutton-8rnr',

--- a/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsNotCompletedModal.ts
+++ b/packages/e2e-tests/pages/patients/TaskPage/modals/MarkAsNotCompletedModal.ts
@@ -16,7 +16,7 @@ export class MarkAsNotCompletedModal {
 
     const testIds = {
       recordedByInput: 'field-maud-input',
-      recordDateTimeField: 'field-sgto-input',
+      recordDateTimeField: 'field-sgto',
       reasonNotCompletedInput: 'field-r3a1-input',
       confirmButton: 'formsubmitcancelrow-y08n-confirmButton',
       cancelButton: 'outlinedbutton-8rnr',
@@ -25,6 +25,8 @@ export class MarkAsNotCompletedModal {
     for (const [key, id] of Object.entries(testIds)) {
       (this as any)[key] = page.getByTestId(id);
     }
+
+    this.recordDateTimeInput = this.recordDateTimeField.locator('input');
   }
 
   async waitForModalToLoad(): Promise<void> {

--- a/packages/e2e-tests/pages/patients/VitalsPage/panes/VitalsPage.ts
+++ b/packages/e2e-tests/pages/patients/VitalsPage/panes/VitalsPage.ts
@@ -26,17 +26,19 @@ export class VitalsPage {
    * @returns A record of the vital values
    */
   async getLatestVitalValues(): Promise<Record<typeof VITALS_FIELD_KEYS[number], string>> {
+    // Wait for at least one data cell (second column) to be visible before reading values
+    const firstRowRegex = new RegExp(`^${STYLED_TABLE_CELL_PREFIX}0-`);
+    await this.page.getByTestId(firstRowRegex).nth(1).waitFor({ state: 'visible', timeout: 30000 });
+
     const vitalValues: any = {};
     for (let i = 0; i < VITALS_FIELD_KEYS.length; i++) {    
       const regex = new RegExp(`^${STYLED_TABLE_CELL_PREFIX}${i}-`);
-      // Get the second cell (index 1) - first is measure label, second is the value
       const cell = this.page.getByTestId(regex).nth(1);
       const text = await cell.textContent();
-      // Strip common units and normalize empty values
       let normalizedValue = text?.trim() || '';
       normalizedValue = normalizedValue
-        .replace(/cm$|kg$|°C$|%$/g, '')  // Remove common units
-        .replace(/^—$/, '')               // Replace em-dash with empty string
+        .replace(/cm$|kg$|°C$|%$/g, '')
+        .replace(/^—$/, '')
         .trim();
       vitalValues[VITALS_FIELD_KEYS[i]] = normalizedValue;
     }

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -20,10 +20,8 @@ module.exports = defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.CI ? 'blob' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -1,7 +1,13 @@
 import { EmergencyPatientsPage } from '@pages/patients/EmergencyPatientsPage';
 import { test } from '../../fixtures/baseFixture';
 import { expect } from '@playwright/test';
-import { assertRecentDateTime, convertDateFormat, getTableItems, formatDateTimeForTable } from '@utils/testHelper';
+import {
+  assertRecentDateTime,
+  convertDateFormat,
+  formatDateTimeForTable,
+  getTableItems,
+  normalizeToIsoDate,
+} from '@utils/testHelper';
 import { VitalsPage } from '@pages/patients/VitalsPage/panes/VitalsPage';
 import { generateNHN } from '@utils/generateNewPatient';
 import type { PatientDetails } from '@pages/patients/PatientDetailsPage/panes/PatientDetailsTabPage';
@@ -10,10 +16,8 @@ import { ImagingRequestPane } from '@pages/patients/ImagingRequestPage/panes/Ima
 import { getUser, createApiContext } from '@utils/apiHelpers';
 import { format } from 'date-fns';
 import path from 'path';
-import { SidebarPage } from '@pages/SidebarPage'; 
+import { SidebarPage } from '@pages/SidebarPage';
 import { CHARTING_FIELD_KEYS } from '@pages/patients/ChartsPage/types';
-
-
 
 test.describe('Basic tests', () => {
   let currentUserDisplayName: string;
@@ -29,216 +33,272 @@ test.describe('Basic tests', () => {
     await context.close();
   });
 
-  test('[BT-0003][AT-2001]Admit the patient to Triage without adding vitals', async ({ newPatient, patientDetailsPage }) => {
-      test.setTimeout(100000);
-      await patientDetailsPage.goToPatient(newPatient);
-      await patientDetailsPage.admitOrCheckinButton.click();
-      const createEncounterModal = patientDetailsPage.getCreateEncounterModal();
-      await createEncounterModal.waitForModalToLoad();
-      await createEncounterModal.triageButton.click();
-      const emergencyTriageModal = patientDetailsPage.getEmergencyTriageModal();
-      await emergencyTriageModal.waitForModalToLoad();
-      await emergencyTriageModal.selectTriageScore(1);
-      const triageFormValues = await emergencyTriageModal.fillTriageForm({
-        triageScore: 1
-      });
-      await emergencyTriageModal.submitButton.click();
-      const emergencyPatientsPage = new EmergencyPatientsPage(patientDetailsPage.page);
-      await emergencyPatientsPage.waitForPageToLoad();
-      await emergencyPatientsPage.arrivalTimeSortButton.click();
-      // Wait for the first patient's arrival time to be 0hrs 0mins
-      await expect
-        .poll(async () => await emergencyPatientsPage.getTableItemValue(0, 'arrivalTime'), { timeout: 60000 })
-        .toContain('0hrs 0mins');
-      const chiefComplaintValue = await emergencyPatientsPage.getTableItemValue(0, 'chiefComplaint');
-      const displayIdValue = await emergencyPatientsPage.getTableItemValue(0, 'displayId');
-      const patientNameValue = await emergencyPatientsPage.getTableItemValue(0, 'patientName');
-      const dateOfBirthValue = await emergencyPatientsPage.getTableItemValue(0, 'dateOfBirth');
-      const sexValue = await emergencyPatientsPage.getTableItemValue(0, 'sex');
-      const areaValue = await emergencyPatientsPage.getTableItemValue(0, 'locationGroupName');
-      const locationValue = await emergencyPatientsPage.getTableItemValue(0, 'locationName');
-      expect(chiefComplaintValue).toBe(triageFormValues.chiefComplaint);
-      expect(displayIdValue).toBe(newPatient.displayId);
-      expect(patientNameValue).toBe(`${newPatient.firstName} ${newPatient.lastName}`);
-      expect(dateOfBirthValue).toBe(convertDateFormat(newPatient.dateOfBirth));
-      expect(sexValue.toLowerCase()).toBe(newPatient.sex.toLowerCase());
-      expect(areaValue).toBe(triageFormValues.area);
-      expect(locationValue).toBe(triageFormValues.location?.split('\n')[0] || '');
-      const level1Value = await emergencyPatientsPage.getLevelCardValue(1);
-      expect(parseInt(level1Value)).toBeGreaterThanOrEqual(1);
+  test('[BT-0003][AT-2001]Admit the patient to Triage without adding vitals', async ({
+    newPatient,
+    patientDetailsPage,
+  }) => {
+    test.setTimeout(100000);
+    await patientDetailsPage.goToPatient(newPatient);
+    await patientDetailsPage.admitOrCheckinButton.click();
+    const createEncounterModal = patientDetailsPage.getCreateEncounterModal();
+    await createEncounterModal.waitForModalToLoad();
+    await createEncounterModal.triageButton.click();
+    const emergencyTriageModal = patientDetailsPage.getEmergencyTriageModal();
+    await emergencyTriageModal.waitForModalToLoad();
+    await emergencyTriageModal.selectTriageScore(1);
+    const triageFormValues = await emergencyTriageModal.fillTriageForm({
+      triageScore: 1,
     });
-    test('[BT-0003][AT-2002]Admit the patient to Triage with adding vitals', async ({ newPatient, patientDetailsPage }) => {
-      test.setTimeout(100000);
-      await patientDetailsPage.goToPatient(newPatient);
-      await patientDetailsPage.admitOrCheckinButton.click();
-      const createEncounterModal = patientDetailsPage.getCreateEncounterModal();
-      await createEncounterModal.waitForModalToLoad();
-      await createEncounterModal.triageButton.click();
-      const emergencyTriageModal = patientDetailsPage.getEmergencyTriageModal();
-      await emergencyTriageModal.waitForModalToLoad();
-      await emergencyTriageModal.selectTriageScore(1);
-      const vitalsFormValues: Record<string, string> = { 
-        heightCm: '180',
-        weightKg: '70',
-        sbp: '120',
-        dbp: '80',
-        heartRate: '70',
-        respiratoryRate: '12',
-        temperature: '37.5',
-        spo2: '95',
-        spo2OnOxygen: '100',
-        tewScore: '10',
-        gcs: '15',
-        painScale: '10',
-        capillaryRefillTime: '4',
-        randomBgl: '100',
-        fastingBgl: '100',
-        ventilatorFlow: '10',
-        fio2: '100',
-        pip: '10',
-        peep: '10',
-        rate: '10',
-        inspiratoryTime: '10',
-        tidalVolume: '10',
-        minuteVentilation: '10',
-      };
-      await emergencyTriageModal.fillTriageForm({
-        triageScore: 1,
-        vitalsValues: vitalsFormValues,
-      });
-      await emergencyTriageModal.submitButton.click();
-      const emergencyPatientsPage = new EmergencyPatientsPage(patientDetailsPage.page);
-      await emergencyPatientsPage.waitForPageToLoad();
-      await emergencyPatientsPage.arrivalTimeSortButton.click();
-      // Wait for the first patient's arrival time to be 0hrs 0mins
-      await expect
-        .poll(async () => await emergencyPatientsPage.getTableItemValue(0, 'arrivalTime'), { timeout: 100000 })
-        .toContain('0hrs 0mins');
-      await emergencyPatientsPage.tableRows.first().click();
-      await patientDetailsPage.navigateToVitalsTab();
-      const vitalsPageSection = new VitalsPage(patientDetailsPage.page);
-      await vitalsPageSection.waitForSectionToLoad();
-      const vitalsValues = await vitalsPageSection.getLatestVitalValues();
-      expect(vitalsValues).toMatchObject(vitalsFormValues);
+    await emergencyTriageModal.submitButton.click();
+    const emergencyPatientsPage = new EmergencyPatientsPage(patientDetailsPage.page);
+    await emergencyPatientsPage.waitForPageToLoad();
+    await emergencyPatientsPage.arrivalTimeSortButton.click();
+    // Wait for the first patient's arrival time to be 0hrs 0mins
+    await expect
+      .poll(async () => await emergencyPatientsPage.getTableItemValue(0, 'arrivalTime'), {
+        timeout: 60000,
+      })
+      .toContain('0hrs 0mins');
+    const chiefComplaintValue = await emergencyPatientsPage.getTableItemValue(0, 'chiefComplaint');
+    const displayIdValue = await emergencyPatientsPage.getTableItemValue(0, 'displayId');
+    const patientNameValue = await emergencyPatientsPage.getTableItemValue(0, 'patientName');
+    const dateOfBirthValue = await emergencyPatientsPage.getTableItemValue(0, 'dateOfBirth');
+    const sexValue = await emergencyPatientsPage.getTableItemValue(0, 'sex');
+    const areaValue = await emergencyPatientsPage.getTableItemValue(0, 'locationGroupName');
+    const locationValue = await emergencyPatientsPage.getTableItemValue(0, 'locationName');
+    expect(chiefComplaintValue).toBe(triageFormValues.chiefComplaint);
+    expect(displayIdValue).toBe(newPatient.displayId);
+    expect(patientNameValue).toBe(`${newPatient.firstName} ${newPatient.lastName}`);
+    expect(dateOfBirthValue).toBe(convertDateFormat(newPatient.dateOfBirth));
+    expect(sexValue.toLowerCase()).toBe(newPatient.sex.toLowerCase());
+    expect(areaValue).toBe(triageFormValues.area);
+    expect(locationValue).toBe(triageFormValues.location?.split('\n')[0] || '');
+    const level1Value = await emergencyPatientsPage.getLevelCardValue(1);
+    expect(parseInt(level1Value)).toBeGreaterThanOrEqual(1);
+  });
+  test('[BT-0003][AT-2002]Admit the patient to Triage with adding vitals', async ({
+    newPatient,
+    patientDetailsPage,
+  }) => {
+    test.setTimeout(100000);
+    await patientDetailsPage.goToPatient(newPatient);
+    await patientDetailsPage.admitOrCheckinButton.click();
+    const createEncounterModal = patientDetailsPage.getCreateEncounterModal();
+    await createEncounterModal.waitForModalToLoad();
+    await createEncounterModal.triageButton.click();
+    const emergencyTriageModal = patientDetailsPage.getEmergencyTriageModal();
+    await emergencyTriageModal.waitForModalToLoad();
+    await emergencyTriageModal.selectTriageScore(1);
+    const vitalsFormValues: Record<string, string> = {
+      heightCm: '180',
+      weightKg: '70',
+      sbp: '120',
+      dbp: '80',
+      heartRate: '70',
+      respiratoryRate: '12',
+      temperature: '37.5',
+      spo2: '95',
+      spo2OnOxygen: '100',
+      tewScore: '10',
+      gcs: '15',
+      painScale: '10',
+      capillaryRefillTime: '4',
+      randomBgl: '100',
+      fastingBgl: '100',
+      ventilatorFlow: '10',
+      fio2: '100',
+      pip: '10',
+      peep: '10',
+      rate: '10',
+      inspiratoryTime: '10',
+      tidalVolume: '10',
+      minuteVentilation: '10',
+    };
+    await emergencyTriageModal.fillTriageForm({
+      triageScore: 1,
+      vitalsValues: vitalsFormValues,
     });
-    /**
-     * Test to edit patient details and verify the changes
-     * @param newPatient - The new patient object
-     * @param patientDetailsPage - The patient details page object
-     */
-    test('[BT-0004][AT-2004]Edit patient details', async ({ newPatient, patientDetailsPage }) => {
-      test.setTimeout(100000);
-      await patientDetailsPage.goToPatient(newPatient);
-      const patientDetailsTabPage = await patientDetailsPage.navigateToPatientDetailsTab();
-      const nhn = generateNHN();
-      const patientDetails: PatientDetails = {
-        firstName: 'John',
-        middleName: 'Michael',
-        lastName: 'Smith',
-        culturalName: 'Johnny Smith',
-        dateOfBirth: '1990-01-01',
-        email: 'john.smith@example.com',
-        nationalHealthNumber: nhn,
-        birthCertificate: 'BRTH12345',
-        drivingLicense: 'DL54321',
-        passport: 'PP987654',
-        primaryContactNumber: '0123456789',
-        secondaryContactNumber: '0987654321',
-        emergencyContactName: 'Jane Smith',
-        emergencyContactNumber: '0112233445',
-        birthLocation: 'Johannesburg',
-        cityTown: 'Johannesburg',
-        residentialLandmark: '123 Main Street',
-        sex: newPatient.sex === 'female' ? 'male' : 'female',
-        selectFirstOption: true,
-      };
+    await emergencyTriageModal.submitButton.click();
+    const emergencyPatientsPage = new EmergencyPatientsPage(patientDetailsPage.page);
+    await emergencyPatientsPage.waitForPageToLoad();
+    await emergencyPatientsPage.arrivalTimeSortButton.click();
+    // Wait for the first patient's arrival time to be 0hrs 0mins
+    await expect
+      .poll(async () => await emergencyPatientsPage.getTableItemValue(0, 'arrivalTime'), {
+        timeout: 100000,
+      })
+      .toContain('0hrs 0mins');
+    await emergencyPatientsPage.tableRows.first().click();
+    await patientDetailsPage.navigateToVitalsTab();
+    const vitalsPageSection = new VitalsPage(patientDetailsPage.page);
+    await vitalsPageSection.waitForSectionToLoad();
+    const vitalsValues = await vitalsPageSection.getLatestVitalValues();
+    expect(vitalsValues).toMatchObject(vitalsFormValues);
+  });
+  /**
+   * Test to edit patient details and verify the changes
+   * @param newPatient - The new patient object
+   * @param patientDetailsPage - The patient details page object
+   */
+  test('[BT-0004][AT-2004]Edit patient details', async ({ newPatient, patientDetailsPage }) => {
+    test.setTimeout(100000);
+    await patientDetailsPage.goToPatient(newPatient);
+    const patientDetailsTabPage = await patientDetailsPage.navigateToPatientDetailsTab();
+    const nhn = generateNHN();
+    const patientDetails: PatientDetails = {
+      firstName: 'John',
+      middleName: 'Michael',
+      lastName: 'Smith',
+      culturalName: 'Johnny Smith',
+      dateOfBirth: '1990-01-01',
+      email: 'john.smith@example.com',
+      nationalHealthNumber: nhn,
+      birthCertificate: 'BRTH12345',
+      drivingLicense: 'DL54321',
+      passport: 'PP987654',
+      primaryContactNumber: '0123456789',
+      secondaryContactNumber: '0987654321',
+      emergencyContactName: 'Jane Smith',
+      emergencyContactNumber: '0112233445',
+      birthLocation: 'Johannesburg',
+      cityTown: 'Johannesburg',
+      residentialLandmark: '123 Main Street',
+      sex: newPatient.sex === 'female' ? 'male' : 'female',
+      selectFirstOption: true,
+    };
     const formValues = await patientDetailsTabPage.updatePatientDetailsFields(patientDetails);
     await patientDetailsTabPage.saveButton.click();
-     const allPatientsPage=await patientDetailsPage.navigateToAllPatientsPage();
-     await allPatientsPage.waitForPageToLoad();
-     await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedNHN).toHaveText(nhn);
-     await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedName).toHaveText(`${patientDetails.firstName} ${patientDetails.lastName}`);
-     const expectedGender = (patientDetails.sex ?? newPatient.sex) ?? '';
-     await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedGender).toHaveText(
-       new RegExp(`^${expectedGender}$`, 'i'),
-     );
-    const formattedDate = RecentlyViewedPatientsList.formatDateForRecentlyViewed(patientDetails.dateOfBirth as string);
-     await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedBirthDate).toHaveText(formattedDate);
-     await allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedName.click();
-     await expect(patientDetailsPage.healthIdText).toHaveText(nhn);
-     const patientDetailsTabPage2 = await patientDetailsPage.navigateToPatientDetailsTab();
-     await patientDetailsTabPage2.waitForSectionToLoad();
+    const allPatientsPage = await patientDetailsPage.navigateToAllPatientsPage();
+    await allPatientsPage.waitForPageToLoad();
+    await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedNHN).toHaveText(nhn);
+    await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedName).toHaveText(
+      `${patientDetails.firstName} ${patientDetails.lastName}`,
+    );
+    const expectedGender = patientDetails.sex ?? newPatient.sex ?? '';
+    await expect(allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedGender).toHaveText(
+      new RegExp(`^${expectedGender}$`, 'i'),
+    );
+    const formattedDate = RecentlyViewedPatientsList.formatDateForRecentlyViewed(
+      patientDetails.dateOfBirth as string,
+    );
+    await expect(
+      allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedBirthDate,
+    ).toHaveText(formattedDate);
+    await allPatientsPage.recentlyViewedPatientsList.firstRecentlyViewedName.click();
+    await expect(patientDetailsPage.healthIdText).toHaveText(nhn);
+    const patientDetailsTabPage2 = await patientDetailsPage.navigateToPatientDetailsTab();
+    await patientDetailsTabPage2.waitForSectionToLoad();
 
-     await expect(patientDetailsTabPage2.firstNameInput).toHaveValue(patientDetails.firstName as string);
-     await expect(patientDetailsTabPage2.lastNameInput).toHaveValue(patientDetails.lastName as string);
-     await expect(patientDetailsTabPage2.dateOfBirthInput.locator('input')).toHaveValue('1990-01-01');
-     if ((patientDetails.sex) === 'female') {
-       await expect(patientDetailsTabPage2.sexFemaleRadio).toBeChecked();
-     } else if ((patientDetails.sex ) === 'male') {
-       await expect(patientDetailsTabPage2.sexMaleRadio).toBeChecked();
-     }
-     await expect(patientDetailsTabPage2.emailInput).toHaveValue(patientDetails.email as string);
-     await expect(patientDetailsTabPage2.nationalHealthNumberInput).toHaveValue(nhn);
-     const patientDetailsTabPage3 = await patientDetailsPage.navigateToPatientDetailsTab();
-     await patientDetailsTabPage3.waitForSectionToLoad();
-     await expect(patientDetailsTabPage3.birthCertificateInput).toHaveValue(patientDetails.birthCertificate as string);
-     await expect(patientDetailsTabPage3.drivingLicenseInput).toHaveValue(patientDetails.drivingLicense as string);
-     await expect(patientDetailsTabPage3.passportInput).toHaveValue(patientDetails.passport as string);
-     await expect(patientDetailsTabPage3.religionInput.locator('input')).toHaveValue(formValues.religion);
-     await expect(patientDetailsTabPage3.educationalAttainmentSelect).toHaveText(formValues.educationalAttainment);
-     await expect(patientDetailsTabPage3.occupationInput.locator('input')).toHaveValue(formValues.occupation);
-     await expect(patientDetailsTabPage3.socialMediaSelect).toHaveText(formValues.socialMedia);
-     await expect(patientDetailsTabPage3.patientTypeSelect).toHaveText(formValues.patientType);
-     await expect(patientDetailsTabPage3.motherInput.locator('input')).toHaveValue(formValues.mother);
-     await expect(patientDetailsTabPage3.fatherInput.locator('input')).toHaveValue(formValues.father);
-     await expect(patientDetailsTabPage3.medicalAreaInput.locator('input')).toHaveValue(formValues.medicalArea);
-     await expect(patientDetailsTabPage3.nursingZoneInput.locator('input')).toHaveValue(formValues.nursingZone);
-     await expect(patientDetailsTabPage3.countryInput.locator('input')).toHaveValue(formValues.country);
-     await expect(patientDetailsTabPage3.cityTownInput).toHaveValue(patientDetails.cityTown as string);
-     await expect(patientDetailsTabPage3.residentialLandmarkInput).toHaveValue(patientDetails.residentialLandmark as string);
+    await expect(patientDetailsTabPage2.firstNameInput).toHaveValue(
+      patientDetails.firstName as string,
+    );
+    await expect(patientDetailsTabPage2.lastNameInput).toHaveValue(
+      patientDetails.lastName as string,
+    );
+    expect(normalizeToIsoDate(await patientDetailsTabPage2.dateOfBirthInput.inputValue())).toBe(
+      '1990-01-01',
+    );
+    if (patientDetails.sex === 'female') {
+      await expect(patientDetailsTabPage2.sexFemaleRadio).toBeChecked();
+    } else if (patientDetails.sex === 'male') {
+      await expect(patientDetailsTabPage2.sexMaleRadio).toBeChecked();
+    }
+    await expect(patientDetailsTabPage2.emailInput).toHaveValue(patientDetails.email as string);
+    await expect(patientDetailsTabPage2.nationalHealthNumberInput).toHaveValue(nhn);
+    const patientDetailsTabPage3 = await patientDetailsPage.navigateToPatientDetailsTab();
+    await patientDetailsTabPage3.waitForSectionToLoad();
+    await expect(patientDetailsTabPage3.birthCertificateInput).toHaveValue(
+      patientDetails.birthCertificate as string,
+    );
+    await expect(patientDetailsTabPage3.drivingLicenseInput).toHaveValue(
+      patientDetails.drivingLicense as string,
+    );
+    await expect(patientDetailsTabPage3.passportInput).toHaveValue(
+      patientDetails.passport as string,
+    );
+    await expect(patientDetailsTabPage3.religionInput.locator('input')).toHaveValue(
+      formValues.religion,
+    );
+    await expect(patientDetailsTabPage3.educationalAttainmentSelect).toHaveText(
+      formValues.educationalAttainment,
+    );
+    await expect(patientDetailsTabPage3.occupationInput.locator('input')).toHaveValue(
+      formValues.occupation,
+    );
+    await expect(patientDetailsTabPage3.socialMediaSelect).toHaveText(formValues.socialMedia);
+    await expect(patientDetailsTabPage3.patientTypeSelect).toHaveText(formValues.patientType);
+    await expect(patientDetailsTabPage3.motherInput.locator('input')).toHaveValue(
+      formValues.mother,
+    );
+    await expect(patientDetailsTabPage3.fatherInput.locator('input')).toHaveValue(
+      formValues.father,
+    );
+    await expect(patientDetailsTabPage3.medicalAreaInput.locator('input')).toHaveValue(
+      formValues.medicalArea,
+    );
+    await expect(patientDetailsTabPage3.nursingZoneInput.locator('input')).toHaveValue(
+      formValues.nursingZone,
+    );
+    await expect(patientDetailsTabPage3.countryInput.locator('input')).toHaveValue(
+      formValues.country,
+    );
+    await expect(patientDetailsTabPage3.cityTownInput).toHaveValue(
+      patientDetails.cityTown as string,
+    );
+    await expect(patientDetailsTabPage3.residentialLandmarkInput).toHaveValue(
+      patientDetails.residentialLandmark as string,
+    );
+  });
+
+  test('[BT-0008][AT-2005]Create and verify new imaging request in imaging request table', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
+    test.setTimeout(100000);
+    await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
+    await patientDetailsPage.navigateToImagingRequestTab();
+    const imagingRequestPane = new ImagingRequestPane(patientDetailsPage.page);
+    await imagingRequestPane.waitForPageToLoad();
+    await imagingRequestPane.createImagingRequestButton.click();
+    const newImagingRequestModal = imagingRequestPane.getNewImagingRequestModal();
+    await newImagingRequestModal.waitForModalToLoad();
+    const imagingRequestCode = await newImagingRequestModal.imagingRequestCodeInput.inputValue();
+
+    await assertRecentDateTime(newImagingRequestModal.orderDateTimeInput);
+
+    const defaultRequestingClinician =
+      await newImagingRequestModal.requestingClinicianInput.inputValue();
+    expect(defaultRequestingClinician).toBe(currentUserDisplayName);
+    const supervisingClinician =
+      await newImagingRequestModal.supervisingClinicianInput.inputValue();
+    expect(supervisingClinician).toBe(currentUserDisplayName);
+
+    const formValues = await newImagingRequestModal.fillForm({
+      imagingRequestType: 'Angiogram',
+      areasToBeImaged: 'Angiogram Imaging Area',
+      notes: 'This is a test note',
     });
+    await newImagingRequestModal.finaliseButton.click();
+    await imagingRequestPane.waitForPageToLoad();
 
-    test('[BT-0008][AT-2005]Create and verify new imaging request in imaging request table', async ({ newPatientWithHospitalAdmission, patientDetailsPage }) => {
-      test.setTimeout(100000);
-      await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
-      await patientDetailsPage.navigateToImagingRequestTab();
-      const imagingRequestPane = new ImagingRequestPane(patientDetailsPage.page);
-      await imagingRequestPane.waitForPageToLoad();
-      await imagingRequestPane.createImagingRequestButton.click();
-      const newImagingRequestModal = imagingRequestPane.getNewImagingRequestModal();
-      await newImagingRequestModal.waitForModalToLoad();
-      const imagingRequestCode= await newImagingRequestModal.imagingRequestCodeInput.inputValue();
-
-      await assertRecentDateTime(newImagingRequestModal.orderDateTimeInput, 'yyyy-MM-dd\'T\'HH:mm');
-
-      const defaultRequestingClinician = await newImagingRequestModal.requestingClinicianInput.inputValue();
-      expect(defaultRequestingClinician).toBe(currentUserDisplayName);
-      const supervisingClinician = await newImagingRequestModal.supervisingClinicianInput.inputValue();
-      expect(supervisingClinician).toBe(currentUserDisplayName);
-
-      const formValues = await newImagingRequestModal.fillForm({
-        imagingRequestType: 'Angiogram',
-        areasToBeImaged: 'Angiogram Imaging Area',
-        notes: 'This is a test note',
-      });
-      await newImagingRequestModal.finaliseButton.click();
-      await imagingRequestPane.waitForPageToLoad();
-      
-       const imagingType = await getTableItems(imagingRequestPane.page, 1, 'imagingType');
-       expect(imagingType[0]).toBe(formValues.imagingRequestType);
-       const requestId = await getTableItems(imagingRequestPane.page, 1, 'displayId');
-       expect(requestId[0]).toBe(imagingRequestCode);
-       const requestedAtTime = await getTableItems(imagingRequestPane.page, 1, 'requestedDate');
-       expect(requestedAtTime[0]).toBe(format(new Date(), 'MM/dd/yyyy'));
-       const requestedBy = await getTableItems(imagingRequestPane.page, 1, 'requestedBy.displayName');
-       expect(requestedBy[0]).toBe(formValues.requestingClinician);
-       const priority = await getTableItems(imagingRequestPane.page, 1, 'priority');
-       expect(priority[0]).toBe(formValues.priority);
-       const status = await getTableItems(imagingRequestPane.page, 1, 'status');
-       expect(status[0]).toBe('Pending');
-    })
+    const imagingType = await getTableItems(imagingRequestPane.page, 1, 'imagingType');
+    expect(imagingType[0]).toBe(formValues.imagingRequestType);
+    const requestId = await getTableItems(imagingRequestPane.page, 1, 'displayId');
+    expect(requestId[0]).toBe(imagingRequestCode);
+    const requestedAtTime = await getTableItems(imagingRequestPane.page, 1, 'requestedDate');
+    expect(requestedAtTime[0]).toBe(format(new Date(), 'MM/dd/yyyy'));
+    const requestedBy = await getTableItems(imagingRequestPane.page, 1, 'requestedBy.displayName');
+    expect(requestedBy[0]).toBe(formValues.requestingClinician);
+    const priority = await getTableItems(imagingRequestPane.page, 1, 'priority');
+    expect(priority[0]).toBe(formValues.priority);
+    const status = await getTableItems(imagingRequestPane.page, 1, 'status');
+    expect(status[0]).toBe('Pending');
+  });
   test.skip('[BT-0009][AT-2006]Add a new prescription', async () => {});
-  test.skip('[BT-0010][AT-2007]add a document and view it', async ({ newPatient, patientDetailsPage }) => {
+  test.skip('[BT-0010][AT-2007]add a document and view it', async ({
+    newPatient,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatient);
     const documentsPane = await patientDetailsPage.navigateToDocumentsTab();
     const fileName = 'Test Document 2';
@@ -250,7 +310,7 @@ test.describe('Basic tests', () => {
       documentOwner: documentOwnerName,
       note: note,
       filePath: filePath,
-    });  
+    });
     expect(formValues.department).toBe('Cardiology');
     const documentName = await getTableItems(documentsPane.page, 1, 'name');
     expect(documentName[0]).toBe(fileName);
@@ -258,7 +318,7 @@ test.describe('Basic tests', () => {
     expect(documentOwnerValue[0]).toBe(documentOwnerName);
     const noteValue = await getTableItems(documentsPane.page, 1, 'note');
     expect(noteValue[0]).toBe(note);
-    const department = await getTableItems(documentsPane.page, 1, 'department.name')
+    const department = await getTableItems(documentsPane.page, 1, 'department.name');
     expect(department[0]).toBe(formValues.department);
     const dateUploaded = await getTableItems(documentsPane.page, 1, 'documentUploadedAt');
     expect(dateUploaded[0]).toBe(format(new Date(), 'MM/dd/yyyy'));
@@ -266,21 +326,26 @@ test.describe('Basic tests', () => {
   test.skip('[BT-0010][AT-2008]add a document and download it', async () => {
     // we can't inspect the download document modal, a blocker to write this test
   });
-  test.skip('[BT-0011][AT-2009]check result tab', async () => {
-
-  });
+  test.skip('[BT-0011][AT-2009]check result tab', async () => {});
   test.skip('[BT-0015][AT-2010]add a new referral and view it', async () => {});
   test.skip('[BT-0016][AT-2011]add a new program and view it', async () => {});
-  test('[BT-0018][AT-2012]admit the patient to hospital', async ({ newPatient, patientDetailsPage }) => {
+  test('[BT-0018][AT-2012]admit the patient to hospital', async ({
+    newPatient,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatient);
     const formValues = await patientDetailsPage.admitToHospital();
-    const encounterValues = await patientDetailsPage.encounterHistoryPane.getLatestEncounterValues();
+    const encounterValues =
+      await patientDetailsPage.encounterHistoryPane.getLatestEncounterValues();
     const sidebarPage = new SidebarPage(patientDetailsPage.page);
     expect(encounterValues.facilityName).toBe(await sidebarPage.getFacilityName());
     expect(encounterValues.area).toBe(formValues.area);
     expect(encounterValues.startDate).toBe(`${format(new Date(), 'MM/dd/yyyy')} – Current`);
   });
-  test.skip('[BT-0019][AT-2013]Change diet', async ({ newPatientWithHospitalAdmission, patientDetailsPage }) => {
+  test.skip('[BT-0019][AT-2013]Change diet', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     test.setTimeout(60000);
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
@@ -293,14 +358,19 @@ test.describe('Basic tests', () => {
     await editEncounterModal.saveChanges();
     await expect(patientDetailsPage.dietLabel).toContainText(expectedDiet);
   });
-  test('[BT-0020][AT-2014]Change Location', async ({ newPatientWithHospitalAdmission, patientDetailsPage }) => {
+  test('[BT-0020][AT-2014]Change Location', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
     await latestEncounter.click();
     await patientDetailsPage.waitForEncounterToBeReady();
     await patientDetailsPage.movePatientButton.click();
-    const moveFormGrid = patientDetailsPage.page.getByTestId('formgrid-wyqp').filter({ hasText: 'Area' });
+    const moveFormGrid = patientDetailsPage.page
+      .getByTestId('formgrid-wyqp')
+      .filter({ hasText: 'Area' });
     await moveFormGrid.waitFor({ state: 'visible' });
     const expectedArea = 'Operating Theatre';
     const expectedLocation = 'Theatre 1';
@@ -316,24 +386,34 @@ test.describe('Basic tests', () => {
     // Confirm the move
     await patientDetailsPage.page.getByRole('button', { name: 'Confirm' }).click();
     await patientDetailsPage.page.waitForLoadState('networkidle');
-    await expect(patientDetailsPage.locationLabel).toHaveText(`${expectedArea}, ${expectedLocation}`);
+    await expect(patientDetailsPage.locationLabel).toHaveText(
+      `${expectedArea}, ${expectedLocation}`,
+    );
   });
-  test('[BT-0021][AT-2015]Add a primary diagnosis', async ({ newPatientWithHospitalAdmission, patientDetailsPage }) => {
+  test('[BT-0021][AT-2015]Add a primary diagnosis', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
     await latestEncounter.click();
     await patientDetailsPage.addDiagnosisButton.click();
     const diagnosisModal = patientDetailsPage.getAddDiagnosisModal();
-    await diagnosisModal.waitForModalToLoad();  
-    expect(await diagnosisModal.dateInput.inputValue()).toBe(format(new Date(), 'yyyy-MM-dd'));
+    await diagnosisModal.waitForModalToLoad();
+    expect(normalizeToIsoDate(await diagnosisModal.dateInput.inputValue())).toBe(
+      format(new Date(), 'yyyy-MM-dd'),
+    );
     expect(await diagnosisModal.clinicianInput.inputValue()).toBe(currentUserDisplayName);
     const formValues = await diagnosisModal.fillForm(true);
     await diagnosisModal.confirmButton.click();
     await expect(patientDetailsPage.diagnosisCategory.first()).toHaveText('P');
     await expect(patientDetailsPage.diagnosisName.first()).toHaveText(formValues.diagnosis);
   });
-  test('[BT-0022][AT-2016]Add a not primary diagnosis', async ({ newPatientWithHospitalAdmission, patientDetailsPage }) => {
+  test('[BT-0022][AT-2016]Add a not primary diagnosis', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -346,7 +426,10 @@ test.describe('Basic tests', () => {
     await expect(patientDetailsPage.diagnosisCategory.first()).toHaveText('S');
     await expect(patientDetailsPage.diagnosisName.first()).toHaveText(formValues.diagnosis);
   });
-  test('[BT-0023][AT-2017] Add a new task set', async ({newPatientWithHospitalAdmission, patientDetailsPage}) => {
+  test('[BT-0023][AT-2017] Add a new task set', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -382,8 +465,11 @@ test.describe('Basic tests', () => {
     const taskNameValue = await getTableItems(tasksPane.page, 2, 'name');
     expect(taskNameValue[0]).toBe('Contact patient family/caretaker');
     expect(taskNameValue[1]).toBe('Patient preparation: Discharge');
-  }); 
-  test('[BT-0024][AT-2018] Add a new repeating task', async ({newPatientWithHospitalAdmission, patientDetailsPage}) => {
+  });
+  test('[BT-0024][AT-2018] Add a new repeating task', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -427,7 +513,10 @@ test.describe('Basic tests', () => {
     const expectedDateTime = formatDateTimeForTable(formValues.dateTime);
     expect(dueAt[0]).toBe(expectedDateTime);
   });
-  test('[BT-0025][AT-2019] Mark a task as completed', async ({newPatientWithHospitalAdmission, patientDetailsPage}) => {
+  test('[BT-0025][AT-2019] Mark a task as completed', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -460,7 +549,10 @@ test.describe('Basic tests', () => {
     await tasksPane.showCompletedTasksCheck.check();
     expect(await tasksPane.tableRows.count()).toBe(1);
   });
-  test('[BT-0026][AT-2020] Mark a task as not completed', async ({newPatientWithHospitalAdmission, patientDetailsPage}) => {
+  test('[BT-0026][AT-2020] Mark a task as not completed', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -492,9 +584,11 @@ test.describe('Basic tests', () => {
     await markAsNotCompletedModal.confirmButton.click();
     await tasksPane.showNotCompletedTasksCheck.check();
     expect(await tasksPane.tableRows.count()).toBe(1);
-
   });
-  test('[BT-0027][AT-2021] Delete a task', async ({newPatientWithHospitalAdmission, patientDetailsPage}) => {
+  test('[BT-0027][AT-2021] Delete a task', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -519,10 +613,15 @@ test.describe('Basic tests', () => {
     await deleteTaskModal.waitForModalToLoad();
     await deleteTaskModal.confirmButton.click();
     await tasksPane.waitForPageToLoad();
-    await expect( tasksPane.noDataContainer).toHaveText('No patient tasks to display. Please try adjusting filters or click ‘+ New task’ to add a task to this patient.');
+    await expect(tasksPane.noDataContainer).toHaveText(
+      'No patient tasks to display. Please try adjusting filters or click ‘+ New task’ to add a task to this patient.',
+    );
   });
-  
-  test('[BT-0028][AT-2022] Record a simple chart and validate', async ({newPatientWithHospitalAdmission, patientDetailsPage}) => {
+
+  test('[BT-0028][AT-2022] Record a simple chart and validate', async ({
+    newPatientWithHospitalAdmission,
+    patientDetailsPage,
+  }) => {
     await patientDetailsPage.goToPatient(newPatientWithHospitalAdmission);
     await patientDetailsPage.encounterHistoryPane.waitForSectionToLoad();
     const latestEncounter = await patientDetailsPage.encounterHistoryPane.getLatestEncounter();
@@ -553,10 +652,13 @@ test.describe('Basic tests', () => {
     });
     await simpleChartModal.confirmButton.click();
     await chartsPane.waitForPageToLoad();
-    const chartValues = await chartsPane.getLatestValuesFromChartsTable(chartsPane.page, CHARTING_FIELD_KEYS);
+    const chartValues = await chartsPane.getLatestValuesFromChartsTable(
+      chartsPane.page,
+      CHARTING_FIELD_KEYS,
+    );
     expect(chartValues).toEqual(formValues);
   });
-  test('[BT-0015][AT-2010] Add a new referral', async ({newPatient, patientDetailsPage}) => {
+  test('[BT-0015][AT-2010] Add a new referral', async ({ newPatient, patientDetailsPage }) => {
     await patientDetailsPage.goToPatient(newPatient);
     const referralPane = await patientDetailsPage.navigateToReferralsTab();
     await referralPane.waitForPageToLoad();
@@ -569,7 +671,7 @@ test.describe('Basic tests', () => {
     const formValues = await addReferralModal.fillCVDPrimaryScreeningForm({
       referralDate: format(new Date(), 'yyyy-MM-dd'),
       referralReason: 'Reason for referral',
-      relevantScreeningHistory: false
+      relevantScreeningHistory: false,
     });
     await addReferralModal.nextButton.click();
     await addReferralModal.completeReferralButton.click();

--- a/packages/e2e-tests/tests/patients/allPatientsTable.spec.ts
+++ b/packages/e2e-tests/tests/patients/allPatientsTable.spec.ts
@@ -28,7 +28,6 @@ test.describe('All patient table tests', () => {
     });
 
     test('[T-0027][AT-0004]Search by DOB', async ({ newPatient, allPatientsPage }) => {
-      console.log('newPatient.dateOfBirth', newPatient.dateOfBirth);
       await allPatientsPage.searchTable({ DOB: newPatient.dateOfBirth, advancedSearch: false });
       await allPatientsPage.validateAtLeastOneSearchResult();
       await allPatientsPage.validateAllRowsDateMatches(newPatient.dateOfBirth!);

--- a/packages/e2e-tests/tests/patients/labRequest.spec.ts
+++ b/packages/e2e-tests/tests/patients/labRequest.spec.ts
@@ -8,7 +8,13 @@ import { selectFieldOption } from '@utils/fieldHelpers';
 import { format } from 'date-fns';
 import { LabRequestDetailsPage, LAB_REQUEST_STATUS } from '@pages/patients/LabRequestPage/LabRequestDetailsPage';
 import { testData } from '@utils/testData';
-import { getTableItems, selectFirstFromDropdown, formatDateTimeForDisplay } from '@utils/testHelper';
+import {
+  fillMuiDateTimeField,
+  getTableItems,
+  selectFirstFromDropdown,
+  formatDateTimeForDisplay,
+  normalizeToIsoDateTimeMinute,
+} from '@utils/testHelper';
 test.setTimeout(80000);
 
 test.describe('Lab Request Tests', () => {
@@ -206,7 +212,7 @@ test.describe('Lab Request Tests', () => {
       const noteToAdd = 'This is a test note';
       await labRequestModal.addNotes(noteToAdd);
       await labRequestModal.nextButton.click();
-      const currentDateTime = labRequestModal.getCurrentDateTime();
+      const currentDateTime = await labRequestModal.getCurrentDateTime();
       for (let i = 0; i < distinctCategories.length; i++) {
         await labRequestModal.individualModal.setDateTimeCollected(currentDateTime, i);
         await labRequestModal.individualModal.selectFirstCollectedBy(i);
@@ -258,7 +264,7 @@ test.describe('Lab Request Tests', () => {
     test('[AT-0063]Should allow navigating back to the previous page for individual lab request', async () => {
       await labRequestPane.newLabRequestButton.click();
       await labRequestModal.waitForModalToLoad();
-      const requestedDateTime = await labRequestModal.requestDateTimeInput.inputValue();
+      const requestedDateTime = normalizeToIsoDateTimeMinute(await labRequestModal.requestDateTimeInput.inputValue());
       await labRequestModal.individualRadioButton.click();
       await labRequestModal.nextButton.click();
       const testsToSelect = [
@@ -283,7 +289,7 @@ test.describe('Lab Request Tests', () => {
       await labRequestModal.backButton.click();
       await labRequestModal.validateDepartment();
       await labRequestModal.validateRequestingClinician();
-      await expect(labRequestModal.requestDateTimeInput).toHaveValue(requestedDateTime);
+      expect(normalizeToIsoDateTimeMinute(await labRequestModal.requestDateTimeInput.inputValue())).toBe(requestedDateTime);
     });
     test('[T-0209][AT-0064]Should not allow creating a lab request without selecting any tests', async () => {
       await labRequestPane.newLabRequestButton.click();
@@ -378,7 +384,7 @@ test.describe('Lab Request Tests', () => {
       const noteToAdd = 'This is a test note';
       await labRequestModal.addNotes(noteToAdd);
       await labRequestModal.nextButton.click();
-      const currentDateTime = labRequestModal.getCurrentDateTime();
+      const currentDateTime = await labRequestModal.getCurrentDateTime();
       await labRequestModal.setDateTimeCollected(currentDateTime);
       await labRequestModal.selectFirstCollectedBy(0);
       await labRequestModal.selectFirstSpecimenType(0);
@@ -466,7 +472,10 @@ test.describe('Lab Request Tests', () => {
       const date = new Date();
       const currentDateTime = format(date, "yyyy-MM-dd'T'HH:mm").toString();
       const expectedDateTime = formatDateTimeForDisplay(date);
-      await labRequestDetailsPage.recordSampleModal.dateTimeCollectedInput.fill(currentDateTime);
+      await fillMuiDateTimeField(
+        labRequestDetailsPage.recordSampleModal.dateTimeCollectedInput,
+        currentDateTime,
+      );
       await labRequestDetailsPage.recordSampleModal.selectFirstFromAllDropdowns();
       await labRequestDetailsPage.recordSampleModal.recordSampleConfirmButton.click();
       await labRequestDetailsPage.recordSampleModal.waitForSampleCollectedModalToClose();

--- a/packages/e2e-tests/tests/patients/note.spec.ts
+++ b/packages/e2e-tests/tests/patients/note.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '@fixtures/baseFixture';
 import { getUser } from '@utils/apiHelpers';
 import { testData } from '@utils/testData';
-import { formatDateTimeForDisplay } from '@utils/testHelper';
 
 test.describe('Notes Tests', () => {
   let user: { displayName: string; [key: string]: any };
@@ -21,7 +20,9 @@ test.describe('Notes Tests', () => {
   });
 
   test.describe('Create Note Tests', () => {
-    test('[T-0186][AT-0075]should create a treatment plan note with basic details', async ({ patientDetailsPage }) => {
+    test('[T-0186][AT-0075]should create a treatment plan note with basic details', async ({
+      patientDetailsPage,
+    }) => {
       const noteContent = 'This is a test treatment plan note';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
@@ -30,36 +31,39 @@ test.describe('Notes Tests', () => {
 
       // Validate note appears in the table
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(NOTE_TYPES.TREATMENT_PLAN);
+      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(
+        NOTE_TYPES.TREATMENT_PLAN,
+      );
       await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(noteContent);
     });
 
-    test('[T-0186][AT-0076]should create a discharge planning note and validate it is shown in the discharge modal', async ({ patientDetailsPage }) => {
+    test('[T-0186][AT-0076]should create a discharge planning note and validate it is shown in the discharge modal', async ({
+      patientDetailsPage,
+    }) => {
       const noteContent = 'This is a discharge planning note';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
-      await newNoteModal?.createBasicNote(
-        NOTE_TYPES.DISCHARGE_PLANNING,
-        noteContent
-      );
+      await newNoteModal?.createBasicNote(NOTE_TYPES.DISCHARGE_PLANNING, noteContent);
       await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
 
       // Validate note appears in the table
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(NOTE_TYPES.DISCHARGE_PLANNING);
+      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(
+        NOTE_TYPES.DISCHARGE_PLANNING,
+      );
       await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(noteContent);
 
       // Validate note appears in prepare discharge modal
       await patientDetailsPage.prepareDischargeButton.click();
       const prepareDischargeModal = patientDetailsPage.getPrepareDischargeModal();
       await prepareDischargeModal.waitForModalToLoad();
-      await expect(
-        prepareDischargeModal.dischargeNoteTextarea,
-      ).toContainText(noteContent);
+      await expect(prepareDischargeModal.dischargeNoteTextarea).toContainText(noteContent);
       await prepareDischargeModal.cancelButton.click();
     });
 
-    test('[T-0186][AT-0077]should create an other note with basic details', async ({ patientDetailsPage }) => {
+    test('[T-0186][AT-0077]should create an other note with basic details', async ({
+      patientDetailsPage,
+    }) => {
       const noteContent = 'This is a test other note';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
@@ -68,35 +72,45 @@ test.describe('Notes Tests', () => {
 
       // Validate note appears in the table
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(NOTE_TYPES.OTHER);
+      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(
+        NOTE_TYPES.OTHER,
+      );
       await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(noteContent);
     });
 
-    test('[T-0186][AT-0078]should validate form field values when creating a note', async ({ patientDetailsPage }) => {
+    test('[T-0186][AT-0078]should validate form field values when creating a note', async ({
+      patientDetailsPage,
+    }) => {
       const noteContent = 'This is a test note for validation';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
       await newNoteModal?.waitForModalToLoad();
-      
+
       // Set up the form
       await newNoteModal?.selectType(NOTE_TYPES.OTHER);
       await newNoteModal?.noteContentTextarea.fill(noteContent);
-      
+
       // Validate form field values
       await expect(newNoteModal?.getWrittenByValue()).resolves.toBe(user.displayName);
-      await expect(newNoteModal?.getDateTimeValue()).resolves.toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
-      
+      await expect(newNoteModal?.getDateTimeValue()).resolves.toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/,
+      );
+
       // Complete the note creation
       await newNoteModal?.confirmButton.click();
       await newNoteModal?.waitForModalToClose();
       await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
-      
+
       // Validate note appears in the table
-      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(NOTE_TYPES.OTHER);
+      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(
+        NOTE_TYPES.OTHER,
+      );
       await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(noteContent);
     });
 
-    test('[T-0186][AT-0079]should not allow creating a note without required fields', async ({ patientDetailsPage }) => {
+    test('[T-0186][AT-0079]should not allow creating a note without required fields', async ({
+      patientDetailsPage,
+    }) => {
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
       await newNoteModal?.waitForModalToLoad();
@@ -106,11 +120,17 @@ test.describe('Notes Tests', () => {
 
       // Modal should still be visible (validation should prevent submission)
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.getNewNoteModal().noteTypeRequiredIndicator).toBeVisible();
-      await expect(patientDetailsPage.notesPane!.getNewNoteModal().noteContentRequiredIndicator).toBeVisible();
+      await expect(
+        patientDetailsPage.notesPane!.getNewNoteModal().noteTypeRequiredIndicator,
+      ).toBeVisible();
+      await expect(
+        patientDetailsPage.notesPane!.getNewNoteModal().noteContentRequiredIndicator,
+      ).toBeVisible();
     });
 
-    test('[T-0186][AT-0080]should allow cancelling note creation', async ({ patientDetailsPage }) => {
+    test('[T-0186][AT-0080]should allow cancelling note creation', async ({
+      patientDetailsPage,
+    }) => {
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
       await newNoteModal?.waitForModalToLoad();
@@ -127,13 +147,15 @@ test.describe('Notes Tests', () => {
       expect(patientDetailsPage.notesPane).toBeDefined();
       const noteContent = await patientDetailsPage.notesPane!.noDataMessage.textContent();
       expect(noteContent).toBe(
-        "This patient has no notes to display. Click ‘New note’ to add a note.",
+        'This patient has no notes to display. Click ‘New note’ to add a note.',
       );
     });
   });
 
   test.describe('Edit Note Tests', () => {
-    test('[T-0191][AT-0081]should edit an existing note and view the change log', async ({ patientDetailsPage }) => {
+    test('[T-0191][AT-0081]should edit an existing note and view the change log', async ({
+      patientDetailsPage,
+    }) => {
       const originalContent = 'Original note content';
       const updatedContent = 'Updated note content';
       const noteType = NOTE_TYPES.OTHER;
@@ -143,103 +165,91 @@ test.describe('Notes Tests', () => {
 
       // Create a note first
       await patientDetailsPage.notesPane?.newNoteButton.click();
-      const firstDateTime = await newNoteModal?.createBasicNote(
-        noteType,
-        originalContent,
-      );
+      await newNoteModal?.createBasicNote(noteType, originalContent);
       await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
 
       // Edit the note
       await patientDetailsPage.notesPane?.editIcons.nth(0).click();
-      const secondDateTime = await editNoteModal?.editNote(updatedContent);
+      await editNoteModal?.editNote(updatedContent);
+
+      await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
 
       // Validate the note was updated
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(updatedContent);
+      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(
+        updatedContent,
+      );
 
       //validate change log
       await patientDetailsPage.notesPane!.editedButtons.first().click();
       expect(changeLogModal).toBeDefined();
       await changeLogModal!.waitForModalToLoad();
-    
+
       // Validate note type
       await expect(changeLogModal!.noteTypeLabel).toHaveText(noteType);
-      
+
       // Validate content entries
       await expect(changeLogModal!.changelogTextContents.first()).toContainText(updatedContent);
       await expect(changeLogModal!.changelogTextContents.nth(1)).toContainText(originalContent);
-      
-      // Format dates for validation
-      const firstNoteFormattedDateTime = formatDateTimeForDisplay(new Date(firstDateTime!));
-      const secondNoteFormattedDateTime = formatDateTimeForDisplay(new Date(secondDateTime!));
-      
-      // Validate date and user information
-      await expect(changeLogModal!.dateLabel).toHaveText(firstNoteFormattedDateTime);
+
+      // Dates: header uses `revisedBy.date` (newest). Changelog rows are oldest-first; nth(1) is the latest revision.
+      // That time can match nth(0) when both edits fall in the same displayed minute.
+      const newerChangeLogDate = (await changeLogModal!.changelogInfoDates
+        .nth(1)
+        .textContent())!.trim();
+      await expect(changeLogModal!.dateLabel).toHaveText(newerChangeLogDate);
       await expect(changeLogModal!.changeLogInfoWrappers.first()).toContainText(user.displayName);
-      await expect(changeLogModal!.changelogInfoDates.first()).toHaveText(firstNoteFormattedDateTime);
-      await expect(changeLogModal!.changelogInfoDates.nth(1)).toHaveText(secondNoteFormattedDateTime);
       await changeLogModal!.closeButton.click();
     });
-    test('[T-0191][AT-0082]should update a treatment plan note and validate the change log', async ({ patientDetailsPage }) => {
+    test('[T-0191][AT-0082]should update a treatment plan note and validate the change log', async ({
+      patientDetailsPage,
+    }) => {
       test.setTimeout(50000);
       const originalContent = 'Original treatment plan';
       const updatedContent = 'Updated treatment plan';
-      const updatedBy = 'System';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
-      const updateTreatmentPlanModal = patientDetailsPage.notesPane?.getUpdateTreatmentPlanModal();
-      const changeLogTreatmentPlanModal = patientDetailsPage.notesPane?.getChangeLogTreatmentPlanModal();
+      const editNoteModal = patientDetailsPage.notesPane?.getEditNoteModal();
+      const changeLogTreatmentPlanModal =
+        patientDetailsPage.notesPane?.getChangeLogTreatmentPlanModal();
 
       // Create a treatment plan note first
       await patientDetailsPage.notesPane?.newNoteButton.click();
-      const firstDateTime = await newNoteModal?.createBasicNote(
-        NOTE_TYPES.TREATMENT_PLAN,
-        originalContent,
-      );
+      await newNoteModal?.createBasicNote(NOTE_TYPES.TREATMENT_PLAN, originalContent);
       await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
 
       // Update the treatment plan
       await patientDetailsPage.notesPane?.editIcons.first().click();
-      const secondDateTime = await updateTreatmentPlanModal?.updateTreatmentPlan(updatedBy, updatedContent);
+      await editNoteModal?.editNote(updatedContent);
+      await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
 
       // Validate the note was updated
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(updatedContent);
-      
+      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(
+        updatedContent,
+        { timeout: 15000 },
+      );
+
       // Validate change log
       await patientDetailsPage.notesPane!.editedButtons.first().click();
       expect(changeLogTreatmentPlanModal).toBeDefined();
       await changeLogTreatmentPlanModal!.waitForModalToLoad();
-      
-      const lastUpdatedBy = `${user.displayName} on behalf of ${updatedBy}`;
-      
-      // Validate note type
-      await expect(changeLogTreatmentPlanModal!.noteTypeLabel).toHaveText(NOTE_TYPES.TREATMENT_PLAN);
-      
-      // Validate last updated by information
-      await expect(changeLogTreatmentPlanModal!.lastUpdatedByValue).toHaveText(lastUpdatedBy);
-      
-      // Validate last updated at information
-      const formattedLastUpdatedAt = formatDateTimeForDisplay(new Date(secondDateTime!));
-      await expect(changeLogTreatmentPlanModal!.lastUpdatedAtValue).toHaveText(formattedLastUpdatedAt);
-  
-      // Validate content entries
-      await expect(changeLogTreatmentPlanModal!.changelogTextContents.first()).toContainText(updatedContent);
-      await expect(changeLogTreatmentPlanModal!.changelogTextContents.nth(1)).toContainText(originalContent);
-      
-      // Format dates for validation
-      const firstNoteFormattedDateTime = formatDateTimeForDisplay(new Date(firstDateTime!));
-      const secondNoteFormattedDateTime = formatDateTimeForDisplay(new Date(secondDateTime!));
-      
-      // Validate change log user and date information
-      await expect(changeLogTreatmentPlanModal!.changeLogInfoWrappers.first()).toContainText(lastUpdatedBy);
-      await expect(changeLogTreatmentPlanModal!.changeLogInfoWrappers.nth(1)).toContainText(user.displayName);
-      await expect(changeLogTreatmentPlanModal!.changelogInfoDates.first()).toHaveText(secondNoteFormattedDateTime);
-      await expect(changeLogTreatmentPlanModal!.changelogInfoDates.nth(1)).toHaveText(firstNoteFormattedDateTime);
-      
-      // Close the modal
+
+      await expect(changeLogTreatmentPlanModal!.noteTypeLabel).toHaveText(
+        NOTE_TYPES.TREATMENT_PLAN,
+      );
+
+      await expect(changeLogTreatmentPlanModal!.changelogTextContents.first()).toContainText(
+        updatedContent,
+      );
+      await expect(changeLogTreatmentPlanModal!.changelogTextContents.nth(1)).toContainText(
+        originalContent,
+      );
+
       await changeLogTreatmentPlanModal!.closeButton.click();
     });
-    test('[T-0191][AT-0083]should edit an discharge planning note and validate it is shown in the discharge modal', async ({ patientDetailsPage }) => {
+    test('[T-0191][AT-0083]should edit an discharge planning note and validate it is shown in the discharge modal', async ({
+      patientDetailsPage,
+    }) => {
       const originalContent = 'Original note content';
       const updatedContent = 'Updated note content';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
@@ -247,10 +257,7 @@ test.describe('Notes Tests', () => {
 
       // Create a note first
       await patientDetailsPage.notesPane?.newNoteButton.click();
-      await newNoteModal?.createBasicNote(
-        NOTE_TYPES.DISCHARGE_PLANNING,
-        originalContent,
-      );
+      await newNoteModal?.createBasicNote(NOTE_TYPES.DISCHARGE_PLANNING, originalContent);
       await patientDetailsPage.notesPane?.waitForNotesPaneToLoad();
 
       // Edit the note
@@ -259,16 +266,18 @@ test.describe('Notes Tests', () => {
 
       // Validate the note was updated
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(updatedContent);
+      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(
+        updatedContent,
+      );
       await patientDetailsPage.prepareDischargeButton.click();
       const prepareDischargeModal = patientDetailsPage.getPrepareDischargeModal();
       await prepareDischargeModal.waitForModalToLoad();
-      await expect(
-        prepareDischargeModal.dischargeNoteTextarea,
-      ).toHaveText(updatedContent);
+      await expect(prepareDischargeModal.dischargeNoteTextarea).toHaveText(updatedContent);
     });
 
-    test('[AT-0084]should show edited indicator after editing a note', async ({ patientDetailsPage }) => {
+    test('[AT-0084]should show edited indicator after editing a note', async ({
+      patientDetailsPage,
+    }) => {
       const originalContent = 'Original note content';
       const updatedContent = 'Updated note content';
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
@@ -311,17 +320,21 @@ test.describe('Notes Tests', () => {
 
       // Validate the note content remains unchanged
       expect(patientDetailsPage.notesPane).toBeDefined();
-      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(originalContent);
+      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(
+        originalContent,
+      );
     });
   });
 
   test.describe('Notes Table Tests', () => {
     test.setTimeout(60000);
-    test('[T-0189][AT-0086]treatment plan note should appear on top when creating multiple notes', async ({ patientDetailsPage }) => {
+    test('[T-0189][AT-0086]treatment plan note should appear on top when creating multiple notes', async ({
+      patientDetailsPage,
+    }) => {
       const notes = [
         { type: NOTE_TYPES.DISCHARGE_PLANNING, content: 'Discharge planning note' },
         { type: NOTE_TYPES.OTHER, content: 'Other note' },
-        { type: NOTE_TYPES.TREATMENT_PLAN, content: 'Treatment plan note' }
+        { type: NOTE_TYPES.TREATMENT_PLAN, content: 'Treatment plan note' },
       ];
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
 
@@ -340,17 +353,25 @@ test.describe('Notes Tests', () => {
       expect(noteCount).toBe(notes.length);
 
       //validate treatment plan note appears on top
-      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(NOTE_TYPES.TREATMENT_PLAN);
+      await expect(patientDetailsPage.notesPane!.noteHeaderTexts.first()).toHaveText(
+        NOTE_TYPES.TREATMENT_PLAN,
+      );
       await expect(patientDetailsPage.notesPane!.noteContents.first()).toHaveText(notes[2].content);
 
       // Validate notes appear in reverse order (last created on top)
       for (let i = 1; i < notes.length; i++) {
         const noteIndex = notes.length - 1 - i; // Reverse the index
-        await expect(patientDetailsPage.notesPane!.noteHeaderTexts.nth(i)).toHaveText(notes[noteIndex].type);
-        await expect(patientDetailsPage.notesPane!.noteContents.nth(i)).toContainText(notes[noteIndex].content);
+        await expect(patientDetailsPage.notesPane!.noteHeaderTexts.nth(i)).toHaveText(
+          notes[noteIndex].type,
+        );
+        await expect(patientDetailsPage.notesPane!.noteContents.nth(i)).toContainText(
+          notes[noteIndex].content,
+        );
       }
     });
-    test('[T-0190][AT-0087]should display read more and show less button when note content is too long', async ({ patientDetailsPage }) => {
+    test('[T-0190][AT-0087]should display read more and show less button when note content is too long', async ({
+      patientDetailsPage,
+    }) => {
       const noteContent = testData.noteContent;
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
       await patientDetailsPage.notesPane?.newNoteButton.click();
@@ -362,12 +383,14 @@ test.describe('Notes Tests', () => {
       await expect(patientDetailsPage.notesPane!.showLessButton.first()).toBeVisible();
     });
 
-    test('[T-0188][AT-0088]should be able to filter notes by note type', async ({ patientDetailsPage }) => {
+    test('[T-0188][AT-0088]should be able to filter notes by note type', async ({
+      patientDetailsPage,
+    }) => {
       test.setTimeout(50000);
       const notes = [
         { type: NOTE_TYPES.DISCHARGE_PLANNING, content: 'Discharge planning note' },
         { type: NOTE_TYPES.OTHER, content: 'Other note' },
-        { type: NOTE_TYPES.TREATMENT_PLAN, content: 'Treatment plan note' }
+        { type: NOTE_TYPES.TREATMENT_PLAN, content: 'Treatment plan note' },
       ];
       const newNoteModal = patientDetailsPage.notesPane?.getNewNoteModal();
 
@@ -384,10 +407,14 @@ test.describe('Notes Tests', () => {
 
       // Filter notes by note type
       await patientDetailsPage.notesPane?.noteTypeSelect.click();
-      await patientDetailsPage.notesPane?.noteTypeOptions.getByText(NOTE_TYPES.TREATMENT_PLAN).click();
+      await patientDetailsPage.notesPane?.noteTypeOptions
+        .getByText(NOTE_TYPES.TREATMENT_PLAN)
+        .click();
       await patientDetailsPage.notesPane?.waitForNoteRowsToEqual(1);
       await expect(patientDetailsPage.notesPane!.noteRows).toHaveCount(1);
-      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(notes[2].content);
+      await expect(patientDetailsPage.notesPane!.noteContents.first()).toContainText(
+        notes[2].content,
+      );
     });
   });
 });

--- a/packages/e2e-tests/tests/patients/patientSideBar.spec.ts
+++ b/packages/e2e-tests/tests/patients/patientSideBar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../fixtures/baseFixture';
+import { fillMuiDateField, fillMuiDateTimeField, normalizeToIsoDate } from '@utils/testHelper';
 
 test.describe('Patient Side Bar', () => {
   test.beforeEach(async ({ patientDetailsPage, newPatient }) => {
@@ -16,7 +17,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedOnGoingConditionName).toHaveValue('Sleep apnea');
-    await expect(patientDetailsPage.savedOnGoingConditionDate).toHaveValue(currentBrowserDate);
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedOnGoingConditionDate.inputValue()),
+    ).toBe(currentBrowserDate);
   });
 
   test('[T-0040][AT-0097]Add ongoing condition with all fields', async ({ patientDetailsPage }) => {
@@ -32,7 +35,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedOnGoingConditionName).toHaveValue('Jaw dislocation');
-    await expect(patientDetailsPage.savedOnGoingConditionDate).toHaveValue('2024-06-20');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedOnGoingConditionDate.inputValue()),
+    ).toBe('2024-06-20');
     await expect(patientDetailsPage.savedOnGoingConditionClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedOnGoingConditionNote).toHaveValue('This is a note');
   });
@@ -72,7 +77,9 @@ test.describe('Patient Side Bar', () => {
     await expect(patientDetailsPage.savedOnGoingConditionName).toHaveValue(
       'Eating habits inadequate',
     );
-    await expect(patientDetailsPage.savedOnGoingConditionDate).toHaveValue('2024-07-13');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedOnGoingConditionDate.inputValue()),
+    ).toBe('2024-07-13');
     await expect(patientDetailsPage.savedOnGoingConditionClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedOnGoingConditionNote).toHaveValue('Edited note');
     await expect(patientDetailsPage.page.getByText('Temporary note')).toBeHidden();
@@ -97,7 +104,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedOnGoingConditionName).toHaveValue('Pain in hand');
-    await expect(patientDetailsPage.savedOnGoingConditionDate).toHaveValue('2024-08-14');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedOnGoingConditionDate.inputValue()),
+    ).toBe('2024-08-14');
     await expect(patientDetailsPage.savedOnGoingConditionClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedOnGoingConditionNote).toHaveValue(
       'This is to test resolving a note',
@@ -118,7 +127,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedAllergyName).toHaveValue('Dust mites');
-    await expect(patientDetailsPage.savedAllergyDate).toHaveValue(currentBrowserDate);
+    expect(normalizeToIsoDate(await patientDetailsPage.savedAllergyDate.inputValue())).toBe(
+      currentBrowserDate,
+    );
   });
 
   test('[T-0042][AT-0102]Add allergy with all fields', async () => {
@@ -177,7 +188,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Hair alopecia');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue(currentBrowserDate);
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedFamilyHistoryDateRecorded.inputValue()),
+    ).toBe(currentBrowserDate);
   });
 
   test('[T-0044][AT-0106]Add family history with all fields', async ({ patientDetailsPage }) => {
@@ -194,7 +207,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Ear burn');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue('2025-05-26');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedFamilyHistoryDateRecorded.inputValue()),
+    ).toBe('2025-05-26');
     await expect(patientDetailsPage.savedFamilyHistoryRelationship).toHaveValue('Mother');
     await expect(patientDetailsPage.savedFamilyClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedFamilyHistoryNote).toHaveValue('Family history note');
@@ -205,7 +220,7 @@ test.describe('Patient Side Bar', () => {
 
     await patientDetailsPage.firstListItem.click();
 
-    await patientDetailsPage.savedFamilyHistoryDateRecorded.fill('2025-05-25');
+    await fillMuiDateField(patientDetailsPage.savedFamilyHistoryDateRecorded, '2025-05-25');
     await patientDetailsPage.savedFamilyHistoryRelationship.fill('Mother');
     await patientDetailsPage.savedFamilyClinician.click();
     await patientDetailsPage.page.getByRole('menuitem', { name: 'Initial Admin' }).click();
@@ -215,7 +230,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Hair alopecia');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue('2025-05-25');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedFamilyHistoryDateRecorded.inputValue()),
+    ).toBe('2025-05-25');
     await expect(patientDetailsPage.savedFamilyHistoryRelationship).toHaveValue('Mother');
     await expect(patientDetailsPage.savedFamilyClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedFamilyHistoryNote).toHaveValue('First edit to note');
@@ -226,7 +243,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedFamilyHistoryName).toHaveValue('Hair alopecia');
-    await expect(patientDetailsPage.savedFamilyHistoryDateRecorded).toHaveValue('2025-05-25');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedFamilyHistoryDateRecorded.inputValue()),
+    ).toBe('2025-05-25');
     await expect(patientDetailsPage.savedFamilyHistoryRelationship).toHaveValue('Mother');
     await expect(patientDetailsPage.savedFamilyClinician).toHaveValue('Initial Admin');
     await expect(patientDetailsPage.savedFamilyHistoryNote).toHaveValue('Second edit to note');
@@ -248,7 +267,9 @@ test.describe('Patient Side Bar', () => {
 
     await expect(patientDetailsPage.savedIssueType).toContainText('Issue');
     await expect(patientDetailsPage.savedOtherPatientIssueNote).toHaveValue('New issue note');
-    await expect(patientDetailsPage.savedOtherPatientIssueDate).toHaveValue(currentBrowserDate);
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedOtherPatientIssueDate.inputValue()),
+    ).toBe(currentBrowserDate);
   });
 
   test('[T-0045][AT-0109]Add other patient issue: warning', async ({ patientDetailsPage }) => {
@@ -290,7 +311,7 @@ test.describe('Patient Side Bar', () => {
     await expect(patientDetailsPage.savedOtherPatientIssueNote).toHaveValue('Test warning');
 
     await patientDetailsPage.savedOtherPatientIssueNote.fill('Edited warning');
-    await patientDetailsPage.savedOtherPatientIssueDate.fill('2025-09-17');
+    await fillMuiDateField(patientDetailsPage.savedOtherPatientIssueDate, '2025-09-17');
     await patientDetailsPage.getOtherPatientIssuesEditSubmitButton().click();
 
     await patientDetailsPage.firstListItem.click();
@@ -311,7 +332,9 @@ test.describe('Patient Side Bar', () => {
     await patientDetailsPage.firstListItem.click();
 
     await expect(patientDetailsPage.savedOtherPatientIssueNote).toHaveValue('Edited warning');
-    await expect(patientDetailsPage.savedOtherPatientIssueDate).toHaveValue('2025-09-17');
+    expect(
+      normalizeToIsoDate(await patientDetailsPage.savedOtherPatientIssueDate.inputValue()),
+    ).toBe('2025-09-17');
     await expect(patientDetailsPage.page.getByText('Test warning')).toBeHidden();
   });
 
@@ -320,7 +343,7 @@ test.describe('Patient Side Bar', () => {
 
     const currentBrowserDate = patientDetailsPage.getCurrentBrowserDateISOFormat();
     const defaultDate = await newCarePlanModal.carePlanDate.inputValue();
-    await expect(defaultDate).toContain(currentBrowserDate);
+    expect(normalizeToIsoDate(defaultDate)).toBe(currentBrowserDate);
 
     await newCarePlanModal.fillOutCarePlan(
       'Diabetes',
@@ -393,7 +416,7 @@ test.describe('Patient Side Bar', () => {
     await additionalNoteKebabMenu.click();
     await completedCarePlanModal.additionalNoteEditButton.click();
 
-    await completedCarePlanModal.additionalNoteSavedDate.fill('2025-04-26T15:40');
+    await fillMuiDateTimeField(completedCarePlanModal.additionalNoteSavedDate, '2025-04-26T15:40');
     await completedCarePlanModal.editableNoteContent.fill('Edited note');
     await completedCarePlanModal.getSaveButton().click();
 

--- a/packages/e2e-tests/tests/patients/procedure.spec.ts
+++ b/packages/e2e-tests/tests/patients/procedure.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@fixtures/baseFixture';
 import { getUser } from '@utils/apiHelpers';
+import { formatForMuiDatePicker } from '@utils/testHelper';
 import { format } from 'date-fns';
 
 test.setTimeout(60000);
@@ -17,9 +18,12 @@ test.describe('Procedures', () => {
     const date = new Date();
     const modal = patientDetailsPage.patientProcedurePane!.getNewProcedureModal();
     await modal.waitForModalToLoad();
-    await expect(modal.getLocatorInput(modal.procedureDateInput)).toHaveValue(format(date, 'yyyy-MM-dd'));
+    await expect(modal.getLocatorInput(modal.procedureDateInput)).toHaveValue(
+      formatForMuiDatePicker(format(date, 'yyyy-MM-dd')),
+    );
     await expect(modal.getLocatorInput(modal.leadClinicianInput)).toHaveValue(user.displayName!);
-    await expect(modal.getLocatorInput(modal.timeStartedInput)).toHaveValue(format(date, 'HH:mm'));
+    // Time started defaults from facility `getCurrentDateTime()`, not the test runner clock — assert display shape only.
+    await expect(modal.getLocatorInput(modal.timeStartedInput)).toHaveValue(/\d{1,2}:\d{2} (AM|PM)/);
   });
 
   test('[T-0197][AT-0090]Add a procedure with all fields filled and validate the procedure table', async ({ patientDetailsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
@@ -71,7 +75,9 @@ test.describe('Procedures', () => {
     const viewModal = patientDetailsPage.patientProcedurePane!.getNewProcedureModal();
     await viewModal.waitForModalToLoad();
     await expect(viewModal.getLocatorInput(viewModal.procedureInput)).toHaveValue(procedureData.procedure!);
-    await expect(viewModal.getLocatorInput(viewModal.procedureDateInput)).toHaveValue(format(new Date(), 'yyyy-MM-dd'));
+    await expect(viewModal.getLocatorInput(viewModal.procedureDateInput)).toHaveValue(
+      formatForMuiDatePicker(format(new Date(), 'yyyy-MM-dd')),
+    );
     await expect(viewModal.getLocatorInput(viewModal.procedureAreaInput)).toHaveValue(procedureData.area!);
     await expect(viewModal.getLocatorInput(viewModal.procedureLocationInput)).toHaveValue(procedureData.location!);
     await expect(viewModal.getLocatorInput(viewModal.departmentInput)).toHaveValue(procedureData.department!);
@@ -108,7 +114,9 @@ test.describe('Procedures', () => {
     await modal.getUnsavedChangesModal().waitForModalToLoad();
     await modal.getUnsavedChangesModal().continueEditingButton.click();
     await expect(modal.getLocatorInput(modal.procedureInput)).toHaveValue(procedureData.procedure!);
-    await expect(modal.getLocatorInput(modal.procedureDateInput)).toHaveValue(format(new Date(), 'yyyy-MM-dd'));
+    await expect(modal.getLocatorInput(modal.procedureDateInput)).toHaveValue(
+      formatForMuiDatePicker(format(new Date(), 'yyyy-MM-dd')),
+    );
     await expect(modal.getLocatorInput(modal.procedureAreaInput)).toHaveValue(procedureData.area!);
     await expect(modal.getLocatorInput(modal.procedureLocationInput)).toHaveValue(procedureData.location!);
     await expect(modal.getLocatorInput(modal.departmentInput)).toHaveValue(procedureData.department!);

--- a/packages/e2e-tests/utils/dateTimeHelpers.ts
+++ b/packages/e2e-tests/utils/dateTimeHelpers.ts
@@ -1,0 +1,301 @@
+import { Locator, expect } from '@playwright/test';
+import { addYears, format, isValid, parse, subYears } from 'date-fns';
+
+const DISPLAY_DATE_TIME_PATTERNS = [
+  'dd/MM/yyyy hh:mm a',
+  'dd/MM/yyyy h:mm a',
+  'dd/MM/yyyy',
+] as const;
+
+/**
+ * Parse values from the app or tests: ISO (`yyyy-MM-dd` or `yyyy-MM-ddTHH:mm…`), then MUI-style `dd/MM/…` text.
+ * ISO datetimes use `new Date` so the time is preserved; bare `yyyy-MM-dd` uses calendar-day parsing (no TZ shift).
+ * If the string starts with `yyyy-MM-dd` but has trailing characters (e.g. space + time without `T`), uses
+ * `new Date(trimmed)` so the time is not dropped. Does **not** fall back to a bare `new Date` for arbitrary
+ * strings — that would be locale-dependent (e.g. `01/02/2025`) and hide parse failures in tests.
+ */
+export function parseTamanuDate(raw: string): Date | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (/^\d{4}-\d{2}-\d{2}T/.test(trimmed)) {
+    const fromIso = new Date(trimmed);
+    if (isValid(fromIso)) return fromIso;
+  }
+
+  const isoDate = trimmed.match(/^(\d{4}-\d{2}-\d{2})([\s\S]*)$/);
+  if (isoDate) {
+    const datePart = isoDate[1];
+    const rest = isoDate[2].trim();
+    if (!rest) {
+      const d = parse(datePart, 'yyyy-MM-dd', new Date());
+      return isValid(d) ? d : null;
+    }
+    const fromNative = new Date(trimmed);
+    if (isValid(fromNative)) return fromNative;
+  }
+
+  for (const pattern of DISPLAY_DATE_TIME_PATTERNS) {
+    const d = parse(trimmed, pattern, new Date());
+    if (isValid(d)) return d;
+  }
+
+  return null;
+}
+
+/** Format test/ISO data for **MUI date-time text fields** (`dd/MM/yyyy hh:mm a`). On failure returns the input. */
+export function formatForMuiDateTimePicker(isoDate: string): string {
+  const parsed = parseTamanuDate(isoDate);
+  if (!parsed) return isoDate;
+  return format(parsed, 'dd/MM/yyyy hh:mm a');
+}
+
+/** Format test/ISO data for **MUI date-only** fields (`dd/MM/yyyy`). */
+export function formatForMuiDatePicker(isoDate: string): string {
+  const parsed = parseTamanuDate(isoDate.trim());
+  if (!parsed) return isoDate;
+  return format(parsed, 'dd/MM/yyyy');
+}
+
+/**
+ * Format a 24h wall time (`HH:mm`) for MUI TimePicker text fields (`DISPLAY_FORMATS.time` in ui-components: `hh:mm a`).
+ */
+export function formatForMuiTimePicker(hhmm24: string): string {
+  const trimmed = hhmm24.trim();
+  const parsed = parse(trimmed, 'HH:mm', new Date());
+  if (!isValid(parsed)) {
+    return trimmed;
+  }
+  return format(parsed, 'hh:mm a');
+}
+
+/**
+ * Shared app date fields use the same MUI-style text format (`dd/MM/yyyy` or `dd/MM/yyyy hh:mm a`).
+ * Fill with {@link fillMuiDateField}, {@link fillMuiDateTimeField}, or {@link fillMuiTimeField}
+ * using ISO-like test fixtures (`yyyy-MM-dd`, `yyyy-MM-dd'T'HH:mm`, `HH:mm` for time-only).
+ * Assert with {@link normalizeToIsoDate} / {@link normalizeToIsoDateTimeMinute} on `inputValue()` when needed.
+ */
+
+/**
+ * Fill an MUI **date-only** field and blur so Formik receives the value.
+ */
+export async function fillMuiDateField(field: Locator, date: string): Promise<void> {
+  await field.fill(formatForMuiDatePicker(date));
+  await field.blur();
+}
+
+/**
+ * Fill an MUI **date-time** field and blur so Formik receives the value.
+ */
+export async function fillMuiDateTimeField(field: Locator, dateTime: string): Promise<void> {
+  await field.fill(formatForMuiDateTimePicker(dateTime));
+  await field.blur();
+}
+
+/**
+ * Fill an MUI **time** field (`HH:mm` test data → `hh:mm a` display) and blur so Formik receives the value.
+ */
+export async function fillMuiTimeField(field: Locator, time: string): Promise<void> {
+  await field.fill(formatForMuiTimePicker(time));
+  await field.blur();
+}
+
+/**
+ * Normalize a test or DOM date value to **US-style short date** `MM/dd/yyyy` for text assertions.
+ *
+ * **Used for** `toContainText`, table cell expectations, and anywhere the UI shows month-first short dates.
+ *
+ * **Behaviour**
+ * - `undefined` / missing → `''`.
+ * - `Date` → formatted with `date-fns` if valid, else `''`.
+ * - String → try {@link parseTamanuDate}; if that fails, a naive `yyyy-MM-dd` split → `MM/DD/YYYY`.
+ *
+ * @param dateInput — ISO string, picker output fragment, or `Date` from test data.
+ * @returns `MM/dd/yyyy` or `''` when empty/unparseable.
+ */
+export const convertDateFormat = (dateInput: string | Date | undefined): string => {
+  if (!dateInput) return '';
+
+  if (dateInput instanceof Date) {
+    return isValid(dateInput) ? format(dateInput, 'MM/dd/yyyy') : '';
+  }
+
+  const parsed = parseTamanuDate(String(dateInput));
+  if (parsed) {
+    return format(parsed, 'MM/dd/yyyy');
+  }
+
+  const s = String(dateInput).trim();
+  const [year, month, day] = s.split('-');
+  if (year && month && day) {
+    return `${month}/${day}/${year}`;
+  }
+  return '';
+};
+
+/**
+ * Build candidate strings for **substring** matching a date in a table cell when locale may flip day/month order.
+ *
+ * Some cells render via `DateDisplay` (or similar) so the same calendar day can appear as `MM/dd/yyyy` or
+ * `dd/MM/yyyy`. Playwright checks often use `includes`; passing both strings covers either rendering.
+ *
+ * **Returns**
+ * - No `dateGiven` → `['Unknown']` (placeholder row convention in some specs).
+ * - Parse succeeds → `[ MM/dd/yyyy, dd/MM/yyyy ]`.
+ * - Parse fails → single fallback from {@link convertDateFormat}.
+ *
+ * @param dateGiven — Test data date string; `undefined` triggers the Unknown placeholder path.
+ */
+export function dateTableMatchStrings(dateGiven: string | undefined): string[] {
+  if (!dateGiven) return ['Unknown'];
+  const parsed = parseTamanuDate(dateGiven.trim());
+  if (!parsed) {
+    return [convertDateFormat(dateGiven)];
+  }
+  return [format(parsed, 'MM/dd/yyyy'), format(parsed, 'dd/MM/yyyy')];
+}
+
+/**
+ * Normalize any supported string to `yyyy-MM-dd` for comparisons.
+ *
+ * @throws Error when the value cannot be parsed — avoids assertions passing with unnormalized strings.
+ */
+export function normalizeToIsoDate(raw: string): string {
+  const parsed = parseTamanuDate(raw);
+  if (!parsed) {
+    throw new Error(`Could not parse date for normalization: ${raw}`);
+  }
+  return format(parsed, 'yyyy-MM-dd');
+}
+
+/**
+ * Normalize a datetime input value to `yyyy-MM-dd'T'HH:mm` (24h, no seconds).
+ *
+ * @throws Error when the value cannot be parsed — avoids assertions passing with unnormalized strings.
+ */
+export function normalizeToIsoDateTimeMinute(raw: string): string {
+  const parsed = parseTamanuDate(raw);
+  if (!parsed) {
+    throw new Error(`Could not parse date-time for normalization: ${raw}`);
+  }
+  return format(parsed, "yyyy-MM-dd'T'HH:mm");
+}
+
+/**
+ * Format a `Date` to match **on-screen datetime copy** in parts of the app: `MM/dd/yyyy` + 12h time with
+ * **lowercase** `am`/`pm` and no space before meridiem (e.g. `02/12/2026 9:31am`).
+ *
+ * @param date — Instant to format (local time per `date-fns` `format`).
+ */
+export function formatDateTimeForDisplay(date: Date): string {
+  return format(date, 'MM/dd/yyyy h:mm a').replace(' AM', 'am').replace(' PM', 'pm');
+}
+
+/**
+ * Convert a datetime string into the **concatenated** table display form used in some grids:
+ * **time** (`h:mm` + lowercase `am`/`pm`, no space) immediately followed by **date** `MM/dd/yy`
+ * (e.g. `6:11am12/01/25`).
+ *
+ * Accepts ISO-like (`2025-12-01T06:11`) and MUI display (`dd/MM/yyyy hh:mm a`) formats.
+ *
+ * @param dateTimeString — Typically from a form field or API fixture.
+ */
+export function formatDateTimeForTable(dateTimeString: string): string {
+  const dateFromForm = parseTamanuDate(dateTimeString);
+  if (!dateFromForm) {
+    throw new Error(`Could not parse date for table formatting: ${dateTimeString}`);
+  }
+  const formattedTime = format(dateFromForm, 'h:mm a').replace(' ', '').toLowerCase(); // "6:11am"
+  const formattedDate = format(dateFromForm, 'MM/dd/yy'); // "12/01/25"
+  return `${formattedTime}${formattedDate}`; // "6:11am12/01/25"
+}
+
+/**
+ * Comparator factory for sorting objects with a **`dateGiven`** ISO-like string (e.g. vaccine rows).
+ *
+ * Uses `new Date(...).getTime()`; invalid date strings sort as `NaN` and may behave unpredictably—keep test
+ * data parseable.
+ *
+ * @param order — `'asc'` (oldest first) or `'desc'` (newest first).
+ */
+export function compareByDate(order: 'asc' | 'desc') {
+  return (a: { dateGiven: string }, b: { dateGiven: string }) => {
+    const dateA = new Date(a.dateGiven).getTime();
+    const dateB = new Date(b.dateGiven).getTime();
+    return order === 'asc' ? dateA - dateB : dateB - dateA;
+  };
+}
+
+/**
+ * Shift a calendar date by a whole number of years; returns **`yyyy-MM-dd`** for fixtures and inputs.
+ *
+ * **Use case** — Age boundaries, eligibility windows, “same day next year” vaccine tests.
+ *
+ * @param dateToOffset — Parseable date string (passed to `new Date`).
+ * @param offset — `'increase'` or `'decrease'`.
+ * @param amountToOffset — Non-negative year delta (applied via `date-fns` `addYears` / `subYears`).
+ * @throws Error when `offset` is not `'increase'` or `'decrease'`.
+ */
+export function offsetYear(
+  dateToOffset: string,
+  offset: 'increase' | 'decrease',
+  amountToOffset: number,
+): string {
+  const formattedDateToOffset = new Date(dateToOffset);
+  let newDate = undefined;
+
+  if (offset === 'increase') newDate = addYears(formattedDateToOffset, amountToOffset);
+  else if (offset === 'decrease') newDate = subYears(formattedDateToOffset, amountToOffset);
+  else throw new Error('Invalid offset');
+
+  return format(newDate, 'yyyy-MM-dd');
+}
+
+/**
+ * Assert the value of a datetime **input** is within `thresholdMinutes` of “now” (wall clock).
+ *
+ * **Use case** — Fields defaulting to current date/time on open (e.g. new imaging request).
+ *
+ * **Parsing** — Accepts MUI display strings and ISO-like values (see {@link parseTamanuDate}).
+ *
+ * @param inputLocator — `input` or element exposing `.inputValue()`.
+ * @param thresholdMinutes — Max absolute difference in minutes (default 2).
+ */
+export async function assertRecentDateTime(
+  inputLocator: Locator,
+  thresholdMinutes: number = 2,
+): Promise<void> {
+  const raw = await inputLocator.inputValue();
+  if (!raw?.trim()) {
+    throw new Error('Datetime input value is empty');
+  }
+  // Parse and compare inside the browser so the timezone matches the app
+  const timeDifferenceMinutes = await inputLocator.page().evaluate((rawValue: string) => {
+    const dateTimeMatch = rawValue.match(
+      /^(\d{2})\/(\d{2})\/(\d{4})\s+(\d{1,2}):(\d{2})\s+(AM|PM)$/i,
+    );
+    const dateOnlyMatch = rawValue.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+
+    let parsed: Date;
+    if (dateTimeMatch) {
+      const [, dd, mm, yyyy, hh, min, ampm] = dateTimeMatch;
+      let hours = parseInt(hh, 10);
+      if (ampm.toUpperCase() === 'PM' && hours !== 12) hours += 12;
+      if (ampm.toUpperCase() === 'AM' && hours === 12) hours = 0;
+      parsed = new Date(parseInt(yyyy), parseInt(mm) - 1, parseInt(dd), hours, parseInt(min));
+    } else if (dateOnlyMatch) {
+      const [, dd, mm, yyyy] = dateOnlyMatch;
+      parsed = new Date(parseInt(yyyy), parseInt(mm) - 1, parseInt(dd));
+    } else {
+      parsed = new Date(rawValue);
+    }
+
+    if (isNaN(parsed.getTime())) {
+      throw new Error(`Could not parse datetime input value: ${rawValue}`);
+    }
+
+    return Math.abs((Date.now() - parsed.getTime()) / (1000 * 60));
+  }, raw);
+
+  expect(timeDifferenceMinutes).toBeLessThan(thresholdMinutes);
+}

--- a/packages/e2e-tests/utils/testHelper.ts
+++ b/packages/e2e-tests/utils/testHelper.ts
@@ -1,7 +1,8 @@
-import { Locator, Page, expect } from '@playwright/test';
-import { subYears, addYears, format, parse, isValid } from 'date-fns';
+import { Locator, Page } from '@playwright/test';
 
 import { SidebarPage } from '../pages/SidebarPage';
+
+export * from './dateTimeHelpers';
 
 /**
  * Prefix for `data-testid` on cells in the app’s styled data tables (e.g. patient lists).
@@ -23,139 +24,6 @@ export const STYLED_TABLE_CELL_PREFIX = 'styledtablecell-2gyy-';
 export async function getSidebarFacilityDisplayName(page: Page): Promise<string> {
   const sidebar = new SidebarPage(page);
   return sidebar.getFacilityName();
-}
-
-const DISPLAY_DATE_TIME_PATTERNS = [
-  'dd/MM/yyyy hh:mm a',
-  'dd/MM/yyyy h:mm a',
-  'dd/MM/yyyy',
-] as const;
-
-/**
- * Parse a date string the way Tamanu / MUI surfaces typically expose it in the browser.
- *
- * **Recognized shapes (first match wins)**
- * 1. **ISO date prefix** — `yyyy-MM-dd` at the start of the string (time or suffix allowed after); calendar date only.
- * 2. **Display / picker strings** — `date-fns` parse with:
- *    - `dd/MM/yyyy hh:mm a` / `dd/MM/yyyy h:mm a` / `dd/MM/yyyy` (common MUI-style text).
- *
- * **Returns**
- * - A valid `Date` in local parsing semantics, or `null` if nothing matches or the result is invalid.
- *
- * **Typical use** — Building other helpers or custom assertions. Most tests should use the higher-level format
- * functions below so the intended surface (assertion vs picker vs ISO) stays explicit.
- *
- * @param raw — Untrimmed input is trimmed before parsing.
- */
-export function parseTamanuDate(raw: string): Date | null {
-  const s = raw.trim();
-  if (!s) return null;
-
-  const isoDate = s.match(/^(\d{4}-\d{2}-\d{2})/);
-  if (isoDate) {
-    const d = parse(isoDate[1], 'yyyy-MM-dd', new Date());
-    return isValid(d) ? d : null;
-  }
-
-  for (const pattern of DISPLAY_DATE_TIME_PATTERNS) {
-    const d = parse(s, pattern, new Date());
-    if (isValid(d)) return d;
-  }
-
-  return null;
-}
-
-/**
- * Normalize a test or DOM date value to **US-style short date** `MM/dd/yyyy` for text assertions.
- *
- * **Used for** `toContainText`, table cell expectations, and anywhere the UI shows month-first short dates.
- *
- * **Behaviour**
- * - `undefined` / missing → `''`.
- * - `Date` → formatted with `date-fns` if valid, else `''`.
- * - String → try {@link parseTamanuDate}; if that fails, a naive `yyyy-MM-dd` split → `MM/DD/YYYY`.
- *
- * @param dateInput — ISO string, picker output fragment, or `Date` from test data.
- * @returns `MM/dd/yyyy` or `''` when empty/unparseable.
- */
-export const convertDateFormat = (dateInput: string | Date | undefined): string => {
-  if (!dateInput) return '';
-
-  if (dateInput instanceof Date) {
-    return isValid(dateInput) ? format(dateInput, 'MM/dd/yyyy') : '';
-  }
-
-  const parsed = parseTamanuDate(String(dateInput));
-  if (parsed) {
-    return format(parsed, 'MM/dd/yyyy');
-  }
-
-  const s = String(dateInput).trim();
-  const [year, month, day] = s.split('-');
-  if (year && month && day) {
-    return `${month}/${day}/${year}`;
-  }
-  return '';
-};
-
-/**
- * Build candidate strings for **substring** matching a date in a table cell when locale may flip day/month order.
- *
- * Some cells render via `DateDisplay` (or similar) so the same calendar day can appear as `MM/dd/yyyy` or
- * `dd/MM/yyyy`. Playwright checks often use `includes`; passing both strings covers either rendering.
- *
- * **Returns**
- * - No `dateGiven` → `['Unknown']` (placeholder row convention in some specs).
- * - Parse succeeds → `[ MM/dd/yyyy, dd/MM/yyyy ]`.
- * - Parse fails → single fallback from {@link convertDateFormat}.
- *
- * @param dateGiven — Test data date string; `undefined` triggers the Unknown placeholder path.
- */
-export function dateTableMatchStrings(dateGiven: string | undefined): string[] {
-  if (!dateGiven) return ['Unknown'];
-  const parsed = parseTamanuDate(dateGiven.trim());
-  if (!parsed) {
-    return [convertDateFormat(dateGiven)];
-  }
-  return [format(parsed, 'MM/dd/yyyy'), format(parsed, 'dd/MM/yyyy')];
-}
-
-/**
- * Normalize picker output, ISO fragments, or display text to **`yyyy-MM-dd`** for value comparisons.
- *
- * **Typical use** — Comparing two strings that should represent the same calendar day (e.g. input value vs test
- * data) when one side came from an MUI field (`dd/MM/…`) and the other from ISO.
- *
- * **Behaviour** — If {@link parseTamanuDate} yields a valid date, returns `yyyy-MM-dd`; otherwise returns
- * `raw` unchanged so callers still see the original string when parsing fails.
- *
- * @param raw — Typically `input.value` or a test fixture string.
- */
-export function normalizeToIsoDate(raw: string): string {
-  const parsed = parseTamanuDate(raw);
-  if (parsed && isValid(parsed)) {
-    return format(parsed, 'yyyy-MM-dd');
-  }
-  return raw;
-}
-
-/**
- * Format a date string for **typing into MUI date-time text fields** (keyboard / `.fill()`).
- *
- * Some MUI date-time pickers do not commit or behave correctly when filled with only `yyyy-MM-dd`; the app
- * expects display-shaped text such as `dd/MM/yyyy hh:mm a`.
- *
- * **Behaviour** — Parses via {@link parseTamanuDate}; on failure returns the original string so callers can
- * still attempt a fill for edge cases.
- *
- * @param isoDate — Usually ISO or ISO-like test data; trimmed before parse.
- */
-export function formatForMuiDateTimePicker(isoDate: string): string {
-  const parsed = parseTamanuDate(isoDate.trim());
-  if (!parsed || !isValid(parsed)) {
-    return isoDate;
-  }
-  return format(parsed, 'dd/MM/yyyy hh:mm a');
 }
 
 /**
@@ -183,9 +51,12 @@ export async function SelectingFromSearchBox(
     await suggestionOption.waitFor({ state: 'visible', timeout });
     await suggestionOption.click();
   } catch (error) {
-    throw new Error(`Failed to handle search box suggestion: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `Failed to handle search box suggestion: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
+
 /**
  * Read text from a column across the first `tableRowCount` rows of a styled table.
  *
@@ -210,83 +81,13 @@ export async function getTableItems(page: Page, tableRowCount: number, columnNam
 }
 
 /**
- * Format a `Date` to match **on-screen datetime copy** in parts of the app: `MM/dd/yyyy` + 12h time with
- * **lowercase** `am`/`pm` and no space before meridiem (e.g. `02/12/2026 9:31am`).
- *
- * @param date — Instant to format (local time per `date-fns` `format`).
- */
-export function formatDateTimeForDisplay(date: Date): string {
-  return format(date, 'MM/dd/yyyy h:mm a').replace(' AM', 'am').replace(' PM', 'pm');
-}
-
-/**
- * Convert an ISO-like datetime string (e.g. `2025-12-01T06:11`) into the **concatenated** table display form
- * used in some grids: **time** (`h:mm` + lowercase `am`/`pm`, no space) immediately followed by **date** `MM/dd/yy`
- * (e.g. `6:11am12/01/25`).
- *
- * **Parsing** — Uses `new Date(dateTimeString)`; invalid strings produce `Invalid Date` output from `date-fns`
- * (callers should pass values known to parse in the test environment).
- *
- * @param dateTimeString — Typically from a form field or API fixture.
- */
-export function formatDateTimeForTable(dateTimeString: string): string {
-  const dateFromForm = new Date(dateTimeString);
-  const formattedTime = format(dateFromForm, 'h:mm a').replace(' ', '').toLowerCase(); // "6:11am"
-  const formattedDate = format(dateFromForm, 'MM/dd/yy'); // "12/01/25"
-  return `${formattedTime}${formattedDate}`; // "6:11am12/01/25"
-}
-
-/**
  * Comparator factory for **locale-aware string sort** (e.g. vaccine names in table order assertions).
  *
  * @param order — `'asc'` or `'desc'`.
  * @returns `(a, b) => number` suitable for `Array.prototype.sort`.
  */
 export function compareAlphabetically(order: 'asc' | 'desc') {
-  return (a: string, b: string) =>
-    order === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
-}
-
-/**
- * Comparator factory for sorting objects with a **`dateGiven`** ISO-like string (e.g. vaccine rows).
- *
- * Uses `new Date(...).getTime()`; invalid date strings sort as `NaN` and may behave unpredictably—keep test
- * data parseable.
- *
- * @param order — `'asc'` (oldest first) or `'desc'` (newest first).
- */
-export function compareByDate(order: 'asc' | 'desc') {
-  return (a: { dateGiven: string }, b: { dateGiven: string }) => {
-    const dateA = new Date(a.dateGiven).getTime();
-    const dateB = new Date(b.dateGiven).getTime();
-    return order === 'asc' ? dateA - dateB : dateB - dateA;
-  };
-}
-
-/**
- * Shift a calendar date by a whole number of years; returns **`yyyy-MM-dd`** for fixtures and inputs.
- *
- * **Use case** — Age boundaries, eligibility windows, “same day next year” vaccine tests.
- *
- * @param dateToOffset — Parseable date string (passed to `new Date`).
- * @param offset — `'increase'` or `'decrease'`.
- * @param amountToOffset — Non-negative year delta (applied via `date-fns` `addYears` / `subYears`).
- * @throws Error when `offset` is not `'increase'` or `'decrease'`.
- */
-export function offsetYear(
-  dateToOffset: string,
-  offset: 'increase' | 'decrease',
-  amountToOffset: number
-): string {
-  //Convert to date format so utility functions can be used
-  const formattedDateToOffset = new Date(dateToOffset);
-  let newDate = undefined;
-
-  if (offset === 'increase') newDate = addYears(formattedDateToOffset, amountToOffset);
-  else if (offset === 'decrease') newDate = subYears(formattedDateToOffset, amountToOffset);
-  else throw new Error('Invalid offset');
-
-  return format(newDate, 'yyyy-MM-dd');
+  return (a: string, b: string) => (order === 'asc' ? a.localeCompare(b) : b.localeCompare(a));
 }
 
 /**
@@ -303,28 +104,5 @@ export const selectFirstFromDropdown = async (page: Page, input: Locator): Promi
   await input.click();
   const firstOption = page.locator('[role="listbox"] li').first();
   await firstOption.click();
-  return await firstOption.textContent() || '';
+  return (await firstOption.textContent()) || '';
 };
-
-/**
- * Assert the value of a datetime **input** is within `thresholdMinutes` of “now” (wall clock).
- *
- * **Use case** — Fields defaulting to current date/time on open (e.g. new encounter).
- *
- * **Parsing** — Uses `date-fns` `parse` with your `dateFormat`; must match the input’s `value` shape exactly.
- *
- * @param inputLocator — `input` or element exposing `.inputValue()`.
- * @param dateFormat — `date-fns` format string matching the input `value` (e.g. ISO-local datetime with a `T` separator).
- * @param thresholdMinutes — Max absolute difference in minutes (default 2).
- */
-export async function assertRecentDateTime(
-  inputLocator: Locator,
-  dateFormat: string,
-  thresholdMinutes: number = 2,
-): Promise<void> {
-  const inputDateTimeValue = await inputLocator.inputValue();
-  const parsedInputDate = parse(inputDateTimeValue, dateFormat, new Date());
-  const now = new Date();
-  const timeDifferenceMinutes = Math.abs((now.getTime() - parsedInputDate.getTime()) / (1000 * 60));
-  expect(timeDifferenceMinutes).toBeLessThan(thresholdMinutes);
-}

--- a/packages/e2e-tests/utils/vaccineTestHelpers.ts
+++ b/packages/e2e-tests/utils/vaccineTestHelpers.ts
@@ -1,5 +1,5 @@
 import { PatientDetailsPage } from '@pages/patients/PatientDetailsPage';
-import { formatForMuiDateTimePicker } from '@utils/testHelper';
+import { fillMuiDateTimeField } from '@utils/testHelper';
 import { createPatient } from '../utils/apiHelpers';
 import { expect } from '@playwright/test';
 import { Vaccine } from 'types/vaccine/Vaccine';
@@ -114,8 +114,7 @@ export async function triggerDateError(
   const dateField = patientDetailsPage.patientVaccinePane!.recordVaccineModal!.dateField;
 
   //Attempt to submit a date that should trigger a validation error
-  await dateField.fill(formatForMuiDateTimePicker(date));
-  await dateField.blur();
+  await fillMuiDateTimeField(dateField, date);
 
   await patientDetailsPage.patientVaccinePane?.recordVaccineModal?.confirmButton.click();
 

--- a/packages/ui-components/src/components/Field/TextField.jsx
+++ b/packages/ui-components/src/components/Field/TextField.jsx
@@ -102,6 +102,7 @@ export const TextInput = ({
   label,
   enablePasting = false,
   ['data-testid']: dataTestId,
+  inputProps,
   ...props
 }) => {
   const { getSetting } = useSettings();
@@ -144,7 +145,7 @@ export const TextInput = ({
         onDragOver={onDragOver}
         onDragEnter={onDragEnter}
         inputProps={{
-          ...props.inputProps,
+          ...inputProps,
           'data-testid': `${dataTestId}-input`,
         }}
         {...props}


### PR DESCRIPTION
### Changes

After the timezone epic was merged most of the tests starting failing due to various datetime issues with fields, timezones etc. I have managed to resolve all those fails however it required some pretty ugly date helper functions and its generally starting to get quite hard to follow even after moving all dateTime logic into one helper file. Merging this for now to 2.51 and 2.52 to pass regression testing however we have a much larger refactor pr coming soon to make E2E tests a bit more easy to expand on

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI execution (sharded Playwright runs, caching, blob reporting) and updates many E2E selectors/date-time interactions, which could cause transient CI failures if assumptions about UI test ids or formatting are off.
> 
> **Overview**
> **Stabilises E2E tests by standardising date/time entry and assertions across the Playwright page objects.** Tests now use shared helpers like `fillMuiDateField`/`fillMuiDateTimeField`/`fillMuiTimeField` and normalize DOM values with `normalizeToIsoDate`/`normalizeToIsoDateTimeMinute`, plus added waits/retries around sorting and table reads to reduce flakiness.
> 
> **Updates CI E2E execution to be faster and more reliable.** The GitHub Action now conditionally installs deps based on cache hit, runs Playwright in 4 shards, switches CI reporting to `blob` (uploaded as artifacts), and aligns E2E local server config with `Pacific/Auckland` timezone and longer auth token duration to avoid time/session-related failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5460fd5f11f362ac7ce7b1c7e118e43dcac56764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->