### PR TITLE
fix(settings): no-issue: Treat secret settings as high risk

### DIFF
--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -154,9 +154,9 @@ export const Category = ({
           editor,
         } = propertySchema;
 
-        const isHighRisk = schema.highRisk || highRisk;
-        const disabled = !canWriteHighRisk && isHighRisk;
         const isSecret = Boolean(secret);
+        const isHighRisk = schema.highRisk || highRisk || isSecret;
+        const disabled = !canWriteHighRisk && isHighRisk;
 
         return type ? (
           <SettingLine key={newPath} data-testid={`settingline-55rw-${testIdSuffix}`}>


### PR DESCRIPTION
## Summary
- Treat `secret: true` settings as high-risk in the admin settings editor.
- Prevent non-admin settings editors from changing secret values unless they have `manage all` access.

## Test plan
- Not run; small UI permission logic change.

Made with [Cursor](https://cursor.com)