### PR TITLE
fix(sync): TAMOC-410: Rebuild encounter_history in sync_lookup for change_type column (HOTFIX 2.49)

### DIFF
--- a/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
+++ b/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
@@ -1,6 +1,7 @@
 import { QueryInterface } from 'sequelize';
 
 export async function up(query: QueryInterface): Promise<void> {
+  // Rebuild sync_lookup for encounter_history after change_type column was changed
   await query.sequelize.query(`
     SELECT flag_lookup_model_to_rebuild('encounter_history');
   `);

--- a/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
+++ b/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
@@ -1,0 +1,11 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('encounter_history');
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No reverse migration
+}


### PR DESCRIPTION
### Changes
- Rebuild encounter_history in sync_lookup as change_type was updated from string to array
### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-purpose migration that only flags `encounter_history` for lookup rebuild; primary risk is increased sync/lookup rebuild work during deployment.
> 
> **Overview**
> Adds a new database migration that calls `flag_lookup_model_to_rebuild('encounter_history')` so the `sync_lookup` entry for `encounter_history` is regenerated after the `change_type` column changed.
> 
> No down migration is provided (one-way rebuild trigger).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9184818f278f4838c94e28bde6bb49367acc2c8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->