### PR TITLE
fix(scheduling): Hotfix v2.54: Date picker weekly view bug

### DIFF
--- a/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
+++ b/packages/web/app/views/scheduling/locationBookings/LocationBookingsCalendarHeader.jsx
@@ -92,10 +92,6 @@ const StyledMonthPicker = styled(MonthPicker)`
   .MuiInputBase-input {
     font-size: inherit;
   }
-
-  body:has(&) > .MuiPickersPopper-root {
-    z-index: 2; // Above the sticky headers
-  }
 `;
 
 export const LocationBookingsCalendarHeader = ({ monthOf, setMonthOf, displayedDates }) => {


### PR DESCRIPTION
## Summary
- backport the location booking date picker fix to release/2.54
- remove the weekly-view global popper z-index override that caused the booking date picker to render behind the drawer
- keep month picker behavior unchanged via its component-scoped popper styling

## Test plan
- [ ] In Scheduling > Location Booking (Weekly), click `+ Book location` and verify the Date picker opens
- [ ] In Scheduling > Location Booking (Daily), verify Date picker still opens
- [ ] In Weekly view, verify month picker in calendar header still opens and displays above sticky header

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly-scoped styling change that only removes a `z-index` override on the month picker popper; main risk is unintended layering/visibility regressions for the calendar header picker.
> 
> **Overview**
> Removes the `body:has(&) > .MuiPickersPopper-root { z-index: 2; }` styling from `LocationBookingsCalendarHeader`’s `StyledMonthPicker`, eliminating a global popper layering override.
> 
> This is intended to stop the weekly-view booking date picker from rendering behind other UI (e.g., the drawer) while leaving the month picker behavior to rely on its component-level popper styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a48c4a6ccaf66a42c616a39cabd538c7e20e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->