### PR TITLE
test: No-issue: Update test timeout

### DIFF
--- a/packages/central-server/__tests__/configureEnvironment.js
+++ b/packages/central-server/__tests__/configureEnvironment.js
@@ -13,7 +13,7 @@ const { TextDecoder } = require('util');
 
 global.TextDecoder = TextDecoder;
 
-jest.setTimeout(30 * 1000); // more generous than the default 5s but not crazy
+jest.setTimeout(45 * 1000); // more generous than the default 5s but not crazy
 jest.mock('../dist/utils/getFreeDiskSpace');
 
 const formatError = response => {


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the Jest global timeout for central-server tests to reduce flaky failures; no production code paths are affected.
> 
> **Overview**
> In `packages/central-server/__tests__/configureEnvironment.js`, increases the Jest global test timeout from **30s** to **45s** to give slower tests more time to complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d427587d417d73f0fec94045f0ab4a4fb83683f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->