### PR TITLE
perf(mobile): Release fix 2.54: improve survey form performance on low-end devices

### DIFF
--- a/packages/mobile/App/models/SurveyResponse.ts
+++ b/packages/mobile/App/models/SurveyResponse.ts
@@ -214,9 +214,13 @@ export class SurveyResponse extends BaseModel implements ISurveyResponse {
         // use optional chaining because vitals survey might not exist
         const isVitalSurvey = surveyId === vitalsSurvey?.id;
 
+        const componentsByCode = new Map(
+          components.map((c) => [c.dataElement.code, c]),
+        );
+
         for (const a of Object.entries(finalValues)) {
           const [dataElementCode, value] = a;
-          const component = components.find((c) => c.dataElement.code === dataElementCode);
+          const component = componentsByCode.get(dataElementCode);
           if (!component) {
             // better to fail entirely than save partial data
             throw new Error(

--- a/packages/mobile/App/ui/components/Forms/FormField.tsx
+++ b/packages/mobile/App/ui/components/Forms/FormField.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useCallback } from 'react';
 import { Field as FormikField, useField, useFormikContext } from 'formik';
 import { SUBMIT_ATTEMPTED_STATUS } from '@tamanu/constants';
 import { TranslatedTextElement } from '../Translations/TranslatedText';
@@ -23,24 +23,18 @@ export const Field = ({
   ...rest
 }: FieldProps): JSX.Element => {
   const [field, meta] = useField(name);
-  const formikContext = useFormikContext();
-  const { validateOnChange, status, submitCount } = formikContext;
+  const { status, submitCount } = useFormikContext();
 
-  // Show errors if
-  // 1. validateOnChange is false OR
-  // 2. if the user has already tried to submit the form (submitCount > 0) OR
-  // 3. if the user has already tried to move to the next page of the form (ie: Survey and status === SUBMIT_ATTEMPTED_STATUS)
-  // We don't want errors displayed by on change events before user submits.
-  const showError =
-    !validateOnChange || status === SUBMIT_ATTEMPTED_STATUS || submitCount;
+  const showError = status === SUBMIT_ATTEMPTED_STATUS || submitCount > 0;
   const error = showError ? meta.error : null;
 
-  const combinedOnChange = (newValue: any, selectedItem: any): any => {
+  const combinedOnChange = useCallback((newValue: any, selectedItem: any): any => {
     if (onChange) {
       onChange(newValue, selectedItem);
     }
     return field.onChange({ target: { name, value: newValue } });
-  };
+  }, [field.onChange, name, onChange]);
+
   return (
     <FormikField
       as={component}

--- a/packages/mobile/App/ui/components/Forms/FormScreenView.tsx
+++ b/packages/mobile/App/ui/components/Forms/FormScreenView.tsx
@@ -4,6 +4,7 @@ import React, {
   Ref,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import {
@@ -44,31 +45,21 @@ export const FormScreenView = ({
   const [scrollOffset, setscrollOffset] = useState(0);
 
   const onContentSizeChange = useCallback(
-    (w: number, h: number) => {
+    (_w: number, h: number) => {
       setContentHeight(h);
     },
-    [contentHeight],
+    [],
   );
 
   const onLayout = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
     setLayoutHeight(nativeEvent.layout.height);
   }, []);
 
-  // Formula to get current position related to end of the screen threshold
-  // contentSize - size of the scrollComponent
-  // offset - scroll offset so far
-  // layoutSize - size of the actual layout of the component
-  // layoutSize + 100%offsetavailable = contentSize
-  // Check if the screen content is bigger then the ScrollContainer
   useEffect(() => {
     if (contentHeight > 0 && layoutHeight > 0) {
       const contentBiggerThanScreen =
         contentHeight - layoutHeight - scrollOffset > beginningEndOfScreenThreshold;
-      if (contentBiggerThanScreen) {
-        setAnimated(true);
-      } else {
-        setAnimated(false);
-      }
+      setAnimated(contentBiggerThanScreen);
     }
   }, [contentHeight, layoutHeight, scrollOffset]);
 
@@ -79,12 +70,14 @@ export const FormScreenView = ({
     [],
   );
 
-  const clock = new Clock();
-  const base = runTiming(clock, -1, 1);
-  const animatedOpacity = interpolateNode(base, {
-    inputRange: [-1, 1],
-    outputRange: [0, 1],
-  });
+  const animatedOpacity = useMemo(() => {
+    const clock = new Clock();
+    const base = runTiming(clock, -1, 1);
+    return interpolateNode(base, {
+      inputRange: [-1, 1],
+      outputRange: [0, 1],
+    });
+  }, []);
 
   return (
     <StyledSafeAreaView flex={1} background={theme.colors.BACKGROUND_GREY}>

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -22,37 +23,27 @@ import { FullView, RowView, StyledText, StyledView } from '../../../styled/commo
 import { theme } from '../../../styled/theme';
 import { SUBMIT_ATTEMPTED_STATUS } from '@tamanu/constants';
 import { BackHandler } from 'react-native';
-import { useBackendEffect } from '~/ui/hooks';
-import { LoadingScreen } from '../../LoadingScreen';
-import { ErrorScreen } from '../../ErrorScreen';
 import { TranslatedText } from '../../Translations/TranslatedText';
 
-interface UseScrollToFirstError {
-  setQuestionPosition: (questionCode: string) => (yPosition: number)  => void;
-  scrollToQuestion: (scrollViewRef: any, questionCode: string) => void;
-}
+const useScrollToFirstError = () => {
+  const questionPositionsRef = useRef<Record<string, number>>({});
 
-const useScrollToFirstError = (): UseScrollToFirstError => {
-  const questionPositionsRef = useRef({});
-
-  const scrollToQuestion = (
+  const scrollToQuestion = useCallback((
     scrollViewRef: MutableRefObject<ScrollView>,
     questionCode: string,
   ): void => {
     const yPosition = questionPositionsRef.current[questionCode];
-
     if (scrollViewRef.current !== null) {
-      // Allow a bit of space at the top of the form field for the form label text
       const offset = 20;
       scrollViewRef.current?.scrollTo({ x: 0, y: yPosition - offset, animated: true });
     }
-  };
+  }, []);
 
-  const setQuestionPosition = (questionCode: string) => (yPosition: string) => {
+  const setQuestionPosition = useCallback((questionCode: string, yPosition: number) => {
     if (yPosition) {
       questionPositionsRef.current[questionCode] = yPosition;
     }
-  };
+  }, []);
 
   return { setQuestionPosition, scrollToQuestion };
 };
@@ -66,6 +57,7 @@ const SurveyQuestionErrorView = ({ error }): ReactElement => (
 interface FormFieldsProps {
   components: ISurveyScreenComponent[];
   patient: IPatient;
+  encounter?: { encounterType?: string };
   isSubmitting: boolean;
   onCancel?: () => Promise<void>;
   onGoBack?: () => void;
@@ -79,6 +71,7 @@ export const FormFields = ({
   setCurrentScreenIndex,
   isSubmitting,
   patient,
+  encounter,
   onCancel,
   onGoBack,
 }: FormFieldsProps): ReactElement => {
@@ -86,24 +79,24 @@ export const FormFields = ({
   const { errors, validateForm, setStatus, submitForm, values, resetForm } =
     useFormikContext<GenericFormValues>();
   const { setQuestionPosition, scrollToQuestion } = useScrollToFirstError();
-  const [encounterResult, encounterError, isEncounterLoading] = useBackendEffect(
-    async ({ models }) => {
-      const encounter = await models.Encounter.getCurrentEncounterForPatient(patient.id);
-      return {
-        encounter,
-      };
-    },
-    [patient.id],
-  );
 
   const [disableSubmit, setDisableSubmit] = useState(false);
+
+  // Stable per-question onLayout callbacks keyed by component code.
+  // Uses a ref-map so SurveyQuestion receives the same function identity across renders.
+  const layoutCallbacksRef = useRef<Record<string, (y: number) => void>>({});
+  const getLayoutCallback = useCallback((code: string) => {
+    if (!layoutCallbacksRef.current[code]) {
+      layoutCallbacksRef.current[code] = (y: number) => setQuestionPosition(code, y);
+    }
+    return layoutCallbacksRef.current[code];
+  }, [setQuestionPosition]);
 
   const shouldShow = useCallback(
     (component: ISurveyScreenComponent) => checkVisibilityCriteria(component, components, values),
     [components, values],
   );
 
-  // Handle back button press or swipe right gesture
   useEffect(() => {
     const backAction = () => {
       if (!onGoBack) {
@@ -116,25 +109,29 @@ export const FormFields = ({
     const backHandler = BackHandler.addEventListener('hardwareBackPress', backAction);
 
     return () => backHandler.remove();
-  }, [onGoBack, currentScreenIndex]); // Re-subscribe if screen index changes, otherwise onGoBack() won't work.
+  }, [onGoBack, currentScreenIndex]);
 
-  if (encounterError) {
-    return <ErrorScreen error={encounterError} />;
-  }
+  const maxIndex = useMemo(
+    () => components.reduce((max, x) => Math.max(max, x.screenIndex), 0),
+    [components],
+  );
 
-  if (isEncounterLoading) {
-    return <LoadingScreen />;
-  }
+  const screenComponents = useMemo(
+    () => components
+      .filter((x) => x.screenIndex === currentScreenIndex)
+      .sort((a, b) => a.componentIndex - b.componentIndex),
+    [components, currentScreenIndex],
+  );
 
-  const { encounter } = encounterResult || {};
-  const maxIndex = components
-    .map((x) => x.screenIndex)
-    .reduce((max, current) => Math.max(max, current), 0);
+  const visibleComponents = useMemo(
+    () => screenComponents.filter(shouldShow),
+    [screenComponents, shouldShow],
+  );
 
-  const screenComponents = components
-    .filter((x) => x.screenIndex === currentScreenIndex)
-    .sort((a, b) => a.componentIndex - b.componentIndex);
-  const visibleComponents = screenComponents.filter(shouldShow);
+  const screenCodeSet = useMemo(
+    () => new Set(screenComponents.map((c) => c.dataElement.code)),
+    [screenComponents],
+  );
 
   const emptyStateMessage = (
     <TranslatedText
@@ -144,19 +141,14 @@ export const FormFields = ({
   );
 
   const submitScreen = async (handleSubmit: () => Promise<void>): Promise<void> => {
-    // Validate form on screen before moving to the next one
     const formErrors = await validateForm();
 
-    // Only include components that are on this page
-    const pageErrors = Object.keys(formErrors).filter((x) =>
-      screenComponents.map((c) => c.dataElement.code).includes(x),
-    );
+    const pageErrors = Object.keys(formErrors).filter((x) => screenCodeSet.has(x));
 
     if (pageErrors.length === 0) {
       setStatus(null);
       await handleSubmit();
     } else {
-      // Only show error messages once the user has attempted to submit the form
       setStatus(SUBMIT_ATTEMPTED_STATUS);
 
       const firstErroredQuestion = components.find(({ dataElement }) =>
@@ -227,7 +219,7 @@ export const FormFields = ({
                       component={component}
                       patient={patient}
                       zIndex={components.length - index}
-                      setPosition={setQuestionPosition(component.dataElement.code)}
+                      onLayout={getLayoutCallback(component.dataElement.code)}
                       setDisableSubmit={setDisableSubmit}
                     />
                   </ErrorBoundary>

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/SurveyQuestion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement, memo, useMemo, useCallback } from 'react';
 import { StyledText, StyledView } from '/styled/common';
 import { IPatient, ISurveyScreenComponent, SurveyScreenConfig } from '~/types';
 import { Field } from '../FormField';
@@ -13,7 +13,7 @@ import { useSettings } from '~/ui/contexts/SettingsContext';
 
 interface SurveyQuestionProps {
   component: ISurveyScreenComponent;
-  setPosition: (pos: string) => void;
+  onLayout: (y: number) => void;
   patient: IPatient;
   // Dropdown components will overlap if there are 2 in a row if a z-index is not explicitly set
   zIndex: number;
@@ -60,26 +60,35 @@ const useGetConfig = component => {
   return configObject;
 };
 
+const optionsCache = new Map<string, { label: any; value: any }[] | null>();
+
 // Keep in sync with web/app/utils/survey.jsx
 function mapOptionsToValues(optionsString: string) {
   if (!optionsString) return null;
+  const cached = optionsCache.get(optionsString);
+  if (cached !== undefined) return cached;
+  let result: { label: any; value: any }[] | null = null;
   try {
     const options = JSON.parse(optionsString);
     if (typeof options === 'object') {
       // sometimes this is a map of value => value
-      return Object.values(options).map(x => ({ label: x, value: x }));
+      result = Object.values(options).map(x => ({ label: x, value: x }));
+    } else if (Array.isArray(options)) {
+      result = options.map(x => ({ label: x, value: x }));
     }
-    if (!Array.isArray(options)) return null;
-    return options.map(x => ({ label: x, value: x }));
   } catch (e) {
-    return null;
+    // invalid JSON — leave as null
   }
+  optionsCache.set(optionsString, result);
+  return result;
 }
 
-export const SurveyQuestion = ({
+const EMPTY_OPTIONS: any[] = [];
+
+export const SurveyQuestion = memo(({
   component,
   patient,
-  setPosition,
+  onLayout,
   zIndex,
   setDisableSubmit,
 }: SurveyQuestionProps): ReactElement => {
@@ -89,7 +98,8 @@ export const SurveyQuestion = ({
   const { dataElement } = component;
   const fieldInput: any = getField(dataElement.type, config);
 
-  const options = mapOptionsToValues(component.options || component.dataElement.defaultOptions);
+  const optionsString = component.options || component.dataElement.defaultOptions;
+  const options = mapOptionsToValues(optionsString);
   const translatedOptions = useMemo(() => {
     // if the question is a patient data question with a select field type,
     // we need to get the options from the patient data field locations, so the users don't need to translate the options twice
@@ -120,7 +130,12 @@ export const SurveyQuestion = ({
         value,
       };
     });
-  }, [getTranslation, dataElement.id, options, dataElement.type, getEnumTranslation, component.config]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getTranslation, dataElement.id, optionsString, dataElement.type, getEnumTranslation, component.config]);
+
+  const handleLayout = useCallback(({ nativeEvent }) => {
+    onLayout(nativeEvent.layout.y);
+  }, [onLayout]);
 
   if (!fieldInput) return null;
   const isMultiline = dataElement.type === FieldTypes.MULTILINE;
@@ -129,15 +144,13 @@ export const SurveyQuestion = ({
     <StyledView
       marginTop={12}
       zIndex={zIndex}
-      onLayout={({ nativeEvent }): void => {
-        setPosition(nativeEvent.layout.y);
-      }}
+      onLayout={handleLayout}
     >
       <Field
         component={fieldInput}
         name={dataElement.code}
         defaultText={dataElement.defaultText}
-        options={translatedOptions || []}
+        options={translatedOptions || EMPTY_OPTIONS}
         multiline={isMultiline}
         patient={patient}
         config={config}
@@ -145,4 +158,6 @@ export const SurveyQuestion = ({
       />
     </StyledView>
   );
-};
+});
+
+SurveyQuestion.displayName = 'SurveyQuestion';

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
@@ -1,14 +1,16 @@
 import React, {
   Dispatch,
+  MutableRefObject,
   ReactElement,
   SetStateAction,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useSelector } from 'react-redux';
-import { FormikHandlers } from 'formik';
+import { useFormikContext } from 'formik';
 import { getFormInitialValues, getFormSchema } from './helpers';
 import { IPatientAdditionalData, ISurveyScreenComponent } from '~/types';
 import { Form } from '../Form';
@@ -23,6 +25,87 @@ import { IPatientProgramRegistration } from '~/types/IPatientProgramRegistration
 import { useTranslation } from '~/ui/contexts/TranslationContext';
 import { usePatientAdditionalData } from '~/ui/hooks/usePatientAdditionalData';
 
+function computeVisibleKey(
+  components: ISurveyScreenComponent[],
+  values: Record<string, any>,
+): string {
+  return components
+    .filter(c => checkVisibilityCriteria(c, components, values))
+    .map(c => c.id)
+    .join(',');
+}
+
+interface SurveyFormInnerProps {
+  components: ISurveyScreenComponent[];
+  hasCalculations: boolean;
+  patient: any;
+  encounterProp?: { encounterType?: string };
+  formValuesRef: MutableRefObject<Record<string, any>>;
+  setVisibleComponentKey: React.Dispatch<React.SetStateAction<string>>;
+  onCancel?: () => Promise<void>;
+  onGoBack?: () => void;
+  setCurrentScreenIndex: Dispatch<SetStateAction<number>>;
+  currentScreenIndex: number;
+}
+
+const SurveyFormInner = ({
+  components,
+  hasCalculations,
+  patient,
+  encounterProp,
+  formValuesRef,
+  setVisibleComponentKey,
+  onCancel,
+  onGoBack,
+  setCurrentScreenIndex,
+  currentScreenIndex,
+}: SurveyFormInnerProps): ReactElement => {
+  const { values, setValues, isSubmitting } = useFormikContext<any>();
+
+  const calculatedValues = useMemo(
+    () => (hasCalculations ? runCalculations(components, values) : {}),
+    [components, hasCalculations, values],
+  );
+
+  const mergedValues = useMemo(
+    () => (hasCalculations ? { ...values, ...calculatedValues } : values),
+    [values, calculatedValues, hasCalculations],
+  );
+
+  // Write calculated values back into Formik so they persist
+  useEffect(() => {
+    const changes = Object.entries(calculatedValues).filter(
+      ([key, value]) => values[key] !== value,
+    );
+    if (changes.length > 0) {
+      setValues(
+        prev => ({ ...prev, ...Object.fromEntries(changes) }),
+        false,
+      );
+    }
+  }, [calculatedValues, setValues, values]);
+
+  // Update the ref (cheap, no render) and only setState when visibility changes
+  useEffect(() => {
+    formValuesRef.current = mergedValues;
+    const nextKey = computeVisibleKey(components, mergedValues);
+    setVisibleComponentKey(prev => (prev === nextKey ? prev : nextKey));
+  }, [components, mergedValues, formValuesRef, setVisibleComponentKey]);
+
+  return (
+    <FormFields
+      components={components}
+      patient={patient}
+      encounter={encounterProp}
+      isSubmitting={isSubmitting}
+      onCancel={onCancel}
+      setCurrentScreenIndex={setCurrentScreenIndex}
+      currentScreenIndex={currentScreenIndex}
+      onGoBack={onGoBack}
+    />
+  );
+};
+
 export type SurveyFormProps = {
   onSubmit: (values: any) => Promise<void>;
   openExitModal: () => Promise<void>;
@@ -30,7 +113,6 @@ export type SurveyFormProps = {
   onCancel?: () => Promise<void>;
   onGoBack?: () => void;
   patient: any;
-  note: string;
   validate?: any;
   patientAdditionalData: IPatientAdditionalData;
   patientProgramRegistration?: IPatientProgramRegistration;
@@ -41,7 +123,6 @@ export type SurveyFormProps = {
 export const SurveyForm = ({
   onSubmit,
   components,
-  note,
   patient,
   patientAdditionalData,
   patientProgramRegistration,
@@ -71,40 +152,45 @@ export const SurveyForm = ({
   const [encounterResult, encounterError, isEncounterLoading] = useBackendEffect(
     async ({ models }) => {
       const encounter = await models.Encounter.getCurrentEncounterForPatient(patient.id);
-      return {
-        encounter,
-      };
+      return { encounter };
     },
     [patient.id],
   );
 
   const { encounter } = encounterResult || {};
-  const [formValues, setFormValues] = useState(initialValues);
-  const formValidationSchema = useMemo(
-    () =>
-      getFormSchema(
-        components.filter(c => checkVisibilityCriteria(c, components, formValues)),
-        { encounterType: encounter?.encounterType },
-        getTranslation,
-      ),
-    [encounter?.encounterType, components, formValues, getTranslation],
+  const encounterProp = useMemo(
+    () => encounter ? { encounterType: encounter.encounterType } : undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [encounter?.encounterType],
   );
+  const hasCalculations = useMemo(
+    () => components.some(c => c.calculation),
+    [components],
+  );
+
+  const formValuesRef = useRef(initialValues);
+  const [visibleComponentKey, setVisibleComponentKey] = useState(
+    () => computeVisibleKey(components, initialValues),
+  );
+
+  const formValidationSchema = useMemo(() => {
+    const visible = components.filter(c =>
+      checkVisibilityCriteria(c, components, formValuesRef.current),
+    );
+    return getFormSchema(visible, { encounterType: encounter?.encounterType }, getTranslation);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleComponentKey, encounter?.encounterType, getTranslation]);
 
   const submitVisibleValues = useCallback(
     (values: any) => {
-      // 1. get a list of visible fields
       const visibleFields = new Set(
         components
           .filter(c => checkVisibilityCriteria(c, components, values))
           .map(x => x.dataElement.code),
       );
-
-      // 2. Filter the form values to only include visible fields
       const visibleValues = Object.fromEntries(
         Object.entries(values).filter(([key]) => visibleFields.has(key)),
       );
-
-      // 3. Set visible values in form state?
       return onSubmit(visibleValues);
     },
     [components, onSubmit],
@@ -127,36 +213,20 @@ export const SurveyForm = ({
       onSubmit={submitVisibleValues}
       validate={validate}
     >
-      {({ values, setFieldValue, isSubmitting }: FormikHandlers): ReactElement => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        useEffect(() => {
-          // recalculate dynamic fields
-          const calculatedValues = runCalculations(components, values);
-
-          // write values that have changed back into answers
-          Object.entries(calculatedValues)
-            .filter(([key, value]) => values[key] !== value)
-            .map(([key, value]) => setFieldValue(key, value, false));
-
-          // set parent formValues variable to the values here
-          setFormValues({
-            ...values,
-            ...calculatedValues,
-          });
-        }, [values, setFieldValue]);
-        return (
-          <FormFields
-            components={components}
-            note={note}
-            patient={patient}
-            isSubmitting={isSubmitting}
-            onCancel={onCancel}
-            setCurrentScreenIndex={setCurrentScreenIndex}
-            currentScreenIndex={currentScreenIndex}
-            onGoBack={onGoBack}
-          />
-        );
-      }}
+      {() => (
+        <SurveyFormInner
+          components={components}
+          hasCalculations={hasCalculations}
+          patient={patient}
+          encounterProp={encounterProp}
+          formValuesRef={formValuesRef}
+          setVisibleComponentKey={setVisibleComponentKey}
+          onCancel={onCancel}
+          setCurrentScreenIndex={setCurrentScreenIndex}
+          currentScreenIndex={currentScreenIndex}
+          onGoBack={onGoBack}
+        />
+      )}
     </Form>
   );
 };

--- a/packages/mobile/App/ui/helpers/fields.ts
+++ b/packages/mobile/App/ui/helpers/fields.ts
@@ -143,7 +143,7 @@ function fallbackParseVisibilityCriteria(
   }
   const expectedTrimmed = expectedAnswer.toLowerCase().trim();
 
-  const comparisonComponent = allComponents.find(x => x.dataElement.code === elementCode);
+  const comparisonComponent = getComponentsByCode(allComponents).get(elementCode);
 
   if (!comparisonComponent) {
     console.warn(`Comparison component ${elementCode} not found!`);
@@ -153,6 +153,17 @@ function fallbackParseVisibilityCriteria(
   const comparisonDataType = comparisonComponent.dataElement.type;
 
   return compareData(comparisonDataType, expectedTrimmed, givenAnswer);
+}
+
+const componentsByCodeCache = new WeakMap<ISurveyScreenComponent[], Map<string, ISurveyScreenComponent>>();
+
+function getComponentsByCode(allComponents: ISurveyScreenComponent[]): Map<string, ISurveyScreenComponent> {
+  let map = componentsByCodeCache.get(allComponents);
+  if (!map) {
+    map = new Map(allComponents.map(c => [c.dataElement?.code, c]));
+    componentsByCodeCache.set(allComponents, map);
+  }
+  return map;
 }
 
 /**

--- a/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseScreen.tsx
+++ b/packages/mobile/App/ui/navigation/screens/programs/SurveyResponseScreen.tsx
@@ -41,7 +41,6 @@ export const SurveyResponseScreen = ({ route }: SurveyResponseScreenProps): Reac
   const canReadRegistration = ability.can('read', 'PatientProgramRegistration');
   const { currentScreenIndex, onNavigatePrevious, setCurrentScreenIndex } = useCurrentScreen();
 
-  const [note, setNote] = useState('');
   const [showModal, setShowModal] = useState(false);
 
   const [survey, surveyError, isSurveyLoading] = useBackendEffect(({ models }) =>
@@ -101,7 +100,6 @@ export const SurveyResponseScreen = ({ route }: SurveyResponseScreenProps): Reac
           encounterReason: 'Form response',
         },
         values,
-        setNote,
       );
 
       if (!response) return;
@@ -173,7 +171,6 @@ export const SurveyResponseScreen = ({ route }: SurveyResponseScreenProps): Reac
           patient={selectedPatient}
           patientAdditionalData={patientAdditionalData}
           patientProgramRegistration={patientProgramRegistration}
-          note={note}
           components={components}
           onSubmit={onSubmit}
           onCancel={openExitModal}

--- a/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/DetectIdleLayer.tsx
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash';
-import React, { ReactElement, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, ReactNode, useCallback, useEffect, useRef } from 'react';
 import {
   AppState,
   AppStateStatus,
@@ -19,77 +19,74 @@ const ONE_MINUTE = 1000 * 60;
 const UI_EXPIRY_TIME = ONE_MINUTE * 30;
 
 export const DetectIdleLayer = ({ children }: DetectIdleLayerProps): ReactElement => {
-  const [idle, setIdle] = useState(0);
-  const [screenOffTime, setScreenOffTime] = useState<number|null>(null);
-  const appState = useRef(AppState.currentState);
+  const lastActivityRef = useRef(Date.now());
+  const screenOffTimeRef = useRef<number | null>(null);
+  const appStateRef = useRef(AppState.currentState);
   const { signOutClient, signedIn } = useAuth();
+  const signOutClientRef = useRef(signOutClient);
+  signOutClientRef.current = signOutClient;
 
-  const resetIdle = (): void => {
-    setIdle(0);
-  };
+  const resetIdle = useCallback((): void => {
+    lastActivityRef.current = Date.now();
+  }, []);
 
-  const debouncedResetIdle = useCallback(debounce(resetIdle, 300), []);
+  const debouncedResetIdle = useCallback(debounce(resetIdle, 300), [resetIdle]);
 
-  const handleResetIdle = (): boolean => {
+  const handleResetIdleRef = useRef((): boolean => {
     debouncedResetIdle();
-    // Returns false to indicate that this component
-    // shouldn't block native components from becoming the JS responder
+    return false;
+  });
+  handleResetIdleRef.current = (): boolean => {
+    debouncedResetIdle();
     return false;
   };
 
-  const handleIdleLogout = (): void => {
-    signOutClient(true);
-  };
-
-  const handleStateChange = (nextAppState: AppStateStatus): void => {
-    if (appState.current === 'active' && nextAppState.match(/inactive|background/)) {
-      // App has moved to the background
-      setScreenOffTime(Date.now());
-    } else if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
-      // App has moved to the foreground
-      if (screenOffTime) {
-        const timeDiff = Date.now() - screenOffTime;
-        const newIdle = idle + timeDiff;
-        setIdle(newIdle);
-        setScreenOffTime(null);
-        if (newIdle >= UI_EXPIRY_TIME) {
-          handleIdleLogout();
-        }
-      }
-    }
-    appState.current = nextAppState;
-  };
+  const stableHandleResetIdle = useCallback(
+    (): boolean => handleResetIdleRef.current(),
+    [],
+  );
 
   useEffect(() => {
-    let intervalId: NodeJS.Timer;
-    let subscriptions: (EmitterSubscription|NativeEventSubscription)[] = [];
-    if (signedIn) {
-      subscriptions = [
-        AppState.addEventListener('change', handleStateChange),
-        Keyboard.addListener('keyboardDidHide', handleResetIdle),
-        Keyboard.addListener('keyboardDidShow', handleResetIdle),
-      ];
-      intervalId = setInterval(() => {
-        const newIdle = idle + ONE_MINUTE;
-        setIdle(newIdle);
-        if (newIdle >= UI_EXPIRY_TIME) {
-          handleIdleLogout();
+    if (!signedIn) return;
+
+    const handleStateChange = (nextAppState: AppStateStatus): void => {
+      if (appStateRef.current === 'active' && nextAppState.match(/^(inactive|background)$/)) {
+        screenOffTimeRef.current = Date.now();
+      } else if (appStateRef.current.match(/^(inactive|background)$/) && nextAppState === 'active') {
+        if (screenOffTimeRef.current) {
+          screenOffTimeRef.current = null;
+          if (Date.now() - lastActivityRef.current >= UI_EXPIRY_TIME) {
+            signOutClientRef.current(true);
+          }
         }
-      }, ONE_MINUTE);
-    }
-    return () => {
-      if (intervalId) {
-        clearInterval(intervalId);
       }
-      subscriptions.forEach(subscription => subscription?.remove());
+      appStateRef.current = nextAppState;
     };
-  }, [idle, signedIn, screenOffTime]);
+
+    const subscriptions: (EmitterSubscription | NativeEventSubscription)[] = [
+      AppState.addEventListener('change', handleStateChange),
+      Keyboard.addListener('keyboardDidHide', stableHandleResetIdle),
+      Keyboard.addListener('keyboardDidShow', stableHandleResetIdle),
+    ];
+
+    const intervalId = setInterval(() => {
+      if (Date.now() - lastActivityRef.current >= UI_EXPIRY_TIME) {
+        signOutClientRef.current(true);
+      }
+    }, ONE_MINUTE);
+
+    return () => {
+      clearInterval(intervalId);
+      subscriptions.forEach(subscription => subscription?.remove());
+      debouncedResetIdle.cancel();
+    };
+  }, [signedIn, stableHandleResetIdle, debouncedResetIdle]);
 
   const panResponder = useRef(
     PanResponder.create({
-      onMoveShouldSetPanResponderCapture: handleResetIdle,
-      onStartShouldSetPanResponderCapture: handleResetIdle,
-      onPanResponderTerminationRequest: handleResetIdle,
+      onMoveShouldSetPanResponderCapture: stableHandleResetIdle,
+      onStartShouldSetPanResponderCapture: stableHandleResetIdle,
+      onPanResponderTerminationRequest: stableHandleResetIdle,
     }),
   );
 

--- a/packages/utils/src/criteria.ts
+++ b/packages/utils/src/criteria.ts
@@ -3,8 +3,20 @@ import { PROGRAM_DATA_ELEMENT_TYPES } from '@tamanu/constants';
 
 const RESERVED_KEYS = ['_conjunction', 'hidden'];
 
+const parsedCriteriaCache = new Map<string, any>();
+const componentsByCodeCache = new WeakMap<Component[], Map<string, Component>>();
+
 interface Component {
   dataElement?: { code?: string; type?: string };
+}
+
+function getComponentsByCode(allComponents: Component[]): Map<string, Component> {
+  let map = componentsByCodeCache.get(allComponents);
+  if (!map) {
+    map = new Map(allComponents.map(c => [c.dataElement?.code ?? '', c]));
+    componentsByCodeCache.set(allComponents, map);
+  }
+  return map;
 }
 
 export function checkJSONCriteria(
@@ -14,17 +26,21 @@ export function checkJSONCriteria(
 ): boolean {
   if (!criteria) return true;
 
-  const criteriaObject = JSON.parse(criteria);
+  let criteriaObject = parsedCriteriaCache.get(criteria);
+  if (criteriaObject === undefined) {
+    criteriaObject = JSON.parse(criteria);
+    parsedCriteriaCache.set(criteria, criteriaObject);
+  }
   if (!criteriaObject) return true;
 
-  const conjunction = criteriaObject._conjunction;
-  delete criteriaObject._conjunction;
-  delete criteriaObject.hidden;
+  const { _conjunction: conjunction, hidden: _hidden, ...restOfCriteria } = criteriaObject;
 
-  if (Object.keys(criteriaObject).length === 0) return true;
+  if (Object.keys(restOfCriteria).length === 0) return true;
+
+  const byCode = getComponentsByCode(allComponents);
 
   const checkIfQuestionMeetsCriteria = ([questionCode, answersEnablingFollowUp]: [string, any]): boolean => {
-    const matchingComponent = allComponents.find(x => x.dataElement?.code === questionCode);
+    const matchingComponent = byCode.get(questionCode);
     const value = values[questionCode];
     if (answersEnablingFollowUp.type === 'range') {
       if (!value && value !== 0) return false;
@@ -55,8 +71,8 @@ export function checkJSONCriteria(
   };
 
   return conjunction === 'and'
-    ? Object.entries(criteriaObject).every(checkIfQuestionMeetsCriteria)
-    : Object.entries(criteriaObject).some(checkIfQuestionMeetsCriteria);
+    ? Object.entries(restOfCriteria).every(checkIfQuestionMeetsCriteria)
+    : Object.entries(restOfCriteria).some(checkIfQuestionMeetsCriteria);
 }
 
 /**


### PR DESCRIPTION
### Changes

Cherry-picks the mobile survey form performance improvements from #9521 into release/2.54. This brings the low-end device optimisations already present on main and earlier release hotfix branches into the 2.54 release branch.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly performance-focused memoization/caching changes, but it refactors survey validation/visibility and idle-logout timing logic, which could cause subtle UX or session-expiry regressions if edge cases are missed.
> 
> **Overview**
> Improves mobile survey form performance by reducing per-render work: caches component lookups by `dataElement.code`, memoizes animation/option generation, and memoizes `SurveyQuestion` with stable `onLayout`/`onChange` callbacks to limit rerenders.
> 
> Refactors survey calculation + validation flow so calculated fields are written back into Formik, and the validation schema only recomputes when the *set of visible components* changes (tracked via a derived key + ref), rather than on every keystroke.
> 
> Optimizes visibility-criteria evaluation in `@tamanu/utils` by caching parsed JSON criteria and reusing component-by-code maps, and updates mobile fallback visibility parsing similarly. Also removes the survey submit progress `note` plumbing and rewrites `DetectIdleLayer` to use refs/timers instead of state to avoid frequent rerenders while preserving idle auto-logout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 137f829ffaa5456b871fa041498163a4b24287ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->