### PR TITLE
fix(mobile): 2.54 hotfix: remove patient title from mobile model

### DIFF
--- a/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
+++ b/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+const TABLE_NAME = 'patients';
+const COLUMN_NAME = 'title';
+
+export class removePatientTitleColumn1778199200000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn(TABLE_NAME, COLUMN_NAME);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      TABLE_NAME,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+}

--- a/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
+++ b/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
@@ -1,16 +1,19 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
 
 const TABLE_NAME = 'patients';
 const COLUMN_NAME = 'title';
 
 export class removePatientTitleColumn1778199200000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropColumn(TABLE_NAME, COLUMN_NAME);
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.dropColumn(table, COLUMN_NAME);
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
     await queryRunner.addColumn(
-      TABLE_NAME,
+      table,
       new TableColumn({
         name: COLUMN_NAME,
         type: 'varchar',

--- a/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
+++ b/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
@@ -1461,6 +1461,11 @@ const PatientTable = new Table({
       type: 'varchar',
     }),
     new TableColumn({
+      name: 'title',
+      type: 'varchar',
+      isNullable: true,
+    }),
+    new TableColumn({
       name: 'firstName',
       type: 'varchar',
       isNullable: true,

--- a/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
+++ b/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
@@ -1461,11 +1461,6 @@ const PatientTable = new Table({
       type: 'varchar',
     }),
     new TableColumn({
-      name: 'title',
-      type: 'varchar',
-      isNullable: true,
-    }),
-    new TableColumn({
       name: 'firstName',
       type: 'varchar',
       isNullable: true,

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -84,6 +84,7 @@ import { addSupportsSecondaryResultsToLabTestType1768527821000 } from './1768527
 import { addSecondaryResultToLabTest1768527821000 } from './1768527821000-addSecondaryResultToLabTest';
 import { updateEncountersTableSetPatientIdNotNull1771277667000 } from './1771277667000-updateEncountersTableSetPatientIdNotNull';
 import { addSurveyFormVisibilityCriteria1773618699809 } from './1773618699809-addSurveyFormVisibilityCriteria';
+import { removePatientTitleColumn1778199200000 } from './1778199200000-removePatientTitleColumn';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -171,4 +172,5 @@ export const migrationList = [
   addSecondaryResultToLabTest1768527821000,
   updateEncountersTableSetPatientIdNotNull1771277667000,
   addSurveyFormVisibilityCriteria1773618699809,
+  removePatientTitleColumn1778199200000,
 ];

--- a/packages/mobile/App/models/Patient.spec.ts
+++ b/packages/mobile/App/models/Patient.spec.ts
@@ -22,7 +22,6 @@ describe('findRecentlyViewed', () => {
     culturalName: 'Fredde',
     village: null,
     villageId: null,
-    title: null,
     additionalData: null,
   };
   const patients: IPatient[] = [

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -29,9 +29,6 @@ export class Patient extends BaseModel implements IPatient {
   displayId: string;
 
   @Column({ nullable: true })
-  title?: string;
-
-  @Column({ nullable: true })
   firstName?: string;
 
   @Column({ nullable: true })

--- a/packages/mobile/App/types/IPatient.ts
+++ b/packages/mobile/App/types/IPatient.ts
@@ -5,7 +5,6 @@ import { IReferenceData } from './IReferenceData';
 export interface IPatient {
   id: string;
   displayId: string;
-  title?: string;
   firstName?: string;
   lastName?: string;
   middleName?: string;

--- a/packages/mobile/tests/helpers/fake.ts
+++ b/packages/mobile/tests/helpers/fake.ts
@@ -31,7 +31,6 @@ import { Task } from '~/models/Task';
 export const fakePatient = (): IPatient => {
   const uuid = uuidv4();
   return {
-    title: 'Ms.',
     id: `patient-id-${uuid}`,
     displayId: `patient_displayId-${uuid}`,
     firstName: `patient_firstName-${uuid}`,


### PR DESCRIPTION
## Summary
- Remove legacy `title` from the mobile `Patient` model and `IPatient` type so `patients` sync records no longer include a field that central does not store.
- Add a mobile migration to drop the obsolete `patients.title` column on upgraded devices while leaving first-time setup history intact.

### Auto-Deploy

- [x] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>


## Test plan
- Read lints on touched mobile files: no diagnostics.
- `git diff --check`: clean.
- Mobile `Patient.spec.ts` focused test was started but interrupted before completion.