### PR TITLE
fix(labs): Release fix v2.53: Lab panel override edge case

### DIFF
--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { LAB_REQUEST_FORM_TYPES } from '@tamanu/constants/labs';
 import { uniqBy } from 'lodash';
 import styled from 'styled-components';
@@ -97,12 +97,25 @@ export const FORM_TYPE_TO_FIELD_CONFIG = {
 
 export const LabRequestFormScreen2 = (props) => {
   const {
+    setFieldValue,
     values: { requestFormType },
     onSelectionChange,
   } = props;
 
   const fieldConfig = useMemo(() => FORM_TYPE_TO_FIELD_CONFIG[requestFormType], [requestFormType]);
   const { subheading, instructions, fieldName } = fieldConfig;
+
+  useEffect(() => {
+    if (requestFormType === LAB_REQUEST_FORM_TYPES.INDIVIDUAL) {
+      setFieldValue('panelIds', []);
+      return;
+    }
+
+    if (requestFormType === LAB_REQUEST_FORM_TYPES.PANEL) {
+      setFieldValue('labTestTypeIds', []);
+    }
+  }, [requestFormType, setFieldValue]);
+
   const handleSelectionChange = ({ selectedObjects }) => {
     if (!onSelectionChange) return;
     const isPanelRequest = requestFormType === LAB_REQUEST_FORM_TYPES.PANEL;

--- a/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
+++ b/packages/web/app/forms/LabRequestForm/LabRequestFormScreen2.jsx
@@ -113,6 +113,13 @@ export const LabRequestFormScreen2 = (props) => {
 
     if (requestFormType === LAB_REQUEST_FORM_TYPES.PANEL) {
       setFieldValue('labTestTypeIds', []);
+      return;
+    }
+
+    if (requestFormType === LAB_REQUEST_FORM_TYPES.SUPERSET) {
+      setFieldValue('panelIds', []);
+      setFieldValue('labTestTypeIds', []);
+      return
     }
   }, [requestFormType, setFieldValue]);
 


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only form-state change that clears fields on type change; main risk is unintended loss of user selections if `requestFormType` toggles unexpectedly.
> 
> **Overview**
> Adds a `useEffect` to `LabRequestFormScreen2` that automatically clears the non-applicable selection arrays (`panelIds` and/or `labTestTypeIds`) whenever `requestFormType` switches between *Individual*, *Panel*, and *Superset*.
> 
> This prevents stale selections from a previous request type from persisting and causing panel/test override edge cases during lab request entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066ad942a4291070662910c344fb67556140319c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->