### PR TITLE
fix(encounters): no-issue: 2.52 fix: encounter type history case mismatch

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -34,8 +34,8 @@ import { useAuth } from '../../../contexts/Auth';
 
 // Support both old format ("Changed location from X to Y") and new bullet-prefixed format
 // ("• Changed location from 'X' to 'Y'"). Also handle "encounter type" vs "type".
-const locationNoteMatcher = /Changed location from '?(?<from>.*?)'? to '?(?<to>.*?)'?\s*$/;
-const encounterTypeNoteMatcher = /Changed (?:encounter )?type from '?(?<from>.*?)'? to '?(?<to>.*?)'?\s*$/;
+const locationNoteMatcher = /Changed location from (?<from>.*?) to (?<to>.*?)\s*$/;
+const encounterTypeNoteMatcher = /Changed (?:encounter )?type from (?<from>.*?) to (?<to>.*?)\s*$/;
 
 // Since 2.49+, multiple changes in a single encounter update are combined into one system note
 // with bullet-prefixed lines. This helper expands combined notes into individual entries so each
@@ -54,7 +54,12 @@ const expandCombinedNotes = (systemNotes, matcher) => {
   return expanded;
 };
 
-const stripQuotes = str => str?.replace(/^'+|'+$/g, '');
+const stripQuotes = str => {
+  if (!str) return str;
+  // Strip any non-letter/number characters from start and end, then lowercase
+  const result = str.trim().replace(/^[^a-zA-Z0-9]+/, '').replace(/[^a-zA-Z0-9]+$/, '').toLowerCase();
+  return result;
+};
 
 // This is the general function that extracts the important values from the notes into an object based on their regex matcher
 const extractUpdateHistoryFromNoteData = (notes, encounterData, matcher) => {
@@ -94,7 +99,7 @@ const extractEncounterTypeHistory = (notes, encounterData) => {
   }
 
   return history.map(({ to: newEncounterType, ...rest }) => ({
-    newEncounterType: newEncounterType.toLowerCase(),
+    newEncounterType,
     ...rest,
   }));
 };

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -56,9 +56,9 @@ const expandCombinedNotes = (systemNotes, matcher) => {
 
 const stripQuotes = str => {
   if (!str) return str;
-  // Strip any non-letter/number characters from start and end, then lowercase
-  const result = str.trim().replace(/^[^a-zA-Z0-9]+/, '').replace(/[^a-zA-Z0-9]+$/, '').toLowerCase();
-  return result;
+  // Remove quote characters from start and end, then lowercase
+  // Handles both ASCII quotes (' ") and Unicode smart quotes (' ' " ")
+  return str.replace(/^['"\u2018\u2019\u201C\u201D]/, '').replace(/['"\u2018\u2019\u201C\u201D]$/, '').trim().toLowerCase();
 };
 
 // This is the general function that extracts the important values from the notes into an object based on their regex matcher

--- a/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/EncounterRecordModal.jsx
@@ -54,6 +54,8 @@ const expandCombinedNotes = (systemNotes, matcher) => {
   return expanded;
 };
 
+const stripQuotes = str => str?.replace(/^'+|'+$/g, '');
+
 // This is the general function that extracts the important values from the notes into an object based on their regex matcher
 const extractUpdateHistoryFromNoteData = (notes, encounterData, matcher) => {
   if (notes?.length > 0 && notes[0].content.match(matcher)) {
@@ -63,14 +65,14 @@ const extractUpdateHistoryFromNoteData = (notes, encounterData, matcher) => {
 
     const history = [
       {
-        to: from,
+        to: stripQuotes(from),
         date: encounterData.startDate,
       },
       ...(notes?.map(({ content, date }) => {
         const {
           groups: { to },
         } = content.match(matcher);
-        return { to, date };
+        return { to: stripQuotes(to), date };
       }) ?? {}),
     ];
     return history;
@@ -92,7 +94,7 @@ const extractEncounterTypeHistory = (notes, encounterData) => {
   }
 
   return history.map(({ to: newEncounterType, ...rest }) => ({
-    newEncounterType,
+    newEncounterType: newEncounterType.toLowerCase(),
     ...rest,
   }));
 };


### PR DESCRIPTION
### Changes

Fix encounter type history values in the progress record printout.

When printing an encounter record, the encounter type change history was failing to match against `ENCOUNTER_TYPE_LABELS` due to two issues:

1. **Surrounding quotes leaking into values** — The regex matchers for location and encounter type change notes were using optional `'?` anchors, but this left single quotes attached to captured values (e.g. `'admission'` instead of `admission`). Simplified the regexes and added a `stripQuotes()` helper to clean captured values.

2. **Case mismatch** — Since 2.49, system notes use `capitalize()` producing `Admission` instead of `admission`, but `ENCOUNTER_TYPE_LABELS` uses lowercase keys. The `stripQuotes()` helper also lowercases the extracted values to ensure consistent matching.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->