### PR TITLE
fix(pdf): no-issue: pad notes and medication cells in PDF printouts

### DIFF
--- a/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/DischargeSummaryPrintout.jsx
@@ -127,7 +127,7 @@ const columns = (getTranslation, getEnumTranslation) => [
     title: getTranslation('pdf.table.column.medication', 'Medication'),
     accessor: ({ medication, notes }) => (
       <View>
-        <Text>{medication?.name + `\n`}</Text>
+        <Text style={{ marginBottom: 4 }}>{medication?.name}</Text>
         <Text style={{ fontFamily: 'Helvetica-Oblique' }}>{notes}</Text>
       </View>
     ),

--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -42,9 +42,11 @@ const textStyles = StyleSheet.create({
   tableColumnHeader: {
     fontWeight: 700,
     fontSize: 10,
+    marginBottom: 4,
   },
   tableCellContent: {
     fontSize: 10,
+    marginBottom: 6,
   },
   tableCellFooter: {
     fontSize: 8,
@@ -322,7 +324,7 @@ const NotesSection = ({ notes }) => {
                     )}
                     style={textStyles.tableColumnHeader}
                   />
-                  <Text style={textStyles.tableCellContent}>{`${note.content}\n`}</Text>
+                  <Text style={textStyles.tableCellContent}>{note.content}</Text>
                   <NoteFooter note={note} />
                   <View
                     style={{

--- a/packages/shared/src/utils/patientCertificates/PrescriptionPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/PrescriptionPrintout.jsx
@@ -21,8 +21,10 @@ const columns = (getTranslation, getEnumTranslation) => [
     title: getTranslation('pdf.table.column.medication', 'Medication'),
     accessor: ({ medication, notes, indication }) => (
       <View>
-        <Text>{medication?.name + `\n`}</Text>
-        {notes && <Text style={{ fontFamily: 'Helvetica-Oblique' }}>{notes + `\n`}</Text>}
+        <Text style={{ marginBottom: 4 }}>{medication?.name}</Text>
+        {notes && (
+          <Text style={{ fontFamily: 'Helvetica-Oblique', marginBottom: 4 }}>{notes}</Text>
+        )}
         {indication && (
           <Text>
             <Text style={{ fontFamily: 'Helvetica-Bold' }}>


### PR DESCRIPTION
### Changes

Fixes text overlap in the Notes section of the encounter record PDF: the "Nurse: name date time" footer could render on top of the note content, and the bold note-type heading at the top of each note sat flush against the content with ascenders/descenders colliding.

Adds explicit `marginBottom` to the heading and content styles in `EncounterRecordPrintout`, and removes a trailing `\n` hack that had been appended to `note.content` as an earlier (insufficient) spacing attempt.

While reviewing, the same `\n`-in-template-literal hack was found in two other printouts — `DischargeSummaryPrintout` and `PrescriptionPrintout`, both in the medication column accessor. Replaced those with explicit `marginBottom` on the preceding `<Text>` blocks too, since the same rendering issue can affect them.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review --> 
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->