### PR TITLE
fix(web): breadcrumb semantics & translations

### DIFF
--- a/packages/ui-components/src/components/Button/Button.jsx
+++ b/packages/ui-components/src/components/Button/Button.jsx
@@ -319,6 +319,7 @@ export const UnstyledHtmlButton = styled.button`
   font-size: inherit;
   font-style: inherit;
   line-height: inherit;
+  padding: 0;
   text-align: inherit;
   text-decoration-thickness: from-font;
   touch-action: manipulation;

--- a/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
@@ -24,25 +24,27 @@ const AnchorLikeButton = styled(UnstyledHtmlButton)`
   }
 `;
 
-export const Breadcrumb = ({ onClick, title }) => (
-  <AnchorLikeButton onClick={onClick}>{title}</AnchorLikeButton>
+export const Breadcrumb = ({ title, ...props }) => (
+  <AnchorLikeButton {...props}>{title}</AnchorLikeButton>
 );
 
-export const PatientBreadcrumb = () => {
+export const PatientBreadcrumb = props => {
   const patient = useSelector(state => state.patient);
   const { navigateToPatient } = usePatientNavigation();
   const onClick = () => navigateToPatient(patient.id);
-  return <Breadcrumb onClick={onClick} title={getPatientNameAsString(patient || {})} />;
+  return <Breadcrumb {...props} onClick={onClick} title={getPatientNameAsString(patient || {})} />;
 };
 
-export const CategoryBreadcrumb = () => {
+export const CategoryBreadcrumb = props => {
   const { navigateToCategory } = usePatientNavigation();
   const params = useParams();
   const onClick = () => navigateToCategory(params.category);
-  return <Breadcrumb onClick={onClick} title={PATIENT_CATEGORY_LABELS[params.category]} />;
+  return (
+    <Breadcrumb {...props} onClick={onClick} title={PATIENT_CATEGORY_LABELS[params.category]} />
+  );
 };
 
-export const ProgramRegistryBreadcrumb = () => {
+export const ProgramRegistryBreadcrumb = props => {
   const location = useLocation();
   const { navigateToProgramRegistry } = usePatientNavigation();
   const match = matchPath(
@@ -60,6 +62,7 @@ export const ProgramRegistryBreadcrumb = () => {
 
   return (
     <Breadcrumb
+      {...props}
       onClick={() => navigateToProgramRegistry(programRegistryId)}
       title={
         <TranslatedReferenceData
@@ -72,11 +75,12 @@ export const ProgramRegistryBreadcrumb = () => {
   );
 };
 
-export const EncounterBreadcrumb = () => {
+export const EncounterBreadcrumb = props => {
   const { encounter } = useEncounter();
   const { navigateToEncounter } = usePatientNavigation();
   return (
     <Breadcrumb
+      {...props}
       onClick={() => navigateToEncounter(encounter.id)}
       title={getEncounterType(encounter || {})}
       key="encounter"
@@ -84,16 +88,13 @@ export const EncounterBreadcrumb = () => {
   );
 };
 
-export const MedicationBreadcrumb = () => {
+export const MedicationBreadcrumb = props => {
   const { encounter } = useEncounter();
   const { navigateToEncounter } = usePatientNavigation();
   return (
     <Breadcrumb
-      onClick={() => {
-        navigateToEncounter(encounter?.id, {
-          tab: ENCOUNTER_TAB_NAMES.MEDICATION,
-        });
-      }}
+      {...props}
+      onClick={() => navigateToEncounter(encounter?.id, { tab: ENCOUNTER_TAB_NAMES.MEDICATION })}
       title={<TranslatedText stringId="encounter.medication.title" fallback="Medication" />}
     />
   );

--- a/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
@@ -16,9 +16,7 @@ import { usePatientNavigation } from '../../utils/usePatientNavigation';
 import { getEncounterType } from '../../views/patients/panes/EncounterInfoPane';
 
 const BreadcrumbLink = styled(UnstyledHtmlButton)`
-  font-size: 12px;
   color: ${props => props.theme.palette.primary.main};
-  font-weight: 400;
   cursor: pointer;
   &:hover {
     text-decoration: underline;

--- a/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
@@ -19,6 +19,7 @@ const BreadcrumbLink = styled(UnstyledHtmlButton)`
   font-size: 12px;
   color: ${props => props.theme.palette.primary.main};
   font-weight: 400;
+  cursor: pointer;
   &:hover {
     text-decoration: underline;
   }

--- a/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
@@ -15,7 +15,8 @@ import { useEncounter } from '../../contexts/Encounter';
 import { usePatientNavigation } from '../../utils/usePatientNavigation';
 import { getEncounterType } from '../../views/patients/panes/EncounterInfoPane';
 
-const BreadcrumbLink = styled(UnstyledHtmlButton)`
+/** Button semantics (uses `onClick` instead of `href`), but looks like an anchor. */
+const AnchorLikeButton = styled(UnstyledHtmlButton)`
   color: ${props => props.theme.palette.primary.main};
   cursor: pointer;
   &:hover {
@@ -24,7 +25,7 @@ const BreadcrumbLink = styled(UnstyledHtmlButton)`
 `;
 
 export const Breadcrumb = ({ onClick, title }) => (
-  <BreadcrumbLink onClick={onClick}>{title}</BreadcrumbLink>
+  <AnchorLikeButton onClick={onClick}>{title}</AnchorLikeButton>
 );
 
 export const PatientBreadcrumb = () => {

--- a/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientBreadcrumbs.jsx
@@ -1,31 +1,31 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import { useLocation, useParams, matchPath } from 'react-router';
+import { matchPath, useLocation, useParams } from 'react-router';
 import styled from 'styled-components';
-import { PATIENT_CATEGORY_LABELS, PATIENT_PATHS } from '../../constants/patientPaths';
-import { ENCOUNTER_TAB_NAMES } from '../../constants/encounterTabNames';
-import { usePatientNavigation } from '../../utils/usePatientNavigation';
-import { getPatientNameAsString, TranslatedText, TranslatedReferenceData } from '../../components';
-import { useEncounter } from '../../contexts/Encounter';
-import { getEncounterType } from '../../views/patients/panes/EncounterInfoPane';
 import { useProgramRegistryQuery } from '../../api/queries';
+import {
+  getPatientNameAsString,
+  TranslatedReferenceData,
+  TranslatedText,
+  UnstyledHtmlButton,
+} from '../../components';
+import { ENCOUNTER_TAB_NAMES } from '../../constants/encounterTabNames';
+import { PATIENT_CATEGORY_LABELS, PATIENT_PATHS } from '../../constants/patientPaths';
+import { useEncounter } from '../../contexts/Encounter';
+import { usePatientNavigation } from '../../utils/usePatientNavigation';
+import { getEncounterType } from '../../views/patients/panes/EncounterInfoPane';
 
-const BreadcrumbLink = styled(Typography)`
+const BreadcrumbLink = styled(UnstyledHtmlButton)`
   font-size: 12px;
   color: ${props => props.theme.palette.primary.main};
   font-weight: 400;
-  text-transform: capitalize;
-  cursor: pointer;
   &:hover {
     text-decoration: underline;
   }
 `;
 
 export const Breadcrumb = ({ onClick, title }) => (
-  <BreadcrumbLink underline="hover" color="inherit" onClick={onClick}>
-    {title}
-  </BreadcrumbLink>
+  <BreadcrumbLink onClick={onClick}>{title}</BreadcrumbLink>
 );
 
 export const PatientBreadcrumb = () => {

--- a/packages/web/app/features/Breadcrumbs/PatientNavigation.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientNavigation.jsx
@@ -55,7 +55,11 @@ const RouteBreadcrumbs = ({ patientRoutes }) => {
     return matchPath({ path: fullPath, end: true }, location.pathname);
   });
 
-  return matchedRoute?.breadcrumbs || [];
+  const breadcrumbs = matchedRoute?.breadcrumbs || [];
+  const last = breadcrumbs.at(-1);
+  return React.isValidElement(last)
+    ? [...breadcrumbs.slice(0, -1), React.cloneElement(last, { 'aria-current': 'page' })]
+    : breadcrumbs;
 };
 
 export const PatientNavigation = ({ patientRoutes }) => {

--- a/packages/web/app/features/Breadcrumbs/PatientNavigation.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientNavigation.jsx
@@ -32,14 +32,13 @@ const VerticalDivider = styled.div`
 `;
 
 const StyledBreadcrumbs = styled(Breadcrumbs)`
-  & ol > .MuiBreadcrumbs-separator {
-    font-size: 12px;
+  font-size: 12px;
+  .MuiBreadcrumbs-separator {
     color: ${Colors.softText};
   }
-  & ol > :last-child > p {
-    pointer-events: none;
+  .MuiBreadcrumbs-li:last-child {
     font-weight: 500;
-    cursor: default;
+    pointer-events: none;
   }
 `;
 

--- a/packages/web/app/features/Breadcrumbs/PatientNavigation.jsx
+++ b/packages/web/app/features/Breadcrumbs/PatientNavigation.jsx
@@ -55,11 +55,7 @@ const RouteBreadcrumbs = ({ patientRoutes }) => {
     return matchPath({ path: fullPath, end: true }, location.pathname);
   });
 
-  const breadcrumbs = matchedRoute?.breadcrumbs || [];
-  const last = breadcrumbs.at(-1);
-  return React.isValidElement(last)
-    ? [...breadcrumbs.slice(0, -1), React.cloneElement(last, { 'aria-current': 'page' })]
-    : breadcrumbs;
+  return matchedRoute?.breadcrumbs || [];
 };
 
 export const PatientNavigation = ({ patientRoutes }) => {

--- a/packages/web/app/routes/PatientRoutes.jsx
+++ b/packages/web/app/routes/PatientRoutes.jsx
@@ -43,9 +43,25 @@ export const usePatientRoutes = () => {
     {
       path: 'programs/new',
       component: ProgramsView,
-      breadcrumbs: [<Breadcrumb key="new-form" title="New Form" />],
+      breadcrumbs: [
+        <Breadcrumb
+          key="new-form"
+          title={<TranslatedText stringId="program.action.newForm" fallback="New form" />}
+        />,
+      ],
     },
-    { path: 'referrals/new', component: ReferralsView, breadcrumbs: 'New Referral' },
+    {
+      path: 'referrals/new',
+      component: ReferralsView,
+      breadcrumbs: [
+        <Breadcrumb
+          key="new-referral"
+          title={
+            <TranslatedText stringId="patient.referral.action.create" fallback="New referral" />
+          }
+        />,
+      ],
+    },
     {
       path: 'encounter/:encounterId/:modal?',
       component: EncounterView,
@@ -93,7 +109,10 @@ export const usePatientRoutes = () => {
       component: ProgramsView,
       breadcrumbs: [
         <EncounterBreadcrumb key="encounter" />,
-        <Breadcrumb key="new-form" title="New Form" />,
+        <Breadcrumb
+          key="new-form"
+          title={<TranslatedText stringId="program.action.newForm" fallback="New form" />}
+        />,
       ],
     },
     {
@@ -122,7 +141,10 @@ export const usePatientRoutes = () => {
       component: ProgramRegistrySurveyView,
       breadcrumbs: [
         <ProgramRegistryBreadcrumb key="program-registry" />,
-        <Breadcrumb key="new-form" title="New Form" />,
+        <Breadcrumb
+          key="new-form"
+          title={<TranslatedText stringId="program.action.newForm" fallback="New form" />}
+        />,
       ],
     },
   ];


### PR DESCRIPTION
### Changes

Still missing `aria-current` attribute on the relevant breadcrumb, but the way we currently render means it’s not a trivial code change to fix

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
