### PR TITLE
fix(invoicing): 2.52 hotfix: keep policy number on invoice PDF when insurance plan selected

### DIFF
--- a/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
@@ -76,7 +76,7 @@ export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsur
             label={getTranslation('encounter.admission.label', 'Admission')}
             value={ENCOUNTER_TYPE_LABELS[encounter?.encounterType]}
           />
-          {enablePatientInsurer && !hasInvoicePlans && (
+          {enablePatientInsurer && (
             <DataItem
               label={getTranslation('invoice.policyNumber.label', 'Policy number')}
               value={insurerPolicyNumber}


### PR DESCRIPTION
### Changes

Fix regression in 2.52.3 where the patient policy number disappears from invoice PDFs whenever an invoice insurance plan is attached.

The PDF header change in #9545 added a `!hasInvoicePlans` guard to the Policy number row, but `insurerPolicyNumber` is a patient-level attribute (`additionalData.insurerPolicyNumber`) and has no relationship to which plan was chosen for a given invoice. It should continue to render whenever the `enablePatientInsurer` feature is on.

```diff
-{enablePatientInsurer && !hasInvoicePlans && (
+{enablePatientInsurer && (
```

Backports to `release/2.53` and `main` will follow as separate PRs.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

### Testing notes

On a deployment with `features.enablePatientInsurer` enabled, open an invoice record and print:

- No plans selected → Insurer + Policy number both show (unchanged)
- One or more plans selected → Insurer shows plan names, Policy number now shows patient's policy number (was missing before this fix)
- `enablePatientInsurer` off → Policy number hidden (unchanged)

Made with [Cursor](https://cursor.com)