### PR TITLE
fix: Release fix: 2.54: Fix locale on server generated PDFs

### DIFF
--- a/packages/shared/src/utils/pdf/withDateTimeContext.jsx
+++ b/packages/shared/src/utils/pdf/withDateTimeContext.jsx
@@ -22,6 +22,8 @@ export const withDateTimeContext = Component => props => {
 
   const facilityTimeZone = getSetting('facilityTimeZone');
   const effectiveTimeZone = facilityTimeZone ?? primaryTimeZone;
+  // TODO: Make configurable through settings
+  const dateLocale = 'en-GB';
 
   const value = useMemo(
     () => ({
@@ -29,9 +31,12 @@ export const withDateTimeContext = Component => props => {
       facilityTimeZone,
       getCurrentDate: () => getCurrentDateStringInTimezone(effectiveTimeZone),
       getCurrentDateTime: () => getCurrentDateTimeStringInTimezone(primaryTimeZone),
-      ...mapValues(dateTimeFormatters, fn => date => fn(date, primaryTimeZone, facilityTimeZone)),
+      ...mapValues(
+        dateTimeFormatters,
+        fn => date => fn(date, primaryTimeZone, facilityTimeZone, dateLocale),
+      ),
     }),
-    [primaryTimeZone, facilityTimeZone, effectiveTimeZone],
+    [primaryTimeZone, facilityTimeZone, effectiveTimeZone, dateLocale],
   );
 
   return (

--- a/packages/utils/src/dateFormatters.ts
+++ b/packages/utils/src/dateFormatters.ts
@@ -6,8 +6,20 @@ const createFormatter =
     fallback: string,
     transform?: (result: string) => string,
   ) =>
-  (date: DateInput, primaryTimeZone: string, facilityTimeZone?: string | null): string => {
-    const result = intlFormatDate(date, formatOptions, fallback, primaryTimeZone, facilityTimeZone);
+  (
+    date: DateInput,
+    primaryTimeZone: string,
+    facilityTimeZone?: string | null,
+    locale?: string,
+  ): string => {
+    const result = intlFormatDate(
+      date,
+      formatOptions,
+      fallback,
+      primaryTimeZone,
+      facilityTimeZone,
+      locale,
+    );
     return transform ? transform(result) : result;
   };
 
@@ -70,13 +82,15 @@ export const formatShortDateTime = (
   date: DateInput,
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  locale?: string,
 ) =>
-  `${formatShort(date, primaryTimeZone, facilityTimeZone)} ${formatTime(date, primaryTimeZone, facilityTimeZone)}`;
+  `${formatShort(date, primaryTimeZone, facilityTimeZone, locale)} ${formatTime(date, primaryTimeZone, facilityTimeZone, locale)}`;
 
 /** "12/04/24 12:30am" */
 export const formatShortestDateTime = (
   date: DateInput,
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  locale?: string,
 ) =>
-  `${formatShortest(date, primaryTimeZone, facilityTimeZone)} ${formatTime(date, primaryTimeZone, facilityTimeZone)}`;
+  `${formatShortest(date, primaryTimeZone, facilityTimeZone, locale)} ${formatTime(date, primaryTimeZone, facilityTimeZone, locale)}`;

--- a/packages/utils/src/dateTime.ts
+++ b/packages/utils/src/dateTime.ts
@@ -305,13 +305,15 @@ export const intlFormatDate = (
   fallback = 'Unknown',
   primaryTimeZone: string,
   facilityTimeZone?: string | null,
+  localeOverride?: string,
 ) => {
   if (!date) return fallback;
+  const displayLocale = localeOverride ?? locale;
 
   try {
     if (date instanceof Date) {
       if (!isValid(date)) return fallback;
-      return date.toLocaleString(locale, formatOptions);
+      return date.toLocaleString(displayLocale, formatOptions);
     }
 
     if (isISO9075DateString(date)) {
@@ -319,9 +321,9 @@ export const intlFormatDate = (
       const timeKeys = ['hour', 'minute', 'second', 'timeStyle', 'dayPeriod'] as const;
       const hasTimeOptions = timeKeys.some(key => key in formatOptions);
       if (hasTimeOptions) {
-        return plainDate.toPlainDateTime().toLocaleString(locale, formatOptions);
+        return plainDate.toPlainDateTime().toLocaleString(displayLocale, formatOptions);
       }
-      return plainDate.toLocaleString(locale, formatOptions);
+      return plainDate.toLocaleString(displayLocale, formatOptions);
     }
 
     const displayTz = getDisplayTimezone(primaryTimeZone, facilityTimeZone);
@@ -331,10 +333,10 @@ export const intlFormatDate = (
       return plain
         .toZonedDateTime(primaryTimeZone)
         .withTimeZone(displayTz)
-        .toLocaleString(locale, formatOptions);
+        .toLocaleString(displayLocale, formatOptions);
     }
 
-    return plain.toLocaleString(locale, formatOptions);
+    return plain.toLocaleString(displayLocale, formatOptions);
   } catch (error) {
     logDateError('intlFormatDate', error, date, primaryTimeZone, facilityTimeZone);
     return fallback;


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to date/time display formatting by adding an optional locale override; existing callers remain compatible, but rendered dates in PDFs (and any new callers passing a locale) may change format.
> 
> **Overview**
> **Date/time formatting now supports an optional locale override.** `intlFormatDate` and all `dateFormatters` accept a `locale` parameter that, when provided, is used for `toLocaleString` formatting instead of the default browser locale.
> 
> **PDF generation is pinned to `en-GB`.** `withDateTimeContext` now passes a hardcoded `en-GB` locale into all date/time formatter functions (with a TODO to make it configurable), ensuring consistent PDF date rendering across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b86c307c05db1c2cb267d366068c6a8b8d6574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->