### PR TITLE
fix(pdf): no-issue: reliably separate note content and footer on encounter progress record

### DIFF
--- a/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
+++ b/packages/shared/src/utils/patientCertificates/EncounterRecordPrintout.jsx
@@ -46,7 +46,6 @@ const textStyles = StyleSheet.create({
   },
   tableCellContent: {
     fontSize: 10,
-    marginBottom: 6,
   },
   tableCellFooter: {
     fontSize: 8,
@@ -319,12 +318,7 @@ const NoteFooter = ({ note }) => {
     },
   );
 
-  return (
-    <Text style={textStyles.tableCellFooter}>
-      {baseLine}
-      {editSuffix}
-    </Text>
-  );
+  return <Text style={textStyles.tableCellFooter}>{`${baseLine}${editSuffix}`}</Text>;
 };
 const NotesMultipageCellPadding = () => {
   let firstPageOccurrence = Number.MAX_SAFE_INTEGER;
@@ -372,7 +366,9 @@ const NotesSection = ({ notes }) => {
                     )}
                     style={textStyles.tableColumnHeader}
                   />
-                  <Text style={textStyles.tableCellContent}>{note.content}</Text>
+                  <View style={{ width: '100%', marginBottom: 10 }}>
+                    <Text style={textStyles.tableCellContent}>{note.content}</Text>
+                  </View>
                   <NoteFooter note={note} />
                   <View
                     style={{


### PR DESCRIPTION
### Changes

On the encounter progress record, the last line of a note's wrapped content was rendering on top of the `NoteFooter` line (see overlap on "Ear Ache (Left ear only)" vs "Initial admin …" in the reported screenshot). The `marginBottom` previously set on the `tableCellContent` Text style — added in #9632 — isn't being honoured reliably for multi-line wrapped Text in `@react-pdf/renderer`.

Wraps the content `<Text>` in a `<View style={{ marginBottom: 10 }}>` so the spacing is enforced through the View box model rather than Text-level margin, and collapses the two adjacent string children in `NoteFooter` into a single template literal (multiple string children of a `Text` can be unreliable when the resulting line wraps).

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [x] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->