### PR TITLE
fix(sync): TAMOC-410: Rebuild encounter_history in sync_lookup for change_type (HOTFIX 2.53)

### DIFF
--- a/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
+++ b/packages/database/src/migrations/1774925167000-RebuildLookupTableForEncounterHistoryChangeType.ts
@@ -1,0 +1,12 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  // Rebuild sync_lookup for encounter_history after change_type column was changed
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('encounter_history');
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No reverse migration
+}


### PR DESCRIPTION
### Changes
- Rebuild encounter_history in sync_lookup for change_type

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Triggers a sync lookup rebuild for `encounter_history`, which can affect downstream sync behavior and data freshness if misapplied, but the change is limited to a single, forward-only migration.
> 
> **Overview**
> Adds a new database migration that flags `encounter_history` for rebuild in `sync_lookup` by calling `flag_lookup_model_to_rebuild('encounter_history')`, addressing a prior `change_type` column change.
> 
> The migration is intentionally one-way (no `down`) and relies on the existing rebuild-flag mechanism rather than directly modifying lookup rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3685262a58d6218a88de683a325cab2faf7d19d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->