### PR TITLE
feat(pharmacyOrders): TAM-6739: Add setting to control the default prescription type when sending an order to the pharmacy

### DIFF
--- a/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
@@ -1808,6 +1808,13 @@
       "facilityId": "facility-CarnationHealthCentre"
     },
     {
+      "id": "department-GeneralClinic-tamanu",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-1"
+    },
+    {
       "id": "department-GeneralMedicine-tamanu",
       "code": "GeneralMedicine",
       "name": "General Medicine",
@@ -1855,6 +1862,13 @@
       "name": "Public Health",
       "visibilityStatus": "current",
       "facilityId": "facility-1"
+    },
+    {
+      "id": "department-GeneralClinic-facility-2",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-2"
     },
     {
       "id": "department-GeneralMedicine",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Departments.json5
@@ -104,7 +104,7 @@
       "code": "GeneralClinic",
       "name": "Clinic",
       "visibilityStatus": "current",
-      "facilityId": "facility-ColonialWarMemorialDivisionalHospital"
+      "facilityId": "facility-1"
     },
     {
       "id": "department-COVID19Team",
@@ -1808,13 +1808,6 @@
       "facilityId": "facility-CarnationHealthCentre"
     },
     {
-      "id": "department-GeneralClinic-tamanu",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-1"
-    },
-    {
       "id": "department-GeneralMedicine-tamanu",
       "code": "GeneralMedicine",
       "name": "General Medicine",
@@ -1862,13 +1855,6 @@
       "name": "Public Health",
       "visibilityStatus": "current",
       "facilityId": "facility-1"
-    },
-    {
-      "id": "department-GeneralClinic-facility-2",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-2"
     },
     {
       "id": "department-GeneralMedicine",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
@@ -85,7 +85,7 @@
       "code": "GeneralClinic",
       "name": "Clinic",
       "visibilityStatus": "current",
-      "facilityId": "facility-ColonialWarMemorialDivisionalHospital"
+      "facilityId": "facility-1"
     },
     {
       "id": "location-DemoLan",
@@ -1775,13 +1775,6 @@
       "facilityId": "facility-Yasawa-I-RaraNursingStation"
     },
     {
-      "id": "location-GeneralClinic-facility-2",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-2"
-    },
-    {
       "id": "location-Outpatient",
       "code": "LHOutpatient",
       "name": "Consultation Room",
@@ -1961,13 +1954,6 @@
       "visibilityStatus": "current",
       "facilityId": "facility-2",
       "locationGroupId": "locationgroup-LilyImmunisationClinic"
-    },
-    {
-      "id": "location-GeneralClinic-tamanu",
-      "code": "GeneralClinic",
-      "name": "General Clinic",
-      "visibilityStatus": "current",
-      "facilityId": "facility-1"
     },
     {
       "id": "location-Outpatient-tamanu",

--- a/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
+++ b/packages/central-server/app/subCommands/defaultProvisioningData/Locations.json5
@@ -1775,6 +1775,13 @@
       "facilityId": "facility-Yasawa-I-RaraNursingStation"
     },
     {
+      "id": "location-GeneralClinic-facility-2",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-2"
+    },
+    {
       "id": "location-Outpatient",
       "code": "LHOutpatient",
       "name": "Consultation Room",
@@ -1954,6 +1961,13 @@
       "visibilityStatus": "current",
       "facilityId": "facility-2",
       "locationGroupId": "locationgroup-LilyImmunisationClinic"
+    },
+    {
+      "id": "location-GeneralClinic-tamanu",
+      "code": "GeneralClinic",
+      "name": "General Clinic",
+      "visibilityStatus": "current",
+      "facilityId": "facility-1"
     },
     {
       "id": "location-Outpatient-tamanu",

--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -308,6 +308,7 @@ export const PHARMACY_PRESCRIPTION_TYPE_LABELS = {
 export const PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES = {
   ENCOUNTER_TYPE: 'encounterType',
   OUTPATIENT_OR_DISCHARGE: 'outpatientOrDischarge',
+  INPATIENT: 'inpatient',
 };
 
 export const DRUG_STOCK_STATUSES = {

--- a/packages/constants/src/medications.ts
+++ b/packages/constants/src/medications.ts
@@ -305,6 +305,11 @@ export const PHARMACY_PRESCRIPTION_TYPE_LABELS = {
   [PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT]: 'Outpatient/Discharge',
 };
 
+export const PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES = {
+  ENCOUNTER_TYPE: 'encounterType',
+  OUTPATIENT_OR_DISCHARGE: 'outpatientOrDischarge',
+};
+
 export const DRUG_STOCK_STATUSES = {
   IN_STOCK: 'in_stock',
   OUT_OF_STOCK: 'out_of_stock',

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -238,6 +238,10 @@ export const facilitySettings = {
                   value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE,
                   label: 'Outpatient/Discharge',
                 },
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.INPATIENT,
+                  label: 'Inpatient',
+                },
               ],
             },
           },

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import { PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES } from '@tamanu/constants';
 
 import { extractDefaults } from './utils';
 import {
@@ -212,6 +213,32 @@ export const facilitySettings = {
               type: yup.string().nullable(),
               defaultValue: null,
               suggesterEndpoint: 'department',
+            },
+          },
+        },
+      },
+    },
+    features: {
+      description: 'Facility-specific feature settings',
+      exposedToWeb: true,
+      properties: {
+        pharmacyOrder: {
+          description: 'Pharmacy order settings',
+          properties: {
+            defaultPrescriptionType: {
+              description: 'Default prescription type in Pharmacy Order modal',
+              type: yup.string().oneOf(Object.values(PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES)),
+              defaultValue: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+              options: [
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+                  label: 'Existing encounter type',
+                },
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE,
+                  label: 'Outpatient/Discharge',
+                },
+              ],
             },
           },
         },

--- a/packages/settings/src/schema/facility.ts
+++ b/packages/settings/src/schema/facility.ts
@@ -193,6 +193,31 @@ export const facilitySettings = {
       name: 'Medication',
       description: 'Settings related to medication management and dispensing',
       properties: {
+        pharmacyOrder: {
+          name: 'Pharmacy orders',
+          description: 'Default prescription type behavior for pharmacy orders',
+          properties: {
+            defaultPrescriptionType: {
+              description: 'Default prescription type in Pharmacy Order modal',
+              type: yup.string().oneOf(Object.values(PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES)),
+              defaultValue: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+              options: [
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+                  label: 'Existing encounter type',
+                },
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE,
+                  label: 'Outpatient/Discharge',
+                },
+                {
+                  value: (PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES as Record<string, string>).INPATIENT,
+                  label: 'Inpatient',
+                },
+              ],
+            },
+          },
+        },
         medicationDispensing: {
           name: 'Medication dispensing',
           description:
@@ -213,36 +238,6 @@ export const facilitySettings = {
               type: yup.string().nullable(),
               defaultValue: null,
               suggesterEndpoint: 'department',
-            },
-          },
-        },
-      },
-    },
-    features: {
-      description: 'Facility-specific feature settings',
-      exposedToWeb: true,
-      properties: {
-        pharmacyOrder: {
-          description: 'Pharmacy order settings',
-          properties: {
-            defaultPrescriptionType: {
-              description: 'Default prescription type in Pharmacy Order modal',
-              type: yup.string().oneOf(Object.values(PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES)),
-              defaultValue: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
-              options: [
-                {
-                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
-                  label: 'Existing encounter type',
-                },
-                {
-                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE,
-                  label: 'Outpatient/Discharge',
-                },
-                {
-                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.INPATIENT,
-                  label: 'Inpatient',
-                },
-              ],
             },
           },
         },

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -27,7 +27,6 @@ import {
 } from './global-settings-properties/layouts';
 import {
   ADMINISTRATION_FREQUENCIES,
-  PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES,
 } from '@tamanu/constants';
 import {
   medicationFrequencyDefault,
@@ -352,21 +351,6 @@ export const globalSettings = {
               description: 'Send pharmacy orders to mSupply (when an integration is configured)',
               type: yup.boolean(),
               defaultValue: false,
-            },
-            defaultPrescriptionType: {
-              description: 'Default prescription type in Pharmacy Order modal',
-              type: yup.string().oneOf(Object.values(PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES)),
-              defaultValue: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
-              options: [
-                {
-                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
-                  label: 'Existing encounter type',
-                },
-                {
-                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE,
-                  label: 'Outpatient/Discharge',
-                },
-              ],
             },
           },
         },

--- a/packages/settings/src/schema/global.ts
+++ b/packages/settings/src/schema/global.ts
@@ -25,7 +25,10 @@ import {
   layoutModuleProperties,
   unhideableLayoutModuleProperties,
 } from './global-settings-properties/layouts';
-import { ADMINISTRATION_FREQUENCIES } from '@tamanu/constants';
+import {
+  ADMINISTRATION_FREQUENCIES,
+  PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES,
+} from '@tamanu/constants';
 import {
   medicationFrequencyDefault,
   medicationFrequencySchema,
@@ -349,6 +352,21 @@ export const globalSettings = {
               description: 'Send pharmacy orders to mSupply (when an integration is configured)',
               type: yup.boolean(),
               defaultValue: false,
+            },
+            defaultPrescriptionType: {
+              description: 'Default prescription type in Pharmacy Order modal',
+              type: yup.string().oneOf(Object.values(PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES)),
+              defaultValue: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+              options: [
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+                  label: 'Existing encounter type',
+                },
+                {
+                  value: PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE,
+                  label: 'Outpatient/Discharge',
+                },
+              ],
             },
           },
         },

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -249,6 +249,10 @@ export const PharmacyOrderModal = React.memo(
         setPrescriptionType(PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT);
         return;
       }
+      if (defaultPrescriptionType === PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.INPATIENT) {
+        setPrescriptionType(PHARMACY_PRESCRIPTION_TYPES.INPATIENT);
+        return;
+      }
 
       if (encounter.encounterType === ENCOUNTER_TYPES.CLINIC) {
         setPrescriptionType(PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT);

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -238,7 +238,7 @@ export const PharmacyOrderModal = React.memo(
       setOrderingClinicianId(currentUser.id);
     }, [currentUser]);
 
-    // Set default prescription type when the modal opens. Defaut is determined by the mode setting.
+    // Set default prescription type when the modal opens. Default is determined by the mode setting.
     useEffect(() => {
       if (!open || !encounter?.encounterType || isOngoingMode) return;
 

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -176,7 +176,7 @@ export const PharmacyOrderModal = React.memo(
 
     const sendViaMSupply = getSetting('features.pharmacyOrder.sendViaMSupply');
     const defaultPrescriptionType = getSetting(
-      'features.pharmacyOrder.defaultPrescriptionType',
+      'medications.pharmacyOrder.defaultPrescriptionType',
       PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
     );
 

--- a/packages/web/app/components/Medication/PharmacyOrderModal.jsx
+++ b/packages/web/app/components/Medication/PharmacyOrderModal.jsx
@@ -12,7 +12,11 @@ import {
   TranslatedText,
   useDateTime,
 } from '@tamanu/ui-components';
-import { ENCOUNTER_TYPES, PHARMACY_PRESCRIPTION_TYPES } from '@tamanu/constants';
+import {
+  ENCOUNTER_TYPES,
+  PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES,
+  PHARMACY_PRESCRIPTION_TYPES,
+} from '@tamanu/constants';
 
 import { AutocompleteInput } from '../Field';
 import { useApi, useSuggester } from '../../api';
@@ -171,13 +175,15 @@ export const PharmacyOrderModal = React.memo(
     );
 
     const sendViaMSupply = getSetting('features.pharmacyOrder.sendViaMSupply');
+    const defaultPrescriptionType = getSetting(
+      'features.pharmacyOrder.defaultPrescriptionType',
+      PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.ENCOUNTER_TYPE,
+    );
 
     // Permission to edit repeats (only relevant for ongoing mode)
     const canEditRepeats = ability.can('write', 'Medication');
 
-    const [prescriptionType, setPrescriptionType] = useState(
-      PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT,
-    );
+    const [prescriptionType, setPrescriptionType] = useState(PHARMACY_PRESCRIPTION_TYPES.INPATIENT);
     // In ongoing mode, always use discharge/outpatient
     const isDischargeOrOutpatient =
       isOngoingMode || prescriptionType === PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT;
@@ -232,17 +238,24 @@ export const PharmacyOrderModal = React.memo(
       setOrderingClinicianId(currentUser.id);
     }, [currentUser]);
 
-    // Set default prescription type based on encounter type when the modal opens
-    // Only applies in encounter mode
+    // Set default prescription type when the modal opens. Defaut is determined by the mode setting.
     useEffect(() => {
       if (!open || !encounter?.encounterType || isOngoingMode) return;
+
+      if (
+        defaultPrescriptionType ===
+        PHARMACY_ORDER_DEFAULT_PRESCRIPTION_MODES.OUTPATIENT_OR_DISCHARGE
+      ) {
+        setPrescriptionType(PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT);
+        return;
+      }
 
       if (encounter.encounterType === ENCOUNTER_TYPES.CLINIC) {
         setPrescriptionType(PHARMACY_PRESCRIPTION_TYPES.DISCHARGE_OR_OUTPATIENT);
       } else {
         setPrescriptionType(PHARMACY_PRESCRIPTION_TYPES.INPATIENT);
       }
-    }, [open, encounter?.encounterType, isOngoingMode]);
+    }, [open, encounter?.encounterType, isOngoingMode, defaultPrescriptionType]);
 
     const handleSelectAll = useCallback(event => {
       const checked = event.target.checked;
@@ -276,13 +289,11 @@ export const PharmacyOrderModal = React.memo(
     const getAlreadyOrderedPrescriptions = useCallback(() => {
       const timeoutHours = Number(medicationAlreadyOrderedConfirmationTimeout) || 0;
       const cutoffMs = Date.now() - timeoutHours * 60 * 60 * 1000;
-      return prescriptions.filter(
-        p => {
-          if (!p.selected || !p.lastOrderedAt) return false;
-          const lastOrderedMs = storedDateTimeToEpochMilliseconds(p.lastOrderedAt);
-          return lastOrderedMs != null && lastOrderedMs > cutoffMs;
-        },
-      );
+      return prescriptions.filter(p => {
+        if (!p.selected || !p.lastOrderedAt) return false;
+        const lastOrderedMs = storedDateTimeToEpochMilliseconds(p.lastOrderedAt);
+        return lastOrderedMs != null && lastOrderedMs > cutoffMs;
+      });
     }, [
       prescriptions,
       medicationAlreadyOrderedConfirmationTimeout,

--- a/packages/web/app/views/administration/settings/components/Category.jsx
+++ b/packages/web/app/views/administration/settings/components/Category.jsx
@@ -122,6 +122,7 @@ export const Category = ({ schema, path = '', getSettingValue, handleChangeSetti
           unit,
           highRisk,
           suggesterEndpoint,
+          options,
         } = propertySchema;
 
         const isHighRisk = schema.highRisk || highRisk;
@@ -144,6 +145,7 @@ export const Category = ({ schema, path = '', getSettingValue, handleChangeSetti
               path={newPath}
               handleChangeSetting={handleChangeSetting}
               unit={unit}
+              options={options}
               disabled={disabled}
               facilityId={facilityId}
               data-testid={`settinginput-2wuw-${testIdSuffix}`}

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -7,6 +7,7 @@ import {
   AutocompleteInput,
   LargeBodyText,
   NumberInput,
+  SelectInput,
   TextButton,
   TextInput,
   TranslatedText,
@@ -90,8 +91,12 @@ export const SettingInput = ({
   disabled,
   suggesterEndpoint,
   facilityId,
+  options,
 }) => {
   const { type } = typeSchema;
+  const oneOfOptions = typeSchema?.describe?.()?.oneOf || [];
+  const hasSelectOptions =
+    type === SETTING_TYPES.STRING && (Array.isArray(options) ? options.length > 0 : oneOfOptions.length > 0);
   const [error, setError] = useState(null);
   const suggesterOptions = facilityId ? { baseQueryParameters: { facilityId } } : undefined;
   const suggester = useSuggester(suggesterEndpoint, suggesterOptions);
@@ -217,15 +222,35 @@ export const SettingInput = ({
     case SETTING_TYPES.STRING:
       return (
         <Flexbox data-testid="flexbox-wwbe">
-          <StyledTextInput
-            value={displayValue ?? ''}
-            onChange={defaultHandleChange}
-            style={{ width: '353px' }}
-            error={error}
-            helperText={error?.message}
-            disabled={disabled}
-            data-testid="styledtextinput-fpam"
-          />
+          {hasSelectOptions ? (
+            <SelectInput
+              value={displayValue ?? ''}
+              onChange={defaultHandleChange}
+              style={{ width: '353px' }}
+              options={
+                Array.isArray(options)
+                  ? options
+                  : oneOfOptions.map(value => ({
+                      value,
+                      label: value,
+                    }))
+              }
+              error={error}
+              helperText={error?.message}
+              disabled={disabled}
+              data-testid="selectinput-settings-string-enum"
+            />
+          ) : (
+            <StyledTextInput
+              value={displayValue ?? ''}
+              onChange={defaultHandleChange}
+              style={{ width: '353px' }}
+              error={error}
+              helperText={error?.message}
+              disabled={disabled}
+              data-testid="styledtextinput-fpam"
+            />
+          )}
           <DefaultButton data-testid="defaultbutton-iw4g" />
         </Flexbox>
       );

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -94,9 +94,7 @@ export const SettingInput = ({
   options,
 }) => {
   const { type } = typeSchema;
-  const oneOfOptions = typeSchema?.describe?.()?.oneOf || [];
-  const hasSelectOptions =
-    type === SETTING_TYPES.STRING && (Array.isArray(options) ? options.length > 0 : oneOfOptions.length > 0);
+  const hasSelectOptions = type === SETTING_TYPES.STRING && Array.isArray(options) && options.length > 0;
   const [error, setError] = useState(null);
   const suggesterOptions = facilityId ? { baseQueryParameters: { facilityId } } : undefined;
   const suggester = useSuggester(suggesterEndpoint, suggesterOptions);
@@ -228,14 +226,7 @@ export const SettingInput = ({
               onChange={defaultHandleChange}
               isClearable={false}
               style={{ width: '353px' }}
-              options={
-                Array.isArray(options)
-                  ? options
-                  : oneOfOptions.map(value => ({
-                      value,
-                      label: value,
-                    }))
-              }
+              options={options}
               error={error}
               helperText={error?.message}
               disabled={disabled}

--- a/packages/web/app/views/administration/settings/components/SettingInput.jsx
+++ b/packages/web/app/views/administration/settings/components/SettingInput.jsx
@@ -226,6 +226,7 @@ export const SettingInput = ({
             <SelectInput
               value={displayValue ?? ''}
               onChange={defaultHandleChange}
+              isClearable={false}
               style={{ width: '353px' }}
               options={
                 Array.isArray(options)


### PR DESCRIPTION
### Changes

Add a new setting which controls what prescription type should be selected by default when ordering a prescription from the pharmacy. In most deployments we want this to fall back to the Encounter type, however in some deployments we always want it to default to Outpatient/Discharge.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
