### PR TITLE
fix(pdf): no-issue: show original note author on encounter record printout

### DIFF
--- a/packages/facility-server/__tests__/apiv1/Note.test.js
+++ b/packages/facility-server/__tests__/apiv1/Note.test.js
@@ -319,6 +319,22 @@ describe('Note', () => {
       });
     });
 
+    it('should include editCount matching the number of revisions on each note', async () => {
+      const response = await app.get(
+        `/api/encounter/${encounter.id}/notes?rowsPerPage=${noteGroupCount}`,
+      );
+      expect(response).toHaveSucceeded();
+      const expectedEditCountById = {};
+      noteGroups.forEach((group) => {
+        // group = [base, ...revisions]; the latest revision is the one returned by the list endpoint
+        const latest = group[group.length - 1];
+        expectedEditCountById[latest.id] = group.length - 1;
+      });
+      response.body.data.forEach((n) => {
+        expect(n.editCount).toEqual(expectedEditCountById[n.id]);
+      });
+    });
+
     it('should paginate notes correctly when they have revisions', async () => {
       // grab the first two pages - they should have the right counts & no duplicates
       const firstPage = await app.get(`/api/encounter/${encounter.id}/notes?rowsPerPage=5`);

--- a/packages/facility-server/app/routeHandlers/notes/noteListHandler.js
+++ b/packages/facility-server/app/routeHandlers/notes/noteListHandler.js
@@ -114,6 +114,35 @@ export const noteListHandler = recordType =>
       where,
     });
 
+    const editChains = [...new Set(rows.map(n => n.revisedById ?? n.id))];
+    if (editChains.length > 0) {
+      const chainCounts = await models.Note.sequelize.query(
+        `
+        SELECT
+          CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END AS chain_id,
+          COUNT(*) AS count
+        FROM notes
+        WHERE record_type = :recordType
+          AND record_id = :recordId
+          AND deleted_at IS NULL
+          AND (CASE WHEN revised_by_id IS NULL THEN id ELSE revised_by_id END) IN (:editChains)
+        GROUP BY chain_id
+        `,
+        {
+          type: QueryTypes.SELECT,
+          replacements: { recordType, recordId, editChains },
+        },
+      );
+      const countByChain = Object.fromEntries(
+        chainCounts.map(({ chain_id, count }) => [chain_id, Number(count)]),
+      );
+      rows.forEach(note => {
+        const chainId = note.revisedById ?? note.id;
+        const totalInChain = countByChain[chainId] ?? 1;
+        note.setDataValue('editCount', Math.max(0, totalInChain - 1));
+      });
+    }
+
     res.send({ data: rows, count: totalCount });
   });
 

--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -258,23 +258,71 @@ const TableSection = ({ title, data, columns, type }) => {
 
 const NoteFooter = ({ note }) => {
   const { getTranslation } = useLanguageContext();
+  const isTreatmentPlan = note.noteTypeId === NOTE_TYPES.TREATMENT_PLAN;
+
+  // For non-TREATMENT_PLAN notes we want to show the original author and date;
+  // the revisedBy association points at the root note when the current record
+  // is a later revision. TREATMENT_PLAN keeps its existing "last updated" behaviour.
+  const originalAuthor =
+    !isTreatmentPlan && note.revisedBy?.author ? note.revisedBy.author : note.author;
+  const originalOnBehalf =
+    !isTreatmentPlan && note.revisedBy ? note.revisedBy.onBehalfOf : note.onBehalfOf;
+  const originalDate =
+    !isTreatmentPlan && note.revisedBy?.date ? note.revisedBy.date : note.date;
+
+  const baseLine = [
+    isTreatmentPlan && `${getTranslation('general.lastUpdated.label', 'Last updated')}:`,
+    originalAuthor?.displayName,
+    originalOnBehalf &&
+      getTranslation('note.table.onBehalfOf', 'on behalf of :changeOnBehalfOfName', {
+        replacements: {
+          changeOnBehalfOfName: originalOnBehalf.displayName,
+        },
+      }),
+    formatShort(originalDate),
+    getDisplayDate(originalDate, 'h:mma'),
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const editCount = !isTreatmentPlan ? note.editCount ?? 0 : 0;
+  if (editCount <= 0) {
+    return <Text style={textStyles.tableCellFooter}>{baseLine}</Text>;
+  }
+
+  const editTimes =
+    editCount === 1
+      ? getTranslation('pdf.encounterRecord.notes.editedOnce', '1 time')
+      : getTranslation('pdf.encounterRecord.notes.editedTimes', ':count times', {
+          replacements: { count: editCount },
+        });
+  const lastEditor = [
+    note.author?.displayName,
+    note.onBehalfOf &&
+      getTranslation('note.table.onBehalfOf', 'on behalf of :changeOnBehalfOfName', {
+        replacements: {
+          changeOnBehalfOfName: note.onBehalfOf.displayName,
+        },
+      }),
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const editSuffix = getTranslation(
+    'pdf.encounterRecord.notes.editedSuffix',
+    ' — Edited :times, last by :editor at :date',
+    {
+      replacements: {
+        times: editTimes,
+        editor: lastEditor,
+        date: `${formatShort(note.date)} ${getDisplayDate(note.date, 'h:mma')}`,
+      },
+    },
+  );
+
   return (
     <Text style={textStyles.tableCellFooter}>
-      {[
-        note.noteTypeId === NOTE_TYPES.TREATMENT_PLAN &&
-          `${getTranslation('general.lastUpdated.label', 'Last updated')}:`,
-        note.author?.displayName,
-        note.onBehalfOf &&
-          getTranslation('note.table.onBehalfOf', 'on behalf of :changeOnBehalfOfName', {
-            replacements: {
-              changeOnBehalfOfName: note.onBehalfOf.displayName,
-            },
-          }),
-        formatShort(note.date),
-        getDisplayDate(note.date, 'h:mma'),
-      ]
-        .filter(Boolean)
-        .join(' ')}
+      {baseLine}
+      {editSuffix}
     </Text>
   );
 };


### PR DESCRIPTION
### Changes

The note footer on the encounter record PDF was showing the name and date of the person who last edited each note, rather than the person who originally wrote it. In the web UI we show the original author and link to the edit history modal, but there is no equivalent in print — so if a note had been touched later it would look like someone else had written it.

This PR:

- Adds `editCount` to the response of `GET /encounter/:id/notes` (via a small secondary count query in `noteListHandler`), counting the number of revisions in each note's edit chain excluding the original.
- Updates `NoteFooter` in `EncounterRecordPrintout` to show the **original** author and creation date (from `revisedBy` when the current record is a later revision). If the note has been edited, a suffix is appended — `— Edited N times, last by <editor> at <date>` — so the full edit context is still visible inline.
- `TREATMENT_PLAN` notes keep their existing "Last updated: \<latest editor\> \<latest date\>" behaviour, matching how the edit-history modal already treats them.

New strings added: `pdf.encounterRecord.notes.editedOnce`, `pdf.encounterRecord.notes.editedTimes`, `pdf.encounterRecord.notes.editedSuffix`.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->