### PR TITLE
feat(AI): TAM-2399: Patient summary backend

### DIFF
--- a/packages/central-server/app/ai/index.js
+++ b/packages/central-server/app/ai/index.js
@@ -1,0 +1,6 @@
+import express from 'express';
+import { patientAiRoute } from './patient';
+
+export const aiRoutes = express.Router();
+
+aiRoutes.use('/patient', patientAiRoute);

--- a/packages/central-server/app/ai/patient/index.js
+++ b/packages/central-server/app/ai/patient/index.js
@@ -1,0 +1,6 @@
+import express from 'express';
+import { patientSummaryRoute } from './patientSummaryRoute';
+
+export const patientAiRoute = express.Router();
+
+patientAiRoute.use('/summary', patientSummaryRoute);

--- a/packages/central-server/app/ai/patient/patientSummaryContext.js
+++ b/packages/central-server/app/ai/patient/patientSummaryContext.js
@@ -1,0 +1,42 @@
+export const PATIENT_SUMMARY_CONTEXT_NAME = 'patient-summary';
+
+export const PATIENT_SUMMARY_SYSTEM_PROMPT = `
+
+You are a clinical documentation assistant helping produce accurate, concise encounter summaries for receiving and follow-up clinicians at the point of patient discharge from an inpatient or emergency department setting.
+
+Your role is strictly to summarize — not interpret, infer, or supplement — the clinical information explicitly documented in the encounter record provided to you.
+
+Task
+
+Using only the encounter data provided below, write a structured discharge encounter summary of 100 words or fewer for a receiving clinician.
+
+Rules — read carefully before generating
+
+You will be given structured patient data in sections:
+- DEMOGRAPHICS: age, sex, blood type
+- ALLERGIES: allergens and reactions
+- ACTIVE CONDITIONS: ongoing diagnoses
+- PATIENT ISSUES: flagged concerns
+- CURRENT ENCOUNTER: type, reason for visit, diagnoses, and clinical notes
+- PAST ENCOUNTERS: visit dates and primary diagnoses
+No hallucination, zero tolerance. Only include information that is explicitly present in the encounter data. If a field is absent or unclear, omit it entirely. Do not infer, extrapolate, or fill gaps with clinical assumptions.
+Flag uncertainty, never resolve it. If data appears contradictory or incomplete, note it as such (e.g., "discharge medications not documented") rather than guessing.
+Clinician-facing language. Use standard medical terminology appropriate for a receiving clinician. Do not simplify for patients.
+Follow-up only if documented. Include follow-up plans, referrals, or prescriptions only if explicitly recorded in the encounter. Do not suggest or imply next steps that are absent from the chart.
+Strict word limit. The summary must not exceed 100 words. Prioritise clinical relevance.
+Required structure (omit any section for which no data is documented)
+- Write in flowing clinical prose — not bullet points
+- Do NOT include patient names, IDs, or any personally identifying information
+- Omit any section that has no data — do not write placeholder text
+- Cover demographics, then active conditions and allergies, then the current encounter, then relevant past history
+
+Presenting complaint
+Key findings (relevant vitals, labs, imaging, procedures)
+Diagnosis / Impression
+Treatment provided (medications, interventions)
+Condition at discharge
+Follow-up plan (only if documented)
+Encounter data
+
+{INSERT STRUCTURED ENCOUNTER DATA HERE — patient notes, vitals, labs, imaging, procedures, medications}
+`;

--- a/packages/central-server/app/ai/patient/patientSummaryRoute.js
+++ b/packages/central-server/app/ai/patient/patientSummaryRoute.js
@@ -1,0 +1,40 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { ForbiddenError } from '@tamanu/errors';
+import { ensurePermissionCheck } from '@tamanu/shared/permissions/middleware';
+import { AI_CONTEXT_NAMES } from '@tamanu/constants';
+
+export const patientSummaryRoute = express.Router();
+
+patientSummaryRoute.use(ensurePermissionCheck);
+
+patientSummaryRoute.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    req.checkPermission('read', 'Patient');
+
+    if (!req.aiService) {
+      throw new ForbiddenError('AI service is not enabled or configured');
+    }
+
+    const { patientData, editFeedback } = req.body;
+
+    let userMessage = JSON.stringify(patientData, null, 2);
+
+    if (editFeedback?.length > 0) {
+      const feedbackSection = editFeedback
+        .map(
+          (f, i) =>
+            `Correction ${i + 1}:\nOriginal AI output: ${f.aiGenerated}\nClinician corrected to: ${f.userEdited}`,
+        )
+        .join('\n\n');
+
+      userMessage += `\n\n---\nPrevious summaries for this patient were corrected by a clinician. Apply these corrections to your output:\n\n${feedbackSection}`;
+    }
+
+    const response = await req.aiService.invoke(AI_CONTEXT_NAMES.PATIENT_SUMMARY, userMessage);
+
+    res.send({ content: response.content });
+  }),
+);

--- a/packages/central-server/app/buildRoutes.js
+++ b/packages/central-server/app/buildRoutes.js
@@ -11,6 +11,7 @@ import { healthRoutes } from './health';
 import { integrationRoutes } from './integrations';
 import { adminRoutes } from './admin';
 import { suggestionsRoutes } from './suggestions';
+import { aiRoutes } from './ai';
 
 export const buildRoutes = ctx => {
   const routes = express.Router();
@@ -38,6 +39,7 @@ export const buildRoutes = ctx => {
   routes.use('/integration', integrationRoutes);
   routes.use('/admin', adminRoutes);
   routes.use('/suggestions', suggestionsRoutes);
+  routes.use('/ai', aiRoutes);
 
   return routes;
 };

--- a/packages/central-server/app/services/AIService.js
+++ b/packages/central-server/app/services/AIService.js
@@ -7,6 +7,7 @@ import { SystemMessage } from '@langchain/core/messages';
 import { RunnableWithMessageHistory } from '@langchain/core/runnables';
 
 import { log } from '@tamanu/shared/services/logging';
+import { AI_CONTEXT_NAMES } from '@tamanu/constants';
 
 const SESSION_TTL_SECONDS = 60 * 60 * 24; // 24 hours
 
@@ -64,8 +65,7 @@ export class AIService {
       historyMessagesKey: 'history',
     });
 
-    // TODO: Register context here so that it's only loaded once. 
-    // Eg: service.registerContext('developer', 'You are a senior backend developer.');
+    await service.registerAllContexts(settings);
 
     log.info(`AIService: initialised with model "${anthropicModel}"`);
     return service;
@@ -73,6 +73,11 @@ export class AIService {
 
   close() {
     this.sessions.close();
+  }
+
+  async registerAllContexts(settings) {
+    const { patientSummarySystemPrompt } = await settings.get('ai');
+    this.registerContext(AI_CONTEXT_NAMES.PATIENT_SUMMARY, patientSummarySystemPrompt);
   }
 
   /**

--- a/packages/constants/src/ai.ts
+++ b/packages/constants/src/ai.ts
@@ -1,0 +1,3 @@
+export const AI_CONTEXT_NAMES = {
+    PATIENT_SUMMARY: 'patient-summary',
+} as const;

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ai.js';
 export * from './appointments.js';
 export * from './auth.js';
 export * from './binary.js';

--- a/packages/database/src/migrations/1778035386449-createAiDocuments.ts
+++ b/packages/database/src/migrations/1778035386449-createAiDocuments.ts
@@ -1,0 +1,60 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+
+export async function up(query: QueryInterface): Promise<void> {
+  await query.createTable('ai_documents', {
+    id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+    },
+    summary_type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    record_type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    record_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'generated',
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    source: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'ai',
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  });
+
+  await query.addIndex('ai_documents', ['record_type', 'record_id', 'summary_type'], {
+    unique: true,
+    name: 'ai_documents_record_type_record_id_summary_type_unique',
+  });
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  await query.dropTable('ai_documents');
+}

--- a/packages/database/src/models/AiDocument.ts
+++ b/packages/database/src/models/AiDocument.ts
@@ -1,0 +1,109 @@
+import { DataTypes } from 'sequelize';
+import { SYNC_DIRECTIONS } from '@tamanu/constants';
+
+import { Model } from './Model';
+import { buildSyncLookupSelect } from '../sync/buildSyncLookupSelect';
+import type { InitOptions, Models } from '../types/model';
+
+const AI_DOCUMENT_SUMMARY_TYPES = ['patient', 'discharge'] as const;
+const AI_DOCUMENT_RECORD_TYPES = ['Patient', 'Discharge'] as const;
+const AI_DOCUMENT_STATUSES = ['generated', 'edited', 'discarded'] as const;
+const AI_DOCUMENT_SOURCES = ['ai', 'human'] as const;
+
+export class AiDocument extends Model {
+  declare id: string;
+  declare summaryType: string;
+  declare recordType: string;
+  declare recordId: string;
+  declare status: string;
+  declare content: string | null;
+  declare source: string;
+
+  static initModel({ primaryKey, ...options }: InitOptions) {
+    super.init(
+      {
+        id: primaryKey,
+        summaryType: {
+          type: DataTypes.STRING,
+          allowNull: false,
+          validate: {
+            isIn: [AI_DOCUMENT_SUMMARY_TYPES as unknown as string[]],
+          },
+        },
+        recordType: {
+          type: DataTypes.STRING,
+          allowNull: false,
+          validate: {
+            isIn: [AI_DOCUMENT_RECORD_TYPES as unknown as string[]],
+          },
+        },
+        recordId: {
+          type: DataTypes.STRING,
+          allowNull: false,
+        },
+        status: {
+          type: DataTypes.STRING,
+          allowNull: false,
+          defaultValue: 'generated',
+          validate: {
+            isIn: [AI_DOCUMENT_STATUSES as unknown as string[]],
+          },
+        },
+        content: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+        source: {
+          type: DataTypes.STRING,
+          allowNull: false,
+          defaultValue: 'ai',
+          validate: {
+            isIn: [AI_DOCUMENT_SOURCES as unknown as string[]],
+          },
+        },
+      },
+      {
+        ...options,
+        syncDirection: SYNC_DIRECTIONS.BIDIRECTIONAL,
+      },
+    );
+  }
+
+  static initRelations(_models: Models) {
+    // no relations yet
+  }
+
+  static buildPatientSyncFilter(
+    patientCount: number,
+    markedForSyncPatientsTable: string,
+  ) {
+    if (patientCount === 0) {
+      return null;
+    }
+    return `
+      LEFT JOIN discharges ON ai_documents.record_id = discharges.id AND ai_documents.record_type = 'Discharge'
+      LEFT JOIN encounters ON discharges.encounter_id = encounters.id
+      WHERE (
+        (ai_documents.record_type = 'Patient' AND ai_documents.record_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+        OR (ai_documents.record_type = 'Discharge' AND encounters.patient_id IN (SELECT patient_id FROM ${markedForSyncPatientsTable}))
+      )
+      AND ai_documents.updated_at_sync_tick > :since
+    `;
+  }
+
+  static async buildSyncLookupQueryDetails() {
+    const patientIdExpr = `
+      CASE
+        WHEN ai_documents.record_type = 'Patient' THEN ai_documents.record_id
+        WHEN ai_documents.record_type = 'Discharge' THEN encounters.patient_id
+      END
+    `;
+    return {
+      select: await buildSyncLookupSelect(this, { patientId: patientIdExpr }),
+      joins: `
+        LEFT JOIN discharges ON ai_documents.record_id = discharges.id AND ai_documents.record_type = 'Discharge'
+        LEFT JOIN encounters ON discharges.encounter_id = encounters.id
+      `,
+    };
+  }
+}

--- a/packages/database/src/models/index.ts
+++ b/packages/database/src/models/index.ts
@@ -158,3 +158,5 @@ export * from './LocationAssignmentTemplate';
 export * from './LocationAssignment';
 export * from './DHIS2PushLog';
 export * from './MSupplyPushLog';
+
+export * from './AiDocument';

--- a/packages/facility-server/app/routes/apiv1/ai/index.js
+++ b/packages/facility-server/app/routes/apiv1/ai/index.js
@@ -1,0 +1,6 @@
+import express from 'express';
+import { patientRoute } from './patient';
+
+export const ai = express.Router();
+
+ai.use('/patient', patientRoute);

--- a/packages/facility-server/app/routes/apiv1/ai/patient/index.js
+++ b/packages/facility-server/app/routes/apiv1/ai/patient/index.js
@@ -1,0 +1,6 @@
+import express from 'express';
+import { patientSummaryRoute } from './patientSummary';
+
+export const patientRoute = express.Router();
+
+patientRoute.use('/summary', patientSummaryRoute);

--- a/packages/facility-server/app/routes/apiv1/ai/patient/patientSummary.js
+++ b/packages/facility-server/app/routes/apiv1/ai/patient/patientSummary.js
@@ -1,0 +1,127 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import { QueryTypes } from 'sequelize';
+
+import { NotFoundError } from '@tamanu/errors';
+import { CentralServerConnection } from '../../../../sync';
+import { fetchPatientSummaryData } from '../../../../services/patientSummaryData';
+
+/**
+ * Query logs.changes for ai_documents that were edited by a human for a given patient.
+ * Returns pairs of { aiGenerated, userEdited } content so the AI can learn from corrections.
+ */
+async function getEditFeedback(patientId, sequelize) {
+  // Find ai_documents for this patient that were edited (source = 'human', status = 'edited')
+  // Then look up the change log to find the original AI-generated content before the edit
+  const editedDocs = await sequelize.query(
+    `SELECT id, content FROM ai_documents
+     WHERE record_type = 'Patient' AND record_id = :patientId
+     AND status = 'edited' AND source = 'human'
+     ORDER BY updated_at DESC
+     LIMIT 5`,
+    { replacements: { patientId }, type: QueryTypes.SELECT },
+  );
+
+  if (editedDocs.length === 0) return [];
+
+  const feedback = [];
+  for (const doc of editedDocs) {
+    // Get the earliest change log entry for this record (the original AI-generated version)
+    const [originalLog] = await sequelize.query(
+      `SELECT record_data->>'content' AS content FROM logs.changes
+       WHERE table_name = 'ai_documents' AND record_id = :recordId
+       AND (record_data->>'source') = 'ai'
+       ORDER BY logged_at ASC
+       LIMIT 1`,
+      { replacements: { recordId: doc.id }, type: QueryTypes.SELECT },
+    );
+
+    if (originalLog?.content && doc.content && originalLog.content !== doc.content) {
+      feedback.push({
+        aiGenerated: originalLog.content,
+        userEdited: doc.content,
+      });
+    }
+  }
+
+  return feedback;
+}
+
+export const patientSummaryRoute = express.Router();
+
+patientSummaryRoute.get(
+  '/:patientId',
+  asyncHandler(async (req, res) => {
+    const { patientId } = req.params;
+    req.checkPermission('read', 'Patient');
+
+    const { AiDocument } = req.models;
+    const existing = await AiDocument.findOne({
+      where: { recordType: 'Patient', recordId: patientId },
+      order: [['createdAt', 'DESC']],
+    });
+
+    res.send({ aiDocument: existing?.forResponse() ?? null });
+  }),
+);
+
+patientSummaryRoute.post(
+  '/:patientId',
+  asyncHandler(async (req, res) => {
+    const { patientId } = req.params;
+    const { deviceId } = req;
+
+    req.checkPermission('read', 'Patient');
+
+    const { Patient, AiDocument } = req.models;
+    const patientExists = await Patient.count({ where: { id: patientId } });
+    if (!patientExists) {
+      throw new NotFoundError(`Patient ${patientId} not found`);
+    }
+
+    const patientData = await fetchPatientSummaryData(patientId, req.models);
+    const editFeedback = await getEditFeedback(patientId, req.db);
+
+    const centralServer = new CentralServerConnection({ deviceId });
+    const aiResponse = await centralServer.fetch('ai/patient/summary', {
+      method: 'POST',
+      body: { patientData, editFeedback },
+      backoff: { maxAttempts: 3, maxWaitMs: 2000 },
+    });
+
+    const doc = await AiDocument.create({
+      summaryType: 'patient',
+      recordType: 'Patient',
+      recordId: patientId,
+      content: aiResponse.content,
+    });
+
+    res.send(doc.forResponse());
+  }),
+);
+
+patientSummaryRoute.put(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    req.checkPermission('read', 'Patient');
+
+    const { AiDocument } = req.models;
+    const doc = await AiDocument.findByPk(req.params.id);
+    if (!doc) {
+      throw new NotFoundError('AI document not found');
+    }
+
+    const { content, status } = req.body;
+    const updateFields = { source: 'human' };
+    if (status === 'discarded') {
+      updateFields.status = 'discarded';
+      updateFields.content = null;
+    } else {
+      updateFields.status = 'edited';
+      updateFields.content = content;
+    }
+    await doc.update(updateFields);
+
+    res.send(doc.forResponse());
+  }),
+);

--- a/packages/facility-server/app/routes/apiv1/index.js
+++ b/packages/facility-server/app/routes/apiv1/index.js
@@ -66,6 +66,7 @@ import { telegramRoutes } from './telegram/telegramRoutes';
 import { tasks } from './task/tasks';
 import { notifications } from './notifications';
 import { random } from './random';
+import { ai } from './ai';
 
 const passthrough = (_req, _res, next) => next();
 
@@ -249,6 +250,7 @@ export function createApiv1({ authLimiter } = {}) {
   patientDataRoutes.use('/vitals', vitals);
   patientDataRoutes.use('/tasks', tasks);
   patientDataRoutes.use('/notifications', notifications);
+  patientDataRoutes.use('/ai', ai);
   
   // reference data endpoints
   referenceDataRoutes.use('/asset', asset);

--- a/packages/facility-server/app/services/patientSummaryData.js
+++ b/packages/facility-server/app/services/patientSummaryData.js
@@ -1,0 +1,210 @@
+import { Op } from 'sequelize';
+import { VISIBILITY_STATUSES } from '@tamanu/constants';
+
+const PAST_ENCOUNTER_LIMIT = 20;
+
+/**
+ * Fetch the data needed to build a patient summary prompt.
+ *
+ * @param {string} patientId
+ * @param {object} models - Sequelize models
+ * @returns {Promise<object>}
+ */
+export async function fetchPatientSummaryData(patientId, models) {
+  const {
+    Patient,
+    PatientAllergy,
+    PatientCondition,
+    PatientIssue,
+    PatientFamilyHistory,
+    PatientCarePlan,
+    Encounter,
+    EncounterDiagnosis,
+    Note,
+  } = models;
+
+  // 1. Demographics
+  const patient = await Patient.findByPk(patientId, {
+    include: ['village'],
+  });
+
+  // 2. Allergies
+  const allergies = await PatientAllergy.findAll({
+    where: { patientId },
+    include: PatientAllergy.getListReferenceAssociations(),
+  });
+
+  // 3. Ongoing conditions
+  const conditions = await PatientCondition.findAll({
+    where: { patientId },
+    include: PatientCondition.getListReferenceAssociations(),
+  });
+
+  // 4. Patient issues / alerts
+  const issues = await PatientIssue.findAll({
+    where: { patientId },
+  });
+
+  // 5. Family history
+  const familyHistory = await PatientFamilyHistory.findAll({
+    where: { patientId },
+    include: PatientFamilyHistory.getListReferenceAssociations(),
+  });
+
+  // 6. Care plans
+  const carePlans = await PatientCarePlan.findAll({
+    where: { patientId },
+    include: PatientCarePlan.getListReferenceAssociations(),
+  });
+
+  // 7. Current active encounter (endDate IS NULL)
+  const activeEncounter = await Encounter.findOne({
+    where: { patientId, endDate: null },
+    include: Encounter.getFullReferenceAssociations(),
+    order: [['startDate', 'DESC']],
+  });
+
+  let activeEncounterDiagnoses = [];
+  let activeEncounterNotes = [];
+
+  if (activeEncounter) {
+    activeEncounterDiagnoses = await EncounterDiagnosis.findAll({
+      where: { encounterId: activeEncounter.id },
+      include: EncounterDiagnosis.getListReferenceAssociations(),
+    });
+
+    activeEncounterNotes = await Note.findAll({
+      where: {
+        recordId: activeEncounter.id,
+        recordType: 'Encounter',
+        visibilityStatus: VISIBILITY_STATUSES.CURRENT,
+      },
+      include: ['author', 'onBehalfOf'],
+      order: [['date', 'DESC']],
+    });
+  }
+
+  // 8. Past encounters (lightweight: dates, type, diagnoses)
+  const pastEncounterWhere = { patientId };
+  if (activeEncounter) {
+    pastEncounterWhere.id = { [Op.ne]: activeEncounter.id };
+  }
+
+  const pastEncounters = await Encounter.findAll({
+    where: pastEncounterWhere,
+    include: [
+      'department',
+      'examiner',
+      {
+        association: 'diagnoses',
+        include: EncounterDiagnosis.getListReferenceAssociations(),
+      },
+    ],
+    order: [['startDate', 'DESC']],
+    limit: PAST_ENCOUNTER_LIMIT,
+  });
+
+  return {
+    patient: formatPatient(patient),
+    allergies: allergies.map(formatAllergy),
+    conditions: conditions.map(formatCondition),
+    issues: issues.map(formatIssue),
+    familyHistory: familyHistory.map(formatFamilyHistory),
+    carePlans: carePlans.map(formatCarePlan),
+    activeEncounter: activeEncounter
+      ? formatActiveEncounter(activeEncounter, activeEncounterDiagnoses, activeEncounterNotes)
+      : null,
+    pastEncounters: pastEncounters.map(formatPastEncounter),
+  };
+}
+
+function formatPatient(p) {
+  if (!p) return null;
+  return {
+    displayId: p.displayId,
+    firstName: p.firstName,
+    lastName: p.lastName,
+    dateOfBirth: p.dateOfBirth,
+    dateOfDeath: p.dateOfDeath,
+    sex: p.sex,
+    village: p.village?.name,
+  };
+}
+
+function formatAllergy(a) {
+  return {
+    allergy: a.allergy?.name,
+    reaction: a.reaction?.name,
+    note: a.note,
+    recordedDate: a.recordedDate,
+  };
+}
+
+function formatCondition(c) {
+  return {
+    condition: c.condition?.name,
+    resolved: c.resolved,
+    recordedDate: c.recordedDate,
+    resolutionDate: c.resolutionDate,
+    note: c.note,
+  };
+}
+
+function formatIssue(i) {
+  return {
+    type: i.type,
+    note: i.note,
+    recordedDate: i.recordedDate,
+  };
+}
+
+function formatFamilyHistory(fh) {
+  return {
+    diagnosis: fh.diagnosis?.name,
+    relationship: fh.relationship,
+    note: fh.note,
+    recordedDate: fh.recordedDate,
+  };
+}
+
+function formatCarePlan(cp) {
+  return {
+    carePlan: cp.carePlan?.name,
+    date: cp.date,
+  };
+}
+
+function formatActiveEncounter(encounter, diagnoses, notes) {
+  return {
+    encounterType: encounter.encounterType,
+    startDate: encounter.startDate,
+    reasonForEncounter: encounter.reasonForEncounter,
+    department: encounter.department?.name,
+    examiner: encounter.examiner?.displayName,
+    location: encounter.location?.name,
+    diagnoses: diagnoses.map(d => ({
+      diagnosis: d.Diagnosis?.name,
+      certainty: d.certainty,
+      isPrimary: d.isPrimary,
+    })),
+    notes: notes.map(n => ({
+      content: n.content,
+      date: n.date,
+      author: n.author?.displayName,
+    })),
+  };
+}
+
+function formatPastEncounter(encounter) {
+  return {
+    encounterType: encounter.encounterType,
+    startDate: encounter.startDate,
+    endDate: encounter.endDate,
+    department: encounter.department?.name,
+    diagnoses: encounter.diagnoses?.map(d => ({
+      diagnosis: d.Diagnosis?.name,
+      certainty: d.certainty,
+      isPrimary: d.isPrimary,
+    })),
+  };
+}

--- a/packages/settings/src/schema/central.ts
+++ b/packages/settings/src/schema/central.ts
@@ -11,6 +11,7 @@ import {
   datelessTimeStringSchema,
 } from './definitions';
 import { extractDefaults } from './utils';
+import { patientSummaryProperties } from './definitions/patientSummary';
 
 export const centralSettings = {
   name: 'Central server settings',
@@ -37,6 +38,12 @@ export const centralSettings = {
           description: 'The Anthropic model to use for AI features',
           type: yup.string(),
           defaultValue: 'claude-sonnet-4-20250514',
+        },
+        patientSummarySystemPrompt: {
+          name: 'Patient summary system prompt',
+          description: 'The system prompt to use for the patient summary',
+          type: yup.string(),
+          defaultValue: '',
         },
       },
     },
@@ -244,6 +251,7 @@ export const centralSettings = {
       },
     },
     formBuilder: formBuilderProperties,
+    patientSummary: patientSummaryProperties,
     integrations: {
       description: 'Integrations with external services',
       properties: {

--- a/packages/settings/src/schema/definitions/patientSummary.ts
+++ b/packages/settings/src/schema/definitions/patientSummary.ts
@@ -1,0 +1,57 @@
+import * as yup from 'yup';
+
+import { SETTING_EDITORS } from '@tamanu/constants';
+
+const PATIENT_SUMMARY_PROMPT = `
+You are a clinical documentation assistant helping produce accurate, concise encounter summaries for receiving and follow-up clinicians at the point of patient discharge from an inpatient or emergency department setting.
+
+Your role is strictly to summarize — not interpret, infer, or supplement — the clinical information explicitly documented in the encounter record provided to you.
+
+Task
+
+Using only the encounter data provided below, write a structured discharge encounter summary of 100 words or fewer for a receiving clinician.
+
+Rules — read carefully before generating
+
+You will be given structured patient data in sections:
+- DEMOGRAPHICS: age, sex, blood type
+- ALLERGIES: allergens and reactions
+- ACTIVE CONDITIONS: ongoing diagnoses
+- PATIENT ISSUES: flagged concerns
+- CURRENT ENCOUNTER: type, reason for visit, diagnoses, and clinical notes
+- PAST ENCOUNTERS: visit dates and primary diagnoses
+No hallucination, zero tolerance. Only include information that is explicitly present in the encounter data. If a field is absent or unclear, omit it entirely. Do not infer, extrapolate, or fill gaps with clinical assumptions.
+Flag uncertainty, never resolve it. If data appears contradictory or incomplete, note it as such (e.g., “discharge medications not documented”) rather than guessing.
+Clinician-facing language. Use standard medical terminology appropriate for a receiving clinician. Do not simplify for patients.
+Follow-up only if documented. Include follow-up plans, referrals, or prescriptions only if explicitly recorded in the encounter. Do not suggest or imply next steps that are absent from the chart.
+Strict word limit. The summary must not exceed 100 words. Prioritise clinical relevance.
+Required structure (omit any section for which no data is documented)
+- Write in flowing clinical prose — not bullet points
+- Do NOT include patient names, IDs, or any personally identifying information
+- Omit any section that has no data — do not write placeholder text
+- Cover demographics, then active conditions and allergies, then the current encounter, then relevant past history
+
+Presenting complaint
+Key findings (relevant vitals, labs, imaging, procedures)
+Diagnosis / Impression
+Treatment provided (medications, interventions)
+Condition at discharge
+Follow-up plan (only if documented)
+Encounter data
+
+{INSERT STRUCTURED ENCOUNTER DATA HERE — patient notes, vitals, labs, imaging, procedures, medications}
+`;
+
+export const patientSummaryProperties = {
+    name: 'Patient summary',
+    description: 'Settings for the patient summary',
+    properties: {
+        prompts: {
+            name: 'System prompt',
+            description: 'The system prompt to use for the patient summary',
+            type: yup.string(),
+            editor: SETTING_EDITORS.MARKDOWN,
+            defaultValue: PATIENT_SUMMARY_PROMPT,
+        },
+    },
+};


### PR DESCRIPTION
### Changes
- Patient summary backend

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new API endpoints and a new bidirectionally-synced table for storing/editing AI-generated clinical text, plus new settings that influence AI output. Risk is mainly around data consistency/migrations and safe handling of AI-generated content paths.
> 
> **Overview**
> Adds a new patient-summary backend flow: the facility server gathers structured patient/encounter data, calls the central server’s new `POST /ai/patient/summary` endpoint, and stores the returned summary as an `AiDocument` that can be retrieved and later edited/discarded.
> 
> Introduces persistence and sync support via a new `ai_documents` table + `AiDocument` model (with patient-aware sync filtering/lookup) and a feedback loop that sends up to 5 prior human edits (diffed via `logs.changes`) back to the AI request.
> 
> Wires AI context registration into `AIService` at startup using a new `AI_CONTEXT_NAMES.PATIENT_SUMMARY` constant, and adds central settings to configure the patient summary system prompt (plus a new `patientSummary` settings section defining the default prompt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4df4aa7b2fd1eaa87fbfcb77e8974ce7b4c993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->