### PR TITLE
fix: Release fix 2.54: Changelog time format

### DIFF
--- a/packages/web/app/components/Medication/Mar/ChangeLogModal.jsx
+++ b/packages/web/app/components/Medication/Mar/ChangeLogModal.jsx
@@ -68,7 +68,7 @@ const LABELS = {
 
 export const ChangeLogModal = ({ open, onClose, medication, marId }) => {
   const [changeLogList, setChangeLogList] = useState([]);
-  const { formatTimeSlot, formatShortest } = useDateTime();
+  const { formatTime, formatShortest } = useDateTime();
   const { getEnumTranslation } = useTranslation();
 
   const { data } = useMarChangelogQuery(marId);
@@ -82,7 +82,7 @@ export const ChangeLogModal = ({ open, onClose, medication, marId }) => {
   const getUserChanged = log => {
     return {
       name: log.changedByUser,
-      date: `${formatShortest(log.createdAt)} ${formatTimeSlot(log.createdAt)}`,
+      date: `${formatShortest(log.createdAt)} ${formatTime(log.createdAt)}`,
     };
   };
 
@@ -123,7 +123,7 @@ export const ChangeLogModal = ({ open, onClose, medication, marId }) => {
                   getEnumTranslation,
                 ),
               },
-              { label: LABELS.timeGiven, value: formatTimeSlot(log.doseGivenTime) },
+              { label: LABELS.timeGiven, value: formatTime(log.doseGivenTime) },
               { label: LABELS.givenBy, value: log.doseGivenByUser.name },
               { label: LABELS.recordedBy, value: log.recordedByUser.name },
             ],
@@ -160,7 +160,7 @@ export const ChangeLogModal = ({ open, onClose, medication, marId }) => {
             });
           }
           if (previousLog?.doseGivenTime !== log.doseGivenTime) {
-            changes.push({ label: LABELS.timeGiven, value: formatTimeSlot(log.doseGivenTime) });
+            changes.push({ label: LABELS.timeGiven, value: formatTime(log.doseGivenTime) });
           }
           if (previousLog?.doseGivenByUser?.id !== log.doseGivenByUser.id) {
             changes.push({ label: LABELS.givenBy, value: log.doseGivenByUser.name });
@@ -262,7 +262,7 @@ export const ChangeLogModal = ({ open, onClose, medication, marId }) => {
                 },
                 {
                   label: LABELS.timeGiven,
-                  value: logs[1].doseGivenTime && formatTimeSlot(logs[1].doseGivenTime),
+                  value: logs[1].doseGivenTime && formatTime(logs[1].doseGivenTime),
                 },
                 { label: LABELS.givenBy, value: logs[1].doseGivenByUser.name },
                 { label: LABELS.recordedBy, value: logs[0].recordedByUser.name },

--- a/packages/web/app/components/Medication/Mar/ChangeLogModal.jsx
+++ b/packages/web/app/components/Medication/Mar/ChangeLogModal.jsx
@@ -332,7 +332,7 @@ export const ChangeLogModal = ({ open, onClose, medication, marId }) => {
                     </Box>
                   ))}
                   <NoteText>
-                    {log.userChanged.name}
+                    {log.userChanged.name}{' '}
                     {log.userChanged.date}
                   </NoteText>
                   {log.doseIndex && (


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only formatting change confined to the MAR changelog modal; no data, permissions, or workflow logic is modified.
> 
> **Overview**
> Updates the Medication MAR `ChangeLogModal` to display all changelog timestamps (created-at and dose given times) using `useDateTime().formatTime` instead of `formatTimeSlot`, aligning the modal with the expected time format.
> 
> Also tweaks the footer line rendering so the user name and timestamp are separated consistently (adds an explicit space).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d665042735140bd7ccaba0660cf6da67a1d0a188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->