### PR TITLE
fix: release fix 2.55: Photo id form not working

### DIFF
--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -76,7 +76,7 @@ export const FormFields = ({
   onGoBack,
 }: FormFieldsProps): ReactElement => {
   const scrollViewRef = useRef(null);
-  const { errors, validateForm, setStatus, submitForm, values, resetForm } =
+  const { errors, validateForm, setStatus, submitForm, values } =
     useFormikContext<GenericFormValues>();
   const { setQuestionPosition, scrollToQuestion } = useScrollToFirstError();
 
@@ -167,7 +167,6 @@ export const FormFields = ({
   const onSubmit = async (): Promise<void> => {
     await submitScreen(async () => {
       await submitForm();
-      resetForm();
     });
   };
 
@@ -218,7 +217,7 @@ export const FormFields = ({
                       key={component.id}
                       component={component}
                       patient={patient}
-                      zIndex={components.length - index}
+                      zIndex={visibleComponents.length - index}
                       onLayout={getLayoutCallback(component.dataElement.code)}
                       setDisableSubmit={setDisableSubmit}
                     />

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
@@ -35,6 +35,8 @@ function computeVisibleKey(
     .join(',');
 }
 
+const EMPTY_CALCULATED_VALUES = {};
+
 interface SurveyFormInnerProps {
   components: ISurveyScreenComponent[];
   hasCalculations: boolean;
@@ -61,9 +63,10 @@ const SurveyFormInner = ({
   currentScreenIndex,
 }: SurveyFormInnerProps): ReactElement => {
   const { values, setValues, isSubmitting } = useFormikContext<any>();
+  const lastAppliedCalculatedValuesRef = useRef<Record<string, any>>({});
 
   const calculatedValues = useMemo(
-    () => (hasCalculations ? runCalculations(components, values) : {}),
+    () => (hasCalculations ? runCalculations(components, values) : EMPTY_CALCULATED_VALUES),
     [components, hasCalculations, values],
   );
 
@@ -78,8 +81,18 @@ const SurveyFormInner = ({
       ([key, value]) => values[key] !== value,
     );
     if (changes.length > 0) {
+      const changedCalculatedValues = Object.fromEntries(changes);
+      const hasNewCalculatedValue = changes.some(
+        ([key, value]) => lastAppliedCalculatedValuesRef.current[key] !== value,
+      );
+      if (!hasNewCalculatedValue) return;
+
+      lastAppliedCalculatedValuesRef.current = {
+        ...lastAppliedCalculatedValuesRef.current,
+        ...changedCalculatedValues,
+      };
       setValues(
-        prev => ({ ...prev, ...Object.fromEntries(changes) }),
+        { ...values, ...changedCalculatedValues },
         false,
       );
     }

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
 import { Popup } from 'popup-ui';
@@ -114,14 +114,6 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
   const [imagePath, setImagePath] = useState(null);
   const { models, centralServer } = useBackend();
 
-  // Use a ref so in-flight async callbacks (camera/library picker) always call the
-  // latest onChange even if the parent re-renders and passes a new handler while the
-  // picker is open (which happens when the SurveyFormInner resume handler fires setValues).
-  const onChangeRef = useRef(onChange);
-  useEffect(() => {
-    onChangeRef.current = onChange;
-  }, [onChange]);
-
   const removeAttachment = useCallback(async (value, imagePath) => {
     if (value) {
       await models.Attachment.delete(value);
@@ -133,7 +125,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
   }, []);
 
   const removePhotoCallback = useCallback(async () => {
-    onChangeRef.current(null);
+    onChange(null);
     setImageData(null);
     await removeAttachment(value, imagePath);
   }, [value, imagePath]);
@@ -190,7 +182,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
         type: 'image/jpeg',
       });
 
-      onChangeRef.current(id);
+      onChange(id);
       setImagePath(path);
       setImageData(image.base64);
       setLoading(false);

--- a/packages/mobile/App/ui/components/UploadPhoto/index.tsx
+++ b/packages/mobile/App/ui/components/UploadPhoto/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
 import RNFS from 'react-native-fs';
 import { Popup } from 'popup-ui';
@@ -114,6 +114,14 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
   const [imagePath, setImagePath] = useState(null);
   const { models, centralServer } = useBackend();
 
+  // Use a ref so in-flight async callbacks (camera/library picker) always call the
+  // latest onChange even if the parent re-renders and passes a new handler while the
+  // picker is open (which happens when the SurveyFormInner resume handler fires setValues).
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
   const removeAttachment = useCallback(async (value, imagePath) => {
     if (value) {
       await models.Attachment.delete(value);
@@ -125,7 +133,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
   }, []);
 
   const removePhotoCallback = useCallback(async () => {
-    onChange(null);
+    onChangeRef.current(null);
     setImageData(null);
     await removeAttachment(value, imagePath);
   }, [value, imagePath]);
@@ -182,7 +190,7 @@ export const UploadPhoto = React.memo(({ onChange, value }: PhotoProps) => {
         type: 'image/jpeg',
       });
 
-      onChange(id);
+      onChangeRef.current(id);
       setImagePath(path);
       setImageData(image.base64);
       setLoading(false);

--- a/packages/mobile/App/ui/hooks/useSecurityInfo.ts
+++ b/packages/mobile/App/ui/hooks/useSecurityInfo.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { NativeModules } from 'react-native';
 import { SETTING_KEYS } from '@tamanu/constants';
 import {
@@ -74,19 +74,34 @@ export const useSecurityInfo = () => {
   const { getSetting } = useSettings();
   const { signedIn } = useAuth();
   const isForeground = useOnForeground();
+  // Track whether the initial check for the current sign-in session has completed.
+  // Subsequent foreground-return checks (e.g. returning from the camera) should still
+  // re-validate security, but must not show the blocking loading screen — doing so
+  // unmounts the entire navigation stack, causing in-flight work (e.g. photo saves) to
+  // be lost and form state to reset.
+  const hasCheckedSinceSignIn = useRef(false);
 
   const allowUnencryptedStorage = getSetting(SETTING_KEYS.SECURITY_MOBILE_ALLOW_UNENCRYPTED_STORAGE);
   const allowUnprotected = getSetting(SETTING_KEYS.SECURITY_MOBILE_ALLOW_UNPROTECTED);
 
   const fetchSecurityInfo = useCallback(async () => {
-    setIsLoading(true);
+    if (!hasCheckedSinceSignIn.current) {
+      setIsLoading(true);
+    }
     const storageEncryptionStatus = await getStorageEncryptionStatus();
     const isStorageEncryptedValue = checkIsStorageEncrypted(storageEncryptionStatus);
     const isDeviceSecureValue = await checkIsDeviceSecure();
     setIsStorageEncrypted(isStorageEncryptedValue);
     setIsDeviceSecure(isDeviceSecureValue);
+    hasCheckedSinceSignIn.current = true;
     setIsLoading(false);
   }, []);
+
+  useEffect(() => {
+    if (!signedIn) {
+      hasCheckedSinceSignIn.current = false;
+    }
+  }, [signedIn]);
 
   useEffect(() => {
     if (signedIn && isForeground) {


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches form submission/state management and foreground-triggered security checks, which can affect user data entry and navigation behavior; logic is localized but timing/edge cases may regress without targeted testing.
> 
> **Overview**
> Fixes mobile survey/photo workflows that were losing state.
> 
> Survey forms no longer call `resetForm()` immediately after `submitForm()`, calculated field values are written back to Formik more defensively to avoid redundant `setValues` loops, and `SurveyQuestion` stacking now uses `visibleComponents` for correct `zIndex` when questions are conditionally hidden.
> 
> Security re-checks on returning to the foreground still run, but the blocking loading screen is now only shown on the first check after sign-in (tracked via `hasCheckedSinceSignIn`) to avoid unmounting navigation and resetting in-flight work (e.g. photo saves).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7a653c0a6239fd3abd18bdc7fcd05e05ddf766b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->