### PR TITLE
fix(programRegistry): HOTFIX-2.52: prevent survey submission from overwriting registration date

### DIFF
--- a/packages/central-server/__tests__/models/SurveyResponse.test.js
+++ b/packages/central-server/__tests__/models/SurveyResponse.test.js
@@ -315,4 +315,119 @@ describe('SurveyResponse.createWithAnswers', () => {
       registrationStatus: REGISTRATION_STATUSES.ACTIVE,
     });
   });
+
+  it('sets registration date to endTime on new registration', async () => {
+    const survey = await createDummySurvey(models);
+    const registry = await models.ProgramRegistry.create(
+      fake(models.ProgramRegistry, {
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        programId: survey.programId,
+      }),
+    );
+    const clinicalStatus = await models.ProgramRegistryClinicalStatus.create(
+      fake(models.ProgramRegistryClinicalStatus, {
+        programRegistryId: registry.id,
+      }),
+    );
+    const { dataElement } = await createDummyDataElement(models, survey, {
+      type: PROGRAM_DATA_ELEMENT_TYPES.PATIENT_DATA,
+      config: {
+        writeToPatient: {
+          fieldName: 'registrationClinicalStatus',
+        },
+      },
+    });
+    const { id: userId } = await models.User.create({
+      displayName: 'Test clinician',
+      email: 'testclinician-date@test.test',
+    });
+
+    const submittedEndTime = '2024-01-15 10:30:00';
+
+    await models.SurveyResponse.sequelize.transaction(() =>
+      models.SurveyResponse.createWithAnswers({
+        patientId,
+        encounterId,
+        userId,
+        surveyId: survey.id,
+        endTime: submittedEndTime,
+        answers: {
+          [dataElement.id]: clinicalStatus.id,
+        },
+      }),
+    );
+
+    const registration = await models.PatientProgramRegistration.findOne();
+    expect(registration.date).toBe(submittedEndTime);
+  });
+
+  it('does not overwrite registration date on subsequent survey submission', async () => {
+    const survey = await createDummySurvey(models);
+    const registry = await models.ProgramRegistry.create(
+      fake(models.ProgramRegistry, {
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+        programId: survey.programId,
+      }),
+    );
+    const clinicalStatus1 = await models.ProgramRegistryClinicalStatus.create(
+      fake(models.ProgramRegistryClinicalStatus, {
+        programRegistryId: registry.id,
+      }),
+    );
+    const clinicalStatus2 = await models.ProgramRegistryClinicalStatus.create(
+      fake(models.ProgramRegistryClinicalStatus, {
+        programRegistryId: registry.id,
+      }),
+    );
+    const { dataElement } = await createDummyDataElement(models, survey, {
+      type: PROGRAM_DATA_ELEMENT_TYPES.PATIENT_DATA,
+      config: {
+        writeToPatient: {
+          fieldName: 'registrationClinicalStatus',
+        },
+      },
+    });
+    const { id: userId } = await models.User.create({
+      displayName: 'Test clinician',
+      email: 'testclinician-noupdate@test.test',
+    });
+
+    const originalEndTime = '2024-01-15 10:30:00';
+
+    await models.SurveyResponse.sequelize.transaction(() =>
+      models.SurveyResponse.createWithAnswers({
+        patientId,
+        encounterId,
+        userId,
+        surveyId: survey.id,
+        endTime: originalEndTime,
+        answers: {
+          [dataElement.id]: clinicalStatus1.id,
+        },
+      }),
+    );
+
+    const registrationAfterCreate = await models.PatientProgramRegistration.findOne();
+    expect(registrationAfterCreate.date).toBe(originalEndTime);
+    expect(registrationAfterCreate.clinicalStatusId).toBe(clinicalStatus1.id);
+
+    const laterEndTime = '2024-06-01 14:00:00';
+
+    await models.SurveyResponse.sequelize.transaction(() =>
+      models.SurveyResponse.createWithAnswers({
+        patientId,
+        encounterId,
+        userId,
+        surveyId: survey.id,
+        endTime: laterEndTime,
+        answers: {
+          [dataElement.id]: clinicalStatus2.id,
+        },
+      }),
+    );
+
+    const registrationAfterUpdate = await models.PatientProgramRegistration.findOne();
+    expect(registrationAfterUpdate.clinicalStatusId).toBe(clinicalStatus2.id);
+    expect(registrationAfterUpdate.date).toBe(originalEndTime);
+  });
 });

--- a/packages/database/src/models/SurveyResponse.ts
+++ b/packages/database/src/models/SurveyResponse.ts
@@ -128,7 +128,6 @@ async function writeToPatientFields(
     const registrationData = {
       patientId,
       programRegistryId: programRegistryDetail.id,
-      date: submittedTime,
       ...valuesByModel.PatientProgramRegistration,
       registeringFacilityId:
         valuesByModel.PatientProgramRegistration.registeringFacilityId || facilityId,
@@ -136,11 +135,12 @@ async function writeToPatientFields(
     };
 
     if (existingRegistration) {
-      // Update the existing record
       await existingRegistration.update(registrationData);
     } else {
-      // Create a new record
-      await models.PatientProgramRegistration.create(registrationData);
+      await models.PatientProgramRegistration.create({
+        date: submittedTime,
+        ...registrationData,
+      });
     }
   }
 }

--- a/packages/mobile/App/models/PatientProgramRegistration.ts
+++ b/packages/mobile/App/models/PatientProgramRegistration.ts
@@ -193,9 +193,9 @@ export class PatientProgramRegistration extends BaseModel implements IPatientPro
     }
 
     return PatientProgramRegistration.createAndSaveOne({
+      ...(submittedTime ? { date: submittedTime } : {}),
       ...getValuesFromRelations(data),
       ...data,
-      ...(submittedTime ? { date: submittedTime } : {}),
       programRegistry: programRegistryId,
       patient: patientId,
     });

--- a/packages/mobile/App/models/PatientProgramRegistration.ts
+++ b/packages/mobile/App/models/PatientProgramRegistration.ts
@@ -175,6 +175,7 @@ export class PatientProgramRegistration extends BaseModel implements IPatientPro
     patientId: string,
     programRegistryId: string,
     data: any,
+    submittedTime?: string,
   ): Promise<PatientProgramRegistration> {
     const { programId } = await ProgramRegistry.findOne({ where: { id: programRegistryId } });
     const existingRegistration = await PatientProgramRegistration.getRecentOne(
@@ -192,9 +193,9 @@ export class PatientProgramRegistration extends BaseModel implements IPatientPro
     }
 
     return PatientProgramRegistration.createAndSaveOne({
-      ...getValuesFromRelations(existingRegistration),
       ...getValuesFromRelations(data),
       ...data,
+      ...(submittedTime ? { date: submittedTime } : {}),
       programRegistry: programRegistryId,
       patient: patientId,
     });

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -95,17 +95,12 @@ async function writeToPatientFields(
     if (!programRegistryDetail?.id) {
       throw new Error('No program registry configured for the current form');
     }
-    const existingRegistration = await PatientProgramRegistration.getRecentOne(
-      programRegistryDetail.programId,
-      patientId,
-    );
     await PatientProgramRegistration.upsertRegistration(patientId, programRegistryDetail.id, {
-      ...(existingRegistration ? {} : { date: submittedTime }),
       ...valuesByModel.PatientProgramRegistration,
       registeringFacilityId:
         valuesByModel.PatientProgramRegistration.registeringFacilityId || facilityId,
       clinicianId: valuesByModel.PatientProgramRegistration.clinicianId || userId,
-    });
+    }, submittedTime);
   }
 }
 

--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -95,8 +95,12 @@ async function writeToPatientFields(
     if (!programRegistryDetail?.id) {
       throw new Error('No program registry configured for the current form');
     }
+    const existingRegistration = await PatientProgramRegistration.getRecentOne(
+      programRegistryDetail.programId,
+      patientId,
+    );
     await PatientProgramRegistration.upsertRegistration(patientId, programRegistryDetail.id, {
-      date: submittedTime,
+      ...(existingRegistration ? {} : { date: submittedTime }),
       ...valuesByModel.PatientProgramRegistration,
       registeringFacilityId:
         valuesByModel.PatientProgramRegistration.registeringFacilityId || facilityId,


### PR DESCRIPTION
### Changes

Fix inconsistent spread order for `date` in `PatientProgramRegistration` create path between server and mobile.

On mobile, `submittedTime` was unconditionally overriding any survey-provided `date` — now it acts as a fallback default, matching server behavior. Also moves the existing-registration check into `upsertRegistration` to avoid a redundant query, matching the server-side implementation.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->