### PR TITLE
fix(invoicing): 2.51 hotfix: use invoice insurance plans in PDF invoice details

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.language": "en-GB",
   "cSpell.words": [
     "clearable",
+    "deletability",
     "dhis2",
     "Formik",
     "ilike",
@@ -26,18 +27,10 @@
     "**/node_modules": true
   },
   "yaml.schemas": {
-    "https://www.artillery.io/schema.json": [
-      "packages/synthetic-tests/src/config/*.yml",
-      "packages/synthetic-tests/src/scenarios/*.yml",
-      "packages/synthetic-tests/src/merged-scenarios.yml"
-    ]
+    "https://www.artillery.io/schema.json": []
   },
   "yaml.validate": true,
   "yaml.format.enable": true,
   "yaml.customTags": [],
   "yaml.schemaStore.enable": false
-  },
-  "yaml.schemas": {
-    "https://www.artillery.io/schema.json": []
-  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "cSpell.language": "en-GB",
   "cSpell.words": [
     "clearable",
-    "deletability",
     "dhis2",
     "Formik",
     "ilike",
@@ -27,10 +26,18 @@
     "**/node_modules": true
   },
   "yaml.schemas": {
-    "https://www.artillery.io/schema.json": []
+    "https://www.artillery.io/schema.json": [
+      "packages/synthetic-tests/src/config/*.yml",
+      "packages/synthetic-tests/src/scenarios/*.yml",
+      "packages/synthetic-tests/src/merged-scenarios.yml"
+    ]
   },
   "yaml.validate": true,
   "yaml.format.enable": true,
   "yaml.customTags": [],
   "yaml.schemaStore.enable": false
+  },
+  "yaml.schemas": {
+    "https://www.artillery.io/schema.json": []
+  }
 }

--- a/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
@@ -32,9 +32,19 @@ const getInvoicePaymentStatus = invoice => {
 export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsurer }) => {
   const { getTranslation } = useLanguageContext();
   const { formatShort } = useDateTime();
+
+  const invoiceInsurancePlans = invoice?.insurancePlans || [];
+  const hasInvoicePlans = invoiceInsurancePlans.length > 0;
+  const insurancePlanNames = invoiceInsurancePlans.map(p => p.name || p.code).join(', ');
+
+  // Fall back to legacy patient-level insurer when no invoice plans are present
   const {
     additionalData: { insurer, insurerPolicyNumber },
   } = patient;
+
+  const showInsurer = hasInvoicePlans || enablePatientInsurer;
+  const insurerDisplayValue = hasInvoicePlans ? insurancePlanNames : insurer?.name;
+
   return (
     <>
       <DataSection
@@ -46,10 +56,10 @@ export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsur
             label={getTranslation('general.date.label', 'Date')}
             value={formatShort(invoice.date)}
           />
-          {enablePatientInsurer && (
+          {showInsurer && (
             <DataItem
               label={getTranslation('invoice.insurer.label', 'Insurer')}
-              value={insurer?.name}
+              value={insurerDisplayValue}
             />
           )}
           <DataItem
@@ -66,7 +76,7 @@ export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsur
             label={getTranslation('encounter.admission.label', 'Admission')}
             value={ENCOUNTER_TYPE_LABELS[encounter?.encounterType]}
           />
-          {enablePatientInsurer && (
+          {enablePatientInsurer && !hasInvoicePlans && (
             <DataItem
               label={getTranslation('invoice.policyNumber.label', 'Policy number')}
               value={insurerPolicyNumber}


### PR DESCRIPTION
### Changes

The invoice PDF header was reading the insurer name from `patient.additionalData.insurer` (a legacy patient-level field) rather than from `invoice.insurancePlans` (the plans actually selected on the invoice). This caused the "Insurer" field to appear blank on printed invoices when the legacy `enablePatientInsurer` setting was disabled, even though insurance plans were visible on the web UI.

Now derives the insurer display from `invoice.insurancePlans` when present, falling back to the legacy patient-level field for backward compatibility.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)