### PR TITLE
fix: TAMOC-414: Program registration date updating on status change

### DIFF
--- a/packages/web/app/features/ProgramRegistry/PatientProgramRegistryActivateModal.jsx
+++ b/packages/web/app/features/ProgramRegistry/PatientProgramRegistryActivateModal.jsx
@@ -62,6 +62,7 @@ export const PatientProgramRegistryActivateModal = ({
           clinicianId: currentUser?.id,
           clinicalStatusId: patientProgramRegistration.clinicalStatus?.id,
           registrationStatus: REGISTRATION_STATUSES.ACTIVE,
+          date: patientProgramRegistration.date,
         }}
         validationSchema={{
           clinicalStatusId: optionalForeignKey().nullable(),

--- a/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
+++ b/packages/web/app/features/ProgramRegistry/RelatedConditionsForm.jsx
@@ -195,7 +195,6 @@ export const RelatedConditionsForm = ({
   const totalInitialValues = {
     clinicalStatusId,
     conditions: getGroupedData(conditions),
-    date: patientProgramRegistration.date,
     ...initialValues,
   };
 


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI form change that only alters where the initial `date` value is sourced; main risk is unintended defaulting if any caller forgets to pass `date` in `initialValues`.
> 
> **Overview**
> Fixes program registry activation/status updates so the registration `date` field is *not implicitly reset* by `RelatedConditionsForm`.
> 
> `RelatedConditionsForm` no longer injects `patientProgramRegistration.date` into its `initialValues`; instead `PatientProgramRegistryActivateModal` explicitly passes `date` via `initialValues`, ensuring the existing registration date is preserved during status changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925b476c20b889b597ebbdafd5f90ec029234760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->