### PR TITLE
refactor(email): no-issue: generalise sender-address config as mail.from

### DIFF
--- a/packages/central-server/app/auth/resetPassword.js
+++ b/packages/central-server/app/auth/resetPassword.js
@@ -7,6 +7,7 @@ import { RateLimitedError } from '@tamanu/errors';
 import { COMMUNICATION_STATUSES, LOCKED_OUT_ERROR_MESSAGE } from '@tamanu/constants';
 import { log } from '@tamanu/shared/services/logging';
 import { getRandomBase64String } from './utils';
+import { getDefaultFromAddress } from '../services/mailConfig';
 
 export const resetPassword = express.Router();
 
@@ -85,7 +86,7 @@ const sendResetEmail = async (emailService, user, token) => {
       tamanu.io`;
 
   const result = await emailService.sendEmail({
-    from: config.mailgun.from,
+    from: getDefaultFromAddress(),
     to: user.email,
     subject: 'Tamanu password reset',
     text: emailText,

--- a/packages/central-server/app/patientPortalApi/auth/login.js
+++ b/packages/central-server/app/patientPortalApi/auth/login.js
@@ -10,6 +10,7 @@ import { BadAuthenticationError } from '@tamanu/errors';
 import { buildToken } from '../../auth/utils';
 import { PortalOneTimeTokenService } from './PortalOneTimeTokenService';
 import { replaceInTemplate } from '@tamanu/utils/replaceInTemplate';
+import { getDefaultFromAddress } from '../../services/mailConfig';
 
 const getOneTimeTokenEmail = async ({ email, token, settings }) => {
   const template = await settings.get('templates.patientPortalLoginEmail');
@@ -22,7 +23,7 @@ const getOneTimeTokenEmail = async ({ email, token, settings }) => {
 
   return {
     to: email,
-    from: config.mailgun.from,
+    from: getDefaultFromAddress(),
     subject,
     text: content,
   };

--- a/packages/central-server/app/report/ReportRunner.js
+++ b/packages/central-server/app/report/ReportRunner.js
@@ -13,6 +13,7 @@ import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { createZippedSpreadsheet, removeFile, writeToSpreadsheet } from '../utils/files';
 import { getLocalisation } from '../localisation';
+import { getDefaultFromAddress } from '../services/mailConfig';
 
 const REPORT_RUNNER_LOG_NAME = 'ReportRunner';
 
@@ -59,7 +60,7 @@ export class ReportRunner {
   async validate(reportModule, reportDataGenerator) {
     const localisation = await getLocalisation();
 
-    if (this.recipients.email && !config.mailgun.from) {
+    if (this.recipients.email && !getDefaultFromAddress()) {
       throw new Error('ReportRunner - Email config missing');
     }
 
@@ -257,7 +258,7 @@ export class ReportRunner {
       });
 
       const result = await this.emailService.sendEmail({
-        from: config.mailgun.from,
+        from: getDefaultFromAddress(),
         to: recipients,
         subject: 'Report delivery',
         text: `Report requested: ${reportName}`,
@@ -285,7 +286,7 @@ export class ReportRunner {
       const user = await this.getRequestedByUser();
       const reportName = await this.getReportName();
       this.emailService.sendEmail({
-        from: config.mailgun.from,
+        from: getDefaultFromAddress(),
         to: user.email,
         subject: 'Failed to generate report',
         message: `Report requested: ${reportName} failed to generate with error: ${e.message}`,

--- a/packages/central-server/app/services/mailConfig.js
+++ b/packages/central-server/app/services/mailConfig.js
@@ -1,0 +1,9 @@
+import config from 'config';
+
+/**
+ * Default sender address for outgoing email. Prefer `mail.from`; fall back to the legacy
+ * `mailgun.from` so existing deployments keep working without a config change.
+ */
+export function getDefaultFromAddress() {
+  return config.mail?.from ?? config.mailgun?.from ?? '';
+}

--- a/packages/central-server/app/services/mailConfig.js
+++ b/packages/central-server/app/services/mailConfig.js
@@ -5,5 +5,5 @@ import config from 'config';
  * `mailgun.from` so existing deployments keep working without a config change.
  */
 export function getDefaultFromAddress() {
-  return config.mail?.from ?? config.mailgun?.from ?? '';
+  return config.mail?.from || config.mailgun?.from || '';
 }

--- a/packages/central-server/app/tasks/BaseCommunicationProcessor.js
+++ b/packages/central-server/app/tasks/BaseCommunicationProcessor.js
@@ -2,6 +2,7 @@ import config from 'config';
 import { ScheduledTask } from '@tamanu/shared/tasks';
 import { log } from '@tamanu/shared/services/logging';
 import { removeFile } from '../utils/files';
+import { getDefaultFromAddress } from '../services/mailConfig';
 
 const maskMiddle = s => s.slice(0, 1) + s.slice(1, -1).replace(/./g, '*') + s.slice(-1);
 const maskEmail = email => email.replace(/[^@]*/g, maskMiddle);
@@ -61,7 +62,7 @@ export class BaseCommunicationProcessor extends ScheduledTask {
 
     const result = await this.context.emailService.sendEmail({
       to: toAddress,
-      from: config.mailgun.from,
+      from: getDefaultFromAddress(),
       subject: emailPlain.subject,
       text: transformedContent,
       attachment: emailPlain.attachment,

--- a/packages/central-server/app/tasks/ReportRequestProcessor.js
+++ b/packages/central-server/app/tasks/ReportRequestProcessor.js
@@ -9,6 +9,7 @@ import { log } from '@tamanu/shared/services/logging';
 
 import { ReportRunner } from '../report/ReportRunner';
 import { getLocalisation } from '../localisation';
+import { getDefaultFromAddress } from '../services/mailConfig';
 
 export class ReportRequestProcessor extends ScheduledTask {
   getName() {
@@ -180,7 +181,7 @@ export class ReportRequestProcessor extends ScheduledTask {
     for (const request of requests) {
       const reportId = request.getReportId();
 
-      if (!config.mailgun.from) {
+      if (!getDefaultFromAddress()) {
         log.error(`ReportRequestProcessorError - Email config missing`);
         await request.update({
           status: REPORT_REQUEST_STATUSES.ERROR,

--- a/packages/central-server/app/tasks/SurveyCompletionNotifierProcessor.js
+++ b/packages/central-server/app/tasks/SurveyCompletionNotifierProcessor.js
@@ -3,6 +3,7 @@ import { ScheduledTask } from '@tamanu/shared/tasks';
 import { log } from '@tamanu/shared/services/logging';
 import { Op } from 'sequelize';
 import { COMMUNICATION_STATUSES } from '@tamanu/constants';
+import { getDefaultFromAddress } from '../services/mailConfig';
 
 export class SurveyCompletionNotifierProcessor extends ScheduledTask {
   /**
@@ -65,7 +66,7 @@ export class SurveyCompletionNotifierProcessor extends ScheduledTask {
     );
     for (const surveyResponse of surveyResponses) {
       const result = await this.context.emailService.sendEmail({
-        from: config.mailgun.from,
+        from: getDefaultFromAddress(),
         to: surveyResponse.survey.notifyEmailAddresses,
         subject: getTranslation(
           'surveyCompletionNotifier.emailSubject',

--- a/packages/central-server/config/default.json5
+++ b/packages/central-server/config/default.json5
@@ -144,11 +144,16 @@
     "apiKey": "",
     "from": ""
   },
-  // Preferred over `mailgun` when `mail.transport` is set. The `transport` value is
-  // passed through to nodemailer's createTransport() unchanged, so any SMTP option
-  // (host/port/secure/auth, service shortcuts, pooling, etc.) or nodemailer transport
-  // plugin can be used. See https://nodemailer.com/transports/. Example:
+  // `mail.from` is the default sender address. It replaces the legacy `mailgun.from` key;
+  // if `mail.from` is unset we fall back to `mailgun.from`, so existing deployments keep
+  // working unchanged.
+  //
+  // `mail.transport` is preferred over `mailgun` when set. The value is passed through to
+  // nodemailer's createTransport() unchanged, so any SMTP option (host/port/secure/auth,
+  // service shortcuts, pooling, etc.) or nodemailer transport plugin can be used.
+  // See https://nodemailer.com/transports/. Example:
   //   "mail": {
+  //     "from": "Tamanu <no-reply@example.com>",
   //     "transport": {
   //       "host": "smtp.example.com",
   //       "port": 587,
@@ -158,6 +163,7 @@
   //     }
   //   }
   "mail": {
+    "from": "",
     "transport": null
   },
   "cors": {


### PR DESCRIPTION
### Changes

`config.mailgun.from` was read at eight call sites, which no longer fits now that email no longer has to go through Mailgun. Introduces `mail.from` as the canonical sender-address config and a small `getDefaultFromAddress()` helper that reads it, falling back to `mailgun.from` so existing deployments keep working without a config change. Also notes the new key in the `config/default.json5` comment.

**Viti: this does not create any need to change any existing configs.**

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->