### PR TITLE
fix(mobile): no-issue: 2.51 fix: vitals survey freezes

### DIFF
--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -82,7 +82,7 @@ export const FormFields = ({
   onGoBack,
 }: FormFieldsProps): ReactElement => {
   const scrollViewRef = useRef(null);
-  const { errors, validateForm, setStatus, submitForm, values, resetForm } =
+  const { errors, validateForm, setStatus, submitForm, values } =
     useFormikContext<GenericFormValues>();
   const { setQuestionPosition, scrollToQuestion } = useScrollToFirstError();
 
@@ -156,7 +156,6 @@ export const FormFields = ({
   const onSubmit = async (): Promise<void> => {
     await submitScreen(async () => {
       await submitForm();
-      resetForm();
     });
   };
 

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -207,7 +207,7 @@ export const FormFields = ({
                       key={component.id}
                       component={component}
                       patient={patient}
-                      zIndex={components.length - index}
+                      zIndex={visibleComponents.length - index}
                       setPosition={setQuestionPosition(component.dataElement.code)}
                       setDisableSubmit={setDisableSubmit}
                     />

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useSelector } from 'react-redux';
@@ -132,6 +133,8 @@ export const SurveyForm = ({
     >
       {({ values, setValues, isSubmitting }: FormikProps<any>): ReactElement => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
+        const lastAppliedCalculatedValuesRef = useRef<Record<string, any>>({});
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
           // recalculate dynamic fields
           const calculatedValues = runCalculations(components, values);
@@ -141,13 +144,19 @@ export const SurveyForm = ({
 
           if (changes.length > 0) {
             const changedCalculatedValues = Object.fromEntries(changes);
-            setValues(
-              prev => ({
-                ...prev,
-                ...changedCalculatedValues,
-              }),
-              false,
+            const hasNewCalculatedValue = changes.some(
+              ([key, value]) => lastAppliedCalculatedValuesRef.current[key] !== value,
             );
+            if (hasNewCalculatedValue) {
+              lastAppliedCalculatedValuesRef.current = {
+                ...lastAppliedCalculatedValuesRef.current,
+                ...changedCalculatedValues,
+              };
+              setValues(
+                { ...values, ...changedCalculatedValues },
+                false,
+              );
+            }
           }
 
           const nextFormValues = {


### PR DESCRIPTION
### Changes

Backports #9723 to release/2.51. This fixes vitals survey freezes by limiting survey question z-indexes to visible fields and avoiding repeated Formik writes for unchanged calculated values.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)