### PR TITLE
fix(mobile): TAM-6743: Attach diagnosis to most recent encounter

### DIFF
--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -255,7 +255,7 @@ export class Encounter extends BaseModel implements IEncounter {
     const encounters = await repo.find({
       where: { patient: { id: patientId } },
       relations: ['location', 'location.facility'],
-      order: { startDate: 'DESC' },
+      order: { startDate: 'DESC', id: 'ASC' },
     });
 
     const notes = await Note.find({

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -162,6 +162,7 @@ export class Encounter extends BaseModel implements IEncounter {
       .where('patientId = :patientId', { patientId })
       .andWhere('endDate IS NULL')
       .orderBy('startDate', 'DESC')
+      .addOrderBy('id', 'ASC')
       .getOne();
   }
 

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -149,6 +149,8 @@ export class Encounter extends BaseModel implements IEncounter {
       .andWhere("startDate >= datetime(:date, 'unixepoch')", {
         date: formatDateForQuery(date),
       })
+      .orderBy('startDate', 'DESC')
+      .addOrderBy('id', 'ASC')
       .getOne();
   }
 

--- a/packages/mobile/App/models/Encounter.ts
+++ b/packages/mobile/App/models/Encounter.ts
@@ -150,7 +150,8 @@ export class Encounter extends BaseModel implements IEncounter {
         date: formatDateForQuery(date),
       })
       .orderBy('startDate', 'DESC')
-      .addOrderBy('id', 'ASC')
+      .addOrderBy('createdAt', 'DESC')
+      .addOrderBy('id', 'DESC')
       .getOne();
   }
 
@@ -162,7 +163,8 @@ export class Encounter extends BaseModel implements IEncounter {
       .where('patientId = :patientId', { patientId })
       .andWhere('endDate IS NULL')
       .orderBy('startDate', 'DESC')
-      .addOrderBy('id', 'ASC')
+      .addOrderBy('createdAt', 'DESC')
+      .addOrderBy('id', 'DESC')
       .getOne();
   }
 
@@ -255,7 +257,7 @@ export class Encounter extends BaseModel implements IEncounter {
     const encounters = await repo.find({
       where: { patient: { id: patientId } },
       relations: ['location', 'location.facility'],
-      order: { startDate: 'DESC', id: 'ASC' },
+      order: { startDate: 'DESC', createdAt: 'DESC', id: 'DESC' },
     });
 
     const notes = await Note.find({


### PR DESCRIPTION
### Changes

We should attach to the most recent encounter I think if it was on the same day. Doesn't matter if it has already been closed. This adds ordering so that we get the latest and also deterministic results

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

