### PR TITLE
fix: no-issue: Date locale parse ordering

### DIFF
--- a/packages/ui-components/src/components/Field/DateField.jsx
+++ b/packages/ui-components/src/components/Field/DateField.jsx
@@ -35,8 +35,7 @@ const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
 const USER_INPUT_FORMATS = ['dd/MM/yyyy hh:mm a', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy', 'HH:mm', 'HH:mm:ss'];
 
-// Parses a string value to Date, trying explicit formats before the generic
-// parser so ambiguous typed values like 05/04/2026 stay day-first.
+// Parses a string value to Date, trying explicit formats before the generic parser
 function parseValue(value, primaryFormat) {
   if (!value) return null;
   const formats = primaryFormat ? [primaryFormat, ...USER_INPUT_FORMATS] : USER_INPUT_FORMATS;

--- a/packages/ui-components/src/components/Field/DateField.jsx
+++ b/packages/ui-components/src/components/Field/DateField.jsx
@@ -35,21 +35,20 @@ const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
 const USER_INPUT_FORMATS = ['dd/MM/yyyy hh:mm a', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy', 'HH:mm', 'HH:mm:ss'];
 
-// Parses a string value to Date, trying storage formats first (ISO 9075),
-// then user-input display formats (dd/MM/yyyy etc) as a fallback for typed input.
+// Parses a string value to Date, trying explicit formats before the generic
+// parser so ambiguous typed values like 05/04/2026 stay day-first.
 function parseValue(value, primaryFormat) {
   if (!value) return null;
-  try {
-    return parseDate(value);
-  } catch {
-    // Not an ISO/storage format — try user-input display formats below
-  }
   const formats = primaryFormat ? [primaryFormat, ...USER_INPUT_FORMATS] : USER_INPUT_FORMATS;
   for (const fmt of formats) {
     const date = parse(value, fmt, new Date());
     if (isValid(date)) return date;
   }
-  return null;
+  try {
+    return parseDate(value);
+  } catch {
+    return null;
+  }
 }
 
 const StyledPopper = styled(({ popperOptions, ...props }) => (


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `DateField` input parsing order that only affects how ambiguous date/time strings are interpreted.
> 
> **Overview**
> Updates `DateField`/`DateInput` string parsing to **try the provided/user-facing formats first** and only fall back to the generic `parseDate` parser if those don’t match, reducing incorrect locale/format interpretations for manually typed values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cbafcb0de1a86f979dc78bd9084ab5f4f6699a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->