### PR TITLE
ci(E2E): Only run on merge queue

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 
 on:
-  pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,7 +1,6 @@
 name: E2E Tests
 
 on:
-  pull_request:
   merge_group:
 
 permissions:
@@ -17,7 +16,6 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group'
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +40,6 @@ jobs:
           path: ${{ env.NODE_MODULES_PATHS }}
 
   e2e_prepare:
-    if: github.event_name == 'merge_group'
     needs: node_modules_cache
     name: Prepare E2E artifacts
     runs-on: ubuntu-latest
@@ -97,7 +94,6 @@ jobs:
           retention-days: 1
 
   e2e:
-    if: github.event_name == 'merge_group'
     needs: e2e_prepare
     name: E2E Tests ${{ matrix.shard }}
     runs-on: ubuntu-latest
@@ -187,11 +183,6 @@ jobs:
     steps:
       - name: Enforce passing E2E workflow
         run: |
-          if [ "${{ github.event_name }}" != "merge_group" ]; then
-            echo "Skipping full E2E outside merge queue."
-            exit 0
-          fi
-
           if [ "${{ needs.e2e.result }}" != "success" ]; then
             echo "E2E tests did not pass."
             exit 1

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,6 +1,7 @@
 name: E2E Tests
 
 on:
+  pull_request:
   merge_group:
 
 permissions:
@@ -16,6 +17,7 @@ env:
 
 jobs:
   node_modules_cache:
+    if: github.event_name == 'merge_group'
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -181,7 +183,8 @@ jobs:
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:
-      - name: Enforce passing E2E workflow
+      - if: github.event_name == 'merge_group'
+        name: Enforce passing E2E workflow (in merge queue)
         run: |
           if [ "${{ needs.e2e.result }}" != "success" ]; then
             echo "E2E tests did not pass."

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,6 +1,7 @@
 name: E2E Tests
 
 on:
+  pull_request:
   merge_group:
 
 permissions:
@@ -16,6 +17,7 @@ env:
 
 jobs:
   node_modules_cache:
+    if: github.event_name == 'merge_group'
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +42,7 @@ jobs:
           path: ${{ env.NODE_MODULES_PATHS }}
 
   e2e_prepare:
+    if: github.event_name == 'merge_group'
     needs: node_modules_cache
     name: Prepare E2E artifacts
     runs-on: ubuntu-latest
@@ -94,6 +97,7 @@ jobs:
           retention-days: 1
 
   e2e:
+    if: github.event_name == 'merge_group'
     needs: e2e_prepare
     name: E2E Tests ${{ matrix.shard }}
     runs-on: ubuntu-latest
@@ -183,6 +187,11 @@ jobs:
     steps:
       - name: Enforce passing E2E workflow
         run: |
+          if [ "${{ github.event_name }}" != "merge_group" ]; then
+            echo "Skipping full E2E outside merge queue."
+            exit 0
+          fi
+
           if [ "${{ needs.e2e.result }}" != "success" ]; then
             echo "E2E tests did not pass."
             exit 1

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -2,6 +2,7 @@ name: Migration determinism
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/ci-non-deterministic.yml
+++ b/.github/workflows/ci-non-deterministic.yml
@@ -24,11 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres:
-          - "14"
-          - "15"
-          - "16"
-          - "17"
+        postgres: ${{ fromJSON(github.event_name == 'pull_request' && '["18"]' || '["14","15","16","17","18"]') }}
     name: on pg=${{ matrix.postgres }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-trigger change; main impact is when CI/E2E run (merge queue vs PR), which could alter developer feedback timing but not production code.
> 
> **Overview**
> Shifts GitHub Actions CI execution to support the merge queue by adding the `merge_group` trigger to `ci.yml` and `ci-non-deterministic.yml`.
> 
> Updates the E2E workflow (`ci-e2e.yml`) to run only on `merge_group` by removing its `pull_request` trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d735eb27adb07af8c6a1868e425d76ba4ec76836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->