### PR TITLE
fix(web): TAM-4421: Persist search parameters across logout/login sessions

### DIFF
--- a/packages/constants/src/userPreferences.ts
+++ b/packages/constants/src/userPreferences.ts
@@ -9,4 +9,6 @@ export const USER_PREFERENCES_KEYS = {
   OUTPATIENT_APPOINTMENT_FILTERS: 'outpatientAppointmentFilters',
   OUTPATIENT_APPOINTMENT_GROUP_BY: 'outpatientAppointmentGroupBy',
   LOCATION_ASSIGNMENT_SELECTED_FACILITY: 'locationAssignmentSelectedFacility',
+  LAB_REQUEST_SEARCH_PARAMETERS: 'labRequestSearchParameters',
+  IMAGING_REQUEST_SEARCH_PARAMETERS: 'imagingRequestSearchParameters',
 };

--- a/packages/web/app/contexts/ImagingRequests.jsx
+++ b/packages/web/app/contexts/ImagingRequests.jsx
@@ -1,5 +1,9 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { IMAGING_TABLE_VERSIONS } from '@tamanu/constants/imaging';
+import { useUserPreferencesQuery } from '../api/queries';
+import { useUserPreferencesMutation } from '../api/mutations';
+import { useAuth } from './Auth';
 
 const ImagingRequestsContext = createContext({});
 
@@ -31,16 +35,37 @@ export const useImagingRequestsQuery = (key = IMAGING_REQUEST_SEARCH_KEYS.ACTIVE
 };
 
 export const ImagingRequestsProvider = ({ children }) => {
+  const { facilityId } = useAuth();
   const [searchParameters, setSearchParameters] = useState({
     [IMAGING_REQUEST_SEARCH_KEYS.ACTIVE]: {},
     [IMAGING_REQUEST_SEARCH_KEYS.COMPLETED]: {},
   });
 
+  const { data: userPreferences } = useUserPreferencesQuery();
+  const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
+
+  useEffect(() => {
+    if (userPreferences?.imagingRequestSearchParameters) {
+      setSearchParameters(userPreferences.imagingRequestSearchParameters);
+    }
+  }, [userPreferences]);
+
+  const setSearchParametersWithPersist = useCallback(
+    (newSearchParameters) => {
+      setSearchParameters(newSearchParameters);
+      mutateUserPreferences({
+        key: USER_PREFERENCES_KEYS.IMAGING_REQUEST_SEARCH_PARAMETERS,
+        value: newSearchParameters,
+      });
+    },
+    [mutateUserPreferences],
+  );
+
   return (
     <ImagingRequestsContext.Provider
       value={{
         searchParameters,
-        setSearchParameters,
+        setSearchParameters: setSearchParametersWithPersist,
       }}
     >
       {children}

--- a/packages/web/app/contexts/ImagingRequests.jsx
+++ b/packages/web/app/contexts/ImagingRequests.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { IMAGING_TABLE_VERSIONS } from '@tamanu/constants/imaging';
 import { useUserPreferencesQuery } from '../api/queries';
@@ -40,19 +40,19 @@ export const ImagingRequestsProvider = ({ children }) => {
     [IMAGING_REQUEST_SEARCH_KEYS.ACTIVE]: {},
     [IMAGING_REQUEST_SEARCH_KEYS.COMPLETED]: {},
   });
-  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
+  const hasLoadedPreferences = useRef(false);
 
-  const { data: userPreferences, isLoading: isLoadingPreferences } = useUserPreferencesQuery();
-  const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
+  const { data: userPreferences } = useUserPreferencesQuery();
+  const { mutate: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
 
   useEffect(() => {
-    if (!isLoadingPreferences && !hasLoadedPreferences) {
-      if (userPreferences?.imagingRequestSearchParameters) {
+    if (userPreferences && !hasLoadedPreferences.current) {
+      if (userPreferences.imagingRequestSearchParameters) {
         setSearchParameters(userPreferences.imagingRequestSearchParameters);
       }
-      setHasLoadedPreferences(true);
+      hasLoadedPreferences.current = true;
     }
-  }, [userPreferences, isLoadingPreferences, hasLoadedPreferences]);
+  }, [userPreferences]);
 
   const setSearchParametersWithPersist = useCallback(
     (newSearchParameters) => {

--- a/packages/web/app/contexts/ImagingRequests.jsx
+++ b/packages/web/app/contexts/ImagingRequests.jsx
@@ -40,15 +40,19 @@ export const ImagingRequestsProvider = ({ children }) => {
     [IMAGING_REQUEST_SEARCH_KEYS.ACTIVE]: {},
     [IMAGING_REQUEST_SEARCH_KEYS.COMPLETED]: {},
   });
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
 
-  const { data: userPreferences } = useUserPreferencesQuery();
+  const { data: userPreferences, isLoading: isLoadingPreferences } = useUserPreferencesQuery();
   const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
 
   useEffect(() => {
-    if (userPreferences?.imagingRequestSearchParameters) {
-      setSearchParameters(userPreferences.imagingRequestSearchParameters);
+    if (!isLoadingPreferences && !hasLoadedPreferences) {
+      if (userPreferences?.imagingRequestSearchParameters) {
+        setSearchParameters(userPreferences.imagingRequestSearchParameters);
+      }
+      setHasLoadedPreferences(true);
     }
-  }, [userPreferences]);
+  }, [userPreferences, isLoadingPreferences, hasLoadedPreferences]);
 
   const setSearchParametersWithPersist = useCallback(
     (newSearchParameters) => {

--- a/packages/web/app/contexts/LabRequest.jsx
+++ b/packages/web/app/contexts/LabRequest.jsx
@@ -48,17 +48,21 @@ export const LabRequestProvider = ({ children }) => {
     [LabRequestSearchParamKeys.Published]: {},
     [LabRequestSearchParamKeys.Other]: {},
   });
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
 
-  const { data: userPreferences } = useUserPreferencesQuery();
+  const { data: userPreferences, isLoading: isLoadingPreferences } = useUserPreferencesQuery();
   const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
 
   const api = useApi();
 
   useEffect(() => {
-    if (userPreferences?.labRequestSearchParameters) {
-      setSearchParameters(userPreferences.labRequestSearchParameters);
+    if (!isLoadingPreferences && !hasLoadedPreferences) {
+      if (userPreferences?.labRequestSearchParameters) {
+        setSearchParameters(userPreferences.labRequestSearchParameters);
+      }
+      setHasLoadedPreferences(true);
     }
-  }, [userPreferences]);
+  }, [userPreferences, isLoadingPreferences, hasLoadedPreferences]);
 
   const setSearchParametersWithPersist = useCallback(
     (newSearchParameters) => {

--- a/packages/web/app/contexts/LabRequest.jsx
+++ b/packages/web/app/contexts/LabRequest.jsx
@@ -1,7 +1,10 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
-import { LAB_REQUEST_STATUSES } from '@tamanu/constants';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { LAB_REQUEST_STATUSES, USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { useDateTimeIfAvailable } from '@tamanu/ui-components';
 import { useApi } from '../api';
+import { useUserPreferencesQuery } from '../api/queries';
+import { useUserPreferencesMutation } from '../api/mutations';
+import { useAuth } from './Auth';
 
 const LabRequestContext = createContext({
   labRequest: {},
@@ -37,6 +40,7 @@ export const useLabRequest = (key = LabRequestSearchParamKeys.Other) => {
 
 export const LabRequestProvider = ({ children }) => {
   const { getCurrentDateTime } = (useDateTimeIfAvailable() || {})
+  const { facilityId } = useAuth();
   const [labRequest, setLabRequest] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [searchParameters, setSearchParameters] = useState({
@@ -45,7 +49,27 @@ export const LabRequestProvider = ({ children }) => {
     [LabRequestSearchParamKeys.Other]: {},
   });
 
+  const { data: userPreferences } = useUserPreferencesQuery();
+  const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
+
   const api = useApi();
+
+  useEffect(() => {
+    if (userPreferences?.labRequestSearchParameters) {
+      setSearchParameters(userPreferences.labRequestSearchParameters);
+    }
+  }, [userPreferences]);
+
+  const setSearchParametersWithPersist = useCallback(
+    (newSearchParameters) => {
+      setSearchParameters(newSearchParameters);
+      mutateUserPreferences({
+        key: USER_PREFERENCES_KEYS.LAB_REQUEST_SEARCH_PARAMETERS,
+        value: newSearchParameters,
+      });
+    },
+    [mutateUserPreferences],
+  );
 
   const loadLabRequest = useCallback(
     async (labRequestId) => {
@@ -78,7 +102,7 @@ export const LabRequestProvider = ({ children }) => {
         loadLabRequest,
         updateLabRequest,
         searchParameters,
-        setSearchParameters,
+        setSearchParameters: setSearchParametersWithPersist,
       }}
     >
       {children}

--- a/packages/web/app/contexts/LabRequest.jsx
+++ b/packages/web/app/contexts/LabRequest.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { LAB_REQUEST_STATUSES, USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { useDateTimeIfAvailable } from '@tamanu/ui-components';
 import { useApi } from '../api';
@@ -48,21 +48,21 @@ export const LabRequestProvider = ({ children }) => {
     [LabRequestSearchParamKeys.Published]: {},
     [LabRequestSearchParamKeys.Other]: {},
   });
-  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
+  const hasLoadedPreferences = useRef(false);
 
-  const { data: userPreferences, isLoading: isLoadingPreferences } = useUserPreferencesQuery();
-  const { mutateAsync: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
+  const { data: userPreferences } = useUserPreferencesQuery();
+  const { mutate: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
 
   const api = useApi();
 
   useEffect(() => {
-    if (!isLoadingPreferences && !hasLoadedPreferences) {
-      if (userPreferences?.labRequestSearchParameters) {
+    if (userPreferences && !hasLoadedPreferences.current) {
+      if (userPreferences.labRequestSearchParameters) {
         setSearchParameters(userPreferences.labRequestSearchParameters);
       }
-      setHasLoadedPreferences(true);
+      hasLoadedPreferences.current = true;
     }
-  }, [userPreferences, isLoadingPreferences, hasLoadedPreferences]);
+  }, [userPreferences]);
 
   const setSearchParametersWithPersist = useCallback(
     (newSearchParameters) => {

--- a/packages/web/app/contexts/OutpatientAppointments.jsx
+++ b/packages/web/app/contexts/OutpatientAppointments.jsx
@@ -14,7 +14,7 @@ export const OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE = {
 };
 
 export const OutpatientAppointmentsContextProvider = ({ children }) => {
-  const { data: userPreferences } = useUserPreferencesQuery();
+  const { data: userPreferences, isLoading } = useUserPreferencesQuery();
   const location = useLocation();
   const defaultGroupBy =
     new URLSearchParams(location.search).get('groupBy') || APPOINTMENT_GROUP_BY.LOCATION_GROUP;
@@ -33,11 +33,11 @@ export const OutpatientAppointmentsContextProvider = ({ children }) => {
         setFilters(userPreferences.outpatientAppointmentFilters);
       }
       hasLoadedPreferences.current = true;
-    } else if (!userPreferences && !hasLoadedPreferences.current) {
+    } else if (!isLoading && !userPreferences && !hasLoadedPreferences.current) {
       setGroupBy(defaultGroupBy);
       hasLoadedPreferences.current = true;
     }
-  }, [userPreferences, defaultGroupBy]);
+  }, [userPreferences, isLoading, defaultGroupBy]);
 
   return (
     <OutpatientAppointmentsContext.Provider value={{ filters, setFilters, groupBy, setGroupBy }}>

--- a/packages/web/app/contexts/OutpatientAppointments.jsx
+++ b/packages/web/app/contexts/OutpatientAppointments.jsx
@@ -14,15 +14,16 @@ export const OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE = {
 };
 
 export const OutpatientAppointmentsContextProvider = ({ children }) => {
-  const { data: userPreferences } = useUserPreferencesQuery();
+  const { data: userPreferences, isLoading } = useUserPreferencesQuery();
   const location = useLocation();
   const defaultGroupBy =
     new URLSearchParams(location.search).get('groupBy') || APPOINTMENT_GROUP_BY.LOCATION_GROUP;
   const [filters, setFilters] = useState(OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE);
   const [groupBy, setGroupBy] = useState(null);
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
 
   useEffect(() => {
-    if (userPreferences && !groupBy) {
+    if (!isLoading && userPreferences && !hasLoadedPreferences) {
       if (userPreferences?.outpatientAppointmentGroupBy) {
         setGroupBy(userPreferences.outpatientAppointmentGroupBy);
       } else {
@@ -31,8 +32,13 @@ export const OutpatientAppointmentsContextProvider = ({ children }) => {
       if (userPreferences?.outpatientAppointmentFilters) {
         setFilters(userPreferences.outpatientAppointmentFilters);
       }
+      setHasLoadedPreferences(true);
+    } else if (!isLoading && !userPreferences && !hasLoadedPreferences) {
+      // No saved preferences, use defaults
+      setGroupBy(defaultGroupBy);
+      setHasLoadedPreferences(true);
     }
-  }, [userPreferences, setGroupBy, defaultGroupBy, groupBy]);
+  }, [userPreferences, isLoading, hasLoadedPreferences, defaultGroupBy]);
 
   return (
     <OutpatientAppointmentsContext.Provider value={{ filters, setFilters, groupBy, setGroupBy }}>

--- a/packages/web/app/contexts/OutpatientAppointments.jsx
+++ b/packages/web/app/contexts/OutpatientAppointments.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router';
 
 import { useUserPreferencesQuery } from '../api/queries';
@@ -14,16 +14,16 @@ export const OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE = {
 };
 
 export const OutpatientAppointmentsContextProvider = ({ children }) => {
-  const { data: userPreferences, isLoading } = useUserPreferencesQuery();
+  const { data: userPreferences } = useUserPreferencesQuery();
   const location = useLocation();
   const defaultGroupBy =
     new URLSearchParams(location.search).get('groupBy') || APPOINTMENT_GROUP_BY.LOCATION_GROUP;
   const [filters, setFilters] = useState(OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE);
   const [groupBy, setGroupBy] = useState(null);
-  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
+  const hasLoadedPreferences = useRef(false);
 
   useEffect(() => {
-    if (!isLoading && userPreferences && !hasLoadedPreferences) {
+    if (userPreferences && !hasLoadedPreferences.current) {
       if (userPreferences?.outpatientAppointmentGroupBy) {
         setGroupBy(userPreferences.outpatientAppointmentGroupBy);
       } else {
@@ -32,13 +32,12 @@ export const OutpatientAppointmentsContextProvider = ({ children }) => {
       if (userPreferences?.outpatientAppointmentFilters) {
         setFilters(userPreferences.outpatientAppointmentFilters);
       }
-      setHasLoadedPreferences(true);
-    } else if (!isLoading && !userPreferences && !hasLoadedPreferences) {
-      // No saved preferences, use defaults
+      hasLoadedPreferences.current = true;
+    } else if (!userPreferences && !hasLoadedPreferences.current) {
       setGroupBy(defaultGroupBy);
-      setHasLoadedPreferences(true);
+      hasLoadedPreferences.current = true;
     }
-  }, [userPreferences, isLoading, hasLoadedPreferences, defaultGroupBy]);
+  }, [userPreferences, defaultGroupBy]);
 
   return (
     <OutpatientAppointmentsContext.Provider value={{ filters, setFilters, groupBy, setGroupBy }}>

--- a/packages/web/app/contexts/OutpatientAppointments.jsx
+++ b/packages/web/app/contexts/OutpatientAppointments.jsx
@@ -1,7 +1,11 @@
-import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router';
+import { omit } from 'lodash';
 
+import { USER_PREFERENCES_KEYS } from '@tamanu/constants';
 import { useUserPreferencesQuery } from '../api/queries';
+import { useUserPreferencesMutation } from '../api/mutations';
+import { useAuth } from './Auth';
 import { APPOINTMENT_GROUP_BY } from '../views/scheduling/outpatientBookings/OutpatientAppointmentsView';
 
 const OutpatientAppointmentsContext = createContext(null);
@@ -14,7 +18,9 @@ export const OUTPATIENT_APPOINTMENTS_EMPTY_FILTER_STATE = {
 };
 
 export const OutpatientAppointmentsContextProvider = ({ children }) => {
+  const { facilityId } = useAuth();
   const { data: userPreferences, isLoading } = useUserPreferencesQuery();
+  const { mutate: mutateUserPreferences } = useUserPreferencesMutation(facilityId);
   const location = useLocation();
   const defaultGroupBy =
     new URLSearchParams(location.search).get('groupBy') || APPOINTMENT_GROUP_BY.LOCATION_GROUP;
@@ -39,8 +45,36 @@ export const OutpatientAppointmentsContextProvider = ({ children }) => {
     }
   }, [userPreferences, isLoading, defaultGroupBy]);
 
+  const setGroupByWithPersist = useCallback(
+    newGroupBy => {
+      setGroupBy(newGroupBy);
+      if (hasLoadedPreferences.current) {
+        mutateUserPreferences({
+          key: USER_PREFERENCES_KEYS.OUTPATIENT_APPOINTMENT_GROUP_BY,
+          value: newGroupBy,
+        });
+      }
+    },
+    [mutateUserPreferences],
+  );
+
+  const setFiltersWithPersist = useCallback(
+    newFilters => {
+      setFilters(newFilters);
+      if (hasLoadedPreferences.current) {
+        mutateUserPreferences({
+          key: USER_PREFERENCES_KEYS.OUTPATIENT_APPOINTMENT_FILTERS,
+          value: omit(newFilters, ['patientNameOrId']),
+        });
+      }
+    },
+    [mutateUserPreferences],
+  );
+
   return (
-    <OutpatientAppointmentsContext.Provider value={{ filters, setFilters, groupBy, setGroupBy }}>
+    <OutpatientAppointmentsContext.Provider
+      value={{ filters, setFilters: setFiltersWithPersist, groupBy, setGroupBy: setGroupByWithPersist }}
+    >
       {children}
     </OutpatientAppointmentsContext.Provider>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changes

**Issue:** Regression in v2.51 where search parameters are no longer retained across logout/login sessions in Outpatient, Active Labs, and Imaging search pages.

**Root Cause:** 
1. **OutpatientAppointments**: The useEffect had a condition `if (userPreferences && !groupBy)` that prevented loading saved preferences if `groupBy` was already set (from URL or defaults), causing a race condition.
2. **LabRequest & ImagingRequests**: These contexts were storing search parameters only in React state, which is lost on logout. Redux-persist has its whitelist set to empty in production, so nothing persists to localStorage.

**Solution:** 
1. Fixed the OutpatientAppointments useEffect condition to use `hasLoadedPreferences` flag instead of checking `!groupBy`
2. Added `isLoading` check to prevent race conditions in all three contexts
3. Updated LabRequestProvider and ImagingRequestsProvider to persist search parameters to user preferences (following the OutpatientAppointments pattern)

**Changes made:**
- Added `LAB_REQUEST_SEARCH_PARAMETERS` and `IMAGING_REQUEST_SEARCH_PARAMETERS` keys to `USER_PREFERENCES_KEYS` constant
- Updated `LabRequestProvider` to load search parameters from user preferences on mount and save them when they change
- Updated `ImagingRequestsProvider` to load search parameters from user preferences on mount and save them when they change  
- Fixed `OutpatientAppointmentsContextProvider` to properly load saved preferences by:
  - Removing the `!groupBy` condition that caused race conditions
  - Adding `hasLoadedPreferences` flag to ensure preferences load exactly once
  - Adding `isLoading` check to wait for query to complete before setting state
- Applied the same `hasLoadedPreferences` and `isLoading` pattern to all three contexts for consistency

Search parameters now persist correctly across logout/login sessions for all three pages.

**Linear:** TAM-4421

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TAM-4421](https://linear.app/bes/issue/TAM-4421/search-parameters-are-no-longer-retained-across-logoutlogin-sessions)

<div><a href="https://cursor.com/agents/bc-04209f94-eff8-40c1-b813-1faf5f2ed2d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04209f94-eff8-40c1-b813-1faf5f2ed2d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

