### PR TITLE
fix(deaths): Hotfix v2.52: Death certificate stuck in loading state when no villageId

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
@@ -47,7 +47,9 @@ export const DeathCertificateModal = ({ patient, deathData }) => {
     additionalData?.fatherId,
   );
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
-  const { data: village, isLoading: isVillageLoading } = useReferenceDataQuery(patient?.villageId);
+  const { data: village, isInitialLoading: isVillageLoading } = useReferenceDataQuery(
+    patient?.villageId,
+  );
 
   const patientData = {
     ...patient,

--- a/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
@@ -47,9 +47,9 @@ export const DeathCertificateModal = ({ patient, deathData }) => {
     additionalData?.fatherId,
   );
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
-  const { data: village, isInitialLoading: isVillageLoading } = useReferenceDataQuery(
-    patient?.villageId,
-  );
+  const { villageId } = patient;
+  const { data: village, isLoading: isVillageDataLoading } = useReferenceDataQuery(villageId);
+  const isVillageLoading = !!villageId && isVillageDataLoading;
 
   const patientData = {
     ...patient,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-side loading-state fix gated on `villageId`, with minimal behavioral impact outside the death certificate modal.
> 
> **Overview**
> Fixes the death certificate print modal getting stuck in a loading state when the patient has no `villageId`.
> 
> `DeathCertificateModal` now derives `isVillageLoading` only when `villageId` is present (instead of relying directly on the reference-data query’s loading flag), avoiding indefinite loading for patients without a village.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13bd7a7f6506b4e39b4e98a7e98aa75c6c3c9238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->