### PR TITLE
tweak(web): SAV-1168: rename "Encounter summary" button to "Encounter record"

### DIFF
--- a/packages/web/app/views/patients/components/EncounterActions.jsx
+++ b/packages/web/app/views/patients/components/EncounterActions.jsx
@@ -76,8 +76,8 @@ export const EncounterActions = React.memo(({ encounter }) => {
             data-testid="styledbutton-00iz"
           >
             <TranslatedText
-              stringId="patient.encounter.action.encounterSummary"
-              fallback="Encounter summary"
+              stringId="patient.encounter.action.encounterRecord"
+              fallback="Encounter record"
               data-testid="translatedtext-ftbh"
             />
           </StyledButton>
@@ -188,8 +188,8 @@ export const EncounterActions = React.memo(({ encounter }) => {
               onClick={() => setOpenModal(ENCOUNTER_MODALS.ENCOUNTER_PROGRESS_RECORD)}
             >
               <TranslatedText
-                stringId="encounter.action.encounterSummary"
-                fallback="Encounter summary"
+                stringId="encounter.action.encounterRecord"
+                fallback="Encounter record"
               />
             </Button>
             <Button size="small" onClick={() => navigateToSummary()}>


### PR DESCRIPTION
### Changes

Renames the post-discharge "Encounter summary" button on the encounter view to "Encounter record" so the label matches what it actually opens (the `EncounterRecordModal`) and reads correctly alongside the sibling "Discharge summary" button. Updates both occurrences in `EncounterActions.jsx` (the discharged-state button and the kebab/threedot path), and renames their `stringId`s to `encounterRecord` per the copy-update rule for meaningful wording changes. No other call sites or tests reference the old strings.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)