### PR TITLE
fix(referenceData): No-issue: Fix maxFileSizeMB setting

### DIFF
--- a/packages/settings/__tests__/schema.test.js
+++ b/packages/settings/__tests__/schema.test.js
@@ -337,6 +337,7 @@ describe('Exposed keys', () => {
         'customisations',
         'features',
         'fields',
+        'fileChooserMbSizeLimit',
         'fsmCrvsCertificates',
         'imagingCancellationReasons',
         'imagingPriorities',

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1043,6 +1043,7 @@ export const globalSettings = {
     fileChooserMbSizeLimit: {
       description:
         'The maximum size in megabytes of files that can be uploaded with the file chooser',
+      exposedToWeb: true,
       exposedToPatientPortal: true,
       type: yup.number().min(1),
       defaultValue: 10,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only marks an existing numeric setting as `exposedToWeb` and updates schema exposure tests; no auth/data-handling logic changes.
> 
> **Overview**
> Makes the `fileChooserMbSizeLimit` global setting available via the `exposedToWeb` settings surface (it was previously only exposed to the patient portal).
> 
> Updates the schema exposure test to assert `fileChooserMbSizeLimit` is included in the expected top-level `exposedToWeb` keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20521134ef3f0cbfeda7ea1d646290573d03d8a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->