### PR TITLE
CI(e2e): Add E2E report artifact to github

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
@@ -174,6 +175,83 @@ jobs:
           name: blob-report-${{ strategy.job-index }}
           path: packages/e2e-tests/blob-report/
           retention-days: 7
+
+  e2e_report:
+    needs: [e2e]
+    name: Build E2E HTML report artifact
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - uses: actions/cache/restore@v5
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+      - run: npm i
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: blob-report-*
+          path: packages/e2e-tests/all-blob-reports
+          merge-multiple: true
+      - name: Merge Playwright blob reports into HTML report
+        run: npx playwright merge-reports --reporter html all-blob-reports
+        working-directory: packages/e2e-tests
+      - name: Zip HTML report for download
+        run: zip -r playwright-report.zip playwright-report
+        working-directory: packages/e2e-tests
+      - name: Upload HTML report zip artifact
+        id: report-artifact-upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-playwright-html-report
+          path: packages/e2e-tests/playwright-report.zip
+          retention-days: 7
+      - name: Post failure report link comment
+        continue-on-error: true
+        if: needs.e2e.result != 'success' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: ${{ steps.report-artifact-upload.outputs.artifact-url }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        with:
+          script: |
+            const { ARTIFACT_URL, BUILD_NUMBER } = process.env;
+            const { repo, owner } = context.repo;
+            const { number: issue_number } = context.issue;
+            if (!issue_number) return;
+
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+            const downloadUrl = ARTIFACT_URL || runUrl;
+
+            const params = { issue_number, owner, repo };
+            const headerContent = "**E2E failure report**";
+            const latestText = " **Latest**";
+            const bodyLine = `- **${BUILD_NUMBER}:** [Download E2E HTML report zip](${downloadUrl})${latestText}`;
+
+            const comments = await github.rest.issues.listComments(params);
+            const existingComment = comments.data.find((comment) => comment.body.includes(headerContent));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                ...params,
+                comment_id: existingComment.id,
+                body: existingComment.body
+                  .replace(latestText, '')
+                  .replace(headerContent, `${headerContent}\n${bodyLine}`),
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...params,
+                body: `${headerContent}\n${bodyLine}`,
+              });
+            }
 
   e2e-required:
     name: E2E Required

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -23,10 +23,10 @@ module.exports = defineConfig({
   reporter: process.env.CI ? 'blob' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    // Enable heavier debugging artifacts only for local runs.
-    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
-    video: process.env.CI ? 'off' : 'retain-on-failure',
-    screenshot: process.env.CI ? 'off' : 'only-on-failure',
+    // Keep debugging artifacts from failed tests so CI reports are actionable.
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
     // Slow down each browser action to make local debugging easier.
     launchOptions: process.env.CI ? undefined : { slowMo: 200 },
     timezoneId: process.env.TZ,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI workflow behavior and permissions (adds `pull-requests: write`) and introduces automated PR commenting; failures in the new report/merge steps could add noise or mask useful artifacts.
> 
> **Overview**
> Adds an always-run `e2e_report` job that downloads shard `blob-report-*` artifacts, merges them into a Playwright HTML report, zips it, uploads it as a single downloadable artifact, and (on PR failures) posts/updates a PR comment linking to the report.
> 
> Updates Playwright configuration to always retain failure debugging artifacts (`trace`, `video`, `screenshot`) so the CI-generated reports are more actionable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f9f63569ca29e1f81861e27faa401fe55ed19e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->