### PR TITLE
fix(sync): no-issue: Suppress sequelize hooks when persisting sync data

### DIFF
--- a/packages/database/__tests__/sync/saveChangesForModel.test.ts
+++ b/packages/database/__tests__/sync/saveChangesForModel.test.ts
@@ -1,3 +1,5 @@
+import { INVOICE_ITEMS_CATEGORIES, INVOICE_STATUSES, REFERENCE_TYPES } from '@tamanu/constants';
+import { fake } from '@tamanu/fake-data/fake';
 import { log } from '@tamanu/shared/services/logging/log';
 import { saveChangesForModel } from '../../src/sync';
 import * as saveChangeModules from '../../src/sync/saveChanges';
@@ -199,6 +201,149 @@ describe('saveChangesForModel', () => {
       });
       expect(updatedRecordInDb).toBeDefined();
       expect(updatedRecordInDb.text).toEqual(newRecord.text);
+    });
+  });
+
+  // Sequelize bulk hooks on bidirectional models (e.g. PharmacyOrderPrescription's
+  // afterBulkCreate, which calls Invoice.addItemToInvoice) must not run while sync
+  // is replaying the canonical state from the snapshot. If they do, the hook may
+  // create a competing invoice_items row with a freshly generated id, racing with
+  // sync's own incoming invoice_items row for the same source values and tripping
+  // the (invoice_id, source_record_type, source_record_id) unique constraint.
+  describe('skips Sequelize hooks during sync persistence', () => {
+    let invoice;
+    let prescription;
+    let pharmacyOrder;
+
+    beforeAll(async () => {
+      const user = await models.User.create(fake(models.User));
+      const facility = await models.Facility.create(fake(models.Facility));
+      const patient = await models.Patient.create(fake(models.Patient));
+      const locationGroup = await models.LocationGroup.create(
+        fake(models.LocationGroup, { facilityId: facility.id }),
+      );
+      const location = await models.Location.create(
+        fake(models.Location, { facilityId: facility.id, locationGroupId: locationGroup.id }),
+      );
+      const department = await models.Department.create(
+        fake(models.Department, { facilityId: facility.id }),
+      );
+      const encounter = await models.Encounter.create(
+        fake(models.Encounter, {
+          patientId: patient.id,
+          locationId: location.id,
+          departmentId: department.id,
+          examinerId: user.id,
+        }),
+      );
+      // In-progress invoice required for Invoice.addItemToInvoice to attempt an upsert.
+      invoice = await models.Invoice.create(
+        fake(models.Invoice, {
+          encounterId: encounter.id,
+          status: INVOICE_STATUSES.IN_PROGRESS,
+        }),
+      );
+      const drug = await models.ReferenceData.create(
+        fake(models.ReferenceData, { type: REFERENCE_TYPES.DRUG }),
+      );
+      // The DRUG-category InvoiceProduct is what the prescription hook would resolve.
+      await models.InvoiceProduct.create(
+        fake(models.InvoiceProduct, {
+          category: INVOICE_ITEMS_CATEGORIES.DRUG,
+          sourceRecordType: 'ReferenceData',
+          sourceRecordId: drug.id,
+        }),
+      );
+      prescription = await models.Prescription.create(
+        fake(models.Prescription, {
+          medicationId: drug.id,
+          prescriberId: user.id,
+        }),
+      );
+      await models.EncounterPrescription.create(
+        fake(models.EncounterPrescription, {
+          encounterId: encounter.id,
+          prescriptionId: prescription.id,
+        }),
+      );
+      // Discharge pharmacy order is the gate that makes the hook attempt to add an invoice item.
+      pharmacyOrder = await models.PharmacyOrder.create(
+        fake(models.PharmacyOrder, {
+          encounterId: encounter.id,
+          orderingClinicianId: user.id,
+          facilityId: facility.id,
+          isDischargePrescription: true,
+        }),
+      );
+    });
+
+    afterEach(async () => {
+      await models.InvoiceItem.destroy({ where: {}, force: true });
+      await models.PharmacyOrderPrescription.destroy({ where: {}, force: true });
+    });
+
+    it('does not create invoice_items when persisting a pharmacy_order_prescription via sync', async () => {
+      const popData = {
+        ...fake(models.PharmacyOrderPrescription, {
+          pharmacyOrderId: pharmacyOrder.id,
+          prescriptionId: prescription.id,
+          quantity: 5,
+        }),
+      };
+
+      await saveChangesForModel(
+        models.PharmacyOrderPrescription,
+        [{ data: popData, isDeleted: false }],
+        false,
+        log,
+      );
+
+      const persistedPop = await models.PharmacyOrderPrescription.findByPk(popData.id);
+      expect(persistedPop).not.toBeNull();
+      expect(persistedPop.quantity).toBe(5);
+
+      // The afterBulkCreate hook would otherwise upsert an invoice_items row here via
+      // recalculateAndApplyInvoiceQuantity -> Invoice.addItemToInvoice. With hooks
+      // disabled on the sync persist path, it must not fire.
+      const invoiceItems = await models.InvoiceItem.findAll({
+        where: { invoiceId: invoice.id },
+        paranoid: false,
+      });
+      expect(invoiceItems).toHaveLength(0);
+    });
+
+    it('does not create invoice_items when updating a pharmacy_order_prescription via sync', async () => {
+      const existing = await models.PharmacyOrderPrescription.create(
+        fake(models.PharmacyOrderPrescription, {
+          pharmacyOrderId: pharmacyOrder.id,
+          prescriptionId: prescription.id,
+          quantity: 1,
+        }),
+      );
+      // Clear any invoice items that may have been created by the local create above,
+      // so we're only asserting on what sync persistence does.
+      await models.InvoiceItem.destroy({ where: {}, force: true });
+
+      await saveChangesForModel(
+        models.PharmacyOrderPrescription,
+        [
+          {
+            data: { ...existing.get({ plain: true }), quantity: 7 },
+            isDeleted: false,
+          },
+        ],
+        false,
+        log,
+      );
+
+      const reloaded = await models.PharmacyOrderPrescription.findByPk(existing.id);
+      expect(reloaded.quantity).toBe(7);
+
+      const invoiceItems = await models.InvoiceItem.findAll({
+        where: { invoiceId: invoice.id },
+        paranoid: false,
+      });
+      expect(invoiceItems).toHaveLength(0);
     });
   });
 });

--- a/packages/database/src/sync/saveChanges.ts
+++ b/packages/database/src/sync/saveChanges.ts
@@ -6,13 +6,15 @@ import type { Model } from '../models/Model';
 
 const persistUpdateWorkerPoolSize = config.sync.persistUpdateWorkerPoolSize;
 
+// We use hooks: false in all transactions here to avoid triggering side effects that may violate other records in the sync payload
+
 export const saveCreates = async (model: typeof Model, records: Record<string, any>[]) => {
   // can end up with duplicate create records, e.g. if syncAllLabRequests is turned on, an
   // encounter may turn up twice, once because it is for a marked-for-sync patient, and once more
   // because it has a lab request attached
   const deduplicated = [];
   const idsAdded = new Set();
-  const idsForSoftDeleted = records.filter((row) => row.isDeleted).map((row) => row.id);
+  const idsForSoftDeleted = records.filter(row => row.isDeleted).map(row => row.id);
 
   for (const record of records) {
     const data = { ...record };
@@ -23,11 +25,11 @@ export const saveCreates = async (model: typeof Model, records: Record<string, a
       idsAdded.add(data.id);
     }
   }
-  await model.bulkCreate(deduplicated);
+  await model.bulkCreate(deduplicated, { hooks: false });
 
   // To create soft deleted records, we need to first create them, then destroy them
   if (idsForSoftDeleted.length > 0) {
-    await model.destroy({ where: { id: { [Op.in]: idsForSoftDeleted } } });
+    await model.destroy({ where: { id: { [Op.in]: idsForSoftDeleted } }, hooks: false });
   }
 };
 
@@ -39,14 +41,14 @@ export const saveUpdates = async (
 ) => {
   const recordsToSave = isCentralServer
     ? // on the central server, merge the records coming in from different clients
-      incomingRecords.map((incoming) => {
+      incomingRecords.map(incoming => {
         const existing = idToExistingRecord[incoming.id];
         return mergeRecord(existing, incoming);
       })
     : // on the facility server, trust the resolved central server version
       incomingRecords;
-  await asyncPool(persistUpdateWorkerPoolSize, recordsToSave, async (r) =>
-    model.update(r, { where: { id: r.id }, paranoid: false }),
+  await asyncPool(persistUpdateWorkerPoolSize, recordsToSave, async r =>
+    model.update(r, { where: { id: r.id }, paranoid: false, hooks: false }),
   );
 };
 
@@ -54,7 +56,10 @@ export const saveUpdates = async (
 export const saveDeletes = async (model: typeof Model, recordsForDelete: Record<string, any>[]) => {
   if (recordsForDelete.length === 0) return;
 
-  await model.destroy({ where: { id: { [Op.in]: recordsForDelete.map((r) => r.id) } } });
+  await model.destroy({
+    where: { id: { [Op.in]: recordsForDelete.map(r => r.id) } },
+    hooks: false,
+  });
 };
 
 export const saveRestores = async (
@@ -62,5 +67,8 @@ export const saveRestores = async (
   recordsForRestore: Record<string, any>[],
 ) => {
   if (recordsForRestore.length === 0) return;
-  await model.restore({ where: { id: { [Op.in]: recordsForRestore.map((r) => r.id) } } });
+  await model.restore({
+    where: { id: { [Op.in]: recordsForRestore.map(r => r.id) } },
+    hooks: false,
+  });
 };

--- a/packages/database/src/sync/saveChanges.ts
+++ b/packages/database/src/sync/saveChanges.ts
@@ -47,9 +47,18 @@ export const saveUpdates = async (
       })
     : // on the facility server, trust the resolved central server version
       incomingRecords;
-  await asyncPool(persistUpdateWorkerPoolSize, recordsToSave, async r =>
-    model.update(r, { where: { id: r.id }, paranoid: false, hooks: false }),
-  );
+  await asyncPool(persistUpdateWorkerPoolSize, recordsToSave, async r => {
+    // Strip `id` from the update payload — it's already in the WHERE clause and is
+    // never supposed to change. Models with GENERATED ALWAYS `id` columns (e.g.
+    // PatientOngoingPrescription, PatientFacility) rely on Sequelize re-picking values
+    // from the validated instance's dataValues (where the column-level `set()` no-op
+    // has already filtered `id` out). With `hooks: false`, `instance.validate()` no
+    // longer returns the instance, so that re-pick is skipped and `id` slips through
+    // into the SET clause — which Postgres rejects for GENERATED columns. Filtering
+    // here keeps the write valid regardless of the hooks/validate behaviour.
+    const { id, ...values } = r;
+    return model.update(values, { where: { id }, paranoid: false, hooks: false });
+  });
 };
 
 // model.update cannot update deleted_at field, so we need to do update (in case there are still any new changes even if it is being deleted) and destroy


### PR DESCRIPTION
### Changes

Don't run sequelize hooks while persisting sync data, as they run mid-transaction which can lead to unexpected side effects and constraint violations with the rest of the incoming sync data.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
