### PR TITLE
fix(notifications): TAM-4041: Use patient display ID instead of lab display ID

### DIFF
--- a/packages/web/app/components/Notification/NotificationDrawer.jsx
+++ b/packages/web/app/components/Notification/NotificationDrawer.jsx
@@ -29,8 +29,7 @@ const NOTIFICATION_ICONS = {
 };
 
 const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
-  const { firstName, lastName } = patient;
-  const { displayId } = metadata;
+  const { firstName, lastName, displayId } = patient;
   const patientName = `${firstName} ${lastName}`;
 
   if (type === NOTIFICATION_TYPES.IMAGING_REQUEST) {
@@ -50,7 +49,7 @@ const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
       return getTranslation(
         'notification.content.labRequest.resultsAmended',
         'Lab results for :patientName (:displayId) have been <strong>amended</strong>',
-        { replacements: { displayId: patient.displayId, patientName } },
+        { replacements: { displayId, patientName } },
       );
     }
 
@@ -59,19 +58,19 @@ const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
         return getTranslation(
           'notification.content.labRequest.published',
           'Lab results for :patientName (:displayId) are <strong>now available</strong>',
-          { replacements: { displayId: patient.displayId, patientName } },
+          { replacements: { displayId, patientName } },
         );
       case LAB_REQUEST_STATUSES.INTERIM_RESULTS:
         return getTranslation(
           'notification.content.labRequest.interimResults',
           'Interim lab results for :patientName (:displayId) are <strong>now available</strong>',
-          { replacements: { displayId: patient.displayId, patientName } },
+          { replacements: { displayId, patientName } },
         );
       case LAB_REQUEST_STATUSES.INVALIDATED:
         return getTranslation(
           'notification.content.labRequest.invalidated',
           'Lab results for :patientName (:displayId) have been <strong>invalidated</strong>',
-          { replacements: { displayId: patient.displayId, patientName } },
+          { replacements: { displayId, patientName } },
         );
     }
   }
@@ -80,7 +79,7 @@ const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
     return getTranslation(
       'notification.content.pharmacyNote',
       'Pharmacy note for :patientName (:displayId)',
-      { replacements: { displayId: patient.displayId, patientName } },
+      { replacements: { displayId, patientName } },
     );
   }
 };

--- a/packages/web/app/components/Notification/NotificationDrawer.jsx
+++ b/packages/web/app/components/Notification/NotificationDrawer.jsx
@@ -50,7 +50,7 @@ const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
       return getTranslation(
         'notification.content.labRequest.resultsAmended',
         'Lab results for :patientName (:displayId) have been <strong>amended</strong>',
-        { replacements: { displayId, patientName } },
+        { replacements: { displayId: patient.displayId, patientName } },
       );
     }
 
@@ -59,19 +59,19 @@ const getNotificationText = ({ getTranslation, type, patient, metadata }) => {
         return getTranslation(
           'notification.content.labRequest.published',
           'Lab results for :patientName (:displayId) are <strong>now available</strong>',
-          { replacements: { displayId, patientName } },
+          { replacements: { displayId: patient.displayId, patientName } },
         );
       case LAB_REQUEST_STATUSES.INTERIM_RESULTS:
         return getTranslation(
           'notification.content.labRequest.interimResults',
           'Interim lab results for :patientName (:displayId) are <strong>now available</strong>',
-          { replacements: { displayId, patientName } },
+          { replacements: { displayId: patient.displayId, patientName } },
         );
       case LAB_REQUEST_STATUSES.INVALIDATED:
         return getTranslation(
           'notification.content.labRequest.invalidated',
           'Lab results for :patientName (:displayId) have been <strong>invalidated</strong>',
-          { replacements: { displayId, patientName } },
+          { replacements: { displayId: patient.displayId, patientName } },
         );
     }
   }


### PR DESCRIPTION
### Changes

These were meant to use the patient display ID instead of the lab display ID

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._
