### PR TITLE
fix(database): prevent skipped baseline rollback

### DIFF
--- a/packages/database/src/migrations/000_baseline.ts
+++ b/packages/database/src/migrations/000_baseline.ts
@@ -4,8 +4,7 @@ import type { QueryInterface } from 'sequelize';
 
 const BASELINE_SQL_PATH = path.join(__dirname, '000_baseline.sql');
 const FROZEN_MIGRATIONS_PATH = path.join(__dirname, '000_baseline_frozen_migrations.json');
-const BASELINE_STATE_SCHEMA = 'tamanu_baseline';
-const BASELINE_APPLIED_TABLE = 'applied';
+const BASELINE_APPLIED_COMMENT = 'tamanu:baseline-applied';
 
 export async function up(query: QueryInterface): Promise<void> {
   const [results] = await query.sequelize.query(`
@@ -57,23 +56,17 @@ export async function up(query: QueryInterface): Promise<void> {
     { bind: [frozenMigrations] },
   );
 
-  await query.sequelize.query(`CREATE SCHEMA IF NOT EXISTS ${BASELINE_STATE_SCHEMA}`);
   await query.sequelize.query(`
-    CREATE TABLE IF NOT EXISTS ${BASELINE_STATE_SCHEMA}.${BASELINE_APPLIED_TABLE} (
-      id boolean PRIMARY KEY DEFAULT true CHECK (id),
-      applied_at timestamptz NOT NULL DEFAULT now()
-    )
-  `);
-  await query.sequelize.query(`
-    INSERT INTO ${BASELINE_STATE_SCHEMA}.${BASELINE_APPLIED_TABLE} (id)
-    VALUES (true)
-    ON CONFLICT DO NOTHING
+    COMMENT ON TABLE "SequelizeMeta" IS '${BASELINE_APPLIED_COMMENT}'
   `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
   const [results] = await query.sequelize.query(`
-    SELECT to_regclass('"${BASELINE_STATE_SCHEMA}"."${BASELINE_APPLIED_TABLE}"') IS NOT NULL AS baseline_applied
+    SELECT COALESCE(
+      obj_description(to_regclass('public."SequelizeMeta"')::oid, 'pg_class') = '${BASELINE_APPLIED_COMMENT}',
+      false
+    ) AS baseline_applied
   `);
 
   if (!(results as any[])[0]?.baseline_applied) {
@@ -85,6 +78,5 @@ export async function down(query: QueryInterface): Promise<void> {
   await query.sequelize.query('DROP SCHEMA IF EXISTS logs CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS sync_snapshots CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS public CASCADE');
-  await query.sequelize.query(`DROP SCHEMA IF EXISTS ${BASELINE_STATE_SCHEMA} CASCADE`);
   await query.sequelize.query('CREATE SCHEMA public');
 }

--- a/packages/database/src/migrations/000_baseline.ts
+++ b/packages/database/src/migrations/000_baseline.ts
@@ -40,6 +40,9 @@ export async function up(query: QueryInterface): Promise<void> {
       );
     }
 
+    await (pgClient as any).query(`
+      COMMENT ON TABLE public."SequelizeMeta" IS '${BASELINE_APPLIED_COMMENT}'
+    `);
     await (pgClient as any).query(sql);
     await (pgClient as any).query('RESET search_path');
   } finally {
@@ -55,10 +58,6 @@ export async function up(query: QueryInterface): Promise<void> {
     `INSERT INTO "SequelizeMeta" (name) SELECT unnest($1::text[]) ON CONFLICT DO NOTHING`,
     { bind: [frozenMigrations] },
   );
-
-  await query.sequelize.query(`
-    COMMENT ON TABLE "SequelizeMeta" IS '${BASELINE_APPLIED_COMMENT}'
-  `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
@@ -70,6 +69,10 @@ export async function down(query: QueryInterface): Promise<void> {
   `);
 
   if (!(results as any[])[0]?.baseline_applied) {
+    console.warn(
+      'Skipping 000_baseline down migration because the baseline-applied marker is absent. ' +
+        'This usually means 000_baseline.up exited early for a pre-existing schema.',
+    );
     return;
   }
 

--- a/packages/database/src/migrations/000_baseline.ts
+++ b/packages/database/src/migrations/000_baseline.ts
@@ -4,6 +4,8 @@ import type { QueryInterface } from 'sequelize';
 
 const BASELINE_SQL_PATH = path.join(__dirname, '000_baseline.sql');
 const FROZEN_MIGRATIONS_PATH = path.join(__dirname, '000_baseline_frozen_migrations.json');
+const BASELINE_STATE_SCHEMA = 'tamanu_baseline';
+const BASELINE_APPLIED_TABLE = 'applied';
 
 export async function up(query: QueryInterface): Promise<void> {
   const [results] = await query.sequelize.query(`
@@ -54,12 +56,35 @@ export async function up(query: QueryInterface): Promise<void> {
     `INSERT INTO "SequelizeMeta" (name) SELECT unnest($1::text[]) ON CONFLICT DO NOTHING`,
     { bind: [frozenMigrations] },
   );
+
+  await query.sequelize.query(`CREATE SCHEMA IF NOT EXISTS ${BASELINE_STATE_SCHEMA}`);
+  await query.sequelize.query(`
+    CREATE TABLE IF NOT EXISTS ${BASELINE_STATE_SCHEMA}.${BASELINE_APPLIED_TABLE} (
+      id boolean PRIMARY KEY DEFAULT true CHECK (id),
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+  await query.sequelize.query(`
+    INSERT INTO ${BASELINE_STATE_SCHEMA}.${BASELINE_APPLIED_TABLE} (id)
+    VALUES (true)
+    ON CONFLICT DO NOTHING
+  `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
+  const [results] = await query.sequelize.query(`
+    SELECT to_regclass('"${BASELINE_STATE_SCHEMA}"."${BASELINE_APPLIED_TABLE}"') IS NOT NULL AS baseline_applied
+  `);
+
+  if (!(results as any[])[0]?.baseline_applied) {
+    return;
+  }
+
+  // DESTRUCTIVE: Only the baseline-created schema can be reverted; all data is dropped.
   await query.sequelize.query('DROP SCHEMA IF EXISTS fhir CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS logs CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS sync_snapshots CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS public CASCADE');
+  await query.sequelize.query(`DROP SCHEMA IF EXISTS ${BASELINE_STATE_SCHEMA} CASCADE`);
   await query.sequelize.query('CREATE SCHEMA public');
 }


### PR DESCRIPTION
### Changes

Fix a rollback edge case in `000_baseline`. `up` can return early when `public.users` already exists, but Umzug still records the baseline as applied; `down` now only drops schemas when the baseline-owned marker is present. The marker is written on `SequelizeMeta` before the raw baseline SQL starts, and skipped rollbacks now warn so operators can see why no destructive rollback occurred.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

Manual checks:

- ReadLints on `packages/database/src/migrations/000_baseline.ts`
- `npm run dbt-generate-model --fail-on-missing-config`

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->