### PR TITLE
Fix audit settings fallback for multi-facility servers

### DIFF
--- a/packages/central-server/app/auth/userMiddleware.js
+++ b/packages/central-server/app/auth/userMiddleware.js
@@ -37,7 +37,9 @@ export const userMiddleware = asyncHandler(async (req, res, next) => {
   req.sessionId = sessionId;
   /* eslint-enable require-atomic-updates */
 
-  const auditSettings = await settings?.[req.facilityId]?.get('audit');
+  // Fallback to global settings when facilityId is undefined (multi-facility servers)
+  const settingsReader = settings?.[req.facilityId] ?? settings.global ?? settings;
+  const auditSettings = await settingsReader?.get('audit');
 
     // Auditing middleware
     req.audit = initAuditActions(req, {

--- a/packages/facility-server/app/middleware/auth.js
+++ b/packages/facility-server/app/middleware/auth.js
@@ -311,7 +311,9 @@ export const authMiddleware = async (req, res, next) => {
         order: [['createdAt', 'DESC']],
       });
 
-    const auditSettings = await settings?.[req.facilityId]?.get('audit');
+    // Fallback to global settings when facilityId is undefined (multi-facility servers)
+    const settingsReader = settings?.[req.facilityId] ?? settings.global ?? settings;
+    const auditSettings = await settingsReader?.get('audit');
 
     // Auditing middleware
     // eslint-disable-next-line require-atomic-updates


### PR DESCRIPTION
### Changes

Fixed audit settings resolution in both central and facility servers to properly fall back to global settings when `facilityId` is undefined. This ensures audit middleware functions correctly on multi-facility server deployments where facility-specific settings may not be available.

The change applies the same fallback pattern (`settings?.[req.facilityId] ?? settings.global ?? settings`) in both:
- `packages/central-server/app/auth/userMiddleware.js`
- `packages/facility-server/app/middleware/auth.js`

This prevents potential undefined errors when accessing audit settings on servers that don't have facility-specific configuration.

### Auto-Deploy

- [ ] **Deploy** <!-- #deploy -->

<details>
<summary>Options</summary>

- [ ] Synthetic test <!-- #deployopt %synthetic -->
- [ ] Generate fake data <!-- #deployopt %fakedata=1 -->
- [ ] More data (20Gi) <!-- #deployopt %dbstorage=20 -->
- [ ] No facility servers (central-only) <!-- #deployopt %facilities=0 -->
- [ ] No sync (facility tasks scaled to zero) <!-- #deployopt %facilitytasks=0 -->
- [ ] AMD64 architecture (default is arm64) <!-- #deployopt %arch=amd64 -->
- [ ] Skip mobile build <!-- #deployopt %mobile=never -->
- [ ] Always build mobile <!-- #deployopt %mobile=always -->
- [ ] Stay up for 8 hours <!-- #deployopt %ttlhours=8 -->
- [ ] Stay up for 24 hours <!-- #deployopt %ttlhours=24 -->
- [ ] Stay up (no TTL) <!-- #deployopt %ttlhours=0 -->
- [ ] Build images only (don't deploy) <!-- #deployopt %imagesonly -->
- [ ] Pause this deploy <!-- #deployopt %pause -->

</details>

### Tests

- [ ] **Run E2E tests** <!-- #e2e -->

### Review Hero

- [ ] **Run Review Hero** <!-- #ai-review -->
- [ ] **Auto-fix review suggestions** <!-- #auto-fix -->
- [ ] **Auto-fix CI failures** <!-- #auto-fix-ci -->
- [ ] **Auto-merge upstream** <!-- #auto-merge -->
- [ ] **Save suppressions** <!-- #save-suppressions -->

https://claude.ai/code/session_01D5qWES3Q2Xd1iiYqVhaUVT