### PR TITLE
fix(mobile): no-issue: hotfix 2.53: remove patient title from mobile model

### DIFF
--- a/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
+++ b/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+const TABLE_NAME = 'patients';
+const COLUMN_NAME = 'title';
+
+export class removePatientTitleColumn1778199200000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn(TABLE_NAME, COLUMN_NAME);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      TABLE_NAME,
+      new TableColumn({
+        name: COLUMN_NAME,
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+}

--- a/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
+++ b/packages/mobile/App/migrations/1778199200000-removePatientTitleColumn.ts
@@ -1,16 +1,19 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './utils/queryRunner';
 
 const TABLE_NAME = 'patients';
 const COLUMN_NAME = 'title';
 
 export class removePatientTitleColumn1778199200000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropColumn(TABLE_NAME, COLUMN_NAME);
+    const table = await getTable(queryRunner, TABLE_NAME);
+    await queryRunner.dropColumn(table, COLUMN_NAME);
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, TABLE_NAME);
     await queryRunner.addColumn(
-      TABLE_NAME,
+      table,
       new TableColumn({
         name: COLUMN_NAME,
         type: 'varchar',

--- a/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
+++ b/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
@@ -1461,6 +1461,11 @@ const PatientTable = new Table({
       type: 'varchar',
     }),
     new TableColumn({
+      name: 'title',
+      type: 'varchar',
+      isNullable: true,
+    }),
+    new TableColumn({
       name: 'firstName',
       type: 'varchar',
       isNullable: true,

--- a/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
+++ b/packages/mobile/App/migrations/firstTimeSetup/databaseDefinition.ts
@@ -1461,11 +1461,6 @@ const PatientTable = new Table({
       type: 'varchar',
     }),
     new TableColumn({
-      name: 'title',
-      type: 'varchar',
-      isNullable: true,
-    }),
-    new TableColumn({
       name: 'firstName',
       type: 'varchar',
       isNullable: true,

--- a/packages/mobile/App/migrations/index.ts
+++ b/packages/mobile/App/migrations/index.ts
@@ -83,6 +83,7 @@ import { addLabRequestResultsInterpretation1763435712934 } from './1763435712934
 import { addSupportsSecondaryResultsToLabTestType1768527821000 } from './1768527821000-addSupportsSecondaryResultsToLabTestType';
 import { addSecondaryResultToLabTest1768527821000 } from './1768527821000-addSecondaryResultToLabTest';
 import { updateEncountersTableSetPatientIdNotNull1771277667000 } from './1771277667000-updateEncountersTableSetPatientIdNotNull';
+import { removePatientTitleColumn1778199200000 } from './1778199200000-removePatientTitleColumn';
 
 export const migrationList = [
   databaseSetup1661160427226,
@@ -169,4 +170,5 @@ export const migrationList = [
   addSupportsSecondaryResultsToLabTestType1768527821000,
   addSecondaryResultToLabTest1768527821000,
   updateEncountersTableSetPatientIdNotNull1771277667000,
+  removePatientTitleColumn1778199200000,
 ];

--- a/packages/mobile/App/models/Patient.spec.ts
+++ b/packages/mobile/App/models/Patient.spec.ts
@@ -22,7 +22,6 @@ describe('findRecentlyViewed', () => {
     culturalName: 'Fredde',
     village: null,
     villageId: null,
-    title: null,
     additionalData: null,
   };
   const patients: IPatient[] = [

--- a/packages/mobile/App/models/Patient.ts
+++ b/packages/mobile/App/models/Patient.ts
@@ -29,9 +29,6 @@ export class Patient extends BaseModel implements IPatient {
   displayId: string;
 
   @Column({ nullable: true })
-  title?: string;
-
-  @Column({ nullable: true })
   firstName?: string;
 
   @Column({ nullable: true })

--- a/packages/mobile/App/types/IPatient.ts
+++ b/packages/mobile/App/types/IPatient.ts
@@ -5,7 +5,6 @@ import { IReferenceData } from './IReferenceData';
 export interface IPatient {
   id: string;
   displayId: string;
-  title?: string;
   firstName?: string;
   lastName?: string;
   middleName?: string;

--- a/packages/mobile/tests/helpers/fake.ts
+++ b/packages/mobile/tests/helpers/fake.ts
@@ -31,7 +31,6 @@ import { Task } from '~/models/Task';
 export const fakePatient = (): IPatient => {
   const uuid = uuidv4();
   return {
-    title: 'Ms.',
     id: `patient-id-${uuid}`,
     displayId: `patient_displayId-${uuid}`,
     firstName: `patient_firstName-${uuid}`,


### PR DESCRIPTION
### Changes

Cherry-pick of mobile-only hotfix from release\/2.54: removes the `title` field from the mobile Patient model, types, spec fixture, and databaseDefinition, and adds a migration to drop the column from existing installs. Fixes mobile-central sync failure caused by mobile sending `patients.title` while the central patients table has no title column.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)