### PR TITLE
fix(invoicing): 2.53 fix: use invoice insurance plans in PDF header instead of legacy patient insurer

### DIFF
--- a/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
@@ -32,9 +32,19 @@ const getInvoicePaymentStatus = invoice => {
 export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsurer }) => {
   const { getTranslation } = useLanguageContext();
   const { formatShort } = useDateTime();
+
+  const invoiceInsurancePlans = invoice?.insurancePlans || [];
+  const hasInvoicePlans = invoiceInsurancePlans.length > 0;
+  const insurancePlanNames = invoiceInsurancePlans.map(p => p.name || p.code).join(', ');
+
+  // Fall back to legacy patient-level insurer when no invoice plans are present
   const {
     additionalData: { insurer, insurerPolicyNumber },
   } = patient;
+
+  const showInsurer = hasInvoicePlans || enablePatientInsurer;
+  const insurerDisplayValue = hasInvoicePlans ? insurancePlanNames : insurer?.name;
+
   return (
     <>
       <DataSection
@@ -46,10 +56,10 @@ export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsur
             label={getTranslation('general.date.label', 'Date')}
             value={formatShort(invoice.date)}
           />
-          {enablePatientInsurer && (
+          {showInsurer && (
             <DataItem
               label={getTranslation('invoice.insurer.label', 'Insurer')}
-              value={insurer?.name}
+              value={insurerDisplayValue}
             />
           )}
           <DataItem
@@ -66,7 +76,7 @@ export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsur
             label={getTranslation('encounter.admission.label', 'Admission')}
             value={ENCOUNTER_TYPE_LABELS[encounter?.encounterType]}
           />
-          {enablePatientInsurer && (
+          {enablePatientInsurer && !hasInvoicePlans && (
             <DataItem
               label={getTranslation('invoice.policyNumber.label', 'Policy number')}
               value={insurerPolicyNumber}


### PR DESCRIPTION
### Changes

Cherry-pick of #9542 to release/2.53. The invoice PDF header was reading the insurer name from the legacy patient-level field instead of from `invoice.insurancePlans`. Now derives the insurer display from invoice insurance plans when present, falling back to legacy for backward compatibility.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)