### PR TITLE
fix(encounters): no-issue: 2.52 fix: encounter progress record history

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -32,8 +32,27 @@ import { useAuth } from '../../../contexts/Auth';
 // These below functions are used to extract the history of changes made to the encounter that are stored in notes.
 // obviously a better solution needs to be to properly implemented for storing and accessing this data, but this is an ok workaround for now.
 
-const locationNoteMatcher = /^Changed location from (?<from>.*) to (?<to>.*)/;
-const encounterTypeNoteMatcher = /^Changed type from (?<from>.*) to (?<to>.*)/;
+// Support both old format ("Changed location from X to Y") and new bullet-prefixed format
+// ("• Changed location from 'X' to 'Y'"). Also handle "encounter type" vs "type".
+const locationNoteMatcher = /Changed location from '?(?<from>.*?)'? to '?(?<to>.*?)'?\s*$/;
+const encounterTypeNoteMatcher = /Changed (?:encounter )?type from '?(?<from>.*?)'? to '?(?<to>.*?)'?\s*$/;
+
+// Since 2.49+, multiple changes in a single encounter update are combined into one system note
+// with bullet-prefixed lines. This helper expands combined notes into individual entries so each
+// matching line becomes its own note object (preserving the parent note's date).
+const expandCombinedNotes = (systemNotes, matcher) => {
+  const expanded = [];
+  for (const note of systemNotes) {
+    const lines = note.content.split('\n');
+    for (const line of lines) {
+      const stripped = line.replace(/^[•\s]+/, '');
+      if (stripped.match(matcher)) {
+        expanded.push({ ...note, content: stripped });
+      }
+    }
+  }
+  return expanded;
+};
 
 // This is the general function that extracts the important values from the notes into an object based on their regex matcher
 const extractUpdateHistoryFromNoteData = (notes, encounterData, matcher) => {
@@ -280,16 +299,12 @@ export const EncounterRecordModal = ({ encounter, open, onClose }) => {
     return note.noteTypeId === NOTE_TYPES.SYSTEM;
   });
 
-  const locationSystemNotes = systemNotes.filter(note => {
-    return note.content.match(locationNoteMatcher);
-  });
+  const locationSystemNotes = expandCombinedNotes(systemNotes, locationNoteMatcher);
   const locationHistory = locationSystemNotes
     ? extractLocationHistory(locationSystemNotes, encounter, locationNoteMatcher)
     : [];
 
-  const encounterTypeSystemNotes = systemNotes.filter(note => {
-    return note.content.match(encounterTypeNoteMatcher);
-  });
+  const encounterTypeSystemNotes = expandCombinedNotes(systemNotes, encounterTypeNoteMatcher);
   const encounterTypeHistory = encounterTypeSystemNotes
     ? extractEncounterTypeHistory(encounterTypeSystemNotes, encounter, encounterTypeNoteMatcher)
     : [];


### PR DESCRIPTION
### Changes

Since the encounter enhancement project (~2.49), system notes for encounter changes use a bullet-prefixed combined format ("• Changed location from...") and "encounter type" instead of "type". The progress record regex patterns didn\'t match the new format, causing it to fall back to showing only the current state with the admission date instead of the full change history with actual move dates. Updated the regexes and added a helper to expand combined bullet-point notes into individual entries.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->