### PR TITLE
fix(sync): no-issue: retain errored snapshot tables for 24h and batch-clean overnight

### DIFF
--- a/database/model/public/sync_sessions.md
+++ b/database/model/public/sync_sessions.md
@@ -55,5 +55,8 @@ If a sync fails, the error(s).
 {% enddocs %}
 
 {% docs sync_sessions__snapshot_dropped_at %}
-TODO
+Timestamp the sync session snapshot was dropped.
+
+Successful snapshots are dropped immediately on completion,
+but ones from errored sync sessions are retained for 24 hours to allow for debugging.
 {% enddocs %}

--- a/database/model/public/sync_sessions.md
+++ b/database/model/public/sync_sessions.md
@@ -53,3 +53,7 @@ Timestamp the sync session snapshot started at
 {% docs sync_sessions__errors %}
 If a sync fails, the error(s).
 {% enddocs %}
+
+{% docs sync_sessions__snapshot_dropped_at %}
+TODO
+{% enddocs %}

--- a/database/model/public/sync_sessions.yml
+++ b/database/model/public/sync_sessions.yml
@@ -73,3 +73,6 @@ sources:
           - name: errors
             data_type: array
             description: "{{ doc('sync_sessions__errors') }}"
+          - name: snapshot_dropped_at
+            data_type: timestamp with time zone
+            description: "{{ doc('sync_sessions__snapshot_dropped_at') }}"

--- a/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
+++ b/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
@@ -1,0 +1,140 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { sub } from 'date-fns';
+
+import { fakeUUID } from '@tamanu/utils/generateId';
+import { createSnapshotTable, dropSnapshotTable } from '@tamanu/database/sync';
+
+import { SnapshotTableCleaner } from '../../dist/tasks/SnapshotTableCleaner';
+import { createTestContext } from '../utilities';
+
+describe('SnapshotTableCleaner', () => {
+  let ctx;
+  let models;
+
+  const runCleaner = (overrideConfig = {}) => {
+    const cleaner = new SnapshotTableCleaner(ctx, {
+      schedule: '',
+      enabled: false,
+      retentionHours: 24,
+      batchSize: 100,
+      batchSleepAsyncDurationInMilliseconds: 1,
+      ...overrideConfig,
+    });
+    return cleaner.run();
+  };
+
+  const createErroredSession = async ({ completedAt, snapshotDroppedAt = null } = {}) => {
+    const id = fakeUUID();
+    await models.SyncSession.create({
+      id,
+      startTime: completedAt ?? new Date(),
+      completedAt: completedAt ?? new Date(),
+      errors: ['simulated failure'],
+      snapshotDroppedAt,
+    });
+    await createSnapshotTable(ctx.store.sequelize, id);
+    return id;
+  };
+
+  const snapshotTableExists = async (sessionId) => {
+    const [rows] = await ctx.store.sequelize.query(
+      `SELECT 1 FROM pg_tables WHERE schemaname = 'sync_snapshots' AND tablename = $sessionId`,
+      { bind: { sessionId } },
+    );
+    return rows.length > 0;
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    ({ models } = ctx.store);
+  });
+
+  afterAll(() => ctx.close());
+
+  beforeEach(async () => {
+    await models.SyncSession.truncate({ cascade: true, force: true });
+  });
+
+  it('drops snapshot tables for errored sessions past the retention window', async () => {
+    const sessionId = await createErroredSession({
+      completedAt: sub(new Date(), { hours: 25 }),
+    });
+
+    await runCleaner();
+
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.snapshotDroppedAt).not.toBeNull();
+    expect(await snapshotTableExists(sessionId)).toBe(false);
+  });
+
+  it('leaves errored sessions within the retention window alone', async () => {
+    const sessionId = await createErroredSession({
+      completedAt: sub(new Date(), { hours: 1 }),
+    });
+
+    await runCleaner();
+
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.snapshotDroppedAt).toBeNull();
+    expect(await snapshotTableExists(sessionId)).toBe(true);
+    await dropSnapshotTable(ctx.store.sequelize, sessionId);
+  });
+
+  it('skips sessions that are already cleaned', async () => {
+    const alreadyCleanedAt = sub(new Date(), { hours: 1 });
+    const sessionId = fakeUUID();
+    await models.SyncSession.create({
+      id: sessionId,
+      startTime: sub(new Date(), { hours: 48 }),
+      completedAt: sub(new Date(), { hours: 48 }),
+      errors: ['simulated failure'],
+      snapshotDroppedAt: alreadyCleanedAt,
+    });
+
+    await runCleaner();
+
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.snapshotDroppedAt.getTime()).toBe(alreadyCleanedAt.getTime());
+  });
+
+  it('ignores successful (non-errored) sessions', async () => {
+    const sessionId = fakeUUID();
+    await models.SyncSession.create({
+      id: sessionId,
+      startTime: sub(new Date(), { hours: 48 }),
+      completedAt: sub(new Date(), { hours: 48 }),
+      errors: null,
+      snapshotDroppedAt: null,
+    });
+
+    await runCleaner();
+
+    const session = await models.SyncSession.findByPk(sessionId);
+    expect(session.snapshotDroppedAt).toBeNull();
+  });
+
+  it('processes at most batchSize sessions per run, oldest first', async () => {
+    const oldest = await createErroredSession({
+      completedAt: sub(new Date(), { hours: 100 }),
+    });
+    const middle = await createErroredSession({
+      completedAt: sub(new Date(), { hours: 50 }),
+    });
+    const newest = await createErroredSession({
+      completedAt: sub(new Date(), { hours: 25 }),
+    });
+
+    await runCleaner({ batchSize: 2 });
+
+    const [oldestRow, middleRow, newestRow] = await Promise.all([
+      models.SyncSession.findByPk(oldest),
+      models.SyncSession.findByPk(middle),
+      models.SyncSession.findByPk(newest),
+    ]);
+    expect(oldestRow.snapshotDroppedAt).not.toBeNull();
+    expect(middleRow.snapshotDroppedAt).not.toBeNull();
+    expect(newestRow.snapshotDroppedAt).toBeNull();
+
+    await dropSnapshotTable(ctx.store.sequelize, newest);
+  });
+});

--- a/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
+++ b/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
@@ -24,10 +24,12 @@ describe('SnapshotTableCleaner', () => {
 
   const createErroredSession = async ({ completedAt, snapshotDroppedAt = null } = {}) => {
     const id = fakeUUID();
+    const when = completedAt ?? new Date();
     await models.SyncSession.create({
       id,
-      startTime: completedAt ?? new Date(),
-      completedAt: completedAt ?? new Date(),
+      startTime: when,
+      lastConnectionTime: when,
+      completedAt: when,
       errors: ['simulated failure'],
       snapshotDroppedAt,
     });
@@ -81,11 +83,13 @@ describe('SnapshotTableCleaner', () => {
 
   it('skips sessions that are already cleaned', async () => {
     const alreadyCleanedAt = sub(new Date(), { hours: 1 });
+    const when = sub(new Date(), { hours: 48 });
     const sessionId = fakeUUID();
     await models.SyncSession.create({
       id: sessionId,
-      startTime: sub(new Date(), { hours: 48 }),
-      completedAt: sub(new Date(), { hours: 48 }),
+      startTime: when,
+      lastConnectionTime: when,
+      completedAt: when,
       errors: ['simulated failure'],
       snapshotDroppedAt: alreadyCleanedAt,
     });
@@ -97,11 +101,13 @@ describe('SnapshotTableCleaner', () => {
   });
 
   it('ignores successful (non-errored) sessions', async () => {
+    const when = sub(new Date(), { hours: 48 });
     const sessionId = fakeUUID();
     await models.SyncSession.create({
       id: sessionId,
-      startTime: sub(new Date(), { hours: 48 }),
-      completedAt: sub(new Date(), { hours: 48 }),
+      startTime: when,
+      lastConnectionTime: when,
+      completedAt: when,
       errors: null,
       snapshotDroppedAt: null,
     });

--- a/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
+++ b/packages/central-server/__tests__/tasks/SnapshotTableCleaner.test.js
@@ -1,4 +1,3 @@
-import { beforeAll, describe, expect, it } from '@jest/globals';
 import { sub } from 'date-fns';
 
 import { fakeUUID } from '@tamanu/utils/generateId';

--- a/packages/central-server/app/tasks/SnapshotTableCleaner.js
+++ b/packages/central-server/app/tasks/SnapshotTableCleaner.js
@@ -63,21 +63,29 @@ export class SnapshotTableCleaner extends ScheduledTask {
 
     log.info('SnapshotTableCleaner.startBatch', { batchSize: sessions.length });
 
-    for (const { id } of sessions) {
+    const droppedIds = [];
+    for (let i = 0; i < sessions.length; i++) {
+      const { id } = sessions[i];
       try {
         await dropSnapshotTable(this.store.sequelize, id);
         await dropMarkedForSyncPatientsTable(this.store.sequelize, id);
-        await SyncSession.update(
-          { snapshotDroppedAt: new Date() },
-          { where: { id } },
-        );
+        droppedIds.push(id);
       } catch (error) {
         log.warn('SnapshotTableCleaner.dropFailed', {
           sessionId: id,
           error: error instanceof Error ? error.message : String(error),
         });
       }
-      await sleepAsync(batchSleepAsyncDurationInMilliseconds);
+      if (i < sessions.length - 1) {
+        await sleepAsync(batchSleepAsyncDurationInMilliseconds);
+      }
+    }
+
+    if (droppedIds.length > 0) {
+      await SyncSession.update(
+        { snapshotDroppedAt: new Date() },
+        { where: { id: { [Op.in]: droppedIds } } },
+      );
     }
   }
 }

--- a/packages/central-server/app/tasks/SnapshotTableCleaner.js
+++ b/packages/central-server/app/tasks/SnapshotTableCleaner.js
@@ -1,0 +1,83 @@
+import config from 'config';
+import { subHours } from 'date-fns';
+import { Op } from 'sequelize';
+
+import { ScheduledTask } from '@tamanu/shared/tasks';
+import { log } from '@tamanu/shared/services/logging';
+import { sleepAsync } from '@tamanu/utils/sleepAsync';
+import {
+  dropMarkedForSyncPatientsTable,
+  dropSnapshotTable,
+} from '@tamanu/database/sync';
+
+import { InvalidConfigError } from '.';
+
+export class SnapshotTableCleaner extends ScheduledTask {
+  getName() {
+    return 'SnapshotTableCleaner';
+  }
+
+  constructor(context, overrideConfig = null) {
+    const conf = {
+      ...config.schedules.snapshotTableCleaner,
+      ...overrideConfig,
+    };
+    const { schedule, jitterTime, enabled } = conf;
+    super(schedule, log, jitterTime, enabled);
+    this.config = conf;
+    this.store = context.store;
+  }
+
+  getWhere() {
+    return {
+      completedAt: { [Op.lt]: subHours(new Date(), this.config.retentionHours) },
+      errors: { [Op.not]: null },
+      snapshotDroppedAt: { [Op.is]: null },
+    };
+  }
+
+  async countQueue() {
+    const { SyncSession } = this.store.models;
+    return SyncSession.count({ where: this.getWhere() });
+  }
+
+  async run() {
+    const { SyncSession } = this.store.models;
+    const { batchSize, batchSleepAsyncDurationInMilliseconds } = this.config;
+
+    if (!batchSize || !batchSleepAsyncDurationInMilliseconds) {
+      throw new InvalidConfigError(
+        'batchSize and batchSleepAsyncDurationInMilliseconds must be set for SnapshotTableCleaner',
+      );
+    }
+
+    const sessions = await SyncSession.findAll({
+      where: this.getWhere(),
+      attributes: ['id'],
+      order: [['completedAt', 'ASC']],
+      limit: batchSize,
+      raw: true,
+    });
+
+    if (sessions.length === 0) return;
+
+    log.info('SnapshotTableCleaner.startBatch', { batchSize: sessions.length });
+
+    for (const { id } of sessions) {
+      try {
+        await dropSnapshotTable(this.store.sequelize, id);
+        await dropMarkedForSyncPatientsTable(this.store.sequelize, id);
+        await SyncSession.update(
+          { snapshotDroppedAt: new Date() },
+          { where: { id } },
+        );
+      } catch (error) {
+        log.warn('SnapshotTableCleaner.dropFailed', {
+          sessionId: id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      await sleepAsync(batchSleepAsyncDurationInMilliseconds);
+    }
+  }
+}

--- a/packages/central-server/app/tasks/index.js
+++ b/packages/central-server/app/tasks/index.js
@@ -17,6 +17,7 @@ import { IPSRequestProcessor } from './IPSRequestProcessor';
 import { AutomaticLabTestResultPublisher } from './AutomaticLabTestResultPublisher';
 import { CovidClearanceCertificatePublisher } from './CovidClearanceCertificatePublisher';
 import { PlannedMoveTimeout } from './PlannedMoveTimeout';
+import { SnapshotTableCleaner } from './SnapshotTableCleaner';
 import { StaleSyncSessionCleaner } from './StaleSyncSessionCleaner';
 import { FhirMissingResources } from './FhirMissingResources';
 import { PatientTelegramCommunicationProcessor } from './PatientTelegramCommunicationProcessor';
@@ -48,6 +49,7 @@ export async function startScheduledTasks(context) {
     VaccinationReminderProcessor,
     AutomaticLabTestResultPublisher,
     CovidClearanceCertificatePublisher,
+    SnapshotTableCleaner,
     StaleSyncSessionCleaner,
     PlannedMoveTimeout,
     FhirMissingResources,

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -250,6 +250,15 @@
       "schedule": "* * * * *",
       "staleSessionSeconds": 3600
     },
+    "snapshotTableCleaner": {
+      "enabled": true,
+      // Once a minute between 01:00 and 05:59 server-local time, which is
+      // usually low-use hours since facility timezones follow their users.
+      "schedule": "* 1-5 * * *",
+      "retentionHours": 24,
+      "batchSize": 1000,
+      "batchSleepAsyncDurationInMilliseconds": 100
+    },
     "processSyncQueue": {
       "enabled": true,
       "schedule": "* * * * *"

--- a/packages/database/src/migrations/1776908908321-addSnapshotDroppedAtToSyncSessions.ts
+++ b/packages/database/src/migrations/1776908908321-addSnapshotDroppedAtToSyncSessions.ts
@@ -1,0 +1,12 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.addColumn('sync_sessions', 'snapshot_dropped_at', {
+    type: DataTypes.DATE,
+    allowNull: true,
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.removeColumn('sync_sessions', 'snapshot_dropped_at');
+}

--- a/packages/database/src/migrations/1776908908321-addSnapshotDroppedAtToSyncSessions.ts
+++ b/packages/database/src/migrations/1776908908321-addSnapshotDroppedAtToSyncSessions.ts
@@ -5,8 +5,16 @@ export async function up(query: QueryInterface): Promise<void> {
     type: DataTypes.DATE,
     allowNull: true,
   });
+  await query.sequelize.query(`
+    CREATE INDEX sync_sessions_pending_snapshot_cleanup_idx
+      ON sync_sessions (completed_at)
+      WHERE errors IS NOT NULL AND snapshot_dropped_at IS NULL;
+  `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
+  await query.sequelize.query(
+    `DROP INDEX IF EXISTS sync_sessions_pending_snapshot_cleanup_idx;`,
+  );
   await query.removeColumn('sync_sessions', 'snapshot_dropped_at');
 }

--- a/packages/database/src/models/SyncSession.ts
+++ b/packages/database/src/models/SyncSession.ts
@@ -12,6 +12,7 @@ export class SyncSession extends Model {
   declare snapshotCompletedAt?: Date;
   declare persistCompletedAt?: Date;
   declare completedAt?: Date;
+  declare snapshotDroppedAt?: Date;
   declare startedAtTick?: number;
   declare pullSince?: number;
   declare pullUntil?: number;
@@ -29,6 +30,7 @@ export class SyncSession extends Model {
         snapshotCompletedAt: { type: DataTypes.DATE },
         persistCompletedAt: { type: DataTypes.DATE },
         completedAt: { type: DataTypes.DATE },
+        snapshotDroppedAt: { type: DataTypes.DATE },
         startedAtTick: { type: DataTypes.BIGINT },
         pullSince: { type: DataTypes.BIGINT },
         pullUntil: { type: DataTypes.BIGINT },

--- a/packages/database/src/sync/completeSyncSession.ts
+++ b/packages/database/src/sync/completeSyncSession.ts
@@ -14,4 +14,5 @@ export const completeSyncSession = async (store: Store, sessionId: string, error
   await session?.save();
   await dropSnapshotTable(store.sequelize, sessionId);
   await dropMarkedForSyncPatientsTable(store.sequelize, sessionId);
+  await session?.update({ snapshotDroppedAt: new Date() });
 };

--- a/packages/database/src/sync/completeSyncSession.ts
+++ b/packages/database/src/sync/completeSyncSession.ts
@@ -2,12 +2,15 @@ import type { Store } from '../types/sync';
 import { dropSnapshotTable, dropMarkedForSyncPatientsTable } from './manageSnapshotTable';
 
 export const completeSyncSession = async (store: Store, sessionId: string, error: string) => {
-  // just drop the snapshots, leaving sessions themselves as an artefact that forms a paper trail
+  // Sessions themselves stay as an artefact that forms a paper trail.
+  // Happy-path snapshots are dropped immediately; errored snapshots are retained
+  // for debugging and later reaped by SnapshotTableCleaner.
   const session = await store.models.SyncSession?.findByPk(sessionId);
-  session!.completedAt = new Date();
   if (error) {
     await session?.markErrored(error);
+    return;
   }
+  session!.completedAt = new Date();
   await session?.save();
   await dropSnapshotTable(store.sequelize, sessionId);
   await dropMarkedForSyncPatientsTable(store.sequelize, sessionId);


### PR DESCRIPTION
### Changes

markErrored previously left the `sync_snapshots.{sessionId}` and marked-for-sync-patients tables on disk because error paths throughout `CentralSyncManager` bypass `completeSyncSession`. One on-prem client accumulated ~190k orphan tables / hundreds of GB.

Instead of dropping tables immediately on error (which loses useful debugging state), retain errored snapshots for 24 hours and let a new scheduled task reap them in batches overnight (01:00–05:59 server-local). Happy-path snapshots are still dropped immediately since there's nothing to refer back to.

New `SnapshotTableCleaner` task tracks progress via a new `sync_sessions.snapshot_dropped_at` column so the backlog is processed gradually — default 1000/min × 5 hours clears the ~190k table backlog in a single night. Knobs live under `schedules.snapshotTableCleaner` in central config.

Supersedes #9643.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->