### PR TITLE
test: no-issue: Update test timeout

### DIFF
--- a/packages/central-server/__tests__/configureEnvironment.js
+++ b/packages/central-server/__tests__/configureEnvironment.js
@@ -13,7 +13,7 @@ const { TextDecoder } = require('util');
 
 global.TextDecoder = TextDecoder;
 
-jest.setTimeout(30 * 1000); // more generous than the default 5s but not crazy
+jest.setTimeout(45 * 1000); // more generous than the default 5s but not crazy
 jest.mock('../dist/utils/getFreeDiskSpace');
 
 const formatError = response => {


### PR DESCRIPTION
## Summary
Cherry-pick of #9593 into release/2.54.

Increases the Jest global test timeout from 30s to 45s in central-server tests to reduce flaky failures.

## Test plan
- CI passes on this branch

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that slightly increases the maximum runtime before failing, with no production code impact.
> 
> **Overview**
> Increases the central-server Jest global test timeout from `30s` to `45s` in `__tests__/configureEnvironment.js` to reduce flaky test failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85bd9c5a89845bcf7546fe370661ee6adccbbf2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->