### PR TITLE
fix(invoicing): no-issue: 2.52 fix: widen date column in payment modal for MUI DatePicker

### DIFF
--- a/packages/web/app/features/Invoice/PatientPaymentStyledComponents.jsx
+++ b/packages/web/app/features/Invoice/PatientPaymentStyledComponents.jsx
@@ -57,7 +57,7 @@ export const PaymentFormCard = styled(BaseFormCard)`
     display: grid;
     align-items: start;
     grid-template-columns: ${props =>
-      props.$isEditMode ? '150px 1fr 150px' : '140px 1fr 120px 80px'};
+      props.$isEditMode ? '170px 1fr 150px' : '170px 1fr 120px 80px'};
     gap: 20px;
   }
 `;


### PR DESCRIPTION
### Changes

The datetime timezone epic replaced native HTML date inputs with MUI DatePicker, which needs more horizontal space. The payment modal grid column was only 140px\/150px, clipping the year digits. Widened to 170px to fit the full date display with the picker icon.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->