### PR TITLE
feat(AI): SAV-1152: AI scaffolding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29553,6 +29553,18 @@
       "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==",
       "license": "ISC"
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -39937,6 +39949,7 @@
         "morgan": "^1.9.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.8",
+        "node-cache": "^5.1.2",
         "node-telegram-bot-api": "^0.65.1",
         "pg": "^8.5.1",
         "pkijs": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,26 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@artilleryio/int-commons": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/@artilleryio/int-commons/-/int-commons-2.21.0.tgz",
@@ -4440,6 +4460,12 @@
         "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -6503,6 +6529,88 @@
         "jsep": "^0.4.0||^1.0.0"
       }
     },
+    "node_modules/@langchain/anthropic": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.28.tgz",
+      "integrity": "sha512-gOF8oXJL8xDdYes2KXNI9vFm/9TldBBBHOjuCdt27kganVaQKzLvTw5kV6R4mjbnFagV5CWteNH7APLZYCpdwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.42"
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.42.tgz",
+      "integrity": "sha512-d0tN96BrwPMryYyWR9VfyAntSivn7EQrZCe5Kpxum93tcjTXbKKmKvItFec8AluQt88iTcmAJrahUZUNfzGwTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/langsmith": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.26.tgz",
+      "integrity": "sha512-HmmFgeQR2n9x1Kq8NiVaNL/j72ta71qN11hYjbyePJ/QuYEnOMhQjbNv9KeyKB3bOetpIzNalQbhHm+RyKoPRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ljharb/resumer": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.1.3.tgz",
@@ -7864,7 +7972,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -8489,7 +8597,7 @@
       "version": "0.205.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.205.0.tgz",
       "integrity": "sha512-bGtFzqiENO2GpJk988mOBMe0MfeNpTQjbLm/LBijas6VRyEDQarUzdBHpFlu89A25k1+BCntdWGsWTa9Ai4FyA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
@@ -8509,7 +8617,7 @@
       "version": "0.205.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
       "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -8522,7 +8630,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -8538,7 +8646,7 @@
       "version": "0.205.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
       "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
@@ -8555,7 +8663,7 @@
       "version": "0.205.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
       "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.205.0",
@@ -8577,7 +8685,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
       "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
@@ -8594,7 +8702,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
       "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
@@ -8611,7 +8719,7 @@
       "version": "0.205.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
       "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.205.0",
@@ -8629,7 +8737,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
       "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
@@ -8811,7 +8919,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -8828,7 +8936,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -8844,7 +8952,7 @@
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -8942,7 +9050,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -8960,7 +9068,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -8976,7 +9084,7 @@
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -8986,7 +9094,7 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -9592,35 +9700,35 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -9631,35 +9739,35 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@react-dnd/asap": {
@@ -12543,6 +12651,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@styled-system/background": {
@@ -26058,6 +26172,15 @@
       "integrity": "sha512-ezHNl95OKis5TzAY180j9fHzIaMr3KDKw1Syf+ABrercb+qADqBdGbQjOb0QtdqdfE97TdF91d3nKbXgtCUwDg==",
       "license": "ISC"
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -26263,6 +26386,19 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -27100,7 +27236,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/long-timeout": {
@@ -29248,6 +29384,15 @@
         "@passcod/mushi-win32-x64-msvc": "0.0.12"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -30449,6 +30594,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -31528,7 +31701,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
       "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -37285,6 +37458,12 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -39708,6 +39887,8 @@
         "@bugsnag/js": "^7.22.4",
         "@bugsnag/plugin-express": "^7.19.0",
         "@casl/ability": "^6.8.0",
+        "@langchain/anthropic": "^1.3.28",
+        "@langchain/core": "^1.1.42",
         "@opentelemetry/api": "^1.9.0",
         "@peculiar/webcrypto": "^1.3.3",
         "@react-pdf/renderer": "^3.4.4",

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -11,6 +11,7 @@ import { EmailService } from './services/EmailService';
 
 import { closeDatabase, initDatabase } from './database';
 import { initIntegrations } from './integrations';
+import { AIService } from './services/AIService';
 import { defineSingletonTelegramBotService } from './services/TelegramBotService';
 import { VERSION } from './middleware/versionCompatibility';
 import { initDeviceId } from '@tamanu/shared/utils';
@@ -38,6 +39,9 @@ export class ApplicationContext {
 
   /** @type {EmailService | null} */
   emailService = null;
+
+  /** @type {AIService | null} */
+  aiService = null;
 
   /** @type {Awaited<ReturnType<typeof defineSingletonTelegramBotService>>|null} */
   telegramBotService = null;
@@ -83,6 +87,8 @@ export class ApplicationContext {
     if (config.db.reportSchemas?.enabled) {
       this.reportSchemaStores = await initReporting(this.store);
     }
+
+    this.aiService = await AIService.init({ settings: this.settings });
 
     this.telegramBotService = await defineSingletonTelegramBotService({
       config,

--- a/packages/central-server/app/ApplicationContext.js
+++ b/packages/central-server/app/ApplicationContext.js
@@ -129,6 +129,7 @@ export class ApplicationContext {
       await hook();
     }
     await closeDatabase();
+    this.aiService?.close();
   }
 
   async waitForClose() {

--- a/packages/central-server/app/createApi.js
+++ b/packages/central-server/app/createApi.js
@@ -61,7 +61,7 @@ function api(ctx, limiters) {
  * @param {import('./ApplicationContext').ApplicationContext} ctx
  */
 export async function createApi(ctx) {
-  const { store, emailService, reportSchemaStores } = ctx;
+  const { store, emailService, reportSchemaStores, aiService } = ctx;
   const express = defineExpress();
   // Express 5 defaults to the "simple" query parser (Node querystring). Bracket
   // keys like includedDataTypes[0]=x become flat keys, breaking many callers and
@@ -114,6 +114,7 @@ export async function createApi(ctx) {
     req.db = store.sequelize;
     req.store = store;
     req.emailService = emailService;
+    req.aiService = aiService;
     req.reportSchemaStores = reportSchemaStores;
     req.ctx = ctx;
     req.language = req.headers['language'];

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -53,7 +53,7 @@ export class AIService {
 
     service.conversationChain = new RunnableWithMessageHistory({
       runnable: prompt.pipe(service.chatModel),
-      getMessageHistory: (sessionId) => {
+      getMessageHistory: sessionId => {
         const session = service.sessions.get(sessionId);
         if (!session) {
           throw new Error(`AI session "${sessionId}" not found`);
@@ -120,10 +120,7 @@ export class AIService {
       throw new Error(`AI session "${sessionId}" not found`);
     }
     this.sessions.ttl(sessionId, SESSION_TTL_SECONDS); // refresh TTL on access
-    return this.conversationChain.invoke(
-      { input: userMessage },
-      { configurable: { sessionId } },
-    );
+    return this.conversationChain.invoke({ input: userMessage }, { configurable: { sessionId } });
   }
 
   /**

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -64,6 +64,9 @@ export class AIService {
       historyMessagesKey: 'history',
     });
 
+    // TODO: Register context here so that it's only loaded once. 
+    // Eg: service.registerContext('developer', 'You are a senior backend developer.');
+
     log.info(`AIService: initialised with model "${anthropicModel}"`);
     return service;
   }

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -1,0 +1,144 @@
+import { nanoid } from 'nanoid';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { InMemoryChatMessageHistory } from '@langchain/core/chat_history';
+import { ChatPromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts';
+import { RunnableWithMessageHistory } from '@langchain/core/runnables/history';
+import { SystemMessage } from '@langchain/core/messages';
+
+import { log } from '@tamanu/shared/services/logging';
+
+export class AIService {
+  /** @type {Map<string, string>} */
+  contexts = new Map();
+
+  /** @type {Map<string, InMemoryChatMessageHistory>} */
+  sessions = new Map();
+
+  /** @type {import('@langchain/anthropic').ChatAnthropic} */
+  chatModel;
+
+  /** @type {RunnableWithMessageHistory} */
+  conversationChain;
+
+  /**
+   * @param {object} options
+   * @param {import('@tamanu/settings').ReadSettings} options.settings
+   */
+  static async init({ settings }) {
+    const { enabled, anthropicApiKey, anthropicModel } = await settings.get('ai');
+
+    if (!enabled) {
+      log.info('AIService: disabled, skipping initialisation');
+      return null;
+    }
+
+    if (!anthropicApiKey) {
+      log.info('AIService: no Anthropic API key configured, skipping initialisation');
+      return null;
+    }
+
+    const service = new AIService();
+    service.chatModel = new ChatAnthropic({
+      anthropicApiKey,
+      modelName: anthropicModel,
+    });
+
+    const prompt = ChatPromptTemplate.fromMessages([
+      new MessagesPlaceholder('history'),
+      ['human', '{input}'],
+    ]);
+
+    service.conversationChain = new RunnableWithMessageHistory({
+      runnable: prompt.pipe(service.chatModel),
+      getMessageHistory: (sessionId) => {
+        const history = service.sessions.get(sessionId);
+        if (!history) {
+          throw new Error(`AI session "${sessionId}" not found`);
+        }
+        return history;
+      },
+      inputMessagesKey: 'input',
+      historyMessagesKey: 'history',
+    });
+
+    // TODO: Register default contexts here when contexts are available in settings
+    // eg: service.registerContext('survey-builder', settings.get('ai.survey-builder.context'));
+
+    log.info(`AIService: initialised with model "${anthropicModel}"`);
+    return service;
+  }
+
+  /**
+   * Register a named context (system prompt). Call once per feature at startup.
+   *
+   * @param {string} name
+   * @param {string} systemPrompt
+   */
+  registerContext(name, systemPrompt) {
+    this.contexts.set(name, systemPrompt);
+  }
+
+  /**
+   * @param {string} contextName
+   * @returns {string}
+   */
+  getContext(contextName) {
+    const systemPrompt = this.contexts.get(contextName);
+    if (!systemPrompt) {
+      throw new Error(`AI context "${contextName}" is not registered`);
+    }
+    return systemPrompt;
+  }
+
+  /**
+   * Create a new multi-turn conversation session using a registered context.
+   *
+   * @param {string} contextName
+   * @returns {Promise<string>} sessionId
+   */
+  async createSession(contextName) {
+    const sessionId = nanoid();
+    const history = new InMemoryChatMessageHistory();
+    await history.addMessage(new SystemMessage(this.getContext(contextName)));
+    this.sessions.set(sessionId, history);
+    return sessionId;
+  }
+
+  /**
+   * Send a user message within an existing session.
+   * History is managed automatically by RunnableWithMessageHistory.
+   *
+   * @param {string} sessionId
+   * @param {string} userMessage
+   * @returns {Promise<import('@langchain/core/messages').AIMessage>}
+   */
+  async sendMessage(sessionId, userMessage) {
+    return this.conversationChain.invoke(
+      { input: userMessage },
+      { configurable: { sessionId } },
+    );
+  }
+
+  /**
+   * Delete a session and free its history.
+   *
+   * @param {string} sessionId
+   */
+  deleteSession(sessionId) {
+    this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Stateless one-shot invocation using a registered context.
+   *
+   * @param {string} contextName
+   * @param {string} userMessage
+   * @returns {Promise<import('@langchain/core/messages').AIMessage>}
+   */
+  async invoke(contextName, userMessage) {
+    return this.chatModel.invoke([
+      new SystemMessage(this.getContext(contextName)),
+      ['human', userMessage],
+    ]);
+  }
+}

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -1,4 +1,5 @@
 import { nanoid } from 'nanoid';
+import NodeCache from 'node-cache';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { InMemoryChatMessageHistory } from '@langchain/core/chat_history';
 import { ChatPromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts';
@@ -7,26 +8,20 @@ import { RunnableWithMessageHistory } from '@langchain/core/runnables';
 
 import { log } from '@tamanu/shared/services/logging';
 
-const SESSION_TTL_MS = 30 * 60 * 1000;
-const SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+const SESSION_TTL_SECONDS = 60 * 60 * 24; // 24 hours
 
 export class AIService {
   /** @type {Map<string, string>} */
   contexts = new Map();
 
-  /**
-   * @type {Map<string, { history: InMemoryChatMessageHistory, lastAccessedAt: number, pending: Promise<void> }>}
-   */
-  sessions = new Map();
+  /** @type {NodeCache} */
+  sessions = new NodeCache({ stdTTL: SESSION_TTL_SECONDS, checkperiod: 300, useClones: false });
 
   /** @type {import('@langchain/anthropic').ChatAnthropic} */
   chatModel;
 
   /** @type {RunnableWithMessageHistory} */
   conversationChain;
-
-  /** @type {ReturnType<typeof setInterval> | null} */
-  _sweepInterval = null;
 
   /**
    * @param {object} options
@@ -63,40 +58,18 @@ export class AIService {
         if (!session) {
           throw new Error(`AI session "${sessionId}" not found`);
         }
-        return session.history;
+        return session;
       },
       inputMessagesKey: 'input',
       historyMessagesKey: 'history',
     });
 
-    service._sweepInterval = setInterval(
-      () => service._sweepStaleSessions(),
-      SESSION_SWEEP_INTERVAL_MS,
-    );
-    service._sweepInterval.unref();
-
-    // TODO: Register default contexts here when contexts are available in settings
-    // eg: service.registerContext('survey-builder', settings.get('ai.survey-builder.context'));
-
     log.info(`AIService: initialised with model "${anthropicModel}"`);
     return service;
   }
 
-  _sweepStaleSessions() {
-    const cutoff = Date.now() - SESSION_TTL_MS;
-    for (const [sessionId, session] of this.sessions) {
-      if (session.lastAccessedAt < cutoff) {
-        this.sessions.delete(sessionId);
-      }
-    }
-  }
-
   close() {
-    if (this._sweepInterval !== null) {
-      clearInterval(this._sweepInterval);
-      this._sweepInterval = null;
-    }
-    this.sessions.clear();
+    this.sessions.close();
   }
 
   /**
@@ -130,14 +103,13 @@ export class AIService {
     const sessionId = nanoid();
     const history = new InMemoryChatMessageHistory();
     await history.addMessage(new SystemMessage(this.getContext(contextName)));
-    this.sessions.set(sessionId, { history, lastAccessedAt: Date.now(), pending: Promise.resolve() });
+    this.sessions.set(sessionId, history);
     return sessionId;
   }
 
   /**
    * Send a user message within an existing session.
    * History is managed automatically by RunnableWithMessageHistory.
-   * Invocations are serialised per session to prevent history corruption from concurrent calls.
    *
    * @param {string} sessionId
    * @param {string} userMessage
@@ -147,18 +119,11 @@ export class AIService {
     if (!this.sessions.has(sessionId)) {
       throw new Error(`AI session "${sessionId}" not found`);
     }
-    const session = this.sessions.get(sessionId);
-    session.lastAccessedAt = Date.now();
-    const result = session.pending.then(() =>
-      this.conversationChain.invoke(
-        { input: userMessage },
-        { configurable: { sessionId } },
-      ),
+    this.sessions.ttl(sessionId, SESSION_TTL_SECONDS); // refresh TTL on access
+    return this.conversationChain.invoke(
+      { input: userMessage },
+      { configurable: { sessionId } },
     );
-    // Update pending so the next sendMessage call waits for this one to finish.
-    // Errors are suppressed on the chain itself so a failed call doesn't block future ones.
-    session.pending = result.then(() => {}).catch(() => {});
-    return result;
   }
 
   /**
@@ -167,7 +132,7 @@ export class AIService {
    * @param {string} sessionId
    */
   deleteSession(sessionId) {
-    this.sessions.delete(sessionId);
+    this.sessions.del(sessionId);
   }
 
   /**

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -7,11 +7,16 @@ import { RunnableWithMessageHistory } from '@langchain/core/runnables';
 
 import { log } from '@tamanu/shared/services/logging';
 
+const SESSION_TTL_MS = 30 * 60 * 1000;
+const SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
 export class AIService {
   /** @type {Map<string, string>} */
   contexts = new Map();
 
-  /** @type {Map<string, InMemoryChatMessageHistory>} */
+  /**
+   * @type {Map<string, { history: InMemoryChatMessageHistory, lastAccessedAt: number, pending: Promise<void> }>}
+   */
   sessions = new Map();
 
   /** @type {import('@langchain/anthropic').ChatAnthropic} */
@@ -19,6 +24,9 @@ export class AIService {
 
   /** @type {RunnableWithMessageHistory} */
   conversationChain;
+
+  /** @type {ReturnType<typeof setInterval> | null} */
+  _sweepInterval = null;
 
   /**
    * @param {object} options
@@ -40,7 +48,7 @@ export class AIService {
     const service = new AIService();
     service.chatModel = new ChatAnthropic({
       anthropicApiKey,
-      modelName: anthropicModel,
+      model: anthropicModel,
     });
 
     const prompt = ChatPromptTemplate.fromMessages([
@@ -51,21 +59,44 @@ export class AIService {
     service.conversationChain = new RunnableWithMessageHistory({
       runnable: prompt.pipe(service.chatModel),
       getMessageHistory: (sessionId) => {
-        const history = service.sessions.get(sessionId);
-        if (!history) {
+        const session = service.sessions.get(sessionId);
+        if (!session) {
           throw new Error(`AI session "${sessionId}" not found`);
         }
-        return history;
+        return session.history;
       },
       inputMessagesKey: 'input',
       historyMessagesKey: 'history',
     });
+
+    service._sweepInterval = setInterval(
+      () => service._sweepStaleSessions(),
+      SESSION_SWEEP_INTERVAL_MS,
+    );
+    service._sweepInterval.unref();
 
     // TODO: Register default contexts here when contexts are available in settings
     // eg: service.registerContext('survey-builder', settings.get('ai.survey-builder.context'));
 
     log.info(`AIService: initialised with model "${anthropicModel}"`);
     return service;
+  }
+
+  _sweepStaleSessions() {
+    const cutoff = Date.now() - SESSION_TTL_MS;
+    for (const [sessionId, session] of this.sessions) {
+      if (session.lastAccessedAt < cutoff) {
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+
+  close() {
+    if (this._sweepInterval !== null) {
+      clearInterval(this._sweepInterval);
+      this._sweepInterval = null;
+    }
+    this.sessions.clear();
   }
 
   /**
@@ -83,11 +114,10 @@ export class AIService {
    * @returns {string}
    */
   getContext(contextName) {
-    const systemPrompt = this.contexts.get(contextName);
-    if (!systemPrompt) {
+    if (!this.contexts.has(contextName)) {
       throw new Error(`AI context "${contextName}" is not registered`);
     }
-    return systemPrompt;
+    return this.contexts.get(contextName);
   }
 
   /**
@@ -100,23 +130,35 @@ export class AIService {
     const sessionId = nanoid();
     const history = new InMemoryChatMessageHistory();
     await history.addMessage(new SystemMessage(this.getContext(contextName)));
-    this.sessions.set(sessionId, history);
+    this.sessions.set(sessionId, { history, lastAccessedAt: Date.now(), pending: Promise.resolve() });
     return sessionId;
   }
 
   /**
    * Send a user message within an existing session.
    * History is managed automatically by RunnableWithMessageHistory.
+   * Invocations are serialised per session to prevent history corruption from concurrent calls.
    *
    * @param {string} sessionId
    * @param {string} userMessage
    * @returns {Promise<import('@langchain/core/messages').AIMessage>}
    */
   async sendMessage(sessionId, userMessage) {
-    return this.conversationChain.invoke(
-      { input: userMessage },
-      { configurable: { sessionId } },
+    if (!this.sessions.has(sessionId)) {
+      throw new Error(`AI session "${sessionId}" not found`);
+    }
+    const session = this.sessions.get(sessionId);
+    session.lastAccessedAt = Date.now();
+    const result = session.pending.then(() =>
+      this.conversationChain.invoke(
+        { input: userMessage },
+        { configurable: { sessionId } },
+      ),
     );
+    // Update pending so the next sendMessage call waits for this one to finish.
+    // Errors are suppressed on the chain itself so a failed call doesn't block future ones.
+    session.pending = result.then(() => {}).catch(() => {});
+    return result;
   }
 
   /**

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -2,8 +2,8 @@ import { nanoid } from 'nanoid';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { InMemoryChatMessageHistory } from '@langchain/core/chat_history';
 import { ChatPromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts';
-import { RunnableWithMessageHistory } from '@langchain/core/runnables/history';
 import { SystemMessage } from '@langchain/core/messages';
+import { RunnableWithMessageHistory } from '@langchain/core/runnables';
 
 import { log } from '@tamanu/shared/services/logging';
 

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -100,6 +100,7 @@
     "morgan": "^1.9.0",
     "ms": "^2.1.3",
     "nanoid": "^3.3.8",
+    "node-cache": "^5.1.2",
     "node-telegram-bot-api": "^0.65.1",
     "pg": "^8.5.1",
     "pkijs": "^2.2.1",

--- a/packages/central-server/package.json
+++ b/packages/central-server/package.json
@@ -50,6 +50,8 @@
     "@bugsnag/js": "^7.22.4",
     "@bugsnag/plugin-express": "^7.19.0",
     "@casl/ability": "^6.8.0",
+    "@langchain/anthropic": "^1.3.28",
+    "@langchain/core": "^1.1.42",
     "@opentelemetry/api": "^1.9.0",
     "@peculiar/webcrypto": "^1.3.3",
     "@react-pdf/renderer": "^3.4.4",

--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -15,6 +15,30 @@ export const centralSettings = {
   name: 'Central server settings',
   description: 'Settings that apply only to a central server',
   properties: {
+    ai: {
+      name: 'AI',
+      description: 'Settings for AI-powered features',
+      properties: {
+        enabled: {
+          name: 'Enabled',
+          description: 'Enable or disable all AI-powered features',
+          type: yup.boolean(),
+          defaultValue: false,
+        },
+        anthropicApiKey: {
+          name: 'Anthropic API key',
+          description: 'API key for the Anthropic API',
+          type: yup.string(),
+          defaultValue: '',
+        },
+        anthropicModel: {
+          name: 'Anthropic model',
+          description: 'The Anthropic model to use for AI features',
+          type: yup.string(),
+          defaultValue: 'claude-sonnet-4-20250514',
+        },
+      },
+    },
     disk: {
       name: 'Disk',
       description: 'Disk settings',


### PR DESCRIPTION
### Changes
- AI scaffolding

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new runtime dependencies and an `AIService` that can call Anthropic via LangChain, plus request-level access to it; misconfiguration or unintended enablement could trigger external API calls and cost/latency. Feature is gated behind settings and currently provides scaffolding without new endpoints, limiting blast radius.
> 
> **Overview**
> Adds **AI scaffolding** to central-server by introducing an `AIService` wrapper around LangChain/Anthropic that supports registered system contexts, one-shot invocations, and cached multi-turn sessions with TTL.
> 
> Wires the service into app startup/shutdown (`ApplicationContext`) and exposes it on incoming requests (`req.aiService`) for future routes to consume.
> 
> Extends central settings with a new `ai` section (enable flag, Anthropic API key, model name) and adds the required npm dependencies (`@langchain/*`, `node-cache`, and transitive lockfile updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa75005add2cbb0fa62974617111dd269b8a169b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->