### PR TITLE
fix(tasks): Release fix 2.53: Update task list on area change

### DIFF
--- a/packages/web/app/components/Tasks/DashboardTaskPane.jsx
+++ b/packages/web/app/components/Tasks/DashboardTaskPane.jsx
@@ -70,7 +70,7 @@ export const DashboardTaskPane = React.memo(() => {
     });
   };
 
-  const onLocationIdChange = (e) => {
+  const onLocationIdChange = e => {
     const { value, groupValue } = e.target;
 
     const paramsWithLocation = value
@@ -81,19 +81,19 @@ export const DashboardTaskPane = React.memo(() => {
       ? { ...paramsWithLocation, locationGroupId: groupValue }
       : omit(paramsWithLocation, 'locationGroupId');
 
-
     updateTaskFilterPreference(newParams);
   };
 
   const onLocationGroupIdChange = locationGroupId => {
+    const paramsWithoutLocation = omit(clinicianDashboardTaskingTableFilter, 'locationId');
     const newParams = locationGroupId
-      ? { ...clinicianDashboardTaskingTableFilter, locationGroupId }
-      : omit(clinicianDashboardTaskingTableFilter, 'locationGroupId');
+      ? { ...paramsWithoutLocation, locationGroupId }
+      : omit(paramsWithoutLocation, 'locationGroupId');
 
     updateTaskFilterPreference(newParams);
   };
 
-  const onHighPriorityOnlyChange = (e) => {
+  const onHighPriorityOnlyChange = e => {
     const { checked } = e.target;
 
     const newParams = checked

--- a/packages/web/app/components/Tasks/DashboardTaskPane.jsx
+++ b/packages/web/app/components/Tasks/DashboardTaskPane.jsx
@@ -63,17 +63,35 @@ export const DashboardTaskPane = React.memo(() => {
   const clinicianDashboardTaskingTableFilter =
     userPreferences?.clinicianDashboardTaskingTableFilter || {};
 
-  const onLocationIdChange = (e) => {
-    const { value } = e.target;
+  const updateTaskFilterPreference = value => {
+    userPreferencesMutation.mutate({
+      key: USER_PREFERENCES_KEYS.CLINICIAN_DASHBOARD_TASKING_TABLE_FILTER,
+      value,
+    });
+  };
 
-    const newParams = value
+  const onLocationIdChange = (e) => {
+    const { value, groupValue } = e.target;
+
+    const paramsWithLocation = value
       ? { ...clinicianDashboardTaskingTableFilter, locationId: value }
       : omit(clinicianDashboardTaskingTableFilter, 'locationId');
 
-    userPreferencesMutation.mutate({
-      key: USER_PREFERENCES_KEYS.CLINICIAN_DASHBOARD_TASKING_TABLE_FILTER,
-      value: newParams,
-    });
+    const newParams = groupValue
+      ? { ...paramsWithLocation, locationGroupId: groupValue }
+      : omit(paramsWithLocation, 'locationGroupId');
+
+
+
+    updateTaskFilterPreference(newParams);
+  };
+
+  const onLocationGroupIdChange = locationGroupId => {
+    const newParams = locationGroupId
+      ? { ...clinicianDashboardTaskingTableFilter, locationGroupId }
+      : omit(clinicianDashboardTaskingTableFilter, 'locationGroupId');
+
+    updateTaskFilterPreference(newParams);
   };
 
   const onHighPriorityOnlyChange = (e) => {
@@ -83,10 +101,7 @@ export const DashboardTaskPane = React.memo(() => {
       ? { ...clinicianDashboardTaskingTableFilter, highPriority: checked }
       : omit(clinicianDashboardTaskingTableFilter, 'highPriority');
 
-    userPreferencesMutation.mutate({
-      key: USER_PREFERENCES_KEYS.CLINICIAN_DASHBOARD_TASKING_TABLE_FILTER,
-      value: newParams,
-    });
+    updateTaskFilterPreference(newParams);
   };
 
   return (
@@ -104,6 +119,7 @@ export const DashboardTaskPane = React.memo(() => {
             <LocationInput
               name="locationId"
               onChange={onLocationIdChange}
+              onGroupChange={onLocationGroupIdChange}
               size="small"
               label={
                 <TranslatedText
@@ -120,6 +136,7 @@ export const DashboardTaskPane = React.memo(() => {
                 />
               }
               value={clinicianDashboardTaskingTableFilter.locationId}
+              groupValue={clinicianDashboardTaskingTableFilter.locationGroupId}
               autofill={false}
               isMulti={true}
               data-testid="locationinput-aabz"

--- a/packages/web/app/components/Tasks/DashboardTaskPane.jsx
+++ b/packages/web/app/components/Tasks/DashboardTaskPane.jsx
@@ -85,7 +85,17 @@ export const DashboardTaskPane = React.memo(() => {
   };
 
   const onLocationGroupIdChange = locationGroupId => {
-    const paramsWithoutLocation = omit(clinicianDashboardTaskingTableFilter, 'locationId');
+    // If we have a locationId but no locationGroupId, this is likely an initialization
+    // where the LocationInput is auto-detecting the group for an existing location.
+    // In this case, preserve the locationId instead of stripping it.
+    const isInitialization =
+      clinicianDashboardTaskingTableFilter.locationId &&
+      !clinicianDashboardTaskingTableFilter.locationGroupId;
+
+    const paramsWithoutLocation = isInitialization
+      ? clinicianDashboardTaskingTableFilter
+      : omit(clinicianDashboardTaskingTableFilter, 'locationId');
+
     const newParams = locationGroupId
       ? { ...paramsWithoutLocation, locationGroupId }
       : omit(paramsWithoutLocation, 'locationGroupId');

--- a/packages/web/app/components/Tasks/DashboardTaskPane.jsx
+++ b/packages/web/app/components/Tasks/DashboardTaskPane.jsx
@@ -82,7 +82,6 @@ export const DashboardTaskPane = React.memo(() => {
       : omit(paramsWithLocation, 'locationGroupId');
 
 
-
     updateTaskFilterPreference(newParams);
   };
 


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dashboard task filtering state persisted in user preferences; subtle initialization logic could cause incorrect filter params or stale results if edge cases are missed.
> 
> **Overview**
> Ensures the dashboard task list filter stored in user preferences updates when the *Area* (location group) changes, not just when a specific location changes.
> 
> Adds `onGroupChange`/`groupValue` wiring for `LocationInput`, centralizes preference updates via `updateTaskFilterPreference`, and adjusts change handlers to keep `locationId`/`locationGroupId` in sync (including a guard to preserve `locationId` during LocationInput auto-detected group initialization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf45c6cd88ce3e8d264efb22c6e70d284018a236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->