### PR TITLE
fix(fhir): COOL-63: De-prioritise FHIR jobs created during migrations

### DIFF
--- a/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
+++ b/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
@@ -1,4 +1,5 @@
 import { Op } from 'sequelize';
+import { JOB_PRIORITIES } from '@tamanu/constants';
 
 import { fake } from '@tamanu/fake-data/fake';
 import { log } from '@tamanu/shared/services/logging';
@@ -9,6 +10,7 @@ import {
   fakeResourcesOfFhirServiceRequestWithImagingRequest,
 } from '../fake/fhir';
 import { allFromUpstream } from '../../dist/tasks/fhir/refresh/allFromUpstream';
+import { entireResource } from '../../dist/tasks/fhir/refresh/entireResource';
 
 describe('FHIR refresh handler', () => {
   let ctx;
@@ -125,6 +127,121 @@ describe('FHIR refresh handler', () => {
       expect(count).toEqual(0);
       expect(rows).toEqual([]);
       await encounter.destroy();
+    });
+
+    it('propagates parent job priority to child refresh jobs', async () => {
+      await allFromUpstream(
+        {
+          payload: {
+            op: 'UPDATE',
+            table: 'public.encounters',
+            id: resources.encounter.id,
+          },
+          priority: JOB_PRIORITIES.MIGRATION,
+        },
+        {
+          log,
+          sequelize: ctx.store.sequelize,
+          models: ctx.store.models,
+        },
+      );
+
+      const rows = await ctx.store.models.FhirJob.findAll({
+        where: {
+          topic: 'fhir.refresh.fromUpstream',
+          payload: {
+            resource: {
+              [Op.ne]: 'MediciReport',
+            },
+          },
+        },
+      });
+
+      expect(rows).not.toEqual([]);
+      expect(rows.every(row => row.priority === JOB_PRIORITIES.MIGRATION)).toBe(true);
+    });
+  });
+
+  describe('entireResource', () => {
+    beforeEach(async () => {
+      await ctx.store.models.FhirJob.destroy({ where: {} });
+    });
+
+    it('propagates parent job priority to child refresh jobs', async () => {
+      await entireResource(
+        {
+          payload: { resource: 'Encounter' },
+          priority: JOB_PRIORITIES.MIGRATION,
+        },
+        {
+          log,
+          sequelize: ctx.store.sequelize,
+          models: ctx.store.models,
+        },
+      );
+
+      const rows = await ctx.store.models.FhirJob.findAll({
+        where: {
+          topic: 'fhir.refresh.fromUpstream',
+          payload: { resource: 'Encounter' },
+        },
+      });
+
+      expect(rows).not.toEqual([]);
+      expect(rows.every(row => row.priority === JOB_PRIORITIES.MIGRATION)).toBe(true);
+    });
+  });
+
+  describe('refresh trigger priority', () => {
+    beforeEach(async () => {
+      await ctx.store.models.FhirJob.destroy({ where: {} });
+      await ctx.store.sequelize.query(`DROP TABLE IF EXISTS public.test_fhir_refresh_priority;`);
+      await ctx.store.sequelize.query(`
+        CREATE TABLE public.test_fhir_refresh_priority (
+          id TEXT PRIMARY KEY
+        );
+      `);
+      await ctx.store.sequelize.query(`
+        CREATE TRIGGER fhir_refresh_test_fhir_refresh_priority
+        AFTER INSERT OR UPDATE OR DELETE ON public.test_fhir_refresh_priority FOR EACH ROW
+        EXECUTE FUNCTION fhir.refresh_trigger();
+      `);
+    });
+
+    afterEach(async () => {
+      await ctx.store.sequelize.query(`DROP TABLE IF EXISTS public.test_fhir_refresh_priority;`);
+    });
+
+    it('uses lower priority when migration context is set', async () => {
+      await ctx.store.sequelize.query(
+        `SELECT set_config('tamanu.audit.migration_context', '{"test":"context"}', false)`,
+      );
+      await ctx.store.sequelize.query(
+        `INSERT INTO public.test_fhir_refresh_priority (id) VALUES ('with-context')`,
+      );
+      await ctx.store.sequelize.query(`SELECT set_config('tamanu.audit.migration_context', '', false)`);
+
+      const job = await ctx.store.models.FhirJob.findOne({
+        where: { topic: 'fhir.refresh.allFromUpstream' },
+        order: [['createdAt', 'DESC']],
+      });
+
+      expect(job).toBeTruthy();
+      expect(job.priority).toBe(JOB_PRIORITIES.MIGRATION);
+    });
+
+    it('uses default priority when migration context is not set', async () => {
+      await ctx.store.sequelize.query(`
+        INSERT INTO public.test_fhir_refresh_priority (id) VALUES ('without-context');
+      `);
+
+      const job = await ctx.store.models.FhirJob.findOne({
+        where: { topic: 'fhir.refresh.allFromUpstream' },
+        order: [['createdAt', 'DESC']],
+      });
+
+      expect(job).toBeTruthy();
+      expect(job.priority).toBe(JOB_PRIORITIES.DEFAULT);
     });
   });
 });

--- a/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
+++ b/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
@@ -19,7 +19,7 @@ describe('FHIR refresh handler', () => {
 
   beforeAll(async () => {
     ctx = await createTestContext();
-    const { FhirEncounter } = ctx.store.models;
+    const { FhirEncounter, FhirServiceRequest } = ctx.store.models;
 
     resources = await fakeResourcesOfFhirServiceRequest(ctx.store.models);
 
@@ -29,12 +29,15 @@ describe('FHIR refresh handler', () => {
       ctx.store.models,
       resources,
     );
+
+    await FhirServiceRequest.materialiseFromUpstream(imagingRequest.id);
   });
+
   afterAll(() => ctx.close());
 
   describe('allFromUpstream', () => {
     beforeEach(async () => {
-      await ctx.store.models.FhirJob.destroy({ where: {} });
+      await ctx.store.models.FhirJob.truncate({ force: true });
     });
 
     it('finds all the FHIR resources that need to be updated', async () => {
@@ -213,12 +216,15 @@ describe('FHIR refresh handler', () => {
     });
 
     it('uses lower priority when migration context is set', async () => {
-      await ctx.store.sequelize.query(
-        `SELECT set_config('tamanu.audit.migration_context', '{"test":"context"}', true)`,
-      );
-      await ctx.store.sequelize.query(
-        `INSERT INTO public.test_fhir_refresh_priority (id) VALUES ('with-context')`,
-      );
+      // set_config(..., true) is SET LOCAL: it only lasts for the current transaction.
+      await ctx.store.sequelize.transaction(async () => {
+        await ctx.store.sequelize.query(
+          `SELECT set_config('tamanu.audit.migration_context', '{"test":"context"}', true)`,
+        );
+        await ctx.store.sequelize.query(
+          `INSERT INTO public.test_fhir_refresh_priority (id) VALUES ('with-context')`,
+        );
+      });
 
       const job = await ctx.store.models.FhirJob.findOne({
         where: { topic: 'fhir.refresh.allFromUpstream' },

--- a/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
+++ b/packages/central-server/__tests__/tasks/FhirRefreshHandler.test.js
@@ -214,12 +214,11 @@ describe('FHIR refresh handler', () => {
 
     it('uses lower priority when migration context is set', async () => {
       await ctx.store.sequelize.query(
-        `SELECT set_config('tamanu.audit.migration_context', '{"test":"context"}', false)`,
+        `SELECT set_config('tamanu.audit.migration_context', '{"test":"context"}', true)`,
       );
       await ctx.store.sequelize.query(
         `INSERT INTO public.test_fhir_refresh_priority (id) VALUES ('with-context')`,
       );
-      await ctx.store.sequelize.query(`SELECT set_config('tamanu.audit.migration_context', '', false)`);
 
       const job = await ctx.store.models.FhirJob.findOne({
         where: { topic: 'fhir.refresh.allFromUpstream' },

--- a/packages/central-server/app/tasks/fhir/refresh/allFromUpstream.js
+++ b/packages/central-server/app/tasks/fhir/refresh/allFromUpstream.js
@@ -1,9 +1,9 @@
 import { Sequelize } from 'sequelize';
-import { FHIR_INTERACTIONS, JOB_TOPICS } from '@tamanu/constants';
+import { FHIR_INTERACTIONS, JOB_PRIORITIES, JOB_TOPICS } from '@tamanu/constants';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { prepareQuery } from '../../../utils/prepareQuery';
 
-export async function allFromUpstream({ payload }, { log, sequelize, models }) {
+export async function allFromUpstream({ payload, priority }, { log, sequelize, models }) {
   const { table, op, id, deletedRow = null } = payload;
   const [schema, tableName] = table.toLowerCase().split('.', 2);
 
@@ -66,7 +66,7 @@ export async function allFromUpstream({ payload }, { log, sequelize, models }) {
 
       const insertSql = `
         WITH upstreams AS (${sql.replaceAll(';', '')})
-        INSERT INTO fhir.jobs (topic, discriminant, payload)
+        INSERT INTO fhir.jobs (topic, discriminant, payload, priority)
         SELECT
           $topic::text,
           concat($resource::text, ':', upstreams.id),
@@ -75,7 +75,8 @@ export async function allFromUpstream({ payload }, { log, sequelize, models }) {
             'upstreamId', upstreams.id,
             'table', $table::text,
             'op', $op::text
-          )
+          ),
+          COALESCE($priority::int, ${JOB_PRIORITIES.DEFAULT})
         FROM upstreams
         ON CONFLICT (discriminant) DO NOTHING
       `;
@@ -87,6 +88,7 @@ export async function allFromUpstream({ payload }, { log, sequelize, models }) {
           resource: Resource.fhirName,
           table,
           op,
+          priority,
         },
       });
       if (!results) {

--- a/packages/central-server/app/tasks/fhir/refresh/allFromUpstream.js
+++ b/packages/central-server/app/tasks/fhir/refresh/allFromUpstream.js
@@ -3,7 +3,10 @@ import { FHIR_INTERACTIONS, JOB_PRIORITIES, JOB_TOPICS } from '@tamanu/constants
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 import { prepareQuery } from '../../../utils/prepareQuery';
 
-export async function allFromUpstream({ payload, priority }, { log, sequelize, models }) {
+export async function allFromUpstream(
+  { payload, priority = JOB_PRIORITIES.DEFAULT },
+  { log, sequelize, models },
+) {
   const { table, op, id, deletedRow = null } = payload;
   const [schema, tableName] = table.toLowerCase().split('.', 2);
 
@@ -76,7 +79,7 @@ export async function allFromUpstream({ payload, priority }, { log, sequelize, m
             'table', $table::text,
             'op', $op::text
           ),
-          COALESCE($priority::int, ${JOB_PRIORITIES.DEFAULT})
+          $priority::int as priority
         FROM upstreams
         ON CONFLICT (discriminant) DO NOTHING
       `;

--- a/packages/central-server/app/tasks/fhir/refresh/entireResource.js
+++ b/packages/central-server/app/tasks/fhir/refresh/entireResource.js
@@ -1,7 +1,10 @@
 import { FHIR_INTERACTIONS, JOB_PRIORITIES, JOB_TOPICS } from '@tamanu/constants';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 
-export async function entireResource({ payload: { resource }, priority }, { log, sequelize, models }) {
+export async function entireResource(
+  { payload: { resource }, priority = JOB_PRIORITIES.DEFAULT },
+  { log, sequelize, models },
+) {
   const materialisableResources = resourcesThatCanDo(
     models,
     FHIR_INTERACTIONS.INTERNAL.MATERIALISE,
@@ -31,7 +34,7 @@ export async function entireResource({ payload: { resource }, priority }, { log,
             'resource', $resource::text,
             'upstreamId', id
           ) as payload,
-          COALESCE($priority::int, ${JOB_PRIORITIES.DEFAULT}) as priority
+          $priority::int as priority
         FROM ${UpstreamModel.tableName}`,
       {
         bind: {

--- a/packages/central-server/app/tasks/fhir/refresh/entireResource.js
+++ b/packages/central-server/app/tasks/fhir/refresh/entireResource.js
@@ -1,7 +1,7 @@
-import { FHIR_INTERACTIONS, JOB_TOPICS } from '@tamanu/constants';
+import { FHIR_INTERACTIONS, JOB_PRIORITIES, JOB_TOPICS } from '@tamanu/constants';
 import { resourcesThatCanDo } from '@tamanu/shared/utils/fhir/resources';
 
-export async function entireResource({ payload: { resource } }, { log, sequelize, models }) {
+export async function entireResource({ payload: { resource }, priority }, { log, sequelize, models }) {
   const materialisableResources = resourcesThatCanDo(
     models,
     FHIR_INTERACTIONS.INTERNAL.MATERIALISE,
@@ -24,18 +24,20 @@ export async function entireResource({ payload: { resource } }, { log, sequelize
     // sequelize can't do streaming queries, so doing it correctly in JS would
     // be a huge pain
     await sequelize.query(
-      `INSERT INTO fhir.jobs (topic, payload)
+      `INSERT INTO fhir.jobs (topic, payload, priority)
         SELECT
           $topic::text as topic,
           json_build_object(
             'resource', $resource::text,
             'upstreamId', id
-          ) as payload
+          ) as payload,
+          COALESCE($priority::int, ${JOB_PRIORITIES.DEFAULT}) as priority
         FROM ${UpstreamModel.tableName}`,
       {
         bind: {
           topic: JOB_TOPICS.FHIR.REFRESH.FROM_UPSTREAM,
           resource,
+          priority,
         },
       },
     );

--- a/packages/constants/src/jobs.ts
+++ b/packages/constants/src/jobs.ts
@@ -11,6 +11,7 @@ export const JOB_TOPICS = {
 
 export const JOB_PRIORITIES = {
   LOW: 500,
+  MIGRATION: 900,
   DEFAULT: 1000,
   HIGH: 1500,
 };

--- a/packages/database/src/migrations/1776324051308-updateFhirRefreshTriggerPriorityForMigrations.ts
+++ b/packages/database/src/migrations/1776324051308-updateFhirRefreshTriggerPriorityForMigrations.ts
@@ -24,7 +24,7 @@ const TRIGGER_FUNCTION_WITH_MIGRATION_PRIORITY = `
     END IF;
 
     at_priority := CASE
-      WHEN coalesce(nullif(current_setting('tamanu.audit.migration_context', true), ''), NULL) IS NOT NULL
+      WHEN nullif(current_setting('tamanu.audit.migration_context', true), '') IS NOT NULL
         THEN ${MIGRATION_PRIORITY}
       ELSE ${JOB_PRIORITIES.DEFAULT}
     END;

--- a/packages/database/src/migrations/1776324051308-updateFhirRefreshTriggerPriorityForMigrations.ts
+++ b/packages/database/src/migrations/1776324051308-updateFhirRefreshTriggerPriorityForMigrations.ts
@@ -1,0 +1,70 @@
+import { QueryInterface } from 'sequelize';
+import { JOB_PRIORITIES } from '@tamanu/constants';
+
+const MIGRATION_PRIORITY = (JOB_PRIORITIES as Record<string, number>).MIGRATION;
+
+const TRIGGER_FUNCTION_WITH_MIGRATION_PRIORITY = `
+  CREATE OR REPLACE FUNCTION fhir.refresh_trigger()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL
+  AS $$
+  DECLARE
+    payload JSONB;
+    at_priority INTEGER;
+  BEGIN
+    payload := jsonb_build_object(
+      'table', (TG_TABLE_SCHEMA::text || '.' || TG_TABLE_NAME::text),
+      'op', TG_OP,
+      'id', COALESCE(NEW.id, OLD.id)::text,
+      'args', to_jsonb(TG_ARGV)
+    );
+
+    IF TG_OP = 'DELETE' THEN
+      payload := payload || jsonb_build_object('deletedRow', OLD);
+    END IF;
+
+    at_priority := CASE
+      WHEN coalesce(nullif(current_setting('tamanu.audit.migration_context', true), ''), NULL) IS NOT NULL
+        THEN ${MIGRATION_PRIORITY}
+      ELSE ${JOB_PRIORITIES.DEFAULT}
+    END;
+
+    PERFORM fhir.job_submit('fhir.refresh.allFromUpstream', payload, at_priority);
+    RETURN NEW;
+  END;
+  $$;
+`;
+
+const TRIGGER_FUNCTION_DEFAULT_PRIORITY = `
+  CREATE OR REPLACE FUNCTION fhir.refresh_trigger()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL
+  AS $$
+  DECLARE
+    payload JSONB;
+  BEGIN
+    payload := jsonb_build_object(
+      'table', (TG_TABLE_SCHEMA::text || '.' || TG_TABLE_NAME::text),
+      'op', TG_OP,
+      'id', COALESCE(NEW.id, OLD.id)::text,
+      'args', to_jsonb(TG_ARGV)
+    );
+
+    IF TG_OP = 'DELETE' THEN
+      payload := payload || jsonb_build_object('deletedRow', OLD);
+    END IF;
+
+    PERFORM fhir.job_submit('fhir.refresh.allFromUpstream', payload);
+    RETURN NEW;
+  END;
+  $$;
+`;
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(TRIGGER_FUNCTION_WITH_MIGRATION_PRIORITY);
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(TRIGGER_FUNCTION_DEFAULT_PRIORITY);
+}
+

--- a/packages/database/src/models/fhir/Job.ts
+++ b/packages/database/src/models/fhir/Job.ts
@@ -138,7 +138,11 @@ export class FhirJob extends Model {
     throw new Error(`Failed to grab job after ${GRAB_RETRY} retries`);
   }
 
-  static async submit(topic: string, payload = {}, { priority = 1000, discriminant = null } = {}) {
+  static async submit(
+    topic: string,
+    payload = {},
+    { priority = JOB_PRIORITIES.DEFAULT, discriminant = null } = {},
+  ) {
     const result = await this.sequelize.query<{ id: string }>(
       `
       SELECT fhir.job_submit(


### PR DESCRIPTION
### Changes

Re-using the audit changes mechanism to check if we're in a migration when running the fhir refresh trigger, and if so using a lower job priority.

Also added logic to propagate the priority through the fhir refresh flow.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
