### PR TITLE
fix(database): no-issue: hotfix 2.54 prevent skipped baseline rollback

### DIFF
--- a/packages/database/src/migrations/000_baseline.ts
+++ b/packages/database/src/migrations/000_baseline.ts
@@ -4,6 +4,7 @@ import type { QueryInterface } from 'sequelize';
 
 const BASELINE_SQL_PATH = path.join(__dirname, '000_baseline.sql');
 const FROZEN_MIGRATIONS_PATH = path.join(__dirname, '000_baseline_frozen_migrations.json');
+const BASELINE_APPLIED_COMMENT = 'tamanu:baseline-applied';
 
 export async function up(query: QueryInterface): Promise<void> {
   const [results] = await query.sequelize.query(`
@@ -54,9 +55,25 @@ export async function up(query: QueryInterface): Promise<void> {
     `INSERT INTO "SequelizeMeta" (name) SELECT unnest($1::text[]) ON CONFLICT DO NOTHING`,
     { bind: [frozenMigrations] },
   );
+
+  await query.sequelize.query(`
+    COMMENT ON TABLE "SequelizeMeta" IS '${BASELINE_APPLIED_COMMENT}'
+  `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
+  const [results] = await query.sequelize.query(`
+    SELECT COALESCE(
+      obj_description(to_regclass('public."SequelizeMeta"')::oid, 'pg_class') = '${BASELINE_APPLIED_COMMENT}',
+      false
+    ) AS baseline_applied
+  `);
+
+  if (!(results as any[])[0]?.baseline_applied) {
+    return;
+  }
+
+  // DESTRUCTIVE: Only the baseline-created schema can be reverted; all data is dropped.
   await query.sequelize.query('DROP SCHEMA IF EXISTS fhir CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS logs CASCADE');
   await query.sequelize.query('DROP SCHEMA IF EXISTS sync_snapshots CASCADE');

--- a/packages/database/src/migrations/000_baseline.ts
+++ b/packages/database/src/migrations/000_baseline.ts
@@ -40,6 +40,9 @@ export async function up(query: QueryInterface): Promise<void> {
       );
     }
 
+    await (pgClient as any).query(`
+      COMMENT ON TABLE public."SequelizeMeta" IS '${BASELINE_APPLIED_COMMENT}'
+    `);
     await (pgClient as any).query(sql);
     await (pgClient as any).query('RESET search_path');
   } finally {
@@ -55,10 +58,6 @@ export async function up(query: QueryInterface): Promise<void> {
     `INSERT INTO "SequelizeMeta" (name) SELECT unnest($1::text[]) ON CONFLICT DO NOTHING`,
     { bind: [frozenMigrations] },
   );
-
-  await query.sequelize.query(`
-    COMMENT ON TABLE "SequelizeMeta" IS '${BASELINE_APPLIED_COMMENT}'
-  `);
 }
 
 export async function down(query: QueryInterface): Promise<void> {
@@ -70,6 +69,10 @@ export async function down(query: QueryInterface): Promise<void> {
   `);
 
   if (!(results as any[])[0]?.baseline_applied) {
+    console.warn(
+      'Skipping 000_baseline down migration because the baseline-applied marker is absent. ' +
+        'This usually means 000_baseline.up exited early for a pre-existing schema.',
+    );
     return;
   }
 


### PR DESCRIPTION
### Changes

Fix a rollback edge case in `000_baseline`. `up` can return early when `public.users` already exists, but Umzug still records the baseline as applied; `down` now only drops schemas when the baseline-owned marker is present. The marker is written on `SequelizeMeta` before the raw baseline SQL starts, and skipped rollbacks now warn so operators can see why no destructive rollback occurred.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->

</details>

### Tests

- [ ] **Run E2E Tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->

Made with [Cursor](https://cursor.com)