### PR TITLE
repo: narrow Kamaka codeowner gate to deploy workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,16 +34,17 @@
 pm2*.config.js  @beyondessential/kamaka
 
 #
-# Kamaka gates the deployment workflows (Tailscale, Pulumi, auto-deploy
-# infrastructure) since changes to these have external implications beyond the
-# repo. The rest of .github/ is open to all stakeholders.
+# Kamaka gates the deployment workflows (Tailscale, Pulumi, release & deploy
+# infrastructure) since changes to these have external implications.
 #
-/.github/workflows/cd.yml                   @beyondessential/kamaka
-/.github/workflows/cd-up.yml                @beyondessential/kamaka
-/.github/workflows/cd-down.yml              @beyondessential/kamaka
-/.github/workflows/cd-fake-data.yml         @beyondessential/kamaka
-/.github/workflows/cleanup-auto-deploy.yml  @beyondessential/kamaka
-/.github/actions/setup-cd/                  @beyondessential/kamaka
+/.github/workflows/cd.yml                      @beyondessential/kamaka
+/.github/workflows/cd-up.yml                   @beyondessential/kamaka
+/.github/workflows/cd-down.yml                 @beyondessential/kamaka
+/.github/workflows/cd-fake-data.yml            @beyondessential/kamaka
+/.github/workflows/cleanup-auto-deploy.yml     @beyondessential/kamaka
+/.github/workflows/stale-auto-deploy.yml       @beyondessential/kamaka
+/.github/workflows/publish-release-version.yml @beyondessential/kamaka
+/.github/actions/setup-cd/                     @beyondessential/kamaka
 
 #
 # Maui needs to be across any changes to database tables

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,12 +34,16 @@
 pm2*.config.js  @beyondessential/kamaka
 
 #
-# Kamaka owns the Github Actions workflows, for verification as breakage affects
-# the deployment processes and may have non-local effects.
+# Kamaka gates the deployment workflows (Tailscale, Pulumi, auto-deploy
+# infrastructure) since changes to these have external implications beyond the
+# repo. The rest of .github/ is open to all stakeholders.
 #
-/.github/actions/    @beyondessential/kamaka
-/.github/scripts/    @beyondessential/kamaka
-/.github/workflows/  @beyondessential/kamaka
+/.github/workflows/cd.yml                   @beyondessential/kamaka
+/.github/workflows/cd-up.yml                @beyondessential/kamaka
+/.github/workflows/cd-down.yml              @beyondessential/kamaka
+/.github/workflows/cd-fake-data.yml         @beyondessential/kamaka
+/.github/workflows/cleanup-auto-deploy.yml  @beyondessential/kamaka
+/.github/actions/setup-cd/                  @beyondessential/kamaka
 
 #
 # Maui needs to be across any changes to database tables


### PR DESCRIPTION
### Changes

Currently I (as the Kamaka team) gate all of `.github`; however imo it's no longer necessary to be so strict and there are many more stakeholders in there nowadays. But I would still like to gate the cd.yml and other workflows related to tailscale and pulumi; these have external implications.

Acking that narrowing the codeowner gate thus may lead to some things slipping through, but the improvement to merge velocity slash botherment reduction feels worth it.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
