### PR TITLE
fix(notifications): Release fix v2.53: Filter notifications linked to sensitive data

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.sensitiveFacilities.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.sensitiveFacilities.test.js
@@ -1,6 +1,12 @@
 import { FACT_CURRENT_SYNC_TICK, FACT_LOOKUP_UP_TO_TICK } from '@tamanu/constants/facts';
 import { fake } from '@tamanu/fake-data/fake';
-import { NOTE_TYPES, REFERENCE_TYPES, SETTINGS_SCOPES, SYSTEM_USER_UUID } from '@tamanu/constants';
+import {
+  NOTE_TYPES,
+  NOTIFICATION_TYPES,
+  REFERENCE_TYPES,
+  SETTINGS_SCOPES,
+  SYSTEM_USER_UUID,
+} from '@tamanu/constants';
 import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 
 import {
@@ -929,6 +935,56 @@ describe('CentralSyncManager Sensitive Facilities', () => {
           model: models.LabRequest,
           sensitiveId: sensitiveLabRequest.id,
           nonSensitiveId: nonSensitiveLabRequest.id,
+        });
+      });
+
+      it("won't sync lab notifications for sensitive encounters", async () => {
+        const sensitiveNotification = await models.Notification.create(
+          fake(models.Notification, {
+            type: NOTIFICATION_TYPES.LAB_REQUEST,
+            patientId: patient.id,
+            userId: practitioner.id,
+            metadata: { id: sensitiveLabRequest.id, encounterId: sensitiveEncounter.id },
+          }),
+        );
+        const nonSensitiveNotification = await models.Notification.create(
+          fake(models.Notification, {
+            type: NOTIFICATION_TYPES.LAB_REQUEST,
+            patientId: patient.id,
+            userId: practitioner.id,
+            metadata: { id: nonSensitiveLabRequest.id, encounterId: nonSensitiveEncounter.id },
+          }),
+        );
+
+        await checkSensitiveRecordFiltering({
+          model: models.Notification,
+          sensitiveId: sensitiveNotification.id,
+          nonSensitiveId: nonSensitiveNotification.id,
+        });
+      });
+
+      it("won't sync imaging notifications for sensitive encounters", async () => {
+        const sensitiveNotification = await models.Notification.create(
+          fake(models.Notification, {
+            type: NOTIFICATION_TYPES.IMAGING_REQUEST,
+            patientId: patient.id,
+            userId: practitioner.id,
+            metadata: { id: 'sensitive-imaging-request', encounterId: sensitiveEncounter.id },
+          }),
+        );
+        const nonSensitiveNotification = await models.Notification.create(
+          fake(models.Notification, {
+            type: NOTIFICATION_TYPES.IMAGING_REQUEST,
+            patientId: patient.id,
+            userId: practitioner.id,
+            metadata: { id: 'non-sensitive-imaging-request', encounterId: nonSensitiveEncounter.id },
+          }),
+        );
+
+        await checkSensitiveRecordFiltering({
+          model: models.Notification,
+          sensitiveId: sensitiveNotification.id,
+          nonSensitiveId: nonSensitiveNotification.id,
         });
       });
 

--- a/packages/database/src/models/Notification.ts
+++ b/packages/database/src/models/Notification.ts
@@ -4,7 +4,11 @@ import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { log } from '@tamanu/shared/services/logging';
 import { Model } from './Model';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
-import { buildPatientSyncFilterViaPatientId, buildSyncLookupSelect } from '../sync';
+import {
+  buildPatientSyncFilterViaPatientId,
+  buildSyncLookupSelect,
+  ADD_SENSITIVE_FACILITY_ID_IF_APPLICABLE,
+} from '../sync';
 
 const NOTIFICATION_TYPE_VALUES = Object.values(NOTIFICATION_TYPES);
 const NOTIFICATION_STATUS_VALUES = Object.values(NOTIFICATION_STATUSES);
@@ -64,13 +68,7 @@ export class Notification extends Model {
     return {
       select: await buildSyncLookupSelect(this, {
         patientId: `${this.tableName}.patient_id`,
-        facilityId: `
-          CASE
-            WHEN facilities.is_sensitive = TRUE
-            THEN facilities.id
-            ELSE NULL
-          END
-        `,
+        facilityId: ADD_SENSITIVE_FACILITY_ID_IF_APPLICABLE,
       }),
       joins: `
         LEFT JOIN encounters

--- a/packages/database/src/models/Notification.ts
+++ b/packages/database/src/models/Notification.ts
@@ -4,7 +4,7 @@ import { getCurrentDateTimeString } from '@tamanu/utils/dateTime';
 import { log } from '@tamanu/shared/services/logging';
 import { Model } from './Model';
 import { dateTimeType, type InitOptions, type Models } from '../types/model';
-import { buildPatientLinkedLookupFilter, buildPatientSyncFilterViaPatientId } from '../sync';
+import { buildPatientSyncFilterViaPatientId, buildSyncLookupSelect } from '../sync';
 
 const NOTIFICATION_TYPE_VALUES = Object.values(NOTIFICATION_TYPES);
 const NOTIFICATION_STATUS_VALUES = Object.values(NOTIFICATION_STATUSES);
@@ -61,7 +61,26 @@ export class Notification extends Model {
   static buildPatientSyncFilter = buildPatientSyncFilterViaPatientId;
 
   static async buildSyncLookupQueryDetails() {
-    return buildPatientLinkedLookupFilter(this);
+    return {
+      select: await buildSyncLookupSelect(this, {
+        patientId: `${this.tableName}.patient_id`,
+        facilityId: `
+          CASE
+            WHEN facilities.is_sensitive = TRUE
+            THEN facilities.id
+            ELSE NULL
+          END
+        `,
+      }),
+      joins: `
+        LEFT JOIN encounters
+          ON encounters.id::text = ${this.tableName}.metadata->>'encounterId'
+        LEFT JOIN locations
+          ON locations.id = encounters.location_id
+        LEFT JOIN facilities
+          ON facilities.id = locations.facility_id
+      `,
+    };
   }
 
   static getFullReferenceAssociations() {


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts central sync lookup generation for `notifications`, which can affect what data is replicated between facilities; mistakes could either leak sensitive encounter-linked notifications or inadvertently suppress legitimate ones.
> 
> **Overview**
> Prevents cross-facility syncing of `notifications` that reference sensitive encounters by changing `Notification.buildSyncLookupQueryDetails()` to join `notifications.metadata.encounterId` through `encounters -> locations -> facilities` and only populate `sync_lookup.facility_id` when the facility is sensitive.
> 
> Expands the sensitive-facility sync test suite to cover lab and imaging notifications, asserting that notifications tied to sensitive encounters are not included when pulling snapshots for a non-sensitive facility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db05950f9625ec6d0640df35a5fbc42af827da03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->