### PR TITLE
fix(database): no-issue: hotfix 2.52 optimise note type migration

### DIFF
--- a/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
+++ b/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
@@ -117,27 +117,34 @@ async function updateNotesInBatches(
   caseExpression: string,
   fallbackValue: string,
 ) {
-  let updatedCount = 0;
+  let lastId: string | null = null;
   do {
-    const [updatedRows] = await query.sequelize.query(`
+    const queryResults = await query.sequelize.query(
+      `
       WITH batch AS (
         SELECT id
         FROM notes
-        WHERE ${filter}
+        WHERE ${lastId ? 'id > :lastId AND' : ''} ${filter}
         ORDER BY id
         LIMIT ${NOTES_BATCH_SIZE}
+      ),
+      updated AS (
+        UPDATE notes
+        SET ${column} = CASE ${column}
+            ${caseExpression}
+            ELSE '${fallbackValue}'
+        END
+        FROM batch
+        WHERE notes.id = batch.id
+        RETURNING notes.id
       )
-      UPDATE notes
-      SET ${column} = CASE ${column}
-          ${caseExpression}
-          ELSE '${fallbackValue}'
-      END
-      FROM batch
-      WHERE notes.id = batch.id
-      RETURNING notes.id
-    `);
-    updatedCount = (updatedRows as unknown[]).length;
-  } while (updatedCount > 0);
+      SELECT max(id)::text AS max_id FROM batch
+    `,
+      { replacements: { lastId } },
+    );
+    const results = queryResults[0] as { max_id: string | null }[];
+    lastId = (results as { max_id: string | null }[])[0]?.max_id ?? null;
+  } while (lastId);
 }
 
 export async function up(query: QueryInterface) {
@@ -167,14 +174,20 @@ export async function up(query: QueryInterface) {
   const upCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
     ({ id, code }) => `WHEN '${code}' THEN '${id}'`,
   ).join('\n        ');
-  await updateNotesInBatches(
-    query,
-    'note_type',
-    `note_type NOT IN (${noteTypeIds})`,
-    upCaseExpression,
-    otherNoteType.id,
-  );
-  await query.renameColumn('notes', 'note_type', 'note_type_id');
+  try {
+    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
+    await updateNotesInBatches(
+      query,
+      'note_type',
+      `note_type NOT IN (${noteTypeIds})`,
+      upCaseExpression,
+      otherNoteType.id,
+    );
+    await query.renameColumn('notes', 'note_type', 'note_type_id');
+  } finally {
+    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
+  }
+
   await query.addConstraint('notes', {
     fields: ['note_type_id'],
     type: 'foreign key',
@@ -194,14 +207,19 @@ export async function down(query: QueryInterface) {
   const downCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
     ({ id, code }) => `WHEN '${id}' THEN '${code}'`,
   ).join('\n        ');
-  await updateNotesInBatches(
-    query,
-    'note_type_id',
-    `note_type_id IN (${noteTypeIds})`,
-    downCaseExpression,
-    otherNoteType.code,
-  );
-  await query.renameColumn('notes', 'note_type_id', 'note_type');
+  try {
+    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
+    await updateNotesInBatches(
+      query,
+      'note_type_id',
+      `note_type_id IN (${noteTypeIds})`,
+      downCaseExpression,
+      otherNoteType.code,
+    );
+    await query.renameColumn('notes', 'note_type_id', 'note_type');
+  } finally {
+    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
+  }
 
   await query.sequelize.query(`DELETE FROM reference_data WHERE type = :noteType`, {
     replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },

--- a/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
+++ b/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
@@ -1,5 +1,8 @@
-import { DataTypes, QueryInterface } from 'sequelize';
+import { QueryInterface } from 'sequelize';
 import { REFERENCE_TYPES } from '@tamanu/constants';
+
+const NOTES_BATCH_SIZE = 10000;
+const NOTES_NOTE_TYPE_ID_FKEY = 'notes_note_type_id_fkey';
 
 /**
  * Hardcoded note types to create in reference_data.
@@ -105,6 +108,38 @@ const NOTE_TYPE_REFERENCE_DATA = [
   },
 ];
 
+const noteTypeIds = NOTE_TYPE_REFERENCE_DATA.map(({ id }) => `'${id}'`).join(', ');
+
+async function updateNotesInBatches(
+  query: QueryInterface,
+  column: 'note_type' | 'note_type_id',
+  filter: string,
+  caseExpression: string,
+  fallbackValue: string,
+) {
+  let updatedCount = 0;
+  do {
+    const [updatedRows] = await query.sequelize.query(`
+      WITH batch AS (
+        SELECT id
+        FROM notes
+        WHERE ${filter}
+        ORDER BY id
+        LIMIT ${NOTES_BATCH_SIZE}
+      )
+      UPDATE notes
+      SET ${column} = CASE ${column}
+          ${caseExpression}
+          ELSE '${fallbackValue}'
+      END
+      FROM batch
+      WHERE notes.id = batch.id
+      RETURNING notes.id
+    `);
+    updatedCount = (updatedRows as unknown[]).length;
+  } while (updatedCount > 0);
+}
+
 export async function up(query: QueryInterface) {
   for (const noteType of NOTE_TYPE_REFERENCE_DATA) {
     await query.sequelize.query(
@@ -128,59 +163,45 @@ export async function up(query: QueryInterface) {
     );
   }
 
-  await query.addColumn('notes', 'note_type_id', {
-    type: DataTypes.STRING(255),
-    allowNull: true,
-    references: {
-      model: 'reference_data',
-      key: 'id',
-    },
-  });
-
   const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
   const upCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
     ({ id, code }) => `WHEN '${code}' THEN '${id}'`,
   ).join('\n        ');
-  await query.sequelize.query(`
-    UPDATE notes
-    SET note_type_id = CASE note_type
-        ${upCaseExpression}
-        ELSE '${otherNoteType.id}'
-    END
-  `);
-
-  await query.changeColumn('notes', 'note_type_id', {
-    type: DataTypes.STRING(255),
-    allowNull: false,
+  await updateNotesInBatches(
+    query,
+    'note_type',
+    `note_type NOT IN (${noteTypeIds})`,
+    upCaseExpression,
+    otherNoteType.id,
+  );
+  await query.renameColumn('notes', 'note_type', 'note_type_id');
+  await query.addConstraint('notes', {
+    fields: ['note_type_id'],
+    type: 'foreign key',
+    name: NOTES_NOTE_TYPE_ID_FKEY,
+    references: {
+      table: 'reference_data',
+      field: 'id',
+    },
+    onDelete: 'NO ACTION',
+    onUpdate: 'NO ACTION',
   });
-
-  await query.removeColumn('notes', 'note_type');
 }
 
 export async function down(query: QueryInterface) {
-  await query.addColumn('notes', 'note_type', {
-    type: DataTypes.STRING(255),
-    allowNull: true,
-  });
-
+  await query.removeConstraint('notes', NOTES_NOTE_TYPE_ID_FKEY);
   const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
   const downCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
     ({ id, code }) => `WHEN '${id}' THEN '${code}'`,
   ).join('\n        ');
-  await query.sequelize.query(`
-    UPDATE notes
-    SET note_type = CASE note_type_id
-        ${downCaseExpression}
-        ELSE '${otherNoteType.code}'
-    END
-  `);
-
-  await query.changeColumn('notes', 'note_type', {
-    type: DataTypes.STRING(255),
-    allowNull: false,
-  });
-
-  await query.removeColumn('notes', 'note_type_id');
+  await updateNotesInBatches(
+    query,
+    'note_type_id',
+    `note_type_id IN (${noteTypeIds})`,
+    downCaseExpression,
+    otherNoteType.code,
+  );
+  await query.renameColumn('notes', 'note_type_id', 'note_type');
 
   await query.sequelize.query(`DELETE FROM reference_data WHERE type = :noteType`, {
     replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },

--- a/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
+++ b/packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts
@@ -1,9 +1,6 @@
 import { QueryInterface } from 'sequelize';
 import { REFERENCE_TYPES } from '@tamanu/constants';
 
-const NOTES_BATCH_SIZE = 10000;
-const NOTES_NOTE_TYPE_ID_FKEY = 'notes_note_type_id_fkey';
-
 /**
  * Hardcoded note types to create in reference_data.
  * These correspond to the NOTE_TYPES constant but are hardcoded here to ensure
@@ -108,45 +105,6 @@ const NOTE_TYPE_REFERENCE_DATA = [
   },
 ];
 
-const noteTypeIds = NOTE_TYPE_REFERENCE_DATA.map(({ id }) => `'${id}'`).join(', ');
-
-async function updateNotesInBatches(
-  query: QueryInterface,
-  column: 'note_type' | 'note_type_id',
-  filter: string,
-  caseExpression: string,
-  fallbackValue: string,
-) {
-  let lastId: string | null = null;
-  do {
-    const queryResults = await query.sequelize.query(
-      `
-      WITH batch AS (
-        SELECT id
-        FROM notes
-        WHERE ${lastId ? 'id > :lastId AND' : ''} ${filter}
-        ORDER BY id
-        LIMIT ${NOTES_BATCH_SIZE}
-      ),
-      updated AS (
-        UPDATE notes
-        SET ${column} = CASE ${column}
-            ${caseExpression}
-            ELSE '${fallbackValue}'
-        END
-        FROM batch
-        WHERE notes.id = batch.id
-        RETURNING notes.id
-      )
-      SELECT max(id)::text AS max_id FROM batch
-    `,
-      { replacements: { lastId } },
-    );
-    const results = queryResults[0] as { max_id: string | null }[];
-    lastId = (results as { max_id: string | null }[])[0]?.max_id ?? null;
-  } while (lastId);
-}
-
 export async function up(query: QueryInterface) {
   for (const noteType of NOTE_TYPE_REFERENCE_DATA) {
     await query.sequelize.query(
@@ -169,58 +127,9 @@ export async function up(query: QueryInterface) {
       },
     );
   }
-
-  const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
-  const upCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
-    ({ id, code }) => `WHEN '${code}' THEN '${id}'`,
-  ).join('\n        ');
-  try {
-    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
-    await updateNotesInBatches(
-      query,
-      'note_type',
-      `note_type NOT IN (${noteTypeIds})`,
-      upCaseExpression,
-      otherNoteType.id,
-    );
-    await query.renameColumn('notes', 'note_type', 'note_type_id');
-  } finally {
-    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
-  }
-
-  await query.addConstraint('notes', {
-    fields: ['note_type_id'],
-    type: 'foreign key',
-    name: NOTES_NOTE_TYPE_ID_FKEY,
-    references: {
-      table: 'reference_data',
-      field: 'id',
-    },
-    onDelete: 'NO ACTION',
-    onUpdate: 'NO ACTION',
-  });
 }
 
 export async function down(query: QueryInterface) {
-  await query.removeConstraint('notes', NOTES_NOTE_TYPE_ID_FKEY);
-  const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
-  const downCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
-    ({ id, code }) => `WHEN '${id}' THEN '${code}'`,
-  ).join('\n        ');
-  try {
-    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
-    await updateNotesInBatches(
-      query,
-      'note_type_id',
-      `note_type_id IN (${noteTypeIds})`,
-      downCaseExpression,
-      otherNoteType.code,
-    );
-    await query.renameColumn('notes', 'note_type_id', 'note_type');
-  } finally {
-    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
-  }
-
   await query.sequelize.query(`DELETE FROM reference_data WHERE type = :noteType`, {
     replacements: { noteType: REFERENCE_TYPES.NOTE_TYPE },
   });

--- a/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
+++ b/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
@@ -67,7 +67,10 @@ async function updateNotesInBatches(
         WHERE notes.id = batch.id
         RETURNING notes.id
       )
-      SELECT max(id)::text AS max_id FROM batch
+      SELECT id::text AS max_id
+      FROM batch
+      ORDER BY id DESC
+      LIMIT 1
     `,
       { replacements: { lastId } },
     );

--- a/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
+++ b/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
@@ -6,7 +6,6 @@ const NOTES_DERIVED_SIDE_EFFECT_TRIGGERS = [
   'notify_notes_changed',
   'record_notes_changelog',
   'fhir_refresh',
-  'fhir_refresh_notes',
 ];
 
 const NOTE_TYPE_REFERENCE_DATA = [
@@ -133,6 +132,8 @@ export async function up(query: QueryInterface): Promise<void> {
       upCaseExpression,
       otherNoteType.id,
     );
+    // Refresh planner stats on note_type after rewriting every value.
+    await query.sequelize.query(`ANALYZE notes`);
   } finally {
     await setKnownDerivedSideEffectTriggersEnabled(query, true);
   }
@@ -156,6 +157,7 @@ export async function down(query: QueryInterface): Promise<void> {
       downCaseExpression,
       otherNoteType.code,
     );
+    await query.sequelize.query(`ANALYZE notes`);
   } finally {
     await setKnownDerivedSideEffectTriggersEnabled(query, true);
   }

--- a/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
+++ b/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
@@ -1,0 +1,123 @@
+import { QueryInterface } from 'sequelize';
+
+const NOTES_BATCH_SIZE = 10000;
+
+const NOTE_TYPE_REFERENCE_DATA = [
+  { id: 'notetype-treatmentPlan', code: 'treatmentPlan' },
+  { id: 'notetype-discharge', code: 'discharge' },
+  { id: 'notetype-clinicalMobile', code: 'clinicalMobile' },
+  { id: 'notetype-handover', code: 'handover' },
+  { id: 'notetype-areaToBeImaged', code: 'areaToBeImaged' },
+  { id: 'notetype-resultDescription', code: 'resultDescription' },
+  { id: 'notetype-other', code: 'other' },
+  { id: 'notetype-system', code: 'system' },
+  { id: 'notetype-admission', code: 'admission' },
+  { id: 'notetype-medical', code: 'medical' },
+  { id: 'notetype-surgical', code: 'surgical' },
+  { id: 'notetype-nursing', code: 'nursing' },
+  { id: 'notetype-dietary', code: 'dietary' },
+  { id: 'notetype-pharmacy', code: 'pharmacy' },
+  { id: 'notetype-physiotherapy', code: 'physiotherapy' },
+  { id: 'notetype-social', code: 'social' },
+];
+
+const noteTypeIds = NOTE_TYPE_REFERENCE_DATA.map(({ id }) => `'${id}'`).join(', ');
+const noteTypeCodes = NOTE_TYPE_REFERENCE_DATA.map(({ code }) => `'${code}'`).join(', ');
+
+async function columnExists(query: QueryInterface, columnName: string): Promise<boolean> {
+  const [results] = await query.sequelize.query(
+    `
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name = 'notes'
+      AND column_name = :columnName
+    ) AS exists
+  `,
+    { replacements: { columnName } },
+  );
+  return Boolean((results as { exists: boolean }[])[0]?.exists);
+}
+
+async function updateNotesInBatches(
+  query: QueryInterface,
+  filter: string,
+  caseExpression: string,
+  fallbackValue: string,
+) {
+  let lastId: string | null = null;
+  do {
+    const queryResults = await query.sequelize.query(
+      `
+      WITH batch AS (
+        SELECT id
+        FROM notes
+        WHERE ${lastId ? 'id > :lastId AND' : ''} ${filter}
+        ORDER BY id
+        LIMIT ${NOTES_BATCH_SIZE}
+      ),
+      updated AS (
+        UPDATE notes
+        SET note_type = CASE note_type
+            ${caseExpression}
+            ELSE '${fallbackValue}'
+        END
+        FROM batch
+        WHERE notes.id = batch.id
+        RETURNING notes.id
+      )
+      SELECT max(id)::text AS max_id FROM batch
+    `,
+      { replacements: { lastId } },
+    );
+    const results = queryResults[0] as { max_id: string | null }[];
+    lastId = results[0]?.max_id ?? null;
+  } while (lastId);
+}
+
+export async function up(query: QueryInterface): Promise<void> {
+  if (!(await columnExists(query, 'note_type')) || (await columnExists(query, 'note_type_id'))) {
+    return;
+  }
+
+  const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
+  const upCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
+    ({ id, code }) => `WHEN '${code}' THEN '${id}'`,
+  ).join('\n        ');
+
+  try {
+    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
+    await updateNotesInBatches(
+      query,
+      `note_type NOT IN (${noteTypeIds})`,
+      upCaseExpression,
+      otherNoteType.id,
+    );
+  } finally {
+    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  if (!(await columnExists(query, 'note_type'))) {
+    return;
+  }
+
+  const otherNoteType = NOTE_TYPE_REFERENCE_DATA.find(({ code }) => code === 'other')!;
+  const downCaseExpression = NOTE_TYPE_REFERENCE_DATA.map(
+    ({ id, code }) => `WHEN '${id}' THEN '${code}'`,
+  ).join('\n        ');
+
+  try {
+    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
+    await updateNotesInBatches(
+      query,
+      `note_type NOT IN (${noteTypeCodes})`,
+      downCaseExpression,
+      otherNoteType.code,
+    );
+  } finally {
+    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
+  }
+}

--- a/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
+++ b/packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts
@@ -2,6 +2,13 @@ import { QueryInterface } from 'sequelize';
 
 const NOTES_BATCH_SIZE = 10000;
 
+const NOTES_DERIVED_SIDE_EFFECT_TRIGGERS = [
+  'notify_notes_changed',
+  'record_notes_changelog',
+  'fhir_refresh',
+  'fhir_refresh_notes',
+];
+
 const NOTE_TYPE_REFERENCE_DATA = [
   { id: 'notetype-treatmentPlan', code: 'treatmentPlan' },
   { id: 'notetype-discharge', code: 'discharge' },
@@ -38,6 +45,35 @@ async function columnExists(query: QueryInterface, columnName: string): Promise<
     { replacements: { columnName } },
   );
   return Boolean((results as { exists: boolean }[])[0]?.exists);
+}
+
+async function triggerExists(query: QueryInterface, triggerName: string): Promise<boolean> {
+  const [results] = await query.sequelize.query(
+    `
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.triggers
+      WHERE event_object_schema = 'public'
+      AND event_object_table = 'notes'
+      AND trigger_name = :triggerName
+    ) AS exists
+  `,
+    { replacements: { triggerName } },
+  );
+  return Boolean((results as { exists: boolean }[])[0]?.exists);
+}
+
+async function setKnownDerivedSideEffectTriggersEnabled(
+  query: QueryInterface,
+  enabled: boolean,
+): Promise<void> {
+  for (const triggerName of NOTES_DERIVED_SIDE_EFFECT_TRIGGERS) {
+    if (await triggerExists(query, triggerName)) {
+      await query.sequelize.query(
+        `ALTER TABLE notes ${enabled ? 'ENABLE' : 'DISABLE'} TRIGGER ${triggerName}`,
+      );
+    }
+  }
 }
 
 async function updateNotesInBatches(
@@ -90,7 +126,7 @@ export async function up(query: QueryInterface): Promise<void> {
   ).join('\n        ');
 
   try {
-    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
+    await setKnownDerivedSideEffectTriggersEnabled(query, false);
     await updateNotesInBatches(
       query,
       `note_type NOT IN (${noteTypeIds})`,
@@ -98,7 +134,7 @@ export async function up(query: QueryInterface): Promise<void> {
       otherNoteType.id,
     );
   } finally {
-    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
+    await setKnownDerivedSideEffectTriggersEnabled(query, true);
   }
 }
 
@@ -113,7 +149,7 @@ export async function down(query: QueryInterface): Promise<void> {
   ).join('\n        ');
 
   try {
-    await query.sequelize.query('ALTER TABLE notes DISABLE TRIGGER USER');
+    await setKnownDerivedSideEffectTriggersEnabled(query, false);
     await updateNotesInBatches(
       query,
       `note_type NOT IN (${noteTypeCodes})`,
@@ -121,6 +157,6 @@ export async function down(query: QueryInterface): Promise<void> {
       otherNoteType.code,
     );
   } finally {
-    await query.sequelize.query('ALTER TABLE notes ENABLE TRIGGER USER');
+    await setKnownDerivedSideEffectTriggersEnabled(query, true);
   }
 }

--- a/packages/database/src/migrations/1759894448778-renameNoteTypeColumn.ts
+++ b/packages/database/src/migrations/1759894448778-renameNoteTypeColumn.ts
@@ -1,0 +1,73 @@
+import { QueryInterface } from 'sequelize';
+
+const NOTES_NOTE_TYPE_ID_FKEY = 'notes_note_type_id_fkey';
+
+async function columnExists(query: QueryInterface, columnName: string): Promise<boolean> {
+  const [results] = await query.sequelize.query(
+    `
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name = 'notes'
+      AND column_name = :columnName
+    ) AS exists
+  `,
+    { replacements: { columnName } },
+  );
+  return Boolean((results as { exists: boolean }[])[0]?.exists);
+}
+
+async function constraintExists(query: QueryInterface, constraintName: string): Promise<boolean> {
+  const [results] = await query.sequelize.query(
+    `
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.table_constraints
+      WHERE table_schema = 'public'
+      AND table_name = 'notes'
+      AND constraint_name = :constraintName
+    ) AS exists
+  `,
+    { replacements: { constraintName } },
+  );
+  return Boolean((results as { exists: boolean }[])[0]?.exists);
+}
+
+export async function up(query: QueryInterface): Promise<void> {
+  const hasNoteType = await columnExists(query, 'note_type');
+  const hasNoteTypeId = await columnExists(query, 'note_type_id');
+
+  if (hasNoteType && !hasNoteTypeId) {
+    await query.renameColumn('notes', 'note_type', 'note_type_id');
+  }
+
+  if (await columnExists(query, 'note_type_id')) {
+    if (!(await constraintExists(query, NOTES_NOTE_TYPE_ID_FKEY))) {
+      await query.addConstraint('notes', {
+        fields: ['note_type_id'],
+        type: 'foreign key',
+        name: NOTES_NOTE_TYPE_ID_FKEY,
+        references: {
+          table: 'reference_data',
+          field: 'id',
+        },
+        onDelete: 'NO ACTION',
+        onUpdate: 'NO ACTION',
+      });
+    }
+  }
+}
+
+export async function down(query: QueryInterface): Promise<void> {
+  if (await constraintExists(query, NOTES_NOTE_TYPE_ID_FKEY)) {
+    await query.removeConstraint('notes', NOTES_NOTE_TYPE_ID_FKEY);
+  }
+
+  const hasNoteType = await columnExists(query, 'note_type');
+  const hasNoteTypeId = await columnExists(query, 'note_type_id');
+
+  if (hasNoteTypeId && !hasNoteType) {
+    await query.renameColumn('notes', 'note_type_id', 'note_type');
+  }
+}


### PR DESCRIPTION
### Changes

Hotfix for `release/2.52` to reduce Windows upgrade time and address review feedback on `1759894448776-migrateNoteTypesToReferenceData`.

The original migration mixed reference-data DML, `notes` value rewrites, and schema changes. This PR now keeps those concerns in separate migrations while preserving the final schema/data shape:

- `1759894448776-migrateNoteTypesToReferenceData.ts` creates/deletes note type reference data only.
- `1759894448777-backfillNoteTypeIds.ts` rewrites `notes.note_type` values in `id` cursor batches of 10k rows, with only the known derived `notes` side-effect triggers temporarily disabled for the deterministic historical rewrite.
- `1759894448778-renameNoteTypeColumn.ts` renames `notes.note_type` to `notes.note_type_id` and adds the FK to `reference_data`.

The new DML and DDL migrations include column/constraint guards so databases that already ran the earlier combined version can still run the newly split migrations safely. Rollback now converts all ID-shaped `note_type` values back to codes, mapping unknown/custom IDs to `other` instead of skipping them.

This intentionally skips per-note changelog/notify/FHIR side effects for a representation-only backfill. `notes` content and relationships are unchanged; only the note type identifier representation changes from legacy codes to reference-data IDs. The migration no longer uses blanket `DISABLE TRIGGER USER`; it only suppresses known generated notify/changelog/FHIR triggers when present, leaving `updated_at` and any unknown/custom `notes` triggers alone. The migration runner already suppresses `updated_at_sync_tick` trigger churn during migrations, and the following migration explicitly rebuilds notes lookup state with `flag_lookup_model_to_rebuild('notes')`.

### Windows/WAL Notes

The main remaining WAL source is the unavoidable heap rewrite from changing every `notes.note_type` value from legacy codes to `notetype-*` reference-data IDs. The conservative PR path avoids the larger Windows-sensitive amplification from generated notify/changelog/FHIR triggers; further large reductions would require a broader change such as non-transactional per-batch migration support, durability/session tuning, or changing the stable note type IDs, none of which are included here.

FHIR note: suppressing the generated FHIR trigger on `notes` also suppresses per-note `fhir.refresh.allFromUpstream` job creation during the backfill. That avoids creating one FHIR refresh job per note during upgrade. If an environment needs materialised FHIR resources to immediately reflect the new note type ID representation, prefer a coarse post-upgrade FHIR refresh for affected resources rather than generating row-level jobs inside this migration.

I checked a conservative DDL alternative: adding the FK as `NOT VALID` and then validating it separately. On a 1M-row synthetic table this was not meaningfully better than the current validated FK add, so the DDL migration is left unchanged.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

Manual checks:

- `npm run --workspace @tamanu/central-server test -- __disttests__/subCommands/generate.test.js` passes.
- ReadLints on the three note type migration files: no diagnostics.
- `npm run lint-all -- packages/database/src/migrations/1759894448776-migrateNoteTypesToReferenceData.ts packages/database/src/migrations/1759894448777-backfillNoteTypeIds.ts packages/database/src/migrations/1759894448778-renameNoteTypeColumn.ts` did not complete because local ESLint config cannot resolve `@typescript-eslint`.

Final local synthetic Postgres benchmark:

- Dataset: 2,267,441 `notes` rows matching the observed note count, with UUID primary keys, 16 note type codes, 200-byte note content, and a simulated `notes` user trigger that updates `updated_at` and writes one side-effect row per note update.
- Before: original release migration shape (`add note_type_id`, full-table update, set not-null, drop `note_type`) took 83.6s, generated 2165.0 MiB WAL, and fired 2,267,441 simulated trigger side-effect rows.
- After: split PR shape (reference data migration, targeted generated-trigger suppression, 10k batched rewrite, rename, FK add) took 81.0s, generated 1815.2 MiB WAL, and fired 0 simulated trigger side-effect rows.
- Result: similar local elapsed time, 16.2% less WAL, and 2,267,441 trigger side-effect rows avoided.

FK validation benchmark:

- Dataset: 1,000,000 already-rewritten `notes.note_type_id` rows, 3 rounds per variant.
- Current validated FK add: median 0.221s, 0.057 MiB WAL.
- `NOT VALID` plus `VALIDATE CONSTRAINT`: median 0.241s, 0.054 MiB WAL.
- Result: no meaningful conservative win; code left unchanged.

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix --> _Wait for Review Hero to finish, resolve any comments you disagree with or want to fix manually, then check this to auto-fix the rest._
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci --> _Check this to auto-fix lint errors, test failures, and other CI issues._
- [ ] **Auto-merge upstream** <!-- #auto-merge --> _Check this to merge the base branch into this PR, with AI conflict resolution if needed._
- [ ] **Save suppressions** <!-- #save-suppressions --> _Check this to capture 👎 reactions on Review Hero comments as suppression rules in `.github/review-hero/suppressions.yml`. Also runs automatically at the end of any auto-fix run._

### Remember to...

- ...write or update tests
- ...add UI screenshots and **testing notes** to the Linear issue
- ...add any **manual upgrade steps** to the Linear issue
- ...update the [config reference](https://beyond-essential.slab.com/posts/reference-config-file-0c70ukly), [settings reference](https://beyond-essential.slab.com/posts/reference-settings-0blw1x2q), or any [relevant runbook(s)](https://beyond-essential.slab.com/topics/runbooks-bs04ml6c)
- ...call out additions or changes to **config files** for the deployment team to take note of

<!-- Thank you! -->
