### PR TITLE
tweak(e2e): No-issue: Generate failure report when running from checkbox

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -228,7 +228,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const { ARTIFACT_URL, RUN_NUMBER, RUN_URL, SHA } = process.env;
+            const { ARTIFACT_URL, RUN_NUMBER, RUN_URL } = process.env;
             const { repo, owner } = context.repo;
             const headRef = context.payload.merge_group?.head_ref ?? '';
             const prNumber =

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -187,7 +187,7 @@ jobs:
 
   e2e_failure_report:
     name: E2E Failure Report
-    if: always() && github.event_name == 'merge_group' && needs.e2e.result != 'success'
+    if: "always() && (github.event_name == 'merge_group' || contains(github.event.pull_request.body, '[x] **Run E2E tests** <!-- #e2e -->')) && needs.e2e.result != 'success'"
     needs: [e2e]
     runs-on: ubuntu-latest
     steps:
@@ -226,7 +226,6 @@ jobs:
           ARTIFACT_URL: ${{ steps.e2e-report-upload.outputs.artifact-url }}
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SHA: ${{ github.sha }}
         with:
           script: |
             const { ARTIFACT_URL, RUN_NUMBER, RUN_URL, SHA } = process.env;
@@ -245,13 +244,11 @@ jobs:
               owner,
               repo,
             };
-            const headerContent = '**E2E merge queue failure report**';
+            const headerContent = '**E2E failure report**';
             const body = [
               headerContent,
               '',
-              context.eventName === 'pull_request'
-                ? `Temporary PR mechanics test: E2E failed for run **${RUN_NUMBER}** (${SHA.slice(0, 7)}).`
-                : `E2E failed in the merge queue for run **${RUN_NUMBER}** (${SHA.slice(0, 7)}).`,
+              `E2E failed for run **${RUN_NUMBER}**.`,
               '',
               `- [View workflow run](${RUN_URL})`,
               `- [Download Playwright failure report](${ARTIFACT_URL})`,

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -25,7 +25,7 @@ module.exports = defineConfig({
   use: {
     // Keep failure media in CI so merge queue reports contain useful debugging context.
     trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
-    video: 'retain-on-failure',
+    video: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
     screenshot: 'only-on-failure',
     // Slow down each browser action to make local debugging easier.
     launchOptions: process.env.CI ? undefined : { slowMo: 200 },

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -250,6 +250,8 @@ test.describe('Basic tests', () => {
     await expect(patientDetailsTabPage3.residentialLandmarkInput).toHaveValue(
       patientDetails.residentialLandmark as string,
     );
+    // TEMP: intentional failure to test e2e_failure_report job
+    expect('fake failure').toBe('this will fail');
   });
 
   test('[BT-0008][AT-2005]Create and verify new imaging request in imaging request table', async ({

--- a/packages/e2e-tests/tests/basic/Basic.spec.ts
+++ b/packages/e2e-tests/tests/basic/Basic.spec.ts
@@ -250,8 +250,6 @@ test.describe('Basic tests', () => {
     await expect(patientDetailsTabPage3.residentialLandmarkInput).toHaveValue(
       patientDetails.residentialLandmark as string,
     );
-    // TEMP: intentional failure to test e2e_failure_report job
-    expect('fake failure').toBe('this will fail');
   });
 
   test('[BT-0008][AT-2005]Create and verify new imaging request in imaging request table', async ({


### PR DESCRIPTION
### Changes

_Add a brief description of the changes in this PR to help give the reviewer context._

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes affecting when the failure-report job posts PR comments and what Playwright media is retained. Main risk is missing expected artifacts/comments due to the updated workflow condition or reporter settings.
> 
> **Overview**
> **E2E failure reports are now generated and posted for PR runs triggered via the “Run E2E tests” checkbox**, not just merge-queue (`merge_group`) runs.
> 
> The failure-report PR comment is simplified (drops SHA-specific messaging) and Playwright CI configuration now records **videos only on first retry** instead of on every failure to reduce retained media noise/size while still preserving debugging context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d895dddc8af2fd405b14958effd577d6e43e210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->