### PR TITLE
feat(encounters): NASS-1853: Add tooltip for hospital encounters with triage and admission dates

### DIFF
--- a/packages/database/src/models/Encounter.ts
+++ b/packages/database/src/models/Encounter.ts
@@ -196,6 +196,7 @@ export class Encounter extends Model {
         association: 'triages',
         include: ['chiefComplaint', 'secondaryComplaint'],
       },
+      'encounterHistory',
     ];
   }
 

--- a/packages/web/app/utils/getHospitalAdmissionDate.js
+++ b/packages/web/app/utils/getHospitalAdmissionDate.js
@@ -1,0 +1,28 @@
+import { ENCOUNTER_TYPES, EncounterChangeType } from '@tamanu/constants';
+
+/**
+ * Gets the hospital admission date from encounter history for encounters
+ * that were transferred from emergency status to hospital admission.
+ *
+ * @param {Object} encounter - The encounter object
+ * @returns {string|null} - The hospital admission date or null if not applicable
+ */
+export const getHospitalAdmissionDate = encounter => {
+  if (!encounter || encounter.encounterType !== ENCOUNTER_TYPES.ADMISSION) {
+    return null;
+  }
+
+  const encounterHistory = encounter.encounterHistory || [];
+  if (encounterHistory.length === 0) {
+    return null;
+  }
+
+  // Find the history record where the encounter type changed to ADMISSION
+  const admissionHistory = encounterHistory.find(
+    history =>
+      history.encounterType === ENCOUNTER_TYPES.ADMISSION &&
+      history.changeType?.includes(EncounterChangeType.EncounterType),
+  );
+
+  return admissionHistory?.date || null;
+};

--- a/packages/web/app/utils/getHospitalAdmissionDate.test.js
+++ b/packages/web/app/utils/getHospitalAdmissionDate.test.js
@@ -1,0 +1,115 @@
+import { ENCOUNTER_TYPES, EncounterChangeType } from '@tamanu/constants';
+import { getHospitalAdmissionDate } from './getHospitalAdmissionDate';
+
+describe('getHospitalAdmissionDate', () => {
+  it('should return null for non-admission encounters', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.TRIAGE,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBeNull();
+  });
+
+  it('should return null for admission encounters without history', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBeNull();
+  });
+
+  it('should return null for admission encounters without encounter type change', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBeNull();
+  });
+
+  it('should return the admission date for encounters transferred from emergency status', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-02-01 09:35:00',
+          changeType: [EncounterChangeType.EncounterType],
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBe('2020-02-01 09:35:00');
+  });
+
+  it('should return null if encounter is null', () => {
+    expect(getHospitalAdmissionDate(null)).toBeNull();
+  });
+
+  it('should return null if encounter is undefined', () => {
+    expect(getHospitalAdmissionDate(undefined)).toBeNull();
+  });
+
+  it('should handle encounters with multiple type changes', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.EMERGENCY,
+          date: '2020-01-31 15:00:00',
+          changeType: [EncounterChangeType.EncounterType],
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-02-01 09:35:00',
+          changeType: [EncounterChangeType.EncounterType],
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBe('2020-02-01 09:35:00');
+  });
+
+  it('should handle encounters with location changes mixed with type changes', () => {
+    const encounter = {
+      encounterType: ENCOUNTER_TYPES.ADMISSION,
+      startDate: '2020-01-31 10:35:00',
+      encounterHistory: [
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 10:35:00',
+          changeType: null,
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.TRIAGE,
+          date: '2020-01-31 12:00:00',
+          changeType: [EncounterChangeType.Location],
+        },
+        {
+          encounterType: ENCOUNTER_TYPES.ADMISSION,
+          date: '2020-02-01 09:35:00',
+          changeType: [EncounterChangeType.EncounterType, EncounterChangeType.Location],
+        },
+      ],
+    };
+    expect(getHospitalAdmissionDate(encounter)).toBe('2020-02-01 09:35:00');
+  });
+});

--- a/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
+++ b/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
@@ -446,12 +446,8 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckIn })
               const shouldShowTooltip =
                 encounterType === ENCOUNTER_TYPES.ADMISSION && hospitalAdmissionDate;
 
-              const dateDisplay = (
-                <DateDisplay date={startDate} data-testid="datedisplay-5hsh" />
-              );
-
               if (!shouldShowTooltip) {
-                return dateDisplay;
+                return <DateDisplay date={startDate} data-testid="datedisplay-5hsh" />;
               }
 
               return (
@@ -488,7 +484,7 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckIn })
                   }
                   data-testid="themedtooltip-encounter-dates"
                 >
-                  {dateDisplay}
+                  <DateDisplay date={startDate} noTooltip data-testid="datedisplay-5hsh" />
                 </ThemedTooltip>
               );
             })()}

--- a/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
+++ b/packages/web/app/views/patients/components/PatientEncounterSummary.jsx
@@ -16,11 +16,13 @@ import {
   TranslatedReferenceData,
   TranslatedText,
 } from '../../../components/Translation';
-import { ENCOUNTER_TYPE_LABELS } from '@tamanu/constants';
+import { ENCOUNTER_TYPE_LABELS, ENCOUNTER_TYPES } from '@tamanu/constants';
 import { NoteModalActionBlocker } from '../../../components/NoteModalActionBlocker';
 import { getEncounterStartDateLabel } from '../../../utils/getEncounterStartDateLabel';
 import { useAuth } from '../../../contexts/Auth';
 import { isEmergencyPatient } from '../../../utils/isEmergencyPatient';
+import { getHospitalAdmissionDate } from '../../../utils/getHospitalAdmissionDate';
+import { ThemedTooltip } from '../../../components/Tooltip';
 
 const Border = css`
   border: 1px solid ${Colors.outline};
@@ -439,7 +441,57 @@ export const PatientEncounterSummary = ({ patient, viewEncounter, openCheckIn })
             {getEncounterStartDateLabel(encounterType)}:
           </ContentLabel>
           <ContentText data-testid="contenttext-nw17">
-            <DateDisplay date={startDate} data-testid="datedisplay-5hsh" />
+            {(() => {
+              const hospitalAdmissionDate = getHospitalAdmissionDate(encounter);
+              const shouldShowTooltip =
+                encounterType === ENCOUNTER_TYPES.ADMISSION && hospitalAdmissionDate;
+
+              const dateDisplay = (
+                <DateDisplay date={startDate} data-testid="datedisplay-5hsh" />
+              );
+
+              if (!shouldShowTooltip) {
+                return dateDisplay;
+              }
+
+              return (
+                <ThemedTooltip
+                  title={
+                    <Box>
+                      <Box fontWeight="500">
+                        <TranslatedText
+                          stringId="encounter.triageDate.label"
+                          fallback="Triage date"
+                        />
+                        {': '}
+                        <DateDisplay
+                          date={startDate}
+                          format="short"
+                          timeFormat="default"
+                          noTooltip
+                        />
+                      </Box>
+                      <Box fontWeight="500">
+                        <TranslatedText
+                          stringId="encounter.hospitalAdmissionDate.label"
+                          fallback="Hospital admission date"
+                        />
+                        {': '}
+                        <DateDisplay
+                          date={hospitalAdmissionDate}
+                          format="short"
+                          timeFormat="default"
+                          noTooltip
+                        />
+                      </Box>
+                    </Box>
+                  }
+                  data-testid="themedtooltip-encounter-dates"
+                >
+                  {dateDisplay}
+                </ThemedTooltip>
+              );
+            })()}
           </ContentText>
         </ContentItem>
         {isEmergencyPatient(encounterType) ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changes

This PR implements a tooltip feature for hospital encounters that displays both the triage date and hospital admission date when an encounter has been transferred from emergency status to hospital admission.

**Implementation Details:**

1. **Backend Changes** (`packages/database/src/models/Encounter.ts`)
   - Added `encounterHistory` to the Encounter model's full reference associations
   - Ensures encounter history data is included when fetching current encounters

2. **Utility Function** (`packages/web/app/utils/getHospitalAdmissionDate.js`)
   - Created a utility to extract the hospital admission date from encounter history
   - Identifies encounters transferred from emergency status (Triage, Active ED care, Emergency short stay) to hospital admission
   - Returns the date when the encounter type changed to admission
   - Includes comprehensive unit tests covering various scenarios

3. **UI Component** (`packages/web/app/views/patients/components/PatientEncounterSummary.jsx`)
   - Added tooltip to the admission date display in the encounter summary pane
   - Tooltip shows both triage start date and hospital admission date
   - Only displays for hospital admission encounters with encounter history
   - Uses `noTooltip` prop to prevent nested tooltips from conflicting

**Example Tooltip:**
```
Triage date: 31/01/2020 10:35am
Hospital admission date: 01/02/2020 9:35am
```

**Related:**
- Figma design: https://www.figma.com/design/sy6gyLBPoSXuJNq5lEEOL8/Tamanu-Desktop-1?node-id=36346-52433&t=RaBCXtE81tAr20yJ-0
- Linear issue: NASS-1853

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests ✅ (Unit tests added for `getHospitalAdmissionDate`)
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NASS-1853](https://linear.app/bes/issue/NASS-1853/add-tooltip-for-hospital-encounters-containing-both-a-triage-and)

<div><a href="https://cursor.com/agents/bc-50177077-bdc6-487f-b136-84b2ece2b677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50177077-bdc6-487f-b136-84b2ece2b677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

