### PR TITLE
tweak: no-issue: restore E2E checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,10 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 
 </details>
 
+### Tests
+
+- [ ] **Run E2E tests** <!-- #e2e -->
+
 ### Review Hero
 
 - [x] **Run Review Hero** <!-- #ai-review -->

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -2,6 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
   merge_group:
 
 permissions:
@@ -19,7 +20,7 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -287,7 +288,7 @@ jobs:
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'merge_group'
+      - if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')
         name: Enforce passing E2E workflow (in merge queue)
         run: |
           if [ "${{ needs.e2e.result }}" != "success" ]; then

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   node_modules_cache:
-    if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')
+    if: "github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')"
     name: Cache node modules
     runs-on: ubuntu-latest
     steps:
@@ -288,7 +288,7 @@ jobs:
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')
+      - if: "github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')"
         name: Enforce passing E2E workflow (in merge queue)
         run: |
           if [ "${{ needs.e2e.result }}" != "success" ]; then


### PR DESCRIPTION
### Changes

Restores the Run E2E tests checkbox to the PR template and wires it into the ci-e2e workflow so E2E tests run when the checkbox is checked. Also adds the `edited` event trigger so toggling the checkbox after PR creation picks it up.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI trigger conditions and required-check enforcement based on PR body contents, which can affect when E2E runs and whether merges are blocked.
> 
> **Overview**
> Restores a **PR-template opt-in** under *Tests* (`[ ] **Run E2E tests** <!-- #e2e -->`).
> 
> Updates the `ci-e2e` GitHub Actions workflow to trigger on `pull_request` *edited* events and to run/enforce E2E only when in the merge queue or when the PR body contains the checked E2E checkbox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29b8b3fe57c12a4d9513188f997e2dff094483f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->