### PR TITLE
fix(permissions): NASS-1906: Fix permission id

### DIFF
--- a/packages/central-server/__tests__/permissions.js
+++ b/packages/central-server/__tests__/permissions.js
@@ -7,6 +7,7 @@ export const makePermissionsForRole = async (models, roleId, perms) =>
   Promise.all(
     perms.map(p =>
       models.Permission.create({
+        id: models.Permission.generatePermissionId(roleId, p.verb, p.noun, p.objectId),
         roleId,
         ...p,
       }),

--- a/packages/central-server/app/admin/permissions.js
+++ b/packages/central-server/app/admin/permissions.js
@@ -194,13 +194,15 @@ permissionsRouter.post(
       for (const { verb, noun, objectId, roleId } of permissions) {
         Permission.validatePermissionSchema(verb, noun, roleId, objectId);
 
-        const where = { verb, noun, roleId, objectId: objectId ?? null };
+        const normalizedObjectId = objectId ?? null;
+        const id = Permission.generatePermissionId(roleId, verb, noun, normalizedObjectId);
+        const where = { verb, noun, roleId, objectId: normalizedObjectId };
         const existing = await Permission.findOne({ where, paranoid: false });
         if (existing && existing.deletedAt) {
           await existing.restore();
           created++;
         } else if (!existing) {
-          await Permission.create(where);
+          await Permission.create({ ...where, id });
           created++;
         }
       }

--- a/packages/central-server/app/admin/referenceDataImporter/loaders.js
+++ b/packages/central-server/app/admin/referenceDataImporter/loaders.js
@@ -295,8 +295,7 @@ export async function permissionLoader(item, { models, pushError }) {
     .map(([role, yCell]) => [role, yCell.toLowerCase().trim()])
     .filter(([, yCell]) => yCell)
     .map(([role, yCell]) => {
-      const id =
-        `${role}-${normalizedVerb}-${normalizedNoun}-${normalizedObjectId || 'any'}`.toLowerCase();
+      const id = models.Permission.generatePermissionId(role, normalizedVerb, normalizedNoun, normalizedObjectId);
 
       const isDeleted = yCell === 'n';
       const deletedAt = isDeleted ? new Date() : null;

--- a/packages/database/src/models/Permission.ts
+++ b/packages/database/src/models/Permission.ts
@@ -73,6 +73,10 @@ export class Permission extends Model {
     };
   }
 
+  static generatePermissionId(roleId: string, verb: string, noun: string, objectId?: string | null): string {
+    return `${roleId}-${verb}-${noun}-${objectId || 'any'}`.toLowerCase();
+  }
+
   static validatePermissionSchema(verb: PermissionVerb, noun: string, roleId: string, objectId: string) {
     if (!verb || !noun || !roleId) {
       throw new ValidationError('Each permission requires verb, noun, and roleId');


### PR DESCRIPTION
### Changes
- Fix permission id

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `Permission.id` is generated/assigned during imports, batch creation, and tests, which could affect deduplication/restores and any code relying on legacy IDs.
> 
> **Overview**
> Centralises `Permission.id` generation via new `Permission.generatePermissionId(roleId, verb, noun, objectId)` and updates callers to use it.
> 
> Batch permission creation (`/admin/permissions/create-batch`), reference data permission imports, and permission test helpers now explicitly set `id` using the same normalisation (including `objectId ?? null` mapping to `'any'`) to ensure consistent IDs across creation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f1e531fdb23d4aab0f99f56f4df465befe1905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->