### PR TITLE
fix(scheduling): Hotfix v2.52: Date picker weekly view bug

### DIFF
--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -92,10 +92,6 @@ const StyledMonthPicker = styled(MonthPicker)`
   .MuiInputBase-input {
     font-size: inherit;
   }
-
-  body:has(&) > .MuiPickersPopper-root {
-    z-index: 2; // Above the sticky headers
-  }
 `;
 
 export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedDates }) => {


### PR DESCRIPTION
## Summary
- backport the location booking date picker fix to release/2.52
- remove the weekly-view global popper z-index override that caused the booking date picker to render behind the drawer
- keep month picker behavior unchanged via its component-scoped popper styling

## Test plan
- [ ] In Scheduling > Location Booking (Weekly), click `+ Book location` and verify the Date picker opens
- [ ] In Scheduling > Location Booking (Daily), verify Date picker still opens
- [ ] In Weekly view, verify month picker in calendar header still opens and displays above sticky header

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change, but it can affect date picker/menu stacking in Scheduling views if other components relied on the removed global z-index override.
> 
> **Overview**
> Removes the `body:has(&) > .MuiPickersPopper-root { z-index: 2; }` styling from the `LocationBookingsCalendarHeader` `StyledMonthPicker`, eliminating a global popper z-index override so picker poppers no longer get forced above sticky headers from this component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 310af0ca386acb3a2b12bed2b56e7fd6a94a0f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->