### PR TITLE
fix(vaccines): no-issue: 2.52 fix: false 'Date cannot be in future' validation error

### DIFF
--- a/packages/web/app/forms/VaccineForm.jsx
+++ b/packages/web/app/forms/VaccineForm.jsx
@@ -20,7 +20,7 @@ import { useAuth } from '../contexts/Auth';
 import { TranslatedText } from '../components/Translation/TranslatedText';
 import { useSettings } from '../contexts/Settings';
 import { usePatientDataQuery } from '../api/queries/usePatientDataQuery';
-import { isAfter, isBefore } from 'date-fns';
+import { isBefore } from 'date-fns';
 import { TranslatedReferenceData } from '../components/Translation';
 
 const validateGivenElsewhereRequiredField = (status, givenElsewhere) =>
@@ -43,7 +43,7 @@ export const VaccineForm = ({
   vaccineRecordingType,
 }) => {
   const { getSetting } = useSettings();
-  const { getCurrentDateTime } = useDateTime();
+  const { getCurrentDateTime, storedDateTimeToEpochMilliseconds } = useDateTime();
 
   const [vaccineLabel, setVaccineLabel] = useState(existingValues?.vaccineLabel);
   const [category, setCategory] = useState(getInitialCategory(editMode, existingValues));
@@ -149,11 +149,14 @@ export const VaccineForm = ({
           fallback="Date cannot be in the future"
           data-testid="translatedtext-rure"
         />,
-        (value) => {
+        value => {
           if (!value) return true;
-          const date = parseDate(value);
-          if (!date) return true;
-          return !isAfter(date, new Date());
+          const storedMs = storedDateTimeToEpochMilliseconds(value);
+          if (storedMs === null) {
+            return true;
+          }
+
+          return storedMs <= Date.now();
         },
       ),
     locationId: yup.string().when(['status', 'givenElsewhere'], {


### PR DESCRIPTION
### Changes

The vaccine date validation compared a timezone-naive stored datetime string (in the primary timezone) against browser local time via new Date(), causing false "Date cannot be in the future" errors when the primary timezone is ahead of the browser timezone. Uses storedDateTimeToEpochMilliseconds to properly convert the stored value before comparing against Date.now(). This is a port of the same fix applied to release\/2.51 in #9417 which was not cherry-picked to release\/2.52.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->