### PR TITLE
tweak: No-issue: Remove repetitive E2E tests already covered by endpoint tests

### DIFF
--- a/packages/e2e-tests/pages/patients/AllPatientsPage.ts
+++ b/packages/e2e-tests/pages/patients/AllPatientsPage.ts
@@ -57,10 +57,6 @@ export class AllPatientsPage extends BasePatientListPage {
   readonly patientPageRecordCount25!: Locator;
   readonly patientPageRecordCount50!: Locator;
   readonly patientPage2!: Locator;
-  readonly firstNameSortButton!: Locator;
-  readonly lastNameSortButton!: Locator;
-  readonly culturalNameSortButton!: Locator;
-  readonly villageSortButton!: Locator;
   readonly dobSortButton!: Locator;
 
   constructor(page: Page) {
@@ -109,10 +105,6 @@ export class AllPatientsPage extends BasePatientListPage {
       patientPageRecordCount25: 'styledmenuitem-fkrw-undefined',
       patientPageRecordCount50: 'styledmenuitem-fkrw-undefined',
       patientPage2: 'paginationitem-c5vg',
-      firstNameSortButton: 'tablesortlabel-0qxx-firstName',
-      lastNameSortButton: 'tablesortlabel-0qxx-lastName',
-      culturalNameSortButton: 'tablesortlabel-0qxx-culturalName',
-      villageSortButton: 'tablesortlabel-0qxx-villageName',
       dobSortButton: 'tablesortlabel-0qxx-dateOfBirth',
     } as const;
 
@@ -147,12 +139,6 @@ export class AllPatientsPage extends BasePatientListPage {
       .getByTestId('styledmenuitem-fkrw-undefined')
       .getByText('50');
     this.patientPage2 = page.getByTestId('paginationitem-c5vg').getByText('2');
-    this.firstNameSortButton = page.getByTestId('tablesortlabel-0qxx-firstName').locator('svg');
-    this.lastNameSortButton = page.getByTestId('tablesortlabel-0qxx-lastName').locator('svg');
-    this.culturalNameSortButton = page
-      .getByTestId('tablesortlabel-0qxx-culturalName')
-      .locator('svg');
-    this.villageSortButton = page.getByTestId('tablesortlabel-0qxx-villageName').locator('svg');
     this.dobSortButton = page.getByTestId('tablesortlabel-0qxx-dateOfBirth').locator('svg');
   }
 

--- a/packages/e2e-tests/pages/patients/BasePatientListPage.ts
+++ b/packages/e2e-tests/pages/patients/BasePatientListPage.ts
@@ -303,14 +303,6 @@ export abstract class BasePatientListPage extends BasePage {
     await this.sortByColumn('displayId');
   }
 
-  async sortByFirstName() {
-    await this.sortByColumn('firstName');
-  }
-
-  async sortByLastName() {
-    await this.sortByColumn('lastName');
-  }
-
   async sortByDOB() {
     await this.sortByColumn('dateOfBirth');
   }

--- a/packages/e2e-tests/pages/patients/PatientTable.ts
+++ b/packages/e2e-tests/pages/patients/PatientTable.ts
@@ -23,11 +23,6 @@ export class PatientTable {
   readonly villageSuggestionList!: Locator;
   readonly searchBtn!: Locator;
   readonly clearSearchBtn!: Locator;
-  readonly firstNameSortButton!: Locator;
-  readonly lastNameSortButton!: Locator;
-  readonly culturalNameSortButton!: Locator;
-  readonly villageSortButton!: Locator;
-  readonly dobSortButton!: Locator;
   readonly NHNTxt!: Locator;
   readonly firstNameTxt!: Locator;
   readonly lastNameTxt!: Locator;
@@ -60,11 +55,6 @@ export class PatientTable {
       villageSuggestionList: 'villagelocalisedfield-mcri-suggestionslist',
       searchBtn: 'searchbutton-nt24',
       clearSearchBtn: 'clearbutton-z9x3',
-      firstNameSortButton: 'tablesortlabel-0qxx-firstName',
-      lastNameSortButton: 'tablesortlabel-0qxx-lastName',
-      culturalNameSortButton: 'tablesortlabel-0qxx-culturalName',
-      villageSortButton: 'tablesortlabel-0qxx-villageName',
-      dobSortButton: 'tablesortlabel-0qxx-dateOfBirth',
       NHNTxt: 'localisedfield-dzml-input',
       firstNameTxt: 'localisedfield-i9br-input',
       lastNameTxt: 'localisedfield-ngsn-input',
@@ -99,13 +89,6 @@ export class PatientTable {
       .getByTestId('villagelocalisedfield-mcri-suggestionslist')
       .locator('ul')
       .locator('li');
-    this.firstNameSortButton = page.getByTestId('tablesortlabel-0qxx-firstName').locator('svg');
-    this.lastNameSortButton = page.getByTestId('tablesortlabel-0qxx-lastName').locator('svg');
-    this.culturalNameSortButton = page
-      .getByTestId('tablesortlabel-0qxx-culturalName')
-      .locator('svg');
-    this.villageSortButton = page.getByTestId('tablesortlabel-0qxx-villageName').locator('svg');
-    this.dobSortButton = page.getByTestId('tablesortlabel-0qxx-dateOfBirth').locator('svg');
     this.DOBTxt = page.getByTestId('field-qk60').getByRole('textbox');
     this.villageSearchBox = page.getByTestId('villagelocalisedfield-mcri-input').locator('input');
     this.DOBFromTxt = page.getByTestId('joinedfield-swzm').getByRole('textbox');

--- a/packages/e2e-tests/tests/patients/allPatientsTable.spec.ts
+++ b/packages/e2e-tests/tests/patients/allPatientsTable.spec.ts
@@ -15,24 +15,6 @@ test.describe('All patient table tests', () => {
       await allPatientsPage.validateFirstRowContainsNHN(newPatient.displayId);
     });
 
-    test('[T-0027][AT-0002]Search by first name', async ({ newPatient, allPatientsPage }) => {
-      await allPatientsPage.searchTable({ firstName: newPatient.firstName, advancedSearch: false });
-      await allPatientsPage.validateAtLeastOneSearchResult();
-      await allPatientsPage.validateAllRowsContain(newPatient.firstName!, 'firstName');
-    });
-
-    test('[T-0027][AT-0003]Search by last name', async ({ newPatient, allPatientsPage }) => {
-      await allPatientsPage.searchTable({ lastName: newPatient.lastName, advancedSearch: false });
-      await allPatientsPage.validateAtLeastOneSearchResult();
-      await allPatientsPage.validateAllRowsContain(newPatient.lastName!, 'lastName');
-    });
-
-    test('[T-0027][AT-0004]Search by DOB', async ({ newPatient, allPatientsPage }) => {
-      await allPatientsPage.searchTable({ DOB: newPatient.dateOfBirth, advancedSearch: false });
-      await allPatientsPage.validateAtLeastOneSearchResult();
-      await allPatientsPage.validateAllRowsDateMatches(newPatient.dateOfBirth!);
-    });
-
     test('[T-0027][AT-0005]Search by cultural name', async ({ newPatient, allPatientsPage }) => {
       await allPatientsPage.searchTable({
         culturalName: newPatient.culturalName,
@@ -42,54 +24,10 @@ test.describe('All patient table tests', () => {
       await allPatientsPage.validateAllRowsContain(newPatient.culturalName!, 'culturalName');
     });
 
-    test('[T-0027][AT-0006]Search by village', async ({ allPatientsPage }) => {
-      await allPatientsPage.searchTable({ village: testData.village, advancedSearch: true });
-      await allPatientsPage.validateAtLeastOneSearchResult();
-      await allPatientsPage.validateAllRowsContain(testData.village, 'villageName');
-    });
-
     test('[T-0027][AT-0007]Search by sex', async ({ newPatient, allPatientsPage }) => {
       await allPatientsPage.searchTable({ sex: newPatient.sex, advancedSearch: true });
       await allPatientsPage.validateAtLeastOneSearchResult();
       await allPatientsPage.validateAllRowsContain(newPatient.sex, 'sex');
-    });
-    test('[T-0027][AT-0008]Search by DOB from including NHN', async ({ newPatient, allPatientsPage }) => {
-      await allPatientsPage.searchTable({
-        DOBFrom: newPatient.dateOfBirth,
-        NHN: newPatient.displayId,
-        advancedSearch: true,
-      });
-      await allPatientsPage.validateOneSearchResult();
-      await allPatientsPage.validateFirstRowContainsNHN(newPatient.displayId);
-      await allPatientsPage.validateAllRowsDateMatches(newPatient.dateOfBirth!);
-    });
-
-    test('[T-0027][AT-0009]Search by DOB to including NHN', async ({ newPatient, allPatientsPage }) => {
-      await allPatientsPage.searchTable({
-        DOBTo: newPatient.dateOfBirth,
-        NHN: newPatient.displayId,
-        advancedSearch: true,
-      });
-      await allPatientsPage.validateOneSearchResult();
-      await allPatientsPage.validateFirstRowContainsNHN(newPatient.displayId);
-      await allPatientsPage.validateAllRowsDateMatches(newPatient.dateOfBirth!);
-    });
-
-    test('[T-0027][AT-0010]Search by filling all the fields', async ({ newPatient, allPatientsPage }) => {
-      await allPatientsPage.searchTable({
-        NHN: newPatient.displayId,
-        firstName: newPatient.firstName,
-        lastName: newPatient.lastName,
-        DOB: newPatient.dateOfBirth,
-        culturalName: newPatient.culturalName,
-        village: testData.village,
-        sex: newPatient.sex,
-        DOBFrom: newPatient.dateOfBirth,
-        DOBTo: newPatient.dateOfBirth,
-        advancedSearch: true,
-      });
-      await allPatientsPage.validateOneSearchResult();
-      await allPatientsPage.validateFirstRowContainsNHN(newPatient.displayId);
     });
 
     test('[T-0027][AT-0011]Search for deceased patient including NHN', async ({
@@ -128,7 +66,9 @@ test.describe('All patient table tests', () => {
   });
 
   test.describe('pagination', () => {
-    test('[AT-0013]number of patient in patient list defaulted to 10', async ({ allPatientsPage }) => {
+    test('[AT-0013]number of patient in patient list defaulted to 10', async ({
+      allPatientsPage,
+    }) => {
       await expect(allPatientsPage.patientTable.pageRecordCountDropDown).toHaveText('10');
       await allPatientsPage.patientTable.validateNumberOfPatients(10);
     });
@@ -167,60 +107,10 @@ test.describe('All patient table tests', () => {
   });
 
   test.describe('sorting', () => {
-  test('[AT-0016]Sort table by Firstname in descending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.firstNameSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(false, 'firstName');
-  });
-  test('[AT-0017]Sort table by Firstname in ascending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.firstNameSortButton.click();
-    await allPatientsPage.firstNameSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(true, 'firstName');
-  });
-  test('[AT-0018]Sort table by Lastname in descending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.lastNameSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(false, 'lastName');
-  });
-  test('[AT-0019]Sort table by Lastname in ascending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.lastNameSortButton.click();
-    await allPatientsPage.lastNameSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(true, 'lastName');
-  });
-  test('[AT-0020]Sort table by cultural name in descending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.culturalNameSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(false, 'culturalName');
-  });
-  test('[AT-0021]Sort table by cultural name in ascending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.culturalNameSortButton.click();
-    await allPatientsPage.culturalNameSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(true, 'culturalName');
-  });
-  test('[AT-0022]Sort table by village in descending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.villageSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(false, 'villageName');
-  });
-  test('[AT-0023]Sort table by village in ascending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.villageSortButton.click();
-    await allPatientsPage.villageSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateSortOrder(true, 'villageName');
-  });
-  test('[AT-0024]Sort table by DOB in descending order', async ({ allPatientsPage }) => {
-    await allPatientsPage.dobSortButton.click();
-    await allPatientsPage.patientTable.waitForTableToLoad();
-    await allPatientsPage.validateDateSortOrder(false);
-  });
-    test('[AT-0025]Sort table by DOB in ascending order', async ({ allPatientsPage }) => {
-      await allPatientsPage.dobSortButton.click();
+    test('[AT-0024]Sort table by DOB in descending order', async ({ allPatientsPage }) => {
       await allPatientsPage.dobSortButton.click();
       await allPatientsPage.patientTable.waitForTableToLoad();
-      await allPatientsPage.validateDateSortOrder(true);
+      await allPatientsPage.validateDateSortOrder(false);
     });
   });
 });

--- a/packages/e2e-tests/tests/patients/inpatient.spec.ts
+++ b/packages/e2e-tests/tests/patients/inpatient.spec.ts
@@ -8,94 +8,20 @@ test.describe('inpatient table tests', () => {
   });
 
   test.describe('search', () => {
-    test('[T-0502][AT-0030] Search by NHN', async ({ newPatientWithHospitalAdmission, inpatientsPage }) => {
+    test('[T-0502][AT-0030] Search by NHN', async ({
+      newPatientWithHospitalAdmission,
+      inpatientsPage,
+    }) => {
       const patientDisplayId = newPatientWithHospitalAdmission.displayId;
       await inpatientsPage.searchTable({ NHN: patientDisplayId, advancedSearch: false });
       await inpatientsPage.validateOneSearchResult();
       await inpatientsPage.validateFirstRowContainsNHN(patientDisplayId);
     });
-    test('[T-0502][AT-0031]Search by first name', async ({ newPatientWithHospitalAdmission, inpatientsPage }) => {
-      const patientFirstName = newPatientWithHospitalAdmission.firstName;
-      await inpatientsPage.searchTable({ firstName: patientFirstName, advancedSearch: false });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(patientFirstName!, 'firstName');
-    });
-    test('[T-0502][AT-0032]Search by last name', async ({ newPatientWithHospitalAdmission, inpatientsPage }) => {
-      const patientLastName = newPatientWithHospitalAdmission.lastName;
-      await inpatientsPage.searchTable({ lastName: patientLastName, advancedSearch: false });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(patientLastName!, 'lastName');
-    });
-    test('[T-0502][AT-0033]Search by area', async ({
-      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
-      inpatientsPage,
-    }) => {
-      const patientArea = testData.areaName;
-      await inpatientsPage.searchTable({ area: patientArea, advancedSearch: false });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(patientArea, 'locationGroupName');
-    });
-    test('[T-0502][AT-0034]Search by department', async ({
-      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
-      inpatientsPage,
-    }) => {
-      const patientDepartment = testData.department;
-      await inpatientsPage.searchTable({ department: patientDepartment, advancedSearch: true });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(patientDepartment, 'departmentName');
-    });
-    test('[T-0502][AT-0035]Search by clinician', async ({
-      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
-      inpatientsPage,
-      api,
-    }) => {
-      const currentUser = await getUser(api);
-      const patientClinician = currentUser.displayName;
-      await inpatientsPage.searchTable({ clinician: patientClinician, advancedSearch: true });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(patientClinician, 'clinician');
-    });
-    test('[T-0502][AT-0036]Search by first selected diet', async ({
-      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
-      inpatientsPage,
-    }) => {
-      const patientDiet = testData.dietName;
-      await inpatientsPage.searchTable({ diet: patientDiet, advancedSearch: true });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(testData.dietSearchResult1, 'diets');
-    });
-    test('[T-0502][AT-0037]Search by second selected diet', async ({
-      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
-      inpatientsPage,
-    }) => {
-      await inpatientsPage.searchTable({ diet: testData.dietName2, advancedSearch: true });
-      await inpatientsPage.validateAtLeastOneSearchResult();
-      await inpatientsPage.validateAllRowsContain(testData.dietSearchResult2, 'diets');
-    });
-    test('[T-0502][AT-0038]Search by filling all the fields', async ({
+    test('[T-0502][AT-0039]Clear search', async ({
       newPatientWithHospitalAdmission,
       inpatientsPage,
       api,
     }) => {
-      const currentUser = await getUser(api);
-      await inpatientsPage.searchTable({
-        NHN: newPatientWithHospitalAdmission.displayId,
-        firstName: newPatientWithHospitalAdmission.firstName,
-        lastName: newPatientWithHospitalAdmission.lastName,
-        area: testData.areaName,
-        department: testData.department,
-        clinician: currentUser.displayName,
-        diet: testData.dietName,
-        advancedSearch: true,
-      });
-      await inpatientsPage.validateOneSearchResult();
-      await inpatientsPage.validateFirstRowContainsNHN(newPatientWithHospitalAdmission.displayId);
-      await inpatientsPage.validateAllRowsContain(testData.areaName, 'locationGroupName');
-      await inpatientsPage.validateAllRowsContain(testData.department, 'departmentName');
-      await inpatientsPage.validateAllRowsContain(currentUser.displayName, 'clinician');
-      await inpatientsPage.validateAllRowsContain(testData.dietSearchResult1, 'diets');
-    });
-    test('[T-0502][AT-0039]Clear search', async ({ newPatientWithHospitalAdmission, inpatientsPage, api }) => {
       const currentUser = await getUser(api);
       await inpatientsPage.searchTable({
         NHN: newPatientWithHospitalAdmission.displayId,
@@ -114,11 +40,14 @@ test.describe('inpatient table tests', () => {
 
   test.describe('pagination', () => {
     //skipping this test for now as it is failing in ci because of less than 10 inpatients
-    test.skip('[AT-0040]number of patients in patient list defaulted to 10', async ({newPatientWithHospitalAdmission:_newPatientWithHospitalAdmission ,inpatientsPage }) => {
+    test.skip('[AT-0040]number of patients in patient list defaulted to 10', async ({
+      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
+      inpatientsPage,
+    }) => {
       await expect(inpatientsPage.patientTable.pageRecordCountDropDown).toHaveText('10');
       await inpatientsPage.patientTable.validateNumberOfPatients(10);
     });
-//skipping this test for now as it is failing in ci because of less than 10 inpatients
+    //skipping this test for now as it is failing in ci because of less than 10 inpatients
     test.skip('[AT-0041]change number of patients per list to 25 and going to next page', async ({
       inpatientsPage,
     }) => {
@@ -153,72 +82,23 @@ test.describe('inpatient table tests', () => {
   });
 
   test.describe('sorting', () => {
+    test('[AT-0049]Sort table by DOB in descending order', async ({
+      inpatientsPage,
+      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
+    }) => {
+      await inpatientsPage.sortByDOB();
+      await inpatientsPage.patientTable.waitForTableToLoad();
+      await inpatientsPage.validateDateSortOrder(false);
+    });
 
-  test('[AT-0043]Sort table by NHN in descending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByNHN();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(false, 'displayId');
-  });
-
-  test('[AT-0044]Sort table by NHN in ascending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByNHN();
-    await inpatientsPage.sortByNHN();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(true, 'displayId');
-  });
-
-  test('[AT-0045]Sort table by First name in descending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByFirstName();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(false, 'firstName');
-  });
-
-  test('[AT-0046]Sort table by First name in ascending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByFirstName();
-    await inpatientsPage.sortByFirstName();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(true, 'firstName');
-  });
-
-  test('[AT-0047]Sort table by Last name in descending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByLastName();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(false, 'lastName');
-  });
-
-  test('[AT-0048]Sort table by Last name in ascending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByLastName();
-    await inpatientsPage.sortByLastName();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(true, 'lastName');
-  });
-
-  test('[AT-0049]Sort table by DOB in descending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByDOB();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateDateSortOrder(false);
-  });
-
-  test('[AT-0050]Sort table by DOB in ascending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortByDOB();
-    await inpatientsPage.sortByDOB();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateDateSortOrder(true);
-  });
-  
-  //sorting by sex is opposite of other sorting in the app, with one click it is sorting in ascending.
-  test('[AT-0051]Sort table by Sex in ascending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-    await inpatientsPage.sortBySex();
-    await inpatientsPage.patientTable.waitForTableToLoad();
-    await inpatientsPage.validateSortOrder(true, 'sex');
-  });
-
-//sorting by sex is opposite of other sorting in the app, with two clicks it is sorting in descending.
-    test('[AT-0052]Sort table by Sex in descending order', async ({ inpatientsPage, newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission }) => {
-      await inpatientsPage.sortBySex();
+    //sorting by sex is opposite of other sorting in the app, with one click it is sorting in ascending.
+    test('[AT-0051]Sort table by Sex in ascending order', async ({
+      inpatientsPage,
+      newPatientWithHospitalAdmission: _newPatientWithHospitalAdmission,
+    }) => {
       await inpatientsPage.sortBySex();
       await inpatientsPage.patientTable.waitForTableToLoad();
-      await inpatientsPage.validateSortOrder(false, 'sex');
+      await inpatientsPage.validateSortOrder(true, 'sex');
     });
   });
 });

--- a/packages/e2e-tests/tests/patients/outpatient.spec.ts
+++ b/packages/e2e-tests/tests/patients/outpatient.spec.ts
@@ -8,72 +8,25 @@ test.describe('outpatient table tests', () => {
   });
 
   test.describe('search', () => {
-    test('[T-0513][AT-0116]Search by NHN', async ({ newPatientWithClinicAdmission, outpatientsPage }) => {
+    test('[T-0513][AT-0116]Search by NHN', async ({
+      newPatientWithClinicAdmission,
+      outpatientsPage,
+    }) => {
       const patientDisplayId = newPatientWithClinicAdmission.displayId;
       await outpatientsPage.searchTable({ NHN: patientDisplayId, advancedSearch: false });
       await outpatientsPage.validateOneSearchResult();
       await outpatientsPage.validateFirstRowContainsNHN(patientDisplayId);
     });
 
-    test('[T-0513][AT-0117]Search by first name', async ({ newPatientWithClinicAdmission, outpatientsPage }) => {
-      const patientFirstName = newPatientWithClinicAdmission.firstName;
-      await outpatientsPage.searchTable({ firstName: patientFirstName, advancedSearch: false });
-      await outpatientsPage.validateAtLeastOneSearchResult();
-      await outpatientsPage.validateAllRowsContain(patientFirstName!, 'firstName');
-    });
-
-    test('[T-0513][AT-0118]Search by last name', async ({ newPatientWithClinicAdmission, outpatientsPage }) => {
-      const patientLastName = newPatientWithClinicAdmission.lastName;
-      await outpatientsPage.searchTable({ lastName: patientLastName, advancedSearch: false });
-      await outpatientsPage.validateAtLeastOneSearchResult();
-      await outpatientsPage.validateAllRowsContain(patientLastName!, 'lastName');
-    });
-
-    test('[T-0513][AT-0119]Search by area', async ({ newPatientWithClinicAdmission: _newPatientWithClinicAdmission, outpatientsPage }) => {
-      const patientArea = testData.areaName;
-      await outpatientsPage.searchTable({ area: patientArea, advancedSearch: false });
-      await outpatientsPage.validateAtLeastOneSearchResult();
-      await outpatientsPage.validateAllRowsContain(patientArea, 'locationGroupName');
-    });
-
-    test('[T-0513][AT-0120]Search by department', async ({ newPatientWithClinicAdmission: _newPatientWithClinicAdmission, outpatientsPage }) => {
-      const patientDepartment = testData.department;
-      await outpatientsPage.searchTable({ department: patientDepartment, advancedSearch: true });
-      await outpatientsPage.validateAtLeastOneSearchResult();
-      await outpatientsPage.validateAllRowsContain(patientDepartment, 'departmentName');
-    });
-
-    test('[T-0513][AT-0121]Search by clinician', async ({ newPatientWithClinicAdmission: _newPatientWithClinicAdmission, outpatientsPage, api }) => {
-      const currentUser = await getUser(api);
-      const patientClinician = currentUser.displayName;
-      await outpatientsPage.searchTable({ clinician: patientClinician, advancedSearch: true });
-      await outpatientsPage.validateAtLeastOneSearchResult();
-      await outpatientsPage.validateAllRowsContain(patientClinician, 'clinician');
-    });
-
-    test('[T-0513][AT-0122]Search by filling all the fields', async ({ newPatientWithClinicAdmission, outpatientsPage, api }) => {
+    test('[T-0513][AT-0123]Clear search', async ({
+      newPatientWithClinicAdmission,
+      outpatientsPage,
+      api,
+    }) => {
       const currentUser = await getUser(api);
       await outpatientsPage.searchTable({
         NHN: newPatientWithClinicAdmission.displayId,
         firstName: newPatientWithClinicAdmission.firstName,
-        lastName: newPatientWithClinicAdmission.lastName,
-        area: testData.areaName,  
-        department: testData.department,
-        clinician: currentUser.displayName,
-        advancedSearch: true,
-      });
-      await outpatientsPage.validateOneSearchResult();
-      await outpatientsPage.validateFirstRowContainsNHN(newPatientWithClinicAdmission.displayId);
-      await outpatientsPage.validateAllRowsContain(testData.areaName, 'locationGroupName');
-      await outpatientsPage.validateAllRowsContain(testData.department, 'departmentName');
-      await outpatientsPage.validateAllRowsContain(currentUser.displayName, 'clinician');
-    });
-
-    test('[T-0513][AT-0123]Clear search', async ({ newPatientWithClinicAdmission, outpatientsPage, api }) => {
-      const currentUser = await getUser(api);
-      await outpatientsPage.searchTable({
-        NHN: newPatientWithClinicAdmission.displayId,
-        firstName: newPatientWithClinicAdmission.firstName,   
         lastName: newPatientWithClinicAdmission.lastName,
         area: testData.areaName,
         department: testData.department,
@@ -87,7 +40,9 @@ test.describe('outpatient table tests', () => {
 
   test.describe('pagination', () => {
     //skipping this test for now as it is failing in ci because of less than 10 outpatients
-    test.skip('[AT-0124]number of patients in patient list defaulted to 10', async ({ outpatientsPage }) => {
+    test.skip('[AT-0124]number of patients in patient list defaulted to 10', async ({
+      outpatientsPage,
+    }) => {
       await expect(outpatientsPage.patientTable.pageRecordCountDropDown).toHaveText('10');
       await outpatientsPage.patientTable.validateNumberOfPatients(10);
     });
@@ -125,44 +80,13 @@ test.describe('outpatient table tests', () => {
   });
 
   test.describe('sorting', () => {
-
-  test('[AT-0127]Sort table by NHN in descending order', async ({ outpatientsPage, newPatientWithClinicAdmission: _newPatientWithClinicAdmission }) => {
-    await outpatientsPage.sortByNHN();
-    await outpatientsPage.patientTable.waitForTableToLoad();
-    await outpatientsPage.validateSortOrder(false, 'displayId');
-  });
-
-  test('[AT-0128]Sort table by NHN in ascending order', async ({ outpatientsPage, newPatientWithClinicAdmission: _newPatientWithClinicAdmission }) => {
-    await outpatientsPage.sortByNHN();
-    await outpatientsPage.sortByNHN();
-    await outpatientsPage.patientTable.waitForTableToLoad();
-    await outpatientsPage.validateSortOrder(true, 'displayId');
-  });
-
-  test('[AT-0129]Sort table by First name in descending order', async ({ outpatientsPage, newPatientWithClinicAdmission: _newPatientWithClinicAdmission }) => {
-    await outpatientsPage.sortByFirstName();
-    await outpatientsPage.patientTable.waitForTableToLoad();
-    await outpatientsPage.validateSortOrder(false, 'firstName');
-  });
-
-  test('[AT-0130]Sort table by First name in ascending order', async ({ outpatientsPage, newPatientWithClinicAdmission: _newPatientWithClinicAdmission }) => {
-    await outpatientsPage.sortByFirstName();
-    await outpatientsPage.sortByFirstName();
-    await outpatientsPage.patientTable.waitForTableToLoad();
-    await outpatientsPage.validateSortOrder(true, 'firstName');
-  });
-
-  test('[AT-0131]Sort table by Last name in descending order', async ({ outpatientsPage, newPatientWithClinicAdmission: _newPatientWithClinicAdmission }) => {
-    await outpatientsPage.sortByLastName();
-    await outpatientsPage.patientTable.waitForTableToLoad();
-    await outpatientsPage.validateSortOrder(false, 'lastName');
-  });
-
-    test('[AT-0132]Sort table by Last name in ascending order', async ({ outpatientsPage, newPatientWithClinicAdmission: _newPatientWithClinicAdmission }) => {
-      await outpatientsPage.sortByLastName();
-      await outpatientsPage.sortByLastName();
+    test('[AT-0127]Sort table by NHN in descending order', async ({
+      outpatientsPage,
+      newPatientWithClinicAdmission: _newPatientWithClinicAdmission,
+    }) => {
+      await outpatientsPage.sortByNHN();
       await outpatientsPage.patientTable.waitForTableToLoad();
-      await outpatientsPage.validateSortOrder(true, 'lastName');
+      await outpatientsPage.validateSortOrder(false, 'displayId');
     });
   });
 });


### PR DESCRIPTION
### Changes

There is a big chunk of repetitive tests that take up about 1/5 of our test suite currently on patient tables. These tests check sorting of each column and that each field can be searched. This functionality is better tested as endpoint tests (which we already do) and removing this chunk should make a significant difference to E2E speed.

I have still left some basic sort and search tests for a basic front end check but we no longer will check every type of sort and search through E2E.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [x] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to Playwright E2E tests and page-object helpers; the main impact is reduced UI regression coverage (fewer search/sort assertions) rather than production behavior.
> 
> **Overview**
> Reduces patient-table E2E coverage by removing most per-field search tests and most column sorting tests for `all patients`, `inpatients`, and `outpatients`, keeping only a small set of smoke checks (e.g., NHN search, clear-search, and limited sort cases).
> 
> Cleans up patient page objects by dropping unused sort-button locators and removing `sortByFirstName`/`sortByLastName` helpers from `BasePatientListPage` to match the trimmed test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ca6ca30c9f846ccde09bad34404d7cca33038a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->