### PR TITLE
fix(integrations): SAV-1150: mSupply use itemCode

### DIFF
--- a/packages/facility-server/__tests__/tasks/mSupplyMedIntegrationProcessor.test.js
+++ b/packages/facility-server/__tests__/tasks/mSupplyMedIntegrationProcessor.test.js
@@ -324,6 +324,13 @@ describe('mSupplyMedIntegrationProcessor', () => {
       await task.run();
 
       expect(fetchWithRetryBackoff).toHaveBeenCalledTimes(2);
+      const pluginCall = fetchWithRetryBackoff.mock.calls[1];
+      const pluginBody = JSON.parse(pluginCall[1].body);
+      expect(pluginBody.variables.input.items).toEqual([
+        { itemCode: 'MED-TEST-001', numberOfUnits: 1 },
+        { itemCode: 'MED-TEST-001', numberOfUnits: 1 },
+      ]);
+
       const successLog = await models.MSupplyPushLog.findOne({
         where: { status: 'success' },
         order: [['createdAt', 'DESC']],
@@ -403,8 +410,8 @@ describe('mSupplyMedIntegrationProcessor', () => {
       });
 
       const debugItems = [
-        { code: 'MED001', description: 'Unknown medication code' },
-        { code: 'MED002', description: 'Quantity mismatch' },
+        { itemCode: 'MED001', description: 'Unknown medication code' },
+        { itemCode: 'MED002', description: 'Quantity mismatch' },
       ];
       mockAuthResponse();
       mockPostResponse(false, 'Validation failed', debugItems);

--- a/packages/facility-server/app/tasks/mSupplyMedIntegrationProcessor.js
+++ b/packages/facility-server/app/tasks/mSupplyMedIntegrationProcessor.js
@@ -126,7 +126,7 @@ export class mSupplyMedIntegrationProcessor extends ScheduledTask {
         invoiceId: minMedicationId, // Identify batch by the first medication's id
         customerCode,
         items: medications.map(medication => ({
-          universalCode: medication.pharmacyOrderPrescription.prescription.medication.code,
+          itemCode: medication.pharmacyOrderPrescription.prescription.medication.code,
           numberOfUnits: medication.quantity,
         })),
       },


### PR DESCRIPTION
### Changes

Use itemCode instead of universalCode per business rules. This is a hotfix for v2.53 of https://github.com/beyondessential/tamanu/pull/9568 however, the stock on hand task wasn't created by this version so it's only the med integration.