### PR TITLE
fix(sync): no-issue: include prescriptions in sync when patient_ongoing_prescription tick changes

### DIFF
--- a/packages/database/src/migrations/1776657862375-RebuildLookupTableForPrescriptionOngoingSync.ts
+++ b/packages/database/src/migrations/1776657862375-RebuildLookupTableForPrescriptionOngoingSync.ts
@@ -1,0 +1,11 @@
+import { QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(`
+    SELECT flag_lookup_model_to_rebuild('prescriptions');
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No reverse migration
+}

--- a/packages/database/src/models/Prescription.ts
+++ b/packages/database/src/models/Prescription.ts
@@ -185,7 +185,10 @@ export class Prescription extends Model {
         OR
         (patient_ongoing_prescriptions.patient_id IS NOT NULL AND patient_ongoing_prescriptions.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
       )
-      AND prescriptions.updated_at_sync_tick > :since
+      AND (
+        prescriptions.updated_at_sync_tick > :since
+        OR patient_ongoing_prescriptions.updated_at_sync_tick > :since
+      )
     `;
   }
 
@@ -200,6 +203,10 @@ export class Prescription extends Model {
         LEFT JOIN patient_ongoing_prescriptions ON prescriptions.id = patient_ongoing_prescriptions.prescription_id
         LEFT JOIN locations ON encounters.location_id = locations.id
         LEFT JOIN facilities ON locations.facility_id = facilities.id
+      `,
+      where: `
+        prescriptions.updated_at_sync_tick > :since
+        OR patient_ongoing_prescriptions.updated_at_sync_tick > :since
       `,
     };
   }


### PR DESCRIPTION
### Changes

A prescription could arrive at a facility after its patient_ongoing_prescription if the facility's sync cursor was already past the prescription's original tick when the POP was created. Mirror the Encounter/lab-request pattern by ORing the POP's updated_at_sync_tick into both the patient sync filter and the lookup table where clause, and rebuild the lookup table to fix existing entries.

Incident thread: https://beyondessential.slack.com/archives/C022N48Q3JQ/p1776401521213449

Manifesting as:

```
SequelizeForeignKeyConstraintError
original=error: insert or update on table "patient_ongoing_prescriptions"
violates foreign key constraint "patient_ongoing_prescriptions_prescription_id_fkey"
sql=INSERT INTO "patient_ongoing_prescriptions"
```

This is essentially a template for the upcoming sync stability project ^^

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
