### PR TITLE
feat(patientSearch): SAV-1138: Configurable additional search fields

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -24,6 +24,7 @@ export * from './medications.js';
 export * from './notes.js';
 export * from './patientFields.js';
 export * from './patientDetails.js';
+export * from './patientSearch.js';
 export * from './permissions.js';
 export * from './referenceData.js';
 export * from './reports.js';

--- a/packages/constants/src/patientSearch.ts
+++ b/packages/constants/src/patientSearch.ts
@@ -1,0 +1,82 @@
+export const PATIENT_MODEL_SEARCH_FIELDS = [
+  'displayId',
+  'firstName',
+  'middleName',
+  'lastName',
+  'culturalName',
+  'dateOfBirth',
+  'dateOfDeath',
+  'sex',
+  'email',
+  'villageId',
+  'visibilityStatus',
+  'mergedIntoId',
+] as const;
+
+export const ALREADY_SEARCHABLE_PATIENT_FIELDS = [
+  'displayId',
+  'firstName',
+  'lastName',
+  'culturalName',
+  'dateOfBirthExact',
+  'dateOfBirthFrom',
+  'dateOfBirthTo',
+  'sex',
+  'villageId',
+  'deceased',
+] as const;
+
+export const PAD_REFERENCE_DATA_FIELDS = [
+  'nationalityId',
+  'countryId',
+  'divisionId',
+  'subdivisionId',
+  'medicalAreaId',
+  'nursingZoneId',
+  'settlementId',
+  'ethnicityId',
+  'occupationId',
+  'religionId',
+  'patientBillingTypeId',
+  'countryOfBirthId',
+  'insurerId',
+  'secondaryVillageId',
+] as const;
+
+export const PAD_TEXT_FIELDS = [
+  'placeOfBirth',
+  'bloodType',
+  'primaryContactNumber',
+  'secondaryContactNumber',
+  'maritalStatus',
+  'cityTown',
+  'streetVillage',
+  'educationalLevel',
+  'socialMedia',
+  'title',
+  'birthCertificate',
+  'drivingLicense',
+  'passport',
+  'emergencyContactName',
+  'emergencyContactNumber',
+  'insurerPolicyNumber',
+] as const;
+
+const patientModelFieldSet = new Set<string>(PATIENT_MODEL_SEARCH_FIELDS);
+const alreadySearchableFieldSet = new Set<string>(ALREADY_SEARCHABLE_PATIENT_FIELDS);
+const padReferenceDataFieldSet = new Set<string>(PAD_REFERENCE_DATA_FIELDS);
+const padTextFieldSet = new Set<string>(PAD_TEXT_FIELDS);
+
+export const isValidAdditionalSearchField = (fieldName: string): boolean => {
+  if (alreadySearchableFieldSet.has(fieldName)) return false;
+  if (patientModelFieldSet.has(fieldName)) return true;
+  if (padTextFieldSet.has(fieldName)) return true;
+  if (padReferenceDataFieldSet.has(fieldName)) return true;
+  return false;
+};
+
+export const isPatientModelSearchField = (fieldName: string): boolean =>
+  patientModelFieldSet.has(fieldName);
+
+export const isReferenceDataSearchField = (fieldName: string): boolean =>
+  padReferenceDataFieldSet.has(fieldName);

--- a/packages/constants/src/patientSearch.ts
+++ b/packages/constants/src/patientSearch.ts
@@ -75,8 +75,12 @@ export const isValidAdditionalSearchField = (fieldName: string): boolean => {
   return false;
 };
 
-export const isPatientModelSearchField = (fieldName: string): boolean =>
-  patientModelFieldSet.has(fieldName);
+export const isPatientModelSearchField = (
+  fieldName: string,
+): fieldName is (typeof PATIENT_MODEL_SEARCH_FIELDS)[number] => patientModelFieldSet.has(fieldName);
 
-export const isReferenceDataSearchField = (fieldName: string): boolean =>
+export const isReferenceDataSearchField = (
+  fieldName: string,
+): fieldName is (typeof PAD_REFERENCE_DATA_FIELDS)[number] =>
   padReferenceDataFieldSet.has(fieldName);
+

--- a/packages/facility-server/__tests__/apiv1/PatientSearchAdditionalFields.test.js
+++ b/packages/facility-server/__tests__/apiv1/PatientSearchAdditionalFields.test.js
@@ -1,0 +1,201 @@
+import config from 'config';
+import { createDummyPatient } from '@tamanu/database/demoData/patients';
+import { SETTINGS_SCOPES } from '@tamanu/constants';
+import { createTestContext } from '../utilities';
+import { selectFacilityIds } from '@tamanu/utils/selectFacilityIds';
+import { afterAll, beforeAll, describe, it, expect } from '@jest/globals';
+
+describe('Patient search - additional search fields', () => {
+  let app;
+  let models;
+  let ctx;
+
+  const [facilityId] = selectFacilityIds(config);
+
+  const createPatientWithAdditionalData = async (patientOverrides, padOverrides) => {
+    const patientData = await createDummyPatient(models, patientOverrides);
+    const patient = await models.Patient.create(patientData);
+    if (padOverrides) {
+      await models.PatientAdditionalData.create({
+        patientId: patient.id,
+        ...padOverrides,
+      });
+    }
+    return patient;
+  };
+
+  const configureAdditionalSearchFields = async fields => {
+    await models.Setting.set(
+      'patientSearch.additionalSearchFields',
+      fields,
+      SETTINGS_SCOPES.GLOBAL,
+    );
+  };
+
+  const searchPatients = query =>
+    app
+      .get(`/api/patient?facilityId=${facilityId}&isAllPatientsListing=true&matchSecondaryIds=true`)
+      .query(query);
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.models;
+    app = await ctx.baseApp.asRole('practitioner');
+  });
+
+  afterAll(() => ctx.close());
+
+  describe('searching by PAD text fields', () => {
+    let patientWithPassport;
+
+    beforeAll(async () => {
+      await configureAdditionalSearchFields(['passport']);
+
+      patientWithPassport = await createPatientWithAdditionalData(
+        { firstName: 'pad-passport-test' },
+        { passport: 'XY123456' },
+      );
+      await createPatientWithAdditionalData(
+        { firstName: 'pad-passport-other' },
+        { passport: 'ZZ999999' },
+      );
+      await createPatientWithAdditionalData({ firstName: 'pad-no-passport' }, {});
+    });
+
+    it('should find a patient by a PAD text field (passport)', async () => {
+      const response = await searchPatients({ passport: 'XY123456' });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(1);
+      expect(response.body.data[0].id).toEqual(patientWithPassport.id);
+    });
+
+    it('should find a patient by partial match (case insensitive)', async () => {
+      const response = await searchPatients({ passport: 'xy123' });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(1);
+      expect(response.body.data[0].id).toEqual(patientWithPassport.id);
+    });
+
+    it('should return no results for non-matching PAD field value', async () => {
+      const response = await searchPatients({ passport: 'NONEXISTENT' });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(0);
+    });
+  });
+
+  describe('searching by patient model fields', () => {
+    let patientWithEmail;
+
+    beforeAll(async () => {
+      await configureAdditionalSearchFields(['email']);
+
+      patientWithEmail = await createPatientWithAdditionalData({
+        firstName: 'email-search-test',
+        email: 'unique-test-email@example.com',
+      });
+    });
+
+    it('should find a patient by an additional patient model field (email)', async () => {
+      const response = await searchPatients({ email: 'unique-test-email' });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(1);
+      expect(response.body.data[0].id).toEqual(patientWithEmail.id);
+    });
+  });
+
+  describe('searching by reference data fields', () => {
+    let patientWithNationality;
+    let nationalityRef;
+
+    beforeAll(async () => {
+      await configureAdditionalSearchFields(['nationalityId']);
+
+      nationalityRef = await models.ReferenceData.create({
+        type: 'nationality',
+        name: 'TestNationalityForSearch',
+        code: 'test-nationality-search',
+      });
+
+      patientWithNationality = await createPatientWithAdditionalData(
+        { firstName: 'nationality-search-test' },
+        { nationalityId: nationalityRef.id },
+      );
+      await createPatientWithAdditionalData(
+        { firstName: 'nationality-search-other' },
+        {},
+      );
+    });
+
+    it('should find a patient by reference data field (nationalityId)', async () => {
+      const response = await searchPatients({ nationalityId: nationalityRef.id });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(1);
+      expect(response.body.data[0].id).toEqual(patientWithNationality.id);
+    });
+
+    it('should not find patients when ID does not match', async () => {
+      const response = await searchPatients({ nationalityId: 'nonexistent-id' });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(0);
+    });
+  });
+
+  describe('ignoring unconfigured fields', () => {
+    beforeAll(async () => {
+      await configureAdditionalSearchFields([]);
+    });
+
+    it('should ignore additional field params when not configured', async () => {
+      await createPatientWithAdditionalData(
+        { firstName: 'unconfigured-field-test' },
+        { passport: 'SHOULD-NOT-FILTER' },
+      );
+
+      const response = await searchPatients({
+        firstName: 'unconfigured-field-test',
+        passport: 'SHOULD-NOT-FILTER',
+      });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('ignoring already-searchable fields in config', () => {
+    beforeAll(async () => {
+      await configureAdditionalSearchFields(['firstName', 'passport']);
+    });
+
+    it('should not double-filter already-searchable fields (firstName is already handled)', async () => {
+      const response = await searchPatients({ firstName: 'pad-passport-test' });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('combining additional fields with existing search fields', () => {
+    let targetPatient;
+
+    beforeAll(async () => {
+      await configureAdditionalSearchFields(['passport']);
+
+      targetPatient = await createPatientWithAdditionalData(
+        { firstName: 'combined-search-test', lastName: 'CombinedLastName' },
+        { passport: 'COMBINED789' },
+      );
+      await createPatientWithAdditionalData(
+        { firstName: 'combined-search-test', lastName: 'DifferentLast' },
+        { passport: 'DIFFERENT456' },
+      );
+    });
+
+    it('should combine additional fields with standard search fields', async () => {
+      const response = await searchPatients({
+        firstName: 'combined-search-test',
+        passport: 'COMBINED789',
+      });
+      expect(response).toHaveSucceeded();
+      expect(response.body.count).toEqual(1);
+      expect(response.body.data[0].id).toEqual(targetPatient.id);
+    });
+  });
+});

--- a/packages/facility-server/app/routes/apiv1/patient/constants.js
+++ b/packages/facility-server/app/routes/apiv1/patient/constants.js
@@ -1,77 +1,8 @@
-const PATIENT_MODEL_FIELDS = new Set([
-  'displayId',
-  'firstName',
-  'middleName',
-  'lastName',
-  'culturalName',
-  'dateOfBirth',
-  'dateOfDeath',
-  'sex',
-  'email',
-  'villageId',
-  'visibilityStatus',
-  'mergedIntoId',
-]);
-
-const ALREADY_SEARCHABLE_FIELDS = new Set([
-  'displayId',
-  'firstName',
-  'lastName',
-  'culturalName',
-  'dateOfBirthExact',
-  'dateOfBirthFrom',
-  'dateOfBirthTo',
-  'sex',
-  'villageId',
-  'deceased',
-]);
-
-const PAD_REFERENCE_DATA_FIELDS = new Set([
-  'nationalityId',
-  'countryId',
-  'divisionId',
-  'subdivisionId',
-  'medicalAreaId',
-  'nursingZoneId',
-  'settlementId',
-  'ethnicityId',
-  'occupationId',
-  'religionId',
-  'patientBillingTypeId',
-  'countryOfBirthId',
-  'insurerId',
-  'secondaryVillageId',
-]);
-
-const VALID_PAD_TEXT_FIELDS = new Set([
-  'placeOfBirth',
-  'bloodType',
-  'primaryContactNumber',
-  'secondaryContactNumber',
-  'maritalStatus',
-  'cityTown',
-  'streetVillage',
-  'educationalLevel',
-  'socialMedia',
-  'title',
-  'birthCertificate',
-  'drivingLicense',
-  'passport',
-  'emergencyContactName',
-  'emergencyContactNumber',
-  'insurerPolicyNumber',
-]);
-
-export const isValidAdditionalSearchField = fieldName => {
-  if (ALREADY_SEARCHABLE_FIELDS.has(fieldName)) return false;
-  if (PATIENT_MODEL_FIELDS.has(fieldName)) return true;
-  if (VALID_PAD_TEXT_FIELDS.has(fieldName)) return true;
-  if (PAD_REFERENCE_DATA_FIELDS.has(fieldName)) return true;
-  return false;
-};
-
-export const isPatientModelField = fieldName => PATIENT_MODEL_FIELDS.has(fieldName);
-export const isReferenceDataField = fieldName => PAD_REFERENCE_DATA_FIELDS.has(fieldName);
+export {
+  isValidAdditionalSearchField,
+  isPatientModelSearchField,
+  isReferenceDataSearchField,
+} from '@tamanu/constants';
 
 export const PATIENT_SORT_KEYS = {
   markedForSync: 'patient_facilities.patient_id',

--- a/packages/facility-server/app/routes/apiv1/patient/constants.js
+++ b/packages/facility-server/app/routes/apiv1/patient/constants.js
@@ -1,9 +1,3 @@
-export {
-  isValidAdditionalSearchField,
-  isPatientModelSearchField,
-  isReferenceDataSearchField,
-} from '@tamanu/constants';
-
 export const PATIENT_SORT_KEYS = {
   markedForSync: 'patient_facilities.patient_id',
   displayId: 'patients.display_id',

--- a/packages/facility-server/app/routes/apiv1/patient/constants.js
+++ b/packages/facility-server/app/routes/apiv1/patient/constants.js
@@ -1,3 +1,78 @@
+const PATIENT_MODEL_FIELDS = new Set([
+  'displayId',
+  'firstName',
+  'middleName',
+  'lastName',
+  'culturalName',
+  'dateOfBirth',
+  'dateOfDeath',
+  'sex',
+  'email',
+  'villageId',
+  'visibilityStatus',
+  'mergedIntoId',
+]);
+
+const ALREADY_SEARCHABLE_FIELDS = new Set([
+  'displayId',
+  'firstName',
+  'lastName',
+  'culturalName',
+  'dateOfBirthExact',
+  'dateOfBirthFrom',
+  'dateOfBirthTo',
+  'sex',
+  'villageId',
+  'deceased',
+]);
+
+const PAD_REFERENCE_DATA_FIELDS = new Set([
+  'nationalityId',
+  'countryId',
+  'divisionId',
+  'subdivisionId',
+  'medicalAreaId',
+  'nursingZoneId',
+  'settlementId',
+  'ethnicityId',
+  'occupationId',
+  'religionId',
+  'patientBillingTypeId',
+  'countryOfBirthId',
+  'insurerId',
+  'secondaryVillageId',
+]);
+
+const VALID_PAD_TEXT_FIELDS = new Set([
+  'placeOfBirth',
+  'bloodType',
+  'primaryContactNumber',
+  'secondaryContactNumber',
+  'maritalStatus',
+  'cityTown',
+  'streetVillage',
+  'educationalLevel',
+  'socialMedia',
+  'title',
+  'birthCertificate',
+  'drivingLicense',
+  'passport',
+  'emergencyContactName',
+  'emergencyContactNumber',
+  'insurerPolicyNumber',
+]);
+
+export const isValidAdditionalSearchField = fieldName => {
+  if (ALREADY_SEARCHABLE_FIELDS.has(fieldName)) return false;
+  if (PATIENT_MODEL_FIELDS.has(fieldName)) return true;
+  if (VALID_PAD_TEXT_FIELDS.has(fieldName)) return true;
+  if (PAD_REFERENCE_DATA_FIELDS.has(fieldName)) return true;
+  return false;
+};
+
+export const isPatientModelField = fieldName => PATIENT_MODEL_FIELDS.has(fieldName);
+export const isReferenceDataField = fieldName => PAD_REFERENCE_DATA_FIELDS.has(fieldName);
+
 export const PATIENT_SORT_KEYS = {
   markedForSync: 'patient_facilities.patient_id',
   displayId: 'patients.display_id',

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -22,7 +22,6 @@ import { renameObjectKeys } from '@tamanu/utils/renameObjectKeys';
 import {
   createPatientFilters,
   createAdditionalSearchFilters,
-  additionalFieldsRequirePadJoin,
 } from '../../../utils/patientFilters';
 import { patientVaccineRoutes } from './patientVaccine';
 import { patientDocumentMetadataRoutes } from './patientDocumentMetadata';
@@ -378,14 +377,15 @@ patientRoute.get(
     const { isAllPatientsListing = false } = filterParams;
     const filters = createPatientFilters(filterParams);
 
+    // ReadSettings.get uses cached getAll() per facility (see packages/settings cache; ~60s TTL).
     const additionalSearchFields =
       isAllPatientsListing && filterParams.facilityId
         ? (await settings[filterParams.facilityId]?.get(
             'patientSearch.additionalSearchFields',
           )) ?? []
         : [];
-    const additionalFilters = createAdditionalSearchFilters(filterParams, additionalSearchFields);
-    const needsPadJoin = additionalFieldsRequirePadJoin(filterParams, additionalSearchFields);
+    const { filters: additionalFilters, requiresPadJoin: needsPadJoin } =
+      createAdditionalSearchFilters(filterParams, additionalSearchFields);
 
     const allFilters = [...filters, ...additionalFilters];
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(

--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -19,7 +19,11 @@ import {
 import { isGeneratedDisplayId, isGeneratedIdFromPattern } from '@tamanu/utils/generateId';
 
 import { renameObjectKeys } from '@tamanu/utils/renameObjectKeys';
-import { createPatientFilters } from '../../../utils/patientFilters';
+import {
+  createPatientFilters,
+  createAdditionalSearchFilters,
+  additionalFieldsRequirePadJoin,
+} from '../../../utils/patientFilters';
 import { patientVaccineRoutes } from './patientVaccine';
 import { patientDocumentMetadataRoutes } from './patientDocumentMetadata';
 import { patientInvoiceRoutes } from './patientInvoice';
@@ -297,6 +301,7 @@ patientRoute.get(
     const {
       models: { Patient },
       query,
+      settings,
     } = req;
 
     req.checkPermission('list', 'Patient');
@@ -372,10 +377,26 @@ patientRoute.get(
     // clauses to improve query speed by removing unused joins
     const { isAllPatientsListing = false } = filterParams;
     const filters = createPatientFilters(filterParams);
+
+    const additionalSearchFields =
+      isAllPatientsListing && filterParams.facilityId
+        ? (await settings[filterParams.facilityId]?.get(
+            'patientSearch.additionalSearchFields',
+          )) ?? []
+        : [];
+    const additionalFilters = createAdditionalSearchFilters(filterParams, additionalSearchFields);
+    const needsPadJoin = additionalFieldsRequirePadJoin(filterParams, additionalSearchFields);
+
+    const allFilters = [...filters, ...additionalFilters];
     const { whereClauses, filterReplacements } = getWhereClausesAndReplacementsFromFilters(
-      filters,
+      allFilters,
       filterParams,
     );
+
+    const padJoin = needsPadJoin
+      ? `LEFT JOIN patient_additional_data
+          ON (patient_additional_data.patient_id = patients.id)`
+      : '';
 
     const from = isAllPatientsListing
       ? `
@@ -399,6 +420,7 @@ patientRoute.get(
           ON (patients.id = psi.patient_id)
         LEFT JOIN patient_facilities
           ON (patient_facilities.patient_id = patients.id AND patient_facilities.facility_id = :facilityId)
+        ${padJoin}
       ${whereClauses && `WHERE ${whereClauses}`}
       `
       : `

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -1,8 +1,14 @@
 import { sub } from 'date-fns';
+import { snakeCase } from 'lodash';
 import { toDateString } from '@tamanu/utils/dateTime';
 import { ENCOUNTER_TYPES } from '@tamanu/constants';
 
 import { makeDeletedAtIsNullFilter, makeFilter } from './query';
+import {
+  isValidAdditionalSearchField,
+  isPatientModelField,
+  isReferenceDataField,
+} from '../routes/apiv1/patient/constants';
 
 export const createPatientFilters = filterParams => {
   const filters = [
@@ -86,4 +92,42 @@ export const createPatientFilters = filterParams => {
   ].filter(f => f);
 
   return filters;
+};
+
+export const createAdditionalSearchFilters = (filterParams, configuredFields = []) => {
+  const filters = [];
+
+  for (const fieldName of configuredFields) {
+    if (!isValidAdditionalSearchField(fieldName)) continue;
+    if (!filterParams[fieldName]) continue;
+
+    const table = isPatientModelField(fieldName) ? 'patients' : 'patient_additional_data';
+    const column = snakeCase(fieldName);
+    const paramKey = `additionalField_${fieldName}`;
+
+    if (isReferenceDataField(fieldName)) {
+      filters.push(
+        makeFilter(true, `${table}.${column} = :${paramKey}`, () => ({
+          [paramKey]: filterParams[fieldName],
+        })),
+      );
+    } else {
+      filters.push(
+        makeFilter(true, `UPPER(${table}.${column}) LIKE UPPER(:${paramKey})`, () => ({
+          [paramKey]: `%${filterParams[fieldName]}%`,
+        })),
+      );
+    }
+  }
+
+  return filters.filter(Boolean);
+};
+
+export const additionalFieldsRequirePadJoin = (filterParams, configuredFields = []) => {
+  return configuredFields.some(
+    fieldName =>
+      isValidAdditionalSearchField(fieldName) &&
+      !isPatientModelField(fieldName) &&
+      Boolean(filterParams[fieldName]),
+  );
 };

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -1,14 +1,14 @@
 import { sub } from 'date-fns';
 import { snakeCase } from 'lodash';
 import { toDateString } from '@tamanu/utils/dateTime';
-import { ENCOUNTER_TYPES } from '@tamanu/constants';
+import {
+  ENCOUNTER_TYPES,
+  isValidAdditionalSearchField,
+  isPatientModelSearchField,
+  isReferenceDataSearchField,
+} from '@tamanu/constants';
 
 import { makeDeletedAtIsNullFilter, makeFilter } from './query';
-import {
-  isValidAdditionalSearchField,
-  isPatientModelField,
-  isReferenceDataField,
-} from '../routes/apiv1/patient/constants';
 
 export const createPatientFilters = filterParams => {
   const filters = [
@@ -101,11 +101,11 @@ export const createAdditionalSearchFilters = (filterParams, configuredFields = [
     if (!isValidAdditionalSearchField(fieldName)) continue;
     if (!filterParams[fieldName]) continue;
 
-    const table = isPatientModelField(fieldName) ? 'patients' : 'patient_additional_data';
+    const table = isPatientModelSearchField(fieldName) ? 'patients' : 'patient_additional_data';
     const column = snakeCase(fieldName);
     const paramKey = `additionalField_${fieldName}`;
 
-    if (isReferenceDataField(fieldName)) {
+    if (isReferenceDataSearchField(fieldName)) {
       filters.push(
         makeFilter(true, `${table}.${column} = :${paramKey}`, () => ({
           [paramKey]: filterParams[fieldName],
@@ -127,7 +127,7 @@ export const additionalFieldsRequirePadJoin = (filterParams, configuredFields = 
   return configuredFields.some(
     fieldName =>
       isValidAdditionalSearchField(fieldName) &&
-      !isPatientModelField(fieldName) &&
+      !isPatientModelSearchField(fieldName) &&
       Boolean(filterParams[fieldName]),
   );
 };

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -96,12 +96,16 @@ export const createPatientFilters = filterParams => {
 
 export const createAdditionalSearchFilters = (filterParams, configuredFields = []) => {
   const filters = [];
+  let requiresPadJoin = false;
 
   for (const fieldName of configuredFields) {
     if (!isValidAdditionalSearchField(fieldName)) continue;
     if (!filterParams[fieldName]) continue;
 
     const table = isPatientModelSearchField(fieldName) ? 'patients' : 'patient_additional_data';
+    if (table === 'patient_additional_data') {
+      requiresPadJoin = true;
+    }
     const column = snakeCase(fieldName);
     const paramKey = `additionalField_${fieldName}`;
 
@@ -112,22 +116,15 @@ export const createAdditionalSearchFilters = (filterParams, configuredFields = [
         })),
       );
     } else {
+      // Prefix match (param ends with %) avoids a leading wildcard so indexes can be
+      // used where present; substring search would need expression indexes / collation.
       filters.push(
         makeFilter(true, `UPPER(${table}.${column}) LIKE UPPER(:${paramKey})`, () => ({
-          [paramKey]: `%${filterParams[fieldName]}%`,
+          [paramKey]: `${filterParams[fieldName]}%`,
         })),
       );
     }
   }
 
-  return filters.filter(Boolean);
-};
-
-export const additionalFieldsRequirePadJoin = (filterParams, configuredFields = []) => {
-  return configuredFields.some(
-    fieldName =>
-      isValidAdditionalSearchField(fieldName) &&
-      !isPatientModelSearchField(fieldName) &&
-      Boolean(filterParams[fieldName]),
-  );
+  return { filters, requiresPadJoin };
 };

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -1613,6 +1613,18 @@ export const globalSettings = {
       type: vitalEditReasonsSchema,
       defaultValue: vitalEditReasonsDefault,
     },
+    patientSearch: {
+      description: 'Patient search configuration',
+      exposedToWeb: true,
+      properties: {
+        additionalSearchFields: {
+          description:
+            'Additional patient or patient additional data fields that are searchable in the all patients listing',
+          type: yup.array(yup.string().required()),
+          defaultValue: [],
+        },
+      },
+    },
     notifications: {
       description: 'Notification settings',
       properties: {

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -25,7 +25,7 @@ import {
   layoutModuleProperties,
   unhideableLayoutModuleProperties,
 } from './global-settings-properties/layouts';
-import { ADMINISTRATION_FREQUENCIES } from '@tamanu/constants';
+import { ADMINISTRATION_FREQUENCIES, isValidAdditionalSearchField } from '@tamanu/constants';
 import {
   medicationFrequencyDefault,
   medicationFrequencySchema,
@@ -1620,7 +1620,24 @@ export const globalSettings = {
         additionalSearchFields: {
           description:
             'Additional patient or patient additional data fields that are searchable in the all patients listing',
-          type: yup.array(yup.string().required()),
+          type: yup
+            .array(
+              yup
+                .string()
+                .required()
+                .test(
+                  'is-valid-search-field',
+                  // eslint-disable-next-line no-template-curly-in-string
+                  '${path} must be a valid, non-default patient or additional data field name',
+                  value => typeof value === 'string' && isValidAdditionalSearchField(value),
+                ),
+            )
+            .test(
+              'no-duplicates',
+              'additionalSearchFields must not contain duplicate entries',
+              value =>
+                !value || new Set(value).size === value.length,
+            ),
           defaultValue: [],
         },
       },

--- a/packages/web/app/components/SearchBar/AdditionalSearchField.jsx
+++ b/packages/web/app/components/SearchBar/AdditionalSearchField.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { startCase } from 'lodash';
+import { PAD_REFERENCE_DATA_FIELDS } from '@tamanu/constants';
+import { AutocompleteField, LocalisedField, SearchField } from '../Field';
+import { useSuggester } from '../../api';
+import { TranslatedText } from '../Translation/TranslatedText';
+
+const referenceDataFieldSet = new Set(PAD_REFERENCE_DATA_FIELDS);
+const getReferenceDataType = fieldName => fieldName.replace(/Id$/, '');
+const getFieldLabel = fieldName => startCase(fieldName.replace(/Id$/, ''));
+
+const ReferenceDataSearchField = ({ fieldName }) => {
+  const referenceType = getReferenceDataType(fieldName);
+  const suggester = useSuggester(referenceType);
+  return (
+    <LocalisedField
+      component={AutocompleteField}
+      name={fieldName}
+      label={
+        <TranslatedText
+          stringId={`general.localisedField.${fieldName}.label.short`}
+          fallback={getFieldLabel(fieldName)}
+        />
+      }
+      suggester={suggester}
+      size="small"
+    />
+  );
+};
+
+const TextSearchField = ({ fieldName }) => (
+  <LocalisedField
+    component={SearchField}
+    name={fieldName}
+    label={
+      <TranslatedText
+        stringId={`general.localisedField.${fieldName}.label.short`}
+        fallback={getFieldLabel(fieldName)}
+      />
+    }
+  />
+);
+
+export const AdditionalSearchField = ({ fieldName }) => {
+  if (referenceDataFieldSet.has(fieldName)) {
+    return <ReferenceDataSearchField fieldName={fieldName} />;
+  }
+  return <TextSearchField fieldName={fieldName} />;
+};

--- a/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Box from '@material-ui/core/Box';
+import { startCase } from 'lodash';
 import { useDateTime } from '@tamanu/ui-components';
 import styled from 'styled-components';
 import { CustomisableSearchBarWithPermissionCheck } from './CustomisableSearchBar';
@@ -34,11 +35,72 @@ const VillageLocalisedField = styled(LocalisedField)`
   font-size: 11px;
 `;
 
+const REFERENCE_DATA_FIELDS = new Set([
+  'nationalityId',
+  'countryId',
+  'divisionId',
+  'subdivisionId',
+  'medicalAreaId',
+  'nursingZoneId',
+  'settlementId',
+  'ethnicityId',
+  'occupationId',
+  'religionId',
+  'patientBillingTypeId',
+  'countryOfBirthId',
+  'insurerId',
+  'secondaryVillageId',
+]);
+
+const getReferenceDataType = fieldName => fieldName.replace(/Id$/, '');
+
+const getFieldLabel = fieldName => startCase(fieldName.replace(/Id$/, ''));
+
+const ReferenceDataSearchField = ({ fieldName }) => {
+  const referenceType = getReferenceDataType(fieldName);
+  const suggester = useSuggester(referenceType);
+  return (
+    <LocalisedField
+      component={AutocompleteField}
+      name={fieldName}
+      label={
+        <TranslatedText
+          stringId={`general.localisedField.${fieldName}.label.short`}
+          fallback={getFieldLabel(fieldName)}
+        />
+      }
+      suggester={suggester}
+      size="small"
+    />
+  );
+};
+
+const TextSearchField = ({ fieldName }) => (
+  <LocalisedField
+    component={SearchField}
+    name={fieldName}
+    label={
+      <TranslatedText
+        stringId={`general.localisedField.${fieldName}.label.short`}
+        fallback={getFieldLabel(fieldName)}
+      />
+    }
+  />
+);
+
+const AdditionalSearchField = ({ fieldName }) => {
+  if (REFERENCE_DATA_FIELDS.has(fieldName)) {
+    return <ReferenceDataSearchField fieldName={fieldName} />;
+  }
+  return <TextSearchField fieldName={fieldName} />;
+};
+
 export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) => {
   const { getCurrentDate } = useDateTime();
   const { getSetting } = useSettings();
   const villageSuggester = useSuggester('village');
   const hideOtherSex = getSetting('features.hideOtherSex') === true;
+  const additionalSearchFields = getSetting('patientSearch.additionalSearchFields') ?? [];
   const [showAdvancedFields, setShowAdvancedFields] = useState(false);
 
   return (
@@ -109,6 +171,9 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             }
             data-testid="searchbarcheckfield-7dw8"
           />
+          {additionalSearchFields.map(fieldName => (
+            <AdditionalSearchField key={fieldName} fieldName={fieldName} />
+          ))}
         </>
       }
       data-testid="customisablesearchbarwithpermissioncheck-al75"

--- a/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import Box from '@material-ui/core/Box';
-import { startCase } from 'lodash';
 import { useDateTime } from '@tamanu/ui-components';
 import styled from 'styled-components';
 import { CustomisableSearchBarWithPermissionCheck } from './CustomisableSearchBar';
@@ -19,6 +18,7 @@ import { SearchBarCheckField } from './SearchBarCheckField';
 import { TranslatedText } from '../Translation/TranslatedText';
 import { SEX_LABELS, SEX_VALUES } from '@tamanu/constants';
 import { useSettings } from '../../contexts/Settings';
+import { AdditionalSearchField } from './AdditionalSearchField';
 
 const TwoColumnsField = styled(Box)`
   grid-column: span 2;
@@ -34,66 +34,6 @@ const SexLocalisedField = styled(LocalisedField)`
 const VillageLocalisedField = styled(LocalisedField)`
   font-size: 11px;
 `;
-
-const REFERENCE_DATA_FIELDS = new Set([
-  'nationalityId',
-  'countryId',
-  'divisionId',
-  'subdivisionId',
-  'medicalAreaId',
-  'nursingZoneId',
-  'settlementId',
-  'ethnicityId',
-  'occupationId',
-  'religionId',
-  'patientBillingTypeId',
-  'countryOfBirthId',
-  'insurerId',
-  'secondaryVillageId',
-]);
-
-const getReferenceDataType = fieldName => fieldName.replace(/Id$/, '');
-
-const getFieldLabel = fieldName => startCase(fieldName.replace(/Id$/, ''));
-
-const ReferenceDataSearchField = ({ fieldName }) => {
-  const referenceType = getReferenceDataType(fieldName);
-  const suggester = useSuggester(referenceType);
-  return (
-    <LocalisedField
-      component={AutocompleteField}
-      name={fieldName}
-      label={
-        <TranslatedText
-          stringId={`general.localisedField.${fieldName}.label.short`}
-          fallback={getFieldLabel(fieldName)}
-        />
-      }
-      suggester={suggester}
-      size="small"
-    />
-  );
-};
-
-const TextSearchField = ({ fieldName }) => (
-  <LocalisedField
-    component={SearchField}
-    name={fieldName}
-    label={
-      <TranslatedText
-        stringId={`general.localisedField.${fieldName}.label.short`}
-        fallback={getFieldLabel(fieldName)}
-      />
-    }
-  />
-);
-
-const AdditionalSearchField = ({ fieldName }) => {
-  if (REFERENCE_DATA_FIELDS.has(fieldName)) {
-    return <ReferenceDataSearchField fieldName={fieldName} />;
-  }
-  return <TextSearchField fieldName={fieldName} />;
-};
 
 export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) => {
   const { getCurrentDate } = useDateTime();


### PR DESCRIPTION
### Changes

In the all patients listing we now have the ability to configure additional search fields (for patient and patient additional data fields).

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
