### PR TITLE
fix(sync): 2.53 fix: filter default location/department lookup by facility

### DIFF
--- a/packages/central-server/app/patientPortalApi/surveys/surveyResponse.js
+++ b/packages/central-server/app/patientPortalApi/surveys/surveyResponse.js
@@ -30,7 +30,7 @@ export const createSurveyResponse = asyncHandler(async (req, res) => {
   const { facilityId } = assignedSurvey;
   const settingsReader = new ReadSettings(models, facilityId);
   const getDefaultId = async resource =>
-    models.SurveyResponseAnswer.getDefaultId(resource, settingsReader);
+    models.SurveyResponseAnswer.getDefaultId(resource, settingsReader, facilityId);
 
   const responseRecord = await req.store.sequelize.transaction(async () => {
     const { locationId, departmentId, ...payload } = body;

--- a/packages/database/src/demoData/departments.js
+++ b/packages/database/src/demoData/departments.js
@@ -1,4 +1,4 @@
-import { randomRecordId, splitIds } from './utilities';
+import { splitIds } from './utilities';
 
 export const DEPARTMENTS = splitIds(`
   Medical
@@ -19,7 +19,12 @@ export const DEPARTMENTS = splitIds(`
 export const seedDepartments = async (models) => {
   const facilities = await models.Facility.findAll();
   const departments = facilities.flatMap((facility) =>
-    DEPARTMENTS.map((d) => ({ ...d, code: d.name, facilityId: facility.id })),
+    DEPARTMENTS.map((d) => ({
+      ...d,
+      id: `${facility.id}:${d.id}`,
+      code: d.name,
+      facilityId: facility.id,
+    })),
   );
   return models.Department.bulkCreate(departments);
 };

--- a/packages/database/src/demoData/departments.js
+++ b/packages/database/src/demoData/departments.js
@@ -17,7 +17,9 @@ export const DEPARTMENTS = splitIds(`
 `);
 
 export const seedDepartments = async (models) => {
-  const facilityId = await randomRecordId(models, 'Facility');
-  const departments = DEPARTMENTS.map((d) => ({ ...d, code: d.name, facilityId }));
+  const facilities = await models.Facility.findAll();
+  const departments = facilities.flatMap((facility) =>
+    DEPARTMENTS.map((d) => ({ ...d, code: d.name, facilityId: facility.id })),
+  );
   return models.Department.bulkCreate(departments);
 };

--- a/packages/database/src/demoData/locations.js
+++ b/packages/database/src/demoData/locations.js
@@ -12,8 +12,10 @@ export const LOCATIONS = splitIds(`
 `);
 
 export const seedLocations = async (models) => {
-  const facilityId = await randomRecordId(models, 'Facility');
-  const locations = LOCATIONS.map((d) => ({ ...d, code: d.name, facilityId, maxOccupancy: 1 }));
+  const facilities = await models.Facility.findAll();
+  const locations = facilities.flatMap((facility) =>
+    LOCATIONS.map((d) => ({ ...d, code: d.name, facilityId: facility.id, maxOccupancy: 1 })),
+  );
   return models.Location.bulkCreate(locations);
 };
 
@@ -29,7 +31,9 @@ export const LOCATIONS_GROUPS = splitIds(`
 `);
 
 export const seedLocationGroups = async (models) => {
-  const facilityId = await randomRecordId(models, 'Facility');
-  const locationGroups = LOCATIONS_GROUPS.map((d) => ({ ...d, code: d.name, facilityId }));
+  const facilities = await models.Facility.findAll();
+  const locationGroups = facilities.flatMap((facility) =>
+    LOCATIONS_GROUPS.map((d) => ({ ...d, code: d.name, facilityId: facility.id })),
+  );
   return models.LocationGroup.bulkCreate(locationGroups);
 };

--- a/packages/database/src/demoData/locations.js
+++ b/packages/database/src/demoData/locations.js
@@ -1,4 +1,4 @@
-import { randomRecordId, splitIds } from './utilities';
+import { splitIds } from './utilities';
 
 export const LOCATIONS = splitIds(`
   Bed 1
@@ -14,7 +14,13 @@ export const LOCATIONS = splitIds(`
 export const seedLocations = async (models) => {
   const facilities = await models.Facility.findAll();
   const locations = facilities.flatMap((facility) =>
-    LOCATIONS.map((d) => ({ ...d, code: d.name, facilityId: facility.id, maxOccupancy: 1 })),
+    LOCATIONS.map((d) => ({
+      ...d,
+      id: `${facility.id}:${d.id}`,
+      code: d.name,
+      facilityId: facility.id,
+      maxOccupancy: 1,
+    })),
   );
   return models.Location.bulkCreate(locations);
 };
@@ -33,7 +39,12 @@ export const LOCATIONS_GROUPS = splitIds(`
 export const seedLocationGroups = async (models) => {
   const facilities = await models.Facility.findAll();
   const locationGroups = facilities.flatMap((facility) =>
-    LOCATIONS_GROUPS.map((d) => ({ ...d, code: d.name, facilityId: facility.id })),
+    LOCATIONS_GROUPS.map((d) => ({
+      ...d,
+      id: `${facility.id}:${d.id}`,
+      code: d.name,
+      facilityId: facility.id,
+    })),
   );
   return models.LocationGroup.bulkCreate(locationGroups);
 };

--- a/packages/database/src/models/SurveyResponseAnswer.ts
+++ b/packages/database/src/models/SurveyResponseAnswer.ts
@@ -102,7 +102,11 @@ export class SurveyResponseAnswer extends Model {
   }
 
   // eslint-disable-next-line no-unused-vars
-  static getDefaultId = async (resource: string, settings: { get: (_arg0: string) => any }) => {
+  static getDefaultId = async (
+    resource: string,
+    settings: { get: (_arg0: string) => any },
+    facilityId?: string,
+  ) => {
     const { models } = this.sequelize;
     const code = await settings.get(`survey.defaultCodes.${resource}`);
 
@@ -112,10 +116,17 @@ export class SurveyResponseAnswer extends Model {
       throw new Error(`Model not found: ${modelName}`);
     }
 
-    const record = await model.findOne({ where: { code } });
+    const where: Record<string, any> = { code };
+    if (facilityId && model.rawAttributes?.facilityId) {
+      where.facilityId = facilityId;
+    }
+
+    const record = await model.findOne({ where });
     if (!record) {
+      const facilityMsg =
+        facilityId && model.rawAttributes?.facilityId ? ` at facility '${facilityId}'` : '';
       throw new Error(
-        `Could not find default answer for '${resource}': code '${code}' not found (check survey.defaultCodes.${resource} in the settings)`,
+        `Could not find default answer for '${resource}': code '${code}'${facilityMsg} not found (check survey.defaultCodes.${resource} in the settings)`,
       );
     }
     return record.id;

--- a/packages/facility-server/__tests__/apiv1/Referrals.test.js
+++ b/packages/facility-server/__tests__/apiv1/Referrals.test.js
@@ -130,9 +130,14 @@ describe('Referrals', () => {
 
   it('should use the default department if one is not provided', async () => {
     const { department: departmentCode } = await settings.get('survey.defaultCodes');
-    const department = await findOneOrCreate(models, models.Department, {
-      code: departmentCode,
-    });
+    const department = await findOneOrCreate(
+      models,
+      models.Department,
+      {
+        code: departmentCode,
+      },
+      { facilityId },
+    );
 
     const { locationId } = encounter;
     const result = await app.post('/api/referral').send({
@@ -154,7 +159,12 @@ describe('Referrals', () => {
 
   it('should use the default location if one is not provided', async () => {
     const { location: locationCode } = await settings.get('survey.defaultCodes');
-    const location = await findOneOrCreate(models, models.Location, { code: locationCode });
+    const location = await findOneOrCreate(
+      models,
+      models.Location,
+      { code: locationCode },
+      { facilityId },
+    );
 
     const { departmentId } = encounter;
     const result = await app.post('/api/referral').send({

--- a/packages/facility-server/__tests__/apiv1/SurveyResponseAnswer.test.js
+++ b/packages/facility-server/__tests__/apiv1/SurveyResponseAnswer.test.js
@@ -66,6 +66,37 @@ describe('SurveyResponseAnswer', () => {
       });
       expect(locationId).toBe(location.id);
     });
+
+    it('should filter by facilityId when the model has a facilityId attribute', async () => {
+      const { Department, Setting, Facility } = models;
+      const otherFacility = await Facility.create(fake(Facility));
+      const code = 'shared-dept-code';
+
+      const deptAtTestFacility = await Department.create({
+        ...fake(Department),
+        code,
+        facilityId,
+      });
+      await Department.create({
+        ...fake(Department),
+        code,
+        facilityId: otherFacility.id,
+      });
+
+      await Setting.set(
+        'survey.defaultCodes.department',
+        code,
+        SETTINGS_SCOPES.FACILITY,
+        facilityId,
+      );
+
+      const result = await models.SurveyResponseAnswer.getDefaultId(
+        'department',
+        settings,
+        facilityId,
+      );
+      expect(result).toEqual(deptAtTestFacility.id);
+    });
   });
 
   describe('vitals', () => {

--- a/packages/facility-server/app/routes/apiv1/referral.js
+++ b/packages/facility-server/app/routes/apiv1/referral.js
@@ -19,7 +19,7 @@ referral.post(
     req.checkPermission('create', 'Referral');
 
     const getDefaultId = async (type) =>
-      models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
+      models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId], facilityId);
     const updatedBody = {
       locationId: body.locationId || (await getDefaultId('location')),
       departmentId: body.departmentId || (await getDefaultId('department')),

--- a/packages/facility-server/app/routes/apiv1/surveyResponse.js
+++ b/packages/facility-server/app/routes/apiv1/surveyResponse.js
@@ -81,7 +81,7 @@ export async function createSurveyResponse(req) {
   }
 
   const getDefaultId = async type =>
-    models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
+    models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId], facilityId);
   const updatedBody = {
     locationId: body.locationId || (await getDefaultId('location')),
     departmentId: body.departmentId || (await getDefaultId('department')),

--- a/packages/facility-server/app/routes/apiv1/triage.js
+++ b/packages/facility-server/app/routes/apiv1/triage.js
@@ -63,7 +63,7 @@ triage.post(
 
     if (vitals) {
       const getDefaultId = async type =>
-        models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId]);
+        models.SurveyResponseAnswer.getDefaultId(type, settings[facilityId], facilityId);
       const updatedBody = {
         locationId: vitals.locationId || (await getDefaultId('location')),
         departmentId: vitals.departmentId || (await getDefaultId('department')),


### PR DESCRIPTION
getDefaultId was finding the first Location/Department by code from any facility. When a referral was created without an existing encounter at a sensitive facility, the auto-created surveyResponse encounter could get a location from a different (non-sensitive) facility, causing the sync lookup to set facility_id = NULL and leak the referral to all facilities.


Made-with: Cursor

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
