### PR TITLE
fix(deaths): Release fix v2.54: Death certificate stuck in loading state when no villageId

### DIFF
--- a/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
+++ b/packages/web/app/components/PatientPrinting/modals/DeathCertificateModal.jsx
@@ -47,7 +47,9 @@ export const DeathCertificateModal = ({ patient, deathData }) => {
     additionalData?.fatherId,
   );
   const { data: certificateData, isFetching: isCertificateFetching } = useCertificate();
-  const { data: village, isLoading: isVillageLoading } = useReferenceDataQuery(patient?.villageId);
+  const { villageId } = patient;
+  const { data: village, isLoading: isVillageDataLoading } = useReferenceDataQuery(villageId);
+  const isVillageLoading = !!villageId && isVillageDataLoading;
 
   const patientData = {
     ...patient,


### PR DESCRIPTION
### Changes

Cherry-pick of #9589 (release/2.53) to release/2.54.

Fixes the death certificate print modal getting stuck in a loading state when the patient has no `villageId`.

`DeathCertificateModal` now derives `isVillageLoading` only when `villageId` is present (instead of relying directly on the reference-data query's loading flag), avoiding indefinite loading for patients without a village.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI-state fix that only changes how `isVillageLoading` is derived for optional village reference data.
> 
> **Overview**
> Prevents the death certificate print modal from getting stuck in a loading state when a patient lacks a `villageId`.
> 
> `DeathCertificateModal` now treats village reference-data loading as conditional (**only** considered loading when `villageId` is present), instead of directly using the query’s `isLoading` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd7c1b3535b8570589d9d92e41fdb7e0b88fc14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->