### PR TITLE
fix(mobile): Release fix 2.55: Security screen clearing state when loading

### DIFF
--- a/packages/mobile/App/ui/hooks/useSecurityInfo.ts
+++ b/packages/mobile/App/ui/hooks/useSecurityInfo.ts
@@ -65,6 +65,7 @@ export const useSecurityInfo = () => {
   const [isStorageEncrypted, setIsStorageEncrypted] = useState<boolean>(true);
   const [isDeviceSecure, setIsDeviceSecure] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [hasCompletedInitialCheck, setHasCompletedInitialCheck] = useState<boolean>(false);
   const { getTranslation } = useTranslation();
   const { getSetting } = useSettings();
   const { signedIn } = useAuth();
@@ -83,6 +84,7 @@ export const useSecurityInfo = () => {
     setIsStorageEncrypted(isStorageEncryptedValue);
     setIsDeviceSecure(isDeviceSecureValue);
     setIsLoading(false);
+    setHasCompletedInitialCheck(true);
   }, []);
 
   useEffect(() => {
@@ -91,11 +93,19 @@ export const useSecurityInfo = () => {
     }
   }, [fetchSecurityInfo, signedIn, isForeground]);
 
+  // Reset completed-check flag on sign-out so the next sign-in is always gated
+  useEffect(() => {
+    if (!signedIn) {
+      setHasCompletedInitialCheck(false);
+    }
+  }, [signedIn]);
+
   const isStorageCompliant = allowUnencryptedStorage ? true : isStorageEncrypted;
   const isPasscodeCompliant = allowUnprotected ? true : isDeviceSecure;
   return {
     securityIssues: getSecurityIssues(getTranslation, { isStorageCompliant, isPasscodeCompliant }),
     isLoading,
+    hasCompletedInitialCheck,
     fetchSecurityInfo,
   };
 };

--- a/packages/mobile/App/ui/hooks/useSecurityInfo.ts
+++ b/packages/mobile/App/ui/hooks/useSecurityInfo.ts
@@ -93,7 +93,7 @@ export const useSecurityInfo = () => {
     }
   }, [fetchSecurityInfo, signedIn, isForeground]);
 
-  // Reset to pre-check state on sign-out so the next sign-in shows loading, not a stale result
+  // Reset to pre-check state on sign-out so the next sign-in shows loading, not a stale result.
   useEffect(() => {
     if (!signedIn) {
       setHasCompletedInitialCheck(false);

--- a/packages/mobile/App/ui/hooks/useSecurityInfo.ts
+++ b/packages/mobile/App/ui/hooks/useSecurityInfo.ts
@@ -93,10 +93,11 @@ export const useSecurityInfo = () => {
     }
   }, [fetchSecurityInfo, signedIn, isForeground]);
 
-  // Reset completed-check flag on sign-out so the next sign-in is always gated
+  // Reset to pre-check state on sign-out so the next sign-in shows loading, not a stale result
   useEffect(() => {
     if (!signedIn) {
       setHasCompletedInitialCheck(false);
+      setIsLoading(true);
     }
   }, [signedIn]);
 

--- a/packages/mobile/App/ui/hooks/useSecurityInfo.ts
+++ b/packages/mobile/App/ui/hooks/useSecurityInfo.ts
@@ -26,7 +26,7 @@ async function getStorageEncryptionStatus(): Promise<StorageEncryptionStatus> {
     return {
       status: 6,
       statusText: 'UNKNOWN',
-    }
+    };
   }
 }
 
@@ -42,10 +42,7 @@ async function checkIsDeviceSecure(): Promise<boolean> {
 // Statuses 0, 1, 2 are not encrypted, 4 is encrypted but less secure
 // so we're only going to trust status 3 and 5.
 function checkIsStorageEncrypted(status: StorageEncryptionStatus): boolean {
-  return [
-    ENCRYPTION_STATUS.ACTIVE,
-    ENCRYPTION_STATUS.ACTIVE_PER_USER
-  ].includes(status.status);
+  return [ENCRYPTION_STATUS.ACTIVE, ENCRYPTION_STATUS.ACTIVE_PER_USER].includes(status.status);
 }
 
 function getSecurityIssues(
@@ -59,9 +56,7 @@ function getSecurityIssues(
     );
   }
   if (!isPasscodeCompliant) {
-    issues.push(
-      getTranslation('general.device.security.issues.passcode', 'No passcode is set'),
-    );
+    issues.push(getTranslation('general.device.security.issues.passcode', 'No passcode is set'));
   }
   return issues;
 }
@@ -75,7 +70,9 @@ export const useSecurityInfo = () => {
   const { signedIn } = useAuth();
   const isForeground = useOnForeground();
 
-  const allowUnencryptedStorage = getSetting(SETTING_KEYS.SECURITY_MOBILE_ALLOW_UNENCRYPTED_STORAGE);
+  const allowUnencryptedStorage = getSetting(
+    SETTING_KEYS.SECURITY_MOBILE_ALLOW_UNENCRYPTED_STORAGE,
+  );
   const allowUnprotected = getSetting(SETTING_KEYS.SECURITY_MOBILE_ALLOW_UNPROTECTED);
 
   const fetchSecurityInfo = useCallback(async () => {
@@ -91,8 +88,6 @@ export const useSecurityInfo = () => {
   useEffect(() => {
     if (signedIn && isForeground) {
       fetchSecurityInfo();
-    } else {
-      setIsLoading(false);
     }
   }, [fetchSecurityInfo, signedIn, isForeground]);
 

--- a/packages/mobile/App/ui/hooks/useSecurityInfo.ts
+++ b/packages/mobile/App/ui/hooks/useSecurityInfo.ts
@@ -69,7 +69,7 @@ function getSecurityIssues(
 export const useSecurityInfo = () => {
   const [isStorageEncrypted, setIsStorageEncrypted] = useState<boolean>(true);
   const [isDeviceSecure, setIsDeviceSecure] = useState<boolean>(true);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const { getTranslation } = useTranslation();
   const { getSetting } = useSettings();
   const { signedIn } = useAuth();
@@ -91,6 +91,8 @@ export const useSecurityInfo = () => {
   useEffect(() => {
     if (signedIn && isForeground) {
       fetchSecurityInfo();
+    } else {
+      setIsLoading(false);
     }
   }, [fetchSecurityInfo, signedIn, isForeground]);
 

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -32,7 +32,7 @@ export const Core: FunctionComponent<any> = () => {
   const { facilityId } = useFacility();
   const { isLoading, securityIssues, hasCompletedInitialCheck, fetchSecurityInfo } = useSecurityInfo();
 
-  if (securityIssues.length > 0 || (signedIn && !hasCompletedInitialCheck)) {
+  if (signedIn && (securityIssues.length > 0 || !hasCompletedInitialCheck)) {
     return (
       <SecurityScreen
         isLoading={isLoading}

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import { StyleSheet, View } from 'react-native';
 // Helpers
 import { Routes } from '/helpers/routes';
 import { noSwipeGestureOnNavigator } from '/helpers/navigators';
@@ -32,35 +33,44 @@ export const Core: FunctionComponent<any> = () => {
   const { facilityId } = useFacility();
   const { isLoading, securityIssues, fetchSecurityInfo } = useSecurityInfo();
 
-  if (isLoading || securityIssues.length > 0) {
-    return (
-      <SecurityScreen
-        isLoading={isLoading}
-        securityIssues={securityIssues}
-        handleRetry={fetchSecurityInfo}
-      />
-    );
+  const securityScreen = (
+    <SecurityScreen
+      isLoading={isLoading}
+      securityIssues={securityIssues}
+      handleRetry={fetchSecurityInfo}
+    />
+  );
+
+  if (securityIssues.length > 0) {
+    return securityScreen;
   }
 
   const initialRouteName = getSignInFlowRoute(signedIn, facilityId);
 
   return (
-    <Stack.Navigator headerMode="none" initialRouteName={initialRouteName}>
-      <Stack.Screen name={Routes.Forms.AutocompleteModal} component={AutocompleteModalScreen} />
-      <Stack.Screen name={Routes.Forms.MultiSelectModal} component={MultiSelectModalScreen} />
-      <Stack.Screen name={Routes.Forms.SelectModal} component={SelectModalScreen} />
-      <Stack.Screen name={Routes.Forms.FrequencySearchModal} component={FrequencySearchModalScreen} />
-      <Stack.Screen
-        name={Routes.SignUpStack.Index}
-        component={SignUpStack}
-        initialParams={{ signedOutFromInactivity: false }}
-      />
-      <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
-      <Stack.Screen
-        options={noSwipeGestureOnNavigator}
-        name={Routes.HomeStack.Index}
-        component={HomeStack}
-      />
-    </Stack.Navigator>
+    <>
+      <Stack.Navigator headerMode="none" initialRouteName={initialRouteName}>
+        <Stack.Screen name={Routes.Forms.AutocompleteModal} component={AutocompleteModalScreen} />
+        <Stack.Screen name={Routes.Forms.MultiSelectModal} component={MultiSelectModalScreen} />
+        <Stack.Screen name={Routes.Forms.SelectModal} component={SelectModalScreen} />
+        <Stack.Screen name={Routes.Forms.FrequencySearchModal} component={FrequencySearchModalScreen} />
+        <Stack.Screen
+          name={Routes.SignUpStack.Index}
+          component={SignUpStack}
+          initialParams={{ signedOutFromInactivity: false }}
+        />
+        <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
+        <Stack.Screen
+          options={noSwipeGestureOnNavigator}
+          name={Routes.HomeStack.Index}
+          component={HomeStack}
+        />
+      </Stack.Navigator>
+      {isLoading && (
+        <View style={StyleSheet.absoluteFill}>
+          {securityScreen}
+        </View>
+      )}
+    </>
   );
 };

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -33,11 +33,11 @@ export const Core: FunctionComponent<any> = () => {
   const { isLoading, securityIssues, fetchSecurityInfo } = useSecurityInfo();
 
   const hasPassedInitialCheck = useRef(false);
-  if (!isLoading && securityIssues.length === 0) {
+  if (signedIn && !isLoading && securityIssues.length === 0) {
     hasPassedInitialCheck.current = true;
   }
 
-  if (securityIssues.length > 0 || !hasPassedInitialCheck.current) {
+  if (securityIssues.length > 0 || (signedIn && !hasPassedInitialCheck.current)) {
     return (
       <SecurityScreen
         isLoading={isLoading}

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -1,5 +1,4 @@
-import React, { FunctionComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { FunctionComponent, useRef } from 'react';
 // Helpers
 import { Routes } from '/helpers/routes';
 import { noSwipeGestureOnNavigator } from '/helpers/navigators';
@@ -33,44 +32,40 @@ export const Core: FunctionComponent<any> = () => {
   const { facilityId } = useFacility();
   const { isLoading, securityIssues, fetchSecurityInfo } = useSecurityInfo();
 
-  const securityScreen = (
-    <SecurityScreen
-      isLoading={isLoading}
-      securityIssues={securityIssues}
-      handleRetry={fetchSecurityInfo}
-    />
-  );
+  const hasPassedInitialCheck = useRef(false);
+  if (!isLoading && securityIssues.length === 0) {
+    hasPassedInitialCheck.current = true;
+  }
 
-  if (securityIssues.length > 0) {
-    return securityScreen;
+  if (securityIssues.length > 0 || !hasPassedInitialCheck.current) {
+    return (
+      <SecurityScreen
+        isLoading={isLoading}
+        securityIssues={securityIssues}
+        handleRetry={fetchSecurityInfo}
+      />
+    );
   }
 
   const initialRouteName = getSignInFlowRoute(signedIn, facilityId);
 
   return (
-    <>
-      <Stack.Navigator headerMode="none" initialRouteName={initialRouteName}>
-        <Stack.Screen name={Routes.Forms.AutocompleteModal} component={AutocompleteModalScreen} />
-        <Stack.Screen name={Routes.Forms.MultiSelectModal} component={MultiSelectModalScreen} />
-        <Stack.Screen name={Routes.Forms.SelectModal} component={SelectModalScreen} />
-        <Stack.Screen name={Routes.Forms.FrequencySearchModal} component={FrequencySearchModalScreen} />
-        <Stack.Screen
-          name={Routes.SignUpStack.Index}
-          component={SignUpStack}
-          initialParams={{ signedOutFromInactivity: false }}
-        />
-        <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
-        <Stack.Screen
-          options={noSwipeGestureOnNavigator}
-          name={Routes.HomeStack.Index}
-          component={HomeStack}
-        />
-      </Stack.Navigator>
-      {isLoading && (
-        <View style={StyleSheet.absoluteFill}>
-          {securityScreen}
-        </View>
-      )}
-    </>
+    <Stack.Navigator headerMode="none" initialRouteName={initialRouteName}>
+      <Stack.Screen name={Routes.Forms.AutocompleteModal} component={AutocompleteModalScreen} />
+      <Stack.Screen name={Routes.Forms.MultiSelectModal} component={MultiSelectModalScreen} />
+      <Stack.Screen name={Routes.Forms.SelectModal} component={SelectModalScreen} />
+      <Stack.Screen name={Routes.Forms.FrequencySearchModal} component={FrequencySearchModalScreen} />
+      <Stack.Screen
+        name={Routes.SignUpStack.Index}
+        component={SignUpStack}
+        initialParams={{ signedOutFromInactivity: false }}
+      />
+      <Stack.Screen name={Routes.SignUpStack.SelectFacility} component={SelectFacilityScreen} />
+      <Stack.Screen
+        options={noSwipeGestureOnNavigator}
+        name={Routes.HomeStack.Index}
+        component={HomeStack}
+      />
+    </Stack.Navigator>
   );
 };

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useRef } from 'react';
+import React, { FunctionComponent } from 'react';
 // Helpers
 import { Routes } from '/helpers/routes';
 import { noSwipeGestureOnNavigator } from '/helpers/navigators';
@@ -30,16 +30,9 @@ function getSignInFlowRoute(signedIn: boolean, facilityId?: string): string {
 export const Core: FunctionComponent<any> = () => {
   const { signedIn } = useAuth();
   const { facilityId } = useFacility();
-  const { isLoading, securityIssues, fetchSecurityInfo } = useSecurityInfo();
+  const { isLoading, securityIssues, hasCompletedInitialCheck, fetchSecurityInfo } = useSecurityInfo();
 
-  const hasPassedInitialCheck = useRef(false);
-  if (!signedIn) {
-    hasPassedInitialCheck.current = false;
-  } else if (signedIn && !isLoading && securityIssues.length === 0) {
-    hasPassedInitialCheck.current = true;
-  }
-
-  if (securityIssues.length > 0 || (signedIn && !hasPassedInitialCheck.current)) {
+  if (securityIssues.length > 0 || (signedIn && !hasCompletedInitialCheck)) {
     return (
       <SecurityScreen
         isLoading={isLoading}

--- a/packages/mobile/App/ui/navigation/stacks/Core.tsx
+++ b/packages/mobile/App/ui/navigation/stacks/Core.tsx
@@ -33,7 +33,9 @@ export const Core: FunctionComponent<any> = () => {
   const { isLoading, securityIssues, fetchSecurityInfo } = useSecurityInfo();
 
   const hasPassedInitialCheck = useRef(false);
-  if (signedIn && !isLoading && securityIssues.length === 0) {
+  if (!signedIn) {
+    hasPassedInitialCheck.current = false;
+  } else if (signedIn && !isLoading && securityIssues.length === 0) {
     hasPassedInitialCheck.current = true;
   }
 
@@ -54,7 +56,10 @@ export const Core: FunctionComponent<any> = () => {
       <Stack.Screen name={Routes.Forms.AutocompleteModal} component={AutocompleteModalScreen} />
       <Stack.Screen name={Routes.Forms.MultiSelectModal} component={MultiSelectModalScreen} />
       <Stack.Screen name={Routes.Forms.SelectModal} component={SelectModalScreen} />
-      <Stack.Screen name={Routes.Forms.FrequencySearchModal} component={FrequencySearchModalScreen} />
+      <Stack.Screen
+        name={Routes.Forms.FrequencySearchModal}
+        component={FrequencySearchModalScreen}
+      />
       <Stack.Screen
         name={Routes.SignUpStack.Index}
         component={SignUpStack}


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sign-in navigation gate for the security screen, which could block users from reaching the app if the initial-check state is mishandled. Scope is small and limited to mobile security-check UI state.
> 
> **Overview**
> Fixes mobile security-screen state so it no longer shows stale results between sessions and only allows navigation past security once the first device check has completed.
> 
> `useSecurityInfo` now starts in a loading state, tracks `hasCompletedInitialCheck`, and resets to a pre-check/loading state on sign-out; `Core` uses this new flag to show `SecurityScreen` for signed-in users until the initial check finishes or issues are detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 743ca2c344c99d12dd17fc028ce7bc7f9a7918b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->