### PR TITLE
Add Save suppressions checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 - [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
 - [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
 - [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
+- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._
 
 ### Remember to...
 


### PR DESCRIPTION
### Changes

Adds the new `Save suppressions` checkbox to the Review Hero section of the PR template, matching the checkbox just added in [review-hero#40](https://github.com/beyondessential/review-hero/pull/40).

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->

### Remember to...

- Template-only change — no behaviour or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)