### PR TITLE
fix(invoicing): no-issue: keep policy number on invoice PDF when insurance plan selected

### DIFF
--- a/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
+++ b/packages/shared/src/utils/patientCertificates/printComponents/InvoiceDetails.jsx
@@ -76,7 +76,7 @@ export const InvoiceDetails = ({ encounter, invoice, patient, enablePatientInsur
             label={getTranslation('encounter.admission.label', 'Admission')}
             value={ENCOUNTER_TYPE_LABELS[encounter?.encounterType]}
           />
-          {enablePatientInsurer && !hasInvoicePlans && (
+          {enablePatientInsurer && (
             <DataItem
               label={getTranslation('invoice.policyNumber.label', 'Policy number')}
               value={insurerPolicyNumber}


### PR DESCRIPTION
### Changes

Backport of #9595 onto `main`.

Fix regression where the patient policy number disappears from invoice PDFs whenever an invoice insurance plan is attached. `insurerPolicyNumber` is a patient-level attribute and has no relationship to the invoice's chosen plan, so it should continue to render whenever the `enablePatientInsurer` feature is on.

```diff
-{enablePatientInsurer && !hasInvoicePlans && (
+{enablePatientInsurer && (
```

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue

### Testing notes

On a deployment with `features.enablePatientInsurer` enabled, open an invoice record and print:

- No plans selected → Insurer + Policy number both show (unchanged)
- One or more plans selected → Insurer shows plan names, Policy number now shows patient's policy number (was missing before this fix)
- `enablePatientInsurer` off → Policy number hidden (unchanged)

Made with [Cursor](https://cursor.com)