### PR TITLE
fix(sync): TAMOC-410: Rebuild encounter_history in sync_lookup for change_type column (HOTFIX 2.50)

### DIFF
--- a/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
+++ b/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
@@ -1,6 +1,7 @@
 import { QueryInterface } from 'sequelize';
 
 export async function up(query: QueryInterface): Promise<void> {
+  // Rebuild sync_lookup for encounter_history after change_type column was changed
   await query.sequelize.query(`
     SELECT flag_lookup_model_to_rebuild('encounter_history');
   `);

--- a/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
+++ b/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
@@ -1,0 +1,11 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('encounter_history');
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No reverse migration
+}


### PR DESCRIPTION
### Changes
- TAMOC-410: Rebuild encounter_history in sync_lookup for change_type column (HOTFIX 2.50)

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it affects sync metadata by triggering a `sync_lookup` rebuild for `encounter_history`, which can impact replication behavior and runtime load during rollout.
> 
> **Overview**
> Forces a `sync_lookup` rebuild of **`encounter_history`** via a new migration that calls `flag_lookup_model_to_rebuild('encounter_history')` to reflect a `change_type` column change.
> 
> The migration is one-way (*no `down` implementation*).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98d1d2e045c964b17466fe0ba2d8c4a989b88682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->