### PR TITLE
tweak: no-issue: Restore e2e checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 <summary>Options</summary>
 
 - [ ] Synthetic test <!-- #deployopt %synthetic -->
+- [ ] E2E tests <!-- #e2e -->
 
 </details>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,12 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 <summary>Options</summary>
 
 - [ ] Synthetic test <!-- #deployopt %synthetic -->
-- [ ] E2E tests <!-- #e2e -->
 
 </details>
+
+### Tests
+
+- [ ] Run E2E tests <!-- #e2e -->
 
 ### Review Hero
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 
 ### Tests
 
-- [ ] Run E2E tests <!-- #e2e -->
+- [ ] **Run E2E tests** <!-- #e2e -->
 
 ### Review Hero
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -288,7 +288,7 @@ jobs:
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'merge_group'
+      - if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')
         name: Enforce passing E2E workflow (in merge queue)
         run: |
           if [ "${{ needs.e2e.result }}" != "success" ]; then

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '- [x] E2E tests <!-- #e2e -->')
+    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] Run E2E tests <!-- #e2e -->')
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] Run E2E tests <!-- #e2e -->')
+    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '- [x] E2E tests <!-- #e2e -->')
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
   merge_group:
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
   merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -2,6 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
   merge_group:
 
 permissions:


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

 ### Tests

- [x] Run E2E tests <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates PR template text and GitHub Actions `if`/trigger conditions to optionally run/enforce E2E based on the PR body.
> 
> **Overview**
> Restores a **PR template checkbox** (`Run E2E tests`) and wires it back into the `E2E Tests` GitHub Actions workflow so E2E runs/enforcement happens when the PR body contains the checked marker.
> 
> Updates the workflow to also listen to `pull_request` `edited` events, ensuring toggling the checkbox can trigger the conditional jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 024a87415138948e0168246ed3047e904b2340bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->