### PR TITLE
fix: No-issue: Bruno bootstrap serviceRequest filtering

### DIFF
--- a/bruno/fhir-api/bootstrap/06-discover-lab-service-request.bru
+++ b/bruno/fhir-api/bootstrap/06-discover-lab-service-request.bru
@@ -11,8 +11,7 @@ get {
 }
 
 params:query {
-  category: 108252007
-  _count: 1
+  _count: 10
   _sort: -_lastUpdated
 }
 
@@ -21,19 +20,21 @@ auth:bearer {
 }
 
 script:post-response {
+  const LAB_REQUEST_ID_SYSTEM = "http://data-dictionary.tamanu-fiji.org/tamanu-id-labrequest.html";
   const LAB_TEST_CODE_SYSTEM = "https://www.senaite.com/testCodes.html";
   const LAB_TEST_EXTERNAL_CODE_SYSTEM = "http://loinc.org";
 
   const body = res.getBody && res.getBody();
-  const resource = body && body.entry && body.entry[0] && body.entry[0].resource;
-
+  const resources = ((body && body.entry) || []).map(e => e.resource);
+  const resource = resources.find(r =>
+    (r.identifier || []).some(i => i.system === LAB_REQUEST_ID_SYSTEM)
+  );
   const orderDetail = (resource && resource.orderDetail) || [];
   const firstCodingSet = (orderDetail[0] && orderDetail[0].coding) || [];
   const labCode = firstCodingSet.find(c => c && c.system === LAB_TEST_CODE_SYSTEM && c.code);
   const externalCode = firstCodingSet.find(c => c && c.system === LAB_TEST_EXTERNAL_CODE_SYSTEM && c.code);
 
   bru.setVar("labServiceRequestId", (resource && resource.id) || "");
-  bru.setVar("serviceRequestId", (resource && resource.id) || "");
   bru.setVar("labTestCode", (labCode && labCode.code) || "");
   bru.setVar("labTestExternalCode", (externalCode && externalCode.code) || "");
 }

--- a/bruno/fhir-api/bootstrap/06-discover-lab-service-request.bru
+++ b/bruno/fhir-api/bootstrap/06-discover-lab-service-request.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest?category=http%3A%2F%2Fsnomed.info%2Fsct%7C108252007&_count=1&_sort=-_lastUpdated
+  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest?category=108252007&_count=1&_sort=-_lastUpdated
   body: none
   auth: bearer
 }

--- a/bruno/fhir-api/bootstrap/06-discover-lab-service-request.bru
+++ b/bruno/fhir-api/bootstrap/06-discover-lab-service-request.bru
@@ -5,14 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest
+  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest?category=http%3A%2F%2Fsnomed.info%2Fsct%7C108252007&_count=1&_sort=-_lastUpdated
   body: none
   auth: bearer
-}
-
-params:query {
-  _count: 10
-  _sort: -_lastUpdated
 }
 
 auth:bearer {
@@ -20,15 +15,11 @@ auth:bearer {
 }
 
 script:post-response {
-  const LAB_REQUEST_ID_SYSTEM = "http://data-dictionary.tamanu-fiji.org/tamanu-id-labrequest.html";
   const LAB_TEST_CODE_SYSTEM = "https://www.senaite.com/testCodes.html";
   const LAB_TEST_EXTERNAL_CODE_SYSTEM = "http://loinc.org";
 
   const body = res.getBody && res.getBody();
-  const resources = ((body && body.entry) || []).map(e => e.resource);
-  const resource = resources.find(r =>
-    (r.identifier || []).some(i => i.system === LAB_REQUEST_ID_SYSTEM)
-  );
+  const resource = body && body.entry && body.entry[0] && body.entry[0].resource;
   const orderDetail = (resource && resource.orderDetail) || [];
   const firstCodingSet = (orderDetail[0] && orderDetail[0].coding) || [];
   const labCode = firstCodingSet.find(c => c && c.system === LAB_TEST_CODE_SYSTEM && c.code);

--- a/bruno/fhir-api/bootstrap/07-discover-imaging-service-request.bru
+++ b/bruno/fhir-api/bootstrap/07-discover-imaging-service-request.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest?category=http%3A%2F%2Fsnomed.info%2Fsct%7C363679005&_count=1&_sort=-_lastUpdated
+  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest?category=363679005&_count=1&_sort=-_lastUpdated
   body: none
   auth: bearer
 }

--- a/bruno/fhir-api/bootstrap/07-discover-imaging-service-request.bru
+++ b/bruno/fhir-api/bootstrap/07-discover-imaging-service-request.bru
@@ -11,8 +11,7 @@ get {
 }
 
 params:query {
-  category: 363679005
-  _count: 1
+  _count: 10
   _sort: -_lastUpdated
 }
 
@@ -21,8 +20,13 @@ auth:bearer {
 }
 
 script:post-response {
+  const IMAGING_REQUEST_ID_SYSTEM = "http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html";
+
   const body = res.getBody && res.getBody();
-  const entry = body && body.entry && body.entry[0] && body.entry[0].resource;
+  const resources = ((body && body.entry) || []).map(e => e.resource);
+  const entry = resources.find(r =>
+    (r.identifier || []).some(i => i.system === IMAGING_REQUEST_ID_SYSTEM)
+  );
   if (entry && entry.id) {
     bru.setVar("imagingServiceRequestId", entry.id);
     bru.setVar("imagingAccessionNumber", "BRUNO-" + Date.now());

--- a/bruno/fhir-api/bootstrap/07-discover-imaging-service-request.bru
+++ b/bruno/fhir-api/bootstrap/07-discover-imaging-service-request.bru
@@ -5,14 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest
+  url: {{baseUrl}}/api/integration/fhir/mat/ServiceRequest?category=http%3A%2F%2Fsnomed.info%2Fsct%7C363679005&_count=1&_sort=-_lastUpdated
   body: none
   auth: bearer
-}
-
-params:query {
-  _count: 10
-  _sort: -_lastUpdated
 }
 
 auth:bearer {
@@ -20,13 +15,8 @@ auth:bearer {
 }
 
 script:post-response {
-  const IMAGING_REQUEST_ID_SYSTEM = "http://data-dictionary.tamanu-fiji.org/tamanu-id-imagingrequest.html";
-
   const body = res.getBody && res.getBody();
-  const resources = ((body && body.entry) || []).map(e => e.resource);
-  const entry = resources.find(r =>
-    (r.identifier || []).some(i => i.system === IMAGING_REQUEST_ID_SYSTEM)
-  );
+  const entry = body && body.entry && body.entry[0] && body.entry[0].resource;
   if (entry && entry.id) {
     bru.setVar("imagingServiceRequestId", entry.id);
     bru.setVar("imagingAccessionNumber", "BRUNO-" + Date.now());

--- a/bruno/fhir-api/environments/local.bru
+++ b/bruno/fhir-api/environments/local.bru
@@ -10,7 +10,6 @@ vars {
   specimenId: 
   immunizationId: 
   medicationRequestId: 
-  serviceRequestId: 
   labServiceRequestId: 
   imagingServiceRequestId: 
   labTestCode: 


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts Bruno test/bootstrap request definitions and environment variables; no runtime application logic changes.
> 
> **Overview**
> Bruno FHIR bootstrap discovery calls for lab and imaging `ServiceRequest` now include `category`, `_count=1`, and `_sort=-_lastUpdated` directly in the request URL, replacing the separate `params:query` block.
> 
> The lab discovery script stops setting the generic `serviceRequestId`, and the local Bruno environment drops the corresponding `serviceRequestId` variable, keeping only `labServiceRequestId`/`imagingServiceRequestId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c80d484ed7bb94e77c0832ca1793f14d650fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->