### PR TITLE
tweak(playwright): no-issue: speed up local e2e defaults

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -8,6 +8,8 @@ import dotenv from 'dotenv';
  */
 dotenv.config({ path: resolve(__dirname, '.env') });
 
+const localSlowMoMs = Number(process.env.PLAYWRIGHT_SLOW_MO_MS ?? 0);
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -27,8 +29,12 @@ module.exports = defineConfig({
     trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
     video: process.env.CI ? 'off' : 'retain-on-failure',
     screenshot: process.env.CI ? 'off' : 'only-on-failure',
-    // Slow down each browser action to make local debugging easier.
-    launchOptions: process.env.CI ? undefined : { slowMo: 200 },
+    // Keep local runs fast by default; opt-in slow motion for interactive debugging.
+    launchOptions: process.env.CI
+      ? undefined
+      : localSlowMoMs > 0
+        ? { slowMo: localSlowMoMs }
+        : undefined,
     timezoneId: process.env.TZ,
     // Pin browser locale so navigator.language-driven date formatting is deterministic across
     // runners (CI Ubuntu defaults to en-US which yields MM/DD/YYYY; tests expect DD/MM/YYYY).

--- a/packages/e2e-tests/tests/setup/auth.setup.ts
+++ b/packages/e2e-tests/tests/setup/auth.setup.ts
@@ -1,4 +1,5 @@
 import { test as setup } from '../../fixtures/baseFixture';
+import { expect } from '@playwright/test';
 import path from 'path';
 
 setup('authenticate', async ({ loginPage }) => {
@@ -13,8 +14,8 @@ setup('authenticate', async ({ loginPage }) => {
 
   await loginPage.login(email, password);
 
-  // Ensure state is persisted
-  await loginPage.page.waitForTimeout(1000);
+  // Ensure the logged-in landing page has rendered before snapshotting auth state.
+  await expect(loginPage.page.getByText('Search All Patients')).toBeVisible();
 
   // Save page context
   const authStatePath = path.join(__dirname, '../../.auth/user.json');

--- a/packages/e2e-tests/utils/testHelper.ts
+++ b/packages/e2e-tests/utils/testHelper.ts
@@ -103,6 +103,7 @@ export function compareAlphabetically(order: 'asc' | 'desc') {
 export const selectFirstFromDropdown = async (page: Page, input: Locator): Promise<string> => {
   await input.click();
   const firstOption = page.locator('[role="listbox"] li').first();
+  await firstOption.waitFor({ state: 'visible', timeout: 10000 });
   await firstOption.click();
   return (await firstOption.textContent()) || '';
 };


### PR DESCRIPTION
## Summary
- make local Playwright runs fast by default by making slow motion opt-in via `PLAYWRIGHT_SLOW_MO_MS`
- replace a fixed auth setup sleep with a readiness assertion before saving storage state
- add an explicit 10s wait budget in `selectFirstFromDropdown` so broken dropdown states fail faster instead of consuming full test timeout

## Test plan
- [x] Run `npm run test --workspace=@tamanu/e2e-tests -- --list`
- [ ] Run a focused local E2E smoke (optional)
- [ ] Verify end-to-end runtime improvement on CI

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Playwright E2E test configuration and helpers, mainly adjusting local timing defaults and replacing fixed sleeps with explicit readiness waits that may slightly affect test timing/flake behavior.
> 
> **Overview**
> Makes local Playwright runs fast by default by removing the hardcoded `slowMo: 200` and instead enabling slow motion only when `PLAYWRIGHT_SLOW_MO_MS` is set.
> 
> Hardens E2E stability by replacing the auth setup’s fixed `waitForTimeout` with an assertion that the post-login landing content is visible before saving `storageState`, and by adding an explicit 10s `waitFor` before clicking the first option in `selectFirstFromDropdown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e146241770b96e35c8cf23c92f9a7e2084ce9174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->