### PR TITLE
fix(mobile): no-issue: 2.52 fix: vitals survey freezes

### DIFF
--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -76,7 +76,7 @@ export const FormFields = ({
   onGoBack,
 }: FormFieldsProps): ReactElement => {
   const scrollViewRef = useRef(null);
-  const { errors, validateForm, setStatus, submitForm, values, resetForm } =
+  const { errors, validateForm, setStatus, submitForm, values } =
     useFormikContext<GenericFormValues>();
   const { setQuestionPosition, scrollToQuestion } = useScrollToFirstError();
 
@@ -167,7 +167,6 @@ export const FormFields = ({
   const onSubmit = async (): Promise<void> => {
     await submitScreen(async () => {
       await submitForm();
-      resetForm();
     });
   };
 

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/FormFields.tsx
@@ -218,7 +218,7 @@ export const FormFields = ({
                       key={component.id}
                       component={component}
                       patient={patient}
-                      zIndex={components.length - index}
+                      zIndex={visibleComponents.length - index}
                       onLayout={getLayoutCallback(component.dataElement.code)}
                       setDisableSubmit={setDisableSubmit}
                     />

--- a/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
+++ b/packages/mobile/App/ui/components/Forms/SurveyForm/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useSelector } from 'react-redux';
@@ -141,6 +142,8 @@ export const SurveyForm = ({
     >
       {({ values, setValues, isSubmitting }: FormikProps<any>): ReactElement => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
+        const lastAppliedCalculatedValuesRef = useRef<Record<string, any>>({});
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
           const calculatedValues = hasCalculations
             ? runCalculations(components, values)
@@ -151,13 +154,19 @@ export const SurveyForm = ({
 
           if (changes.length > 0) {
             const changedCalculatedValues = Object.fromEntries(changes);
-            setValues(
-              prev => ({
-                ...prev,
-                ...changedCalculatedValues,
-              }),
-              false,
+            const hasNewCalculatedValue = changes.some(
+              ([key, value]) => lastAppliedCalculatedValuesRef.current[key] !== value,
             );
+            if (hasNewCalculatedValue) {
+              lastAppliedCalculatedValuesRef.current = {
+                ...lastAppliedCalculatedValuesRef.current,
+                ...changedCalculatedValues,
+              };
+              setValues(
+                { ...values, ...changedCalculatedValues },
+                false,
+              );
+            }
           }
 
           const nextFormValues = hasCalculations


### PR DESCRIPTION
### Changes

Backports #9723 to release/2.52. This fixes vitals survey freezes by limiting survey question z-indexes to visible fields and avoiding repeated Formik writes for unchanged calculated values.

### Deploys

- [ ] **Deploy to Tamanu Internal** <!-- #deploy -->

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)