### PR TITLE
fix(scheduling): no-issue: Date picker bug in admin location assignments (hotfix 2.55)

### DIFF
--- a/packages/web/app/views/administration/locationAssignments/LocationAssignmentsCalendarHeader.jsx
+++ b/packages/web/app/views/administration/locationAssignments/LocationAssignmentsCalendarHeader.jsx
@@ -75,10 +75,6 @@ const StyledMonthPicker = styled(MonthPicker)`
   .MuiInputBase-input {
     font-size: 11px;
   }
-
-  body:has(&) > .MuiPickersPopper-root {
-    z-index: 2; // Above the sticky headers
-  }
 `;
 
 export const LocationAssignmentsCalendarHeader = ({ monthOf, setMonthOf, displayedDates }) => {


### PR DESCRIPTION
### Changes

Removes a global MUI popper z-index override in the admin location assignments calendar header that was blocking the date picker from appearing. This is the same fix applied to the location bookings calendar in the 2.52–2.54 hotfixes.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a global CSS override; main risk is potential layering regressions for the month picker popper in this view.
> 
> **Overview**
> Removes the global `body:has(&) > .MuiPickersPopper-root { z-index: 2; }` override from the admin Location Assignments calendar header month picker styling.
> 
> This avoids forcing the MUI date picker popper above sticky headers, which was interfering with the picker’s visibility/interaction in this view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2fcacf62295f1065f4ddbb4740a40c65aba260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->