### PR TITLE
test: test agent

### DIFF
--- a/packages/facility-server/app/routes/apiv1/patient/patient.js
+++ b/packages/facility-server/app/routes/apiv1/patient/patient.js
@@ -76,6 +76,28 @@ patientRoute.post(
 );
 
 patientRoute.get(
+  '/$/markedForSyncCount',
+  asyncHandler(async (req, res) => {
+    const {
+      models: { PatientFacility },
+      query: { facilityId },
+    } = req;
+
+    req.checkPermission('list', 'Patient');
+
+    if (!facilityId) {
+      throw new InvalidParameterError('Missing facilityId');
+    }
+
+    const count = await PatientFacility.count({
+      where: { facilityId },
+    });
+
+    res.send({ count });
+  }),
+);
+
+patientRoute.get(
   '/:id',
   asyncHandler(async (req, res) => {
     const {

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -60,6 +60,7 @@ export const createPatientFilters = filterParams => {
     makeFilter(filterParams.locationId, `location.id = :locationId`),
     makeFilter(filterParams.locationGroupId, `location_group.id = :locationGroupId`),
     makeFilter(filterParams.departmentId, `department.id = :departmentId`),
+    makeFilter(filterParams.markedForSync, `patient_facilities.patient_id IS NOT NULL`),
     makeFilter(
       !filterParams.isAllPatientsListing && filterParams.facilityId,
       `location.facility_id = :facilityId`,

--- a/packages/facility-server/app/utils/patientFilters.js
+++ b/packages/facility-server/app/utils/patientFilters.js
@@ -62,6 +62,10 @@ export const createPatientFilters = filterParams => {
     makeFilter(filterParams.departmentId, `department.id = :departmentId`),
     makeFilter(filterParams.markedForSync, `patient_facilities.patient_id IS NOT NULL`),
     makeFilter(
+      filterParams.markedForSync === true || filterParams.markedForSync === 'true',
+      `patient_facilities.patient_id IS NOT NULL`,
+    ),
+    makeFilter(
       !filterParams.isAllPatientsListing && filterParams.facilityId,
       `location.facility_id = :facilityId`,
     ),

--- a/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
+++ b/packages/web/app/components/SearchBar/AllPatientsSearchBar.jsx
@@ -111,6 +111,17 @@ export const AllPatientsSearchBar = React.memo(({ onSearch, searchParameters }) 
             }
             data-testid="searchbarcheckfield-7dw8"
           />
+          <SearchBarCheckField
+            name="markedForSync"
+            label={
+              <TranslatedText
+                stringId="patientList.table.onlyMarkedForSyncCheckbox.label"
+                fallback="Only marked for sync"
+                data-testid="translatedtext-synconly"
+              />
+            }
+            data-testid="searchbarcheckfield-markedforsync"
+          />
           {additionalSearchFields.map(fieldName => (
             <AdditionalSearchField key={fieldName} fieldName={fieldName} />
           ))}

--- a/packages/web/app/components/Sidebar/FacilityMenuItems.jsx
+++ b/packages/web/app/components/Sidebar/FacilityMenuItems.jsx
@@ -92,6 +92,19 @@ export const FACILITY_MENU_ITEMS = [
         key: 'patientsOutpatients',
         ability: { action: 'read' },
       },
+      {
+        label: (
+          <TranslatedText
+            stringId="sidebar.patients.syncQueue"
+            fallback="Sync queue"
+            data-testid="translatedtext-patients-syncqueue"
+          />
+        ),
+        color: Colors.blue,
+        path: '/patients/sync',
+        key: 'patientsSyncQueue',
+        ability: { action: 'read' },
+      },
     ],
   },
   {

--- a/packages/web/app/constants/patientPaths.js
+++ b/packages/web/app/constants/patientPaths.js
@@ -3,6 +3,7 @@ export const PATIENT_CATEGORIES = {
   EMERGENCY: 'emergency',
   INPATIENT: 'inpatient',
   OUTPATIENT: 'outpatient',
+  SYNC: 'sync',
 };
 
 export const PATIENT_CATEGORY_LABELS = {
@@ -10,6 +11,7 @@ export const PATIENT_CATEGORY_LABELS = {
   [PATIENT_CATEGORIES.EMERGENCY]: 'Emergency Patients',
   [PATIENT_CATEGORIES.OUTPATIENT]: 'Outpatients',
   [PATIENT_CATEGORIES.INPATIENT]: 'Inpatients',
+  [PATIENT_CATEGORIES.SYNC]: 'Sync Queue',
 };
 
 const CATEGORY_PATH = `/patients/:category`;

--- a/packages/web/app/routes/PatientsRoutes.jsx
+++ b/packages/web/app/routes/PatientsRoutes.jsx
@@ -4,6 +4,7 @@ import {
   AdmittedPatientsView,
   OutpatientsView,
   PatientListingView,
+  SyncedPatientsView,
   TriageListingView,
 } from '../views';
 import { PatientRoutes } from './PatientRoutes';
@@ -20,6 +21,8 @@ const CategoryComponent = () => {
       return <AdmittedPatientsView />;
     case 'outpatient':
       return <OutpatientsView />;
+    case 'sync':
+      return <SyncedPatientsView />;
     default:
       return <Navigate to="/patients/all" replace />;
   }

--- a/packages/web/app/views/patients/PatientListingView.jsx
+++ b/packages/web/app/views/patients/PatientListingView.jsx
@@ -212,6 +212,47 @@ export const PatientListingView = ({ onViewPatient }) => {
   );
 };
 
+export const SyncedPatientsView = () => {
+  const [searchParameters, setSearchParameters] = useState({});
+  const { facilityId } = useAuth();
+
+  return (
+    <PageContainer data-testid="pagecontainer-sync">
+      <TopBar
+        title={
+          <TranslatedText
+            stringId="patientList.syncQueue.title"
+            fallback="Sync queue"
+            data-testid="translatedtext-syncqueue-title"
+          />
+        }
+        data-testid="topbar-sync"
+      />
+      <ContentPane data-testid="contentpane-sync">
+        <SearchTableTitle data-testid="searchtabletitle-sync">
+          <TranslatedText
+            stringId="patientList.syncQueue.search.title"
+            fallback="Patients marked for sync"
+            data-testid="translatedtext-syncqueue-search"
+          />
+        </SearchTableTitle>
+        <AllPatientsSearchBar onSearch={setSearchParameters} data-testid="allpatientssearchbar-sync" />
+        <PatientTable
+          fetchOptions={{ matchSecondaryIds: true }}
+          searchParameters={{
+            isAllPatientsListing: true,
+            markedForSync: true,
+            facilityId,
+            ...searchParameters,
+          }}
+          columns={LISTING_COLUMNS}
+          data-testid="patienttable-sync"
+        />
+      </ContentPane>
+    </PageContainer>
+  );
+};
+
 export const AdmittedPatientsView = () => {
   const { searchParameters, setSearchParameters } = usePatientSearch(
     PatientSearchKeys.AdmittedPatientsView,

--- a/packages/web/app/views/patients/index.js
+++ b/packages/web/app/views/patients/index.js
@@ -1,4 +1,4 @@
-export { PatientListingView, AdmittedPatientsView, OutpatientsView } from './PatientListingView';
+export { PatientListingView, SyncedPatientsView, AdmittedPatientsView, OutpatientsView } from './PatientListingView';
 export { PatientView } from './PatientView';
 export { EncounterView } from './EncounterView';
 export { LabRequestView } from './LabRequestView';


### PR DESCRIPTION
This reverts commit 97182824d36f8468e5a551370f36fd81ee7a1c19.

### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new patient listing route and backend filtering around `patient_facilities`, which can impact patient search results and permissions-sensitive API behavior. The new `markedForSync` filter logic appears duplicated and may unintentionally filter even when set to false/any truthy value.
> 
> **Overview**
> Adds a new **Patients → Sync queue** view (`/patients/sync`) that lists only patients marked for sync in the current facility and exposes a new search checkbox to filter listings by `markedForSync`.
> 
> On the backend, extends patient list filtering to support `markedForSync` via the `patient_facilities` join, and adds a new `GET /apiv1/patient/$/markedForSyncCount?facilityId=...` endpoint to return the count of patients marked for sync for a facility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63a57249716135468f654098db8ffba4d51b76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->