### PR TITLE
fix(sync): 2.53 fix: Filter task designations from sensitive facility sync

### DIFF
--- a/packages/database/src/migrations/1775783404000-RebuildLookupTableForTaskDesignations.ts
+++ b/packages/database/src/migrations/1775783404000-RebuildLookupTableForTaskDesignations.ts
@@ -1,0 +1,16 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    DELETE FROM sync_lookup
+    WHERE record_type = 'task_designations';
+  `);
+
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('task_designations');
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No reverse migration
+}

--- a/packages/database/src/models/TaskDesignation.ts
+++ b/packages/database/src/models/TaskDesignation.ts
@@ -1,10 +1,10 @@
 import { SYNC_DIRECTIONS } from '@tamanu/constants';
 import { Model } from './Model';
+import { buildEncounterLinkedSyncFilter } from '../sync/buildEncounterLinkedSyncFilter';
 import {
-  buildEncounterLinkedSyncFilter,
-  buildEncounterLinkedSyncFilterJoins,
-} from '../sync/buildEncounterLinkedSyncFilter';
-import { buildSyncLookupSelect } from '../sync/buildSyncLookupSelect';
+  buildEncounterLinkedLookupSelect,
+  buildEncounterLinkedLookupJoins,
+} from '../sync/buildEncounterLinkedLookupFilter';
 import type { InitOptions, Models } from '../types/model';
 
 export class TaskDesignation extends Model {
@@ -45,10 +45,8 @@ export class TaskDesignation extends Model {
 
   static async buildSyncLookupQueryDetails() {
     return {
-      select: await buildSyncLookupSelect(this, {
-        patientId: 'encounters.patient_id',
-      }),
-      joins: buildEncounterLinkedSyncFilterJoins([this.tableName, 'tasks', 'encounters']),
+      select: await buildEncounterLinkedLookupSelect(this),
+      joins: buildEncounterLinkedLookupJoins(this, ['tasks', 'encounters']),
     };
   }
 }


### PR DESCRIPTION
## Summary
- TaskDesignation sync lookup was not applying the sensitive facility filter, causing FK violations when non-sensitive facilities received task designations referencing tasks they couldn't see
- Updated `TaskDesignation.buildSyncLookupQueryDetails()` to use `buildEncounterLinkedLookupSelect`/`buildEncounterLinkedLookupJoins`, which joins through `tasks → encounters → locations → facilities` and populates `facility_id` in sync_lookup for sensitive facilities
- Added migration to rebuild sync_lookup rows for task_designations so existing rows get the corrected facility_id
## Root Cause
When a facility is marked as sensitive, `Task` records are correctly filtered via `buildEncounterLinkedLookupFilter` (populating `facility_id` in sync_lookup). However, `TaskDesignation` was using raw `buildSyncLookupSelect` without joining to locations/facilities, so its sync_lookup rows had `facility_id = NULL` — meaning they synced to all facilities. This caused FK constraint failures on the receiving facility since the parent Task was filtered out.


### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
