### PR TITLE
fix(integrations): SAV-1150: mSupply use itemCode

### DIFF
--- a/packages/facility-server/__tests__/tasks/MSupplyStockOnHandProcessor.test.js
+++ b/packages/facility-server/__tests__/tasks/MSupplyStockOnHandProcessor.test.js
@@ -60,10 +60,10 @@ function mockStockLinesErrorResponse(errorMessage) {
   });
 }
 
-function makeStockLine({ universalCode, availableNumberOfPacks, totalNumberOfPacks, packSize }) {
+function makeStockLine({ code, availableNumberOfPacks, totalNumberOfPacks, packSize }) {
   return {
     id: `stock-${Math.random().toString(36).slice(2)}`,
-    item: { universalCode },
+    item: { code },
     availableNumberOfPacks,
     totalNumberOfPacks,
     packSize,
@@ -201,12 +201,12 @@ describe('MSupplyStockOnHandProcessor', () => {
   });
 
   describe('stock aggregation', () => {
-    it('aggregates multiple stock lines for the same universal code', () => {
+    it('aggregates multiple stock lines for the same item code', () => {
       const task = new MSupplyStockOnHandProcessor(context);
       const stockLines = [
-        makeStockLine({ universalCode: 'MED-001', availableNumberOfPacks: 5, totalNumberOfPacks: 10, packSize: 10 }),
-        makeStockLine({ universalCode: 'MED-001', availableNumberOfPacks: 3, totalNumberOfPacks: 5, packSize: 10 }),
-        makeStockLine({ universalCode: 'MED-002', availableNumberOfPacks: 2, totalNumberOfPacks: 2, packSize: 20 }),
+        makeStockLine({ code: 'MED-001', availableNumberOfPacks: 5, totalNumberOfPacks: 10, packSize: 10 }),
+        makeStockLine({ code: 'MED-001', availableNumberOfPacks: 3, totalNumberOfPacks: 5, packSize: 10 }),
+        makeStockLine({ code: 'MED-002', availableNumberOfPacks: 2, totalNumberOfPacks: 2, packSize: 20 }),
       ];
 
       const result = task.aggregateStockByCode(stockLines);
@@ -215,11 +215,11 @@ describe('MSupplyStockOnHandProcessor', () => {
       expect(result.get('MED-002')).toBe(40);
     });
 
-    it('skips stock lines without a universal code', () => {
+    it('skips stock lines without an item code', () => {
       const task = new MSupplyStockOnHandProcessor(context);
       const stockLines = [
-        makeStockLine({ universalCode: 'MED-001', availableNumberOfPacks: 5, totalNumberOfPacks: 10, packSize: 10 }),
-        makeStockLine({ universalCode: null, availableNumberOfPacks: 3, totalNumberOfPacks: 5, packSize: 10 }),
+        makeStockLine({ code: 'MED-001', availableNumberOfPacks: 5, totalNumberOfPacks: 10, packSize: 10 }),
+        makeStockLine({ code: null, availableNumberOfPacks: 3, totalNumberOfPacks: 5, packSize: 10 }),
         { id: 'no-item', item: null, availableNumberOfPacks: 1, totalNumberOfPacks: 1, packSize: 1 },
       ];
 
@@ -232,7 +232,7 @@ describe('MSupplyStockOnHandProcessor', () => {
     it('treats missing packSize as 1', () => {
       const task = new MSupplyStockOnHandProcessor(context);
       const stockLines = [
-        { id: 's1', item: { universalCode: 'MED-001' }, availableNumberOfPacks: 5, totalNumberOfPacks: 10, packSize: null },
+        { id: 's1', item: { code: 'MED-001' }, availableNumberOfPacks: 5, totalNumberOfPacks: 10, packSize: null },
       ];
 
       const result = task.aggregateStockByCode(stockLines);
@@ -291,8 +291,8 @@ describe('MSupplyStockOnHandProcessor', () => {
 
       mockAuthResponse();
       mockStockLinesResponse([
-        makeStockLine({ universalCode: drugCode1, availableNumberOfPacks: 10, totalNumberOfPacks: 10, packSize: 5 }),
-        makeStockLine({ universalCode: drugCode2, availableNumberOfPacks: 0, totalNumberOfPacks: 0, packSize: 1 }),
+        makeStockLine({ code: drugCode1, availableNumberOfPacks: 10, totalNumberOfPacks: 10, packSize: 5 }),
+        makeStockLine({ code: drugCode2, availableNumberOfPacks: 0, totalNumberOfPacks: 0, packSize: 1 }),
       ]);
 
       const task = new MSupplyStockOnHandProcessor(context);
@@ -323,7 +323,7 @@ describe('MSupplyStockOnHandProcessor', () => {
 
       mockAuthResponse();
       mockStockLinesResponse([
-        makeStockLine({ universalCode: drugCode1, availableNumberOfPacks: 2, totalNumberOfPacks: 2, packSize: 5 }),
+        makeStockLine({ code: drugCode1, availableNumberOfPacks: 2, totalNumberOfPacks: 2, packSize: 5 }),
       ]);
 
       const task = new MSupplyStockOnHandProcessor(context);
@@ -343,8 +343,8 @@ describe('MSupplyStockOnHandProcessor', () => {
 
       mockAuthResponse();
       mockStockLinesResponse([
-        makeStockLine({ universalCode: 'NON-EXISTENT-CODE', availableNumberOfPacks: 99, totalNumberOfPacks: 99, packSize: 1 }),
-        makeStockLine({ universalCode: drugCode1, availableNumberOfPacks: 3, totalNumberOfPacks: 3, packSize: 1 }),
+        makeStockLine({ code: 'NON-EXISTENT-CODE', availableNumberOfPacks: 99, totalNumberOfPacks: 99, packSize: 1 }),
+        makeStockLine({ code: drugCode1, availableNumberOfPacks: 3, totalNumberOfPacks: 3, packSize: 1 }),
       ]);
 
       const task = new MSupplyStockOnHandProcessor(context);
@@ -358,15 +358,15 @@ describe('MSupplyStockOnHandProcessor', () => {
       expect(allStock[0].quantity).toBe(3);
     });
 
-    it('skips stock lines without a universal code', async () => {
+    it('skips stock lines without an item code', async () => {
       await models.ReferenceDrugFacility.bulkCreate([
         { referenceDrugId: referenceDrugId1, facilityId: FACILITY_ID, quantity: null, stockStatus: DRUG_STOCK_STATUSES.UNKNOWN },
       ]);
 
       mockAuthResponse();
       mockStockLinesResponse([
-        makeStockLine({ universalCode: null, availableNumberOfPacks: 50, totalNumberOfPacks: 50, packSize: 1 }),
-        makeStockLine({ universalCode: drugCode1, availableNumberOfPacks: 7, totalNumberOfPacks: 7, packSize: 1 }),
+        makeStockLine({ code: null, availableNumberOfPacks: 50, totalNumberOfPacks: 50, packSize: 1 }),
+        makeStockLine({ code: drugCode1, availableNumberOfPacks: 7, totalNumberOfPacks: 7, packSize: 1 }),
       ]);
 
       const task = new MSupplyStockOnHandProcessor(context);
@@ -386,8 +386,8 @@ describe('MSupplyStockOnHandProcessor', () => {
 
       mockAuthResponse();
       mockStockLinesResponse([
-        makeStockLine({ universalCode: drugCode1, availableNumberOfPacks: 4, totalNumberOfPacks: 4, packSize: 10 }),
-        makeStockLine({ universalCode: drugCode1, availableNumberOfPacks: 6, totalNumberOfPacks: 6, packSize: 10 }),
+        makeStockLine({ code: drugCode1, availableNumberOfPacks: 4, totalNumberOfPacks: 4, packSize: 10 }),
+        makeStockLine({ code: drugCode1, availableNumberOfPacks: 6, totalNumberOfPacks: 6, packSize: 10 }),
       ]);
 
       const task = new MSupplyStockOnHandProcessor(context);

--- a/packages/facility-server/__tests__/tasks/mSupplyMedIntegrationProcessor.test.js
+++ b/packages/facility-server/__tests__/tasks/mSupplyMedIntegrationProcessor.test.js
@@ -324,6 +324,13 @@ describe('mSupplyMedIntegrationProcessor', () => {
       await task.run();
 
       expect(fetchWithRetryBackoff).toHaveBeenCalledTimes(2);
+      const pluginCall = fetchWithRetryBackoff.mock.calls[1];
+      const pluginBody = JSON.parse(pluginCall[1].body);
+      expect(pluginBody.variables.input.items).toEqual([
+        { itemCode: 'MED-TEST-001', numberOfUnits: 1 },
+        { itemCode: 'MED-TEST-001', numberOfUnits: 1 },
+      ]);
+
       const successLog = await models.MSupplyPushLog.findOne({
         where: { status: 'success' },
         order: [['createdAt', 'DESC']],
@@ -403,8 +410,8 @@ describe('mSupplyMedIntegrationProcessor', () => {
       });
 
       const debugItems = [
-        { code: 'MED001', description: 'Unknown medication code' },
-        { code: 'MED002', description: 'Quantity mismatch' },
+        { itemCode: 'MED001', description: 'Unknown medication code' },
+        { itemCode: 'MED002', description: 'Quantity mismatch' },
       ];
       mockAuthResponse();
       mockPostResponse(false, 'Validation failed', debugItems);

--- a/packages/facility-server/app/tasks/MSupplyStockOnHandProcessor.js
+++ b/packages/facility-server/app/tasks/MSupplyStockOnHandProcessor.js
@@ -19,7 +19,7 @@ function getStockLinesQuery(storeId) {
           nodes {
             id
             item {
-              universalCode
+              code
             }
             availableNumberOfPacks
             totalNumberOfPacks
@@ -70,12 +70,12 @@ export class MSupplyStockOnHandProcessor extends ScheduledTask {
     const aggregated = new Map();
 
     for (const line of stockLines) {
-      const universalCode = line.item?.universalCode;
-      if (!universalCode) continue;
+      const code = line.item?.code;
+      if (!code) continue;
 
       const totalUnits = (line.availableNumberOfPacks ?? 0) * (line.packSize ?? 1);
-      const current = aggregated.get(universalCode) ?? 0;
-      aggregated.set(universalCode, current + totalUnits);
+      const current = aggregated.get(code) ?? 0;
+      aggregated.set(code, current + totalUnits);
     }
 
     return aggregated;
@@ -158,7 +158,7 @@ export class MSupplyStockOnHandProcessor extends ScheduledTask {
 
     const stockByCode = this.aggregateStockByCode(stockLines);
 
-    log.info('MSupplyStockOnHandProcessor: aggregated stock by universal code', {
+    log.info('MSupplyStockOnHandProcessor: aggregated stock by item code', {
       uniqueMedications: stockByCode.size,
     });
 

--- a/packages/facility-server/app/tasks/mSupplyMedIntegrationProcessor.js
+++ b/packages/facility-server/app/tasks/mSupplyMedIntegrationProcessor.js
@@ -67,7 +67,7 @@ export class mSupplyMedIntegrationProcessor extends ScheduledTask {
         invoiceId: minMedicationId, // Identify batch by the first medication's id
         customerCode,
         items: medications.map(medication => ({
-          universalCode: medication.pharmacyOrderPrescription.prescription.medication.code,
+          itemCode: medication.pharmacyOrderPrescription.prescription.medication.code,
           numberOfUnits: medication.quantity,
         })),
       },


### PR DESCRIPTION
### Changes

Use itemCode instead of universalCode per business rules. This is a hotfix for v2.54 of https://github.com/beyondessential/tamanu/pull/9568 