### PR TITLE
ci(E2E): No-issue: Actually enforce E2E on merge

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 
 on:
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,10 @@ jobs:
       - run: npm i
       - run: git diff --exit-code
 
+  e2e:
+    name: E2E
+    uses: ./.github/workflows/ci-e2e.yml
+
   dbt-model:
     needs: node_modules_cache
     name: DBT model up to date
@@ -390,6 +394,7 @@ jobs:
       - test-mobile
       - test-facility-offline
       - test-package-lock
+      - e2e
       - dbt-model
       - dbt-todos
       - typos


### PR DESCRIPTION
### Changes

Turns out I didn't actually stop a merge from happening if the checks were failing.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI gating by making the reusable E2E workflow a required dependency for the merge-blocking `tests-pass` job; misconfiguration could block merges or allow failures through.
> 
> **Overview**
> **E2E is now enforced as part of required CI.** The `ci-e2e.yml` workflow is converted from `pull_request` to `workflow_call`, and `ci.yml` adds a dedicated `e2e` job that invokes it.
> 
> `tests-pass` now explicitly `needs: e2e`, so merges are blocked unless the E2E workflow succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a519bf4cdf144b1f99c50e98cb637911e9fe284a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->