### PR TITLE
fix(scheduledTasks): no issue: Explicitly use primaryTimeZone in scheduled tasks

### DIFF
--- a/packages/shared/__tests__/tasks/ScheduledTask.test.js
+++ b/packages/shared/__tests__/tasks/ScheduledTask.test.js
@@ -1,4 +1,4 @@
-import { addMilliseconds, addHours, isWithinInterval } from 'date-fns';
+import { addMilliseconds, addHours, addDays, addMonths, isWithinInterval } from 'date-fns';
 
 import { ScheduledTask } from '../../src/tasks/ScheduledTask';
 import { log } from '../../src/services/logging/log';
@@ -44,7 +44,7 @@ jest.useFakeTimers().setSystemTime(systemTime);
 jest.mock('@tamanu/utils/sleepAsync', () => {
   return {
     __esModule: true,
-    sleepAsync: (ms) => {
+    sleepAsync: ms => {
       // Update the Date.now() whenever we sleep to mock the jitter behaviour
       jest.useFakeTimers().setSystemTime(addMilliseconds(systemTime, ms));
     },
@@ -89,20 +89,20 @@ describe('ScheduledTask', () => {
     });
     const tasks = [onEveryHour, onMidnightEveryDay, onFirstDayEveryMonth];
 
-    tasks.forEach((task) => task.beginPolling());
+    tasks.forEach(task => task.beginPolling());
 
     expect(onEveryHour.job.nextInvocation().toISOString()).toEqual(
       addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
     );
     expect(onMidnightEveryDay.job.nextInvocation().toISOString()).toEqual(
-      addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
+      addDays(systemTime, 1, { tz: 'UTC' }).toISOString(),
     );
     expect(onFirstDayEveryMonth.job.nextInvocation().toISOString()).toEqual(
-      addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
+      addMonths(systemTime, 1, { tz: 'UTC' }).toISOString(),
     );
 
-    tasks.forEach((task) => task.cancelPolling());
-    tasks.forEach((task) => expect(task.job).toBeNull());
+    tasks.forEach(task => task.cancelPolling());
+    tasks.forEach(task => expect(task.job).toBeNull());
   });
 
   it('Can add some jitter between runs', async () => {
@@ -163,12 +163,12 @@ describe('ScheduledTask', () => {
     const runStartedPromises = [];
     const completeRunResolves = [];
     runStartedPromises.push(
-      new Promise((resolve) => {
+      new Promise(resolve => {
         runStartedResolves.push(resolve);
       }),
     );
     runStartedPromises.push(
-      new Promise((resolve) => {
+      new Promise(resolve => {
         runStartedResolves.push(resolve);
       }),
     );
@@ -177,7 +177,7 @@ describe('ScheduledTask', () => {
       const runStartedResolve = runStartedResolves[runsStarted];
       runsStarted += 1;
       runStartedResolve();
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         completeRunResolves.push(resolve);
       }).then(() => {
         runsCompleted += 1;

--- a/packages/shared/__tests__/tasks/ScheduledTask.test.js
+++ b/packages/shared/__tests__/tasks/ScheduledTask.test.js
@@ -1,4 +1,4 @@
-import { addMilliseconds, addHours, addDays, addMonths, isWithinInterval } from 'date-fns';
+import { addMilliseconds, addHours, isWithinInterval } from 'date-fns';
 
 import { ScheduledTask } from '../../src/tasks/ScheduledTask';
 import { log } from '../../src/services/logging/log';
@@ -59,15 +59,26 @@ describe('ScheduledTask', () => {
     jest.useFakeTimers().setSystemTime(systemTime);
   });
 
+  it('adds the configured timezone to schedules', () => {
+    const task = new TestScheduledTask(() => {}, {
+      schedule: '0 2 * * *',
+    });
+
+    expect(task.schedule).toEqual({
+      rule: '0 2 * * *',
+      tz: 'Australia/Melbourne',
+    });
+  });
+
   it('Should run a task on a schedule', () => {
     const onEveryHour = new TestScheduledTask(() => {}, {
-      schedule: { rule: '0 * * * *', tz: 'UTC' },
+      schedule: '0 * * * *',
     });
     const onMidnightEveryDay = new TestScheduledTask(() => {}, {
-      schedule: { rule: '0 0 * * *', tz: 'UTC' },
+      schedule: '0 0 * * *',
     });
     const onFirstDayEveryMonth = new TestScheduledTask(() => {}, {
-      schedule: { rule: '0 0 1 * *', tz: 'UTC' },
+      schedule: '0 0 1 * *',
     });
     const tasks = [onEveryHour, onMidnightEveryDay, onFirstDayEveryMonth];
 
@@ -77,10 +88,10 @@ describe('ScheduledTask', () => {
       addHours(systemTime, 1).toISOString(),
     );
     expect(onMidnightEveryDay.job.nextInvocation().toISOString()).toEqual(
-      addDays(systemTime, 1).toISOString(),
+      '2020-01-01T13:00:00.000Z',
     );
     expect(onFirstDayEveryMonth.job.nextInvocation().toISOString()).toEqual(
-      addMonths(systemTime, 1).toISOString(),
+      '2020-01-31T13:00:00.000Z',
     );
 
     tasks.forEach((task) => task.cancelPolling());
@@ -96,7 +107,7 @@ describe('ScheduledTask', () => {
         taskRanAt = new Date();
       },
       {
-        schedule: { rule: '0 * * * *', tz: 'UTC' },
+        schedule: '0 * * * *',
         jitterTime,
       },
     );
@@ -123,7 +134,7 @@ describe('ScheduledTask', () => {
         hasRun = true;
       },
       {
-        schedule: { rule: '0 * * * *', tz: 'UTC' },
+        schedule: '0 * * * *',
         enabled: false,
       },
     );

--- a/packages/shared/__tests__/tasks/ScheduledTask.test.js
+++ b/packages/shared/__tests__/tasks/ScheduledTask.test.js
@@ -70,28 +70,35 @@ describe('ScheduledTask', () => {
     });
   });
 
+  it('preserves object schedules', () => {
+    const schedule = { rule: '0 2 * * *', tz: 'Pacific/Auckland' };
+    const task = new TestScheduledTask(() => {}, { schedule });
+
+    expect(task.schedule).toBe(schedule);
+  });
+
   it('Should run a task on a schedule', () => {
     const onEveryHour = new TestScheduledTask(() => {}, {
-      schedule: '0 * * * *',
+      schedule: { rule: '0 * * * *', tz: 'UTC' },
     });
     const onMidnightEveryDay = new TestScheduledTask(() => {}, {
-      schedule: '0 0 * * *',
+      schedule: { rule: '0 0 * * *', tz: 'UTC' },
     });
     const onFirstDayEveryMonth = new TestScheduledTask(() => {}, {
-      schedule: '0 0 1 * *',
+      schedule: { rule: '0 0 1 * *', tz: 'UTC' },
     });
     const tasks = [onEveryHour, onMidnightEveryDay, onFirstDayEveryMonth];
 
     tasks.forEach((task) => task.beginPolling());
 
     expect(onEveryHour.job.nextInvocation().toISOString()).toEqual(
-      addHours(systemTime, 1).toISOString(),
+      addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
     );
     expect(onMidnightEveryDay.job.nextInvocation().toISOString()).toEqual(
-      '2020-01-01T13:00:00.000Z',
+      addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
     );
     expect(onFirstDayEveryMonth.job.nextInvocation().toISOString()).toEqual(
-      '2020-01-31T13:00:00.000Z',
+      addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
     );
 
     tasks.forEach((task) => task.cancelPolling());
@@ -107,7 +114,7 @@ describe('ScheduledTask', () => {
         taskRanAt = new Date();
       },
       {
-        schedule: '0 * * * *',
+        schedule: { rule: '0 * * * *', tz: 'UTC' },
         jitterTime,
       },
     );
@@ -134,7 +141,7 @@ describe('ScheduledTask', () => {
         hasRun = true;
       },
       {
-        schedule: '0 * * * *',
+        schedule: { rule: '0 * * * *', tz: 'UTC' },
         enabled: false,
       },
     );

--- a/packages/shared/__tests__/tasks/ScheduledTask.test.js
+++ b/packages/shared/__tests__/tasks/ScheduledTask.test.js
@@ -92,13 +92,13 @@ describe('ScheduledTask', () => {
     tasks.forEach(task => task.beginPolling());
 
     expect(onEveryHour.job.nextInvocation().toISOString()).toEqual(
-      addHours(systemTime, 1, { tz: 'UTC' }).toISOString(),
+      addHours(systemTime, 1).toISOString(),
     );
     expect(onMidnightEveryDay.job.nextInvocation().toISOString()).toEqual(
-      addDays(systemTime, 1, { tz: 'UTC' }).toISOString(),
+      addDays(systemTime, 1).toISOString(),
     );
     expect(onFirstDayEveryMonth.job.nextInvocation().toISOString()).toEqual(
-      addMonths(systemTime, 1, { tz: 'UTC' }).toISOString(),
+      addMonths(systemTime, 1).toISOString(),
     );
 
     tasks.forEach(task => task.cancelPolling());

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -12,10 +12,7 @@ import { getPrimaryTimeZone } from '../utils/timeZoneCheck';
 const wrapScheduleWithTimeZone = schedule => {
   const primaryTimeZone = getPrimaryTimeZone(config);
   if (typeof schedule === 'object') {
-    if (schedule.tz) {
-      return schedule;
-    }
-    return { ...schedule, tz: primaryTimeZone };
+    return schedule.tz ? schedule : { ...schedule, tz: primaryTimeZone };
   }
   return { rule: schedule, tz: primaryTimeZone };
 };

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -160,7 +160,7 @@ export class ScheduledTask {
 
     if (!this.job) {
       const name = this.getName();
-      this.log.info(`ScheduledTask: ${name}: Scheduled for ${this.schedule}`);
+      this.log.info(`ScheduledTask: ${name}: Scheduled for ${this.schedule.rule}`);
       this.job = scheduleJob(this.schedule, async () => {
         if (this.jitterTime) {
           const randomOffset = Math.floor(Math.random() * ms(this.jitterTime));

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -21,7 +21,7 @@ export class ScheduledTask {
       name: this.getName(),
     });
 
-    this.schedule = {
+    this.schedule = schedule && {
       rule: schedule,
       tz: getPrimaryTimeZone(config),
     };

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -21,6 +21,10 @@ export class ScheduledTask {
       name: this.getName(),
     });
 
+    if (schedule && typeof schedule !== 'string') {
+      throw new Error(`ScheduledTask: schedule must be a cron string, received ${typeof schedule}`);
+    }
+
     this.schedule = schedule && {
       rule: schedule,
       tz: getPrimaryTimeZone(config),

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -12,12 +12,15 @@ import { getPrimaryTimeZone } from '../utils/timeZoneCheck';
 const wrapScheduleWithTimeZone = schedule => {
   const primaryTimeZone = getPrimaryTimeZone(config);
   if (typeof schedule === 'object') {
-    return {tz: primaryTimeZone, ...schedule};
+    if (schedule.tz) {
+      return schedule;
+    }
+    return { ...schedule, tz: primaryTimeZone };
   } else if (typeof schedule === 'string') {
     return { tz: primaryTimeZone, rule: schedule };
   }
   throw new Error(`Invalid schedule: ${schedule}`);
-}
+};
 
 export class ScheduledTask {
   getName() {
@@ -31,7 +34,7 @@ export class ScheduledTask {
       name: this.getName(),
     });
 
-    this.schedule = wrapScheduleWithTimeZone(schedule);
+    this.schedule = schedule && wrapScheduleWithTimeZone(schedule);
     this.job = null;
     this.log = log;
     this.isRunning = false;

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { SpanStatusCode } from '@opentelemetry/api';
 import shortid from 'shortid';
 import { scheduleJob } from 'node-schedule';
@@ -6,6 +7,7 @@ import ms from 'ms';
 import { sleepAsync } from '@tamanu/utils/sleepAsync';
 
 import { getTracer, spanWrapFn } from '../services/logging';
+import { getPrimaryTimeZone } from '../utils/timeZoneCheck';
 
 export class ScheduledTask {
   getName() {
@@ -19,7 +21,10 @@ export class ScheduledTask {
       name: this.getName(),
     });
 
-    this.schedule = schedule;
+    this.schedule = {
+      rule: schedule,
+      tz: getPrimaryTimeZone(config),
+    };
     this.job = null;
     this.log = log;
     this.isRunning = false;

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -12,10 +12,10 @@ import { getPrimaryTimeZone } from '../utils/timeZoneCheck';
 const wrapScheduleWithTimeZone = schedule => {
   const primaryTimeZone = getPrimaryTimeZone(config);
   if (typeof schedule === 'object') {
-    return schedule.tz ? schedule : { ...schedule, tz: primaryTimeZone };
+    return {tz: primaryTimeZone, ...schedule};
   }
-  return { rule: schedule, tz: primaryTimeZone };
-};
+  return { tz: primaryTimeZone, rule: schedule };
+}
 
 export class ScheduledTask {
   getName() {

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -9,6 +9,17 @@ import { sleepAsync } from '@tamanu/utils/sleepAsync';
 import { getTracer, spanWrapFn } from '../services/logging';
 import { getPrimaryTimeZone } from '../utils/timeZoneCheck';
 
+const wrapScheduleWithTimeZone = schedule => {
+  const primaryTimeZone = getPrimaryTimeZone(config);
+  if (typeof schedule === 'object') {
+    if (schedule.tz) {
+      return schedule;
+    }
+    return { ...schedule, tz: primaryTimeZone };
+  }
+  return { rule: schedule, tz: primaryTimeZone };
+};
+
 export class ScheduledTask {
   getName() {
     // Note that this.constructor.name will only work in dev,
@@ -21,14 +32,7 @@ export class ScheduledTask {
       name: this.getName(),
     });
 
-    if (schedule && typeof schedule !== 'string') {
-      throw new Error(`ScheduledTask: schedule must be a cron string, received ${typeof schedule}`);
-    }
-
-    this.schedule = schedule && {
-      rule: schedule,
-      tz: getPrimaryTimeZone(config),
-    };
+    this.schedule = wrapScheduleWithTimeZone(schedule);
     this.job = null;
     this.log = log;
     this.isRunning = false;

--- a/packages/shared/src/tasks/ScheduledTask.js
+++ b/packages/shared/src/tasks/ScheduledTask.js
@@ -13,8 +13,10 @@ const wrapScheduleWithTimeZone = schedule => {
   const primaryTimeZone = getPrimaryTimeZone(config);
   if (typeof schedule === 'object') {
     return {tz: primaryTimeZone, ...schedule};
+  } else if (typeof schedule === 'string') {
+    return { tz: primaryTimeZone, rule: schedule };
   }
-  return { tz: primaryTimeZone, rule: schedule };
+  throw new Error(`Invalid schedule: ${schedule}`);
 }
 
 export class ScheduledTask {


### PR DESCRIPTION
### Changes

Supply configured primary timezone so node-schedule does not fall back to the process timezone.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
