### PR TITLE
fix(reports): NOTAM-566: 2.53 hotfix: always include :timezone in report query replacements

### DIFF
--- a/packages/shared/src/utils/reports/getReportQueryReplacements.js
+++ b/packages/shared/src/utils/reports/getReportQueryReplacements.js
@@ -1,8 +1,20 @@
 import { subDays, startOfDay, subYears, addDays, endOfDay, parseISO } from 'date-fns';
+import config from 'config';
 import { REPORT_DEFAULT_DATE_RANGES } from '@tamanu/constants';
 import { toDateTimeString, getCurrentDateTimeString } from '@tamanu/utils/dateTime';
+import { getPrimaryTimeZone } from '../timeZoneCheck';
 
 const START_OF_EPOCH = '1970-01-01 00:00:00';
+
+const isValidTimeZone = (tz) => {
+  if (!tz) return false;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 const getFromDate = (dateRange, { toDate, fromDate }) => {
   const defaultedToDate = toDate || getCurrentDateTimeString();
@@ -55,11 +67,16 @@ export const getReportQueryReplacements = async (
   dateRange = REPORT_DEFAULT_DATE_RANGES.TWENTY_FOUR_HOURS,
 ) => {
   const paramDefaults = paramDefinitions.reduce((obj, { name }) => ({ ...obj, [name]: null }), {});
+
+  const candidateTimezone = params.timezone ?? getPrimaryTimeZone(config);
+  const timezone = isValidTimeZone(candidateTimezone) ? candidateTimezone : 'UTC';
+
   return {
     ...paramDefaults,
     ...params,
     fromDate: getFromDate(dateRange, params),
     toDate: getToDate(dateRange, params),
     currentFacilityId: facilityId,
+    timezone,
   };
 };


### PR DESCRIPTION
### Changes

Hotfix propagation of #9626 (NOTAM-566) from release/2.51. Clean cherry-pick.

`getReportQueryReplacements` now always includes `timezone` in the replacement map, falling back to the primary timezone from config (and to UTC if that is missing or invalid). Fixes `Invalid query: Named replacement ":timezone" has no entry in the replacement map.` when importing reports that reference `:timezone`.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->