### PR TITLE
fix(provisioning): No-issue: Update provisioning data to work with default survey code

### DIFF
--- a/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
@@ -1808,6 +1808,13 @@
       "facilityId": "facility-CarnationHealthCentre"
     },
     {
+      "id": "department-GeneralClinic-tamanu",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-1"
+    },
+    {
       "id": "department-GeneralMedicine-tamanu",
       "code": "GeneralMedicine",
       "name": "General Medicine",
@@ -1855,6 +1862,13 @@
       "name": "Public Health",
       "visibilityStatus": "current",
       "facilityId": "facility-1"
+    },
+    {
+      "id": "department-GeneralClinic-facility-2",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-2"
     },
     {
       "id": "department-GeneralMedicine",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
@@ -1775,6 +1775,13 @@
       "facilityId": "facility-Yasawa-I-RaraNursingStation"
     },
     {
+      "id": "location-GeneralClinic-facility-2",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-2"
+    },
+    {
       "id": "location-Outpatient",
       "code": "LHOutpatient",
       "name": "Consultation Room",
@@ -1954,6 +1961,13 @@
       "visibilityStatus": "current",
       "facilityId": "facility-2",
       "locationGroupId": "locationgroup-LilyImmunisationClinic"
+    },
+    {
+      "id": "location-GeneralClinic-tamanu",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-1"
     },
     {
       "id": "location-Outpatient-tamanu",


### PR DESCRIPTION
### Changes

We now enforce that the default location and department code for surveys must be linked to the current facility. This is how it should be set up anyways but we now enforce for sensitivity reasons.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change that adds missing default `GeneralClinic` department/location records; main risk is mis-linked `facilityId` or duplicate codes affecting provisioning in new deployments.
> 
> **Overview**
> Adds `GeneralClinic` **department** entries for both `facility-1` (Tamanu) and `facility-2` in `Departments.json5`.
> 
> Adds matching `GeneralClinic` **location** entries for both facilities in `Locations.json5`, ensuring each facility has its own default `GeneralClinic` record during provisioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db51d02b629d91a8e4d5c648e5612e612d515d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->