### PR TITLE
chore(mobile): no-issue: upgrade axios to 1.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40095,7 +40095,7 @@
         "@tamanu/shared": "*",
         "@tamanu/utils": "*",
         "@testing-library/react-native": "^12.5.3",
-        "axios": "^1.11.0",
+        "axios": "^1.15.2",
         "chance": "^1.1.8",
         "date-fns": "^2.25.0",
         "deprecated-react-native-prop-types": "^5.0.0",
@@ -40216,6 +40216,17 @@
         "yup": "*"
       }
     },
+    "packages/mobile/node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "packages/mobile/node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -40285,6 +40296,35 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "packages/mobile/node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mobile/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/mobile/node_modules/typeorm": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -37,7 +37,7 @@
     "@tamanu/shared": "*",
     "@tamanu/utils": "*",
     "@testing-library/react-native": "^12.5.3",
-    "axios": "^1.11.0",
+    "axios": "^1.15.2",
     "chance": "^1.1.8",
     "date-fns": "^2.25.0",
     "deprecated-react-native-prop-types": "^5.0.0",


### PR DESCRIPTION
### Changes

Bumps the direct axios dependency in `packages/mobile` from 1.11.0 to 1.15.2 (latest). Lockfile change is scoped to the mobile nested axios entry and its transitive deps (`follow-redirects`, `proxy-from-env`); the root override stays at its security floor (`^1.8.2`), so transitive consumers (e.g. `mailgun.js` in `central-server`) are unaffected.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->