### PR TITLE
ci(e2e): No-issue: Post report artifact on merge failure

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group'
+    # TODO: Restore merge_group-only after validating E2E failure report comments from this PR.
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -185,7 +185,8 @@ jobs:
 
   e2e_failure_report:
     name: E2E Failure Report
-    if: always() && github.event_name == 'merge_group' && needs.e2e.result != 'success'
+    # TODO: Restore merge_group-only after validating E2E failure report comments from this PR.
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.e2e.result != 'success'
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:
@@ -230,10 +231,11 @@ jobs:
             const { ARTIFACT_URL, RUN_NUMBER, RUN_URL, SHA } = process.env;
             const { repo, owner } = context.repo;
             const headRef = context.payload.merge_group?.head_ref ?? '';
-            const prNumber = headRef.match(/\/pr-(\d+)-/)?.[1];
+            const prNumber =
+              context.issue.number ?? headRef.match(/\/pr-(\d+)-/)?.[1];
 
             if (!prNumber) {
-              core.warning(`Could not determine PR number from merge queue head_ref: ${headRef}`);
+              core.warning(`Could not determine PR number from event ${context.eventName} and merge queue head_ref: ${headRef}`);
               return;
             }
 
@@ -246,7 +248,9 @@ jobs:
             const body = [
               headerContent,
               '',
-              `E2E failed in the merge queue for run **${RUN_NUMBER}** (${SHA.slice(0, 7)}).`,
+              context.eventName === 'pull_request'
+                ? `Temporary PR mechanics test: E2E failed for run **${RUN_NUMBER}** (${SHA.slice(0, 7)}).`
+                : `E2E failed in the merge queue for run **${RUN_NUMBER}** (${SHA.slice(0, 7)}).`,
               '',
               `- [View workflow run](${RUN_URL})`,
               `- [Download Playwright failure report](${ARTIFACT_URL})`,

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   node_modules_cache:
-    # TODO: Restore merge_group-only after validating E2E failure report comments from this PR.
+    if: github.event_name == 'merge_group'
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -186,8 +186,7 @@ jobs:
 
   e2e_failure_report:
     name: E2E Failure Report
-    # TODO: Restore merge_group-only after validating E2E failure report comments from this PR.
-    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.e2e.result != 'success'
+    if: always() && github.event_name == 'merge_group' && needs.e2e.result != 'success'
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
@@ -116,6 +117,7 @@ jobs:
       TEST_EMAIL: admin@tamanu.io
       TEST_PASSWORD: admin
       TZ: Pacific/Auckland
+      FORCE_E2E_FAILURE_FOR_REPORT_TESTING: ${{ github.event_name == 'merge_group' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -181,6 +183,94 @@ jobs:
           name: blob-report-${{ strategy.job-index }}
           path: packages/e2e-tests/blob-report/
           retention-days: 7
+
+  e2e_failure_report:
+    name: E2E Failure Report
+    if: always() && github.event_name == 'merge_group' && needs.e2e.result != 'success'
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - uses: actions/cache/restore@v5
+        with:
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          path: ${{ env.NODE_MODULES_PATHS }}
+      - run: npm i
+      - name: Download blob reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: blob-report-*
+          path: packages/e2e-tests/all-blob-reports
+          merge-multiple: true
+      - name: Merge Playwright reports
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        working-directory: packages/e2e-tests
+      - name: Upload E2E failure report
+        id: e2e-report-upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-failure-report-${{ github.run_number }}
+          path: packages/e2e-tests/playwright-report/
+          retention-days: 7
+      - name: Post comment with E2E failure report
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: ${{ steps.e2e-report-upload.outputs.artifact-url }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        with:
+          script: |
+            const { ARTIFACT_URL, RUN_NUMBER, RUN_URL, SHA } = process.env;
+            const { repo, owner } = context.repo;
+            const headRef = context.payload.merge_group?.head_ref ?? '';
+            const prNumber = headRef.match(/\/pr-(\d+)-/)?.[1];
+
+            if (!prNumber) {
+              core.warning(`Could not determine PR number from merge queue head_ref: ${headRef}`);
+              return;
+            }
+
+            const params = {
+              issue_number: Number(prNumber),
+              owner,
+              repo,
+            };
+            const headerContent = '**E2E merge queue failure report**';
+            const body = [
+              headerContent,
+              '',
+              `E2E failed in the merge queue for run **${RUN_NUMBER}** (${SHA.slice(0, 7)}).`,
+              '',
+              `- [View workflow run](${RUN_URL})`,
+              `- [Download Playwright failure report](${ARTIFACT_URL})`,
+              '',
+              'The report artifact contains the merged Playwright HTML report with failure videos, screenshots, and traces where available.',
+            ].join('\n');
+            const comments = await github.rest.issues.listComments(params);
+            const existingComment = comments.data.find((comment) =>
+              comment.body?.includes(headerContent)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                ...params,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...params,
+                body,
+              });
+            }
 
   e2e-required:
     name: E2E Required

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 env:
   NODE_OPTIONS: "--max-old-space-size=6144"
@@ -257,10 +258,16 @@ jobs:
               '',
               'The report artifact contains the merged Playwright HTML report with failure videos, screenshots, and traces where available.',
             ].join('\n');
-            const comments = await github.rest.issues.listComments(params);
-            const existingComment = comments.data.find((comment) =>
-              comment.body?.includes(headerContent)
-            );
+            let existingComment = null;
+            for await (const { data: comments } of github.paginate.iterator(
+              github.rest.issues.listComments,
+              params
+            )) {
+              existingComment = comments.find((comment) =>
+                comment.body?.includes(headerContent)
+              );
+              if (existingComment) break;
+            }
 
             if (existingComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -117,7 +117,6 @@ jobs:
       TEST_EMAIL: admin@tamanu.io
       TEST_PASSWORD: admin
       TZ: Pacific/Auckland
-      FORCE_E2E_FAILURE_FOR_REPORT_TESTING: ${{ github.event_name == 'merge_group' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -23,10 +23,10 @@ module.exports = defineConfig({
   reporter: process.env.CI ? 'blob' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    // Enable heavier debugging artifacts only for local runs.
+    // Keep failure media in CI so merge queue reports contain useful debugging context.
     trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
-    video: process.env.CI ? 'off' : 'retain-on-failure',
-    screenshot: process.env.CI ? 'off' : 'only-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
     // Slow down each browser action to make local debugging easier.
     launchOptions: process.env.CI ? undefined : { slowMo: 200 },
     timezoneId: process.env.TZ,

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -77,6 +77,11 @@ test.describe('Basic tests', () => {
     expect(locationValue).toBe(triageFormValues.location?.split('\n')[0] || '');
     const level1Value = await emergencyPatientsPage.getLevelCardValue(1);
     expect(parseInt(level1Value)).toBeGreaterThanOrEqual(1);
+    if (process.env.FORCE_E2E_FAILURE_FOR_REPORT_TESTING === 'true') {
+      await expect(
+        patientDetailsPage.page.getByText('Intentional merge queue E2E failure'),
+      ).toBeVisible();
+    }
   });
   test('[BT-0003][AT-2002]Admit the patient to Triage with adding vitals', async ({
     newPatient,

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -77,11 +77,10 @@ test.describe('Basic tests', () => {
     expect(locationValue).toBe(triageFormValues.location?.split('\n')[0] || '');
     const level1Value = await emergencyPatientsPage.getLevelCardValue(1);
     expect(parseInt(level1Value)).toBeGreaterThanOrEqual(1);
-    if (process.env.FORCE_E2E_FAILURE_FOR_REPORT_TESTING === 'true') {
-      await expect(
-        patientDetailsPage.page.getByText('Intentional merge queue E2E failure'),
-      ).toBeVisible();
-    }
+    // TODO: Remove this intentional failure after validating merge queue E2E report comments.
+    await expect(
+      patientDetailsPage.page.getByText('Intentional merge queue E2E failure'),
+    ).toBeVisible();
   });
   test('[BT-0003][AT-2002]Admit the patient to Triage with adding vitals', async ({
     newPatient,

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -77,10 +77,6 @@ test.describe('Basic tests', () => {
     expect(locationValue).toBe(triageFormValues.location?.split('\n')[0] || '');
     const level1Value = await emergencyPatientsPage.getLevelCardValue(1);
     expect(parseInt(level1Value)).toBeGreaterThanOrEqual(1);
-    // TODO: Remove this intentional failure after validating merge queue E2E report comments.
-    await expect(
-      patientDetailsPage.page.getByText('Intentional merge queue E2E failure'),
-    ).toBeVisible();
   });
   test('[BT-0003][AT-2002]Admit the patient to Triage with adding vitals', async ({
     newPatient,


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the E2E GitHub Actions workflow to add `issues`/`pull-requests` write permissions and automated PR commenting, which could spam or mis-target comments if PR detection fails.
> 
> **Overview**
> When E2E tests fail in the merge queue, the workflow now **merges shard `blob` reports into a single Playwright HTML report**, uploads it as an artifact, and **posts/updates a PR comment** linking to the workflow run and downloadable report.
> 
> To make the merged report useful, Playwright CI settings now **retain failure videos and screenshots** (instead of disabling them on CI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8981d35369a2326fd485fd0d38fe9c9f83a5786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->