### PR TITLE
ci(autoDeploy): add ttlHours to auto-suspend deploys

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,9 @@ _Add a brief description of the changes in this PR to help give the reviewer con
 <summary>Options</summary>
 
 - [ ] Synthetic test <!-- #deployopt %synthetic -->
+- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
+- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
+- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
 
 </details>
 

--- a/packages/scripts/src/ghaCdHelpers.mjs
+++ b/packages/scripts/src/ghaCdHelpers.mjs
@@ -194,6 +194,15 @@ const OPTIONS = [
     defaultValue: 0,
     parse: input => intBounds(input, [0, 100]),
   },
+  {
+    /*
+     * Hours after the latest `pulumi up` before the deployment auto-suspends.
+     * Set to 0 to disable the TTL and keep the deployment running.
+     */
+    key: 'ttlhours',
+    defaultValue: 4,
+    parse: input => intBounds(input, [0, 720]),
+  },
 ];
 
 function stripPercent(str) {
@@ -254,6 +263,7 @@ export function configMap(deployName, imageTag, options) {
       dbStorage: `${options.dbstorage}Gi`,
       facilities: options.facilities,
       facilityNames: options.facilitynames && JSON.stringify(options.facilitynames),
+      ttlHours: options.ttlhours,
       timezone: options.timezone,
       ipAllowList: options.ip,
       nodeEnv: options.env,


### PR DESCRIPTION
### Changes

Adds the TTL hours option set to auto deploys.

Now deploying a PR will kick off a 4 hour (with options to make it longer) countdown after which the deploy will hibernate. Pushing to the PR will bring the deploy back and/or reset the countdown. That means most deploys will be down up until the point they're needed.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
