### PR TITLE
fix(tests): Flaky CentralSyncManager test

### DIFF
--- a/packages/central-server/__tests__/sync/CentralSyncManager.connectToSession.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.connectToSession.test.js
@@ -100,11 +100,27 @@ describe('CentralSyncManager.connectToSession', () => {
     const { sessionId } = await centralSyncManager.startSession();
     await waitForSession(centralSyncManager, sessionId);
 
+    // Reset timestamps so this test doesn't depend on how long session preparation
+    // took on CI. The first connect call below should always be within timeout.
+    await models.SyncSession.update(
+      { createdAt: new Date(), updatedAt: new Date() },
+      {
+        where: { id: sessionId },
+        silent: true,
+      },
+    );
+
+    // Wait long enough to exceed syncSessionTimeoutMs from the reset baseline.
+    // We intentionally do this *before* the first connect call because the timeout
+    // check uses (updatedAt - createdAt), not wall-clock time directly.
     await sleepAsync(500);
 
-    // updated_at will be set to timestamp that is 500ms later
+    // First call should succeed, and it updates lastConnectionTime (therefore updatedAt).
+    // This validates the "can still connect" path after setup.
     await centralSyncManager.connectToSession(sessionId);
 
+    // Second call should now fail because updatedAt has moved further away from createdAt,
+    // so the timeout predicate evaluates true.
     await expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow(
       `Sync session '${sessionId}' encountered an error: Sync session ${sessionId} timed out`,
     );

--- a/packages/central-server/__tests__/sync/CentralSyncManager.connectToSession.test.js
+++ b/packages/central-server/__tests__/sync/CentralSyncManager.connectToSession.test.js
@@ -88,39 +88,35 @@ describe('CentralSyncManager.connectToSession', () => {
   });
 
   it("throws an error when connecting to a session that has taken longer than configured 'syncSessionTimeoutMs'", async () => {
+    // waitForSession → checkSessionReady → connectToSession, so syncSessionTimeoutMs applies
+    // during polling. Use 1000ms so normal session prep stays under the limit.
+    const syncSessionTimeoutMs = 1000;
     const centralSyncManager = initializeCentralSyncManager({
       sync: {
         lookupTable: {
           enabled: false,
         },
-        syncSessionTimeoutMs: 200,
+        syncSessionTimeoutMs,
         maxRecordsPerSnapshotChunk: DEFAULT_MAX_RECORDS_PER_SNAPSHOT_CHUNKS,
       },
     });
     const { sessionId } = await centralSyncManager.startSession();
     await waitForSession(centralSyncManager, sessionId);
 
-    // Reset timestamps so this test doesn't depend on how long session preparation
-    // took on CI. The first connect call below should always be within timeout.
+    // Timeout is based on ORM (DB) createdAt/updatedAt, not on Jest's clock — advancing fake
+    // timers does not move Postgres timestamps. Pin both to the same moment in the past so
+    // the first connect sees zero age; that connect refreshes updatedAt, opening a gap > limit.
+    const baseline = new Date(Date.now() - syncSessionTimeoutMs * 5);
     await models.SyncSession.update(
-      { createdAt: new Date(), updatedAt: new Date() },
+      { createdAt: baseline, updatedAt: baseline },
       {
         where: { id: sessionId },
         silent: true,
       },
     );
 
-    // Wait long enough to exceed syncSessionTimeoutMs from the reset baseline.
-    // We intentionally do this *before* the first connect call because the timeout
-    // check uses (updatedAt - createdAt), not wall-clock time directly.
-    await sleepAsync(500);
-
-    // First call should succeed, and it updates lastConnectionTime (therefore updatedAt).
-    // This validates the "can still connect" path after setup.
     await centralSyncManager.connectToSession(sessionId);
 
-    // Second call should now fail because updatedAt has moved further away from createdAt,
-    // so the timeout predicate evaluates true.
     await expect(centralSyncManager.connectToSession(sessionId)).rejects.toThrow(
       `Sync session '${sessionId}' encountered an error: Sync session ${sessionId} timed out`,
     );


### PR DESCRIPTION
### Changes

This test was failing intermittently because sometimes the preparation between the sync session and the first call to connectToSession was longer than the configured timeout. With this change, we ensure a deterministic result while preserving test reliability.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._
