### PR TITLE
fix(dateTime): Hotfix 2.52: Date locale parse ordering

### DIFF
--- a/packages/ui-components/src/components/Field/DateField.jsx
+++ b/packages/ui-components/src/components/Field/DateField.jsx
@@ -35,21 +35,19 @@ const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
 const USER_INPUT_FORMATS = ['dd/MM/yyyy hh:mm a', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy', 'HH:mm', 'HH:mm:ss'];
 
-// Parses a string value to Date, trying storage formats first (ISO 9075),
-// then user-input display formats (dd/MM/yyyy etc) as a fallback for typed input.
+// Parses a string value to Date, trying explicit formats before the generic parser
 function parseValue(value, primaryFormat) {
   if (!value) return null;
-  try {
-    return parseDate(value);
-  } catch {
-    // Not an ISO/storage format — try user-input display formats below
-  }
   const formats = primaryFormat ? [primaryFormat, ...USER_INPUT_FORMATS] : USER_INPUT_FORMATS;
   for (const fmt of formats) {
     const date = parse(value, fmt, new Date());
     if (isValid(date)) return date;
   }
-  return null;
+  try {
+    return parseDate(value);
+  } catch {
+    return null;
+  }
 }
 
 const StyledPopper = styled(({ popperOptions, ...props }) => (


### PR DESCRIPTION
### Changes

Cherry-picks 0b0c403c026679a5e874f3bc8d4bd83b06fb0b1f onto this release branch to fix date locale parse ordering.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI parsing change, but it can subtly alter how ambiguous date strings are interpreted for manual entry.
> 
> **Overview**
> Updates `DateField` parsing so manually typed values are interpreted by **explicit locale/user formats first** (e.g. `dd/MM/yyyy`, `hh:mm a`) and only fall back to the generic `parseDate`/storage parser if none match, fixing incorrect parse ordering for ambiguous inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2053cafdbe4a677b1184e0c01d89c46a486911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->