### PR TITLE
fix(charting): show permission denied message instead of misleading no-charts message

### DIFF
--- a/packages/web/app/views/patients/EncounterView.jsx
+++ b/packages/web/app/views/patients/EncounterView.jsx
@@ -81,9 +81,14 @@ const TABS = [
     ),
     key: ENCOUNTER_TAB_NAMES.CHARTS,
     render: props => (
-      <ChartDataProvider data-testid="chartdataprovider-dwj3">
-        <ChartsPane {...props} data-testid="chartspane-l442" />
-      </ChartDataProvider>
+      <EncounterPaneWithPermissionCheck
+        permissionNoun="Charting"
+        data-testid="encounterpanewithpermissioncheck-chart"
+      >
+        <ChartDataProvider data-testid="chartdataprovider-dwj3">
+          <ChartsPane {...props} data-testid="chartspane-l442" />
+        </ChartDataProvider>
+      </EncounterPaneWithPermissionCheck>
     ),
     condition: getSetting => getSetting(SETTING_KEYS.FEATURES_DESKTOP_CHARTING_ENABLED),
   },


### PR DESCRIPTION
When a user lacks Charting list permission, the server filters out all chart surveys. The ChartsPane then shows "no charts available" instead of a proper permission denied message. Wrap ChartsPane with EncounterPaneWithPermissionCheck to match other permission-gated tabs.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
