### PR TITLE
fix(invoicing): no-issue: parse price list rules JSON on import (MAIN)

### DIFF
--- a/packages/central-server/__tests__/importers/invoicePriceList.test.js
+++ b/packages/central-server/__tests__/importers/invoicePriceList.test.js
@@ -1,0 +1,158 @@
+import { write, utils } from 'xlsx';
+import { importerTransaction } from '../../app/admin/importer/importerEndpoint';
+import { referenceDataImporter } from '../../app/admin/referenceDataImporter';
+import { createTestContext } from '../utilities';
+
+function buildWorkbookBuffer(sheetName, headers, rows) {
+  const ws = {};
+
+  headers.forEach((h, idx) => {
+    const cell = utils.encode_cell({ r: 0, c: idx });
+    ws[cell] = { t: 's', v: h };
+  });
+
+  rows.forEach((row, rIdx) => {
+    headers.forEach((h, cIdx) => {
+      const v = row[h];
+      if (v === undefined) return;
+      const cell = utils.encode_cell({ r: rIdx + 1, c: cIdx });
+      ws[cell] = typeof v === 'number' ? { t: 'n', v } : { t: 's', v: String(v) };
+    });
+  });
+
+  ws['!ref'] = utils.encode_range({
+    s: { r: 0, c: 0 },
+    e: { r: rows.length, c: headers.length - 1 },
+  });
+
+  const wb = { SheetNames: [sheetName], Sheets: { [sheetName]: ws } };
+  return write(wb, { type: 'buffer', bookType: 'xlsx' });
+}
+
+async function doImport(ctx, { buffer }) {
+  return importerTransaction({
+    importer: referenceDataImporter,
+    data: buffer,
+    models: ctx.store.models,
+    includedDataTypes: ['invoicePriceList'],
+    checkPermission: () => true,
+  });
+}
+
+describe('Invoice price list import', () => {
+  let ctx;
+  let models;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    models = ctx.store.models;
+  }, 120 * 1000);
+
+  afterAll(async () => {
+    await ctx.close();
+  });
+
+  afterEach(async () => {
+    const { InvoicePriceListItem, InvoicePriceList } = models;
+    await InvoicePriceListItem.destroy({ where: {}, force: true });
+    await InvoicePriceList.destroy({ where: {}, force: true });
+  });
+
+  const headers = ['id', 'code', 'name', 'rules', 'visibilityStatus'];
+
+  it('parses rules JSON text into an object', async () => {
+    const buffer = buildWorkbookBuffer('invoicePriceList', headers, [
+      {
+        id: 'pl-seniors',
+        code: 'PL-SENIORS',
+        name: 'Seniors',
+        rules: '{ "facilityId": "facility-a", "patientAge": { "min": 65 } }',
+        visibilityStatus: 'current',
+      },
+    ]);
+
+    const { errors } = await doImport(ctx, { buffer });
+    expect(errors).toEqual([]);
+
+    const row = await models.InvoicePriceList.findByPk('pl-seniors');
+    expect(row.rules).toEqual({
+      facilityId: 'facility-a',
+      patientAge: { min: 65 },
+    });
+    expect(row.rules.patientAge.min).toBe(65);
+  });
+
+  it('stores an empty rules cell as null', async () => {
+    const buffer = buildWorkbookBuffer('invoicePriceList', headers, [
+      {
+        id: 'pl-default',
+        code: 'PL-DEFAULT',
+        name: 'Default',
+        rules: '',
+        visibilityStatus: 'current',
+      },
+    ]);
+
+    const { errors } = await doImport(ctx, { buffer });
+    expect(errors).toEqual([]);
+
+    const row = await models.InvoicePriceList.findByPk('pl-default');
+    expect(row.rules).toBeNull();
+  });
+
+  it('rejects malformed JSON (e.g. missing outer braces)', async () => {
+    const buffer = buildWorkbookBuffer('invoicePriceList', headers, [
+      {
+        id: 'pl-bad',
+        code: 'PL-BAD',
+        name: 'Bad',
+        rules: '"patientAge": { "max": 64 }',
+        visibilityStatus: 'current',
+      },
+    ]);
+
+    const { errors } = await doImport(ctx, { buffer });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/rules is not valid JSON/);
+
+    const row = await models.InvoicePriceList.findByPk('pl-bad');
+    expect(row).toBeNull();
+  });
+
+  it('rejects unknown top-level keys in rules', async () => {
+    const buffer = buildWorkbookBuffer('invoicePriceList', headers, [
+      {
+        id: 'pl-typo',
+        code: 'PL-TYPO',
+        name: 'Typo',
+        rules: '{ "facility_id": "facility-a" }',
+        visibilityStatus: 'current',
+      },
+    ]);
+
+    const { errors } = await doImport(ctx, { buffer });
+    expect(errors.length).toBeGreaterThan(0);
+
+    const row = await models.InvoicePriceList.findByPk('pl-typo');
+    expect(row).toBeNull();
+  });
+
+  it('rejects non-object rules (array, scalar)', async () => {
+    const buffer = buildWorkbookBuffer('invoicePriceList', headers, [
+      {
+        id: 'pl-array',
+        code: 'PL-ARRAY',
+        name: 'Array',
+        rules: '["patientAge"]',
+        visibilityStatus: 'current',
+      },
+    ]);
+
+    const { errors } = await doImport(ctx, { buffer });
+    expect(errors.length).toBeGreaterThan(0);
+
+    const row = await models.InvoicePriceList.findByPk('pl-array');
+    expect(row).toBeNull();
+  });
+
+});

--- a/packages/central-server/app/admin/importSchemas/baseSchemas.js
+++ b/packages/central-server/app/admin/importSchemas/baseSchemas.js
@@ -370,6 +370,47 @@ export const UserFacility = yup.object().shape({
   userId: yup.string().required(),
 });
 
+// yup's .noUnknown() silently strips unknown keys in non-strict validate() mode, so
+// we use an explicit .test() to surface typos (e.g. "facility_id" instead of "facilityId").
+const KNOWN_RULE_KEYS = ['facilityId', 'patientType', 'patientAge'];
+const KNOWN_AGE_KEYS = ['min', 'max'];
+
+const invoicePriceListRulesSchema = yup
+  .object()
+  .nullable()
+  .default(null)
+  .test('known-keys', 'invalid rules', function (value) {
+    if (value == null) return true;
+    const unknown = Object.keys(value).filter(k => !KNOWN_RULE_KEYS.includes(k));
+    if (unknown.length > 0) {
+      return this.createError({
+        message: `rules has unknown keys: ${unknown.join(', ')} (expected ${KNOWN_RULE_KEYS.join(', ')})`,
+      });
+    }
+    const { patientAge } = value;
+    if (patientAge != null && typeof patientAge === 'object') {
+      const unknownAge = Object.keys(patientAge).filter(k => !KNOWN_AGE_KEYS.includes(k));
+      if (unknownAge.length > 0) {
+        return this.createError({
+          message: `rules.patientAge has unknown keys: ${unknownAge.join(', ')} (expected min, max)`,
+        });
+      }
+    } else if (patientAge != null && typeof patientAge !== 'number') {
+      return this.createError({
+        message: 'rules.patientAge must be a number or an object like {min, max}',
+      });
+    }
+    return true;
+  });
+
+export const InvoicePriceList = yup.object().shape({
+  id: fieldTypes.id.required(),
+  code: fieldTypes.code.required(),
+  name: yup.string().nullable(),
+  rules: invoicePriceListRulesSchema,
+  visibilityStatus,
+});
+
 export const InvoiceProduct = yup.object().shape({
   id: yup.string().required(),
   name: yup.string().required(),

--- a/packages/central-server/app/admin/referenceDataImporter/dependencies.js
+++ b/packages/central-server/app/admin/referenceDataImporter/dependencies.js
@@ -17,6 +17,7 @@ import {
 } from './loaders';
 import { invoicePriceListItemLoaderFactory } from './invoicePriceListItemLoaderFactory';
 import { invoiceInsurancePlanItemLoaderFactory } from './invoiceInsurancePlanItemLoaderFactory';
+import { invoicePriceListLoader } from './invoicePriceListLoader';
 
 // All reference data is imported first, so that can be assumed for ordering.
 //
@@ -72,7 +73,9 @@ export default {
     needs: [OTHER_REFERENCE_TYPES.LAB_TEST_TYPE, OTHER_REFERENCE_TYPES.LAB_TEST_PANEL],
   },
 
-  invoicePriceList: {},
+  invoicePriceList: {
+    loader: invoicePriceListLoader,
+  },
   invoicePriceListItem: {
     get loader() {
       // Use a getter to create a fresh loader instance on each access

--- a/packages/central-server/app/admin/referenceDataImporter/invoicePriceListLoader.js
+++ b/packages/central-server/app/admin/referenceDataImporter/invoicePriceListLoader.js
@@ -1,0 +1,57 @@
+// Parses the `rules` cell (JSON text) into an object before handing it to Sequelize.
+// Without this, Sequelize's JSONB serialiser JSON.stringify's the raw string, storing
+// a JSON string literal rather than an object — every rule would then look empty at
+// read time and every price list would match every encounter.
+export function invoicePriceListLoader(item, { pushError } = {}) {
+  // eslint-disable-next-line no-unused-vars
+  const { note, rules, ...fields } = item;
+
+  const parsedRules = parseRulesCell(rules, pushError);
+  if (parsedRules === INVALID) return [];
+
+  return [
+    {
+      model: 'InvoicePriceList',
+      values: { ...fields, rules: parsedRules },
+    },
+  ];
+}
+
+const INVALID = Symbol('invalid-rules');
+
+function parseRulesCell(raw, pushError) {
+  if (raw == null || raw === '') return null;
+
+  if (typeof raw === 'object' && !Array.isArray(raw)) return raw;
+
+  if (typeof raw !== 'string') {
+    pushError?.(
+      `rules must be a JSON object, got ${Array.isArray(raw) ? 'array' : typeof raw}`,
+      'InvoicePriceList',
+    );
+    return INVALID;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    pushError?.(
+      `rules is not valid JSON (${e.message}). Expected an object like {"patientAge": {"min": 65}}`,
+      'InvoicePriceList',
+    );
+    return INVALID;
+  }
+
+  if (parsed === null) return null;
+
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    pushError?.(
+      `rules must be a JSON object, got ${Array.isArray(parsed) ? 'array' : typeof parsed}`,
+      'InvoicePriceList',
+    );
+    return INVALID;
+  }
+
+  return parsed;
+}

--- a/packages/database/src/migrations/1776925435521-fixStringifiedInvoicePriceListRules.ts
+++ b/packages/database/src/migrations/1776925435521-fixStringifiedInvoicePriceListRules.ts
@@ -1,0 +1,45 @@
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Repairs rows where rules was JSON.stringify'd a second time by Sequelize's JSONB
+// serialiser (i.e. stored as a JSON string literal rather than a JSON object).
+// After this migration rules is always either NULL or an object; rows whose stored
+// string was not parseable or not an object are reset to NULL.
+
+export async function up(query: QueryInterface): Promise<void> {
+  const rows = await query.sequelize.query<{ id: string; rules: unknown }>(
+    `SELECT id, rules FROM invoice_price_lists WHERE jsonb_typeof(rules) = 'string';`,
+    { type: QueryTypes.SELECT },
+  );
+
+  for (const { id, rules } of rows) {
+    // The pg driver has already parsed the JSONB column, so a JSONB string comes back as a JS string.
+    let fixed: Record<string, unknown> | null = null;
+    if (typeof rules === 'string') {
+      try {
+        const parsed = JSON.parse(rules);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          fixed = parsed;
+        }
+      } catch {
+        // leave as null — the stored string wasn't valid JSON (e.g. the spreadsheet cell was
+        // a JSON fragment without outer braces). Operator needs to re-import that row.
+      }
+    }
+
+    await query.sequelize.query(
+      `UPDATE invoice_price_lists SET rules = :rules::jsonb WHERE id = :id;`,
+      {
+        type: QueryTypes.UPDATE,
+        replacements: { id, rules: fixed === null ? null : JSON.stringify(fixed) },
+      },
+    );
+  }
+
+  // Rules is synced as part of the row payload, so rebuild the lookup entries
+  // to reflect the repaired objects on the next sync pull.
+  await query.sequelize.query(`SELECT flag_lookup_model_to_rebuild('invoice_price_lists');`);
+}
+
+export async function down(_query: QueryInterface): Promise<void> {
+  // DESTRUCTIVE: cannot restore the original stringified form — and there is no reason to.
+}


### PR DESCRIPTION
Cherry picked from 2.52

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invoicing reference-data import and includes a data repair migration; mistakes could null out rules or change which price lists match encounters. Scope is contained to `invoice_price_lists.rules` parsing/validation and importer behavior.
> 
> **Overview**
> Fixes `invoicePriceList` imports so the `rules` column is parsed from JSON text into a JSON object (or `null`) before saving, and surfaces clear import errors for malformed/non-object JSON.
> 
> Tightens schema validation for `InvoicePriceList.rules` to reject unknown keys (including nested `patientAge` keys) instead of silently stripping them.
> 
> Adds a DB migration to repair existing rows where `rules` was stored as a JSONB string literal by re-parsing into an object (or resetting to `NULL` if invalid) and flags lookups for rebuild, plus new importer tests covering valid/invalid `rules` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e5c1b3f4c60db42966a794a7259d9dd50e7332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->