### PR TITLE
feat: Add locale setting for dates

### DIFF
--- a/packages/central-server/app/createApi.js
+++ b/packages/central-server/app/createApi.js
@@ -4,10 +4,12 @@ import config from 'config';
 import defineExpress from 'express';
 import asyncHandler from 'express-async-handler';
 import helmet from 'helmet';
+import { AsyncLocalStorage } from 'async_hooks';
 
 import { getLoggingMiddleware, log } from '@tamanu/shared/services/logging';
 import { constructPermission } from '@tamanu/shared/permissions/middleware';
 import { SERVER_TYPES } from '@tamanu/constants';
+import { setDateTimeLocaleGetter } from '@tamanu/utils/dateTime';
 
 import { buildRoutes } from './buildRoutes';
 import { authModule } from './auth';
@@ -24,6 +26,23 @@ import { createServer } from 'http';
 
 import { settingsReaderMiddleware } from '@tamanu/settings/middleware';
 import { attachAuditUserToDbSession } from '@tamanu/database/utils/audit';
+
+const dateTimeLocaleStorage = new AsyncLocalStorage();
+setDateTimeLocaleGetter(() => dateTimeLocaleStorage.getStore()?.locale);
+
+const bindRequestDateTimeLocale = (req, _res, next) => {
+  dateTimeLocaleStorage.run({ locale: null }, async () => {
+    try {
+      const store = dateTimeLocaleStorage.getStore();
+      if (store && req.settings?.get) {
+        store.locale = await req.settings.get('locale');
+      }
+      next();
+    } catch (error) {
+      next(error);
+    }
+  });
+};
 
 const rawBodySaver = function (req, res, buf) {
   if (buf && buf.length) {
@@ -108,6 +127,7 @@ export async function createApi(ctx) {
   });
 
   express.use(settingsReaderMiddleware);
+  express.use(bindRequestDateTimeLocale);
 
   express.get('/$', (req, res) => {
     res.send({

--- a/packages/constants/src/suggesters.ts
+++ b/packages/constants/src/suggesters.ts
@@ -31,6 +31,7 @@ export const SUGGESTER_ENDPOINTS = [
   'role',
   'encounter',
   'reportDefinition',
+  'locale',
   'timeZone',
   'patientFieldDefinitionCategory',
   'invoicePriceList',

--- a/packages/facility-server/__tests__/apiv1/Suggestions.test.js
+++ b/packages/facility-server/__tests__/apiv1/Suggestions.test.js
@@ -1247,4 +1247,45 @@ describe('Suggestions', () => {
     expect(body.length).toBeGreaterThan(0);
     expect(body[0]).toHaveProperty('id', childSubdivision.id);
   });
+
+  describe('Locales', () => {
+    beforeAll(async () => {
+      await findOneOrCreate(
+        models,
+        models.TranslatedString,
+        {
+          stringId: 'test.locale.en',
+          language: 'en',
+        },
+        {
+          text: 'English',
+        },
+      );
+
+      await findOneOrCreate(
+        models,
+        models.TranslatedString,
+        {
+          stringId: 'test.locale.fr',
+          language: 'fr',
+        },
+        {
+          text: 'French',
+        },
+      );
+    });
+
+    it('should return locale suggestions from available language codes', async () => {
+      const result = await userApp.get('/api/suggestions/locale');
+      expect(result).toHaveSucceeded();
+      expect(result.body).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'en' })]));
+      expect(result.body).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'fr' })]));
+    });
+
+    it('should return a specific locale by id', async () => {
+      const result = await userApp.get('/api/suggestions/locale/fr');
+      expect(result).toHaveSucceeded();
+      expect(result.body).toEqual({ id: 'fr', name: 'fr' });
+    });
+  });
 });

--- a/packages/facility-server/app/createApiApp.js
+++ b/packages/facility-server/app/createApiApp.js
@@ -1,10 +1,12 @@
 import config from 'config';
 import defineExpress from 'express';
 import helmet from 'helmet';
+import { AsyncLocalStorage } from 'async_hooks';
 
 import { settingsReaderMiddleware } from '@tamanu/settings/middleware';
 import { defineDbNotifier } from '@tamanu/shared/services/dbNotifier';
 import { NOTIFY_CHANNELS } from '@tamanu/constants';
+import { setDateTimeLocaleGetter } from '@tamanu/utils/dateTime';
 
 import routes from './routes';
 import errorHandler from './middleware/errorHandler';
@@ -14,6 +16,38 @@ import { createServer } from 'http';
 import { defineWebsocketService } from './services/websocketService';
 import { defineWebsocketClientService } from './services/websocketClientService';
 import { addFacilityMiddleware } from './addFacilityMiddleware';
+
+const dateTimeLocaleStorage = new AsyncLocalStorage();
+setDateTimeLocaleGetter(() => dateTimeLocaleStorage.getStore()?.locale);
+
+const getFacilityRequestLocale = async req => {
+  if (!req.settings || typeof req.settings.get === 'function') {
+    return req.settings?.get ? req.settings.get('locale') : null;
+  }
+
+  const requestedFacilityId =
+    req.facilityId || req.params?.facilityId || req.query?.facilityId || req.body?.facilityId;
+  const configuredFacilityIds = Object.keys(req.settings);
+  const facilityId =
+    requestedFacilityId || (configuredFacilityIds.length === 1 ? configuredFacilityIds[0] : null);
+  if (!facilityId) return null;
+
+  return req.settings[facilityId]?.get('locale') ?? null;
+};
+
+const bindRequestDateTimeLocale = (req, _res, next) => {
+  dateTimeLocaleStorage.run({ locale: null }, async () => {
+    try {
+      const store = dateTimeLocaleStorage.getStore();
+      if (store) {
+        store.locale = await getFacilityRequestLocale(req);
+      }
+      next();
+    } catch (error) {
+      next(error);
+    }
+  });
+};
 
 /**
  * @param {import('./ApplicationContext').ApplicationContext} ctx
@@ -66,6 +100,7 @@ export async function createApiApp({
   express.use(versionCompatibility);
 
   express.use(settingsReaderMiddleware);
+  express.use(bindRequestDateTimeLocale);
 
   // index route for debugging connectivity
   express.get('/$', (req, res) => {

--- a/packages/patient-portal/src/utils/format.ts
+++ b/packages/patient-portal/src/utils/format.ts
@@ -1,5 +1,6 @@
 import { SEX_LABELS } from '@tamanu/constants';
 import { startOfWeek, parseISO } from 'date-fns';
+import { resolveDateTimeLocale } from '@tamanu/utils/dateTime';
 import type {
   Location,
   Appointment,
@@ -8,7 +9,7 @@ import type {
   AdministeredVaccine,
 } from '@tamanu/shared/schemas/patientPortal';
 
-const locale = globalThis.navigator?.language ?? 'default';
+const locale = resolveDateTimeLocale();
 
 const dateFormatter = new Intl.DateTimeFormat(locale, { dateStyle: 'short' });
 const dateTimeFormatter = new Intl.DateTimeFormat(locale, {

--- a/packages/settings/__tests__/schema.test.js
+++ b/packages/settings/__tests__/schema.test.js
@@ -88,6 +88,10 @@ describe('Schemas', () => {
   });
 
   describe('Global settings', () => {
+    it('Should default locale to en', () => {
+      expect(globalDefaults.locale).toBe('en');
+    });
+
     it('Should validate valid settings', async () => {
       const validSettings = {
         customisations: {
@@ -209,6 +213,10 @@ describe('Schemas', () => {
   });
 
   describe('Facility settings', () => {
+    it('Should default locale to null', () => {
+      expect(facilityDefaults.locale).toBeNull();
+    });
+
     it('Should validate valid settings', async () => {
       const validSettings = {
         vaccinations: {},
@@ -344,6 +352,7 @@ describe('Exposed keys', () => {
         'invoice',
         'labsCancellationReasons',
         'layouts',
+        'locale',
         'locationAssignments',
         'medications',
         'printMeasures',

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -141,6 +141,13 @@ export const facilitySettings = {
       defaultValue: null,
       suggesterEndpoint: 'timeZone',
     },
+    locale: {
+      exposedToWeb: true,
+      description: 'Locale used for date and time formatting',
+      type: yup.string().nullable(),
+      defaultValue: null,
+      suggesterEndpoint: 'locale',
+    },
     patientDisplayIdPattern: {
       exposedToWeb: true,
       highRisk: true,

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -97,6 +97,13 @@ export const globalSettings = {
       type: ageDisplayFormatSchema,
       defaultValue: ageDisplayFormatDefault,
     },
+    locale: {
+      exposedToWeb: true,
+      description: 'Locale used for date and time formatting',
+      type: yup.string(),
+      defaultValue: 'en',
+      suggesterEndpoint: 'locale',
+    },
     appointments: {
       description: 'Appointment settings',
       exposedToWeb: true,

--- a/packages/shared/src/services/suggestions/suggestions.js
+++ b/packages/shared/src/services/suggestions/suggestions.js
@@ -1289,6 +1289,10 @@ const timeZoneValues =
 const TIME_ZONES = timeZoneValues.map(tz => ({ id: tz, name: tz }));
 const TIME_ZONES_LOWER = timeZoneValues.map(tz => tz.toLowerCase());
 
+const DEFAULT_LOCALE = 'en';
+const mapLanguageToLocale = language =>
+  language === DEFAULT_LANGUAGE_CODE ? DEFAULT_LOCALE : language;
+
 suggestions.get(
   '/timeZone$',
   asyncHandler(async (req, res) => {
@@ -1308,6 +1312,38 @@ suggestions.get(
     const tz = TIME_ZONES.find(t => t.id === req.params.id);
     if (!tz) throw new NotFoundError();
     res.send(tz);
+  }),
+);
+
+suggestions.get(
+  '/locale$',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const searchQuery = (req.query.q || '').trim().toLowerCase();
+    const { languagesInDb } = await req.models.TranslatedString.getPossibleLanguages();
+
+    const locales = [...new Set(languagesInDb.map(({ language }) => mapLanguageToLocale(language)))];
+    const localeOptions = locales.map(locale => ({ id: locale, name: locale }));
+    const filteredOptions = searchQuery
+      ? localeOptions.filter(({ id, name }) => {
+          const lowerId = id.toLowerCase();
+          const lowerName = name.toLowerCase();
+          return lowerId.includes(searchQuery) || lowerName.includes(searchQuery);
+        })
+      : localeOptions;
+
+    res.send(filteredOptions.slice(0, DEFAULT_LIMIT));
+  }),
+);
+
+suggestions.get(
+  '/locale/:id',
+  asyncHandler(async (req, res) => {
+    req.flagPermissionChecked();
+    const { languagesInDb } = await req.models.TranslatedString.getPossibleLanguages();
+    const locales = new Set(languagesInDb.map(({ language }) => mapLanguageToLocale(language)));
+    if (!locales.has(req.params.id)) throw new NotFoundError();
+    res.send({ id: req.params.id, name: req.params.id });
   }),
 );
 

--- a/packages/shared/src/utils/pdf/withDateTimeContext.jsx
+++ b/packages/shared/src/utils/pdf/withDateTimeContext.jsx
@@ -21,17 +21,22 @@ export const withDateTimeContext = Component => props => {
   const getSetting = getSettingProp ?? (key => get(settings, key));
 
   const facilityTimeZone = getSetting('facilityTimeZone');
+  const locale = getSetting('locale');
   const effectiveTimeZone = facilityTimeZone ?? primaryTimeZone;
 
   const value = useMemo(
     () => ({
       primaryTimeZone,
       facilityTimeZone,
+      locale,
       getCurrentDate: () => getCurrentDateStringInTimezone(effectiveTimeZone),
       getCurrentDateTime: () => getCurrentDateTimeStringInTimezone(primaryTimeZone),
-      ...mapValues(dateTimeFormatters, fn => date => fn(date, primaryTimeZone, facilityTimeZone)),
+      ...mapValues(
+        dateTimeFormatters,
+        fn => date => fn(date, primaryTimeZone, facilityTimeZone, locale),
+      ),
     }),
-    [primaryTimeZone, facilityTimeZone, effectiveTimeZone],
+    [primaryTimeZone, facilityTimeZone, effectiveTimeZone, locale],
   );
 
   return (

--- a/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
+++ b/packages/ui-components/src/components/DateDisplay/DateDisplay.jsx
@@ -25,6 +25,7 @@ const DateTooltip = ({
   timeOnlyTooltip,
   facilityTimeZone,
   primaryTimeZone,
+  locale,
   children,
 }) => {
   const isDateOnly = typeof rawDate === 'string' && isISO9075DateString(rawDate);
@@ -61,6 +62,7 @@ const DateTooltip = ({
       displayDate={displayDate}
       primaryTimeZone={primaryTimeZone}
       facilityTimeZone={facilityTimeZone}
+      locale={locale}
     />
   ) : (
     dateTooltip
@@ -139,7 +141,7 @@ const useFormattedDate = (dateValue, { dateFormat, timeFormat, weekdayFormat }) 
  */
 export const TimeDisplay = React.memo(
   ({ date: dateValue, format: timeFormat = 'default', noTooltip = false, style, ...props }) => {
-    const { primaryTimeZone, facilityTimeZone } = useDateTime();
+    const { primaryTimeZone, facilityTimeZone, locale } = useDateTime();
     const displayTime = useFormattedDate(dateValue, { timeFormat });
 
     const content = (
@@ -157,6 +159,7 @@ export const TimeDisplay = React.memo(
         timeOnlyTooltip
         facilityTimeZone={facilityTimeZone}
         primaryTimeZone={primaryTimeZone}
+        locale={locale}
       >
         {content}
       </DateTooltip>
@@ -217,7 +220,7 @@ export const DateDisplay = React.memo(
     timeOnlyTooltip = false,
     ...props
   }) => {
-    const { primaryTimeZone, facilityTimeZone } = useDateTime();
+    const { primaryTimeZone, facilityTimeZone, locale } = useDateTime();
 
     const displayDate = useFormattedDate(dateValue, {
       dateFormat,
@@ -240,6 +243,7 @@ export const DateDisplay = React.memo(
         timeOnlyTooltip={timeOnlyTooltip}
         facilityTimeZone={facilityTimeZone}
         primaryTimeZone={primaryTimeZone}
+        locale={locale}
       >
         {content}
       </DateTooltip>

--- a/packages/ui-components/src/components/DateDisplay/DiagnosticInfo.jsx
+++ b/packages/ui-components/src/components/DateDisplay/DiagnosticInfo.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { getTimezoneOffset } from 'date-fns-tz';
 
-import { locale } from '@tamanu/utils/dateTime';
+import { resolveDateTimeLocale } from '@tamanu/utils/dateTime';
 
 /**
  * Get the formatted offset for a given timezone.
@@ -18,7 +18,13 @@ const getFormattedOffset = (tz) => {
   return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 };
 
-export const DiagnosticInfo = ({ rawDate, displayDate, facilityTimeZone, primaryTimeZone }) => {
+export const DiagnosticInfo = ({
+  rawDate,
+  displayDate,
+  facilityTimeZone,
+  primaryTimeZone,
+  locale,
+}) => {
   const displayTimeZone = facilityTimeZone || primaryTimeZone;
   const displayOffset = getFormattedOffset(displayTimeZone);
   const parsedRawDate = typeof rawDate === 'string' ? rawDate : rawDate.toISOString();
@@ -29,7 +35,7 @@ export const DiagnosticInfo = ({ rawDate, displayDate, facilityTimeZone, primary
       <strong>Displayed timezone:</strong> {displayTimeZone} <br />
       <strong>Displayed offset:</strong> {displayOffset} <br />
       <strong>Display date:</strong> {displayDate} <br />
-      <strong>Locale:</strong> {locale}
+      <strong>Locale:</strong> {resolveDateTimeLocale(locale)}
     </div>
   );
 };

--- a/packages/ui-components/src/contexts/DateTimeContext.tsx
+++ b/packages/ui-components/src/contexts/DateTimeContext.tsx
@@ -25,6 +25,7 @@ type WrappedFormatters = {
 export interface DateTimeContextValue extends WrappedFormatters {
   primaryTimeZone: string;
   facilityTimeZone?: string | null;
+  locale?: string | null;
   /** Get current date string in facilityTimeZone */
   getCurrentDate: () => string;
   /** Get current datetime string in primaryTimeZone (ISO 9075) */
@@ -45,6 +46,7 @@ interface DateTimeProviderProps {
   children: React.ReactNode;
   primaryTimeZone?: string;
   facilityTimeZone?: string | null;
+  locale?: string | null;
 }
 
 /** Exported so consumers can inject a datetime value (e.g. when rendering in an isolated root for export). */
@@ -67,21 +69,24 @@ const DateTimeProviderInner = ({
   children,
   primaryTimeZone,
   facilityTimeZone,
+  locale,
 }: {
   children: React.ReactNode;
   primaryTimeZone: string;
   facilityTimeZone?: string | null;
+  locale?: string | null;
 }) => {
   const bindTimeZones = useCallback(
     (fn: (...args: any[]) => any) => (date?: DateInput) =>
-      fn(date, primaryTimeZone, facilityTimeZone),
-    [primaryTimeZone, facilityTimeZone],
+      fn(date, primaryTimeZone, facilityTimeZone, locale),
+    [primaryTimeZone, facilityTimeZone, locale],
   );
 
   const value = useMemo(
     (): DateTimeContextValue => ({
       primaryTimeZone,
       facilityTimeZone,
+      locale,
       ...(mapValues(dateTimeFormatters, bindTimeZones) as WrappedFormatters),
       getCurrentDate: () => getCurrentDateStringInTimezone(facilityTimeZone ?? primaryTimeZone),
       getCurrentDateTime: () => getCurrentDateTimeStringInTimezone(primaryTimeZone),
@@ -92,7 +97,7 @@ const DateTimeProviderInner = ({
       storedDateTimeToEpochMilliseconds: storedValue =>
         storedDateTimeToEpochMilliseconds(storedValue, primaryTimeZone),
     }),
-    [primaryTimeZone, facilityTimeZone, bindTimeZones],
+    [primaryTimeZone, facilityTimeZone, locale, bindTimeZones],
   );
 
   return React.createElement(DateTimeProviderContext.Provider, { value }, children);
@@ -102,6 +107,7 @@ export const DateTimeProvider = ({
   children,
   primaryTimeZone: primaryTimeZoneProp,
   facilityTimeZone: facilityTimeZoneProp,
+  locale: localeProp,
 }: DateTimeProviderProps) => {
   const { primaryTimeZone: authPrimaryTimeZone } = useAuth();
   const { getSetting } = useSettings();
@@ -119,11 +125,13 @@ export const DateTimeProvider = ({
   const facilityTimeZone = usePropsMode
     ? facilityTimeZoneProp
     : (getSetting('facilityTimeZone') as string | undefined);
+  const locale = usePropsMode ? localeProp : (getSetting('locale') as string | undefined);
 
   return (
     <DateTimeProviderInner
       primaryTimeZone={primaryTimeZone}
       facilityTimeZone={facilityTimeZone}
+      locale={locale}
     >
       {children}
     </DateTimeProviderInner>

--- a/packages/utils/__test__/dateTime.test.ts
+++ b/packages/utils/__test__/dateTime.test.ts
@@ -1,13 +1,15 @@
-import { describe, test, expect, it } from 'vitest';
+import { afterEach, describe, test, expect, it } from 'vitest';
 import {
   datetimeCustomValidation,
   doAgeRangesHaveGaps,
   doAgeRangesOverlap,
   endpointsOfDay,
+  intlFormatDate,
   isIntervalWithinInterval,
   isWithinIntervalExcludingEnd,
   maxValidDate,
   minValidDate,
+  setDateTimeLocaleGetter,
   type AgeRange,
 } from '../src/dateTime';
 import { startOfDay, endOfDay } from 'date-fns';
@@ -70,6 +72,33 @@ describe('dateTime utilities', () => {
 
     expect(minValidDate(dates)).toEqual(new Date('2023-10-09'));
     expect(minValidDate(invalidDates)).toBeNull();
+  });
+});
+
+describe('date locale resolution', () => {
+  afterEach(() => {
+    setDateTimeLocaleGetter(null);
+  });
+
+  it('should use locale passed directly to intlFormatDate', () => {
+    setDateTimeLocaleGetter(() => 'fr');
+    const result = intlFormatDate(
+      '2024-03-18',
+      { weekday: 'long' },
+      'Unknown',
+      'UTC',
+      undefined,
+      'en',
+    );
+
+    expect(result.toLowerCase()).toContain('monday');
+  });
+
+  it('should use request-bound locale when no explicit locale is passed', () => {
+    setDateTimeLocaleGetter(() => 'fr');
+    const result = intlFormatDate('2024-03-18', { weekday: 'long' }, 'Unknown', 'UTC');
+
+    expect(result.toLowerCase()).toContain('lundi');
   });
 });
 

--- a/packages/utils/src/dateFormatters.ts
+++ b/packages/utils/src/dateFormatters.ts
@@ -1,4 +1,4 @@
-import { intlFormatDate, type DateInput } from './dateTime';
+import { intlFormatDate, type DateInput, type LocaleInput } from './dateTime';
 
 const createFormatter =
   (
@@ -6,8 +6,20 @@ const createFormatter =
     fallback: string,
     transform?: (result: string) => string,
   ) =>
-  (date: DateInput, primaryTimeZone: string, facilityTimeZone?: string | null): string => {
-    const result = intlFormatDate(date, formatOptions, fallback, primaryTimeZone, facilityTimeZone);
+  (
+    date: DateInput,
+    primaryTimeZone: string,
+    facilityTimeZone?: string | null,
+    locale?: LocaleInput,
+  ): string => {
+    const result = intlFormatDate(
+      date,
+      formatOptions,
+      fallback,
+      primaryTimeZone,
+      facilityTimeZone,
+      locale,
+    );
     return transform ? transform(result) : result;
   };
 
@@ -70,13 +82,15 @@ export const formatShortDateTime = (
   date: DateInput,
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  locale?: LocaleInput,
 ) =>
-  `${formatShort(date, primaryTimeZone, facilityTimeZone)} ${formatTime(date, primaryTimeZone, facilityTimeZone)}`;
+  `${formatShort(date, primaryTimeZone, facilityTimeZone, locale)} ${formatTime(date, primaryTimeZone, facilityTimeZone, locale)}`;
 
 /** "12/04/24 12:30am" */
 export const formatShortestDateTime = (
   date: DateInput,
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  locale?: LocaleInput,
 ) =>
-  `${formatShortest(date, primaryTimeZone, facilityTimeZone)} ${formatTime(date, primaryTimeZone, facilityTimeZone)}`;
+  `${formatShortest(date, primaryTimeZone, facilityTimeZone, locale)} ${formatTime(date, primaryTimeZone, facilityTimeZone, locale)}`;

--- a/packages/utils/src/dateTime.ts
+++ b/packages/utils/src/dateTime.ts
@@ -29,6 +29,7 @@ import { z } from 'zod';
 import { TIME_UNIT_OPTIONS } from '@tamanu/constants';
 
 export type DateInput = string | Date | null | undefined;
+export type LocaleInput = string | null | undefined;
 
 export const ISO9075_DATE_FORMAT = 'yyyy-MM-dd';
 export const ISO9075_DATETIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
@@ -200,6 +201,15 @@ export const differenceInMilliseconds = (a: number | string | Date, b: number | 
 
 export const locale = globalThis.navigator?.language ?? 'default';
 
+let dateTimeLocaleGetter: (() => LocaleInput) | null = null;
+
+export const setDateTimeLocaleGetter = (getter: (() => LocaleInput) | null) => {
+  dateTimeLocaleGetter = getter;
+};
+
+export const resolveDateTimeLocale = (inputLocale?: LocaleInput): string =>
+  inputLocale || dateTimeLocaleGetter?.() || locale;
+
 export const isStartOfThisWeek = (date: Date | number) =>
   isSameDay(date, startOfWeek(new Date(), { weekStartsOn: 1 }));
 
@@ -305,13 +315,15 @@ export const intlFormatDate = (
   fallback = 'Unknown',
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  localeInput?: LocaleInput,
 ) => {
   if (!date) return fallback;
+  const resolvedLocale = resolveDateTimeLocale(localeInput);
 
   try {
     if (date instanceof Date) {
       if (!isValid(date)) return fallback;
-      return date.toLocaleString(locale, formatOptions);
+      return date.toLocaleString(resolvedLocale, formatOptions);
     }
 
     if (isISO9075DateString(date)) {
@@ -319,9 +331,9 @@ export const intlFormatDate = (
       const timeKeys = ['hour', 'minute', 'second', 'timeStyle', 'dayPeriod'] as const;
       const hasTimeOptions = timeKeys.some(key => key in formatOptions);
       if (hasTimeOptions) {
-        return plainDate.toPlainDateTime().toLocaleString(locale, formatOptions);
+        return plainDate.toPlainDateTime().toLocaleString(resolvedLocale, formatOptions);
       }
-      return plainDate.toLocaleString(locale, formatOptions);
+      return plainDate.toLocaleString(resolvedLocale, formatOptions);
     }
 
     const displayTz = getDisplayTimezone(primaryTimeZone, facilityTimeZone);
@@ -331,10 +343,10 @@ export const intlFormatDate = (
       return plain
         .toZonedDateTime(primaryTimeZone)
         .withTimeZone(displayTz)
-        .toLocaleString(locale, formatOptions);
+        .toLocaleString(resolvedLocale, formatOptions);
     }
 
-    return plain.toLocaleString(locale, formatOptions);
+    return plain.toLocaleString(resolvedLocale, formatOptions);
   } catch (error) {
     logDateError('intlFormatDate', error, date, primaryTimeZone, facilityTimeZone);
     return fallback;

--- a/packages/web/app/components/Medication/Mar/MarTable.jsx
+++ b/packages/web/app/components/Medication/Mar/MarTable.jsx
@@ -6,7 +6,7 @@ import {
   getDateFromTimeString,
   findAdministrationTimeSlotFromIdealTime,
 } from '@tamanu/shared/utils/medication';
-import { toDateString, locale } from '@tamanu/utils/dateTime';
+import { toDateString, resolveDateTimeLocale } from '@tamanu/utils/dateTime';
 import { useDateTime } from '@tamanu/ui-components';
 
 import { Colors } from '../../../constants';
@@ -153,12 +153,12 @@ const LoadingContainer = styled.div`
 `;
 
 // Convert time string to locale-specific time string no timezone conversion is applied
-const formatSlotTime = timeStr =>
-  Intl.DateTimeFormat(locale, { hour: 'numeric', hour12: true }).format(
+const formatSlotTime = (timeStr, locale) =>
+  Intl.DateTimeFormat(resolveDateTimeLocale(locale), { hour: 'numeric', hour12: true }).format(
     new Date(`2000-01-01T${timeStr === '24:00' ? '00:00' : timeStr}:00`),
   );
 
-const TimeSlotHeader = ({ periodLabel, startTime, endTime, selectedDate, facilityNow }) => {
+const TimeSlotHeader = ({ periodLabel, startTime, endTime, selectedDate, facilityNow, locale }) => {
   const now = facilityNow.getTime();
   const startDate = getDateFromTimeString(startTime, facilityNow).getTime();
   const endDate = getDateFromTimeString(endTime, facilityNow).getTime();
@@ -170,7 +170,7 @@ const TimeSlotHeader = ({ periodLabel, startTime, endTime, selectedDate, facilit
       <TimeSlotText>
         <TimeSlotLabel>{periodLabel || ''}</TimeSlotLabel>
         <div>
-          {formatSlotTime(startTime)} - {formatSlotTime(endTime)}
+          {formatSlotTime(startTime, locale)} - {formatSlotTime(endTime, locale)}
         </div>
       </TimeSlotText>
     </TimeSlotHeaderContainer>
@@ -179,7 +179,7 @@ const TimeSlotHeader = ({ periodLabel, startTime, endTime, selectedDate, facilit
 
 export const MarTable = ({ selectedDate }) => {
   const { encounter } = useEncounter();
-  const { getFacilityNowDate } = useDateTime();
+  const { getFacilityNowDate, locale } = useDateTime();
   const facilityNow = getFacilityNowDate();
   const scheduledSectionRef = useRef(null);
   const scheduledHeaderRef = useRef(null);
@@ -324,6 +324,7 @@ export const MarTable = ({ selectedDate }) => {
             index={index}
             selectedDate={selectedDate}
             facilityNow={facilityNow}
+            locale={locale}
           />
         ))}
       </HeaderRow>


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how date/time strings are formatted across server-rendered PDFs and multiple UIs, and introduces request-scoped `AsyncLocalStorage` state in both central and facility servers.
> 
> **Overview**
> Adds a new `locale` setting (global default `en`, facility default `null`) and exposes it to the web, including a new `suggestions/locale` endpoint backed by available translation language codes.
> 
> Plumbs locale through the date/time formatting stack: `@tamanu/utils/dateTime` now resolves locale via an overridable getter, servers bind the locale per request using `AsyncLocalStorage`, and UI/PDF components pass `locale` into shared date formatters (including patient portal formatting and MAR time-slot headers). Tests are added/updated to cover locale defaults, suggester behavior, and locale resolution precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410cca493468ba615db6da18d133bbbe0647df58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->