### PR TITLE
fix(syntheticUsage): no-issue: Fixed up errors when running synthetic usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41796,6 +41796,7 @@
       "license": "ISC",
       "dependencies": {
         "@tamanu/api-client": "*",
+        "@tamanu/constants": "*",
         "@tamanu/fake-data": "*",
         "js-yaml": "^4.1.0"
       },

--- a/packages/constants/src/patientFields.ts
+++ b/packages/constants/src/patientFields.ts
@@ -1,6 +1,12 @@
 // Please keep in sync with:
 // - mobile/App/constants/patientFields.ts
 
+/**
+ * Default facility `patientDisplayIdPattern`: four random letters + six random digits
+ * (see `generateIdFromPattern` in @tamanu/utils).
+ */
+export const DEFAULT_PATIENT_DISPLAY_ID_PATTERN = 'AAAA000000';
+
 export const PATIENT_FIELD_DEFINITION_TYPES = {
   STRING: 'string',
   NUMBER: 'number',

--- a/packages/database/src/models/Device.ts
+++ b/packages/database/src/models/Device.ts
@@ -13,11 +13,14 @@ import {
   MissingCredentialError,
   QuotaExceededError,
 } from '@tamanu/errors';
+import { stringToStableInteger } from '@tamanu/shared/utils';
 import { Model } from './Model';
 import type { ReadSettings } from '@tamanu/settings';
 import type { SettingPath } from '@tamanu/settings/types';
 import type { User } from './User';
 import type { InitOptions, Models } from '../types/model';
+
+const BASE_DEVICE_REGISTRATION_ADVISORY_KEY = 'deviceRegistrationAdvisoryLock';
 
 export class Device extends Model {
   declare id: string;
@@ -131,6 +134,9 @@ export class Device extends Model {
           }
         }
 
+        // If the same user tries to register two devices concurrently, the second will wait until the first is complete.
+        await Device.acquireRegistrationLockForUser(user.id);
+
         const syncDevice = await Device.findByPk(deviceId);
         if (syncDevice) {
           if (difference(scopes, syncDevice.scopes).length > 0) {
@@ -162,6 +168,13 @@ export class Device extends Model {
         return device;
       },
     );
+  }
+
+  private static async acquireRegistrationLockForUser(userId: string): Promise<void> {
+    const lockId = stringToStableInteger(`${BASE_DEVICE_REGISTRATION_ADVISORY_KEY}:${userId}`);
+    await Device.sequelize.query(`SELECT pg_advisory_xact_lock(:lockId)`, {
+      replacements: { lockId },
+    });
   }
 }
 

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -188,6 +188,12 @@ syncRoutes.use('/sync', sync);
 syncRoutes.use('/syncHealth', syncHealth);
 syncRoutes.use('/patientFacility', patientFacility);
 
-if (process.env.NODE_ENV === 'test') {
+// Random record picker for tests / synthetic load (see packages/synthetic-tests RandomEntityFetcher).
+// Off by default in non-test environments; set TAMANU_ENABLE_SYNTHETIC_RANDOM_API=true to enable.
+const enableRandomRecordApi =
+  process.env.NODE_ENV === 'test' ||
+  process.env.TAMANU_ENABLE_SYNTHETIC_RANDOM_API === 'true';
+
+if (enableRandomRecordApi) {
   apiv1.use('/random', random);
 }

--- a/packages/facility-server/app/routes/apiv1/random.js
+++ b/packages/facility-server/app/routes/apiv1/random.js
@@ -107,7 +107,11 @@ function buildRandomRecordQuery(baseWhere, clientWhere, clientInclude) {
   }
 
   const where =
-    whereParts.length === 0 ? {} : whereParts.length === 1 ? whereParts[0] : { [Op.and]: whereParts };
+    whereParts.length === 0
+      ? {}
+      : whereParts.length === 1
+        ? whereParts[0]
+        : { [Op.and]: whereParts };
 
   return { where, include };
 }
@@ -141,16 +145,12 @@ random.get(
     const { models, facilityId } = req;
     const model = models[modelName];
 
-    const baseWhere =
-      facilityId && model.rawAttributes.facilityId ? { facilityId } : {};
+    const baseWhere = facilityId && model.rawAttributes.facilityId ? { facilityId } : {};
 
     const clientWhere = parseOptionalJsonObject(req.query.where, 'where');
     const clientInclude = parseOptionalJsonArray(req.query.include, 'include');
 
     for (const includeModelName of collectIncludeModelNames(clientInclude)) {
-      if (!WHITELISTED_MODEL_NAMES.has(includeModelName)) {
-        throw new InvalidParameterError(`include: model "${includeModelName}" is not permitted`);
-      }
       req.checkPermission('read', includeModelName);
     }
 

--- a/packages/facility-server/app/routes/apiv1/random.js
+++ b/packages/facility-server/app/routes/apiv1/random.js
@@ -57,6 +57,25 @@ function parseOptionalJsonArray(raw, paramName) {
   }
 }
 
+const WHITELISTED_MODEL_NAMES = new Set(Object.values(WHITELISTED_ENTITIES));
+
+/** Recursively collect all string model names from a nested include list. */
+function collectIncludeModelNames(includeList) {
+  const names = [];
+  if (!includeList?.length) {
+    return names;
+  }
+  for (const item of includeList) {
+    if (typeof item.model === 'string') {
+      names.push(item.model);
+    }
+    if (item.include?.length) {
+      names.push(...collectIncludeModelNames(item.include));
+    }
+  }
+  return names;
+}
+
 /** Replace string `model` keys with Sequelize model classes (JSON cannot carry class refs). */
 function resolveIncludeModelStrings(includeList, models) {
   if (!includeList?.length) {
@@ -127,6 +146,14 @@ random.get(
 
     const clientWhere = parseOptionalJsonObject(req.query.where, 'where');
     const clientInclude = parseOptionalJsonArray(req.query.include, 'include');
+
+    for (const includeModelName of collectIncludeModelNames(clientInclude)) {
+      if (!WHITELISTED_MODEL_NAMES.has(includeModelName)) {
+        throw new InvalidParameterError(`include: model "${includeModelName}" is not permitted`);
+      }
+      req.checkPermission('read', includeModelName);
+    }
+
     resolveIncludeModelStrings(clientInclude, models);
 
     const { where, include } = buildRandomRecordQuery(baseWhere, clientWhere, clientInclude);
@@ -146,6 +173,8 @@ random.get(
           }
         : queryBase;
 
+    // Note: count + random OFFSET is O(n) — both queries scan the (joined) result set up to
+    // the chosen offset. Only use this endpoint against reasonably-sized tables.
     const count = await model.count(countOptions);
     if (count === 0) {
       throw new NotFoundError('No record found');
@@ -156,6 +185,11 @@ random.get(
       ...queryBase,
       offset,
     });
+
+    // Guard against TOCTOU: a record may have been deleted between count and findOne
+    if (!record) {
+      throw new NotFoundError('No record found');
+    }
 
     res.send(instanceToPlainRootModelOnly(record, model));
   }),

--- a/packages/facility-server/app/routes/apiv1/random.js
+++ b/packages/facility-server/app/routes/apiv1/random.js
@@ -18,6 +18,7 @@ const WHITELISTED_ENTITIES = {
  *
  * - `where`: URL-encoded JSON object merged into the Sequelize query.
  * - `include`: URL-encoded JSON array; `"model": "Encounter"` strings are resolved to `models[model]`.
+ *   Includes affect filtering/count only; the response body is always the root entity (no nested rows).
  */
 
 function parseOptionalJsonObject(raw, paramName) {
@@ -92,6 +93,18 @@ function buildRandomRecordQuery(baseWhere, clientWhere, clientInclude) {
   return { where, include };
 }
 
+/** JSON for the root model only; `include` is not serialized (still used for filtering/count). */
+function instanceToPlainRootModelOnly(instance, model) {
+  const plain = instance.get({ plain: true });
+  const out = {};
+  for (const key of Object.keys(model.rawAttributes)) {
+    if (Object.hasOwn(plain, key)) {
+      out[key] = plain[key];
+    }
+  }
+  return out;
+}
+
 export const random = express.Router();
 
 random.get(
@@ -144,6 +157,6 @@ random.get(
       offset,
     });
 
-    res.send(record);
+    res.send(instanceToPlainRootModelOnly(record, model));
   }),
 );

--- a/packages/facility-server/app/routes/apiv1/random.js
+++ b/packages/facility-server/app/routes/apiv1/random.js
@@ -1,6 +1,7 @@
-import { NotFoundError } from '@tamanu/errors';
+import { InvalidParameterError, NotFoundError } from '@tamanu/errors';
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+import { Op } from 'sequelize';
 
 const WHITELISTED_ENTITIES = {
   patient: 'Patient',
@@ -11,6 +12,85 @@ const WHITELISTED_ENTITIES = {
   programRegistry: 'ProgramRegistry',
   department: 'Department',
 };
+
+/**
+ * Random record API (tests / synthetic load only).
+ *
+ * - `where`: URL-encoded JSON object merged into the Sequelize query.
+ * - `include`: URL-encoded JSON array; `"model": "Encounter"` strings are resolved to `models[model]`.
+ */
+
+function parseOptionalJsonObject(raw, paramName) {
+  if (raw == null || raw === '') {
+    return null;
+  }
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new InvalidParameterError(`${paramName} must be a JSON object`);
+    }
+    return parsed;
+  } catch (e) {
+    if (e instanceof InvalidParameterError) {
+      throw e;
+    }
+    throw new InvalidParameterError(`${paramName}: invalid JSON`);
+  }
+}
+
+function parseOptionalJsonArray(raw, paramName) {
+  if (raw == null || raw === '') {
+    return null;
+  }
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!Array.isArray(parsed)) {
+      throw new InvalidParameterError(`${paramName} must be a JSON array`);
+    }
+    return parsed;
+  } catch (e) {
+    if (e instanceof InvalidParameterError) {
+      throw e;
+    }
+    throw new InvalidParameterError(`${paramName}: invalid JSON`);
+  }
+}
+
+/** Replace string `model` keys with Sequelize model classes (JSON cannot carry class refs). */
+function resolveIncludeModelStrings(includeList, models) {
+  if (!includeList?.length) {
+    return;
+  }
+  for (const item of includeList) {
+    if (typeof item.model === 'string') {
+      const resolved = models[item.model];
+      if (!resolved) {
+        throw new InvalidParameterError(`include: no model registered as "${item.model}"`);
+      }
+      item.model = resolved;
+    }
+    if (item.include?.length) {
+      resolveIncludeModelStrings(item.include, models);
+    }
+  }
+}
+
+function buildRandomRecordQuery(baseWhere, clientWhere, clientInclude) {
+  const include = clientInclude?.length ? [...clientInclude] : [];
+  const whereParts = [];
+
+  if (Object.keys(baseWhere).length > 0) {
+    whereParts.push(baseWhere);
+  }
+  if (clientWhere && Object.keys(clientWhere).length > 0) {
+    whereParts.push(clientWhere);
+  }
+
+  const where =
+    whereParts.length === 0 ? {} : whereParts.length === 1 ? whereParts[0] : { [Op.and]: whereParts };
+
+  return { where, include };
+}
 
 export const random = express.Router();
 
@@ -27,17 +107,42 @@ random.get(
     req.checkPermission('read', modelName);
 
     const { models, facilityId } = req;
+    const model = models[modelName];
 
-    const where =
-      facilityId && models[modelName].rawAttributes.facilityId ? { facilityId } : {};
+    const baseWhere =
+      facilityId && model.rawAttributes.facilityId ? { facilityId } : {};
 
-    const count = await models[modelName].count({ where });
+    const clientWhere = parseOptionalJsonObject(req.query.where, 'where');
+    const clientInclude = parseOptionalJsonArray(req.query.include, 'include');
+    resolveIncludeModelStrings(clientInclude, models);
+
+    const { where, include } = buildRandomRecordQuery(baseWhere, clientWhere, clientInclude);
+
+    const queryBase = {
+      where,
+      include,
+      subQuery: false,
+    };
+
+    const countOptions =
+      include.length > 0
+        ? {
+            ...queryBase,
+            distinct: true,
+            col: model.primaryKeyAttribute,
+          }
+        : queryBase;
+
+    const count = await model.count(countOptions);
     if (count === 0) {
       throw new NotFoundError('No record found');
     }
 
     const offset = Math.floor(Math.random() * count);
-    const record = await models[modelName].findOne({ where, offset });
+    const record = await model.findOne({
+      ...queryBase,
+      offset,
+    });
 
     res.send(record);
   }),

--- a/packages/facility-server/app/routes/apiv1/random.js
+++ b/packages/facility-server/app/routes/apiv1/random.js
@@ -57,8 +57,6 @@ function parseOptionalJsonArray(raw, paramName) {
   }
 }
 
-const WHITELISTED_MODEL_NAMES = new Set(Object.values(WHITELISTED_ENTITIES));
-
 /** Recursively collect all string model names from a nested include list. */
 function collectIncludeModelNames(includeList) {
   const names = [];

--- a/packages/fake-data/src/fake/fakeRequest/createPatient.ts
+++ b/packages/fake-data/src/fake/fakeRequest/createPatient.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { DEFAULT_PATIENT_DISPLAY_ID_PATTERN } from '@tamanu/constants';
 import { createPatientSchema } from '@tamanu/shared/schemas/facility/requests/createPatient.schema';
 import { generateIdFromPattern } from '@tamanu/utils/generateId';
 import { keysFor, type WithRequired } from '../utils/types.js';
@@ -21,9 +22,6 @@ const buildPatientBodyWithoutDisplayId = createFakeSchemaFactory(
 );
 
 type RequiredKeys = (typeof requiredKeys)[number];
-
-/** Must stay aligned with `patientDisplayIdPattern.defaultValue` in @tamanu/settings facility schema. */
-const DEFAULT_PATIENT_DISPLAY_ID_PATTERN = 'AAAA000000';
 
 export type FakeCreatePatientRequestOverrides = WithRequired<Schema, RequiredKeys> & {
   /** Facility `patientDisplayIdPattern` (A = random letter, 0 = random digit, literal in []). */

--- a/packages/fake-data/src/fake/fakeRequest/createPatient.ts
+++ b/packages/fake-data/src/fake/fakeRequest/createPatient.ts
@@ -1,17 +1,46 @@
 import { z } from 'zod';
 
 import { createPatientSchema } from '@tamanu/shared/schemas/facility/requests/createPatient.schema';
-import { keysFor } from '../utils/types.js';
+import { generateIdFromPattern } from '@tamanu/utils/generateId';
+import { keysFor, type WithRequired } from '../utils/types.js';
 import { createFakeSchemaFactory } from '../utils/schemaFaker.js';
 
 type Schema = z.infer<typeof createPatientSchema>;
 
 const requiredKeys = keysFor<Schema>()('facilityId', 'registeredById');
 
-const excludedFields = keysFor<Schema>()('patientFields');
+// invoiceInsurancePlanId is a foreignKey[]; zocker supplies undefined for each foreignKey, which
+// becomes null in JSON and causes invalid inserts into patient_invoice_insurance_plans.
+// displayId is required at the DB layer; zocker often omits or falsifies optional strings.
+const excludedFields = keysFor<Schema>()('patientFields', 'invoiceInsurancePlanId', 'displayId');
 
-export const fakeCreatePatientRequestBody = createFakeSchemaFactory(
+const buildPatientBodyWithoutDisplayId = createFakeSchemaFactory(
   createPatientSchema,
   requiredKeys,
   excludedFields,
 );
+
+type RequiredKeys = (typeof requiredKeys)[number];
+
+/** Must stay aligned with `patientDisplayIdPattern.defaultValue` in @tamanu/settings facility schema. */
+const DEFAULT_PATIENT_DISPLAY_ID_PATTERN = 'AAAA000000';
+
+export type FakeCreatePatientRequestOverrides = WithRequired<Schema, RequiredKeys> & {
+  /** Facility `patientDisplayIdPattern` (A = random letter, 0 = random digit, literal in []). */
+  patientDisplayIdPattern?: string;
+};
+
+/**
+ * Fake patient create payload. Always includes a displayId (generated unless overridden) because
+ * Patient.displayId is NOT NULL in the database. Generated IDs use the facility display-id pattern
+ * language (same as the web app), defaulting to four letters + six digits.
+ */
+export const fakeCreatePatientRequestBody = (overrides: FakeCreatePatientRequestOverrides): Schema => {
+  const { patientDisplayIdPattern, displayId, ...schemaOverrides } = overrides;
+  const body = buildPatientBodyWithoutDisplayId(schemaOverrides);
+  const resolvedDisplayId =
+    typeof displayId === 'string' && displayId.length > 0
+      ? displayId
+      : generateIdFromPattern(patientDisplayIdPattern ?? DEFAULT_PATIENT_DISPLAY_ID_PATTERN);
+  return { ...body, displayId: resolvedDisplayId };
+};

--- a/packages/fake-data/src/services/RandomEntityFetcher.ts
+++ b/packages/fake-data/src/services/RandomEntityFetcher.ts
@@ -10,11 +10,15 @@ export class RandomEntityFetcher {
     this.api = api;
   }
 
-  async getRandom(entity: string) {
-    if (CACHEABLE_ENTITIES.has(entity)) {
+  /**
+   * @param query Optional query string params for `/api/random/:entity` — JSON `where` / `include`
+   *   (string model names in include are resolved server-side). See facility-server `random.js`.
+   */
+  async getRandom(entity: string, query: Record<string, string> = {}) {
+    if (CACHEABLE_ENTITIES.has(entity) && Object.keys(query).length === 0) {
       return this.getRandomCached(entity);
     }
-    return this.api.get(`random/${entity}`);
+    return this.api.get(`random/${entity}`, query);
   }
 
   private async getRandomCached(entity: string) {

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 
+import { DEFAULT_PATIENT_DISPLAY_ID_PATTERN } from '@tamanu/constants';
 import { extractDefaults } from './utils';
 import {
   emailSchema,
@@ -148,7 +149,7 @@ export const facilitySettings = {
         Wrapping characters in [] will allow static characters to be used. For example,
         '[B]AAAA000000' will generate an 11 character ID with a static B followed by 4 letter and 6 numbers.`,
       type: yup.string().matches(/^(?:(?:\[.+?\])(?=\[|[A0]|$)|[A0])+$/, 'Invalid pattern'),
-      defaultValue: 'AAAA000000',
+      defaultValue: DEFAULT_PATIENT_DISPLAY_ID_PATTERN,
     },
     questionCodeIds: {
       deprecated: true,

--- a/packages/synthetic-tests/package.json
+++ b/packages/synthetic-tests/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@tamanu/api-client": "*",
+    "@tamanu/constants": "*",
     "@tamanu/fake-data": "*",
     "js-yaml": "^4.1.0"
   },

--- a/packages/synthetic-tests/src/hooks/authenticate.ts
+++ b/packages/synthetic-tests/src/hooks/authenticate.ts
@@ -1,13 +1,14 @@
+import { randomUUID } from 'node:crypto';
+
 import { RandomEntityFetcher } from '@tamanu/fake-data/services/RandomEntityFetcher';
 
 import { TamanuApi } from '@tamanu/api-client';
 import { version } from '../../package.json';
 
-const DEVICE_ID_POOL_SIZE = 5;
-const deviceIds = Array.from({ length: DEVICE_ID_POOL_SIZE }, (_, i) => `synthetic-tests-${i}`);
-
-function pickDeviceId(): string {
-  return deviceIds[Math.floor(Math.random() * deviceIds.length)];
+/** One device id per login. A small fixed pool caused concurrent updates to the same `devices` row
+ * (`last_seen_at`) under Artillery load and PostgreSQL serialization failures. */
+function newSyntheticDeviceId(): string {
+  return `synthetic-tests-${randomUUID()}`;
 }
 
 async function resolveToken(
@@ -33,7 +34,7 @@ export async function authenticate(context: any, _events: any): Promise<void> {
     endpoint: `${context.vars.target}/api`,
     agentName: 'Tamanu Desktop',
     agentVersion: version,
-    deviceId: pickDeviceId(),
+    deviceId: newSyntheticDeviceId(),
     logger: console,
   });
 

--- a/packages/synthetic-tests/src/hooks/authenticate.ts
+++ b/packages/synthetic-tests/src/hooks/authenticate.ts
@@ -4,9 +4,14 @@ import { TamanuApi } from '@tamanu/api-client';
 import { version } from '../../package.json';
 
 /**
- * Bounded pool of device ids: at most `SYNTHETIC_DEVICE_POOL_SIZE` logins run at once; others wait
- * for a slot before `TamanuApi` is constructed. The id is returned to the pool after `login` finishes
- * (success or failure). Same ids are reused across Artillery workers.
+ * Bounded pool of device ids: at most `SYNTHETIC_DEVICE_POOL_SIZE` logins run at once **per
+ * Artillery worker process**; others wait for a slot before `TamanuApi` is constructed. The id
+ * is returned to the pool after `login` finishes (success or failure).
+ *
+ * Note: Artillery spawns one Node.js process per worker, so this pool is not shared across
+ * workers. Under a multi-worker run, total concurrent logins can reach
+ * `SYNTHETIC_DEVICE_POOL_SIZE × workerCount`. The advisory lock in `Device.ensureRegistration`
+ * still prevents DB-level races regardless of worker count.
  *
  * @see packages/database Device.ensureRegistration (per-user advisory lock) for concurrent login safety.
  */

--- a/packages/synthetic-tests/src/hooks/authenticate.ts
+++ b/packages/synthetic-tests/src/hooks/authenticate.ts
@@ -1,14 +1,43 @@
-import { randomUUID } from 'node:crypto';
-
 import { RandomEntityFetcher } from '@tamanu/fake-data/services/RandomEntityFetcher';
 
 import { TamanuApi } from '@tamanu/api-client';
 import { version } from '../../package.json';
 
-/** One device id per login. A small fixed pool caused concurrent updates to the same `devices` row
- * (`last_seen_at`) under Artillery load and PostgreSQL serialization failures. */
-function newSyntheticDeviceId(): string {
-  return `synthetic-tests-${randomUUID()}`;
+/**
+ * Bounded pool of device ids: at most `SYNTHETIC_DEVICE_POOL_SIZE` logins run at once; others wait
+ * for a slot before `TamanuApi` is constructed. The id is returned to the pool after `login` finishes
+ * (success or failure). Same ids are reused across Artillery workers.
+ *
+ * @see packages/database Device.ensureRegistration (per-user advisory lock) for concurrent login safety.
+ */
+const SYNTHETIC_DEVICE_POOL_SIZE = 32;
+
+const SYNTHETIC_DEVICE_IDS = Array.from(
+  { length: SYNTHETIC_DEVICE_POOL_SIZE },
+  (_, i) => `synthetic-tests-artillery-pool-${i}`,
+);
+
+const availableSyntheticDeviceIds: string[] = [...SYNTHETIC_DEVICE_IDS];
+const syntheticDeviceIdWaiters: Array<(id: string) => void> = [];
+
+function acquireSyntheticDeviceId(): Promise<string> {
+  return new Promise(resolve => {
+    const id = availableSyntheticDeviceIds.pop();
+    if (id !== undefined) {
+      resolve(id);
+    } else {
+      syntheticDeviceIdWaiters.push(resolve);
+    }
+  });
+}
+
+function releaseSyntheticDeviceId(id: string): void {
+  const waiter = syntheticDeviceIdWaiters.shift();
+  if (waiter) {
+    waiter(id);
+  } else {
+    availableSyntheticDeviceIds.push(id);
+  }
 }
 
 async function resolveToken(
@@ -30,15 +59,22 @@ async function resolveToken(
 export async function authenticate(context: any, _events: any): Promise<void> {
   const { email = 'admin@tamanu.io', password = 'admin' } = context.vars;
 
-  const api = new TamanuApi({
-    endpoint: `${context.vars.target}/api`,
-    agentName: 'Tamanu Desktop',
-    agentVersion: version,
-    deviceId: newSyntheticDeviceId(),
-    logger: console,
-  });
+  const deviceId = await acquireSyntheticDeviceId();
+  let api: TamanuApi;
+  let loginResponse: any;
+  try {
+    api = new TamanuApi({
+      endpoint: `${context.vars.target}/api`,
+      agentName: 'Tamanu Desktop',
+      agentVersion: version,
+      deviceId,
+      logger: console,
+    });
+    loginResponse = await api.login(email, password);
+  } finally {
+    releaseSyntheticDeviceId(deviceId);
+  }
 
-  const loginResponse: any = await api.login(email, password);
   const { user, availableFacilities } = loginResponse;
 
   const facilityId = availableFacilities?.[0]?.id;

--- a/packages/synthetic-tests/src/hooks/createEncounter.ts
+++ b/packages/synthetic-tests/src/hooks/createEncounter.ts
@@ -1,14 +1,16 @@
 import { fakeCreateEncounterRequestBody } from '@tamanu/fake-data/fake/fakeRequest/createEncounter';
 
+import { RANDOM_PATIENT_NO_OPEN_ENCOUNTER_QUERY } from './randomPatientQuery';
+
 /**
- * Generates an encounter payload with a random patient, location, and department.
+ * Generates an encounter payload with a random patient (with no active encounter), location, and department.
  * Stores the payload and selected patient in context.vars.
  */
 export async function generateEncounterPayload(context: any, _events: any): Promise<void> {
   const { entityFetcher } = context.vars;
 
   const [randomPatient, randomLocation, randomDepartment] = await Promise.all([
-    entityFetcher.getRandom('patient'),
+    entityFetcher.getRandom('patient', { ...RANDOM_PATIENT_NO_OPEN_ENCOUNTER_QUERY }),
     entityFetcher.getRandom('location'),
     entityFetcher.getRandom('department'),
   ]);

--- a/packages/synthetic-tests/src/hooks/randomPatientQuery.ts
+++ b/packages/synthetic-tests/src/hooks/randomPatientQuery.ts
@@ -1,0 +1,17 @@
+/**
+ * Query string fragments for GET /api/random/patient — patients with no active encounter.
+ * Matches Sequelize default hasMany alias `Encounters` on Patient → Encounter.
+ */
+export const RANDOM_PATIENT_NO_OPEN_ENCOUNTER_QUERY = {
+  where: JSON.stringify({
+    '$Encounters.id$': null,
+  }),
+  include: JSON.stringify([
+    {
+      model: 'Encounter',
+      required: false,
+      where: { endDate: null },
+      attributes: [],
+    },
+  ]),
+} as const;

--- a/packages/utils/src/generateId.ts
+++ b/packages/utils/src/generateId.ts
@@ -1,18 +1,9 @@
+import { DEFAULT_PATIENT_DISPLAY_ID_PATTERN } from '@tamanu/constants';
 import { v4 } from 'uuid';
 
 const generators: Record<string, () => string> = {
   A: () => String.fromCharCode(65 + Math.floor(Math.random() * 26)),
   '0': () => Math.floor(Math.random() * 10).toFixed(0),
-};
-
-const DISPLAY_ID_FORMAT = 'AAAA000000';
-
-// Checks if the passed displayId was generated using generateId function above
-// with the specific 10 digit format DISPLAY_ID_FORMAT. It will need to be reevaluated
-// if the format ever changes.
-export const isGeneratedDisplayId = (displayId: string) => {
-  if (DISPLAY_ID_FORMAT !== 'AAAA000000') return false;
-  return /^[A-Z]{4}\d{6}$/.test(displayId);
 };
 
 // Max pattern length to avoid ReDoS with PATTERN_TOKEN_REGEX on long input
@@ -62,7 +53,7 @@ export const generateIdFromPattern = (pattern: string) => {
   });
 };
 
-export const generateId = () => generateIdFromPattern(DISPLAY_ID_FORMAT);
+export const generateId = () => generateIdFromPattern(DEFAULT_PATIENT_DISPLAY_ID_PATTERN);
 
 /**
  * Validates if a display ID matches a given pattern.
@@ -82,6 +73,10 @@ export const isGeneratedIdFromPattern = (displayId: string, pattern: string) => 
   const patternRegex = new RegExp(`^${expression}$`);
   return patternRegex.test(displayId);
 };
+
+/** True if `displayId` matches the default patient display-id pattern (`generateId`). */
+export const isGeneratedDisplayId = (displayId: string) =>
+  isGeneratedIdFromPattern(displayId, DEFAULT_PATIENT_DISPLAY_ID_PATTERN);
 
 /**
  * Makes a 'fake' but valid uuid like '2964ea0d-073d-0000-bda1-ce47fd5de340'.


### PR DESCRIPTION
### Changes

A few issues fixed here:
1. When running the usage we can attempt to login with the same user and a different device at the same time which breaks the device registration transaction. Added an advisory lock to wait until any devices that this user is trying to register have completed
2. Were providing `undefined` for patient.displayId, have added defaulting to random generating based on default patient display id pattern (also moved this to constants)
3. Added a custom `TAMANU_ENABLE_SYNTHETIC_RANDOM_API` flag to allow running the facility-server with the random api enabled, so that we can do this on non-test environments
4. We were attempting to open encounters for the same patient twice, which is a validation error as a patient can only have one open encounter. Added ability to specify a where clause on the random api so that we can filter which resources it returns

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
