### PR TITLE
fix(provisioning): No-issue: Revert duplicate codes in location provisioning

### DIFF
--- a/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
@@ -104,7 +104,7 @@
       "code": "GeneralClinic",
       "name": "Clinic",
       "visibilityStatus": "current",
-      "facilityId": "facility-ColonialWarMemorialDivisionalHospital"
+      "facilityId": "facility-1"
     },
     {
       "id": "department-COVID19Team",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
@@ -1808,13 +1808,6 @@
       "facilityId": "facility-CarnationHealthCentre"
     },
     {
-      "id": "department-GeneralClinic-tamanu",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-1"
-    },
-    {
       "id": "department-GeneralMedicine-tamanu",
       "code": "GeneralMedicine",
       "name": "General Medicine",
@@ -1862,13 +1855,6 @@
       "name": "Public Health",
       "visibilityStatus": "current",
       "facilityId": "facility-1"
-    },
-    {
-      "id": "department-GeneralClinic-facility-2",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-2"
     },
     {
       "id": "department-GeneralMedicine",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
@@ -85,7 +85,7 @@
       "code": "GeneralClinic",
       "name": "Clinic",
       "visibilityStatus": "current",
-      "facilityId": "facility-ColonialWarMemorialDivisionalHospital"
+      "facilityId": "facility-1"
     },
     {
       "id": "location-DemoLan",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
@@ -1775,13 +1775,6 @@
       "facilityId": "facility-Yasawa-I-RaraNursingStation"
     },
     {
-      "id": "location-GeneralClinic-facility-2",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-2"
-    },
-    {
       "id": "location-Outpatient",
       "code": "LHOutpatient",
       "name": "Consultation Room",
@@ -1961,13 +1954,6 @@
       "visibilityStatus": "current",
       "facilityId": "facility-2",
       "locationGroupId": "locationgroup-LilyImmunisationClinic"
-    },
-    {
-      "id": "location-GeneralClinic-tamanu",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-1"
     },
     {
       "id": "location-Outpatient-tamanu",


### PR DESCRIPTION
… with default survey code (#9600)"

This reverts commit 6605d5ec7a5657e743fdac9fccb40c3a4851aa5f.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes default provisioning seed data for departments/locations, which can affect newly provisioned environments and any automation expecting the previous facility mappings.
> 
> **Overview**
> Adjusts default provisioning data to avoid duplicate `GeneralClinic` codes across facilities.
> 
> Updates the seeded `department-GeneralClinic` and `location-GeneralClinic` to belong to `facility-1`, and removes extra seeded `GeneralClinic` department/location rows for `facility-1` (tamanu) and `facility-2` to ensure code uniqueness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7a26cfe77119bd33aa9e6ddccaf07770dbdc62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->