### PR TITLE
e2e failure report

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -106,6 +106,7 @@ jobs:
       ADMIN_FRONTEND_URL: http://localhost:5174
       LAUNCH_LOCAL_SERVERS_WHEN_RUNNING_TESTS: true
       IS_PLAYWRIGHT_TEST: true
+      PLAYWRIGHT_DEBUG_ARTIFACTS: true
       TEST_EMAIL: admin@tamanu.io
       TEST_PASSWORD: admin
       TZ: Pacific/Auckland
@@ -174,11 +175,55 @@ jobs:
           name: blob-report-${{ strategy.job-index }}
           path: packages/e2e-tests/blob-report/
           retention-days: 7
+      - name: Upload Playwright debug artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-debug-${{ strategy.job-index }}
+          path: |
+            packages/e2e-tests/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  e2e-report:
+    if: always() && needs.e2e.result != 'success'
+    needs: e2e
+    name: E2E Failure Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - uses: actions/cache/restore@v5
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+      - run: npm i
+      - name: Download all blob reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: blob-report-*
+          path: packages/e2e-tests/all-blob-reports
+          merge-multiple: true
+      - name: Merge Playwright reports
+        run: npx playwright merge-reports --reporter html all-blob-reports
+        working-directory: packages/e2e-tests
+      - name: Upload merged Playwright report
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-merged
+          path: packages/e2e-tests/playwright-report/
+          if-no-files-found: error
+          retention-days: 14
 
   e2e-required:
     name: E2E Required
     if: always()
-    needs: [e2e]
+    needs: [e2e, e2e-report]
     runs-on: ubuntu-latest
     steps:
       - name: Enforce passing E2E workflow

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 
 on:
-  pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -8,6 +8,9 @@ import dotenv from 'dotenv';
  */
 dotenv.config({ path: resolve(__dirname, '.env') });
 
+const isCI = !!process.env.CI;
+const keepDebugArtifactsInCI = process.env.PLAYWRIGHT_DEBUG_ARTIFACTS === 'true';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -16,17 +19,17 @@ module.exports = defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: isCI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? 'blob' : 'html',
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? 'blob' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    // Enable heavier debugging artifacts only for local runs.
-    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
-    video: process.env.CI ? 'off' : 'retain-on-failure',
-    screenshot: process.env.CI ? 'off' : 'only-on-failure',
+    // Keep heavy debug artifacts by default locally, and optionally in CI via PLAYWRIGHT_DEBUG_ARTIFACTS.
+    trace: isCI ? (keepDebugArtifactsInCI ? 'retain-on-failure' : 'on-first-retry') : 'retain-on-failure',
+    video: isCI ? (keepDebugArtifactsInCI ? 'retain-on-failure' : 'off') : 'retain-on-failure',
+    screenshot: isCI ? (keepDebugArtifactsInCI ? 'only-on-failure' : 'off') : 'only-on-failure',
     // Slow down each browser action to make local debugging easier.
     launchOptions: process.env.CI ? undefined : { slowMo: 200 },
     timezoneId: process.env.TZ,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow/reporting and Playwright debug settings, with the main impact being increased artifact retention/storage and slightly different CI debugging behavior.
> 
> **Overview**
> Improves E2E CI debuggability by optionally retaining Playwright `trace`/`video`/`screenshot` artifacts in CI via `PLAYWRIGHT_DEBUG_ARTIFACTS`, and uploading `test-results/` artifacts when shards fail.
> 
> Adds an `e2e-report` job that runs when E2E fails to download all shard blob reports, merge them into a single HTML report, and upload the merged `playwright-report` artifact; updates `e2e-required` to depend on this reporting job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f4ac084fe18d2c2542db8446aaf198ab3bfa9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->